### PR TITLE
Fix server error on 404 page. create custom 404 page and implement ge…

### DIFF
--- a/cypress/integration/404_page.spec.ts
+++ b/cypress/integration/404_page.spec.ts
@@ -1,0 +1,22 @@
+describe('404 Page', () => {
+    const BAD_PATH = '/bad_path';
+    const EXPECTED_ENGLISH = '404 | Page not found';
+    
+    it('loads custom 404 page on response status 404, and links back to the home page', () => {
+        cy.request({ 
+            failOnStatusCode: false, 
+            url: BAD_PATH,
+        }).then(res => {
+            expect(res.status).equal(404);
+        });
+        cy.visit(BAD_PATH, { failOnStatusCode: false });
+        cy.contains(EXPECTED_ENGLISH);
+        cy.get('[data-test="back-home-link"]')
+            .should('be.visible')
+            .click();
+        cy.url().should('match', /http:\/\/www\.dev\.zetkin\.org\//);
+    });
+});
+    
+// Hack to flag for typescript as module
+export {};

--- a/src/locale/pages/404/en.yml
+++ b/src/locale/pages/404/en.yml
@@ -1,0 +1,2 @@
+pageNotFound: 404 | Page not found
+backToHomePage: Back to home page

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,8 +1,9 @@
-import { getMessages } from '../utils/locale';
 import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import { FormattedMessage as Msg } from 'react-intl';
 import { Content, Flex, Heading, Link } from '@adobe/react-spectrum';
+
+import { getMessages } from '../utils/locale';
 
 export const getStaticProps: GetStaticProps = async () => {
     const lang = 'en';

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,46 @@
+import { getMessages } from '../utils/locale';
+import { GetStaticProps } from 'next';
+import Head from 'next/head';
+import { FormattedMessage as Msg } from 'react-intl';
+import { Link as AdobeLink, Content, Flex, Heading } from '@adobe/react-spectrum';
+
+const options = {
+    localeScope: [
+        'pages.404',
+        'misc.publicHeader',
+    ],
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+    const lang = 'en';
+    const messages = await getMessages(lang, options?.localeScope ?? []);
+    return {
+        props: { lang, messages },
+    };
+};
+
+export default function Custom404() : JSX.Element {
+    return (
+        <>
+            <Head>
+                <title>Zetkin</title>
+            </Head>
+            <Content>
+                <Flex
+                    alignItems="center"
+                    direction="column"
+                    height="size-6000"
+                    justifyContent="center">
+                    <Heading level={ 1 }>
+                        <Msg id="pages.404.pageNotFound"/>
+                    </Heading>
+                    <AdobeLink>
+                        <a href="/">
+                            <Msg id="pages.404.backToHomePage"/>
+                        </a>
+                    </AdobeLink>
+                </Flex>
+            </Content>
+        </>
+    );
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,18 +2,14 @@ import { getMessages } from '../utils/locale';
 import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import { FormattedMessage as Msg } from 'react-intl';
-import { Link as AdobeLink, Content, Flex, Heading } from '@adobe/react-spectrum';
-
-const options = {
-    localeScope: [
-        'pages.404',
-        'misc.publicHeader',
-    ],
-};
+import { Content, Flex, Heading, Link } from '@adobe/react-spectrum';
 
 export const getStaticProps: GetStaticProps = async () => {
     const lang = 'en';
-    const messages = await getMessages(lang, options?.localeScope ?? []);
+    const messages = await getMessages(lang, [
+        'pages.404',
+        'misc.publicHeader',
+    ]);
     return {
         props: { lang, messages },
     };
@@ -34,11 +30,11 @@ export default function Custom404() : JSX.Element {
                     <Heading level={ 1 }>
                         <Msg id="pages.404.pageNotFound"/>
                     </Heading>
-                    <AdobeLink>
+                    <Link>
                         <a href="/">
                             <Msg id="pages.404.backToHomePage"/>
                         </a>
-                    </AdobeLink>
+                    </Link>
                 </Flex>
             </Content>
         </>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -30,7 +30,7 @@ export default function Custom404() : JSX.Element {
                     <Heading level={ 1 }>
                         <Msg id="pages.404.pageNotFound"/>
                     </Heading>
-                    <Link>
+                    <Link data-test="back-home-link">
                         <a href="/">
                             <Msg id="pages.404.backToHomePage"/>
                         </a>


### PR DESCRIPTION
This PR implements a custom 404 page. Since only static prop fetching is available for the 404 page in Next, it hard codes 'en' as the language for messages. Fixes #105