### PR TITLE
Issue 95/show map on event page

### DIFF
--- a/cypress/integration/event_page.spec.ts
+++ b/cypress/integration/event_page.spec.ts
@@ -75,6 +75,17 @@ describe('/o/[orgId]/events/[eventId]', () => {
             //TODO: Verify that API request is done corrently.
         });
     });
+
+    it('contains a map with marker that shows title of event when clicked', () => {
+        cy.visit('/o/1/events/25');
+        cy.waitUntilReactRendered();
+        cy.get('.leaflet-container').should('be.visible');
+        cy.get('.leaflet-marker-icon').should('be.visible').click().then(() => {
+            cy.get('.leaflet-popup-content')
+                .should('be.visible')
+                .should('contain.text', 'Haubtstrasse');
+        });
+    });
 });
 
 // Hack to flag for typescript as module

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "@react-spectrum/tabs": "^3.0.0-alpha.3",
     "@spectrum-icons/workflow": "^3.2.0",
     "@types/negotiator": "^0.6.1",
+    "leaflet": "^1.7.1",
     "negotiator": "^0.6.2",
     "next": "^10.0.3",
     "next-session": "^3.4.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-intl": "^5.13.2",
+    "react-leaflet": "^3.1.0",
     "react-query": "^3.5.11",
     "yaml": "^1.10.0",
     "zetkin": "^1.2.1"
