### PR TITLE
Add cross-env and change ' to " ,to enable yarn tdd on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "devproxy": "moxy -f http://api.dev.zetkin.org",
     "devserver": "next dev -p 80",
     "lint": "eslint src cypress && tsc --noEmit && echo 'Finished linting without errors!'",
-    "tdd": "concurrently 'NODE_ENV=test yarn devserver' 'yarn devproxy' 'yarn cypress open'",
+    "tdd": "concurrently \"cross-env NODE_ENV=test yarn devserver\" \"yarn devproxy\" \"yarn cypress open\"",
     "watch": "chokidar 'src/**/*' -c 'npm run lint'",
     "ci-start": "concurrently 'next start -p 80' 'yarn devproxy'",
     "start": "next start -p 80"
@@ -45,6 +45,7 @@
     "babel-loader": "^8.2.2",
     "chokidar-cli": "^2.1.0",
     "concurrently": "^5.3.0",
+    "cross-env": "^7.0.3",
     "cypress": "6.8.0",
     "eslint": "^7.15.0",
     "eslint-loader": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4389,7 +4389,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
yarn tdd did not run on Windows, so updated tdd-line in package.json to have escaped " instead of ' , and added cross-env as dependency for development