### PR TITLE
Links from EventList to event

### DIFF
--- a/cypress/integration/org_events_page.spec.ts
+++ b/cypress/integration/org_events_page.spec.ts
@@ -5,10 +5,14 @@ describe('/o/[orgId]/events', () => {
         cy.contains('My Organization');
     });
 
-    xit('contains events', () => {
+    xit('contains events which are linked to event pages', () => {
         // TODO: Figure out why this fails on GitHub
         cy.visit('/o/1/events');
         cy.get('[data-test="event"]').should('be.visible');
+        cy.get('[data-test="more-info-button-22"]')
+            .should('be.visible')
+            .click();
+        cy.url().should('match', /\/o\/1\/events\/[0-9]+$/);
     });
 
     xit('contains a placeholder if there are no events', () => {

--- a/cypress/integration/org_events_page.spec.ts
+++ b/cypress/integration/org_events_page.spec.ts
@@ -8,11 +8,11 @@ describe('/o/[orgId]/events', () => {
     xit('contains events which are linked to event pages', () => {
         // TODO: Figure out why this fails on GitHub
         cy.visit('/o/1/events');
-        cy.get('[data-test="event"]').should('be.visible');
-        cy.get('[data-test="more-info-button-22"]')
-            .should('be.visible')
+        cy.get('[data-test="event"]')
+            .eq(1)
+            .findByText('More info')
             .click();
-        cy.url().should('match', /\/o\/1\/events\/[0-9]+$/);
+        cy.url().should('match', /\/o\/1\/events\/22$/);
     });
 
     xit('contains a placeholder if there are no events', () => {

--- a/src/components/EventList.spec.tsx
+++ b/src/components/EventList.spec.tsx
@@ -53,6 +53,14 @@ describe('EventList', () => {
         cy.contains('misc.eventList.signup');
     });
 
+    it('contains a button for more info on each event', () => {
+        mountWithProviders(
+            <EventList events={ dummyEvents } org={ dummyOrg }/>,
+        );
+
+        cy.contains('misc.eventList.moreInfo');
+    });
+
     it('shows a placeholder when the list is empty', () => {
         dummyEvents = [];
         mountWithProviders(

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,4 +1,10 @@
-import { Button, Flex, Text, View } from '@adobe/react-spectrum';
+import NextLink from 'next/link';
+import {
+    Button,
+    Flex,
+    Text,
+    View,
+} from '@adobe/react-spectrum';
 import {
     FormattedDate,
     FormattedTime,
@@ -53,9 +59,16 @@ const EventList = ({ events, org } : EventListProps) : JSX.Element => {
                             />
                         </View>
                         <View data-test="location-title">{ e.location.title }</View>
-                        <Button data-test="sign-up-button" variant="cta">
+                        <Button data-test="sign-up-button" marginTop="size-50" variant="cta">
                             <Msg id="misc.eventList.signup"/>
                         </Button>
+                        <NextLink href={ `/o/${org?.id}/events/${e.id}` }>
+                            <a>
+                                <Button data-test={ `more-info-button-${e.id}` } marginTop="size-50" variant="cta">
+                                    <Msg id="misc.eventList.moreInfo"/>
+                                </Button>
+                            </a>
+                        </NextLink>
                     </Flex>
                 )) }
             </Flex>

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -64,7 +64,7 @@ const EventList = ({ events, org } : EventListProps) : JSX.Element => {
                         </Button>
                         <NextLink href={ `/o/${org?.id}/events/${e.id}` }>
                             <a>
-                                <Button data-test={ `more-info-button-${e.id}` } marginTop="size-50" variant="cta">
+                                <Button marginTop="size-50" variant="cta">
                                     <Msg id="misc.eventList.moreInfo"/>
                                 </Button>
                             </a>

--- a/src/locale/misc/eventList/en.yml
+++ b/src/locale/misc/eventList/en.yml
@@ -1,2 +1,3 @@
 placeholder: Sorry, there are no planned events at the moment.
+moreInfo: More info
 signup: Sign-up

--- a/src/locale/misc/eventList/sv.yml
+++ b/src/locale/misc/eventList/sv.yml
@@ -1,2 +1,3 @@
 placeholder: Tyvärr finns det inga planerade händelser för tillfället.
+moreInfo: Mer info
 signup: Anmälan


### PR DESCRIPTION
This PR adds links to each event in `EventList`, leading to separate `[eventID]` pages.

<img width="1440" alt="Skärmavbild 2021-03-18 kl  16 50 03" src="https://user-images.githubusercontent.com/51208557/111655678-2367fc80-880a-11eb-90b0-48827fda940d.png">

Fixes #87 