### PR TITLE
transition organize dashboard to MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@adobe/react-spectrum": "^3.7.0",
     "@cypress/code-coverage": "^3.9.2",
     "@cypress/webpack-preprocessor": "^5.5.0",
+    "@material-ui/core": "^4.11.4",
+    "@material-ui/icons": "^4.11.2",
     "@react-spectrum/tabs": "^3.0.0-alpha.3",
     "@spectrum-icons/workflow": "^3.2.0",
     "@types/negotiator": "^0.6.1",

--- a/src/components/DashboardCampaigns.tsx
+++ b/src/components/DashboardCampaigns.tsx
@@ -1,7 +1,8 @@
+import grey from '@material-ui/core/colors/grey';
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
 import { useQuery } from 'react-query';
-import { Button, Flex, Heading, Link, View } from '@adobe/react-spectrum';
+import { Box, Button, Link, List, ListItem, makeStyles, Typography } from '@material-ui/core';
 
 import getCampaigns from '../fetching/getCampaigns';
 import { ZetkinCampaign } from '../types/zetkin';
@@ -10,46 +11,56 @@ interface DashboardCampaignProps {
     orgId: string;
 }
 
+const useStyles = makeStyles((theme) => ({
+    responsiveFlexBox: {
+        alignItems: 'center',
+        display: 'flex',
+        gap: '5%',
+        justifyContent: 'flex-end',
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+        },
+    },
+}));
+
 const DashboardCampaigns = ({ orgId } : DashboardCampaignProps) : JSX.Element => {
     const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
     const campaigns = campaignsQuery.data;
+    const classes = useStyles();
 
     return (
-        <View>
-            <Heading level={ 2 }>
+        <Box border={ 1 } m={ 2 } p={ 2 }>
+            <Typography component="h2" variant="body1">
                 <Msg id="pages.organize.currentProjects.title"/>
-            </Heading>
+            </Typography>
             { campaigns && (
-                <ul style={{ padding: 0 }}>
-                    { campaigns.map((item: ZetkinCampaign) => (
-                        <li key={ item.id } style={{
-                            border: '2px solid gray',
-                            listStyle: 'none',
-                            padding: '1rem',
-                        }}>
-                            <Link>
+                <Typography variant="h5">
+                    <List>
+                        { campaigns.map((item: ZetkinCampaign) => (
+                            <ListItem key={ item.id } style={{ background: grey[200], border: '1px solid', margin: '1rem 0'  }}>
                                 <NextLink href={ `/organize/${orgId}/campaigns/${item.id}` }>
-                                    <a>{ item.title }</a>
+                                    <Link color="inherit" href="#">
+                                        { item.title }
+                                    </Link>
                                 </NextLink>
-                            </Link>
-                        </li>
-                    )) }
-                </ul>) }
-            <Flex alignItems="center" justifyContent="end" margin="1rem 0rem">
-                <Link>
-                    <NextLink href={ `/organize/${orgId}/campaigns` }>
-                        <a style={{ color: 'mediumpurple', margin:'0 2rem' }}>
-                            <Msg id="pages.organize.currentProjects.all"/>
-                        </a>
-                    </NextLink>
-                </Link>
+                            </ListItem>
+                        )) }
+                    </List>
+                </Typography>
+            ) }
+            <Box className={ classes.responsiveFlexBox }>
+                <NextLink href={ `/organize/${orgId}/campaigns` }>
+                    <Link href="#">
+                        <Msg id="pages.organize.currentProjects.all"/>
+                    </Link>
+                </NextLink>
                 <NextLink href={ `/organize/${orgId}/campaigns/new` }>
-                    <Button variant="cta">
+                    <Button color="primary" href="#" variant="outlined">
                         <Msg id="pages.organize.currentProjects.new"/>
                     </Button>
                 </NextLink>
-            </Flex>
-        </View>
+            </Box>
+        </Box>
     );
 };
 

