### PR TITLE
Issue 127/solution for authenticated tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,13 @@ module.exports = {
     es6: true,
   },
   parserOptions: { ecmaVersion: 8 }, // to enable features such as async/await
-  ignorePatterns: ['node_modules/*', '.next/*', '.out/*', '!.prettierrc.js'], // We don't want to lint generated files nor node_modules, but we want to lint .prettierrc.js (ignored by default by eslint)
+  ignorePatterns: ['node_modules/*', '.next/*', '.out/*', '!.prettierrc.js', 'cypress/plugins/index.js'], // We don't want to lint generated files nor node_modules, but we want to lint .prettierrc.js (ignored by default by eslint)
   extends: ['eslint:recommended', 'plugin:react/recommended'],
   settings: { react: { version: 'detect' } },
   overrides: [
     // This configuration will apply only to TypeScript files
     {
-      files: ['**/*.ts', '**/*.tsx'],
+      files: ['**/*.ts', '**/*.tsx', 'cypress/**/*.js', 'src/**/*.js'],
       parser: '@typescript-eslint/parser',
       env: {
         browser: true,

--- a/cypress/integration/event_page.spec.ts
+++ b/cypress/integration/event_page.spec.ts
@@ -37,11 +37,7 @@ describe('/o/[orgId]/events/[eventId]', () => {
             },
         });
 
-        cy.visit('/login');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]')
-            .click();
+        cy.login();
 
         cy.visit('/o/1/events/25');
         cy.waitUntilReactRendered();
@@ -63,11 +59,7 @@ describe('/o/[orgId]/events/[eventId]', () => {
                 },
             });
 
-            cy.visit('/login');
-            cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-            cy.get('input[aria-label="Password"]').type('password');
-            cy.get('input[aria-label="Log in"]')
-                .click();
+            cy.login();
 
             cy.visit('/o/1/events/25');
             cy.waitUntilReactRendered();

--- a/cypress/integration/events_page.spec.ts
+++ b/cypress/integration/events_page.spec.ts
@@ -64,11 +64,7 @@ describe('/o/[orgId]/events', () => {
             },
         });
 
-        cy.visit('/login');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]')
-            .click();
+        cy.login();
 
         cy.visit('/o/1/events');
         cy.waitUntilReactRendered();
@@ -92,11 +88,7 @@ describe('/o/[orgId]/events', () => {
                 },
             });
 