@@ -37,6 +39,7 @@
   "devDependencies": {
     "@cypress/react": "^4.16.3",
     "@testing-library/cypress": "^7.0.4",
+    "@types/leaflet": "^1.7.0",
     "@types/node": "^14.14.14",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.10.0",

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -1,6 +1,6 @@
 import Calendar from '@spectrum-icons/workflow/Calendar';
 import Flag from '@spectrum-icons/workflow/Flag';
-import Head from 'next/Head';
+import Head from 'next/head';
 import Location from '@spectrum-icons/workflow/Location';
 import NextLink from 'next/link';
 import {

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -113,12 +113,7 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
             <Text data-testid="info-text" marginY="size-300">
                 { event.info_text }
             </Text>
-            <View
-                bottom="size-200"
-                left="size-200"
-                marginTop="size-200"
-                position="absolute"
-                right="size-200">
+            <View>
                 { response ? (
                     <Button
                         data-testid="event-response-button"

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -1,5 +1,6 @@
 import Calendar from '@spectrum-icons/workflow/Calendar';
 import Flag from '@spectrum-icons/workflow/Flag';
+import Head from 'next/Head';
 import Location from '@spectrum-icons/workflow/Location';
 import NextLink from 'next/link';
 import {
@@ -19,6 +20,7 @@ import {
     FormattedMessage as Msg,
 } from 'react-intl';
 
+import Map from './maps/Map';
 import {
     ZetkinEvent,
     ZetkinEventResponse,
@@ -36,6 +38,12 @@ interface EventDetailsProps {
 const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDetailsProps) : JSX.Element => {
     return (
         <>
+            <Head>
+                <link crossOrigin="" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+                    integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+                    rel="stylesheet"
+                />
+            </Head>
             <Header marginBottom="size-300">
                 <Image
                     alt="Cover image"
@@ -100,6 +108,7 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 <Location marginEnd="size-100" size="S" />
                 <Text data-testid="location">{ event.location.title }</Text>
             </Flex>
+            <Map markers={ [ event.location ] } />
             <Divider />
             <Text data-testid="info-text" marginY="size-300">
                 { event.info_text }

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -108,7 +108,7 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 <Location marginEnd="size-100" size="S" />
                 <Text data-testid="location">{ event.location.title }</Text>
             </Flex>
-            <Map markers={ [ event.location ] } />
+            <Map height={ 500 } markers={ [event.location] }/>
             <Divider />
             <Text data-testid="info-text" marginY="size-300">
                 { event.info_text }

--- a/src/components/maps/BrowserMap.tsx
+++ b/src/components/maps/BrowserMap.tsx
@@ -1,7 +1,7 @@
 import { MapProps } from './types';
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
 
-export default function Map({ markers }: MapProps): JSX.Element {
+export default function Map({ height, markers, width }: MapProps): JSX.Element {
     const latSum = markers.reduce((sum, marker) => sum + marker.lat, 0);
     const lngSum = markers.reduce((sum, marker) => sum + marker.lng, 0);
 
@@ -9,7 +9,8 @@ export default function Map({ markers }: MapProps): JSX.Element {
 
     return (
         <>
-            <MapContainer center={ avgPos } scrollWheelZoom={ false } zoom={ 13 }>
+            <MapContainer center={ avgPos } scrollWheelZoom={ false }
+                style={{ height: height || '20rem', width: width || '100%' }} zoom={ 13 }>
                 <TileLayer
                     attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/src/components/maps/BrowserMap.tsx
+++ b/src/components/maps/BrowserMap.tsx
@@ -7,7 +7,7 @@ export default function BrowserMap({ height, markers, width }: MapProps): JSX.El
 
     const avgPos: [number, number] = [latSum/markers.length, lngSum/markers.length];
 
-    return (  
+    return (
         <MapContainer center={ avgPos } scrollWheelZoom={ false }
             style={{ height: height || '20rem', width: width || '100%' }} zoom={ 13 }>
             <TileLayer

--- a/src/components/maps/BrowserMap.tsx
+++ b/src/components/maps/BrowserMap.tsx
@@ -1,0 +1,31 @@
+import { MapProps } from './types';
+import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
+
+export default function Map({ markers }: MapProps): JSX.Element {
+    const latSum = markers.reduce((sum, marker) => sum + marker.lat, 0);
+    const lngSum = markers.reduce((sum, marker) => sum + marker.lng, 0);
+
+    const avgPos: [number, number] = [latSum/markers.length, lngSum/markers.length];
+
+    return (
+        <>
+            <MapContainer center={ avgPos } scrollWheelZoom={ false } zoom={ 13 }>
+                <TileLayer
+                    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                />
+                {
+                    markers.map((marker, index) => (
+                        <Marker key={ marker.id || index } position={ [marker.lat, marker.lng] }>
+                            <Popup>
+                                { marker.title }
+                            </Popup>
+                        </Marker>
+                    ))
+                };
+            </MapContainer>
+        </>
+    );
+}
+
+

--- a/src/components/maps/BrowserMap.tsx
+++ b/src/components/maps/BrowserMap.tsx
@@ -1,31 +1,29 @@
 import { MapProps } from './types';
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
 
-export default function Map({ height, markers, width }: MapProps): JSX.Element {
+export default function BrowserMap({ height, markers, width }: MapProps): JSX.Element {
     const latSum = markers.reduce((sum, marker) => sum + marker.lat, 0);
     const lngSum = markers.reduce((sum, marker) => sum + marker.lng, 0);
 
     const avgPos: [number, number] = [latSum/markers.length, lngSum/markers.length];
 
-    return (
-        <>
-            <MapContainer center={ avgPos } scrollWheelZoom={ false }
-                style={{ height: height || '20rem', width: width || '100%' }} zoom={ 13 }>
-                <TileLayer
-                    attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                />
-                {
-                    markers.map((marker, index) => (
-                        <Marker key={ marker.id || index } position={ [marker.lat, marker.lng] }>
-                            <Popup>
-                                { marker.title }
-                            </Popup>
-                        </Marker>
-                    ))
-                };
-            </MapContainer>
-        </>
+    return (  
+        <MapContainer center={ avgPos } scrollWheelZoom={ false }
+            style={{ height: height || '20rem', width: width || '100%' }} zoom={ 13 }>
+            <TileLayer
+                attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+            {
+                markers.map((marker, index) => (
+                    <Marker key={ marker.id || index } position={ [marker.lat, marker.lng] }>
+                        <Popup>
+                            { marker.title }
+                        </Popup>
+                    </Marker>
+                ))
+            };
+        </MapContainer>
     );
 }
 

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -5,7 +5,7 @@ const DynamicMap = dynamic(() => {
     return import('./BrowserMap');
 }, { ssr: false });
 
-export default function Map({ markers }: MapProps): JSX.Element {
+export default function Map({ height, markers , width }: MapProps): JSX.Element {
     const CastMap = DynamicMap as MapComponent;
-    return (<CastMap markers={ markers }/>);
+    return (<CastMap height={ height } markers={ markers } width={ width }/>);
 }

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+import { MapComponent, MapProps } from './types';
+
+const DynamicMap = dynamic(() => {
+    return import('./BrowserMap');
+}, { ssr: false });
+
+export default function Map({ markers }: MapProps): JSX.Element {
+    const CastMap = DynamicMap as MapComponent;
+    return (<CastMap markers={ markers }/>);
+}

--- a/src/components/maps/Map.tsx
+++ b/src/components/maps/Map.tsx
@@ -1,11 +1,11 @@
 import dynamic from 'next/dynamic';
 import { MapComponent, MapProps } from './types';
 
-const DynamicMap = dynamic(() => {
+const BrowserMap = dynamic(() => {
     return import('./BrowserMap');
 }, { ssr: false });
 
 export default function Map({ height, markers , width }: MapProps): JSX.Element {
-    const CastMap = DynamicMap as MapComponent;
+    const CastMap = BrowserMap as MapComponent;
     return (<CastMap height={ height } markers={ markers } width={ width }/>);
 }

--- a/src/components/maps/types.ts
+++ b/src/components/maps/types.ts
@@ -1,0 +1,14 @@
+import { FunctionComponent } from 'react';
+
+export interface MapMarker {
+    id?: number;
+    lat: number;
+    lng: number;
+    title: string;
+}
+
+export interface MapProps {
+    markers: MapMarker[];
+}
+
+export type MapComponent = FunctionComponent<MapProps>;

--- a/src/components/maps/types.ts
+++ b/src/components/maps/types.ts
@@ -8,7 +8,9 @@ export interface MapMarker {
 }
 
 export interface MapProps {
+    height?: string | number;
     markers: MapMarker[];
+    width?: string | number;
 }
 
 export type MapComponent = FunctionComponent<MapProps>;

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -26,7 +26,12 @@ export interface ZetkinEvent {
     end_time: string;
     id: number;
     info_text: string;
-    location: { title: string };
+    location: {
+        id: number;
+        lat: number;
+        lng: number;
+        title: string;
+    };
     start_time: string;
     title?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,6 +1550,11 @@
     "@react-aria/utils" "^3.3.0"
     clsx "^1.1.1"
 
+"@react-leaflet/core@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.0.2.tgz#39c6a73f61c666d5dcf673741cea2672fa4bbae1"
+  integrity sha512-QbleYZTMcgujAEyWGki8Lx6cXQqWkNtQlqf5c7NImlIp8bKW66bFpez/6EVatW7+p9WKBOEOVci/9W7WW70EZg==
+
 "@react-spectrum/actiongroup@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@react-spectrum/actiongroup/-/actiongroup-3.1.2.tgz#02649bd0c9f50ea5804d08eefa5df22a57411c64"
@@ -2614,6 +2619,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/geojson@*":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -2652,6 +2662,13 @@
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
+"@types/leaflet@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.7.0.tgz#3700fb5d29a8214fbd496565b08ec28e40cee808"
+  integrity sha512-ltv5jR+VjKSMtoDkxH61Rsbo0zLU7iqyOXpVPkAX4F+79fg2eymC7t0msWsfNaEZO1FGTIQATCCCQe+ijWoicg==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/mime@^1":
   version "1.3.2"
@@ -6723,6 +6740,11 @@ lazy-ass@1.6.0, lazy-ass@^1.6.0:
   resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
 
+leaflet@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
+  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -8299,6 +8321,13 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-leaflet@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-3.1.0.tgz#42deb5e454518016eff8bc85511ae58812f910f5"
+  integrity sha512-kdZS8NYbYFPmkQr7zSDR2gkKGFeWvkxqoqcmZEckzHL4d5c85dJ2gbbqhaPDpmWWgaRw9O29uA/77qpKmK4mTQ==
+  dependencies:
+    "@react-leaflet/core" "^1.0.2"
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This PR uses Leaflet and React Leaflet to add a Map element to each individual event page. The maps can have one or more markers that show the location of the event/s. Fixes #95 