### PR TITLE
Issue 177 - Search Drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/negotiator": "^0.6.1",
     "@types/random-seed": "^0.3.3",
     "leaflet": "^1.7.1",
+    "lodash.debounce": "^4.0.8",
     "negotiator": "^0.6.2",
     "next": "^10.0.3",
     "next-session": "^3.4.0",

--- a/src/components/SearchDrawer.tsx
+++ b/src/components/SearchDrawer.tsx
@@ -4,7 +4,6 @@ import Search from '@material-ui/icons/Search';
 import { useIntl } from 'react-intl';
 import { useState } from 'react';
 import { Box, InputAdornment, makeStyles, TextField, Typography } from '@material-ui/core';
-import { Flex } from '@react-spectrum/layout';
 
 
 const useStyles = makeStyles(() => ({
@@ -70,11 +69,11 @@ const SearchDrawer = (): JSX.Element | null => {
                     />
                     {/* Search Drawer Content */}
                     <Box display={ drawerOpen ? 'block' : 'none' }>
-                        <Flex direction="row-reverse">
+                        <Box display="flex" flexDirection="row-reverse">
                             <Typography variant="body2">
                                 <Msg id="layout.organize.search.drawerLabel"/>
                             </Typography>
-                        </Flex>
+                        </Box>
                     </Box>
                 </div>
             </div>

--- a/src/components/SearchDrawer.tsx
+++ b/src/components/SearchDrawer.tsx
@@ -18,15 +18,14 @@ interface SearchDrawerProps {
 
 const SearchDrawer: FunctionComponent<SearchDrawerProps> = ({ orgId }): JSX.Element | null => {
     const intl = useIntl();
-    const [searchQuery, setSearchQuery] = useState<string>('');
+    const [searchQuery, setSearchQuery] = useState<string>('')
     const [drawerOpen, setDrawerOpen] = useState(false);
     const classes = useStyles();
 
     // Gets the search results if user stops typing
-    const debouncedSearch = useDebounce(async (searchQuery: string) => {
+    const debouncedSearch = useDebounce(async (debouncedSearchQuery: string) => {
         if (searchQuery.length > 0) {
-            const data = getSearchDrawerResults(searchQuery, orgId)
-            console.log(data)
+            getSearchDrawerResults(searchQuery, orgId)
         }
     }, 600);
 

--- a/src/components/SearchDrawer.tsx
+++ b/src/components/SearchDrawer.tsx
@@ -1,10 +1,9 @@
-import { FocusEventHandler } from 'react';
-import { FormattedMessage as Msg } from 'react-intl';
-import Search from '@material-ui/icons/Search';
-import { useIntl } from 'react-intl';
-import { useState } from 'react';
+import { useState, FocusEventHandler } from 'react';
+import { useIntl, FormattedMessage as Msg } from 'react-intl';
 import { Box, InputAdornment, makeStyles, TextField, Typography } from '@material-ui/core';
+import Search from '@material-ui/icons/Search';
 
+import useDebounce from '../hooks/useDebounce';
 
 const useStyles = makeStyles(() => ({
     textField: {
@@ -14,9 +13,13 @@ const useStyles = makeStyles(() => ({
 
 const SearchDrawer = (): JSX.Element | null => {
     const intl = useIntl();
-    const [currentText, setCurrentText] = useState('');
     const [drawerOpen, setDrawerOpen] = useState(false);
     const classes = useStyles();
+
+    // Gets the search results if user stops typing
+    const debouncedSearch = useDebounce(async (searchQuery: string) => {
+        console.log(searchQuery)
+    }, 600);
 
     const collapse:FocusEventHandler<Element> = (e) => {
         e.stopPropagation();
@@ -49,10 +52,10 @@ const SearchDrawer = (): JSX.Element | null => {
                             ),
                         }}
                         onChange={ e => {
-                            setCurrentText(e.target.value);
                             if (!drawerOpen) {
                                 setDrawerOpen(true);
                             }
+                            debouncedSearch(e.target.value)
                         } }
                         onFocus={ expand }
                         onKeyUp={ e => {
@@ -63,7 +66,6 @@ const SearchDrawer = (): JSX.Element | null => {
                         placeholder={ intl.formatMessage({
                             id: 'layout.organize.search.placeholder',
                         }) }
-                        value={ currentText }
                         variant="outlined"
                         size="small"
                     />

--- a/src/components/SearchDrawer.tsx
+++ b/src/components/SearchDrawer.tsx
@@ -1,13 +1,23 @@
 import { FocusEventHandler } from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
+import Search from '@material-ui/icons/Search';
 import { useIntl } from 'react-intl';
 import { useState } from 'react';
-import { SearchField, Text, View } from '@adobe/react-spectrum';
+import { Box, InputAdornment, makeStyles, TextField, Typography } from '@material-ui/core';
+import { Flex } from '@react-spectrum/layout';
+
+
+const useStyles = makeStyles(() => ({
+    textField: {
+        width: '100%',
+    },
+}));
 
 const SearchDrawer = (): JSX.Element | null => {
     const intl = useIntl();
     const [currentText, setCurrentText] = useState('');
     const [drawerOpen, setDrawerOpen] = useState(false);
+    const classes = useStyles();
 
     const collapse:FocusEventHandler<Element> = (e) => {
         e.stopPropagation();
@@ -26,12 +36,21 @@ const SearchDrawer = (): JSX.Element | null => {
                 onFocus={ collapse } tabIndex={ -1 }>
                 <div
                     className={ `drawer ${drawerOpen ? 'expanded' : 'collapsed'}` }>
-                    <SearchField
+                    <TextField
                         aria-label={ intl.formatMessage({
                             id: 'layout.organize.search.label',
                         }) }
-                        onChange={ text => {
-                            setCurrentText(text);
+                        className={ classes.textField }
+                        id="input-with-icon-textfield"
+                        InputProps={{
+                            startAdornment: (
+                                <InputAdornment position="start">
+                                    <Search />
+                                </InputAdornment>
+                            ),
+                        }}
+                        onChange={ e => {
+                            setCurrentText(e.target.value);
                             if (!drawerOpen) {
                                 setDrawerOpen(true);
                             }
@@ -46,13 +65,17 @@ const SearchDrawer = (): JSX.Element | null => {
                             id: 'layout.organize.search.placeholder',
                         }) }
                         value={ currentText }
-                        width="100%"
+                        variant="outlined"
+                        size="small"
                     />
-                    <View isHidden={ !drawerOpen }>
-                        <Text>
-                            <Msg id="layout.organize.search.drawerLabel"/>
-                        </Text>
-                    </View>
+                    {/* Search Drawer Content */}
+                    <Box display={ drawerOpen ? 'block' : 'none' }>
+                        <Flex direction="row-reverse">
+                            <Typography variant="body2">
+                                <Msg id="layout.organize.search.drawerLabel"/>
+                            </Typography>
+                        </Flex>
+                    </Box>
                 </div>
             </div>
 
@@ -72,7 +95,6 @@ const SearchDrawer = (): JSX.Element | null => {
                 .hidden {
                     width: 0; height: 0;
                 }
-
                 .drawer {
                     width: 25vw;
                     transition: width 500ms;
@@ -89,6 +111,11 @@ const SearchDrawer = (): JSX.Element | null => {
                     top: 0;
                     right: 0;
                     z-index: 3;
+                }
+                @media screen and (max-width: 600px) {
+                    .drawer {
+                        width: 40vw;
+                    }
                 }
                 ` }
             </style>

--- a/src/components/SearchDrawer.tsx
+++ b/src/components/SearchDrawer.tsx
@@ -1,24 +1,33 @@
-import { useState, FocusEventHandler } from 'react';
+import { useState, FocusEventHandler, FunctionComponent } from 'react';
 import { useIntl, FormattedMessage as Msg } from 'react-intl';
+import { useQuery } from 'react-query';
 import { Box, InputAdornment, makeStyles, TextField, Typography } from '@material-ui/core';
 import Search from '@material-ui/icons/Search';
 
+import getSearchDrawerResults from '../fetching/getSearchDrawerResults';
 import useDebounce from '../hooks/useDebounce';
-
 const useStyles = makeStyles(() => ({
     textField: {
         width: '100%',
     },
 }));
 
-const SearchDrawer = (): JSX.Element | null => {
+interface SearchDrawerProps {
+    orgId: string
+}
+
+const SearchDrawer: FunctionComponent<SearchDrawerProps> = ({ orgId }): JSX.Element | null => {
     const intl = useIntl();
+    const [searchQuery, setSearchQuery] = useState<string>('');
     const [drawerOpen, setDrawerOpen] = useState(false);
     const classes = useStyles();
 
     // Gets the search results if user stops typing
     const debouncedSearch = useDebounce(async (searchQuery: string) => {
-        console.log(searchQuery)
+        if (searchQuery.length > 0) {
+            const data = getSearchDrawerResults(searchQuery, orgId)
+            console.log(data)
+        }
     }, 600);
 
     const collapse:FocusEventHandler<Element> = (e) => {

--- a/src/components/layout/OrganizeLayout.tsx
+++ b/src/components/layout/OrganizeLayout.tsx
@@ -23,7 +23,7 @@ const OrganizeLayout : FunctionComponent<OrganizeLayoutProps> = ({ children, org
                                 <BreadcrumbTrail/>
                             </View>
                             <Flex justifyContent="end" width="50%">
-                                <SearchDrawer />
+                                <SearchDrawer {...{orgId}} />
                             </Flex>
                         </Flex>
                     </View>

--- a/src/fetching/getSearchDrawerResults.ts
+++ b/src/fetching/getSearchDrawerResults.ts
@@ -1,0 +1,22 @@
+import { defaultFetch } from ".";
+import apiUrl from "../utils/apiUrl";
+
+export default async function getSearchDrawerResults(
+    searchQuery: string,
+    orgId: string,
+    fetch = defaultFetch
+) {
+    const body = JSON.stringify({
+        "q": searchQuery,
+    });
+
+    const res = await fetch(`/orgs/${orgId}/search/campaign`, {
+        method: "POST",
+        headers: {
+          "Content-Type": 'application/json'
+        },
+        body,
+    });
+    const data = await res.json();
+    return data;
+}

--- a/src/fetching/getSearchDrawerResults.ts
+++ b/src/fetching/getSearchDrawerResults.ts
@@ -7,13 +7,13 @@ export default async function getSearchDrawerResults(
     fetch = defaultFetch
 ) {
     const body = JSON.stringify({
-        "q": searchQuery,
+        q: searchQuery,
     });
 
     const res = await fetch(`/orgs/${orgId}/search/campaign`, {
         method: "POST",
         headers: {
-          "Content-Type": 'application/json'
+            "Content-Type": "application/json",
         },
         body,
     });

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,7 +1,13 @@
 import { useCallback, useRef, useEffect } from 'react';
 import debounce from 'lodash.debounce';
 
-export default (callback: () => any, delay: number) => {
+type DefaultCallbackArgs = Array<any>
+type CallbackFn<Args extends DefaultCallbackArgs> =(...args: Args) => Promise<void>
+
+/**
+ * Runs the callback function only if the delay time has passed.
+ */
+export default <Args extends DefaultCallbackArgs>(callback: CallbackFn<Args>, delay: number) => {
   // Memoizing the callback because if it's an arrow function
   // it would be different on each render
   const memoizedCallback = useCallback(callback, []);

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,15 @@
+import { useCallback, useRef, useEffect } from 'react';
+import debounce from 'lodash.debounce';
+
+export default (callback: () => any, delay: number) => {
+  // Memoizing the callback because if it's an arrow function
+  // it would be different on each render
+  const memoizedCallback = useCallback(callback, []);
+  const debouncedFn = useRef(debounce(memoizedCallback, delay));
+
+  useEffect(() => {
+    debouncedFn.current = debounce(memoizedCallback, delay);
+  }, [memoizedCallback, debouncedFn, delay]);
+
+  return debouncedFn.current;
+};


### PR DESCRIPTION
Resolves: #209 

This PR:
- [x]  Migrates `SearchDrawer` to MUI (from @nehahirve's work)
- [ ] Displays people search results in the search drawer. Uses debounced search.
- [ ] Creates a SearchResultsList component, which is used in the drawer
- [ ] Navigates to organization search page when pressing "enter" from the navigation drawer.
- [ ] Allows use of arrows to navigate in results list. Pressing enter triggers the "onClick" action
