### PR TITLE
Clean-up layouts

### DIFF
--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -34,6 +34,8 @@ const PublicHeader = ({ user } : PublicHeaderProps) : JSX.Element => {
                         <Image
                             alt="User avatar"
                             data-test="user-avatar"
+                            height="size-600"
+                            objectFit="contain"
                             src={ `/api/users/${user.id}/avatar` }
                         />
                     </View>

--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -15,7 +15,7 @@ interface PublicHeaderProps {
 
 const PublicHeader = ({ user } : PublicHeaderProps) : JSX.Element => {
     return (
-        <Header>
+        <Header margin="size-200">
             <Flex
                 alignItems="center"
                 direction="row"

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -10,10 +10,9 @@ const DefaultLayout : FunctionComponent = ({ children }) => {
     return (
         <Flex
             direction="column"
-            gap="size-100"
-            margin="size-200">
+            gap="size-100">
             <PublicHeader user={ user }/>
-            <Content>
+            <Content margin="size-200">
                 { children }
             </Content>
         </Flex>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -21,6 +21,7 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
         <Header>
             <Image
                 alt="Cover image"
+                height="size-2000"
                 objectFit="cover"
                 src="/cover.jpg"
                 width="100%"
@@ -28,17 +29,16 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
             <Flex
                 alignItems="center"
                 direction="row"
-                justifyContent="space-between"
-                marginX="size-200">
+                justifyContent="space-between">
                 <Image
                     alt="Organization avatar"
-                    objectFit="cover"
+                    height="size-600"
+                    objectFit="contain"
                     src={ apiUrl(`/orgs/${org.id}/avatar`) }
                 />
                 <Flex
                     alignItems="center"
-                    direction="row"
-                    marginX="size-200">
+                    direction="row">
                     <View marginX="size-200">
                         <Link>
                             <NextLink href="/">


### PR DESCRIPTION
Fixes #70 

Adjusts oversized avatars and reduces height on org cover image. Also removes white top/bottom white margin.

![FireShot Capture 037 -  - localhost](https://user-images.githubusercontent.com/51208557/109955912-50cd8a00-7ce3-11eb-872c-cf65bb468716.png)

![FireShot Capture 043 -  - www dev zetkin org](https://user-images.githubusercontent.com/51208557/109955916-51feb700-7ce3-11eb-8e78-323b49ebe76d.png)
