### PR TITLE
More style rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
         'plugin:react-hooks/recommended', // React hooks rules
         'plugin:jsx-a11y/recommended', // Accessibility rules
       ],
+      plugins: [
+          'no-switch-statements',
+      ],
       rules: {
         '@typescript-eslint/no-unused-vars': ['error'],
         '@typescript-eslint/explicit-function-return-type': [
@@ -40,6 +43,7 @@ module.exports = {
         'jsx-a11y/anchor-is-valid': 'off',
         'keyword-spacing': ['error', {}],
         'no-console': 'warn',
+        'no-switch-statements/no-switch': 'error',
         'object-curly-spacing': ['error', 'always'],
         'prefer-const': ['error', {}],
         'react/jsx-closing-bracket-location': ['error', {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,17 @@ module.exports = {
         'no-console': 'warn',
         'no-switch-statements/no-switch': 'error',
         'object-curly-spacing': ['error', 'always'],
+        'padding-line-between-statements': ['error',
+            // imports go together, but last import must be followed by newline
+            { blankLine: 'always', prev: 'import', next: '*' },
+            { blankLine: 'any', prev: 'import', next: 'import' },
+
+            { blankLine: 'always', prev: 'export', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'export' },
+
+            { blankLine: 'always', prev: 'function', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'function' },
+        ],
         'prefer-const': ['error', {}],
         'react/jsx-closing-bracket-location': ['error', {
             'nonEmpty': 'after-props',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,6 +95,11 @@ module.exports = {
         'react/prop-types': 'off',
         'react/react-in-jsx-scope': 'off',
         'semi': ['error', 'always'],
+        'sort-imports': ['error', {
+            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
+        }],
+        'sort-keys': 'error',
+        'sort-vars': 'error',
         'space-before-blocks': ['error', 'always'],
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
           },
         ],
 
+        'brace-style': ['error', 'stroustrup'],
         'indent': ['error', 4],
         'jsx-a11y/anchor-is-valid': 'off',
         'keyword-spacing': ['error', {}],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,7 @@ module.exports = {
         'react/react-in-jsx-scope': 'off',
         'semi': ['error', 'always'],
         'sort-imports': ['error', {
+            allowSeparatedGroups: true,
             memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
         }],
         'sort-keys': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1507,6 +1507,15 @@
         }
       }
     },
+    "create-eslint-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/create-eslint-index/-/create-eslint-index-1.0.0.tgz",
+      "integrity": "sha1-2VQ3LYbVeS/NZ+nyt5GxqxYkEbs=",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.3.0"
+      }
+    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -2245,6 +2254,16 @@
         }
       }
     },
+    "eslint-ast-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz",
+      "integrity": "sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.4.2",
+        "lodash.zip": "^4.2.0"
+      }
+    },
     "eslint-loader": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-4.0.2.tgz",
@@ -2283,6 +2302,17 @@
           "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-no-switch-statements": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-switch-statements/-/eslint-plugin-no-switch-statements-1.0.0.tgz",
+      "integrity": "sha512-dgnNOcTJpCCJPUM1ZmKZKWsW4vdNj8LdPwn8xyDk7BeJIDjZSvI7k8N4xvl2hBgUXcHI6mQrksvnIZs1Hvhmrw==",
+      "dev": true,
+      "requires": {
+        "create-eslint-index": "^1.0.0",
+        "eslint-ast-utils": "^1.1.0",
+        "req-all": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -3617,10 +3647,22 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4977,6 +5019,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "req-all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/req-all/-/req-all-1.0.0.tgz",
+      "integrity": "sha1-0ShWlFHDQLQyQJxlbPFmJgzSYo0=",
+      "dev": true
     },
     "resolve": {
       "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^7.15.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-no-switch-statements": "^1.0.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "typescript": "^4.1.3"


### PR DESCRIPTION
This PR adds a few more code style rules to `.eslintrc`:

* Prohibit use of `switch` entirely. There are few cases (if any) where they're better than `if`/`else`
* Require newline after closing `}`
* Require empty lines after blocks of imports, and around individual functions and exports
* Require imports, keys and vars to be sorted