### PR TITLE
Issue 136/organizer dashboard

### DIFF
--- a/src/components/DashboardCampaigns.tsx
+++ b/src/components/DashboardCampaigns.tsx
@@ -1,9 +1,10 @@
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
 import { useQuery } from 'react-query';
-import { Button, Flex, Heading, Item, Link, ListBox, View } from '@adobe/react-spectrum';
+import { Button, Flex, Heading, Link, View } from '@adobe/react-spectrum';
 
 import getCampaigns from '../fetching/getCampaigns';
+import { ZetkinCampaign } from '../types/zetkin';
 
 interface DashboardCampaignProps {
     orgId: string;
@@ -11,19 +12,33 @@ interface DashboardCampaignProps {
 
 const DashboardCampaigns = ({ orgId } : DashboardCampaignProps) : JSX.Element => {
     const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
+    const campaigns = campaignsQuery.data;
 
     return (
         <View>
             <Heading level={ 2 }>
                 <Msg id="pages.organize.currentProjects.title"/>
             </Heading>
-            <ListBox items={ campaignsQuery?.data } selectionMode="none">
-                { (item) => <Item>{ item.title }</Item> }
-            </ListBox>
-            <Flex justifyContent="end">
+            { campaigns && (
+                <ul style={{ padding: 0 }}>
+                    { campaigns.map((item: ZetkinCampaign) => (
+                        <li key={ item.id } style={{
+                            border: '2px solid gray',
+                            listStyle: 'none',
+                            padding: '1rem',
+                        }}>
+                            <Link>
+                                <NextLink href={ `/organize/${orgId}/campaigns/${item.id}` }>
+                                    <a>{ item.title }</a>
+                                </NextLink>
+                            </Link>
+                        </li>
+                    )) }
+                </ul>) }
+            <Flex alignItems="center" justifyContent="end" margin="1rem 0rem">
                 <Link>
                     <NextLink href={ `/organize/${orgId}/campaigns` }>
-                        <a>
+                        <a style={{ color: 'mediumpurple', margin:'0 2rem' }}>
                             <Msg id="pages.organize.currentProjects.all"/>
                         </a>
                     </NextLink>

--- a/src/components/DashboardCampaigns.tsx
+++ b/src/components/DashboardCampaigns.tsx
@@ -1,0 +1,41 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import NextLink from 'next/link';
+import { useQuery } from 'react-query';
+import { Button, Flex, Heading, Item, Link, ListBox, View } from '@adobe/react-spectrum';
+
+import getCampaigns from '../fetching/getCampaigns';
+
+interface DashboardCampaignProps {
+    orgId: string;
+}
+
+const DashboardCampaigns = ({ orgId } : DashboardCampaignProps) : JSX.Element => {
+    const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
+
+    return (
+        <View>
+            <Heading level={ 2 }>
+                <Msg id="pages.organize.currentProjects.title"/>
+            </Heading>
+            <ListBox items={ campaignsQuery?.data } selectionMode="none">
+                { (item) => <Item>{ item.title }</Item> }
+            </ListBox>
+            <Flex justifyContent="end">
+                <Link>
+                    <NextLink href={ `/organize/${orgId}/campaigns` }>
+                        <a>
+                            <Msg id="pages.organize.currentProjects.all"/>
+                        </a>
+                    </NextLink>
+                </Link>
+                <NextLink href={ `/organize/${orgId}/campaigns/new` }>
+                    <Button variant="cta">
+                        <Msg id="pages.organize.currentProjects.new"/>
+                    </Button>
+                </NextLink>
+            </Flex>
+        </View>
+    );
+};
+
+export default DashboardCampaigns;

--- a/src/components/DashboardPeople.tsx
+++ b/src/components/DashboardPeople.tsx
@@ -1,0 +1,21 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { Heading, View } from '@adobe/react-spectrum';
+
+
+interface DashboardPeopleProps {
+    orgId: string;
+}
+
+const DashboardPeople = ({ orgId } : DashboardPeopleProps) : JSX.Element => {
+
+    return (
+        <View>
+            <Heading level={ 2 }>
+                <Msg id="pages.organize.people.title"/>
+            </Heading>
+            { orgId }
+        </View>
+    );
+};
+
+export default DashboardPeople;

--- a/src/fetching/getCampaign.ts
+++ b/src/fetching/getCampaign.ts
@@ -1,9 +1,6 @@
 import apiUrl from '../utils/apiUrl';
+import { ZetkinCampaign } from '../types/zetkin';
 
-export interface ZetkinCampaign {
-    info_text: string;
-    title: string;
-}
 
 export default function getCampaign(orgId : string, campId : string) {
     return async () : Promise<ZetkinCampaign> => {

--- a/src/fetching/getCampaigns.ts
+++ b/src/fetching/getCampaigns.ts
@@ -1,9 +1,9 @@
-import apiUrl from '../utils/apiUrl';
+import { defaultFetch } from '.';
 import { ZetkinCampaign } from '../types/zetkin';
 
-export default function getCampaigns(orgId : string) {
+export default function getCampaigns(orgId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinCampaign[]> => {
-        const cRes = await fetch(apiUrl(`/orgs/${orgId}/campaigns`));
+        const cRes = await fetch(`/orgs/${orgId}/campaigns`);
         const cData = await cRes.json();
         return cData.data;
     };

--- a/src/fetching/getCampaigns.ts
+++ b/src/fetching/getCampaigns.ts
@@ -1,7 +1,8 @@
 import apiUrl from '../utils/apiUrl';
+import { ZetkinCampaign } from '../types/zetkin';
 
 export default function getCampaigns(orgId : string) {
-    return async () : Promise<{ id: number; title: string }[]> => {
+    return async () : Promise<ZetkinCampaign[]> => {
         const cRes = await fetch(apiUrl(`/orgs/${orgId}/campaigns`));
         const cData = await cRes.json();
         return cData.data;

--- a/src/locale/pages/organize/en.yml
+++ b/src/locale/pages/organize/en.yml
@@ -1,0 +1,13 @@
+linkGroup:
+  public: Public Page
+  manage: Manage Organization
+  settings: Edit Settings
+currentProjects:
+  title: Current Projects & Campaigns
+  all: All projects & campaigns
+  new: New Campaign
+people:
+  title: Do you know this member?
+  all: All People
+  skip: Skip
+  profile: profile

--- a/src/locale/pages/organize/sv.yml
+++ b/src/locale/pages/organize/sv.yml
@@ -3,8 +3,8 @@ linkGroup:
   manage: Hantera organisation
   settings: Ändra inställningar
 currentProjects:
-  title: Nuvarande projekter och kampanjer
-  all: Alla projekter och kampanjer
+  title: Nuvarande projekt och kampanjer
+  all: Alla projekt och kampanjer
   new: Skapa kampanj
 people:
   title: Känner du det har medlem?

--- a/src/locale/pages/organize/sv.yml
+++ b/src/locale/pages/organize/sv.yml
@@ -1,0 +1,13 @@
+linkGroup:
+  public: Offentlig sida
+  manage: Hantera organisation
+  settings: Ändra inställningar
+currentProjects:
+  title: Nuvarande projekter och kampanjer
+  all: Alla projekter och kampanjer
+  new: Skapa kampanj
+people:
+  title: Känner du det har medlem?
+  all: Alla personer
+  skip: Hoppa över
+  profile: profil

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -1,0 +1,126 @@
+import Actions from '@spectrum-icons/workflow/Actions';
+import Cloud from '@spectrum-icons/workflow/Cloud';
+import { GetServerSideProps } from 'next';
+import { FormattedMessage as Msg } from 'react-intl';
+import NextLink from 'next/link';
+import Settings from '@spectrum-icons/workflow/Settings';
+import { Flex, Header, Heading, Image, View } from '@adobe/react-spectrum';
+
+import apiUrl from '../../../utils/apiUrl';
+import DashboardCampaigns from '../../../components/DashboardCampaigns';
+import DashboardPeople from '../../../components/DashboardPeople';
+import getCampaigns from '../../../fetching/getCampaigns';
+import getOrg from '../../../fetching/getOrg';
+import { PageWithLayout } from '../../../types';
+import { scaffold } from '../../../utils/next';
+import { useQuery } from 'react-query';
+
+const scaffoldOptions = {
+    authLevelRequired: 1,
+    localeScope: [
+        'layout.organize', 'misc.breadcrumbs', 'pages.organize',
+    ],
+};
+
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { orgId } = context.params!;
+
+    await context.queryClient.prefetchQuery(['campaigns', orgId], getCampaigns(orgId as string));
+    await context.queryClient.prefetchQuery(['org', orgId], getOrg(orgId as string));
+
+    const campaignsState = context.queryClient.getQueryState(['campaigns', orgId]);
+    const orgState = context.queryClient.getQueryState(['org', orgId]);
+
+    if (campaignsState?.status === 'success' && orgState?.status === 'success') {
+        return {
+            props: {
+                orgId,
+            },
+        };
+    }
+    else {
+        return {
+            notFound: true,
+        };
+    }
+}, scaffoldOptions);
+
+type OrganizePageProps = {
+    orgId: string;
+};
+
+const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId  }) => {
+
+    const orgQuery = useQuery(['org', orgId], getOrg(orgId));
+
+    return (
+        <>
+            <View borderColor="celery-400" borderWidth="thick">
+                <Header height="size-1200">
+                    <Flex height="100%" justifyContent="start" width="100%">
+                        <Image
+                            alt="Organization avatar"
+                            data-testid="org-avatar"
+                            height="size-1200"
+                            objectFit="contain"
+                            src={ apiUrl(`/orgs/${orgId}/avatar`) }
+                            width="size-1200"
+                        />
+                        <View>
+                            <Flex direction="column">
+                                <Heading level={ 1 }>
+                                    { orgQuery.data?.title }
+                                </Heading>
+                                <View>
+                                    <Cloud aria-label="Cloud" size="XS" />
+                                    <NextLink href={ `/o/${orgId}` }>
+                                        <a>
+                                            <Msg id="pages.organize.linkGroup.public"/>
+                                        </a>
+                                    </NextLink>
+                                    <Actions aria-label="Actions" size="XS" />
+                                    <NextLink href={ `/organize/${orgId}/organization` }>
+                                        <a>
+                                            <Msg id="pages.organize.linkGroup.manage"/>
+                                        </a>
+                                    </NextLink>
+                                    <Settings aria-label="Settings" size="XS" />
+                                    <NextLink href={ `/organize/${orgId}/settings` }>
+                                        <a>
+                                            <Msg id="pages.organize.linkGroup.settings"/>
+                                        </a>
+                                    </NextLink>
+                                </View>
+                            </Flex>
+                        </View>
+                    </Flex>
+                </Header>
+            </View>
+            <View>
+                <Flex wrap>
+                    <View width="50%">
+                        <View borderWidth="thick">
+                            <DashboardCampaigns orgId={ orgId }/>
+                        </View>
+                        <View borderWidth="thick">
+                            <DashboardPeople orgId={ orgId }/>
+                        </View>
+                        <View borderWidth="thick">Areas</View>
+                    </View>
+                    <View borderColor="celery-400" borderWidth="thick" height="size-1200" width="50%">Inbox</View>
+                </Flex>
+            </View>
+        </>
+    );
+};
+
+OrganizePage.getLayout = function getLayout(page) {
+    return (
+        <div>
+            { page }
+        </div>
+    );
+};
+
+export default OrganizePage;

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -1,4 +1,3 @@
-
 import Actions from '@spectrum-icons/workflow/Actions';
 import Cloud from '@spectrum-icons/workflow/Cloud';
 import { GetServerSideProps } from 'next';
@@ -16,7 +15,6 @@ import getOrg from '../../../fetching/getOrg';
 import OrganizeLayout from '../../../components/layout/OrganizeLayout';
 import { PageWithLayout } from '../../../types';
 import { scaffold } from '../../../utils/next';
-
 
 const scaffoldOptions = {
     authLevelRequired: 1,

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -56,38 +56,37 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId  }) => {
 
     return (
         <>
-            <View borderColor="celery-400" borderWidth="thick">
-                <Header height="size-1200">
+            <View borderColor="gray-400" borderWidth="thick" margin="1rem" padding="1rem">
+                <Header>
                     <Flex height="100%" justifyContent="start" width="100%">
                         <Image
                             alt="Organization avatar"
                             data-testid="org-avatar"
-                            height="size-1200"
                             objectFit="contain"
                             src={ apiUrl(`/orgs/${orgId}/avatar`) }
                             width="size-1200"
                         />
                         <View>
-                            <Flex direction="column">
+                            <Flex direction="column" margin="0 1rem">
                                 <Heading level={ 1 }>
                                     { orgQuery.data?.title }
                                 </Heading>
                                 <View>
                                     <Cloud aria-label="Cloud" size="XS" />
                                     <NextLink href={ `/o/${orgId}` }>
-                                        <a>
+                                        <a style={{ margin:'0.5rem' }}>
                                             <Msg id="pages.organize.linkGroup.public"/>
                                         </a>
                                     </NextLink>
                                     <Actions aria-label="Actions" size="XS" />
                                     <NextLink href={ `/organize/${orgId}/organization` }>
-                                        <a>
+                                        <a style={{ margin:'0.5rem' }}>
                                             <Msg id="pages.organize.linkGroup.manage"/>
                                         </a>
                                     </NextLink>
                                     <Settings aria-label="Settings" size="XS" />
                                     <NextLink href={ `/organize/${orgId}/settings` }>
-                                        <a>
+                                        <a style={{ margin:'0.5rem' }}>
                                             <Msg id="pages.organize.linkGroup.settings"/>
                                         </a>
                                     </NextLink>
@@ -98,17 +97,19 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId  }) => {
                 </Header>
             </View>
             <View>
-                <Flex wrap>
+                <Flex>
                     <View width="50%">
-                        <View borderWidth="thick">
+                        <View borderColor="gray-400" borderWidth="thick" margin="size-200" padding="size-200">
                             <DashboardCampaigns orgId={ orgId }/>
                         </View>
-                        <View borderWidth="thick">
+                        <View borderColor="gray-400" borderWidth="thick" margin="size-200" padding="size-200">
                             <DashboardPeople orgId={ orgId }/>
                         </View>
-                        <View borderWidth="thick">Areas</View>
+                        <View borderColor="gray-400" borderWidth="thick" margin="size-200">
+                            Areas
+                        </View>
                     </View>
-                    <View borderColor="celery-400" borderWidth="thick" height="size-1200" width="50%">Inbox</View>
+                    <View borderColor="gray-400" borderWidth="thick" height="size-1200" margin="size-200" width="50%">Inbox</View>
                 </Flex>
             </View>
         </>

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -29,8 +29,8 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
 
-    await context.queryClient.prefetchQuery(['campaigns', orgId], getCampaigns(orgId as string));
-    await context.queryClient.prefetchQuery(['org', orgId], getOrg(orgId as string));
+    await context.queryClient.prefetchQuery(['campaigns', orgId], getCampaigns(orgId as string, context.apiFetch));
+    await context.queryClient.prefetchQuery(['org', orgId], getOrg(orgId as string, context.apiFetch));
 
     const campaignsState = context.queryClient.getQueryState(['campaigns', orgId]);
     const orgState = context.queryClient.getQueryState(['org', orgId]);

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,3 +2,7 @@ body {
     margin: 0;
     height: 100%;
 }
+
+* {
+    box-sizing: border-box;
+}

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -1,3 +1,9 @@
+export interface ZetkinCampaign {
+    info_text: string;
+    title: string;
+    id: string;
+}
+
 export interface ZetkinMembership {
     organization: ZetkinOrganization;
     profile: {


### PR DESCRIPTION
This PR creates the layout for the organizer dashboard at /organize/{orgID}. 

It uses \<ul> and \<li> elements instead of ListBox since I can’t make it work with links — that component doesn’t seem to be designed for a list of links, rather a list of options.

I also cannot find a good way to make the layout responsive for mobile widths. 
Will note these in the Adobe spectrum discussion. 
![image](https://user-images.githubusercontent.com/62522290/117127061-e779fe00-ad9b-11eb-9963-d17dcd30dcc8.png)

Fixes #136