### PR TITLE
fix/skip public page cypress tests

### DIFF
--- a/cypress/integration/campaign_page.spec.ts
+++ b/cypress/integration/campaign_page.spec.ts
@@ -1,4 +1,4 @@
-describe('/o/[orgId]/campaigns/[campId]', () => {
+describe.skip('/o/[orgId]/campaigns/[campId]', () => {
 
     it('contains campaign content', () => {
         cy.visit('/o/1/campaigns/2');

--- a/cypress/integration/event_page.spec.ts
+++ b/cypress/integration/event_page.spec.ts
@@ -1,6 +1,6 @@
 import { ZetkinEvent, ZetkinEventResponse } from '../../src/types/zetkin';
 
-describe('/o/[orgId]/events/[eventId]', () => {
+describe.skip('/o/[orgId]/events/[eventId]', () => {
     let dummyBookedEvents : {data: ZetkinEvent[]};
     let dummyEventResponses : {data: ZetkinEventResponse[]};
     let dummyEvents : {data: ZetkinEvent[]};

--- a/cypress/integration/events_page.spec.ts
+++ b/cypress/integration/events_page.spec.ts
@@ -1,6 +1,6 @@
 import { ZetkinEvent, ZetkinEventResponse } from '../../src/types/zetkin';
 
-describe('/o/[orgId]/events', () => {
+describe.skip('/o/[orgId]/events', () => {
     let dummyEventResponses : {data: ZetkinEventResponse[]};
     let dummyEvents : {data: ZetkinEvent[]};
 

--- a/cypress/integration/homepage.spec.ts
+++ b/cypress/integration/homepage.spec.ts
@@ -1,4 +1,4 @@
-describe('/', () => {
+describe.skip('/', () => {
     it('contains zetkin logo', () => {
         cy.visit('/');
         cy.get('[data-testid="zetkin-logotype"]').should('be.visible');

--- a/cypress/integration/my_orgs_page.spec.ts
+++ b/cypress/integration/my_orgs_page.spec.ts
@@ -1,6 +1,6 @@
 import { ZetkinMembership } from '../../src/types/zetkin';
 
-describe('/my/orgs', () => {
+describe.skip('/my/orgs', () => {
     let dummyFollowing : {data: ZetkinMembership[]};
 
     before(() => {

--- a/cypress/integration/my_page.spec.ts
+++ b/cypress/integration/my_page.spec.ts
@@ -1,6 +1,6 @@
 import { ZetkinCampaign, ZetkinEvent, ZetkinMembership } from '../../src/types/zetkin';
 
-describe('/my', () => {
+describe.skip('/my', () => {
     let dummyEvents : {data: ZetkinEvent[]};
     let dummyFollowing : {data: ZetkinMembership[]};
     let dummyCampaigns : {data: ZetkinCampaign[]};

--- a/cypress/integration/my_todo_page.spec.ts
+++ b/cypress/integration/my_todo_page.spec.ts
@@ -1,6 +1,6 @@
 import { ZetkinEvent, ZetkinEventResponse, ZetkinMembership } from '../../src/types/zetkin';
 
-describe('/my/todo', () => {
+describe.skip('/my/todo', () => {
     let dummyEventResponses : {data: ZetkinEventResponse[]};
     let dummyBookedEvents : {data: ZetkinEvent[]};
     let dummyEvents : {data: ZetkinEvent[]};

--- a/cypress/integration/reocurring_functionality.spec.ts
+++ b/cypress/integration/reocurring_functionality.spec.ts
@@ -1,4 +1,4 @@
-describe('Reocurring functionality', () => {
+describe.skip('Reocurring functionality', () => {
 
     it('contains a clickable org logo which leads to org page', () => {
         cy.visit('/o/1/events');


### PR DESCRIPTION
Skips cypress tests for public facing pages. These have been flaky and sometimes block merging. 