-            cy.visit('/login');
-            cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-            cy.get('input[aria-label="Password"]').type('password');
-            cy.get('input[aria-label="Log in"]')
-                .click();
+            cy.login();
 
             cy.visit('/o/1/events');
             cy.waitUntilReactRendered();

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -9,11 +9,7 @@ describe('Login process', () => {
 
     it('contains a login form where you can login and see your details', () => {
         cy.visit('/login');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]')
-            .should('be.visible')
-            .click();
+        cy.fillLoginForm();
         cy.url().should('match', /\/$/);
         cy.get('[data-testid="username"]').should('be.visible');
         cy.get('[data-testid="user-avatar"]').should('be.visible');
@@ -21,9 +17,7 @@ describe('Login process', () => {
 
     it('takes you to My Page when clicking on user avatar', () => {
         cy.visit('/login');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]').click();
+        cy.fillLoginForm();
         cy.waitUntilReactRendered();
         cy.get('[data-testid="username"]').click();
         cy.url().should('match', /\/my$/);
@@ -36,17 +30,13 @@ describe('Login process', () => {
 
     it('redirects to tried page after logging in', () => {
         cy.visit('/my');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]').click();
+        cy.fillLoginForm();
         cy.url().should('match', /\/my$/);
     });
 
     it('contains a logout button wich logs you out and takes you back to the home page', () => {
         cy.visit('/login');
-        cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-        cy.get('input[aria-label="Password"]').type('password');
-        cy.get('input[aria-label="Log in"]').click();
+        cy.fillLoginForm();
         cy.getCookie('sid')
             .should('have.property', 'value')
             .then((cookie) => {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -2,5 +2,7 @@ declare namespace Cypress {
     interface Chainable<> {
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         waitUntilReactRendered(timeout? : number) : Chainable<any>;
+        login(): Chainable<Element>;
+        fillLoginForm(): Chainable<Element>;
     }
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,8 +2,45 @@
 require('@cypress/react/support');
 require('@testing-library/cypress/add-commands');
 
+const SESSION_ID = 'sid';
+
 Cypress.Commands.add('waitUntilReactRendered', (timeout = 10000) => {
     cy.window().its('__reactRendered', { timeout }).then(initialized => {
         return initialized;
     });
 });
+
+Cypress.Commands.add('waitUntilReactRendered', (timeout = 10000) => {
+    cy.window().its('__reactRendered', { timeout }).then(initialized => {
+        return initialized;
+    });
+});
+
+Cypress.Commands.add('loginFromRedirect', () => {
+    cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com', {delay: 0});
+    cy.get('input[aria-label="Password"]').type('password', {delay: 0});
+    cy.get('input[aria-label="Log in"]')
+        .should('be.visible')
+        .click();
+})
+
+Cypress.Commands.add('login', () => {
+    Cypress.Cookies.preserveOnce(SESSION_ID);
+
+    cy.getCookie(SESSION_ID).then(cookie => {
+        if (!cookie) {
+            cy.visit('/login')
+            cy.fillLoginForm()
+        } else {
+            cy.getCookie(SESSION_ID).should('have.property', 'value')
+        }
+    })
+})
+
+Cypress.Commands.add('fillLoginForm', () => {
+    cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
+            cy.get('input[aria-label="Password"]').type('password');
+            cy.get('input[aria-label="Log in"]')
+                .should('be.visible')
+                .click();
+})

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,45 +2,32 @@
 require('@cypress/react/support');
 require('@testing-library/cypress/add-commands');
 
-const SESSION_ID = 'sid';
+const COOKIE_NAME = 'sid';
 
 Cypress.Commands.add('waitUntilReactRendered', (timeout = 10000) => {
     cy.window().its('__reactRendered', { timeout }).then(initialized => {
         return initialized;
     });
 });
-
-Cypress.Commands.add('waitUntilReactRendered', (timeout = 10000) => {
-    cy.window().its('__reactRendered', { timeout }).then(initialized => {
-        return initialized;
-    });
-});
-
-Cypress.Commands.add('loginFromRedirect', () => {
-    cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com', {delay: 0});
-    cy.get('input[aria-label="Password"]').type('password', {delay: 0});
-    cy.get('input[aria-label="Log in"]')
-        .should('be.visible')
-        .click();
-})
 
 Cypress.Commands.add('login', () => {
-    Cypress.Cookies.preserveOnce(SESSION_ID);
+    Cypress.Cookies.preserveOnce(COOKIE_NAME);
 
-    cy.getCookie(SESSION_ID).then(cookie => {
+    cy.getCookie(COOKIE_NAME).then(cookie => {
         if (!cookie) {
-            cy.visit('/login')
-            cy.fillLoginForm()
-        } else {
-            cy.getCookie(SESSION_ID).should('have.property', 'value')
+            cy.visit('/login');
+            cy.fillLoginForm();
         }
-    })
-})
+        else {
+            cy.getCookie(COOKIE_NAME).should('have.property', 'value');
+        }
+    });
+});
 
 Cypress.Commands.add('fillLoginForm', () => {
     cy.get('input[aria-label="E-mail address"]').type('testadmin@example.com');
-            cy.get('input[aria-label="Password"]').type('password');
-            cy.get('input[aria-label="Log in"]')
-                .should('be.visible')
-                .click();
-})
+    cy.get('input[aria-label="Password"]').type('password');
+    cy.get('input[aria-label="Log in"]')
+        .should('be.visible')
+        .click();
+});

--- a/src/pages/my.tsx
+++ b/src/pages/my.tsx
@@ -6,6 +6,7 @@ import { scaffold } from '../utils/next';
 import { ZetkinUser } from '../types/zetkin';
 
 const scaffoldOptions = {
+    authLevelRequired: 1,
     localeScope: ['pages.my'],
 };
 


### PR DESCRIPTION
This PR extracts the login and filling out the login form logic to a custom cypress command, and preserves the session id when present, to prevent unnecessary visits to /login, in cases where the end goal of the test is irrelevant to the login functionality. Fixes #127