### PR TITLE
User Connections Page

### DIFF
--- a/cypress/fixtures/dummyFollowing.json
+++ b/cypress/fixtures/dummyFollowing.json
@@ -1,16 +1,16 @@
 {
     "data": [
         {
+            "follow": true,
+            "inherited": false,
             "organization": {
                 "title": "My Dummy Organization",
                 "id": 1
             },
-            "follow": true,
             "profile": {
                 "name": "Dummy User",
                 "id": 2
             },
-            "inherited": false,
             "role": "admin"
         }
     ]

--- a/cypress/fixtures/dummyFollowing.json
+++ b/cypress/fixtures/dummyFollowing.json
@@ -1,0 +1,17 @@
+{
+    "data": [
+        {
+            "organization": {
+                "title": "My Dummy Organization",
+                "id": 1
+            },
+            "follow": true,
+            "profile": {
+                "name": "Dummy User",
+                "id": 2
+            },
+            "inherited": false,
+            "role": "admin"
+        }
+    ]
+}

--- a/cypress/integration/my_orgs_page.spec.ts
+++ b/cypress/integration/my_orgs_page.spec.ts
@@ -1,12 +1,12 @@
 import { ZetkinMembership } from '../../src/types/zetkin';
 
 describe('/my/orgs', () => {
-    let dummyMemberships : {data: ZetkinMembership[]};
+    let dummyFollowing : {data: ZetkinMembership[]};
 
     before(() => {
-        cy.fixture('dummyMemberships.json')
+        cy.fixture('dummyFollowing.json')
             .then((data : {data: ZetkinMembership[]}) => {
-                dummyMemberships = data;
+                dummyFollowing = data;
             });
     });
 
@@ -18,10 +18,10 @@ describe('/my/orgs', () => {
         cy.request('delete', 'http://localhost:8001/_mocks');
     });
 
-    it('contains membership orgs', () => {
-        cy.request('put', 'http://localhost:8001/v1/users/me/memberships/_mocks/get', {
+    it('contains followed organizations', () => {
+        cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
             response: {
-                data: dummyMemberships,
+                data: dummyFollowing,
             },
         });
 
@@ -32,8 +32,8 @@ describe('/my/orgs', () => {
         cy.get('a[href*="/o/"]').should('have.length', 1);
     });
 
-    it('contains a placeholder if there are no memberships', () => {
-        cy.request('put', 'http://localhost:8001/v1/users/me/memberships/_mocks/get', {
+    it('contains a placeholder if there are no followed organizations', () => {
+        cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
             response: {
                 data: {
                     data: [],
@@ -45,6 +45,19 @@ describe('/my/orgs', () => {
 
         cy.visit('/my/orgs');
         cy.contains('You are not connected to any organizations yet.');
+    });
+
+    it('contains an unfollow button for each organization', () => {
+        cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
+            response: {
+                data: dummyFollowing,
+            },
+        });
+
+        cy.login();
+
+        cy.visit('/my/orgs');
+        cy.contains('Unfollow');
     });
 });
 

--- a/cypress/integration/my_orgs_page.spec.ts
+++ b/cypress/integration/my_orgs_page.spec.ts
@@ -1,0 +1,52 @@
+import { ZetkinMembership } from '../../src/types/zetkin';
+
+describe('/my/orgs', () => {
+    let dummyMemberships : {data: ZetkinMembership[]};
+
+    before(() => {
+        cy.fixture('dummyMemberships.json')
+            .then((data : {data: ZetkinMembership[]}) => {
+                dummyMemberships = data;
+            });
+    });
+
+    beforeEach(() => {
+        cy.request('delete', 'http://localhost:8001/_mocks');
+    });
+
+    after(() => {
+        cy.request('delete', 'http://localhost:8001/_mocks');
+    });
+
+    it('contains membership orgs', () => {
+        cy.request('put', 'http://localhost:8001/v1/users/me/memberships/_mocks/get', {
+            response: {
+                data: dummyMemberships,
+            },
+        });
+
+        cy.login();
+
+        cy.visit('/my/orgs');
+        cy.waitUntilReactRendered();
+        cy.get('a[href*="/o/"]').should('have.length', 1);
+    });
+
+    it('contains a placeholder if there are no memberships', () => {
+        cy.request('put', 'http://localhost:8001/v1/users/me/memberships/_mocks/get', {
+            response: {
+                data: {
+                    data: [],
+                },
+            },
+        });
+
+        cy.login();
+
+        cy.visit('/my/orgs');
+        cy.contains('You are not connected to any organizations yet.');
+    });
+});
+
+// Hack to flag for typescript as module
+export {};

--- a/cypress/integration/my_orgs_page.spec.ts
+++ b/cypress/integration/my_orgs_page.spec.ts
@@ -18,7 +18,7 @@ describe('/my/orgs', () => {
         cy.request('delete', 'http://localhost:8001/_mocks');
     });
 
-    it('contains followed organizations', () => {
+    it('contains a list of followed organizations', () => {
         cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
             response: {
                 data: dummyFollowing,
@@ -30,34 +30,6 @@ describe('/my/orgs', () => {
         cy.visit('/my/orgs');
         cy.waitUntilReactRendered();
         cy.get('a[href*="/o/"]').should('have.length', 1);
-    });
-
-    it('contains a placeholder if there are no followed organizations', () => {
-        cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
-            response: {
-                data: {
-                    data: [],
-                },
-            },
-        });
-
-        cy.login();
-
-        cy.visit('/my/orgs');
-        cy.contains('You are not connected to any organizations yet.');
-    });
-
-    it('contains an unfollow button for each organization', () => {
-        cy.request('put', 'http://localhost:8001/v1/users/me/following/_mocks/get', {
-            response: {
-                data: dummyFollowing,
-            },
-        });
-
-        cy.login();
-
-        cy.visit('/my/orgs');
-        cy.contains('Unfollow');
     });
 });
 

--- a/src/components/UserFollowingList.spec.tsx
+++ b/src/components/UserFollowingList.spec.tsx
@@ -1,0 +1,84 @@
+import { mountWithProviders } from '../utils/testing';
+import UserFollowingList from './UserFollowingList';
+import { ZetkinMembership } from '../types/zetkin';
+
+describe('UserFollowingList', () => {
+    let dummyFollowing : ZetkinMembership[];
+
+    before(() => {
+        cy.fixture('dummyFollowing.json')
+            .then((data : {data: ZetkinMembership[]}) => {
+                dummyFollowing = data.data;
+            });
+    });
+
+    it('contains data for each followed organization', () => {
+        mountWithProviders(
+            <UserFollowingList
+                following={ dummyFollowing }
+                onUnfollow={ () => null }
+            />,
+        );
+
+        cy.get('[data-testid="following-list"]').each((item) => {
+            cy.wrap(item)
+                .get('[data-testid="org-avatar"]').should('be.visible')
+                .get('[data-testid="org-title"]').should('be.visible')
+                .get('[data-testid="user-role"]').should('be.visible');
+        });
+    });
+
+    it('contains a placeholder if user has no role', () => {
+        dummyFollowing[0].role = null;
+
+        mountWithProviders(
+            <UserFollowingList
+                following={ dummyFollowing }
+                onUnfollow={ () => null }
+            />,
+        );
+
+        cy.get('[data-testid="following-item"]')
+            .should('contain', 'pages.myOrgs.rolePlaceholder')
+            .should('not.contain', 'undefined');
+    });
+
+    it('contains a placeholder if user does not follow any organizations', () => {
+        mountWithProviders(
+            <UserFollowingList
+                following={ [] }
+                onUnfollow={ () => null }
+            />,
+        );
+
+        cy.contains('pages.myOrgs.orgsPlaceholder');
+    });
+
+    it('contains an unfollow button for each organization', () => {
+        const spyOnSignup = cy.spy();
+
+        mountWithProviders(
+            <UserFollowingList
+                following={ dummyFollowing }
+                onUnfollow={ spyOnSignup }
+            />,
+        );
+
+        cy.findByText('pages.myOrgs.unfollow')
+            .click()
+            .then(() => {
+                expect(spyOnSignup).to.be.calledOnce;
+            });
+    });
+
+    it('contains links for each organization', () => {
+        mountWithProviders(
+            <UserFollowingList
+                following={ dummyFollowing }
+                onUnfollow={ () => null }
+            />,
+        );
+
+        cy.get('a[href*="/o/"]').should('have.length', 1);
+    });
+});

--- a/src/components/UserFollowingList.tsx
+++ b/src/components/UserFollowingList.tsx
@@ -25,7 +25,7 @@ const UserFollowingList = ({ following, onUnfollow } : UserFollowingListProps) :
         <Flex data-testid="following-list" direction="column">
             { following.map(follow => (
                 <Flex
-                    key="follow.organization.id"
+                    key={ follow.organization.id }
                     alignItems="center"
                     marginY="size-200">
                     <Flex data-testid="following-item">

--- a/src/components/UserFollowingList.tsx
+++ b/src/components/UserFollowingList.tsx
@@ -46,7 +46,7 @@ const UserFollowingList = ({ following, onUnfollow } : UserFollowingListProps) :
                             { follow.role
                                 ? (
                                     <Text data-testid="user-role" marginX="size-200">
-                                        <Msg id={ `pages.myOrgs.${follow.role}` }/>
+                                        <Msg id={ `pages.myOrgs.roles.${follow.role}` }/>
                                     </Text>
                                 ) : (
                                     <Text marginX="size-200">

--- a/src/components/UserFollowingList.tsx
+++ b/src/components/UserFollowingList.tsx
@@ -25,7 +25,7 @@ const UserFollowingList = ({ following, onUnfollow } : UserFollowingListProps) :
         <Flex data-testid="following-list" direction="column">
             { following.map(follow => (
                 <Flex
-                    key="follow.profile.id"
+                    key="follow.organization.id"
                     alignItems="center"
                     marginY="size-200">
                     <Flex data-testid="following-item">

--- a/src/components/UserFollowingList.tsx
+++ b/src/components/UserFollowingList.tsx
@@ -44,8 +44,11 @@ const UserFollowingList = ({ following, onUnfollow } : UserFollowingListProps) :
                                 </a>
                             </NextLink>
                             { follow.role
-                                ? <Text data-testid="user-role" marginX="size-200">{ follow.role }</Text>
-                                : (
+                                ? (
+                                    <Text data-testid="user-role" marginX="size-200">
+                                        <Msg id={ `pages.myOrgs.${follow.role}` }/>
+                                    </Text>
+                                ) : (
                                     <Text marginX="size-200">
                                         <Msg id="pages.myOrgs.rolePlaceholder"/>
                                     </Text>

--- a/src/components/UserFollowingList.tsx
+++ b/src/components/UserFollowingList.tsx
@@ -1,0 +1,68 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import NextLink from 'next/link';
+import { Button, Flex, Image, Text } from '@adobe/react-spectrum';
+
+import apiUrl from '../utils/apiUrl';
+import { ZetkinMembership } from '../types/zetkin';
+
+
+interface UserFollowingListProps {
+    following: ZetkinMembership[] | undefined;
+    onUnfollow: (orgId : number) => void;
+}
+
+const UserFollowingList = ({ following, onUnfollow } : UserFollowingListProps) : JSX.Element => {
+
+    if (!following || following.length === 0) {
+        return (
+            <Text data-testid="no-orgs-placeholder">
+                <Msg id="pages.myOrgs.orgsPlaceholder"/>
+            </Text>
+        );
+    }
+
+    return (
+        <Flex data-testid="following-list" direction="column">
+            { following.map(follow => (
+                <Flex
+                    key="follow.profile.id"
+                    alignItems="center"
+                    marginY="size-200">
+                    <Flex data-testid="following-item">
+                        <Image
+                            alt="Organization avatar"
+                            data-testid="org-avatar"
+                            height="size-600"
+                            objectFit="contain"
+                            src={ apiUrl(`/orgs/${follow.organization.id}/avatar`) }
+                            width="size-600"
+                        />
+                        <Flex direction="column">
+                            <NextLink href={ `/o/${follow.organization.id}` }>
+                                <a>
+                                    <Text data-testid="org-title" marginX="size-200">{ follow.organization.title }</Text>
+                                </a>
+                            </NextLink>
+                            { follow.role
+                                ? <Text data-testid="user-role" marginX="size-200">{ follow.role }</Text>
+                                : (
+                                    <Text marginX="size-200">
+                                        <Msg id="pages.myOrgs.rolePlaceholder"/>
+                                    </Text>
+                                )
+                            }
+                        </Flex>
+                    </Flex>
+                    <Button
+                        isQuiet
+                        onPress={ () => onUnfollow(follow.organization.id) }
+                        variant="negative">
+                        <Msg id="pages.myOrgs.unfollow"/>
+                    </Button>
+                </Flex>
+            )) }
+        </Flex>
+    );
+};
+
+export default UserFollowingList;

--- a/src/components/layout/MainOrgLayout.tsx
+++ b/src/components/layout/MainOrgLayout.tsx
@@ -10,6 +10,7 @@ import { Item, Tabs } from '@react-spectrum/tabs';
 import DefaultOrgLayout from './DefaultOrgLayout';
 import getOrg from '../../fetching/getOrg';
 import OrgHeader from './OrgHeader';
+import { useUserFollowing } from '../../hooks';
 
 interface MainOrgLayoutProps {
     orgId: string;
@@ -17,6 +18,9 @@ interface MainOrgLayoutProps {
 
 const MainOrgLayout : FunctionComponent<MainOrgLayoutProps> = ({ children, orgId }) => {
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
+
+    const { following, onFollow, onUnfollow } = useUserFollowing();
+
     const router = useRouter();
     const path =  router.pathname.split('/');
     let currentTab = path.pop();
@@ -40,7 +44,12 @@ const MainOrgLayout : FunctionComponent<MainOrgLayoutProps> = ({ children, orgId
 
     return (
         <DefaultOrgLayout orgId={ orgId }>
-            <OrgHeader org={ orgQuery.data! }/>
+            <OrgHeader
+                following={ following }
+                onFollow={ onFollow }
+                onUnfollow={ onUnfollow }
+                org={ orgQuery.data! }
+            />
             <Tabs
                 aria-label="Organization submenu"
                 onSelectionChange={ onSelectTab }

--- a/src/components/layout/OrgHeader.spec.tsx
+++ b/src/components/layout/OrgHeader.spec.tsx
@@ -1,0 +1,70 @@
+import { mountWithProviders } from '../../utils/testing';
+import OrgHeader from './OrgHeader';
+import { UserContext } from '../../hooks';
+import {
+    ZetkinMembership,
+    ZetkinOrganization,
+} from '../../types/zetkin';
+
+describe('OrgHeader', () => {
+    let dummyOrg : ZetkinOrganization;
+    let dummyFollowing : ZetkinMembership[];
+
+    const dummyUser = {
+        first_name: 'Firstname',
+        id: 100,
+        last_name: 'Lastname',
+        username: 'Username',
+    };
+
+    before(()=> {
+        cy.fixture('dummyOrg.json')
+            .then((data : ZetkinOrganization) => {
+                dummyOrg = data;
+            });
+        cy.fixture('dummyFollowing.json')
+            .then((data : {data: ZetkinMembership[]}) => {
+                dummyFollowing = data.data;
+            });
+    });
+
+    it('contains a follow button if user is logged in and not following', () => {
+        const spyOnSignup = cy.spy();
+        mountWithProviders(
+            <UserContext.Provider value={ dummyUser }>
+                <OrgHeader
+                    following={ [] }
+                    onFollow={ spyOnSignup }
+                    onUnfollow={ () => null }
+                    org={ dummyOrg }
+                />
+            </UserContext.Provider>,
+        );
+
+        cy.findByText('layout.org.actions.follow')
+            .click()
+            .then(() => {
+                expect(spyOnSignup).to.be.calledOnce;
+            });
+    });
+
+    it('contains a unfollow button if user is logged in and following', () => {
+        const spyOnSignup = cy.spy();
+        mountWithProviders(
+            <UserContext.Provider value={ dummyUser }>
+                <OrgHeader
+                    following={ dummyFollowing }
+                    onFollow={ () => null }
+                    onUnfollow={ spyOnSignup }
+                    org={ dummyOrg }
+                />
+            </UserContext.Provider>,
+        );
+
+        cy.findByText('layout.org.actions.unfollow')
+            .click()
+            .then(() => {
+                expect(spyOnSignup).to.be.calledOnce;
+            });
+    });
+});

--- a/src/components/layout/OrgHeader.spec.tsx
+++ b/src/components/layout/OrgHeader.spec.tsx
@@ -67,18 +67,4 @@ describe('OrgHeader', () => {
                 expect(spyOnSignup).to.be.calledOnce;
             });
     });
-
-    it('contains a sign-up button when user is not logged in', () => {
-        mountWithProviders(
-            <OrgHeader
-                following={ [] }
-                onFollow={ () => null }
-                onUnfollow={ () => null }
-                org={ dummyOrg }
-            />,
-        );
-        cy.get('[data-test="dialog-trigger-button"]').should('exist');
-        cy.get('[data-test="follow-button"]').should('not.exist');
-        cy.get('[data-test="unfollow-button"]').should('not.exist');
-    });
 });

--- a/src/components/layout/OrgHeader.spec.tsx
+++ b/src/components/layout/OrgHeader.spec.tsx
@@ -67,4 +67,18 @@ describe('OrgHeader', () => {
                 expect(spyOnSignup).to.be.calledOnce;
             });
     });
+
+    it('contains a sign-up button when user is not logged in', () => {
+        mountWithProviders(
+            <OrgHeader
+                following={ [] }
+                onFollow={ () => null }
+                onUnfollow={ () => null }
+                org={ dummyOrg }
+            />,
+        );
+        cy.get('[data-test="dialog-trigger-button"]').should('exist');
+        cy.get('[data-test="follow-button"]').should('not.exist');
+        cy.get('[data-test="unfollow-button"]').should('not.exist');
+    });
 });

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -48,25 +48,23 @@ const OrgHeader = ({ following, onFollow, onUnfollow, org } : OrgHeaderProps) : 
                         </Link>
                     </View>
                     { user ? (
-                        <>
-                            { follows ? (
-                                <Button
-                                    data-testid="unfollow-button"
-                                    onPress={ () => onUnfollow(org.id) }
-                                    variant="cta">
-                                    <Msg id="layout.org.actions.unfollow"/>
-                                </Button>
-                            ) : (
-                                <Button
-                                    data-testid="follow-button"
-                                    onPress={ () => onFollow(org.id) }
-                                    variant="cta">
-                                    <Msg id="layout.org.actions.follow"/>
-                                </Button>
-                            ) }
-                        </>
+                        follows ? (
+                            <Button
+                                data-testid="unfollow-button"
+                                onPress={ () => onUnfollow(org.id) }
+                                variant="cta">
+                                <Msg id="layout.org.actions.unfollow"/>
+                            </Button>
+                        ) : (
+                            <Button
+                                data-testid="follow-button"
+                                onPress={ () => onFollow(org.id) }
+                                variant="cta">
+                                <Msg id="layout.org.actions.follow"/>
+                            </Button>
+                        )
                     //TODO: Create button alternative for non-users
-                    ) : <></>  }
+                    ) : <></> }
                 </Flex>
             </Flex>
             <View>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -10,13 +10,20 @@ import {
     View,
 } from '@adobe/react-spectrum';
 
-import { ZetkinOrganization } from '../../types/zetkin';
+import { useUser } from '../../hooks/';
+import { ZetkinMembership, ZetkinOrganization } from '../../types/zetkin';
 
 interface OrgHeaderProps {
+    following: ZetkinMembership[] | undefined;
+    onFollow: (orgId: number) => void;
+    onUnfollow: (orgId: number) => void;
     org: ZetkinOrganization;
 }
 
-const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
+const OrgHeader = ({ following, onFollow, onUnfollow, org } : OrgHeaderProps) : JSX.Element => {
+    const follows = following?.some(follow => follow.organization.id === org.id);
+    const user = useUser();
+
     return (
         <Header>
             <Image
@@ -40,9 +47,26 @@ const OrgHeader = ({ org } : OrgHeaderProps) : JSX.Element => {
                             </NextLink>
                         </Link>
                     </View>
-                    <Button data-testid="unfollow-button" variant="cta">
-                        <Msg id="layout.org.actions.unfollow"/>
-                    </Button>
+                    { user ? (
+                        <>
+                            { follows ? (
+                                <Button
+                                    data-testid="unfollow-button"
+                                    onPress={ () => onUnfollow(org.id) }
+                                    variant="cta">
+                                    <Msg id="layout.org.actions.unfollow"/>
+                                </Button>
+                            ) : (
+                                <Button
+                                    data-testid="follow-button"
+                                    onPress={ () => onFollow(org.id) }
+                                    variant="cta">
+                                    <Msg id="layout.org.actions.follow"/>
+                                </Button>
+                            ) }
+                        </>
+                    //TODO: Add account sign-up button or other JSX.Element
+                    ) : <></> }
                 </Flex>
             </Flex>
             <View>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -10,6 +10,7 @@ import {
     View,
 } from '@adobe/react-spectrum';
 
+import SignupDialogTrigger from '../SignupDialog';
 import { useUser } from '../../hooks/';
 import { ZetkinMembership, ZetkinOrganization } from '../../types/zetkin';
 
@@ -65,8 +66,7 @@ const OrgHeader = ({ following, onFollow, onUnfollow, org } : OrgHeaderProps) : 
                                 </Button>
                             ) }
                         </>
-                    //TODO: Add account sign-up button or other JSX.Element
-                    ) : <></> }
+                    ) : <SignupDialogTrigger />  }
                 </Flex>
             </Flex>
             <View>

--- a/src/components/layout/OrgHeader.tsx
+++ b/src/components/layout/OrgHeader.tsx
@@ -10,7 +10,6 @@ import {
     View,
 } from '@adobe/react-spectrum';
 
-import SignupDialogTrigger from '../SignupDialog';
 import { useUser } from '../../hooks/';
 import { ZetkinMembership, ZetkinOrganization } from '../../types/zetkin';
 
@@ -66,7 +65,8 @@ const OrgHeader = ({ following, onFollow, onUnfollow, org } : OrgHeaderProps) : 
                                 </Button>
                             ) }
                         </>
-                    ) : <SignupDialogTrigger />  }
+                    //TODO: Create button alternative for non-users
+                    ) : <></>  }
                 </Flex>
             </Flex>
             <View>

--- a/src/fetching/deleteUserFollowing.ts
+++ b/src/fetching/deleteUserFollowing.ts
@@ -1,0 +1,7 @@
+import apiUrl from '../utils/apiUrl';
+
+export default async function deleteUserFollowing(orgId : number) : Promise<void> {
+    await fetch(apiUrl(`/users/me/following/${orgId}`), {
+        method: 'DELETE',
+    });
+}

--- a/src/fetching/getUserFollowing.ts
+++ b/src/fetching/getUserFollowing.ts
@@ -1,0 +1,11 @@
+import { defaultFetch } from '.';
+import { ZetkinMembership } from '../types/zetkin';
+
+export default function getUserFollowing(fetch = defaultFetch) {
+    return async () : Promise<ZetkinMembership[]> => {
+        const fRes = await fetch(`/users/me/following`);
+        const fData = await fRes.json();
+
+        return fData.data;
+    };
+}

--- a/src/fetching/putUserFollowing.ts
+++ b/src/fetching/putUserFollowing.ts
@@ -1,0 +1,20 @@
+import apiUrl from '../utils/apiUrl';
+import { ZetkinMembership } from '../types/zetkin';
+
+export default async function putUserFollowing(orgId : number) : Promise<ZetkinMembership> {
+    const mRes = await fetch(apiUrl('/users/me/memberships'));
+    const mData = await mRes.json();
+    //TODO: Memberships should be cached.
+    const orgMembership = mData.data.find((m : ZetkinMembership ) => m.organization.id === orgId);
+
+    if (orgMembership) {
+        const fRes = await fetch(apiUrl(`/users/me/following/${orgId}`), {
+            method: 'PUT',
+        });
+        const fResData = await fRes.json();
+
+        return fResData.data;
+    }
+
+    throw 'no membership';
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,10 +2,13 @@ import React from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import deleteEventResponse from '../fetching/deleteEventResponse';
+import deleteUserFollowing from '../fetching/deleteUserFollowing';
 import getEventResponses from '../fetching/getEventResponses';
 import getRespondEvents from '../fetching/getRespondEvents';
+import getUserFollowing from '../fetching/getUserFollowing';
 import putEventResponse from '../fetching/putEventResponse';
-import { ZetkinEvent, ZetkinEventResponse, ZetkinUser } from '../types/zetkin';
+import putUserFollowing from '../fetching/putUserFollowing';
+import { ZetkinEvent, ZetkinEventResponse, ZetkinMembership, ZetkinUser } from '../types/zetkin';
 
 export const UserContext = React.createContext<ZetkinUser | null>(null);
 
@@ -73,4 +76,42 @@ export const useRespondEvents = () : RespondEvents => {
     }
 
     return { onUndoSignup, respondEvents };
+};
+
+type OnFollow = (orgId : number) => void;
+type OnUnfollow = (orgId : number) => void;
+
+type UserFollowing = {
+    following: ZetkinMembership[] | undefined;
+    onFollow: OnFollow;
+    onUnfollow: OnUnfollow;
+}
+
+export const useUserFollowing = () : UserFollowing => {
+    const followingQuery = useQuery('following', getUserFollowing());
+    const following = followingQuery.data;
+
+    const queryClient = useQueryClient();
+
+    const removeFunc = useMutation(deleteUserFollowing, {
+        onSettled: () => {
+            queryClient.invalidateQueries('following');
+        },
+    });
+
+    const addFunc = useMutation(putUserFollowing, {
+        onSettled: () => {
+            queryClient.invalidateQueries('following');
+        },
+    });
+
+    function onUnfollow (orgId : number) {
+        removeFunc.mutate(orgId);
+    }
+
+    function onFollow (orgId : number) {
+        addFunc.mutate(orgId);
+    }
+
+    return { following, onFollow, onUnfollow };
 };

--- a/src/locale/layout/org/en.yml
+++ b/src/locale/layout/org/en.yml
@@ -1,5 +1,6 @@
 actions:
   edit: Edit Page
+  follow: Follow
   unfollow: Unfollow
 tabs:
   home: Home

--- a/src/locale/layout/org/sv.yml
+++ b/src/locale/layout/org/sv.yml
@@ -1,5 +1,6 @@
 actions:
   edit: Redigera sida
+  follow: Följ
   unfollow: Sluta följa
 tabs:
   home: Hem

--- a/src/locale/pages/myOrgs/en.yml
+++ b/src/locale/pages/myOrgs/en.yml
@@ -1,4 +1,4 @@
 heading: Organizations
-rolePlaceholder: You don't have a role yet
+rolePlaceholder: You don't have a role.
 orgsPlaceholder: You are not connected to any organizations yet.
 unfollow: Unfollow

--- a/src/locale/pages/myOrgs/en.yml
+++ b/src/locale/pages/myOrgs/en.yml
@@ -1,6 +1,7 @@
-admin: Admin
 heading: Organizations
-organizer: Organizer
 orgsPlaceholder: You are not connected to any organizations yet.
+roles:
+  admin: Admin
+  organizer: Organizer
 rolePlaceholder: You don't have a role.
 unfollow: Unfollow

--- a/src/locale/pages/myOrgs/en.yml
+++ b/src/locale/pages/myOrgs/en.yml
@@ -1,4 +1,6 @@
+admin: Admin
 heading: Organizations
-rolePlaceholder: You don't have a role.
+organizer: Organizer
 orgsPlaceholder: You are not connected to any organizations yet.
+rolePlaceholder: You don't have a role.
 unfollow: Unfollow

--- a/src/locale/pages/myOrgs/en.yml
+++ b/src/locale/pages/myOrgs/en.yml
@@ -1,3 +1,4 @@
 heading: Organizations
 rolePlaceholder: You don't have a role yet
 orgsPlaceholder: You are not connected to any organizations yet.
+unfollow: Unfollow

--- a/src/locale/pages/myOrgs/en.yml
+++ b/src/locale/pages/myOrgs/en.yml
@@ -1,1 +1,3 @@
 heading: Organizations
+rolePlaceholder: You don't have a role yet
+orgsPlaceholder: You are not connected to any organizations yet.

--- a/src/locale/pages/myOrgs/sv.yml
+++ b/src/locale/pages/myOrgs/sv.yml
@@ -1,3 +1,4 @@
 heading: Organisationer
 rolePlaceholder: Du har ingen funktionärsroll ännu
 orgsPlaceholder: Du är inte kopplad till några organisationer ännu.
+unfollow: Sluta följa

--- a/src/locale/pages/myOrgs/sv.yml
+++ b/src/locale/pages/myOrgs/sv.yml
@@ -1,6 +1,7 @@
-admin: Administratör
 heading: Organisationer
-organizer: Organisatör
 orgsPlaceholder: Du är inte kopplad till några organisationer ännu.
+roles:
+  admin: Administratör
+  organizer: Organisatör
 rolePlaceholder: Du har ingen funktionärsroll.
 unfollow: Sluta följa

--- a/src/locale/pages/myOrgs/sv.yml
+++ b/src/locale/pages/myOrgs/sv.yml
@@ -1,1 +1,3 @@
 heading: Organisationer
+rolePlaceholder: Du har ingen funktionärsroll ännu
+orgsPlaceholder: Du är inte kopplad till några organisationer ännu.

--- a/src/locale/pages/myOrgs/sv.yml
+++ b/src/locale/pages/myOrgs/sv.yml
@@ -1,4 +1,4 @@
 heading: Organisationer
-rolePlaceholder: Du har ingen funktionärsroll ännu
+rolePlaceholder: Du har ingen funktionärsroll.
 orgsPlaceholder: Du är inte kopplad till några organisationer ännu.
 unfollow: Sluta följa

--- a/src/locale/pages/myOrgs/sv.yml
+++ b/src/locale/pages/myOrgs/sv.yml
@@ -1,4 +1,6 @@
+admin: Administratör
 heading: Organisationer
-rolePlaceholder: Du har ingen funktionärsroll.
+organizer: Organisatör
 orgsPlaceholder: Du är inte kopplad till några organisationer ännu.
+rolePlaceholder: Du har ingen funktionärsroll.
 unfollow: Sluta följa

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -21,15 +21,9 @@ const scaffoldOptions = {
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const { user } = context;
 
-    let followingState;
-
     if (user) {
         await context.queryClient.prefetchQuery('following', getUserFollowing(context.apiFetch));
 
-        followingState = context.queryClient.getQueryState('following');
-    }
-
-    if (followingState?.status === 'success') {
         return {
             props: {},
         };

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -54,7 +54,7 @@ const MyOrgsPage : PageWithLayout = () => {
                     <Msg id="pages.myOrgs.heading"/>
                 </Heading>
                 <Text data-testid="no-orgs-placeholder">
-                    You are not connected to any organizations yet.
+                    <Msg id="pages.myOrgs.orgsPlaceholder"/>
                 </Text>
             </>
         );
@@ -82,7 +82,7 @@ const MyOrgsPage : PageWithLayout = () => {
                                     <Text marginX="size-200">{ membership.organization.title }</Text>
                                     { membership.role
                                         ? <Text marginX="size-200">{ membership.role }</Text>
-                                        : <Text marginX="size-200">You do not have a role yet</Text>
+                                        : <Text marginX="size-200"><Msg id="pages.myOrgs.rolePlaceholder"/></Text>
                                     }
                                 </Flex>
                             </Flex>

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -1,10 +1,15 @@
 import { GetServerSideProps } from 'next';
-import { Heading } from '@adobe/react-spectrum';
 import { FormattedMessage as Msg } from 'react-intl';
+import NextLink from 'next/link';
+import { useQuery } from 'react-query';
+import { Flex, Heading, Image, Text } from '@adobe/react-spectrum';
 
+import apiUrl from '../../utils/apiUrl';
+import getUserMemberships from '../../fetching/getUserMemberships';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
+
 
 const scaffoldOptions = {
     authLevelRequired: 1,
@@ -15,18 +20,77 @@ const scaffoldOptions = {
     ],
 };
 
-export const getServerSideProps : GetServerSideProps = scaffold(async () => {
-    return {
-        props: {},
-    };
+export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
+    const { user } = context;
+
+    let membershipsState;
+
+    if (user) {
+        await context.queryClient.prefetchQuery('memberships', getUserMemberships(context.apiFetch));
+
+        membershipsState = context.queryClient.getQueryState('memberships');
+    }
+
+    if (membershipsState?.status === 'success') {
+        return {
+            props: {},
+        };
+    }
+    else {
+        return {
+            notFound: true,
+        };
+    }
 }, scaffoldOptions);
 
 const MyOrgsPage : PageWithLayout = () => {
+    const membershipsQuery = useQuery('memberships', getUserMemberships());
+    const memberships = membershipsQuery.data;
+
+    if (!memberships || memberships.length === 0) {
+        return (
+            <>
+                <Heading level={ 1 }>
+                    <Msg id="pages.myOrgs.heading"/>
+                </Heading>
+                <Text data-testid="no-orgs-placeholder">
+                    You are not connected to any organizations yet.
+                </Text>
+            </>
+        );
+    }
 
     return (
-        <Heading level={ 1 }>
-            <Msg id="pages.myOrgs.heading"/>
-        </Heading>
+        <>
+            <Heading level={ 1 }>
+                <Msg id="pages.myOrgs.heading"/>
+            </Heading>
+            <Flex direction="column">
+                { memberships.map(membership => (
+                    <NextLink key="membership.profile.id" href={ `/o/${membership.organization.id}` }>
+                        <a>
+                            <Flex alignItems="center" marginY="size-200">
+                                <Image
+                                    alt="Organization avatar"
+                                    data-testid="org-avatar"
+                                    height="size-600"
+                                    objectFit="contain"
+                                    src={ apiUrl(`/orgs/${membership.organization.id}/avatar`) }
+                                    width="size-600"
+                                />
+                                <Flex direction="column">
+                                    <Text marginX="size-200">{ membership.organization.title }</Text>
+                                    { membership.role
+                                        ? <Text marginX="size-200">{ membership.role }</Text>
+                                        : <Text marginX="size-200">You do not have a role yet</Text>
+                                    }
+                                </Flex>
+                            </Flex>
+                        </a>
+                    </NextLink>
+                )) }
+            </Flex>
+        </>
     );
 };
 

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -1,13 +1,12 @@
 import { GetServerSideProps } from 'next';
+import { Heading } from '@adobe/react-spectrum';
 import { FormattedMessage as Msg } from 'react-intl';
-import NextLink from 'next/link';
-import { Button, Flex, Heading, Image, Text } from '@adobe/react-spectrum';
 
-import apiUrl from '../../utils/apiUrl';
 import getUserFollowing from '../../fetching/getUserFollowing';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
+import UserFollowingList from '../../components/UserFollowingList';
 import { useUserFollowing } from '../../hooks';
 
 const scaffoldOptions = {
@@ -46,64 +45,15 @@ const MyOrgsPage : PageWithLayout = () => {
 
     const { following, onUnfollow } = useUserFollowing();
 
-    if (!following || following.length === 0) {
-        return (
-            <>
-                <Heading level={ 1 }>
-                    <Msg id="pages.myOrgs.heading"/>
-                </Heading>
-                <Text data-testid="no-orgs-placeholder">
-                    <Msg id="pages.myOrgs.orgsPlaceholder"/>
-                </Text>
-            </>
-        );
-    }
-
     return (
         <>
             <Heading level={ 1 }>
                 <Msg id="pages.myOrgs.heading"/>
             </Heading>
-            <Flex direction="column">
-                { following.map(follow => (
-                    <Flex
-                        key="follow.profile.id"
-                        alignItems="center"
-                        marginY="size-200">
-                        <Flex>
-                            <Image
-                                alt="Organization avatar"
-                                data-testid="org-avatar"
-                                height="size-600"
-                                objectFit="contain"
-                                src={ apiUrl(`/orgs/${follow.organization.id}/avatar`) }
-                                width="size-600"
-                            />
-                            <Flex direction="column">
-                                <NextLink href={ `/o/${follow.organization.id}` }>
-                                    <a>
-                                        <Text marginX="size-200">{ follow.organization.title }</Text>
-                                    </a>
-                                </NextLink>
-                                { follow.role
-                                    ? <Text marginX="size-200">{ follow.role }</Text>
-                                    : (
-                                        <Text marginX="size-200">
-                                            <Msg id="pages.myOrgs.rolePlaceholder"/>
-                                        </Text>
-                                    )
-                                }
-                            </Flex>
-                        </Flex>
-                        <Button
-                            isQuiet
-                            onPress={ () => onUnfollow(follow.organization.id) }
-                            variant="negative">
-                            <Msg id="pages.myOrgs.unfollow"/>
-                        </Button>
-                    </Flex>
-                )) }
-            </Flex>
+            <UserFollowingList
+                following={ following }
+                onUnfollow={ onUnfollow }
+            />
         </>
     );
 };

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -1,15 +1,15 @@
 import { GetServerSideProps } from 'next';
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
-import { useQuery } from 'react-query';
-import { Flex, Heading, Image, Text } from '@adobe/react-spectrum';
+import { Button, Flex, Heading, Image, Text } from '@adobe/react-spectrum';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import apiUrl from '../../utils/apiUrl';
-import getUserMemberships from '../../fetching/getUserMemberships';
+import deleteUserFollowing from '../../fetching/deleteUserFollowing';
+import getUserFollowing from '../../fetching/getUserFollowing';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
-
 
 const scaffoldOptions = {
     authLevelRequired: 1,
@@ -23,15 +23,15 @@ const scaffoldOptions = {
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     const { user } = context;
 
-    let membershipsState;
+    let followingState;
 
     if (user) {
-        await context.queryClient.prefetchQuery('memberships', getUserMemberships(context.apiFetch));
+        await context.queryClient.prefetchQuery('following', getUserFollowing(context.apiFetch));
 
-        membershipsState = context.queryClient.getQueryState('memberships');
+        followingState = context.queryClient.getQueryState('following');
     }
 
-    if (membershipsState?.status === 'success') {
+    if (followingState?.status === 'success') {
         return {
             props: {},
         };
@@ -44,10 +44,22 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 }, scaffoldOptions);
 
 const MyOrgsPage : PageWithLayout = () => {
-    const membershipsQuery = useQuery('memberships', getUserMemberships());
-    const memberships = membershipsQuery.data;
+    const followingQuery = useQuery('following', getUserFollowing());
+    const following = followingQuery.data;
 
-    if (!memberships || memberships.length === 0) {
+    const queryClient = useQueryClient();
+
+    const removeFunc = useMutation(deleteUserFollowing, {
+        onSettled: () => {
+            queryClient.invalidateQueries('following');
+        },
+    });
+
+    function onDisconnect (orgId : number) {
+        removeFunc.mutate(orgId);
+    }
+
+    if (!following || following.length === 0) {
         return (
             <>
                 <Heading level={ 1 }>
@@ -66,28 +78,43 @@ const MyOrgsPage : PageWithLayout = () => {
                 <Msg id="pages.myOrgs.heading"/>
             </Heading>
             <Flex direction="column">
-                { memberships.map(membership => (
-                    <NextLink key="membership.profile.id" href={ `/o/${membership.organization.id}` }>
-                        <a>
-                            <Flex alignItems="center" marginY="size-200">
-                                <Image
-                                    alt="Organization avatar"
-                                    data-testid="org-avatar"
-                                    height="size-600"
-                                    objectFit="contain"
-                                    src={ apiUrl(`/orgs/${membership.organization.id}/avatar`) }
-                                    width="size-600"
-                                />
-                                <Flex direction="column">
-                                    <Text marginX="size-200">{ membership.organization.title }</Text>
-                                    { membership.role
-                                        ? <Text marginX="size-200">{ membership.role }</Text>
-                                        : <Text marginX="size-200"><Msg id="pages.myOrgs.rolePlaceholder"/></Text>
-                                    }
-                                </Flex>
+                { following.map(follow => (
+                    <Flex
+                        key="follow.profile.id"
+                        alignItems="center"
+                        marginY="size-200">
+                        <Flex>
+                            <Image
+                                alt="Organization avatar"
+                                data-testid="org-avatar"
+                                height="size-600"
+                                objectFit="contain"
+                                src={ apiUrl(`/orgs/${follow.organization.id}/avatar`) }
+                                width="size-600"
+                            />
+                            <Flex direction="column">
+                                <NextLink href={ `/o/${follow.organization.id}` }>
+                                    <a>
+                                        <Text marginX="size-200">{ follow.organization.title }</Text>
+                                    </a>
+                                </NextLink>
+                                { follow.role
+                                    ? <Text marginX="size-200">{ follow.role }</Text>
+                                    : (
+                                        <Text marginX="size-200">
+                                            <Msg id="pages.myOrgs.rolePlaceholder"/>
+                                        </Text>
+                                    )
+                                }
                             </Flex>
-                        </a>
-                    </NextLink>
+                        </Flex>
+                        <Button
+                            isQuiet
+                            onPress={ () => onDisconnect(follow.organization.id) }
+                            variant="negative">
+                            <Msg id="pages.myOrgs.disconnect"/>
+                        </Button>
+                    </Flex>
                 )) }
             </Flex>
         </>

--- a/src/pages/my/orgs.tsx
+++ b/src/pages/my/orgs.tsx
@@ -2,14 +2,13 @@ import { GetServerSideProps } from 'next';
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
 import { Button, Flex, Heading, Image, Text } from '@adobe/react-spectrum';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import apiUrl from '../../utils/apiUrl';
-import deleteUserFollowing from '../../fetching/deleteUserFollowing';
 import getUserFollowing from '../../fetching/getUserFollowing';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
+import { useUserFollowing } from '../../hooks';
 
 const scaffoldOptions = {
     authLevelRequired: 1,
@@ -44,20 +43,8 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 }, scaffoldOptions);
 
 const MyOrgsPage : PageWithLayout = () => {
-    const followingQuery = useQuery('following', getUserFollowing());
-    const following = followingQuery.data;
 
-    const queryClient = useQueryClient();
-
-    const removeFunc = useMutation(deleteUserFollowing, {
-        onSettled: () => {
-            queryClient.invalidateQueries('following');
-        },
-    });
-
-    function onDisconnect (orgId : number) {
-        removeFunc.mutate(orgId);
-    }
+    const { following, onUnfollow } = useUserFollowing();
 
     if (!following || following.length === 0) {
         return (
@@ -110,9 +97,9 @@ const MyOrgsPage : PageWithLayout = () => {
                         </Flex>
                         <Button
                             isQuiet
-                            onPress={ () => onDisconnect(follow.organization.id) }
+                            onPress={ () => onUnfollow(follow.organization.id) }
                             variant="negative">
-                            <Msg id="pages.myOrgs.disconnect"/>
+                            <Msg id="pages.myOrgs.unfollow"/>
                         </Button>
                     </Flex>
                 )) }

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -6,10 +6,12 @@ export interface ZetkinCampaign {
 
 export interface ZetkinMembership {
     organization: ZetkinOrganization;
+    follow?: boolean;
     profile: {
         id: number;
         name: string;
     };
+    inherited?: false;
     role : string | null;
 }
 


### PR DESCRIPTION
This PR contains fetching and rendering of organizations followed by user on `MyOrgsPage`. This is also applied in `MainOrgLayout` where the follow/unfollow button is activated. All fetch functionality for `following` is available via the `useUserFollowing` hook.

<img width="1440" alt="Skärmavbild 2021-05-11 kl  14 38 39" src="https://user-images.githubusercontent.com/51208557/117817017-76d55480-b267-11eb-87c0-6217e399769d.png">

<img width="1440" alt="Skärmavbild 2021-05-11 kl  14 47 50" src="https://user-images.githubusercontent.com/51208557/117817442-e5b2ad80-b267-11eb-9087-b46a94cf3332.png">

Fixes #44 