### PR TITLE
Consistently show user in header

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -15,8 +15,6 @@ describe('Login process', () => {
             .should('be.visible')
             .click();
         cy.url().should('match', /\/$/);
-        //TODO: Remove cy.visit('/my'); when user is visible in homepage header
-        cy.visit('/my');
         cy.get('[data-test="username"]').should('be.visible');
         cy.get('[data-test="user-avatar"]').should('be.visible');
     });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,15 +2,16 @@ import { applySession } from 'next-session';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import stringToBool from '../utils/stringToBool';
+import { Content, Heading } from '@adobe/react-spectrum';
 
 import { AppSession } from '../types';
-import { Content, Heading } from '@adobe/react-spectrum';
+import { scaffold } from '../utils/next';
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Z = require('zetkin');
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const { query, req, res } = context;
 
     const z = Z.construct({
@@ -50,7 +51,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             props: {},
         };
     }
-};
+});
 
 export default function Home() : JSX.Element {
     return (

--- a/src/pages/o/[orgId].tsx
+++ b/src/pages/o/[orgId].tsx
@@ -4,8 +4,9 @@ import Link from 'next/link';
 import { QueryClient, useQuery } from 'react-query';
 
 import getOrg from '../../fetching/getOrg';
+import { scaffold } from '../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
@@ -27,7 +28,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgPageProps = {
     orgId: string;

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -4,8 +4,9 @@ import { QueryClient, useQuery } from 'react-query';
 
 import getCampaigns from '../../../fetching/getCampaigns';
 import getOrg from '../../../fetching/getOrg';
+import { scaffold } from '../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
@@ -29,7 +30,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgCampaignsPageProps = {
     orgId: string;

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -7,9 +7,9 @@ import { QueryClient, useQuery } from 'react-query';
 import getCampaign from '../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../fetching/getCampaignEvents';
 import getOrg from '../../../../fetching/getOrg';
+import { scaffold } from '../../../../utils/next';
 
-
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { campId, orgId } = context.params!;
@@ -36,7 +36,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgCampaignPageProps = {
     campId: string;

--- a/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId]/events.tsx
@@ -5,8 +5,9 @@ import { QueryClient, useQuery } from 'react-query';
 import getCampaign from '../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
 import getOrg from '../../../../../fetching/getOrg';
+import { scaffold } from '../../../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId, campId } = context.params!;
@@ -33,7 +34,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgCampaignEventsPageProps = {
     campId: string;

--- a/src/pages/o/[orgId]/contact.tsx
+++ b/src/pages/o/[orgId]/contact.tsx
@@ -5,8 +5,9 @@ import { QueryClient } from 'react-query';
 import getOrg from '../../../fetching/getOrg';
 import OrgLayout from '../../../components/layout/OrgLayout';
 import { PageWithLayout } from '../../../types';
+import { scaffold } from '../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
@@ -28,7 +29,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 const OrgContactPage : PageWithLayout = () => {
     return (

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -8,8 +8,9 @@ import getEvents from '../../../fetching/getEvents';
 import getOrg from '../../../fetching/getOrg';
 import OrgLayout from '../../../components/layout/OrgLayout';
 import { PageWithLayout } from '../../../types';
+import { scaffold } from '../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
@@ -33,7 +34,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 const OrgEventsPage : PageWithLayout = (page, props) => {
     const { orgId } = props;

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -6,8 +6,9 @@ import { QueryClient, useQuery } from 'react-query';
 
 import getEvent from '../../../../fetching/getEvent';
 import getOrg from '../../../../fetching/getOrg';
+import { scaffold } from '../../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId, eventId } = context.params!;
@@ -32,7 +33,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgEventPageProps = {
     eventId: string;

--- a/src/pages/o/[orgId]/surveys/[surId].tsx
+++ b/src/pages/o/[orgId]/surveys/[surId].tsx
@@ -4,8 +4,9 @@ import { QueryClient, useQuery } from 'react-query';
 
 import getOrg from '../../../../fetching/getOrg';
 import getSurvey from '../../../../fetching/getSurvey';
+import { scaffold } from '../../../../utils/next';
 
-export const getServerSideProps : GetServerSideProps = async (context) => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const queryClient = new QueryClient();
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { surId, orgId } = context.params!;
@@ -30,7 +31,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
             notFound: true,
         };
     }
-};
+});
 
 type OrgSurveyPageProps = {
     surId: string;

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -53,17 +53,24 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSide
             ctx.z.setTokenData(reqWithSession.session.tokenData);
         }
 
-        const user = await ctx.z.resource('users', 'me').get();
-
         const result = await wrapped(ctx);
 
-        if (hasProps(result)) {
-            const scaffoldedProps : ScaffoldedProps = {
-                ...result.props,
-                user: user.data.data as ZetkinUser,
-            };
+        const resultProps = (user : ZetkinUser | null) => {
+            if (hasProps(result)) {
+                const scaffoldedProps : ScaffoldedProps = {
+                    ...result.props,
+                    user,
+                };
+                result.props = scaffoldedProps;
+            }
+        };
 
-            result.props = scaffoldedProps;
+        try {
+            const user = await ctx.z.resource('users', 'me').get();
+            resultProps(user.data.data as ZetkinUser);
+        }
+        catch (error) {
+            resultProps(null);
         }
 
         return result as GetServerSidePropsResult<ScaffoldedProps>;

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -55,7 +55,7 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSide
 
         const result = await wrapped(ctx);
 
-        const resultProps = (user : ZetkinUser | null) => {
+        const augmentProps = (user : ZetkinUser | null) => {
             if (hasProps(result)) {
                 const scaffoldedProps : ScaffoldedProps = {
                     ...result.props,
@@ -67,10 +67,10 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps) : GetServerSide
 
         try {
             const user = await ctx.z.resource('users', 'me').get();
-            resultProps(user.data.data as ZetkinUser);
+            augmentProps(user.data.data as ZetkinUser);
         }
         catch (error) {
-            resultProps(null);
+            augmentProps(null);
         }
 
         return result as GetServerSidePropsResult<ScaffoldedProps>;


### PR DESCRIPTION
Fixes #68 

Applies `scaffold` to all pages, making user props accessible to `UserContext` and `DefaultLayout`/`PublicHeader`.

![FireShot Capture 050 - Zetkin - www dev zetkin org](https://user-images.githubusercontent.com/51208557/110121953-4f718f80-7dbf-11eb-956a-6497a7e3b39b.png)

![FireShot Capture 047 -  - www dev zetkin org](https://user-images.githubusercontent.com/51208557/110121878-3a94fc00-7dbf-11eb-900f-b59d9193e213.png)