### PR TITLE
Use sdk 'z' from context in index.tsx and create interface ZetkinTokenData

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { scaffold } from '../utils/next';
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const Z = require('zetkin');
 
 const scaffoldOptions = {
     localeScope: [
@@ -22,25 +21,19 @@ const scaffoldOptions = {
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const { query, req, res } = context;
 
-    const z = Z.construct({
-        clientId: process.env.ZETKIN_CLIENT_ID,
-        clientSecret: process.env.ZETKIN_CLIENT_SECRET,
-        ssl: stringToBool(process.env.ZETKIN_USE_TLS),
-        zetkinDomain: process.env.ZETKIN_API_DOMAIN,
-    });
-
     const code = query?.code;
+
     if (code) {
         const protocol = stringToBool(process.env.NEXT_PUBLIC_APP_USE_TLS)? 'https' : 'http';
         const host = process.env.NEXT_PUBLIC_APP_HOST;
 
         try {
-            await z.authenticate(`${protocol}://${host}/?code=${code}`);
+            await context.z.authenticate(`${protocol}://${host}/?code=${code}`);
             await applySession(req, res);
 
             const reqWithSession = req as { session? : AppSession };
             if (reqWithSession.session) {
-                reqWithSession.session.tokenData = z.getTokenData();
+                reqWithSession.session.tokenData = context.z.getTokenData();
             }
         }
         catch (err) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,11 @@
 import { NextPage } from 'next/types';
 import { Session } from 'next-session/dist/types';
 
+import { ZetkinTokenData } from './sdk';
+
+
 export type AppSession = Session & {
-    tokenData?: {
-        access_token: string;
-        expires_in: number;
-        refresh_token: string;
-        token_type: string;
-    };
+    tokenData?: ZetkinTokenData | null;
 };
 
 interface GetLayout {

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -16,7 +16,16 @@ export interface ZetkinZResource {
     put: (data : any) => Promise<ZetkinZResult>;
 }
 
+export interface ZetkinTokenData {
+    access_token: string;
+    expires_in: number;
+    refresh_token: string;
+    token_type: string;
+}
+
 export interface ZetkinZ {
     resource: (...args : string[]) => ZetkinZResource;
-    setTokenData: (data : Record<string,unknown>) => void;
+    setTokenData: (data: ZetkinTokenData) => void;
+    authenticate: (callbackUrl: string) => Promise<void>;
+    getTokenData: () => ZetkinTokenData | null;
 }

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -65,6 +65,7 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps, options? : Scaf
             host: process.env.ZETKIN_API_HOST,
             port: process.env.ZETKIN_API_PORT,
             ssl: stringToBool(process.env.ZETKIN_USE_TLS),
+            zetkinDomain: process.env.ZETKIN_API_DOMAIN,
         });
 
         const { req, res } = contextFromNext;


### PR DESCRIPTION
In this index.tsx is updated to use 'z' from context instead of as a local instantiation. In consequence interface ZetkinZ is updated to include 2 more functions, and interface ZetkinTokenData is created and applied where approperiate. To fix a problem with the sdk authenticate function the zetkinDomain attirbute was added to 'z' in scaffold function. Fixes #117 