--- a/src/components/DashboardCampaigns.tsx
+++ b/src/components/DashboardCampaigns.tsx
@@ -38,8 +38,8 @@ const DashboardCampaigns = ({ orgId } : DashboardCampaignProps) : JSX.Element =>
                     <List>
                         { campaigns.map((item: ZetkinCampaign) => (
                             <ListItem key={ item.id } style={{ background: grey[200], border: '1px solid', margin: '1rem 0'  }}>
-                                <NextLink href={ `/organize/${orgId}/campaigns/${item.id}` }>
-                                    <Link color="inherit" href="#">
+                                <NextLink href={ `/organize/${orgId}/campaigns/${item.id}` } passHref>
+                                    <Link color="inherit">
                                         { item.title }
                                     </Link>
                                 </NextLink>
@@ -49,13 +49,13 @@ const DashboardCampaigns = ({ orgId } : DashboardCampaignProps) : JSX.Element =>
                 </Typography>
             ) }
             <Box className={ classes.responsiveFlexBox }>
-                <NextLink href={ `/organize/${orgId}/campaigns` }>
-                    <Link href="#">
+                <NextLink href={ `/organize/${orgId}/campaigns` } passHref>
+                    <Link>
                         <Msg id="pages.organize.currentProjects.all"/>
                     </Link>
                 </NextLink>
-                <NextLink href={ `/organize/${orgId}/campaigns/new` }>
-                    <Button color="primary" href="#" variant="outlined">
+                <NextLink href={ `/organize/${orgId}/campaigns/new` } passHref>
+                    <Button color="primary" variant="outlined">
                         <Msg id="pages.organize.currentProjects.new"/>
                     </Button>
                 </NextLink>

--- a/src/components/DashboardPeople.tsx
+++ b/src/components/DashboardPeople.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage as Msg } from 'react-intl';
-import { Heading, View } from '@adobe/react-spectrum';
+import { Box, Typography } from '@material-ui/core';
 
 
 interface DashboardPeopleProps {
@@ -9,12 +9,12 @@ interface DashboardPeopleProps {
 const DashboardPeople = ({ orgId } : DashboardPeopleProps) : JSX.Element => {
 
     return (
-        <View>
-            <Heading level={ 2 }>
+        <Box border={ 1 } m={ 2 } p={ 2 }>
+            <Typography component="h2" variant="body1">
                 <Msg id="pages.organize.people.title"/>
-            </Heading>
+            </Typography>
             { orgId }
-        </View>
+        </Box>
     );
 };
 

--- a/src/components/OrganizeSidebar.spec.tsx
+++ b/src/components/OrganizeSidebar.spec.tsx
@@ -6,11 +6,13 @@ import OrganizeSidebar from './OrganizeSidebar';
 describe('OrganizeSidebar', () => {
     const dummyOrgId= '1';
 
-    it('contains navigation buttons', () => {
+    beforeEach(() => {
         cy.stub(Router, 'useRouter').callsFake(() => {
-            return { pathname: `/organize/[orgId]` };
+            return { pathname: `/organize/[orgId]`, prefetch: async () => null };
         });
+    });
 
+    it('contains navigation buttons', () => {
         mountWithProviders(<OrganizeSidebar orgId={ dummyOrgId }/>);
         cy.get('[data-test="home-button"]').should('be.visible');
         cy.get('[data-test="people-button"]').should('be.visible');
@@ -20,30 +22,25 @@ describe('OrganizeSidebar', () => {
         cy.get('[data-test="user-button"]').should('be.visible');
     });
 
-    it('disables people button when on the people page', () => {
-        cy.stub(Router, 'useRouter').callsFake(() => {
-            return { pathname: `/organize/[orgId]/people` };
-        });
-
+    it('is hidden when the viewport is narrow', () => {
+        cy.viewport(500, 800);
         mountWithProviders(<OrganizeSidebar orgId={ dummyOrgId }/>);
-        cy.get('[data-test="people-button"]').should('be.disabled');
+        cy.get('[data-test="home-button"]').should('not.be.visible');
+        cy.get('[data-test="people-button"]').should('not.be.visible');
+        cy.get('[data-test="area-button"]').should('not.be.visible');
+        cy.get('[data-test="calendar-button"]').should('not.be.visible');
     });
 
-    it('disables map button when on the areas page', () => {
-        cy.stub(Router, 'useRouter').callsFake(() => {
-            return { pathname: `/organize/[orgId]/areas` };
-        });
-
+    it('toggles with the menu button when the viewport is narrow', () => {
+        cy.viewport(500, 800);
         mountWithProviders(<OrganizeSidebar orgId={ dummyOrgId }/>);
-        cy.get('[data-test="area-button"]').should('be.disabled');
-    });
-
-    it('disables calendar button when on the calendar page', () => {
-        cy.stub(Router, 'useRouter').callsFake(() => {
-            return { pathname: `/organize/[orgId]/campaigns/calendar` };
-        });
-
-        mountWithProviders(<OrganizeSidebar orgId={ dummyOrgId }/>);
-        cy.get('[data-test="calendar-button"]').should('be.disabled');
+        cy.get('[data-test="menu-button"]')
+            .click()
+            .then(() => {
+                cy.get('[data-test="home-button"]').should('be.visible');
+                cy.get('[data-test="people-button"]').should('be.visible');
+                cy.get('[data-test="area-button"]').should('be.visible');
+                cy.get('[data-test="calendar-button"]').should('be.visible');
+            });
     });
 });

--- a/src/components/OrganizeSidebar.tsx
+++ b/src/components/OrganizeSidebar.tsx
@@ -1,57 +1,160 @@
-import Calendar from '@spectrum-icons/workflow/Calendar';
-import Home from '@spectrum-icons/workflow/Home';
-import Inbox from '@spectrum-icons/workflow/Inbox';
-import MapView from '@spectrum-icons/workflow/MapView';
+import grey from '@material-ui/core/colors/grey';
 import NextLink from 'next/link';
-import PeopleGroup from '@spectrum-icons/workflow/PeopleGroup';
-import User from '@spectrum-icons/workflow/User';
 import { useRouter } from 'next/router';
-import {
-    Button, Flex,
-} from '@adobe/react-spectrum';
-
+import { useState } from 'react';
+import { AppBar, Box, Button, Drawer, Hidden, IconButton, List, ListItem, Toolbar } from '@material-ui/core';
+import { Event,  Home, Inbox, Map, Menu, People, Person } from '@material-ui/icons/';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 
 interface OrganizeSidebarProps {
     orgId: string;
 }
 
+const drawerWidth = '5rem';
+
+const useStyles = makeStyles((theme) => ({
+    appBar: {
+        [theme.breakpoints.up('sm')]: {
+            display: 'none',
+        },
+    },
+    content: {
+        flexGrow: 1,
+        padding: theme.spacing(3),
+    },
+    drawer: {
+        [theme.breakpoints.up('sm')]: {
+            flexShrink: 0,
+            width: drawerWidth,
+        },
+    },
+    drawerPaper: {
+        width: drawerWidth,
+    },
+    menuButton: {
+        marginRight: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            display: 'none',
+        },
+
+    },
+    root: {
+        display: 'flex',
+    },
+    roundButton: {
+        background: 'white',
+        borderRadius: '50%',
+        height: '4rem',
+    },
+    // necessary for content to be below app bar
+    toolbar: theme.mixins.toolbar,
+}));
+
 const OrganizeSidebar = ({ orgId  } : OrganizeSidebarProps) : JSX.Element =>{
+    const classes = useStyles();
+    const theme = useTheme();
+    const [mobileOpen, setMobileOpen] = useState(false);
+
+    const handleDrawerToggle = () => {
+        setMobileOpen(!mobileOpen);
+    };
+
     const router = useRouter();
     const key = router.pathname.split('[orgId]')[1];
 
+    const drawer = (
+        <Box alignItems="center" bgcolor={ grey[100] } display="flex" flexDirection="column" height="100%" justifyContent="space-between">
+            <List>
+                <Box display="flex" flexDirection="column">
+                    <ListItem>
+                        <NextLink href={ `/organize/${orgId}` }>
+                            <Button aria-label="Home" className={ classes.roundButton } color={ key === '' ?  'primary' : 'secondary' } data-test="home-button" href="#">
+                                <Home />
+                            </Button>
+                        </NextLink>
+                    </ListItem>
+                    <ListItem>
+                        <NextLink href={ `/organize/${orgId}/people` }>
+                            <Button aria-label="People" className={ classes.roundButton } color={ key.startsWith('/people') ?  'primary' : 'secondary' } data-test="people-button" href="#">
+                                <People />
+                            </Button>
+                        </NextLink>
+                    </ListItem>
+                    <ListItem>
+                        <NextLink href={ `/organize/${orgId}/areas` }>
+                            <Button aria-label="Areas" className={ classes.roundButton } color={ key.startsWith('/areas') ?  'primary' : 'secondary' } data-test="area-button" href="#">
+                                <Map />
+                            </Button>
+                        </NextLink>
+                    </ListItem>
+                    <ListItem>
+                        <NextLink href={ `/organize/${orgId}/campaigns/calendar` }>
+                            <Button aria-label="Campaigns" className={ classes.roundButton } color={ key.startsWith('/campaigns') ?  'primary' : 'secondary' } data-test="calendar-button" href="#">
+                                <Event />
+                            </Button>
+                        </NextLink>
+                    </ListItem>
+                </Box>
+            </List>
+            <Box display="flex" flexDirection="column">
+                <List>
+                    <ListItem>
+                        <Button aria-label="Inbox" className={ classes.roundButton } color="secondary" data-test="inbox-button">
+                            <Inbox />
+                        </Button>
+                    </ListItem>
+                    <ListItem>
+                        <Button aria-label="Organize" className={ classes.roundButton } color="secondary" data-test="user-button">
+                            <Person />
+                        </Button>
+                    </ListItem>
+                </List>
+            </Box>
+        </Box>
+    );
+
     return (
-        <Flex direction="column" height="100%" justifyContent="space-between">
-            <Flex direction="column">
-                <NextLink href={ `/organize/${orgId}` }>
-                    <Button data-test="home-button" isDisabled={ key === '' } margin="size-100" variant="primary" width="size-00">
-                        <Home aria-label="Home" />
-                    </Button>
-                </NextLink>
-                <NextLink href={ `/organize/${orgId}/people` }>
-                    <Button data-test="people-button" isDisabled={ key.startsWith('/people') } margin="size-100" variant="primary">
-                        <PeopleGroup aria-label="People" />
-                    </Button>
-                </NextLink>
-                <NextLink href={ `/organize/${orgId}/areas` }>
-                    <Button data-test="area-button" isDisabled={ key.startsWith('/area') } margin="size-100" variant="primary">
-                        <MapView aria-label="Areas" />
-                    </Button>
-                </NextLink>
-                <NextLink href={ `/organize/${orgId}/campaigns/calendar` }>
-                    <Button data-test="calendar-button" isDisabled={ key.startsWith('/campaigns') } margin="size-100" variant="primary">
-                        <Calendar aria-label="Calendar" />
-                    </Button>
-                </NextLink>
-            </Flex>
-            <Flex direction="column">
-                <Button data-test="inbox-button" margin="size-100" variant="secondary">
-                    <Inbox aria-label="Inbox" />
-                </Button>
-                <Button data-test="user-button" margin="size-100" variant="secondary">
-                    <User aria-label="User" />
-                </Button>
-            </Flex>
-        </Flex>
+        <div className={ classes.root }>
+            <AppBar className={ classes.appBar } position="fixed">
+                <Toolbar>
+                    <IconButton
+                        aria-label="open drawer"
+                        className={ classes.menuButton }
+                        color="inherit"
+                        edge="start"
+                        onClick={ handleDrawerToggle }>
+                        <Menu data-test="menu-button"/>
+                    </IconButton>
+                </Toolbar>
+            </AppBar>
+            <nav aria-label="mailbox folders" className={ classes.drawer }>
+                <Hidden implementation="css" smUp>
+                    <Drawer
+                        anchor={ theme.direction === 'rtl' ? 'right' : 'left' }
+                        classes={{
+                            paper: classes.drawerPaper,
+                        }}
+                        ModalProps={{
+                            keepMounted: true, // Better open performance on mobile.
+                        }}
+                        onClose={ handleDrawerToggle }
+                        open={ mobileOpen }
+                        variant="temporary">
+                        { drawer }
+                    </Drawer>
+                </Hidden>
+                <Hidden implementation="css" xsDown>
+                    <Drawer
+                        classes={{
+                            paper: classes.drawerPaper,
+                        }}
+                        open
+                        variant="permanent">
+                        { drawer }
+                    </Drawer>
+                </Hidden>
+            </nav>
+        </div>
     );
 };
 

--- a/src/components/OrganizeSidebar.tsx
+++ b/src/components/OrganizeSidebar.tsx
@@ -67,29 +67,29 @@ const OrganizeSidebar = ({ orgId  } : OrganizeSidebarProps) : JSX.Element =>{
             <List>
                 <Box display="flex" flexDirection="column">
                     <ListItem>
-                        <NextLink href={ `/organize/${orgId}` }>
-                            <Button aria-label="Home" className={ classes.roundButton } color={ key === '' ?  'primary' : 'secondary' } data-test="home-button" href="#">
+                        <NextLink href={ `/organize/${orgId}` } passHref>
+                            <Button aria-label="Home" className={ classes.roundButton } color={ key === '' ?  'primary' : 'secondary' } data-test="home-button">
                                 <Home />
                             </Button>
                         </NextLink>
                     </ListItem>
                     <ListItem>
-                        <NextLink href={ `/organize/${orgId}/people` }>
-                            <Button aria-label="People" className={ classes.roundButton } color={ key.startsWith('/people') ?  'primary' : 'secondary' } data-test="people-button" href="#">
+                        <NextLink href={ `/organize/${orgId}/people` } passHref>
+                            <Button aria-label="People" className={ classes.roundButton } color={ key.startsWith('/people') ?  'primary' : 'secondary' } data-test="people-button">
                                 <People />
                             </Button>
                         </NextLink>
                     </ListItem>
                     <ListItem>
-                        <NextLink href={ `/organize/${orgId}/areas` }>
-                            <Button aria-label="Areas" className={ classes.roundButton } color={ key.startsWith('/areas') ?  'primary' : 'secondary' } data-test="area-button" href="#">
+                        <NextLink href={ `/organize/${orgId}/areas` } passHref>
+                            <Button aria-label="Areas" className={ classes.roundButton } color={ key.startsWith('/areas') ?  'primary' : 'secondary' } data-test="area-button">
                                 <Map />
                             </Button>
                         </NextLink>
                     </ListItem>
                     <ListItem>
-                        <NextLink href={ `/organize/${orgId}/campaigns/calendar` }>
-                            <Button aria-label="Campaigns" className={ classes.roundButton } color={ key.startsWith('/campaigns') ?  'primary' : 'secondary' } data-test="calendar-button" href="#">
+                        <NextLink href={ `/organize/${orgId}/campaigns/calendar` } passHref>
+                            <Button aria-label="Campaigns" className={ classes.roundButton } color={ key.startsWith('/campaigns') ?  'primary' : 'secondary' } data-test="calendar-button">
                                 <Event />
                             </Button>
                         </NextLink>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,13 @@
 import '../styles.css';
 import { AppProps } from 'next/app';
+import CssBaseline from '@material-ui/core/CssBaseline';
 import { Hydrate } from 'react-query/hydration';
 import { IntlProvider } from 'react-intl';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { SSRProvider } from '@react-aria/ssr';
+import theme from '../theme';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { useEffect } from 'react';
 import { UserContext } from '../hooks';
 import { defaultTheme, Provider } from '@adobe/react-spectrum';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -28,22 +32,33 @@ function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
         window.__reactRendered = true;
     }
 
+    useEffect(() => {
+        // Remove the server-side injected CSS.
+        const jssStyles = document.querySelector('#jss-server-side');
+        if (jssStyles) {
+            jssStyles.parentElement?.removeChild(jssStyles);
+        }
+    }, []);
+
     return (
         <UserContext.Provider value={ pageProps.user }>
             <SSRProvider>
-                <Provider theme={ defaultTheme }>
-                    <IntlProvider
-                        defaultLocale="en"
-                        locale={ lang }
-                        messages={ messages }>
-                        <QueryClientProvider client={ queryClient }>
-                            <Hydrate state={ dehydratedState }>
-                                { getLayout(<Component { ...restProps } />, restProps) }
-                            </Hydrate>
-                            <ReactQueryDevtools initialIsOpen={ false } />
-                        </QueryClientProvider>
-                    </IntlProvider>
-                </Provider>
+                <ThemeProvider theme={ theme }>
+                    <Provider theme={ defaultTheme }>
+                        <IntlProvider
+                            defaultLocale="en"
+                            locale={ lang }
+                            messages={ messages }>
+                            <QueryClientProvider client={ queryClient }>
+                                <Hydrate state={ dehydratedState }>
+                                    <CssBaseline />
+                                    { getLayout(<Component { ...restProps } />, restProps) }
+                                </Hydrate>
+                                <ReactQueryDevtools initialIsOpen={ false } />
+                            </QueryClientProvider>
+                        </IntlProvider>
+                    </Provider>
+                </ThemeProvider>
             </SSRProvider>
         </UserContext.Provider>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,68 @@
+import { Children } from 'react';
+import { ServerStyleSheets } from '@material-ui/core/styles';
+import theme from '../theme';
+import Document, { Head, Html, Main, NextScript } from 'next/document';
+
+export default class MyDocument extends Document {
+    render():JSX.Element {
+        return (
+            <Html lang="en">
+                <Head>
+                    { /* PWA primary color */ }
+                    <meta content={ theme.palette.primary.main } name="theme-color" />
+                    <link
+                        href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+                        rel="stylesheet"
+                    />
+                </Head>
+                <body>
+                    <Main />
+                    <NextScript />
+                </body>
+            </Html>
+        );
+    }
+}
+
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with server-side generation (SSG).
+MyDocument.getInitialProps = async (ctx) => {
+    // Resolution order
+    //
+    // On the server:
+    // 1. app.getInitialProps
+    // 2. page.getInitialProps
+    // 3. document.getInitialProps
+    // 4. app.render
+    // 5. page.render
+    // 6. document.render
+    //
+    // On the server with error:
+    // 1. document.getInitialProps
+    // 2. app.render
+    // 3. page.render
+    // 4. document.render
+    //
+    // On the client
+    // 1. app.getInitialProps
+    // 2. page.getInitialProps
+    // 3. app.render
+    // 4. page.render
+
+    // Render app and page and get the context of the page with collected side effects.
+    const sheets = new ServerStyleSheets();
+    const originalRenderPage = ctx.renderPage;
+
+    ctx.renderPage = () =>
+        originalRenderPage({
+            enhanceApp: (App) => (props) => sheets.collect(<App { ...props } />),
+        });
+
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return {
+        ...initialProps,
+        // Styles fragment is rendered after the app and page rendering finish.
+        styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()],
+    };
+};

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,6 +3,8 @@ import { ServerStyleSheets } from '@material-ui/core/styles';
 import theme from '../theme';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
+// boilerplate page taken from https://github.com/mui-org/material-ui/tree/master/examples/nextjs
+
 export default class MyDocument extends Document {
     render():JSX.Element {
         return (
@@ -24,32 +26,7 @@ export default class MyDocument extends Document {
     }
 }
 
-// `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with server-side generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
-    // Resolution order
-    //
-    // On the server:
-    // 1. app.getInitialProps
-    // 2. page.getInitialProps
-    // 3. document.getInitialProps
-    // 4. app.render
-    // 5. page.render
-    // 6. document.render
-    //
-    // On the server with error:
-    // 1. document.getInitialProps
-    // 2. app.render
-    // 3. page.render
-    // 4. document.render
-    //
-    // On the client
-    // 1. app.getInitialProps
-    // 2. page.getInitialProps
-    // 3. app.render
-    // 4. page.render
-
-    // Render app and page and get the context of the page with collected side effects.
     const sheets = new ServerStyleSheets();
     const originalRenderPage = ctx.renderPage;
 
@@ -62,7 +39,6 @@ MyDocument.getInitialProps = async (ctx) => {
 
     return {
         ...initialProps,
-        // Styles fragment is rendered after the app and page rendering finish.
         styles: [...Children.toArray(initialProps.styles), sheets.getStyleElement()],
     };
 };

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -52,7 +52,7 @@ type OrganizePageProps = {
 const useStyles = makeStyles((theme) => ({
     responsiveFlexBox: {
         display: 'flex',
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down('sm')]: {
             flexDirection: 'column',
         },
     },
@@ -73,7 +73,7 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId }) => {
                         { orgQuery.data?.title }
                     </Typography>
                     <Typography color="primary">
-                        <Box display="flex" p={ 0 }>
+                        <Box className={ classes.responsiveFlexBox } p={ 0 }>
                             <Box display="flex" p={ 1 } pl={ 0 }>
                                 <Public />
                                 <NextLink href={ `/o/${orgId}` }>
@@ -104,15 +104,11 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId }) => {
             </Box>
             <Box className={ classes.responsiveFlexBox } p={ 2 }>
                 <Box flex={ 1 } width="100%">
-                    <Box border={ 1 } m={ 2 } p={ 2 }>
-                        <DashboardCampaigns orgId={ orgId }/>
-                    </Box>
-                    <Box border={ 1 } m={ 2 } p={ 2 }>
-                        <DashboardPeople orgId={ orgId }/>
-                    </Box>
+                    <DashboardCampaigns orgId={ orgId }/>
+                    <DashboardPeople orgId={ orgId }/>
                     <Box border={ 1 } m={ 2 } p={ 2 }>Areas</Box>
                 </Box>
-                <Box border={ 1 } flex={ 1 } p={ 2 } width="100%">inbox</Box>
+                <Box border={ 1 } flex={ 1 } m={ 2 } p={ 2 } width="100%">inbox</Box>
             </Box>
         </>
     );

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -76,24 +76,24 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId }) => {
                         <Box className={ classes.responsiveFlexBox } p={ 0 }>
                             <Box display="flex" p={ 1 } pl={ 0 }>
                                 <Public />
-                                <NextLink href={ `/o/${orgId}` }>
-                                    <Link color="inherit" href="#">
+                                <NextLink href={ `/o/${orgId}` } passHref>
+                                    <Link color="inherit">
                                         <Msg id="pages.organize.linkGroup.public"/>
                                     </Link>
                                 </NextLink>
                             </Box>
                             <Box display="flex" p={ 1 }>
                                 <SupervisorAccount />
-                                <NextLink href={ `/organize/${orgId}/organization` }>
-                                    <Link color="inherit" href="#">
+                                <NextLink href={ `/organize/${orgId}/organization` } passHref>
+                                    <Link color="inherit">
                                         <Msg id="pages.organize.linkGroup.manage"/>
                                     </Link>
                                 </NextLink>
                             </Box>
                             <Box display="flex" p={ 1 }>
                                 <Settings />
-                                <NextLink href={ `/organize/${orgId}/settings` }>
-                                    <Link color="inherit" href="#">
+                                <NextLink href={ `/organize/${orgId}/settings` } passHref>
+                                    <Link color="inherit">
                                         <Msg id="pages.organize.linkGroup.settings"/>
                                     </Link>
                                 </NextLink>

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -1,11 +1,9 @@
-import Actions from '@spectrum-icons/workflow/Actions';
-import Cloud from '@spectrum-icons/workflow/Cloud';
 import { GetServerSideProps } from 'next';
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
-import Settings from '@spectrum-icons/workflow/Settings';
 import { useQuery } from 'react-query';
-import { Flex, Header, Heading, Image, View } from '@adobe/react-spectrum';
+import { Avatar, Box, Link, makeStyles, Typography } from '@material-ui/core';
+import { Public, Settings, SupervisorAccount } from '@material-ui/icons';
 
 import apiUrl from '../../../utils/apiUrl';
 import DashboardCampaigns from '../../../components/DashboardCampaigns';
@@ -51,68 +49,71 @@ type OrganizePageProps = {
     orgId: string;
 };
 
+const useStyles = makeStyles((theme) => ({
+    responsiveFlexBox: {
+        display: 'flex',
+        [theme.breakpoints.down('md')]: {
+            flexDirection: 'column',
+        },
+    },
+}));
+
 const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId }) => {
 
     const orgQuery = useQuery(['org', orgId], getOrg(orgId));
-
+    const classes = useStyles();
     return (
         <>
-            <View borderColor="gray-400" borderWidth="thick" margin="1rem" padding="1rem">
-                <Header>
-                    <Flex height="100%" justifyContent="start" width="100%">
-                        <Image
-                            alt="Organization avatar"
-                            data-testid="org-avatar"
-                            objectFit="contain"
-                            src={ apiUrl(`/orgs/${orgId}/avatar`) }
-                            width="size-1200"
-                        />
-                        <View>
-                            <Flex direction="column" margin="0 1rem">
-                                <Heading level={ 1 }>
-                                    { orgQuery.data?.title }
-                                </Heading>
-                                <View>
-                                    <Cloud aria-label="Cloud" size="XS" />
-                                    <NextLink href={ `/o/${orgId}` }>
-                                        <a style={{ margin:'0.5rem' }}>
-                                            <Msg id="pages.organize.linkGroup.public"/>
-                                        </a>
-                                    </NextLink>
-                                    <Actions aria-label="Actions" size="XS" />
-                                    <NextLink href={ `/organize/${orgId}/organization` }>
-                                        <a style={{ margin:'0.5rem' }}>
-                                            <Msg id="pages.organize.linkGroup.manage"/>
-                                        </a>
-                                    </NextLink>
-                                    <Settings aria-label="Settings" size="XS" />
-                                    <NextLink href={ `/organize/${orgId}/settings` }>
-                                        <a style={{ margin:'0.5rem' }}>
-                                            <Msg id="pages.organize.linkGroup.settings"/>
-                                        </a>
-                                    </NextLink>
-                                </View>
-                            </Flex>
-                        </View>
-                    </Flex>
-                </Header>
-            </View>
-            <View>
-                <Flex>
-                    <View width="50%">
-                        <View borderColor="gray-400" borderWidth="thick" margin="size-200" padding="size-200">
-                            <DashboardCampaigns orgId={ orgId }/>
-                        </View>
-                        <View borderColor="gray-400" borderWidth="thick" margin="size-200" padding="size-200">
-                            <DashboardPeople orgId={ orgId }/>
-                        </View>
-                        <View borderColor="gray-400" borderWidth="thick" margin="size-200">
-                            Areas
-                        </View>
-                    </View>
-                    <View borderColor="gray-400" borderWidth="thick" height="size-1200" margin="size-200" width="50%">Inbox</View>
-                </Flex>
-            </View>
+            <Box className={ classes.responsiveFlexBox } p={ 3 }>
+                <Box p={ 2 }>
+                    <Avatar src={ apiUrl(`/orgs/${orgId}/avatar`) } style={{ height: '100px', width: '100px' }}></Avatar>
+                </Box>
+                <Box display="flex" flexDirection="column" p={ 2 }>
+                    <Typography component="h1" variant="h3">
+                        { orgQuery.data?.title }
+                    </Typography>
+                    <Typography color="primary">
+                        <Box display="flex" p={ 0 }>
+                            <Box display="flex" p={ 1 } pl={ 0 }>
+                                <Public />
+                                <NextLink href={ `/o/${orgId}` }>
+                                    <Link color="inherit" href="#">
+                                        <Msg id="pages.organize.linkGroup.public"/>
+                                    </Link>
+                                </NextLink>
+                            </Box>
+                            <Box display="flex" p={ 1 }>
+                                <SupervisorAccount />
+                                <NextLink href={ `/organize/${orgId}/organization` }>
+                                    <Link color="inherit" href="#">
+                                        <Msg id="pages.organize.linkGroup.manage"/>
+                                    </Link>
+                                </NextLink>
+                            </Box>
+                            <Box display="flex" p={ 1 }>
+                                <Settings />
+                                <NextLink href={ `/organize/${orgId}/settings` }>
+                                    <Link color="inherit" href="#">
+                                        <Msg id="pages.organize.linkGroup.settings"/>
+                                    </Link>
+                                </NextLink>
+                            </Box>
+                        </Box>
+                    </Typography>
+                </Box>
+            </Box>
+            <Box className={ classes.responsiveFlexBox } p={ 2 }>
+                <Box flex={ 1 } width="100%">
+                    <Box border={ 1 } m={ 2 } p={ 2 }>
+                        <DashboardCampaigns orgId={ orgId }/>
+                    </Box>
+                    <Box border={ 1 } m={ 2 } p={ 2 }>
+                        <DashboardPeople orgId={ orgId }/>
+                    </Box>
+                    <Box border={ 1 } m={ 2 } p={ 2 }>Areas</Box>
+                </Box>
+                <Box border={ 1 } flex={ 1 } p={ 2 } width="100%">inbox</Box>
+            </Box>
         </>
     );
 };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -14,7 +14,7 @@ const theme = createMuiTheme({
             main: '#553cd6',
         },
         secondary: {
-            main: '#19857b',
+            main: '#585858',
         },
     },
 });

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,22 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+import { red } from '@material-ui/core/colors';
+
+// Create a theme instance.
+const theme = createMuiTheme({
+    palette: {
+        background: {
+            default: '#fff',
+        },
+        error: {
+            main: red.A400,
+        },
+        primary: {
+            main: '#553cd6',
+        },
+        secondary: {
+            main: '#19857b',
+        },
+    },
+});
+
+export default theme;

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -1,12 +1,16 @@
 import { IntlProvider } from 'react-intl';
 import { mount } from '@cypress/react';
+import theme from '../theme';
+import { ThemeProvider } from '@material-ui/core/styles';
 import { defaultTheme, Provider } from '@adobe/react-spectrum';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const mountWithProviders = (elem : any) : any => mount(
     <Provider theme={ defaultTheme }>
-        <IntlProvider locale="en">
-            { elem }
-        </IntlProvider>
+        <ThemeProvider theme={ theme }>
+            <IntlProvider locale="en">
+                { elem }
+            </IntlProvider>
+        </ThemeProvider>
     </Provider>,
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,14 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
+      "es6",
       "dom",
       "dom.iterable",
       "esnext"
     ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,6 +807,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.4.4":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -977,6 +984,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@emotion/hash@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -1107,6 +1119,77 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@material-ui/core@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.4.tgz#4fb9fe5dec5dcf780b687e3a40cff78b2b9640a4"
+  integrity sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.11.3"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.5.1"
+    jss-plugin-camel-case "^10.5.1"
+    jss-plugin-default-unit "^10.5.1"
+    jss-plugin-global "^10.5.1"
+    jss-plugin-nested "^10.5.1"
+    jss-plugin-props-sort "^10.5.1"
+    jss-plugin-rule-value-function "^10.5.1"
+    jss-plugin-vendor-prefixer "^10.5.1"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.11.3":
+  version "4.11.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
+  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@next/env@10.0.8":
   version "10.0.8"
@@ -2705,6 +2788,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/react-transition-group@^4.2.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
+  integrity sha512-vIo69qKKcYoJ8wKCJjwSgCTM+z3chw3g18dkrDfVX665tMH7tmbDxEAnPdey4gTlwZz5QuHGzd+hul0OVZDqqQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.0":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
@@ -4119,7 +4209,7 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clsx@^1.1.1:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -4465,6 +4555,14 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^3.0.0"
     fastparse "^1.1.2"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css.escape@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
@@ -4490,6 +4588,11 @@ cssnano-simple@1.2.2:
   dependencies:
     cssnano-preset-simple "1.2.2"
     postcss "^7.0.32"
+
+csstype@^2.5.2:
+  version "2.6.17"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
+  integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
 
 csstype@^3.0.2:
   version "3.0.7"
@@ -4763,6 +4866,14 @@ dom-helpers@^3.3.1, dom-helpers@^3.4.0:
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 domain-browser@^1.1.1, domain-browser@^1.2.0:
   version "1.2.0"
@@ -5986,6 +6097,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -6064,6 +6180,13 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indefinite-observable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/indefinite-observable/-/indefinite-observable-2.0.1.tgz#574af29bfbc17eb5947793797bddc94c9d859400"
+  integrity sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==
+  dependencies:
+    symbol-observable "1.2.0"
 
 indent-string@^3.0.0:
   version "3.2.0"
@@ -6344,6 +6467,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-installed-globally@^0.3.2:
   version "0.3.2"
@@ -6682,6 +6810,77 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+jss-plugin-camel-case@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz#93d2cd704bf0c4af70cc40fb52d74b8a2554b170"
+  integrity sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.6.0"
+
+jss-plugin-default-unit@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz#af47972486819b375f0f3a9e0213403a84b5ef3b"
+  integrity sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.6.0"
+
+jss-plugin-global@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz#3e8011f760f399cbadcca7f10a485b729c50e3ed"
+  integrity sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.6.0"
+
+jss-plugin-nested@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz#5f83c5c337d3b38004834e8426957715a0251641"
+  integrity sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.6.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz#297879f35f9fe21196448579fee37bcde28ce6bc"
+  integrity sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.6.0"
+
+jss-plugin-rule-value-function@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz#3c1a557236a139d0151e70a82c810ccce1c1c5ea"
+  integrity sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.6.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz#e1fcd499352846890c38085b11dbd7aa1c4f2c78"
+  integrity sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.6.0"
+
+jss@10.6.0, jss@^10.5.1:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.6.0.tgz#d92ff9d0f214f65ca1718591b68e107be4774149"
+  integrity sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    indefinite-observable "^2.0.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
@@ -7944,6 +8143,11 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 popsicle-content-encoding@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz#2ab419083fee0387bf6e64d21b1a9af560795adb"
@@ -8317,6 +8521,11 @@ react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+"react-is@^16.8.0 || ^17.0.0":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
 react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
@@ -8357,6 +8566,16 @@ react-transition-group@^2.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.4.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@17.0.1:
   version "17.0.1"
@@ -9312,7 +9531,7 @@ supports-color@^7.1.0, supports-color@^7.2.0:
   dependencies:
     has-flag "^4.0.0"
 
-symbol-observable@^1.1.0:
+symbol-observable@1.2.0, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -9413,6 +9632,11 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tmp@~0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This PR transitions from Adobe spectrum to MUI for the Organize dahsboard page and its components. Updates tests. 

Something to look into is the best way to use the styles API -- right now I'm using useStyles() inside each component.

![Screenshot 2021-06-10 at 16 30 36](https://user-images.githubusercontent.com/62522290/121543429-31907800-ca09-11eb-88a1-e17d60b691a7.png)

![Screenshot 2021-06-10 at 16 30 59](https://user-images.githubusercontent.com/62522290/121543488-3ead6700-ca09-11eb-8a03-de5624da46d4.png)

