### PR TITLE
Add user data to context

### DIFF
--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -1,19 +1,23 @@
 import { FunctionComponent } from 'react';
-
-import PublicHeader from '../PublicHeader';
-
 import { Content, Flex } from '@adobe/react-spectrum';
 
-const DefaultLayout : FunctionComponent = ({ children }) => (
-    <Flex
-        direction="column"
-        gap="size-100"
-        margin="size-200">
-        <PublicHeader user={ null }/>
-        <Content>
-            { children }
-        </Content>
-    </Flex>
-);
+import PublicHeader from '../PublicHeader';
+import { useUser } from '../../hooks';
+
+const DefaultLayout : FunctionComponent = ({ children }) => {
+    const user = useUser();
+
+    return (
+        <Flex
+            direction="column"
+            gap="size-100"
+            margin="size-200">
+            <PublicHeader user={ user }/>
+            <Content>
+                { children }
+            </Content>
+        </Flex>
+    );
+};
 
 export default DefaultLayout;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+import { ZetkinUser } from '../interfaces/ZetkinUser';
+
+export const UserContext = React.createContext(null);
+
+export const useUser = () : ZetkinUser | null => {
+    return React.useContext(UserContext);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import { AppProps } from 'next/app';
 import { Hydrate } from 'react-query/hydration';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { SSRProvider } from '@react-aria/ssr';
+import { UserContext } from '../hooks';
 import { defaultTheme, Provider } from '@adobe/react-spectrum';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
@@ -17,16 +18,18 @@ function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
     const getLayout = c.getLayout || (page => <DefaultLayout>{ page }</DefaultLayout>);
 
     return (
-        <SSRProvider>
-            <Provider theme={ defaultTheme }>
-                <QueryClientProvider client={ queryClient }>
-                    <Hydrate state={ dehydratedState }>
-                        { getLayout(<Component { ...restProps } />, restProps) }
-                    </Hydrate>
-                    <ReactQueryDevtools initialIsOpen={ false } />
-                </QueryClientProvider>
-            </Provider>
-        </SSRProvider>
+        <UserContext.Provider value={ pageProps.user }>
+            <SSRProvider>
+                <Provider theme={ defaultTheme }>
+                    <QueryClientProvider client={ queryClient }>
+                        <Hydrate state={ dehydratedState }>
+                            { getLayout(<Component { ...restProps } />, restProps) }
+                        </Hydrate>
+                        <ReactQueryDevtools initialIsOpen={ false } />
+                    </QueryClientProvider>
+                </Provider>
+            </SSRProvider>
+        </UserContext.Provider>
     );
 }
 

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -1,14 +1,11 @@
 import { GetServerSideProps } from 'next';
+
+import { scaffold } from '../utils/next';
 import { ZetkinUser } from '../interfaces/ZetkinUser';
-import { scaffold, ScaffoldedContext } from '../utils/next';
 
-export const getServerSideProps : GetServerSideProps = scaffold(async (context : ScaffoldedContext) => {
-    const user = await context.z.resource('users', 'me').get();
-
+export const getServerSideProps : GetServerSideProps = scaffold(async () => {
     return {
-        props: {
-            user: user.data.data,
-        },
+        props: {},
     };
 });
 

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -1,5 +1,3 @@
-//TODO: Enable eslint rule and fix errors
-/* eslint-disable  @typescript-eslint/no-var-requires */
 import { applySession } from 'next-session';
 import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 
@@ -9,12 +7,16 @@ import { ZetkinUser } from '../interfaces/ZetkinUser';
 import { ZetkinZ } from '../types/sdk';
 
 //TODO: Create module definition and revert to import.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const Z = require('zetkin');
 
-export type ScaffoldedProps = {
+type RegularProps = {
     /* eslint-disable @typescript-eslint/no-explicit-any */
     [key: string]: any;
-    user?: ZetkinUser;
+};
+
+export type ScaffoldedProps = RegularProps & {
+    user: ZetkinUser | null;
 };
 
 export type ScaffoldedContext = GetServerSidePropsContext & {
@@ -22,7 +24,7 @@ export type ScaffoldedContext = GetServerSidePropsContext & {
 };
 
 export type ScaffoldedGetServerSideProps = (context: ScaffoldedContext) =>
-    Promise<GetServerSidePropsResult<ScaffoldedProps>>;
+    Promise<GetServerSidePropsResult<RegularProps>>;
 
 interface ResultWithProps {
     props: ScaffoldedProps;
@@ -32,8 +34,8 @@ const hasProps = (result : any) : result is ResultWithProps => {
     return (result as ResultWithProps).props !== undefined;
 };
 
-export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSideProps => {
-    const getServerSideProps : GetServerSideProps = async (contextFromNext : GetServerSidePropsContext) => {
+export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSideProps<ScaffoldedProps> => {
+    const getServerSideProps : GetServerSideProps<ScaffoldedProps> = async (contextFromNext : GetServerSidePropsContext) => {
         const ctx = contextFromNext as ScaffoldedContext;
 
         ctx.z = Z.construct({
@@ -56,10 +58,15 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSide
         const result = await wrapped(ctx);
 
         if (hasProps(result)) {
-            result.props.user = user.data.data as ZetkinUser;
+            const scaffoldedProps : ScaffoldedProps = {
+                ...result.props,
+                user: user.data.data as ZetkinUser,
+            };
+
+            result.props = scaffoldedProps;
         }
 
-        return result;
+        return result as GetServerSidePropsResult<ScaffoldedProps>;
     };
 
     return getServerSideProps;


### PR DESCRIPTION
This PR augments `scaffold()` to decorate all props with a `user` attribute for the current user. It also adds this user object to the React context in `_app.tsx` and adds a hook, `useUser()` to retrieve the user anywhere.

The new hook is used in `DefaultLayout` to pass the user to `PublicHeader` which displays it instead of the login button.

To test:

1. Navigate to http://www.dev.zetkin.org/login
2. Log in using "testadmin@example.com" and "password"
3. Once returned to the app, navigate to /my
4. Verify that the current user is displayed in the top right corner (way oversized for now)

This PR is relevant to #68 but does not solve it.