### PR TITLE
API token refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-leaflet": "^3.1.0",
     "react-query": "^3.5.11",
     "yaml": "^1.10.0",
-    "zetkin": "1.3.0"
+    "zetkin": "~1.3.1"
   },
   "devDependencies": {
     "@cypress/react": "^4.16.3",

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -120,6 +120,11 @@ export const scaffold = (wrapped : ScaffoldedGetServerSideProps, options? : Scaf
             }
         }
 
+        // Update token data in session, in case it was refreshed
+        if (reqWithSession.session) {
+            reqWithSession.session.tokenData = ctx.z.getTokenData();
+        }
+
         const result = await wrapped(ctx) || {};
 
         // Figure out browser's preferred language

--- a/yarn.lock
+++ b/yarn.lock
@@ -10081,10 +10081,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zetkin@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/zetkin/-/zetkin-1.3.0.tgz#220d0cbd83f6f0badd9ee4af832fc6d5beab1698"
-  integrity sha512-vEi8kg8JprJy+Fv8MReugpBTby4TsGUDig8z/gnh8KHJb2EmE5vaXtc85uIWEIW1LXhfsTwoXGik4tglLNPtlA==
+zetkin@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/zetkin/-/zetkin-1.3.1.tgz#b642caa8c98123fded363de6fdcd3f2da9670364"
+  integrity sha512-cbND1Rq2cBv1dP6NnHJ30Y8DiXfu1AniLolIuryRsucfP7E+Va4KHYsG1SZTV+PEiF1jeSgHlgbhZnD51fcB6w==
   dependencies:
     atob "^2.1.1"
     btoa "^1.2.1"


### PR DESCRIPTION
This PR fixes issues related to API token refresh. It updates the Zetkin SDK to a version that properly refreshes the tokens when used with the new API gateway. The PR also adds code to update the token data stored in the session after a refresh.