### PR TITLE
Server-side API requests with cookies

### DIFF
--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -1,6 +1,8 @@
+import { dehydrate } from 'react-query/hydration';
 import { GetServerSideProps } from 'next';
 import { Heading } from '@adobe/react-spectrum';
 import { FormattedMessage as Msg } from 'react-intl';
+import { QueryClient } from 'react-query';
 
 import { scaffold } from '../utils/next';
 import { ZetkinUser } from '../interfaces/ZetkinUser';
@@ -9,9 +11,19 @@ const scaffoldOptions = {
     localeScope: ['pages.my'],
 };
 
-export const getServerSideProps : GetServerSideProps = scaffold(async () => {
+export const getServerSideProps : GetServerSideProps = scaffold(async (ctx) => {
+    const queryClient = new QueryClient();
+
+    await queryClient.prefetchQuery('userActionResponses', async () => {
+        const res = await ctx.apiFetch('/users/me/action_responses');
+        const data = await res.json();
+        return data;
+    });
+
     return {
-        props: {},
+        props: {
+            dehydratedState: dehydrate(queryClient),
+        },
     };
 }, scaffoldOptions);
 

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -1,3 +1,4 @@
+import apiUrl from './apiUrl';
 import { applySession } from 'next-session';
 import Negotiator from 'negotiator';
 import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
@@ -24,6 +25,7 @@ export type ScaffoldedProps = RegularProps & {
 };
 
 export type ScaffoldedContext = GetServerSidePropsContext & {
+    apiFetch: (path : string, init? : RequestInit) => Promise<Response>;
     z: ZetkinZ;
 };
 
@@ -45,6 +47,16 @@ const hasProps = (result : any) : result is ResultWithProps => {
 export const scaffold = (wrapped : ScaffoldedGetServerSideProps, options? : ScaffoldOptions) : GetServerSideProps<ScaffoldedProps> => {
     const getServerSideProps : GetServerSideProps<ScaffoldedProps> = async (contextFromNext : GetServerSidePropsContext) => {
         const ctx = contextFromNext as ScaffoldedContext;
+
+        ctx.apiFetch = (path, init?) => {
+            return fetch(apiUrl(path), {
+                ...init,
+                headers: {
+                    cookie: contextFromNext.req.headers.cookie || '',
+                    ...init?.headers,
+                },
+            });
+        };
 
         ctx.z = Z.construct({
             clientId: process.env.ZETKIN_CLIENT_ID,


### PR DESCRIPTION
This PR adds framework utilities for making authenticated API requests from server-side code, i.e. `getServerSideProps()`. 

The new `apiFetch()` function on the `ScaffoldedContext` can be used to make API requests from the server to the server-side API proxy while retaining cookies, including the session information and hence the API tokens.

The `apiFetch()` function wraps the regular `fetch()` function and can be used *almost* interchangeably. The only difference is that `apiFetch()` automatically translates paths to the correct API URL.

It's used for a pure server-side proof of concept in `my.tsx` in this PR. But it would also be possible to update "fetching" functions like `getOrg()` or `getEvent()` to inject the fetch method they should use, e.g. like this:

```typescript

function defaultFetch(path : string, init? : RequestInit) {
  const url = apiUrl(path);
  return fetch(url, init);
}

async function getOrg(orgId, fetch = defaultFetch) {
  // Use fetch the same as ever, but with API paths
  const res = await fetch(`/orgs/${orgId}`);
}

getOrg(1); // Use the default fetch method on client
getOrg(1, ctx.apiFetch); // Use fetch method with cookies on server
```

Fixes #97