### PR TITLE
Apply OrgLayout

### DIFF
--- a/src/components/PublicHeader.spec.tsx
+++ b/src/components/PublicHeader.spec.tsx
@@ -1,6 +1,7 @@
 import { mount } from '@cypress/react';
 
 import PublicHeader from './PublicHeader';
+import { ZetkinOrganization } from '../interfaces/ZetkinOrganization';
 
 describe('PublicHeader', () => {
 
@@ -29,5 +30,21 @@ describe('PublicHeader', () => {
     it('contains user avatar if logged in', () => {
         mount(<PublicHeader user={ dummyUser }/>);
         cy.get('[data-test="user-avatar"]').should('be.visible');
+    });
+
+    it('contains a zetkin logo when component has no org prop', () => {
+        mount(<PublicHeader user={ dummyUser }/>);
+        cy.get('[data-test="zetkin-logotype"]').should('be.visible');
+    });
+
+    it('contains org avatar instead of zetkin logo when component has an org prop', () => {
+        cy.fixture('dummyOrg.json')
+            .then((data : ZetkinOrganization) => {
+                const dummyOrg = data;
+                mount(<PublicHeader org={ dummyOrg } user={ dummyUser }/>);
+
+                cy.get('[data-test="zetkin-logotype"]').should('not.exist');
+                cy.get('[data-test="org-avatar"]').should('be.visible');
+            });
     });
 }); 

--- a/src/components/PublicHeader.spec.tsx
+++ b/src/components/PublicHeader.spec.tsx
@@ -40,8 +40,7 @@ describe('PublicHeader', () => {
     it('contains org avatar instead of zetkin logo when component has an org prop', () => {
         cy.fixture('dummyOrg.json')
             .then((data : ZetkinOrganization) => {
-                const dummyOrg = data;
-                mount(<PublicHeader org={ dummyOrg } user={ dummyUser }/>);
+                mount(<PublicHeader org={ data } user={ dummyUser }/>);
 
                 cy.get('[data-test="zetkin-logotype"]').should('not.exist');
                 cy.get('[data-test="org-avatar"]').should('be.visible');

--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -8,13 +8,16 @@ import {
     View,
 } from '@adobe/react-spectrum';
 
+import apiUrl from '../utils/apiUrl';
+import { ZetkinOrganization } from '../interfaces/ZetkinOrganization';
 import { ZetkinUser } from '../interfaces/ZetkinUser';
 
 interface PublicHeaderProps {
     user: ZetkinUser | null;
+    org?: ZetkinOrganization | null;
 }
 
-const PublicHeader = ({ user } : PublicHeaderProps) : JSX.Element => {
+const PublicHeader = ({ user, org } : PublicHeaderProps) : JSX.Element => {
     return (
         <Header margin="size-200">
             <Flex
@@ -22,14 +25,25 @@ const PublicHeader = ({ user } : PublicHeaderProps) : JSX.Element => {
                 direction="row"
                 height="size-600"
                 justifyContent="space-between">
-                <Image
-                    alt="Zetkin logo"
-                    data-test="zetkin-logotype"
-                    height="size-600"
-                    objectFit="contain"
-                    src="/logo-zetkin.png"
-                    width="size-600"
-                />
+                { org ? (
+                    <Image
+                        alt="Organization avatar"
+                        data-test="org-avatar"
+                        height="size-600"
+                        objectFit="contain"
+                        src={ apiUrl(`/orgs/${org.id}/avatar`) }
+                        width="size-600"
+                    />
+                ) : (
+                    <Image
+                        alt="Zetkin logo"
+                        data-test="zetkin-logotype"
+                        height="size-600"
+                        objectFit="contain"
+                        src="/logo-zetkin.png"
+                        width="size-600"
+                    />
+                ) }
                 { user ? (
                     <View>
                         <Text data-test="username">

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -3,15 +3,20 @@ import { Content, Flex } from '@adobe/react-spectrum';
 
 import PublicHeader from '../PublicHeader';
 import { useUser } from '../../hooks';
+import { ZetkinOrganization } from '../../interfaces/ZetkinOrganization';
 
-const DefaultLayout : FunctionComponent = ({ children }) => {
+interface DefaultLayoutProps {
+    org?: ZetkinOrganization;
+}
+
+const DefaultLayout : FunctionComponent<DefaultLayoutProps> = ({ children, org }) => {
     const user = useUser();
 
     return (
         <Flex
             direction="column"
             gap="size-100">
-            <PublicHeader user={ user }/>
+            <PublicHeader org={ org || null } user={ user }/>
             <Content margin="size-200">
                 { children }
             </Content>

--- a/src/components/layout/DefaultLayout.tsx
+++ b/src/components/layout/DefaultLayout.tsx
@@ -16,7 +16,7 @@ const DefaultLayout : FunctionComponent<DefaultLayoutProps> = ({ children, org }
         <Flex
             direction="column"
             gap="size-100">
-            <PublicHeader org={ org || null } user={ user }/>
+            <PublicHeader org={ org } user={ user }/>
             <Content margin="size-200">
                 { children }
             </Content>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -12,7 +12,7 @@ import {
 import { ZetkinOrganization } from '../../interfaces/ZetkinOrganization';
 
 interface OrgHeaderProps {
-    org?: ZetkinOrganization;
+    org: ZetkinOrganization;
 }
 
 const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
@@ -44,7 +44,7 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
             </Flex>
             <View>
                 <Heading level={ 1 }>
-                    { org?.title }
+                    { org.title }
                 </Heading>
             </View>
         </Header>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -9,11 +9,10 @@ import {
     View,
 } from '@adobe/react-spectrum';
 
-import apiUrl from '../../utils/apiUrl';
 import { ZetkinOrganization } from '../../interfaces/ZetkinOrganization';
 
 interface OrgHeaderProps {
-    org: ZetkinOrganization;
+    org?: ZetkinOrganization;
 }
 
 const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
@@ -30,13 +29,6 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
                 alignItems="center"
                 direction="row"
                 justifyContent="space-between">
-                <Image
-                    alt="Organization avatar"
-                    height="size-600"
-                    objectFit="contain"
-                    src={ apiUrl(`/orgs/${org.id}/avatar`) }
-                    width="size-600"
-                />
                 <Flex
                     alignItems="center"
                     direction="row">
@@ -52,7 +44,7 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
             </Flex>
             <View>
                 <Heading level={ 1 }>
-                    { org.title }
+                    { org?.title }
                 </Heading>
             </View>
         </Header>

--- a/src/components/layout/OrgLayout.tsx
+++ b/src/components/layout/OrgLayout.tsx
@@ -18,12 +18,21 @@ interface OrgLayoutProps {
 const OrgLayout = ({ children, orgId } : OrgLayoutProps) : JSX.Element => {
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
     const router = useRouter();
+    const path =  router.pathname.split('/');
+    let currentTab = path.pop();
+
+    if (currentTab === '[orgId]') {
+        currentTab = 'home';
+    }
 
     const onSelectTab = (key : ReactText) : void => {
-        router.push(`/o/${orgId}/${key}`);
+        if (key === 'home') {
+            router.push(`/o/${orgId}`);
+        }
+        else {
+            router.push(`/o/${orgId}/${key}`);
+        }
     };
-
-    const currentTab = router.pathname.split('/').pop();
 
     return (
         <DefaultLayout org={ orgQuery.data! }>
@@ -32,6 +41,9 @@ const OrgLayout = ({ children, orgId } : OrgLayoutProps) : JSX.Element => {
                 aria-label="Organization submenu"
                 onSelectionChange={ onSelectTab }
                 selectedKey={ currentTab }>
+                <Item key="home" title="Home">
+                    <Content>{ children }</Content>
+                </Item>
                 <Item key="events" title="Coming up">
                     <Content>{ children }</Content>
                 </Item>

--- a/src/components/layout/OrgLayout.tsx
+++ b/src/components/layout/OrgLayout.tsx
@@ -26,7 +26,7 @@ const OrgLayout = ({ children, orgId } : OrgLayoutProps) : JSX.Element => {
     const currentTab = router.pathname.split('/').pop();
 
     return (
-        <DefaultLayout>
+        <DefaultLayout org={ orgQuery.data! }>
             <OrgHeader org={ orgQuery.data! }/>
             <Tabs
                 aria-label="Organization submenu"

--- a/src/components/layout/OrgLayout.tsx
+++ b/src/components/layout/OrgLayout.tsx
@@ -35,10 +35,7 @@ const OrgLayout = ({ children, orgId } : OrgLayoutProps) : JSX.Element => {
                 <Item key="events" title="Coming up">
                     <Content>{ children }</Content>
                 </Item>
-                <Item key="contact" title="Contact">
-                    <Content>{ children }</Content>
-                </Item>
-                <Item key="custom" title="Some Custom Page">
+                <Item key="campaigns" title="Campaigns">
                     <Content>{ children }</Content>
                 </Item>
             </Tabs>

--- a/src/pages/o/[orgId].tsx
+++ b/src/pages/o/[orgId].tsx
@@ -31,11 +31,15 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     }
 });
 
-const OrgPage : PageWithLayout = (page, props) => {
+type OrgPageProps = {
+    orgId: string;
+};
+
+const OrgPage : PageWithLayout<OrgPageProps> = (props) =>{
     const { orgId } = props;
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
 
-    return ( 
+    return (
         <>
             <h1>{ orgQuery.data?.title }</h1>
         </>

--- a/src/pages/o/[orgId].tsx
+++ b/src/pages/o/[orgId].tsx
@@ -1,9 +1,10 @@
 import { dehydrate } from 'react-query/hydration';
 import { GetServerSideProps } from 'next';
-import Link from 'next/link';
 import { QueryClient, useQuery } from 'react-query';
 
 import getOrg from '../../fetching/getOrg';
+import OrgLayout from '../../components/layout/OrgLayout';
+import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
 
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
@@ -30,21 +31,23 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     }
 });
 
-type OrgPageProps = {
-    orgId: string;
-};
-
-export default function OrgPage(props : OrgPageProps) : JSX.Element {
+const OrgPage : PageWithLayout = (page, props) => {
     const { orgId } = props;
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
 
     return ( 
         <>
             <h1>{ orgQuery.data?.title }</h1>
-            <ul>
-                <li><Link href={ `/o/${orgId}/campaigns` }>Campaigns</Link></li>
-                <li><Link href={ `/o/${orgId}/events` }>Events</Link></li>
-            </ul>
         </>
     );
-}
+};
+
+OrgPage.getLayout = function getLayout(page, props) {
+    return (
+        <OrgLayout orgId={ props.orgId as string }>
+            { page }
+        </OrgLayout>
+    );
+};
+
+export default OrgPage;

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -4,6 +4,8 @@ import { QueryClient, useQuery } from 'react-query';
 
 import getCampaigns from '../../../fetching/getCampaigns';
 import getOrg from '../../../fetching/getOrg';
+import OrgLayout from '../../../components/layout/OrgLayout';
+import { PageWithLayout } from '../../../types';
 import { scaffold } from '../../../utils/next';
 
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
@@ -32,11 +34,7 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     }
 });
 
-type OrgCampaignsPageProps = {
-    orgId: string;
-};
-
-export default function OrgCampaignsPage(props : OrgCampaignsPageProps) : JSX.Element {
+const OrgCampaignsPage : PageWithLayout = (page, props) => {
     const { orgId } = props;
     const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
@@ -51,4 +49,14 @@ export default function OrgCampaignsPage(props : OrgCampaignsPageProps) : JSX.El
             </ul>
         </>
     );
-}
+};
+
+OrgCampaignsPage.getLayout = function getLayout(page, props) {
+    return (
+        <OrgLayout orgId={ props.orgId as string }>
+            { page }
+        </OrgLayout>
+    );
+};
+
+export default OrgCampaignsPage;

--- a/src/pages/o/[orgId]/campaigns.tsx
+++ b/src/pages/o/[orgId]/campaigns.tsx
@@ -34,7 +34,11 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     }
 });
 
-const OrgCampaignsPage : PageWithLayout = (page, props) => {
+type OrgCampaignsPageProps = {
+    orgId: string;
+};
+
+const OrgCampaignsPage : PageWithLayout<OrgCampaignsPageProps> = (props) => {
     const { orgId } = props;
     const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -36,7 +36,11 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     }
 });
 
-const OrgEventsPage : PageWithLayout = (page, props) => {
+type OrgEventsPageProps = {
+    orgId: string;
+};
+
+const OrgEventsPage : PageWithLayout<OrgEventsPageProps> = (props) => {
     const { orgId } = props;
     const eventsQuery = useQuery('events', getEvents(orgId));
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,6 @@ interface GetLayout {
     (page: JSX.Element, props: Record<string, unknown>): JSX.Element;
 }
 
-export type PageWithLayout = NextPage & {
+export type PageWithLayout<P = Record<string, unknown>> = NextPage<P> & {
     getLayout: GetLayout;
 };


### PR DESCRIPTION
This PR does the following: 

- Applies `getLayout` on pages accessible via the tabs section in `OrgLayout`.
- Creates conditional rendering of Zetkin logo/organization avatar in `PublicHeader`
- Solves an issue with routing in regards to the `Tabs` UI component.
- Solves an issue with the wrong props (`page` and `props` instead of only `props`) being sent to components using `getLayout`.

![FireShot Capture 053 -  - www dev zetkin org](https://user-images.githubusercontent.com/51208557/110766578-9b0bb980-8255-11eb-948a-06a1d4c9d5eb.png)

Fixes #69 