### PR TITLE
Redirect restricted pages to login

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -33,6 +33,14 @@ describe('Login process', () => {
         cy.url().should('match', /login.dev.zetkin.org/);
     });
 
+    it('redirects to tried page after logging in', () => {
+        cy.visit('/my');
+        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
+        cy.get('input[aria-label="Password"]').type('password');
+        cy.get('input[aria-label="Log in"]').click();
+        cy.url().should('match', /\/my$/);
+    });
+
     it('contains a logout button wich logs you out and takes you back to the home page', () => {
         cy.visit('/login');
         cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -28,6 +28,11 @@ describe('Login process', () => {
         cy.url().should('match', /\/my$/);
     });
 
+    it('redirects from /my to login when not already logged in', () => {
+        cy.visit('/my');
+        cy.url().should('match', /login.dev.zetkin.org/);
+    });
+
     it('contains a logout button wich logs you out and takes you back to the home page', () => {
         cy.visit('/login');
         cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -8,6 +8,7 @@ import { scaffold } from '../../utils/next';
 import { ZetkinUser } from '../../interfaces/ZetkinUser';
 
 const scaffoldOptions = {
+    authLevelRequired: 1,
     localeScope: [
         'layout.my',
         'misc.publicHeader',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import { ZetkinTokenData } from './sdk';
 
 export type AppSession = Session & {
     tokenData?: ZetkinTokenData | null;
+    redirAfterLogin: string | null;
 };
 
 interface GetLayout {

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -1,3 +1,5 @@
+import { ZetkinUser } from '../interfaces/ZetkinUser';
+
 export interface ZetkinMembership {
     organization: {
         id: number;
@@ -16,4 +18,10 @@ export interface ZetkinEventResponse {
         id: number;
     };
     id: number;
+}
+
+export interface ZetkinSession {
+    created: string;
+    level: number;
+    user: ZetkinUser;
 }

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -39,6 +39,7 @@ interface ResultWithProps {
 }
 
 interface ScaffoldOptions {
+    // Level can be 1 (simple sign-in) or 2 (two-factor authentication)
     authLevelRequired?: number;
     localeScope?: string[];
 }
@@ -101,6 +102,8 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps, options? : Scaf
 
             if (authLevel < options.authLevelRequired) {
                 if (reqWithSession.session) {
+                    // Store the URL that the user tried to access, so that they
+                    // can be redirected back here after logging in
                     reqWithSession.session.redirAfterLogin = req.url || null;
                 }
 


### PR DESCRIPTION
This PR adds logic to `scaffold()` to easily redirect user to login when they're not authenticated to a high enough level to access a page. The level can be either 1 (when logging in using just e-mail and password) or 2 (when using two-factor authentication).

It does so by adding an `authLevelRequired` option to the `ScaffoldOptions` object, and checking the status of authenticated users when they try to access the page.

The PR also adds logic to redirect the user back to that page after logging in, where previously they would have just ended up on the home page.

Fixes #96