### PR TITLE
Lint workflow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-unused-vars': ['error'],
         '@typescript-eslint/explicit-function-return-type': [
-          'warn',
+          'error',
           {
             allowExpressions: true,
             allowConciseArrowFunctionExpressionsStartingWithVoid: true,
@@ -42,7 +42,7 @@ module.exports = {
         'indent': ['error', 4],
         'jsx-a11y/anchor-is-valid': 'off',
         'keyword-spacing': ['error', {}],
-        'no-console': 'warn',
+        'no-console': 'error',
         'no-switch-statements/no-switch': 'error',
         'object-curly-spacing': ['error', 'always'],
         'padding-line-between-statements': ['error',

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker-compose run linter npm run lint

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker-compose run linter npm run lint
+docker-compose run --rm linter npm run lint

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Run the deveopment build using [Docker Compose](https://docs.docker.com/compose/
 ```
 $ docker-compose up --build
 ```
+
+To avoid commiting anything that breaks linting rules, you can set up a git
+pre-commit hook. The `.githooks/` directory contains such a hook, so the easiest
+way to set it up is to just configure git to use hooks from there:
+
+```
+$ git config core.hooksPath .githooks
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,17 @@ version: "3"
 services:
     main:
         build: .
+        image: main
         ports:
             - "3000:3000"
         volumes:
             - "./src:/var/app/src"
             - "./public:/var/app/public"
+
+    linter:
+        command: npm run watch
+        environment:
+            SHELL: "sh"
+        image: main
+        volumes:
+            - "./src:/var/app/src"

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ module.exports = {
         test: /\.(j|t)sx?$/,
         exclude: /node_modules/,
         loader: 'eslint-loader',
+        options: {
+          emitWarning: true,
+        }
       });
     };
     return config;

--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,5 @@
 module.exports = {
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
-    if (dev) {
-      config.module.rules.push({
-        test: /\.(j|t)sx?$/,
-        exclude: /node_modules/,
-        loader: 'eslint-loader',
-        options: {
-          emitWarning: true,
-        }
-      });
-    };
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "lint": "eslint src && tsc",
+    "watch": "chokidar 'src/**/*' -c 'npm run lint'",
     "start": "next start"
   },
   "dependencies": {
@@ -18,6 +20,7 @@
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
+    "chokidar-cli": "^2.1.0",
     "eslint": "^7.15.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { AppProps } from 'next/app';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { Hydrate } from 'react-query/hydration';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 const queryClient = new QueryClient();
 

--- a/src/pages/o/[orgId].tsx
+++ b/src/pages/o/[orgId].tsx
@@ -1,10 +1,7 @@
-import {
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     let props;
 
     try {

--- a/src/pages/o/[orgId].tsx
+++ b/src/pages/o/[orgId].tsx
@@ -31,7 +31,10 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgPageProps = {
-    org: Record<string, unknown>,
+    org: {
+        id: number,
+        title: string,
+    },
 }
 
 export default function OrgPage(props : OrgPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -1,9 +1,6 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     let props;
 
     try {

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -12,8 +12,8 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
         const oData = await oRes.json();
 
         props = {
-            org: oData.data,
             campaigns: cData.data,
+            org: oData.data,
         };
     }
     catch (err) {

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -33,8 +33,13 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgCampaignsPageProps = {
-    org: Record<string, unknown>,
-    campaigns: array<Record<string, unknown>>,
+    campaigns: Array<{
+        id: string,
+        title: string,
+    }>,
+    org: {
+        title: string,
+    },
 }
 
 export default function OrgCampaignsPage(props : OrgCampaignsPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -12,8 +12,8 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
         const oData = await oRes.json();
 
         props = {
-            org: oData.data,
             campaign: cIdData.data,
+            org: oData.data,
         };
     }
     catch (err) {

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -1,9 +1,6 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     let props;
 
     try {

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -33,8 +33,12 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgCampaignsPageProps = {
-    org: Record<string, unknown>,
-    campaign: array<Record<string, unknown>>,
+    campaign: {
+        title: string,
+    },
+    org: {
+        title: string,
+    },
 }
 
 export default function OrgCampaignPage(props : OrgCampaignsPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
@@ -1,9 +1,6 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     let props;
 
     try {

--- a/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
@@ -36,9 +36,19 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgCampaignsPageProps = {
-    org: Record<string, unknown>,
-    campaign: array<Record<string, unknown>>,
-    events: array<Record<string, unknown>>,
+    campaign: {
+        title: string,
+    },
+    events: Array<{
+        activity: {
+            title: string,
+        },
+        id: number,
+        title: string,
+    }>,
+    org: {
+        title: string,
+    },
 }
 
 export default function OrgCampaignEventsPage(props : OrgCampaignsPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
@@ -14,8 +14,8 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
         const oData = await oRes.json();
 
         props = {
-            events: eventsData.data,
             campaign: cIdData.data,
+            events: eventsData.data,
             org: oData.data,
         };
     }

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from 'next';
-import { QueryClient, useQuery } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
+import { QueryClient, useQuery } from 'react-query';
 
 function getEvents(orgId) {
     return async () => {

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -1,7 +1,4 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 import { QueryClient, useQuery } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
 
@@ -47,7 +44,7 @@ function getOrg(orgId) {
     };
 }
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     const queryClient = new QueryClient();
     const { orgId } = context.params;
 

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -1,9 +1,6 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     let props;
 
     try {

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -26,8 +26,8 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 
         if (eventData) {
             props = {
-                org: oData.data,
                 eventData,
+                org: oData.data,
             };
         }
     }

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -48,8 +48,12 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgEventsPageProps = {
-    org: Record<string, unknown>,
-    eventData: Record<string, unknown>,
+    eventData: {
+        title: string,
+    },
+    org: {
+        title: string,
+    },
 }
 
 export default function OrgEventsPage(props : OrgEventsPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/surveys/[surId].tsx
+++ b/src/pages/o/[orgId]/surveys/[surId].tsx
@@ -1,7 +1,6 @@
 import { GetServerSideProps } from 'next';
 
 export const getServerSideProps : GetServerSideProps = async (context) => {
-    const { orgId, surId } = context.params;
     let props;
 
     try {

--- a/src/pages/o/[orgId]/surveys/[surId].tsx
+++ b/src/pages/o/[orgId]/surveys/[surId].tsx
@@ -34,8 +34,12 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
 };
 
 type OrgSurveyPageProps = {
-    org: Record<string, unknown>,
-    survey: array<Record<string, unknown>>,
+    org: {
+        title: string,
+    },
+    survey: {
+        title: string,
+    },
 }
 
 export default function OrgSurveyPage(props : OrgSurveyPageProps) : JSX.Element {

--- a/src/pages/o/[orgId]/surveys/[surId].tsx
+++ b/src/pages/o/[orgId]/surveys/[surId].tsx
@@ -1,9 +1,6 @@
-import { 
-    GetServerSideProps,
-    NextPageContext,
-} from 'next';
+import { GetServerSideProps } from 'next';
 
-export const getServerSideProps : GetServerSideProps = async (context : NextPageContext) => {
+export const getServerSideProps : GetServerSideProps = async (context) => {
     const { orgId, surId } = context.params;
     let props;
 


### PR DESCRIPTION
This PR improves the developer experience around linting and type-checking. It does so in a number of ways.

# Improvements

## Less disruptive linting and type-checking
Linting will no longer raise build-preventing errors. This makes it ok to have temporary issues in your code while you're developing, as long as you fix them before committing.

The TypeScript type-checker [does not run during NEXTjs development](https://github.com/vercel/next.js/issues/6466) to avoid disrupting the development process. The philosophy is sane, but it did mean that it would never run with our existing setup, so our code actually contained errors which we weren't noticing.

With this PR, `docker-compose up` will spin up a separate container which just does typescript compilation and linting, alongside but separate from the NEXTjs development server. This means that we get linting and typescript errors in the terminal, but without disrupting the development flow.

## Standalone linting and pre-commit hook
The linting can now be run standalone using `docker-compose run main npm run lint` (or as part of the existing `main` container using `docker-compose exec main npm run lint`.

This command can also be used as a pre-commit hook, so that you never forget to verify style and type safety before committing code. This PR adds a hook in `.githooks/pre-commit` and an explanation in the README on how to configure it.

![image](https://user-images.githubusercontent.com/550212/104094008-8ed3a200-528e-11eb-94f7-d173eb1f5b1a.png)

# How to test
1. Check out the branch
2. Configure the git hook if you want (recommended, `git config core.hooksPath .githooks`)
3. Rebuild and restart the docker-composition (`docker-compose up --build`)
4. Edit some code, introducing a style or type issue, e.g. declaring a variable that is never used or adding `console.log()` somewhere
5. Try committing your code (`git commit -a`)

## Expected result:
After step 4, the `linter` container should print out an error in the terminal. The code should still run ok in the browser.

After step 5, another `linter` container should start up and run the `eslint src && tsc` commands to validate the code. It should fail (due to the bad code introduced in step 4) and the commit should be prevented.