### PR TITLE
Testing improvements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["next/babel"],
+    "plugins": ["istanbul"]
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,10 @@
 {
     "baseUrl": "http://www.dev.zetkin.org",
+    "env": {
+        "codeCoverage": {
+            "url": "/api/coverage"
+        }
+    },
     "componentFolder": "src",
     "defaultCommandTimeout": 5000,
     "experimentalComponentTesting": true,

--- a/cypress/integration/org_event_page.spec.ts
+++ b/cypress/integration/org_event_page.spec.ts
@@ -9,6 +9,7 @@ describe('/o/[orgId]/events/[eventId]', () => {
 
     it('contains clickable org name that leads to org page', () => {
         cy.visit('/o/1/events/22');
+        cy.waitUntilReactRendered();
         cy.contains('My Organization');
         cy.findByText('My Organization').click();
         cy.url().should('match', /\/o\/1$/);
@@ -16,6 +17,7 @@ describe('/o/[orgId]/events/[eventId]', () => {
 
     it('contains clickable campaign name that leads to campaign page', () => {
         cy.visit('/o/1/events/22');
+        cy.waitUntilReactRendered();
         cy.contains('Second campaign').click();
         cy.url().should('match', /\/o\/1\/campaigns\/2$/);
     });

--- a/cypress/integration/org_event_page.spec.ts
+++ b/cypress/integration/org_event_page.spec.ts
@@ -18,7 +18,8 @@ describe('/o/[orgId]/events/[eventId]', () => {
     it('contains clickable campaign name that leads to campaign page', () => {
         cy.visit('/o/1/events/22');
         cy.waitUntilReactRendered();
-        cy.contains('Second campaign').click();
+        cy.contains('Second campaign');
+        cy.findByText('Second campaign').click();
         cy.url().should('match', /\/o\/1\/campaigns\/2$/);
     });
 

--- a/cypress/integration/org_event_page.spec.ts
+++ b/cypress/integration/org_event_page.spec.ts
@@ -9,7 +9,8 @@ describe('/o/[orgId]/events/[eventId]', () => {
 
     it('contains clickable org name that leads to org page', () => {
         cy.visit('/o/1/events/22');
-        cy.contains('My Organization').click();
+        cy.contains('My Organization');
+        cy.findByText('My Organization').click();
         cy.url().should('match', /\/o\/1$/);
     });
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -31,15 +31,5 @@ module.exports = (on, config) => {
         }
     }));
 
-    on('before:browser:launch', (browser = {}, options) => {
-        if (browser.name === 'firefox') {
-            options.args.push('--devtools');
-        }
-        else if (browser.name === 'chrome') {
-            options.args.push('--auto-open-devtools-for-tabs');
-        }
-
-        return options;
-    });
     return config;
 }

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace Cypress {
+    interface Chainable<> {
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        waitUntilReactRendered(timeout? : number) : Chainable<any>;
+    }
+}

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,2 +1,9 @@
+/* eslint-disable no-undef */
 require('@cypress/react/support');
 require('@testing-library/cypress/add-commands');
+
+Cypress.Commands.add('waitUntilReactRendered', (timeout = 10000) => {
+    cy.window().its('__reactRendered', { timeout }).then(initialized => {
+        return initialized;
+    });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,2 @@
 require('@cypress/react/support');
+require('@testing-library/cypress/add-commands');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@cypress/react": "^4.16.3",
+    "@testing-library/cypress": "^7.0.4",
     "@types/node": "^14.14.14",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@adobe/react-spectrum": "^3.7.0",
+    "@cypress/code-coverage": "^3.9.2",
     "@cypress/webpack-preprocessor": "^5.5.0",
     "@react-spectrum/tabs": "^3.0.0-alpha.3",
     "next": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "watch": "chokidar 'src/**/*' -c 'npm run lint'",
     "start": "next start -p 80"
   },
+  "nyc": {
+    "reporter": ["html"]
+  },
   "dependencies": {
     "@adobe/react-spectrum": "^3.7.0",
     "@cypress/code-coverage": "^3.9.2",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,10 +12,20 @@ import { PageWithLayout } from '../types';
 
 const queryClient = new QueryClient();
 
+declare global {
+    interface Window {
+        __reactRendered: boolean;
+    }
+}
+
 function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
     const { dehydratedState, ...restProps } = pageProps;
     const c = Component as PageWithLayout;
     const getLayout = c.getLayout || (page => <DefaultLayout>{ page }</DefaultLayout>);
+
+    if (typeof window !== 'undefined') {
+        window.__reactRendered = true;
+    }
 
     return (
         <UserContext.Provider value={ pageProps.user }>

--- a/src/pages/api/coverage.ts
+++ b/src/pages/api/coverage.ts
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+const globalAny : any = global;
+
+export default (req : NextApiRequest, res : NextApiResponse) : void => {
+    // TODO: Disable this in production
+    res.status(200).json({
+        coverage: globalAny.__coverage__ || null,
+    });
+};

--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -17,7 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["cypress", "@testing-library/cypress"],
+    "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
     "jsx": "react-jsx"
   },
   "include": [

--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -17,6 +17,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["cypress", "@testing-library/cypress"],
     "jsx": "react-jsx"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["cypress", "@testing-library/cypress"],
     "jsx": "preserve"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["cypress", "@testing-library/cypress"],
+    "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
     "jsx": "preserve"
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,6 +884,19 @@
     js-yaml "3.14.0"
     nyc "15.1.0"
 
+"@cypress/code-coverage@^3.9.2":
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.9.2.tgz#582cdb3a7858b3ecf294933b043d0bc236ce0bd9"
+  integrity sha512-YnzkRBxdsY/Ek/68nr+MowqW59UJsd28j10mFOerW/wrSkuxGrWvOldMs8Y4tU70L4fgd4wDPqGGMer3+UzbwA==
+  dependencies:
+    "@cypress/browserify-preprocessor" "3.0.1"
+    debug "4.3.1"
+    execa "4.1.0"
+    globby "11.0.2"
+    istanbul-lib-coverage "3.0.0"
+    js-yaml "3.14.1"
+    nyc "15.1.0"
+
 "@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
@@ -5505,7 +5518,7 @@ globby@11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.1:
+globby@11.0.2, globby@^11.0.1:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
   integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
@@ -6237,7 +6250,7 @@ js-yaml@3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1:
+js-yaml@3.14.1, js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,7 +63,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
   integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
@@ -1028,6 +1028,17 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
 
 "@next/env@10.0.7":
   version "10.0.7"
@@ -2469,10 +2480,61 @@
     "@adobe/react-spectrum-workflow" "^1.0.0"
     "@react-spectrum/icon" "^3.2.0"
 
+"@testing-library/cypress@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-7.0.4.tgz#38a55880712f222ddb9671bc899fe80f8c41bfc0"
+  integrity sha512-5I1amLVB2ExIRWuHlvG35dVFVC2KiNBZ0U1ASJUJZASFPQ0BhqJG4s0B8B8wNAE7TrR8KWlrzcNutkgxXL6VOg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
+"@testing-library/dom@^7.28.1":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.0.tgz#53697851f7708a1448cc30b74a2ea056dd709cd6"
+  integrity sha512-v4GzWtltaiDE0yRikLlcLAfEiiK8+ptu6OuuIebm9GdC2XlZTNDPGEfM2UkEtnH7hr9TRq2sivT5EA9P1Oy7bw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/node@*":
+  version "14.14.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.32.tgz#90c5c4a8d72bbbfe53033f122341343249183448"
+  integrity sha512-/Ctrftx/zp4m8JOujM5ZhwzlWLx22nbQJiVqz8/zE15gOeEW+uly3FSX4fGFpcfEvFzXcMCJwq9lGVWgyARXhg==
 
 "@types/node@12.12.50":
   version "12.12.50"
@@ -2511,6 +2573,18 @@
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.7.tgz#979434b5900f9d710f5d4e15c466cadb8e9fdc47"
   integrity sha512-rMQbgMGxnLsdn8e9aPVyuN+zMQLrZ2QW8xlv7eWS1mydfGXN+tsTKffcIzd8rGCcLdmi3xvQw2MDaZI1bBNTaw==
+
+"@types/yargs-parser@*":
+  version "20.2.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.0.tgz#dd3e6699ba3237f0348cd085e4698780204842f9"
+  integrity sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+
+"@types/yargs@^15.0.0":
+  version "15.0.13"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
+  integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^4.10.0":
   version "4.15.2"
@@ -4490,6 +4564,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-helpers@^3.3.1, dom-helpers@^3.4.0:
   version "3.4.0"
@@ -6546,6 +6625,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 make-dir@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -7670,6 +7754,16 @@ pretty-bytes@^5.4.1:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -7846,6 +7940,11 @@ react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This PR makes a number of changes to the Cypress testing code and configuration:

* Add `cypress-testing-library` and use `findByText()` instead of chaining on `contains()`
* By default, don't open dev tools whenever running tests in cypress
* Add new `cy.waitUntilReactRendered()` command (and support code in `_app.ts`) to prevent avoid flaky tests when interactivity is involved
* Add support for coverage reporting