### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Make sure that the following line exists somewhere in the file
 Once it's configured, you can access the app at http://www.dev.zetkin.org.
 
 ## Contributing
+This repository has an `.editorconfig` file which can automatically configure
+your editor to the correct style. Make sure [your editor supports](https://editorconfig.org/#pre-installed)
+`.editorconfig` files, or [install a plugin](https://editorconfig.org/#download).
+
 The CI server will run eslint and typescript to verify type safety and code
 style. You can run the linter yourself like this:
 


### PR DESCRIPTION
This PR adds an `.editorconfig` file ([more info](https://editorconfig.org/)), which can be used by contributors to configure the editor correctly to follow the style of this repo. Fixes #119 