### PR TITLE
Refactor fetching of events

### DIFF
--- a/cypress/fixtures/dummyEvents.json
+++ b/cypress/fixtures/dummyEvents.json
@@ -22,7 +22,9 @@
             "organization": {
                 "id": 1,
                 "title": "Dummy Org"
-            }
+            },
+            "userBooked": false,
+            "userResponse": false
         }
     ]
 }

--- a/src/components/EventDetails.spec.tsx
+++ b/src/components/EventDetails.spec.tsx
@@ -1,16 +1,10 @@
 import EventDetails from './EventDetails';
 import { mountWithProviders } from '../utils/testing';
 import { UserContext } from '../hooks';
-import {
-    ZetkinEvent,
-    ZetkinEventResponse,
-    ZetkinOrganization,
-} from '../types/zetkin';
+import { ZetkinEvent } from '../types/zetkin';
 
 describe('EventDetails', () => {
-    let dummyOrg : ZetkinOrganization;
     let dummyEvent : ZetkinEvent;
-    let dummyEventResponse : ZetkinEventResponse | undefined;
     const dummyUser = {
         first_name: 'Firstname',
         id: 100,
@@ -19,17 +13,9 @@ describe('EventDetails', () => {
     };
 
     beforeEach(()=> {
-        cy.fixture('dummyOrg.json')
-            .then((data : ZetkinOrganization) => {
-                dummyOrg = data;
-            });
         cy.fixture('dummyEvents.json')
             .then((data : {data: ZetkinEvent[]}) => {
                 dummyEvent = data.data[0];
-            });
-        cy.fixture('dummyEventResponses.json')
-            .then((data : {data: ZetkinEventResponse[]}) => {
-                dummyEventResponse = data.data[0];
             });
     });
 
@@ -39,8 +25,6 @@ describe('EventDetails', () => {
                 event={ dummyEvent }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
-                org={ dummyOrg }
-                response={ dummyEventResponse }
             />,
         );
         cy.get('[data-testid="event-title"]').should('be.visible');
@@ -59,8 +43,6 @@ describe('EventDetails', () => {
                 event={ dummyEvent }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
-                org={ dummyOrg }
-                response={ dummyEventResponse }
             />,
         );
         cy.get('[data-testid="info-text"]').should('not.be.visible');
@@ -73,8 +55,6 @@ describe('EventDetails', () => {
                 event={ dummyEvent }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
-                org={ dummyOrg }
-                response={ dummyEventResponse }
             />,
         );
         cy.get('[data-testid="event-title"]')
@@ -88,12 +68,10 @@ describe('EventDetails', () => {
                 event={ dummyEvent }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
-                org={ dummyOrg }
-                response={ dummyEventResponse }
             />,
         );
         cy.get('[data-testid="org-title"]')
-            .should('have.attr', 'href', `/o/${dummyOrg.id}`);
+            .should('have.attr', 'href', `/o/${dummyEvent.organization.id}`);
     });
 
     it('contains a link back to the campaign page', () => {
@@ -102,12 +80,10 @@ describe('EventDetails', () => {
                 event={ dummyEvent }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
-                org={ dummyOrg }
-                response={ dummyEventResponse }
             />,
         );
         cy.get('[data-testid="campaign-title"]')
-            .should('have.attr', 'href', `/o/${dummyOrg.id}/campaigns/${dummyEvent.campaign.id}`);
+            .should('have.attr', 'href', `/o/${dummyEvent.organization.id}/campaigns/${dummyEvent.campaign.id}`);
     });
 
     it('contains a sign-up button for the event', () => {
@@ -118,8 +94,6 @@ describe('EventDetails', () => {
                     event={ dummyEvent }
                     onSignup={ spyOnSignup }
                     onUndoSignup={ () => null }
-                    org={ dummyOrg }
-                    response={ undefined }
                 />
             </UserContext.Provider>,
         );
@@ -128,12 +102,16 @@ describe('EventDetails', () => {
             .eq(0)
             .click()
             .then(() => {
-                expect(spyOnSignup).to.be.calledOnceWith(dummyEvent.id, dummyOrg.id);
+                expect(spyOnSignup).to.be.calledOnceWith(
+                    dummyEvent.id,
+                    dummyEvent.organization.id,
+                );
             });
     });
 
     it('contains a cancel sign-up button for the event if already signed up', () => {
         const spyOnUndoSignup = cy.spy();
+        dummyEvent.userResponse = true;
 
         mountWithProviders(
             <UserContext.Provider value={ dummyUser }>
@@ -141,8 +119,6 @@ describe('EventDetails', () => {
                     event={ dummyEvent }
                     onSignup={ () => null }
                     onUndoSignup={ spyOnUndoSignup }
-                    org={ dummyOrg }
-                    response={ dummyEventResponse }
                 />
             </UserContext.Provider>,
         );
@@ -151,7 +127,10 @@ describe('EventDetails', () => {
             .eq(0)
             .click()
             .then(() => {
-                expect(spyOnUndoSignup).to.be.calledOnceWith(dummyEvent.id, dummyOrg.id);
+                expect(spyOnUndoSignup).to.be.calledOnceWith(
+                    dummyEvent.id,
+                    dummyEvent.organization.id,
+                );
             });
     });
 
@@ -162,8 +141,6 @@ describe('EventDetails', () => {
                     event={ dummyEvent }
                     onSignup={ () => null }
                     onUndoSignup={ () => null }
-                    org={ dummyOrg }
-                    response={ undefined }
                 />
             </UserContext.Provider>,
         );

--- a/src/components/EventDetails.spec.tsx
+++ b/src/components/EventDetails.spec.tsx
@@ -98,7 +98,7 @@ describe('EventDetails', () => {
             </UserContext.Provider>,
         );
 
-        cy.findByText('pages.orgEvent.actions.signup')
+        cy.findByText('misc.eventResponseButton.actions.signup')
             .eq(0)
             .click()
             .then(() => {
@@ -123,7 +123,7 @@ describe('EventDetails', () => {
             </UserContext.Provider>,
         );
 
-        cy.findByText('pages.orgEvent.actions.undoSignup')
+        cy.findByText('misc.eventResponseButton.actions.undoSignup')
             .eq(0)
             .click()
             .then(() => {
@@ -132,6 +132,22 @@ describe('EventDetails', () => {
                     dummyEvent.organization.id,
                 );
             });
+    });
+
+    it('contains an indicator that the user has been booked', () => {
+        dummyEvent.userBooked = true;
+
+        mountWithProviders(
+            <UserContext.Provider value={ dummyUser }>
+                <EventDetails
+                    event={ dummyEvent }
+                    onSignup={ () => null }
+                    onUndoSignup={ () => null }
+                />
+            </UserContext.Provider>,
+        );
+
+        cy.contains('misc.eventResponseButton.booked');
     });
 
     it('contains a sign-up button for the event when not logged in', () => {

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -4,7 +4,6 @@ import Head from 'next/head';
 import Location from '@spectrum-icons/workflow/Location';
 import NextLink from 'next/link';
 import {
-    Button,
     Divider,
     Flex,
     Header,
@@ -17,9 +16,9 @@ import {
 import {
     FormattedDate,
     FormattedTime,
-    FormattedMessage as Msg,
 } from 'react-intl';
 
+import EventResponseButton from './EventResponseButton';
 import Map from './maps/Map';
 import SignupDialog from './SignupDialog';
 import { useUser } from '../hooks';
@@ -112,22 +111,12 @@ const EventDetails = ({ event, onSignup, onUndoSignup } : EventDetailsProps) : J
                 { event.info_text }
             </Text>
             <View>
-                { user ? event.userResponse ? (
-                    <Button
-                        data-testid="event-response-button"
-                        onPress={ () => onUndoSignup(event.id, event.organization.id) }
-                        variant="cta"
-                        width="100%">
-                        <Msg id="pages.orgEvent.actions.undoSignup" />
-                    </Button>
-                ) : (
-                    <Button
-                        data-testid="event-response-button"
-                        onPress={ () => onSignup(event.id, event.organization.id) }
-                        variant="cta"
-                        width="100%">
-                        <Msg id="pages.orgEvent.actions.signup" />
-                    </Button>
+                { user ? (
+                    <EventResponseButton
+                        event={ event }
+                        onSignup={ onSignup }
+                        onUndoSignup={ onUndoSignup }
+                    />
                 ) : <SignupDialog /> }
             </View>
         </>

--- a/src/components/EventDetails.tsx
+++ b/src/components/EventDetails.tsx
@@ -23,21 +23,15 @@ import {
 import Map from './maps/Map';
 import SignupDialog from './SignupDialog';
 import { useUser } from '../hooks';
-import {
-    ZetkinEvent,
-    ZetkinEventResponse,
-    ZetkinOrganization,
-} from '../types/zetkin';
+import { ZetkinEvent } from '../types/zetkin';
 
 interface EventDetailsProps {
     event: ZetkinEvent;
-    org: ZetkinOrganization;
     onSignup: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
-    response: ZetkinEventResponse | undefined;
 }
 
-const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDetailsProps) : JSX.Element => {
+const EventDetails = ({ event, onSignup, onUndoSignup } : EventDetailsProps) : JSX.Element => {
     const user = useUser();
 
     return (
@@ -64,8 +58,8 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 </Heading>
                 <Link>
                     <NextLink
-                        href={ `/o/${org.id}` }>
-                        <a data-testid="org-title">{ org.title }</a>
+                        href={ `/o/${event.organization.id}` }>
+                        <a data-testid="org-title">{ event.organization.title }</a>
                     </NextLink>
                 </Link>
             </Header>
@@ -73,7 +67,7 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 <Flag marginEnd="size-100" size="S" />
                 <Link>
                     <NextLink
-                        href={ `/o/${org.id}/campaigns/${event.campaign.id}` }>
+                        href={ `/o/${event.organization.id}/campaigns/${event.campaign.id}` }>
                         <a data-testid="campaign-title">{ event.campaign.title } </a>
                     </NextLink>
                 </Link>
@@ -118,10 +112,10 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 { event.info_text }
             </Text>
             <View>
-                { user ? response ? (
+                { user ? event.userResponse ? (
                     <Button
                         data-testid="event-response-button"
-                        onPress={ () => onUndoSignup(event.id, org.id) }
+                        onPress={ () => onUndoSignup(event.id, event.organization.id) }
                         variant="cta"
                         width="100%">
                         <Msg id="pages.orgEvent.actions.undoSignup" />
@@ -129,7 +123,7 @@ const EventDetails = ({ event, org, onSignup, onUndoSignup, response } : EventDe
                 ) : (
                     <Button
                         data-testid="event-response-button"
-                        onPress={ () => onSignup(event.id, org.id) }
+                        onPress={ () => onSignup(event.id, event.organization.id) }
                         variant="cta"
                         width="100%">
                         <Msg id="pages.orgEvent.actions.signup" />

--- a/src/components/EventList.spec.tsx
+++ b/src/components/EventList.spec.tsx
@@ -1,15 +1,10 @@
 import EventList from './EventList';
 import { mountWithProviders } from '../utils/testing';
 import { UserContext } from '../hooks';
-import {
-    ZetkinEvent,
-    ZetkinEventResponse,
-} from '../types/zetkin';
+import { ZetkinEvent } from '../types/zetkin';
 
 describe('EventList', () => {
     let dummyEvents : ZetkinEvent[];
-    let dummyEventResponses : ZetkinEventResponse[];
-    let dummyBookedEvents : ZetkinEvent[];
     const dummyUser = {
         first_name: 'Firstname',
         id: 100,
@@ -22,21 +17,11 @@ describe('EventList', () => {
             .then((data : {data: ZetkinEvent[]}) => {
                 dummyEvents = data.data;
             });
-        cy.fixture('dummyEventResponses.json')
-            .then((data : {data: ZetkinEventResponse[]}) => {
-                dummyEventResponses = data.data;
-            });
-        cy.fixture('dummyBookedEvents.json')
-            .then((data : {data: ZetkinEvent[]}) => {
-                dummyBookedEvents = data.data;
-            });
     });
 
     it('contains data for each event', () => {
         mountWithProviders(
             <EventList
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ dummyEvents }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
@@ -56,8 +41,6 @@ describe('EventList', () => {
 
         mountWithProviders(
             <EventList
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ dummyEvents }
                 onSignup={ () => null }
                 onUndoSignup={ () => null }
@@ -74,7 +57,6 @@ describe('EventList', () => {
         mountWithProviders(
             <UserContext.Provider value={ dummyUser }>
                 <EventList
-                    bookedEvents={ undefined }
                     events={ dummyEvents }
                     onSignup={ spyOnSignup }
                     onUndoSignup={ () => null }
@@ -93,8 +75,6 @@ describe('EventList', () => {
         mountWithProviders(
             <UserContext.Provider value={ null }>
                 <EventList
-                    bookedEvents={ undefined }
-                    eventResponses={ dummyEventResponses }
                     events={ dummyEvents }
                     onSignup={ () => null }
                     onUndoSignup={ () => null }
@@ -109,8 +89,6 @@ describe('EventList', () => {
     it('contains a button for more info on each event', () => {
         mountWithProviders(
             <EventList
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ dummyEvents }
                 onSignup={ () => null  }
                 onUndoSignup={ () => null  }
@@ -123,8 +101,6 @@ describe('EventList', () => {
     it('shows a placeholder when the list is empty', () => {
         mountWithProviders(
             <EventList
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ [] }
                 onSignup={ () => null  }
                 onUndoSignup={ () => null  }
@@ -137,8 +113,6 @@ describe('EventList', () => {
     it('shows a placeholder when the list is undefined', () => {
         mountWithProviders(
             <EventList
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ undefined }
                 onSignup={ () => null  }
                 onUndoSignup={ () => null  }
@@ -149,11 +123,11 @@ describe('EventList', () => {
     });
 
     it('contains a booked event', () => {
+        dummyEvents[0].userBooked = true;
+
         mountWithProviders(
             <UserContext.Provider value={ dummyUser }>
                 <EventList
-                    bookedEvents={ dummyBookedEvents }
-                    eventResponses={ dummyEventResponses }
                     events={ dummyEvents }
                     onSignup={ () => null  }
                     onUndoSignup={ () => null  }

--- a/src/components/EventList.spec.tsx
+++ b/src/components/EventList.spec.tsx
@@ -64,7 +64,7 @@ describe('EventList', () => {
             </UserContext.Provider>,
         );
 
-        cy.findByText('misc.eventList.signup')
+        cy.findByText('misc.eventResponseButton.actions.signup')
             .click()
             .then(() => {
                 expect(spyOnSignup).to.be.calledOnce;
@@ -135,6 +135,6 @@ describe('EventList', () => {
             </UserContext.Provider>,
         );
 
-        cy.contains('misc.eventList.booked');
+        cy.contains('misc.eventResponseButton.booked');
     });
 });

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -22,7 +22,7 @@ import {
 
 interface EventListProps {
     events: ZetkinEvent[] | undefined;
-    onSignup?: (eventId: number, orgId: number) => void;
+    onSignup: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
 }
 
@@ -62,7 +62,7 @@ export default function EventList ({ events, onSignup, onUndoSignup } : EventLis
 
 interface EventListItemProps {
     event: ZetkinEvent;
-    onSignup?: (eventId: number, orgId: number) => void;
+    onSignup: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
 }
 

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -1,4 +1,3 @@
-import Checkmark from '@spectrum-icons/workflow/Checkmark';
 import NextLink from 'next/link';
 import {
     Button,
@@ -14,6 +13,7 @@ import {
     FormattedMessage as Msg,
 } from 'react-intl';
 
+import EventResponseButton from './EventResponseButton';
 import SignupDialogTrigger from './SignupDialog';
 import { useUser } from '../hooks';
 import {
@@ -112,65 +112,6 @@ const EventListItem = ({ event, onSignup, onUndoSignup }: EventListItemProps): J
                 </Flex>
             </Flex>
             <Divider size="S" />
-        </>
-    );
-};
-
-interface EventResponseButtonProps {
-    event: ZetkinEvent;
-    onSignup?: (eventId: number, orgId: number) => void;
-    onUndoSignup: (eventId: number, orgId: number) => void;
-}
-
-const EventResponseButton = ({ event, onSignup, onUndoSignup } : EventResponseButtonProps): JSX.Element => {
-
-    if (event.userBooked) {
-        return (
-            <Flex
-                alignItems="center"
-                data-testid="booked"
-                marginTop="3px"
-                minHeight="32px">
-                <Checkmark aria-label="Inbokad" color="positive" />
-                <Msg id="misc.eventList.booked" />
-            </Flex>
-        );
-    }
-
-    //TODO: Remove when getRespondEvents and eventResponses has been refactored.
-    if (!onSignup) {
-        return (
-            <Button
-                data-testid="event-response-button"
-                marginTop="size-50"
-                onPress={ () => onUndoSignup(event.id, event.organization.id) }
-                variant="negative">
-                <Msg id="misc.eventList.undoSignup" />
-            </Button>
-        );
-    }
-
-    return (
-        <>
-            { event.userResponse ? (
-                <Button
-                    data-testid="event-response-button"
-                    marginTop="size-50"
-                    onPress={ () => onUndoSignup(event.id, event.organization.id) }
-                    variant="negative"
-                    width="100%">
-                    <Msg id="misc.eventList.undoSignup" />
-                </Button>
-            ) : (
-                <Button
-                    data-testid="event-response-button"
-                    marginTop="size-50"
-                    onPress={ () => onSignup(event.id, event.organization.id) }
-                    variant="primary"
-                    width="100%">
-                    <Msg id="misc.eventList.signup" />
-                </Button>
-            ) }
         </>
     );
 };

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -18,18 +18,15 @@ import SignupDialogTrigger from './SignupDialog';
 import { useUser } from '../hooks';
 import {
     ZetkinEvent,
-    ZetkinEventResponse,
 } from '../types/zetkin';
 
 interface EventListProps {
-    bookedEvents: ZetkinEvent[] | undefined;
     events: ZetkinEvent[] | undefined;
     onSignup?: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
-    eventResponses?: ZetkinEventResponse[];
 }
 
-export default function EventList ({ bookedEvents, eventResponses, events, onSignup, onUndoSignup } : EventListProps) : JSX.Element {
+export default function EventList ({ events, onSignup, onUndoSignup } : EventListProps) : JSX.Element {
 
     if (!events || events.length === 0) {
         return (
@@ -50,16 +47,11 @@ export default function EventList ({ bookedEvents, eventResponses, events, onSig
                 marginBottom="size-200"
                 width="100%">
                 { events?.map((event) => {
-                    const response = eventResponses?.find(response => response.action_id === event.id);
-                    const booked = bookedEvents?.some(booked => booked.id === event.id);
-
                     return (<EventListItem
                         key={ event.id }
-                        booked={ booked }
                         event={ event }
                         onSignup={ onSignup }
                         onUndoSignup={ onUndoSignup }
-                        response={ response }
                     />
                     );
                 }) }
@@ -69,14 +61,12 @@ export default function EventList ({ bookedEvents, eventResponses, events, onSig
 }
 
 interface EventListItemProps {
-    booked: boolean | undefined;
     event: ZetkinEvent;
     onSignup?: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
-    response: ZetkinEventResponse | undefined;
 }
 
-const EventListItem = ({ booked, event, response, onSignup, onUndoSignup }: EventListItemProps): JSX.Element => {
+const EventListItem = ({ event, onSignup, onUndoSignup }: EventListItemProps): JSX.Element => {
     const user = useUser();
 
     return (
@@ -107,11 +97,9 @@ const EventListItem = ({ booked, event, response, onSignup, onUndoSignup }: Even
                 <Flex direction="column" width="size-2000">
                     { user ? (
                         <EventResponseButton
-                            booked={ booked }
                             event={ event }
                             onSignup={ onSignup }
                             onUndoSignup={ onUndoSignup }
-                            response={ response }
                         />
                     ) : <SignupDialogTrigger /> }
                     <NextLink href={ `/o/${event.organization.id}/events/${ event.id }` }>
@@ -129,16 +117,14 @@ const EventListItem = ({ booked, event, response, onSignup, onUndoSignup }: Even
 };
 
 interface EventResponseButtonProps {
-    booked: boolean | undefined;
     event: ZetkinEvent;
     onSignup?: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
-    response: ZetkinEventResponse | undefined;
 }
 
-const EventResponseButton = ({ booked, event, onSignup, onUndoSignup, response } : EventResponseButtonProps): JSX.Element => {
+const EventResponseButton = ({ event, onSignup, onUndoSignup } : EventResponseButtonProps): JSX.Element => {
 
-    if (booked) {
+    if (event.userBooked) {
         return (
             <Flex
                 alignItems="center"
@@ -166,7 +152,7 @@ const EventResponseButton = ({ booked, event, onSignup, onUndoSignup, response }
 
     return (
         <>
-            { response ? (
+            { event.userResponse ? (
                 <Button
                     data-testid="event-response-button"
                     marginTop="size-50"

--- a/src/components/EventResponseButton.tsx
+++ b/src/components/EventResponseButton.tsx
@@ -6,7 +6,7 @@ import { ZetkinEvent } from '../types/zetkin';
 
 interface EventResponseButtonProps {
     event: ZetkinEvent;
-    onSignup?: (eventId: number, orgId: number) => void;
+    onSignup: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
 }
 
@@ -23,20 +23,6 @@ export default function EventResponseButton ({ event, onSignup, onUndoSignup } :
             </Flex>
         );
     }
-
-    //TODO: Remove when getRespondEvents and eventResponses has been refactored.
-    if (!onSignup) {
-        return (
-            <Button
-                data-testid="event-response-button"
-                marginTop="size-50"
-                onPress={ () => onUndoSignup(event.id, event.organization.id) }
-                variant="negative">
-                <Msg id="misc.eventResponseButton.actions.undoSignup" />
-            </Button>
-        );
-    }
-
     return (
         <>
             { event.userResponse ? (

--- a/src/components/EventResponseButton.tsx
+++ b/src/components/EventResponseButton.tsx
@@ -1,0 +1,64 @@
+import Checkmark from '@spectrum-icons/workflow/Checkmark';
+import { FormattedMessage as Msg } from 'react-intl';
+import { Button, Flex } from '@adobe/react-spectrum';
+
+import { ZetkinEvent } from '../types/zetkin';
+
+interface EventResponseButtonProps {
+    event: ZetkinEvent;
+    onSignup?: (eventId: number, orgId: number) => void;
+    onUndoSignup: (eventId: number, orgId: number) => void;
+}
+
+export default function EventResponseButton ({ event, onSignup, onUndoSignup } : EventResponseButtonProps) : JSX.Element {
+    if (event.userBooked) {
+        return (
+            <Flex
+                alignItems="center"
+                data-testid="booked"
+                marginTop="3px"
+                minHeight="32px">
+                <Checkmark aria-label="Inbokad" color="positive" />
+                <Msg id="misc.eventResponseButton.booked" />
+            </Flex>
+        );
+    }
+
+    //TODO: Remove when getRespondEvents and eventResponses has been refactored.
+    if (!onSignup) {
+        return (
+            <Button
+                data-testid="event-response-button"
+                marginTop="size-50"
+                onPress={ () => onUndoSignup(event.id, event.organization.id) }
+                variant="negative">
+                <Msg id="misc.eventResponseButton.actions.undoSignup" />
+            </Button>
+        );
+    }
+
+    return (
+        <>
+            { event.userResponse ? (
+                <Button
+                    data-testid="event-response-button"
+                    marginTop="size-50"
+                    onPress={ () => onUndoSignup(event.id, event.organization.id) }
+                    variant="negative"
+                    width="100%">
+                    <Msg id="misc.eventResponseButton.actions.undoSignup" />
+                </Button>
+            ) : (
+                <Button
+                    data-testid="event-response-button"
+                    marginTop="size-50"
+                    onPress={ () => onSignup(event.id, event.organization.id) }
+                    variant="primary"
+                    width="100%">
+                    <Msg id="misc.eventResponseButton.actions.signup" />
+                </Button>
+            ) }
+        </>
+    );
+
+}

--- a/src/components/EventTabs.spec.tsx
+++ b/src/components/EventTabs.spec.tsx
@@ -1,24 +1,11 @@
 import EventTabs from './EventTabs';
 import { mountWithProviders } from '../utils/testing';
-import {
-    ZetkinEvent,
-    ZetkinEventResponse,
-} from '../types/zetkin';
+import { ZetkinEvent } from '../types/zetkin';
 
 describe('EventTabs', () => {
-    let dummyEventResponses : ZetkinEventResponse[];
     let dummyEvents : ZetkinEvent[];
-    let dummyBookedEvents : ZetkinEvent[];
 
     before(()=> {
-        cy.fixture('dummyEventResponses.json')
-            .then((data : {data: ZetkinEventResponse[]}) => {
-                dummyEventResponses = data.data;
-            });
-        cy.fixture('dummyBookedEvents.json')
-            .then((data : {data: ZetkinEvent[]}) => {
-                dummyBookedEvents = data.data;
-            });
         cy.fixture('dummyEvents.json')
             .then((data : {data: ZetkinEvent[]}) => {
                 dummyEvents = data.data;
@@ -44,8 +31,6 @@ describe('EventTabs', () => {
 
         mountWithProviders(
             <EventTabs
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ multipleDummyEvents }
                 onSignup={ () => null  }
                 onUndoSignup={ () => null  }
@@ -64,8 +49,6 @@ describe('EventTabs', () => {
 
         mountWithProviders(
             <EventTabs
-                bookedEvents={ dummyBookedEvents }
-                eventResponses={ dummyEventResponses }
                 events={ dummyEvents }
                 onSignup={ () => null  }
                 onUndoSignup={ () => null  }

--- a/src/components/EventTabs.tsx
+++ b/src/components/EventTabs.tsx
@@ -3,11 +3,9 @@ import { FormattedMessage as Msg } from 'react-intl';
 import { Item, Tabs } from '@react-spectrum/tabs';
 
 import EventList from './EventList';
-import { ZetkinEvent, ZetkinEventResponse } from '../types/zetkin';
+import { ZetkinEvent } from '../types/zetkin';
 
 interface EventTabsProps {
-    bookedEvents: ZetkinEvent[] | undefined;
-    eventResponses?: ZetkinEventResponse[] | undefined;
     events: ZetkinEvent[] | undefined;
     onSignup?: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
@@ -15,8 +13,6 @@ interface EventTabsProps {
 
 const EventTabs = (
     {
-        bookedEvents,
-        eventResponses,
         events,
         onSignup,
         onUndoSignup,
@@ -59,8 +55,6 @@ const EventTabs = (
                 title={ <Msg id="misc.eventTabs.tabs.today"/> }>
                 <Content>
                     <EventList
-                        bookedEvents={ bookedEvents }
-                        eventResponses={ eventResponses }
                         events={ today }
                         onSignup={ onSignup }
                         onUndoSignup={ onUndoSignup }
@@ -77,8 +71,6 @@ const EventTabs = (
                 title={ <Msg id="misc.eventTabs.tabs.tomorrow"/> }>
                 <Content>
                     <EventList
-                        bookedEvents={ bookedEvents }
-                        eventResponses={ eventResponses }
                         events={ tomorrow }
                         onSignup={ onSignup }
                         onUndoSignup={ onUndoSignup }
@@ -95,8 +87,6 @@ const EventTabs = (
                 title={ <Msg id="misc.eventTabs.tabs.thisWeek"/> }>
                 <Content>
                     <EventList
-                        bookedEvents={ bookedEvents }
-                        eventResponses={ eventResponses }
                         events={ week }
                         onSignup={ onSignup }
                         onUndoSignup={ onUndoSignup }
@@ -113,8 +103,6 @@ const EventTabs = (
                 title={ <Msg id="misc.eventTabs.tabs.later"/> }>
                 <Content>
                     <EventList
-                        bookedEvents={ bookedEvents }
-                        eventResponses={ eventResponses }
                         events={ later }
                         onSignup={ onSignup }
                         onUndoSignup={ onUndoSignup }

--- a/src/components/EventTabs.tsx
+++ b/src/components/EventTabs.tsx
@@ -7,7 +7,7 @@ import { ZetkinEvent } from '../types/zetkin';
 
 interface EventTabsProps {
     events: ZetkinEvent[] | undefined;
-    onSignup?: (eventId: number, orgId: number) => void;
+    onSignup: (eventId: number, orgId: number) => void;
     onUndoSignup: (eventId: number, orgId: number) => void;
 }
 

--- a/src/components/SignupDialog.spec.tsx
+++ b/src/components/SignupDialog.spec.tsx
@@ -10,7 +10,7 @@ describe('SignupDialog', () => {
         cy.get('[data-test="login-button"]').should('not.exist');
         cy.get('[data-test="close-button"]').should('not.exist');
 
-        cy.findByText('pages.orgEvent.actions.signup')
+        cy.findByText('misc.eventResponseButton.actions.signup')
             .click()
             .then(() => {
                 cy.get('[data-test="register-button"]').should('be.visible');
@@ -23,7 +23,7 @@ describe('SignupDialog', () => {
         mountWithProviders(
             <SignupDialogTrigger/>,
         );
-        cy.findByText('pages.orgEvent.actions.signup')
+        cy.findByText('misc.eventResponseButton.actions.signup')
             .click()
             .then(() => {
                 cy.get('[data-test="close-button"]').should('be.visible')

--- a/src/components/SignupDialog.tsx
+++ b/src/components/SignupDialog.tsx
@@ -17,7 +17,7 @@ const SignupDialogTrigger = (): JSX.Element => {
     return (
         <DialogTrigger>
             <Button data-test="dialog-trigger-button" variant="cta" width="100%">
-                <Msg id="pages.orgEvent.actions.signup" />
+                <Msg id="misc.eventResponseButton.actions.signup" />
             </Button>
             { (close) => (
                 <Dialog size="L">

--- a/src/fetching/getCampaignEvents.ts
+++ b/src/fetching/getCampaignEvents.ts
@@ -39,6 +39,7 @@ export default function getCampaignEvents(
                 userResponse: hasEventResponse,
             });
         }
+
         return campaignEventsData;
     };
 }

--- a/src/fetching/getCampaignEvents.ts
+++ b/src/fetching/getCampaignEvents.ts
@@ -1,5 +1,5 @@
 import { defaultFetch } from '.';
-import { ZetkinEvent } from '../types/zetkin';
+import { ZetkinEvent, ZetkinEventResponse } from '../types/zetkin';
 
 export default function getCampaignEvents(
     orgId : string,

--- a/src/fetching/getCampaignEvents.ts
+++ b/src/fetching/getCampaignEvents.ts
@@ -26,11 +26,18 @@ export default function getCampaignEvents(
         const campaignEventsData : ZetkinEvent[] = [];
 
         for (const eObj of eventsData.data) {
-            const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
-                booked.id === eObj.id);
+            let isBookedEvent = false;
+            let hasEventResponse = false;
 
-            const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
-                response.action_id === eObj.id);
+            if (bookedData.data) {
+                isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                    booked.id === eObj.id);
+            }
+
+            if (rData.data) {
+                hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                    response.action_id === eObj.id);
+            }
 
             campaignEventsData.push({
                 ...eObj,

--- a/src/fetching/getEvent.ts
+++ b/src/fetching/getEvent.ts
@@ -1,16 +1,46 @@
 import { defaultFetch } from '.';
-import { ZetkinEvent } from '../types/zetkin';
+import { ZetkinEvent, ZetkinEventResponse } from '../types/zetkin';
 
 export default function getEvent(orgId : string, eventId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinEvent> => {
         const cRes = await fetch(`/orgs/${orgId}/campaigns`);
         const cData = await cRes.json();
 
+        const oRes = await fetch(`/orgs/${orgId}`);
+        const oData = await oRes.json();
+
+        const bookedRes = await fetch('/users/me/actions');
+        const bookedData = await bookedRes.json();
+
+        const rRes = await fetch('/users/me/action_responses');
+        const rData = await rRes.json();
+
+        const org = {
+            id: oData.data.id,
+            title: oData.data.title,
+        };
+
         for (const obj of cData.data) {
             const eventsRes = await fetch(`/orgs/${orgId}/campaigns/${obj.id}/actions`);
             const campaignEvents = await eventsRes.json();
-            const eventData = campaignEvents.data.find((event : ZetkinEvent) => event.id.toString() === eventId);
-            if (eventData) {
+
+            const campaignEvent = campaignEvents.data?.find((event : ZetkinEvent) =>
+                event.id.toString() === eventId);
+
+            if (campaignEvent) {
+                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                    booked.id === campaignEvent.id);
+
+                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                    response.action_id === campaignEvent.id);
+
+                const eventData = {
+                    ...campaignEvent,
+                    organization: org,
+                    userBooked: isBookedEvent,
+                    userResponse: hasEventResponse,
+                };
+
                 return eventData;
             }
         }

--- a/src/fetching/getEvent.ts
+++ b/src/fetching/getEvent.ts
@@ -28,11 +28,18 @@ export default function getEvent(orgId : string, eventId : string, fetch = defau
                 event.id.toString() === eventId);
 
             if (campaignEvent) {
-                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
-                    booked.id === campaignEvent.id);
+                let isBookedEvent = false;
+                let hasEventResponse = false;
 
-                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
-                    response.action_id === campaignEvent.id);
+                if (bookedData.data) {
+                    isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                        booked.id === campaignEvent.id);
+                }
+
+                if (rData.data) {
+                    hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                        response.action_id === campaignEvent.id);
+                }
 
                 const eventData = {
                     ...campaignEvent,

--- a/src/fetching/getEvent.ts
+++ b/src/fetching/getEvent.ts
@@ -40,7 +40,6 @@ export default function getEvent(orgId : string, eventId : string, fetch = defau
                     userBooked: isBookedEvent,
                     userResponse: hasEventResponse,
                 };
-
                 return eventData;
             }
         }

--- a/src/fetching/getEvents.ts
+++ b/src/fetching/getEvents.ts
@@ -1,12 +1,19 @@
 import { defaultFetch } from '.';
-import { ZetkinEvent } from '../types/zetkin';
+import { ZetkinEvent, ZetkinEventResponse } from '../types/zetkin';
 
 export default function getEvents(orgId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinEvent[]> => {
         const cRes = await fetch(`/orgs/${orgId}/campaigns`);
         const cData = await cRes.json();
+
         const oRes = await fetch(`/orgs/${orgId}`);
         const oData = await oRes.json();
+
+        const bookedRes = await fetch('/users/me/actions');
+        const bookedData = await bookedRes.json();
+
+        const rRes = await fetch('/users/me/action_responses');
+        const rData = await rRes.json();
 
         const org = {
             id: oData.data.id,
@@ -20,9 +27,21 @@ export default function getEvents(orgId : string, fetch = defaultFetch) {
             const campaignEvents = await eventsRes.json();
 
             for (const eObj of campaignEvents.data) {
-                allEventsData.push({ ...eObj, organization: org });
+                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                    booked.id === eObj.id);
+
+                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                    response.action_id === eObj.id);
+
+                allEventsData.push({
+                    ...eObj,
+                    organization: org,
+                    userBooked: isBookedEvent,
+                    userResponse: hasEventResponse,
+                });
             }
         }
+
         return allEventsData;
     };
 }

--- a/src/fetching/getEvents.ts
+++ b/src/fetching/getEvents.ts
@@ -27,11 +27,18 @@ export default function getEvents(orgId : string, fetch = defaultFetch) {
             const campaignEvents = await eventsRes.json();
 
             for (const eObj of campaignEvents.data) {
-                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
-                    booked.id === eObj.id);
+                let isBookedEvent = false;
+                let hasEventResponse = false;
 
-                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
-                    response.action_id === eObj.id);
+                if (bookedData.data) {
+                    isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                        booked.id === eObj.id);
+                }
+
+                if (rData.data) {
+                    hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                        response.action_id === eObj.id);
+                }
 
                 allEventsData.push({
                     ...eObj,

--- a/src/fetching/getEventsFromFollowedOrgs.ts
+++ b/src/fetching/getEventsFromFollowedOrgs.ts
@@ -1,18 +1,18 @@
 import { defaultFetch } from '.';
 import { ZetkinEvent, ZetkinEventResponse } from '../types/zetkin';
 
-export default function getRespondEvents(fetch = defaultFetch) {
+export default function getEventsFromFollowedOrgs(fetch = defaultFetch) {
     return async () : Promise<ZetkinEvent[]> => {
         const fRes = await fetch(`/users/me/following`);
         const fData = await fRes.json();
 
-        const rRes = await fetch('/users/me/action_responses');
-        const rData = await rRes.json();
-
         const bookedRes = await fetch('/users/me/actions');
         const bookedData = await bookedRes.json();
 
-        const respondEvents = [];
+        const rRes = await fetch('/users/me/action_responses');
+        const rData = await rRes.json();
+
+        const eventsFromFollowedOrgsData = [];
 
         for (const fObj of fData.data) {
             const eventsRes = await fetch(`/orgs/${fObj.organization.id}/actions`);
@@ -30,17 +30,15 @@ export default function getRespondEvents(fetch = defaultFetch) {
                 const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
                     response.action_id === eObj.id);
 
-                if (isBookedEvent || hasEventResponse) {
-                    respondEvents.push({
-                        ...eObj,
-                        organization: org,
-                        userBooked: isBookedEvent,
-                        userResponse: hasEventResponse,
-                    });
-                }
+                eventsFromFollowedOrgsData.push({
+                    ...eObj,
+                    organization: org,
+                    userBooked: isBookedEvent,
+                    userResponse: hasEventResponse,
+                });
             }
         }
 
-        return respondEvents;
+        return eventsFromFollowedOrgsData;
     };
 }

--- a/src/fetching/getRespondEvents.ts
+++ b/src/fetching/getRespondEvents.ts
@@ -14,34 +14,33 @@ export default function getRespondEvents(fetch = defaultFetch) {
 
         const respondEvents = [];
 
-        if (fData.data) {
-            for (const fObj of fData.data) {
-                const eventsRes = await fetch(`/orgs/${fObj.organization.id}/actions`);
-                const eventsData = await eventsRes.json();
+        for (const fObj of fData.data) {
+            const eventsRes = await fetch(`/orgs/${fObj.organization.id}/actions`);
+            const eventsData = await eventsRes.json();
 
-                const org = {
-                    id: fObj.organization.id,
-                    title: fObj.organization.title,
-                };
+            const org = {
+                id: fObj.organization.id,
+                title: fObj.organization.title,
+            };
 
-                for (const eObj of eventsData.data) {
-                    const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
-                        booked.id === eObj.id);
+            for (const eObj of eventsData.data) {
+                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                    booked.id === eObj.id);
 
-                    const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
-                        response.action_id === eObj.id);
+                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                    response.action_id === eObj.id);
 
-                    if (isBookedEvent || hasEventResponse) {
-                        respondEvents.push({
-                            ...eObj,
-                            organization: org,
-                            userBooked: isBookedEvent,
-                            userResponse: hasEventResponse,
-                        });
-                    }
+                if (isBookedEvent || hasEventResponse) {
+                    respondEvents.push({
+                        ...eObj,
+                        organization: org,
+                        userBooked: isBookedEvent,
+                        userResponse: hasEventResponse,
+                    });
                 }
             }
         }
+
         return respondEvents;
     };
 }

--- a/src/fetching/getUserEvents.ts
+++ b/src/fetching/getUserEvents.ts
@@ -6,11 +6,11 @@ export default function getUserEvents(fetch = defaultFetch) {
         const fRes = await fetch(`/users/me/following`);
         const fData = await fRes.json();
 
-        const bookedRes = await fetch('/users/me/actions');
-        const bookedData = await bookedRes.json();
-
         const rRes = await fetch('/users/me/action_responses');
         const rData = await rRes.json();
+
+        const bookedRes = await fetch('/users/me/actions');
+        const bookedData = await bookedRes.json();
 
         const userEventsData = [];
 
@@ -30,12 +30,14 @@ export default function getUserEvents(fetch = defaultFetch) {
                 const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
                     response.action_id === eObj.id);
 
-                userEventsData.push({
-                    ...eObj,
-                    organization: org,
-                    userBooked: isBookedEvent,
-                    userResponse: hasEventResponse,
-                });
+                if (isBookedEvent || hasEventResponse) {
+                    userEventsData.push({
+                        ...eObj,
+                        organization: org,
+                        userBooked: isBookedEvent,
+                        userResponse: hasEventResponse,
+                    });
+                }
             }
         }
 

--- a/src/fetching/getUserEvents.ts
+++ b/src/fetching/getUserEvents.ts
@@ -14,34 +14,31 @@ export default function getUserEvents(fetch = defaultFetch) {
 
         const userEventsData = [];
 
-        if (fData.data) {
-            for (const fObj of fData.data) {
-                const eventsRes = await fetch(`/orgs/${fObj.organization.id}/actions`);
-                const eventsData = await eventsRes.json();
+        for (const fObj of fData.data) {
+            const eventsRes = await fetch(`/orgs/${fObj.organization.id}/actions`);
+            const eventsData = await eventsRes.json();
 
-                const org = {
-                    id: fObj.organization.id,
-                    title: fObj.organization.title,
-                };
+            const org = {
+                id: fObj.organization.id,
+                title: fObj.organization.title,
+            };
 
-                if (eventsData.data && eventsData.data.length > 0) {
-                    for (const eObj of eventsData.data) {
-                        const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
-                            booked.id === eObj.id);
+            for (const eObj of eventsData.data) {
+                const isBookedEvent = bookedData.data.some((booked : ZetkinEvent) =>
+                    booked.id === eObj.id);
 
-                        const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
-                            response.action_id === eObj.id);
+                const hasEventResponse = rData.data.some((response : ZetkinEventResponse) =>
+                    response.action_id === eObj.id);
 
-                        userEventsData.push({
-                            ...eObj,
-                            organization: org,
-                            userBooked: isBookedEvent,
-                            userResponse: hasEventResponse,
-                        });
-                    }
-                }
+                userEventsData.push({
+                    ...eObj,
+                    organization: org,
+                    userBooked: isBookedEvent,
+                    userResponse: hasEventResponse,
+                });
             }
         }
+
         return userEventsData;
     };
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,11 +3,10 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import deleteEventResponse from '../fetching/deleteEventResponse';
 import deleteUserFollowing from '../fetching/deleteUserFollowing';
-import getRespondEvents from '../fetching/getRespondEvents';
 import getUserFollowing from '../fetching/getUserFollowing';
 import putEventResponse from '../fetching/putEventResponse';
 import putUserFollowing from '../fetching/putUserFollowing';
-import { ZetkinEvent, ZetkinMembership, ZetkinUser } from '../types/zetkin';
+import { ZetkinMembership, ZetkinUser } from '../types/zetkin';
 
 export const UserContext = React.createContext<ZetkinUser | null>(null);
 
@@ -48,30 +47,6 @@ export const useEventResponses = (key : string) : EventResponses => {
     }
 
     return { onSignup, onUndoSignup };
-};
-
-type RespondEvents = {
-    onUndoSignup: OnUndoSignup;
-    respondEvents: ZetkinEvent[] | undefined;
-}
-
-export const useRespondEvents = () : RespondEvents => {
-    const respondEventsQuery = useQuery('respondEvents', getRespondEvents());
-    const respondEvents = respondEventsQuery.data;
-
-    const queryClient = useQueryClient();
-
-    const removeFunc = useMutation(deleteEventResponse, {
-        onSettled: () => {
-            queryClient.invalidateQueries('respondEvents');
-        },
-    });
-
-    function onUndoSignup (eventId : number, orgId : number) {
-        removeFunc.mutate({ eventId, orgId });
-    }
-
-    return { onUndoSignup, respondEvents };
 };
 
 type OnFollow = (orgId : number) => void;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,12 +3,11 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import deleteEventResponse from '../fetching/deleteEventResponse';
 import deleteUserFollowing from '../fetching/deleteUserFollowing';
-import getEventResponses from '../fetching/getEventResponses';
 import getRespondEvents from '../fetching/getRespondEvents';
 import getUserFollowing from '../fetching/getUserFollowing';
 import putEventResponse from '../fetching/putEventResponse';
 import putUserFollowing from '../fetching/putUserFollowing';
-import { ZetkinEvent, ZetkinEventResponse, ZetkinMembership, ZetkinUser } from '../types/zetkin';
+import { ZetkinEvent, ZetkinMembership, ZetkinUser } from '../types/zetkin';
 
 export const UserContext = React.createContext<ZetkinUser | null>(null);
 
@@ -20,26 +19,23 @@ type OnSignup = (eventId : number, orgId : number) => void;
 type OnUndoSignup = (eventId : number, orgId : number) => void;
 
 type EventResponses = {
-    eventResponses: ZetkinEventResponse[] | undefined;
     onSignup: OnSignup;
     onUndoSignup: OnUndoSignup;
 }
 
-export const useEventResponses = () : EventResponses => {
-    const responseQuery = useQuery('eventResponses', getEventResponses());
-    const eventResponses = responseQuery.data;
+export const useEventResponses = (key : string) : EventResponses => {
 
     const queryClient = useQueryClient();
 
     const removeFunc = useMutation(deleteEventResponse, {
         onSettled: () => {
-            queryClient.invalidateQueries('eventResponses');
+            queryClient.invalidateQueries(key);
         },
     });
 
     const addFunc = useMutation(putEventResponse, {
         onSettled: () => {
-            queryClient.invalidateQueries('eventResponses');
+            queryClient.invalidateQueries(key);
         },
     });
 
@@ -51,7 +47,7 @@ export const useEventResponses = () : EventResponses => {
         removeFunc.mutate({ eventId, orgId });
     }
 
-    return { eventResponses, onSignup, onUndoSignup };
+    return { onSignup, onUndoSignup };
 };
 
 type RespondEvents = {

--- a/src/locale/misc/eventList/en.yml
+++ b/src/locale/misc/eventList/en.yml
@@ -1,5 +1,2 @@
 placeholder: Sorry, there are no planned events at the moment.
 moreInfo: More info
-signup: Sign-up
-undoSignup: Undo sign-up
-booked: Booked

--- a/src/locale/misc/eventList/sv.yml
+++ b/src/locale/misc/eventList/sv.yml
@@ -1,5 +1,2 @@
 placeholder: Tyvärr finns det inga planerade händelser för tillfället.
 moreInfo: Mer info
-signup: Anmälan
-undoSignup: Ångra anmälan
-booked: Bokad

--- a/src/locale/misc/eventResponseButton/en.yml
+++ b/src/locale/misc/eventResponseButton/en.yml
@@ -1,3 +1,4 @@
 actions:
   signup: Sign-up
   undoSignup: Undo sign-up
+booked: Booked

--- a/src/locale/misc/eventResponseButton/sv.yml
+++ b/src/locale/misc/eventResponseButton/sv.yml
@@ -1,0 +1,4 @@
+actions:
+  signup: Anmälan
+  undoSignup: Ångra anmälan
+booked: Bokad

--- a/src/locale/pages/orgEvent/sv.yml
+++ b/src/locale/pages/orgEvent/sv.yml
@@ -1,3 +1,0 @@
-actions:
-  signup: Anmälan
-  undoSignup: Ångra anmälan

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -66,7 +66,7 @@ const MyPage : PageWithLayout<MyPageProps> = (props) => {
 
     const userEvents = userEventsQuery.data;
 
-    const { onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses('userEvents');
 
     if (!userEvents || userEvents.length === 0) {
         return (

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -12,8 +12,6 @@ import {
 } from '@adobe/react-spectrum';
 
 import EventTabs from '../../components/EventTabs';
-import getBookedEvents from '../../fetching/getBookedEvents';
-import getEventResponses from '../../fetching/getEventResponses';
 import getUserCampaigns from '../../fetching/getUserCampaigns';
 import getUserEvents from '../../fetching/getUserEvents';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
@@ -39,8 +37,6 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 
     if (user) {
         await context.queryClient.prefetchQuery('userEvents', getUserEvents(context.apiFetch));
-        await context.queryClient.prefetchQuery('bookedEvents', getBookedEvents(context.apiFetch));
-        await context.queryClient.prefetchQuery('eventResponses', getEventResponses(context.apiFetch));
         await context.queryClient.prefetchQuery('userCampaigns', getUserCampaigns(context.apiFetch));
 
         return {

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -27,6 +27,7 @@ const scaffoldOptions = {
     localeScope: [
         'layout.my',
         'misc.eventList',
+        'misc.eventResponseButton',
         'misc.eventTabs',
         'misc.publicHeader',
         'pages.my',

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -12,8 +12,8 @@ import {
 } from '@adobe/react-spectrum';
 
 import EventTabs from '../../components/EventTabs';
+import getEventsFromFollowedOrgs from '../../fetching/getEventsFromFollowedOrgs';
 import getUserCampaigns from '../../fetching/getUserCampaigns';
-import getUserEvents from '../../fetching/getUserEvents';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
@@ -36,7 +36,7 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     const { user } = context;
 
     if (user) {
-        await context.queryClient.prefetchQuery('userEvents', getUserEvents(context.apiFetch));
+        await context.queryClient.prefetchQuery('eventsFromFollowedOrgs', getEventsFromFollowedOrgs(context.apiFetch));
         await context.queryClient.prefetchQuery('userCampaigns', getUserCampaigns(context.apiFetch));
 
         return {
@@ -58,13 +58,13 @@ const MyPage : PageWithLayout<MyPageProps> = (props) => {
     const { user } = props;
 
     const userCampaignsQuery = useQuery('userCampaigns', getUserCampaigns());
-    const userEventsQuery = useQuery('userEvents', getUserEvents());
+    const eventsFromFollowedOrgsQuery = useQuery('eventsFromFollowedOrgs', getEventsFromFollowedOrgs());
 
-    const userEvents = userEventsQuery.data;
+    const eventsFromFollowedOrgs = eventsFromFollowedOrgsQuery.data;
 
-    const { onSignup, onUndoSignup } = useEventResponses('userEvents');
+    const { onSignup, onUndoSignup } = useEventResponses('eventsFromFollowedOrgs');
 
-    if (!userEvents || userEvents.length === 0) {
+    if (!eventsFromFollowedOrgs || eventsFromFollowedOrgs.length === 0) {
         return (
             <>
                 <Heading level={ 1 }>
@@ -86,7 +86,7 @@ const MyPage : PageWithLayout<MyPageProps> = (props) => {
                 <Msg id="pages.my.events"/>
             </Heading>
             <EventTabs
-                events={ userEvents }
+                events={ eventsFromFollowedOrgs }
                 onSignup={ onSignup }
                 onUndoSignup={ onUndoSignup }
             />

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -60,13 +60,12 @@ interface MyPageProps {
 const MyPage : PageWithLayout<MyPageProps> = (props) => {
     const { user } = props;
 
-    const bookedEventsQuery = useQuery('bookedEvents', getBookedEvents());
     const userCampaignsQuery = useQuery('userCampaigns', getUserCampaigns());
     const userEventsQuery = useQuery('userEvents', getUserEvents());
 
     const userEvents = userEventsQuery.data;
 
-    const { eventResponses, onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses();
 
     if (!userEvents || userEvents.length === 0) {
         return (
@@ -90,8 +89,6 @@ const MyPage : PageWithLayout<MyPageProps> = (props) => {
                 <Msg id="pages.my.events"/>
             </Heading>
             <EventTabs
-                bookedEvents={ bookedEventsQuery.data }
-                eventResponses={ eventResponses }
                 events={ userEvents }
                 onSignup={ onSignup }
                 onUndoSignup={ onUndoSignup }

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -45,7 +45,6 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 }, scaffoldOptions);
 
 const MyTodoPage : PageWithLayout = () => {
-    const bookedEventsQuery = useQuery('bookedEvents', getBookedEvents());
     const callAssignmentsQuery = useQuery('callAssignments', getCallAssignments());
 
     const { respondEvents, onUndoSignup } = useRespondEvents();
@@ -89,7 +88,6 @@ const MyTodoPage : PageWithLayout = () => {
                     <Msg id="pages.myTodo.events"/>
                 </Heading>
                 <EventTabs
-                    bookedEvents={ bookedEventsQuery.data }
                     events={ respondEvents }
                     onUndoSignup={ onUndoSignup }
                 />

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -11,7 +11,7 @@ import getRespondEvents from '../../fetching/getRespondEvents';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
-import { useRespondEvents } from '../../hooks';
+import { useEventResponses } from '../../hooks';
 
 const scaffoldOptions = {
     authLevelRequired: 1,
@@ -47,10 +47,11 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 
 const MyTodoPage : PageWithLayout = () => {
     const callAssignmentsQuery = useQuery('callAssignments', getCallAssignments());
+    const respondEventsQuery = useQuery('respondEvents', getRespondEvents());
 
-    const { respondEvents, onUndoSignup } = useRespondEvents();
+    const { onUndoSignup } = useEventResponses('respondEvents');
 
-    if ((!respondEvents || respondEvents.length === 0)
+    if ((!respondEventsQuery.data || respondEventsQuery.data.length === 0)
         && (!callAssignmentsQuery.data || callAssignmentsQuery.data?.length === 0)) {
         return (
             <>
@@ -89,7 +90,7 @@ const MyTodoPage : PageWithLayout = () => {
                     <Msg id="pages.myTodo.events"/>
                 </Heading>
                 <EventTabs
-                    events={ respondEvents }
+                    events={ respondEventsQuery.data }
                     onUndoSignup={ onUndoSignup }
                 />
             </View>

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -5,7 +5,6 @@ import { Heading, Text, View } from '@adobe/react-spectrum';
 
 import CallAssignmentList from '../../components/CallAssignmentList';
 import EventTabs from '../../components/EventTabs';
-import getBookedEvents from '../../fetching/getBookedEvents';
 import getCallAssignments from '../../fetching/getCallAssignments';
 import getRespondEvents from '../../fetching/getRespondEvents';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
@@ -31,7 +30,6 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 
     if (user) {
         await context.queryClient.prefetchQuery('respondEvents', getRespondEvents(context.apiFetch));
-        await context.queryClient.prefetchQuery('bookedEvents', getBookedEvents(context.apiFetch));
         await context.queryClient.prefetchQuery('callAssignments', getCallAssignments(context.apiFetch));
 
         return {

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -6,7 +6,7 @@ import { Heading, Text, View } from '@adobe/react-spectrum';
 import CallAssignmentList from '../../components/CallAssignmentList';
 import EventTabs from '../../components/EventTabs';
 import getCallAssignments from '../../fetching/getCallAssignments';
-import getRespondEvents from '../../fetching/getRespondEvents';
+import getUserEvents from '../../fetching/getUserEvents';
 import MyHomeLayout from '../../components/layout/MyHomeLayout';
 import { PageWithLayout } from '../../types';
 import { scaffold } from '../../utils/next';
@@ -29,7 +29,7 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     const { user } = context;
 
     if (user) {
-        await context.queryClient.prefetchQuery('respondEvents', getRespondEvents(context.apiFetch));
+        await context.queryClient.prefetchQuery('userEvents', getUserEvents(context.apiFetch));
         await context.queryClient.prefetchQuery('callAssignments', getCallAssignments(context.apiFetch));
 
         return {
@@ -45,11 +45,11 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
 
 const MyTodoPage : PageWithLayout = () => {
     const callAssignmentsQuery = useQuery('callAssignments', getCallAssignments());
-    const respondEventsQuery = useQuery('respondEvents', getRespondEvents());
+    const userEventsQuery = useQuery('userEvents', getUserEvents());
 
-    const { onSignup, onUndoSignup } = useEventResponses('respondEvents');
+    const { onSignup, onUndoSignup } = useEventResponses('userEvents');
 
-    if ((!respondEventsQuery.data || respondEventsQuery.data.length === 0)
+    if ((!userEventsQuery.data || userEventsQuery.data.length === 0)
         && (!callAssignmentsQuery.data || callAssignmentsQuery.data?.length === 0)) {
         return (
             <>
@@ -88,7 +88,7 @@ const MyTodoPage : PageWithLayout = () => {
                     <Msg id="pages.myTodo.events"/>
                 </Heading>
                 <EventTabs
-                    events={ respondEventsQuery.data }
+                    events={ userEventsQuery.data }
                     onSignup={ onSignup }
                     onUndoSignup={ onUndoSignup }
                 />

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -19,6 +19,7 @@ const scaffoldOptions = {
         'layout.my',
         'misc.callAssignmentList',
         'misc.eventList',
+        'misc.eventResponseButton',
         'misc.eventTabs',
         'misc.publicHeader',
         'pages.myTodo',

--- a/src/pages/my/todo.tsx
+++ b/src/pages/my/todo.tsx
@@ -49,7 +49,7 @@ const MyTodoPage : PageWithLayout = () => {
     const callAssignmentsQuery = useQuery('callAssignments', getCallAssignments());
     const respondEventsQuery = useQuery('respondEvents', getRespondEvents());
 
-    const { onUndoSignup } = useEventResponses('respondEvents');
+    const { onSignup, onUndoSignup } = useEventResponses('respondEvents');
 
     if ((!respondEventsQuery.data || respondEventsQuery.data.length === 0)
         && (!callAssignmentsQuery.data || callAssignmentsQuery.data?.length === 0)) {
@@ -91,6 +91,7 @@ const MyTodoPage : PageWithLayout = () => {
                 </Heading>
                 <EventTabs
                     events={ respondEventsQuery.data }
+                    onSignup={ onSignup }
                     onUndoSignup={ onUndoSignup }
                 />
             </View>

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -56,7 +56,7 @@ const CampaignPage : PageWithLayout<CampaignPageProps> = (props) => {
     const campaignQuery = useQuery(['campaign', campId], getCampaign(orgId, campId));
     const campaignEventsQuery = useQuery(['campaignEvents', campId], getCampaignEvents(orgId, campId));
 
-    const { onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses('campaignEvents');
 
     return (
         <Flex direction="column" marginY="size-500">

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -4,10 +4,8 @@ import { Flex, Heading, Text } from '@adobe/react-spectrum';
 
 import DefaultOrgLayout from '../../../../components/layout/DefaultOrgLayout';
 import EventList from '../../../../components/EventList';
-import getBookedEvents from '../../../../fetching/getBookedEvents';
 import getCampaign from '../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../fetching/getCampaignEvents';
-import getEventResponses from '../../../../fetching/getEventResponses';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
 import { useEventResponses } from '../../../../hooks';
@@ -15,17 +13,11 @@ import { useEventResponses } from '../../../../hooks';
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { campId, orgId } = context.params!;
-    const { user } = context;
 
     await context.queryClient.prefetchQuery(['campaign', campId], getCampaign(orgId as string, campId as string));
     await context.queryClient.prefetchQuery(
         ['campaignEvents', campId],
         getCampaignEvents(orgId as string, campId as string, context.apiFetch));
-
-    if (user) {
-        await context.queryClient.prefetchQuery('eventResponses', getEventResponses(context.apiFetch));
-        await context.queryClient.prefetchQuery('bookedEvents', getBookedEvents(context.apiFetch));
-    }
 
     const campaignState = context.queryClient.getQueryState(['campaign', campId]);
     const campaignEvents = context.queryClient.getQueryState(['campaignEvents', campId]);

--- a/src/pages/o/[orgId]/campaigns/[campId].tsx
+++ b/src/pages/o/[orgId]/campaigns/[campId].tsx
@@ -55,9 +55,8 @@ const CampaignPage : PageWithLayout<CampaignPageProps> = (props) => {
     const { campId, orgId } = props;
     const campaignQuery = useQuery(['campaign', campId], getCampaign(orgId, campId));
     const campaignEventsQuery = useQuery(['campaignEvents', campId], getCampaignEvents(orgId, campId));
-    const bookedEventsQuery = useQuery('bookedEvents', getBookedEvents());
 
-    const { eventResponses, onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses();
 
     return (
         <Flex direction="column" marginY="size-500">
@@ -68,8 +67,6 @@ const CampaignPage : PageWithLayout<CampaignPageProps> = (props) => {
                 { campaignQuery.data?.info_text }
             </Text>
             <EventList
-                bookedEvents={ bookedEventsQuery.data }
-                eventResponses={ eventResponses }
                 events={ campaignEventsQuery.data }
                 onSignup={ onSignup }
                 onUndoSignup={ onUndoSignup }

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -16,6 +16,7 @@ const scaffoldOptions = {
     localeScope: [
         'layout.org',
         'misc.eventList',
+        'misc.eventResponseButton',
         'misc.publicHeader',
         'misc.signupDialog',
     ],

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -59,15 +59,12 @@ type EventsPageProps = {
 const EventsPage : PageWithLayout<EventsPageProps> = (props) => {
     const { orgId } = props;
     const eventsQuery = useQuery('events', getEvents(orgId));
-    const bookedEventsQuery = useQuery('bookedEvents', getBookedEvents());
 
-    const { eventResponses, onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses();
 
     return (
         <Flex marginY="size-500">
             <EventList
-                bookedEvents={ bookedEventsQuery.data }
-                eventResponses={ eventResponses }
                 events={ eventsQuery.data }
                 onSignup={ onSignup }
                 onUndoSignup={ onUndoSignup }

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -61,7 +61,7 @@ const EventsPage : PageWithLayout<EventsPageProps> = (props) => {
     const { orgId } = props;
     const eventsQuery = useQuery('events', getEvents(orgId));
 
-    const { onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses('events');
 
     return (
         <Flex marginY="size-500">

--- a/src/pages/o/[orgId]/events.tsx
+++ b/src/pages/o/[orgId]/events.tsx
@@ -3,8 +3,6 @@ import { GetServerSideProps } from 'next';
 import { useQuery } from 'react-query';
 
 import EventList from '../../../components/EventList';
-import getBookedEvents from '../../../fetching/getBookedEvents';
-import getEventResponses from '../../../fetching/getEventResponses';
 import getEvents from '../../../fetching/getEvents';
 import getOrg from '../../../fetching/getOrg';
 import MainOrgLayout from '../../../components/layout/MainOrgLayout';
@@ -25,15 +23,9 @@ const scaffoldOptions = {
 export const getServerSideProps : GetServerSideProps = scaffold(async (context) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { orgId } = context.params!;
-    const { user } = context;
 
     await context.queryClient.prefetchQuery('events', getEvents(orgId as string, context.apiFetch));
     await context.queryClient.prefetchQuery(['org', orgId], getOrg(orgId as string, context.apiFetch));
-
-    if (user) {
-        await context.queryClient.prefetchQuery('eventResponses', getEventResponses(context.apiFetch));
-        await context.queryClient.prefetchQuery('bookedEvents', getBookedEvents(context.apiFetch));
-    }
 
     const eventsState = context.queryClient.getQueryState('events');
     const orgState = context.queryClient.getQueryState(['org', orgId]);

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -75,7 +75,7 @@ type EventPageProps = {
 const EventPage: PageWithLayout<EventPageProps> = (props) => {
     const { orgId, eventId } = props;
     const eventQuery = useQuery(['event', eventId], getEvent(orgId, eventId));
-    const { onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses('event');
 
     if (!eventQuery.data) {
         return null;

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -12,7 +12,11 @@ import { useEventResponses } from '../../../../hooks';
 import { ZetkinEvent } from '../../../../types/zetkin';
 
 const scaffoldOptions = {
-    localeScope: ['misc.publicHeader', 'pages.orgEvent', 'misc.signupDialog'],
+    localeScope: [
+        'misc.publicHeader',
+        'misc.eventResponseButton',
+        'misc.signupDialog',
+    ],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -4,7 +4,6 @@ import { useQuery } from 'react-query';
 import DefaultOrgLayout from '../../../../components/layout/DefaultOrgLayout';
 import EventDetails from '../../../../components/EventDetails';
 import getEvent from '../../../../fetching/getEvent';
-import getEventResponses from '../../../../fetching/getEventResponses';
 import getOrg from '../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
@@ -23,7 +22,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     async (context) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const { orgId, eventId } = context.params!;
-        const { user } = context;
 
         await context.queryClient.prefetchQuery(
             ['event', eventId],
@@ -33,16 +31,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
             ['org', orgId],
             getOrg(orgId as string, context.apiFetch),
         );
-
-        if (user) {
-            await context.queryClient.prefetchQuery(
-                'eventResponses',
-                getEventResponses(context.apiFetch),
-            );
-        }
-        else {
-            null;
-        }
 
         const eventState = context.queryClient.getQueryState(['event', eventId]);
         const orgState = context.queryClient.getQueryState(['org', orgId]);

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -9,7 +9,7 @@ import getOrg from '../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
 import { useEventResponses } from '../../../../hooks';
-import { ZetkinEvent, ZetkinOrganization } from '../../../../types/zetkin';
+import { ZetkinEvent } from '../../../../types/zetkin';
 
 const scaffoldOptions = {
     localeScope: ['misc.publicHeader', 'pages.orgEvent', 'misc.signupDialog'],
@@ -71,27 +71,19 @@ type EventPageProps = {
 const EventPage: PageWithLayout<EventPageProps> = (props) => {
     const { orgId, eventId } = props;
     const eventQuery = useQuery(['event', eventId], getEvent(orgId, eventId));
-    const orgQuery = useQuery(['org', orgId], getOrg(orgId));
-    const { eventResponses, onSignup, onUndoSignup } = useEventResponses();
+    const { onSignup, onUndoSignup } = useEventResponses();
 
     if (!eventQuery.data) {
         return null;
     }
 
     const event = eventQuery.data as ZetkinEvent;
-    const org = orgQuery.data as ZetkinOrganization;
-
-    const response = eventResponses?.find(
-        (response) => response.action_id === event.id,
-    );
 
     return (
         <EventDetails
             event={ event }
             onSignup={ onSignup }
             onUndoSignup={ onUndoSignup }
-            org={ org }
-            response={ response }
         />
     );
 };

--- a/src/pages/o/[orgId]/events/[eventId].tsx
+++ b/src/pages/o/[orgId]/events/[eventId].tsx
@@ -4,7 +4,6 @@ import { useQuery } from 'react-query';
 import DefaultOrgLayout from '../../../../components/layout/DefaultOrgLayout';
 import EventDetails from '../../../../components/EventDetails';
 import getEvent from '../../../../fetching/getEvent';
-import getOrg from '../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
 import { useEventResponses } from '../../../../hooks';
@@ -27,18 +26,10 @@ export const getServerSideProps: GetServerSideProps = scaffold(
             ['event', eventId],
             getEvent(orgId as string, eventId as string, context.apiFetch),
         );
-        await context.queryClient.prefetchQuery(
-            ['org', orgId],
-            getOrg(orgId as string, context.apiFetch),
-        );
 
         const eventState = context.queryClient.getQueryState(['event', eventId]);
-        const orgState = context.queryClient.getQueryState(['org', orgId]);
 
-        if (
-            eventState?.status === 'success' &&
-            orgState?.status === 'success'
-        ) {
+        if (eventState?.status === 'success') {
             return {
                 props: {
                     eventId,

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -50,6 +50,8 @@ export interface ZetkinEvent {
         id: number;
         title: string;
     };
+    userBooked?: boolean;
+    userResponse?: boolean;
 }
 
 export interface ZetkinUser {


### PR DESCRIPTION
This pull request contains refactoring of event fetching and is part of issue #163 

`organization`, `userBooked`  and `userResponse` properties are added to all events objects and makes `useRespondEvents` redundant as well as creates simpler ways of rendering event data.

Using the new event data structure entails refactoring of `EventList`, `EventDetails`, `useEventReponses` and pages rendering events: `EventsPage`, `CampaignPage`, `EventPage`, `MyPage` and `MyTodoPage`.