### PR TITLE
issue-226/interactive calendar bar

### DIFF
--- a/src/components/MonthCalendar.spec.tsx
+++ b/src/components/MonthCalendar.spec.tsx
@@ -44,7 +44,7 @@ describe('MonthCalendar', () => {
 
     it('shows a grid with 5 rows and 7 columns', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 3, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 3, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="calendar-wrapper"]').should('have.css', 'display', 'grid');
         cy.get('[data-testid="calendar-wrapper"]').children().should('have.length', 35);
@@ -70,7 +70,7 @@ describe('MonthCalendar', () => {
 
     it('shows a grid with 4 rows when the month is exactly 4 weeks starting on Monday', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 1, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 1, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="calendar-wrapper"]').should('have.css', 'display', 'grid');
         cy.get('[data-testid="calendar-wrapper"]').children().should('have.length', 28);
@@ -96,7 +96,7 @@ describe('MonthCalendar', () => {
 
     it('shows a grid with 6 rows when the month takes up more than 5 rows', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="calendar-wrapper"]').should('have.css', 'display', 'grid');
         cy.get('[data-testid="calendar-wrapper"]').children().should('have.length', 42);
@@ -122,7 +122,7 @@ describe('MonthCalendar', () => {
 
     it('displays the correct date on each grid square', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="griditem-5"]').contains('01');
         cy.get('[data-testid="griditem-35"]').contains('31');
@@ -130,7 +130,7 @@ describe('MonthCalendar', () => {
 
     it('displays the correct events on the corresponding date', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="griditem-1"]').contains('id 24');
         cy.get('[data-testid="griditem-14"]').contains('id 26');
@@ -139,7 +139,7 @@ describe('MonthCalendar', () => {
 
     it('shows out of range dates with another colour', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
 
         cy.get('[data-testid="griditem-4"]')
@@ -160,7 +160,7 @@ describe('MonthCalendar', () => {
 
     it('works with a leap year february', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2020, 1, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2020, 1, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="griditem-5"]').contains('01');
         cy.get('[data-testid="griditem-33"]').contains('29');
@@ -168,7 +168,7 @@ describe('MonthCalendar', () => {
 
     it('works across year boundaries', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2020, 11, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2020, 11, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="griditem-1"]').contains('01');
         cy.get('[data-testid="griditem-31"]').contains('31');
@@ -176,7 +176,7 @@ describe('MonthCalendar', () => {
 
     it('displays events in chronological order within a day', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="event-26"]').then(el => {
             const firstEventYPos = el[0].getBoundingClientRect().top;
@@ -189,7 +189,7 @@ describe('MonthCalendar', () => {
 
     it('shows back and forward widget buttons', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="back-button"]').should('be.visible');
         cy.get('[data-testid="fwd-button"]').should('be.visible');
@@ -197,7 +197,7 @@ describe('MonthCalendar', () => {
 
     it('shows the current displayed month in the widget', () => {
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
         cy.get('[data-testid="selected-month"]').contains('May');
         cy.get('[data-testid="selected-month"]').contains('2021');
@@ -206,7 +206,7 @@ describe('MonthCalendar', () => {
     it('sets the focus date a month ago when back is clicked', () => {
         const spyOnFocusDate = cy.spy();
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ spyOnFocusDate }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ spyOnFocusDate } orgId="1"  />,
         );
 
         cy.findByText('misc.calendar.prev')
@@ -222,7 +222,7 @@ describe('MonthCalendar', () => {
     it('sets the focus date a month forward when next is clicked', () => {
         const spyOnFocusDate = cy.spy();
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ spyOnFocusDate }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ spyOnFocusDate } orgId="1"  />,
         );
 
         cy.findByText('misc.calendar.next')
@@ -244,7 +244,7 @@ describe('MonthCalendar', () => {
             'start_time': '2021-04-27T15:37:00+00:00',
         };
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
 
         cy.get('[data-testid="event-26"]')
@@ -279,7 +279,7 @@ describe('MonthCalendar', () => {
             'start_time': '2021-04-29T15:37:00+00:00',
         };
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }/>,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"/>,
         );
 
         cy.get('[data-testid="calendar-bar-941"]').should('be.visible');
@@ -296,7 +296,7 @@ describe('MonthCalendar', () => {
             });
     });
 
-    it.only('does not overflow the calendar grid when there are too many events', () => {
+    it('does not overflow the calendar grid when there are too many events', () => {
         cy.viewport(800, 500);
         dummyEvents[4] = {
             ...dummyEvents[0],
@@ -327,7 +327,7 @@ describe('MonthCalendar', () => {
             'start_time': '2021-04-29T15:37:00+00:00',
         };
         mountWithProviders(
-            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }/>,
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"/>,
         );
 
         cy.get('[data-testid="griditem-3"]').should('be.visible');
@@ -344,4 +344,28 @@ describe('MonthCalendar', () => {
             });
     });
 
+    it('shows a tooltip when hovering over the weekly bar with campaign name', () => {
+        dummyEvents[4] = {
+            ...dummyEvents[0],
+            'campaign': { 'id': 942,'title': 'test-campaign' },
+            'end_time': '2021-04-27T17:37:00+00:00',
+            'id': 27,
+            'start_time': '2021-04-27T15:37:00+00:00',
+        };
+        dummyEvents[5] = {
+            ...dummyEvents[0],
+            'campaign': { 'id': 942,'title': 'test-campaign' },
+            'end_time': '2021-04-29T17:37:00+00:00',
+            'id': 30,
+            'start_time': '2021-04-29T15:37:00+00:00',
+        };
+        mountWithProviders(
+            <MonthCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"/>,
+        );
+
+        cy.get('[data-testid="calendar-bar-941"]').should('be.visible');
+
+        cy.get('[data-testid="calendar-bar-941"]').trigger('mouseover');
+        cy.findByText('Dummy campaign').should('be.visible');
+    });
 });

--- a/src/components/MonthCalendar.tsx
+++ b/src/components/MonthCalendar.tsx
@@ -1,6 +1,7 @@
 import { getContrastColor } from '../utils/colorUtils';
 import { grey } from '@material-ui/core/colors';
-import { Box, Button, makeStyles, Typography } from '@material-ui/core';
+import NextLink from 'next/link';
+import { Box, Button, Link, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg } from 'react-intl';
 import  { useEffect, useRef, useState } from 'react';
 import { ZetkinCampaign, ZetkinEvent } from '../types/zetkin';
@@ -9,6 +10,7 @@ interface MonthCalendarProps {
     campaigns: ZetkinCampaign[];
     events: ZetkinEvent[];
     focusDate: Date;
+    orgId: string;
     onFocusDate: (date: Date) => void;
 }
 
@@ -37,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const MonthCalendar = ({ campaigns, events, onFocusDate, focusDate }: MonthCalendarProps): JSX.Element => {
+const MonthCalendar = ({ orgId, campaigns, events, onFocusDate, focusDate }: MonthCalendarProps): JSX.Element => {
     const gridItem = useRef<HTMLUListElement>(null);
     const listItem = useRef<HTMLLIElement>(null);
     const windowHeight = useWindowHeight();
@@ -113,7 +115,7 @@ const MonthCalendar = ({ campaigns, events, onFocusDate, focusDate }: MonthCalen
                                 return new Date(a.start_time).getTime() - new Date(b.start_time).getTime();
                             });
                         return campaignEvents.length ? (
-                            <CalendarBar key={ c.id } campaign={ c } events={ campaignEvents } firstCalendarDay={ firstCalendarDay } firstMonthDay={ firstMonthDay } gridItems={ gridItems } month={ month } totalDaysInMonth={ totalDaysInMonth }/>
+                            <CalendarBar key={ c.id } campaign={ c } events={ campaignEvents } firstCalendarDay={ firstCalendarDay } firstMonthDay={ firstMonthDay } gridItems={ gridItems } month={ month } orgId={ orgId } totalDaysInMonth={ totalDaysInMonth }/>
                         ) : null;
                     }) }
                 </Box>
@@ -184,10 +186,11 @@ interface CalendarBarProps {
     firstMonthDay: Date;
     totalDaysInMonth: number;
     gridItems: number;
+    orgId: string;
 }
 
-const CalendarBar = ({ campaign, events, month, gridItems, firstCalendarDay, firstMonthDay, totalDaysInMonth }: CalendarBarProps): JSX.Element | null => {
-    const { id, color } = campaign;
+const CalendarBar = ({ orgId, campaign, events, month, gridItems, firstCalendarDay, firstMonthDay, totalDaysInMonth }: CalendarBarProps): JSX.Element | null => {
+    const { id, color, title } = campaign;
 
     const lastCalendarDay = new Date(new Date(firstCalendarDay).setDate(firstCalendarDay.getDate() + gridItems));
 
@@ -235,10 +238,16 @@ const CalendarBar = ({ campaign, events, month, gridItems, firstCalendarDay, fir
 
     return (
         <Box height={ 1 } position="relative" width="0.5rem">
-            <Box
-                bgcolor={ color }
-                data-testid={ `calendar-bar-${id}` } height={ `${height}%` } position="absolute" top={ `${top}%` } width={ 1 }>
-            </Box>
+            <NextLink href={ `/organize/${orgId}/campaigns/${id}` } passHref>
+                <Link>
+                    <Tooltip arrow data-testid={ `calendar-bar-popover-${id}` } placement="top" title={ title }>
+                        <Box
+                            bgcolor={ color }
+                            data-testid={ `calendar-bar-${id}` } height={ `${height}%` } position="absolute" top={ `${top}%` } width={ 1 }>
+                        </Box>
+                    </Tooltip>
+                </Link>
+            </NextLink>
         </Box>
     );
 };

--- a/src/components/WeekCalendar.spec.tsx
+++ b/src/components/WeekCalendar.spec.tsx
@@ -41,7 +41,7 @@ describe('WeekCalendar', () => {
 
     it('shows seven days of the current week starting on Monday', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
 
         cy.get('[data-testid="weekday-0"]').should('be.visible');
@@ -64,7 +64,7 @@ describe('WeekCalendar', () => {
 
     it('shows events that occur on the specified date', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
         cy.get('[data-testid="day-0-events"]').contains('event with id 25');
         cy.get('[data-testid="day-0-events"]').contains('event with id 26');
@@ -76,7 +76,7 @@ describe('WeekCalendar', () => {
         dummyEvents[0].end_time = '2020-12-31T14:37:00+00:00';
 
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
 
         cy.get('[data-testid="date-0"]').contains(28);
@@ -92,7 +92,7 @@ describe('WeekCalendar', () => {
 
     it('shows the days events in the correct order', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
         cy.get('[data-testid="event-26"]').then(el => {
             const firstEventYPos = el[0].getBoundingClientRect().top;
@@ -105,7 +105,7 @@ describe('WeekCalendar', () => {
 
     it('shows longer events with more height than shorter events', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
         cy.get('[data-testid="event-26"]').then(el => {
             const firstEventHeight = el[0].getBoundingClientRect().top;
@@ -122,7 +122,7 @@ describe('WeekCalendar', () => {
         dummyEvents[1].start_time = '2021-05-10T23:00:00+00:00';
         dummyEvents[1].end_time = '2021-05-10T23:59:00+00:00';
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } />,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1" />,
         );
         cy.get('[data-testid="day-0-events"]').contains('event with id 25');
         cy.get('[data-testid="day-0-events"]').contains('event with id 26');
@@ -139,7 +139,7 @@ describe('WeekCalendar', () => {
                 right: 0,
                 top: 0,
             }}>
-                <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+                <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
             </div>,
         );
         cy.get('[data-testid="calendar-wrapper"]').then(el => {
@@ -159,7 +159,7 @@ describe('WeekCalendar', () => {
                 right: 0,
                 top: 0,
             }}>
-                <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+                <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
             </div>,
         );
         cy.get('[data-testid="calendar-wrapper"]').then(el => {
@@ -170,7 +170,7 @@ describe('WeekCalendar', () => {
 
     it('shows back and forward widget buttons', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
         cy.get('[data-testid="back-button"]').should('be.visible');
         cy.get('[data-testid="fwd-button"]').should('be.visible');
@@ -178,7 +178,7 @@ describe('WeekCalendar', () => {
 
     it('shows the correct calendar start date in the widget', () => {
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ () => null } orgId="1"/>,
         );
         cy.get('[data-testid="selected-date"]').contains('19');
     });
@@ -186,7 +186,7 @@ describe('WeekCalendar', () => {
     it('sets the focus date a week ago when back is clicked', () => {
         const spyOnFocusDate = cy.spy();
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ spyOnFocusDate }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ spyOnFocusDate } orgId="1"/>,
         );
 
         cy.findByText('misc.calendar.prev')
@@ -202,7 +202,7 @@ describe('WeekCalendar', () => {
     it('sets the focus date a week forward when next is clicked', () => {
         const spyOnFocusDate = cy.spy();
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ spyOnFocusDate } />,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ dummyDate } onFocusDate={ spyOnFocusDate } orgId="1" />,
         );
 
         cy.findByText('misc.calendar.next')
@@ -224,7 +224,7 @@ describe('WeekCalendar', () => {
             'start_time': '2021-05-11T15:37:00+00:00',
         };
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }  />,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"  />,
         );
 
         cy.get('[data-testid="event-26"]')
@@ -252,7 +252,7 @@ describe('WeekCalendar', () => {
             'start_time': '2021-05-11T15:37:00+00:00',
         };
         mountWithProviders(
-            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null }/>,
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"/>,
         );
 
         cy.get('[data-testid="calendar-bar-941"]').should('be.visible');
@@ -267,5 +267,16 @@ describe('WeekCalendar', () => {
                         expect(firstBarBgColor).to.not.eq(secondBarBgColor);
                     });
             });
+    });
+
+    it('shows a tooltip when hovering over the weekly bar with campaign name', () => {
+        mountWithProviders(
+            <WeekCalendar campaigns={ dummyCampaigns } events={ dummyEvents } focusDate={ new Date(2021, 4, 10) } onFocusDate={ () => null } orgId="1"/>,
+        );
+
+        cy.get('[data-testid="calendar-bar-941"]').should('be.visible');
+
+        cy.get('[data-testid="calendar-bar-941"]').trigger('mouseover');
+        cy.findByText('Dummy campaign').should('be.visible');
     });
 });

--- a/src/components/WeekCalendar.tsx
+++ b/src/components/WeekCalendar.tsx
@@ -1,6 +1,7 @@
 import { getContrastColor } from '../utils/colorUtils';
 import { grey } from '@material-ui/core/colors';
-import { Box, Button, List, makeStyles, Typography } from '@material-ui/core';
+import NextLink from 'next/link';
+import { Box, Button, Link, List, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg } from 'react-intl';
 import { useEffect, useRef } from 'react';
 import { ZetkinCampaign, ZetkinEvent } from '../types/zetkin';
@@ -11,6 +12,7 @@ interface WeekCalendarProps {
     events: ZetkinEvent[];
     focusDate: Date;
     onFocusDate: (date: Date)=> void;
+    orgId: string;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -29,7 +31,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const WeekCalendar = ({ campaigns, events, focusDate, onFocusDate }: WeekCalendarProps): JSX.Element => {
+const WeekCalendar = ({ orgId, campaigns, events, focusDate, onFocusDate }: WeekCalendarProps): JSX.Element => {
     const classes = useStyles();
     const calendar = useRef<HTMLDivElement>(null);
     const calendarWrapper = useRef<HTMLDivElement>(null);
@@ -118,7 +120,7 @@ const WeekCalendar = ({ campaigns, events, focusDate, onFocusDate }: WeekCalenda
                                 return new Date(a.start_time).getTime() - new Date(b.start_time).getTime();
                             });
                         return campaignEvents.length ? (
-                            <CalendarBar key={ c.id } campaign={ c } events={ campaignEvents } firstCalendarDay={ calendarStartDate }/>
+                            <CalendarBar key={ c.id } campaign={ c } events={ campaignEvents } firstCalendarDay={ calendarStartDate } orgId={ orgId }/>
                         ): null;
                     }) }
                 </Box>
@@ -155,13 +157,14 @@ const WeekCalendar = ({ campaigns, events, focusDate, onFocusDate }: WeekCalenda
 export default WeekCalendar;
 
 interface CalendarBarProps {
+    orgId: string;
     campaign: ZetkinCampaign;
     events: ZetkinEvent[];
     firstCalendarDay: Date;
 }
 
-const CalendarBar = ({ campaign, events, firstCalendarDay }: CalendarBarProps): JSX.Element | null => {
-    const { id, color } = campaign;
+const CalendarBar = ({ orgId, campaign, events, firstCalendarDay }: CalendarBarProps): JSX.Element | null => {
+    const { id, color, title } = campaign;
 
     const lastCalendarDay = new Date(new Date(firstCalendarDay).setDate(firstCalendarDay.getDate() + 7));
 
@@ -195,10 +198,16 @@ const CalendarBar = ({ campaign, events, firstCalendarDay }: CalendarBarProps): 
 
     return (
         <Box height="0.5rem" position="relative" width={ 1 }>
-            <Box
-                bgcolor={ color }
-                data-testid={ `calendar-bar-${id}` } height={ 1 } left={ `${left}%` } position="absolute" width={ `${width}%` }>
-            </Box>
+            <NextLink href={ `/organize/${orgId}/campaigns/${id}` } passHref>
+                <Link>
+                    <Tooltip arrow data-testid={ `calendar-bar-popover-${id}` } title={ title }>
+                        <Box
+                            bgcolor={ color }
+                            data-testid={ `calendar-bar-${id}` } height={ 1 } left={ `${left}%` } position="absolute" width={ `${width}%` }>
+                        </Box>
+                    </Tooltip>
+                </Link>
+            </NextLink>
         </Box>
     );
 };

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar.tsx
@@ -93,8 +93,8 @@ const CampaignCalendarPage : PageWithLayout<OrganizeCalendarPageProps> = ({ orgI
                 </FormControl>
             </Box>
             <Box height="80vh" overflow="auto">
-                { calendarView === 'month' && <MonthCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } /> }
-                { calendarView === 'week' && <WeekCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) }/> }
+                { calendarView === 'month' && <MonthCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } orgId={ orgId } /> }
+                { calendarView === 'week' && <WeekCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } orgId={ orgId }/> }
             </Box>
         </Box>
     );

--- a/src/pages/organize/[orgId]/campaigns/calendar.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar.tsx
@@ -91,8 +91,8 @@ const AllCampaignsCalendarPage : PageWithLayout<AllCampaignsCalendarPageProps> =
                 </FormControl>
             </Box>
             <Box height="80vh" overflow="auto">
-                { calendarView === 'month' && <MonthCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } /> }
-                { calendarView === 'week' && <WeekCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) }/> }
+                { calendarView === 'month' && <MonthCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } orgId={ orgId } /> }
+                { calendarView === 'week' && <WeekCalendar campaigns={ campaigns } events={ events } focusDate={ focusDate } onFocusDate={ date => setFocusDate(date) } orgId={ orgId }/> }
             </Box>
         </Box>
     );


### PR DESCRIPTION
Resolves #226 

This PR implements the following:

- [x] Add a tooltip displaying the name of the campaign on hover
- [x] Clicking the bar should take you to the campaign summary

Can we upgrade to MUI v. 5.0 in order to use the followCursor prop on the toolbar? In this way the toolbar will follow the cursor around instead of appearing in a predetermined position