### PR TITLE
Issue 288/campaign page details header

### DIFF
--- a/src/components/CampaignForm.tsx
+++ b/src/components/CampaignForm.tsx
@@ -163,7 +163,7 @@ const CampaignForm = ({ onSubmit, onCancel, campaign }: CampaignFormProps): JSX.
     const handleSubmit = (values: Record<string, string>) => {
         const { info_text, status, title, visibility, manager_id } = values;
         onSubmit({
-            ...info_text ? { info_text } : null,
+            info_text: info_text == undefined ? '' : info_text,
             manager_id,
             published:status === 'draft' ? false : true,
             title: title,

--- a/src/components/CampaignForm.tsx
+++ b/src/components/CampaignForm.tsx
@@ -163,7 +163,7 @@ const CampaignForm = ({ onSubmit, onCancel, campaign }: CampaignFormProps): JSX.
     const handleSubmit = (values: Record<string, string>) => {
         const { info_text, status, title, visibility, manager_id } = values;
         onSubmit({
-            info_text: info_text == undefined ? '' : info_text,
+            info_text: info_text ?? '',
             manager_id,
             published:status === 'draft' ? false : true,
             title: title,

--- a/src/components/organize/CampaignDetailsHeader.tsx
+++ b/src/components/organize/CampaignDetailsHeader.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Avatar, Box, Button, makeStyles, Typography } from '@material-ui/core';
+import { Avatar, Box, Button, Grid, makeStyles, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
@@ -70,12 +70,16 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
             <Box p={ 4 }>
                 { /* Description */ }
                 { campaign.info_text && (
-                    <Typography variant="body1">
-                        { campaign.info_text }
-                    </Typography>
+                    <Grid container>
+                        <Grid item lg={ 6 } md={ 8 } sm={ 12 } xs={ 12 }>
+                            <Typography variant="body1">
+                                { campaign.info_text }
+                            </Typography>
+                        </Grid>
+                    </Grid>
                 ) }
 
-                { /* Dades / Buttons  */ }
+                { /* Dates / Buttons  */ }
                 <Box className={ classes.responsiveFlexBox } mt={ 2 }>
                     { /* Campaign Dates */ }
                     <Box flexGrow={ 1 } mb={ 2 }>
@@ -134,7 +138,7 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
                 ) :
                     // If no campaign manager
                     <Typography variant="body1">
-                        <Msg id="pages.organizeCampaigns.noCampaignManager" />
+                        <Msg id="pages.organizeCampaigns.noManager" />
                     </Typography>
                 }
             </Box>

--- a/src/components/organize/CampaignDetailsHeader.tsx
+++ b/src/components/organize/CampaignDetailsHeader.tsx
@@ -5,12 +5,12 @@ import { Avatar, Box, Button, makeStyles, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
-import CampaignForm from '../../CampaignForm';
-import ZetkinDialog from '../../ZetkinDialog';
+import CampaignForm from '../CampaignForm';
+import ZetkinDialog from '../ZetkinDialog';
 
-import getCampaignEvents from '../../../fetching/getCampaignEvents';
-import patchCampaign from '../../../fetching/patchCampaign';
-import { ZetkinCampaign } from '../../../types/zetkin';
+import getCampaignEvents from '../../fetching/getCampaignEvents';
+import patchCampaign from '../../fetching/patchCampaign';
+import { ZetkinCampaign } from '../../types/zetkin';
 
 const useStyles = makeStyles((theme) => ({
     personContainer: {

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -1,9 +1,8 @@
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Avatar, Box, Button, Link, makeStyles, Typography } from '@material-ui/core';
+import { Box, Button, makeStyles, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
-import { Public, Settings } from '@material-ui/icons';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import CampaignForm from '../../CampaignForm';
@@ -62,61 +61,43 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
 
     return (
         <>
-            <Box className={ classes.responsiveFlexBox }>
-                <Box flex={ 1 } p={ 1 }>
-                    <Box className={ classes.responsiveText } p={ 1 }>
-                        <Typography variant="body1">
-                            { campaign?.info_text }
-                        </Typography>
-                    </Box>
+            { /* First Row */ }
+            <Box className={ classes.responsiveFlexBox } p={ 5 }>
+                { /* Campaign Dates */ }
+                <Box flexGrow={ 1 }>
+                    <Typography variant="h4">
+                        { startDate && endDate ? (
+                            <>
+                                <FormattedDate
+                                    day="2-digit"
+                                    month="long"
+                                    value={ startDate }
+                                />
+                                { ` - ` }
+                                <FormattedDate
+                                    day="2-digit"
+                                    month="long"
+                                    value={ endDate }
+                                    year="numeric"
+                                />
+                            </>
+                        ) : (
+                            <Msg id="pages.organizeCampaigns.indefinite" />
+                        ) }
+                    </Typography>
                 </Box>
-                <Box display="flex" flex={ 1 } p={ 1 }>
-                    <Box p={ 1 }>
-                        <Avatar
-                            src={ campaign?.manager ?
-                                `/api/orgs/${orgId}/people/${campaign?.manager.id}/avatar` : undefined }>
-                        </Avatar>
-                    </Box>
-                    <Box display="flex" flexDirection="column" p={ 1 }>
-                        <Typography variant="h6">
-                            { campaign?.manager?.name || <Msg id="pages.organizeCampaigns.noManager" /> }
-                        </Typography>
-                        <Typography variant="subtitle2">
-                            { startDate && endDate ? (
-                                <>
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ startDate }
-                                    />
-                                    { ` - ` }
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ endDate }
-                                        year="numeric"
-                                    />
-                                </>
-                            ) : (
-                                <Msg id="pages.organizeCampaigns.indefinite" />
-                            ) }
-                        </Typography>
-                        <Box display="flex" p={ 1 } pl={ 0 }>
-                            <Box display="flex" p={ 1 } pl={ 0 }>
-                                <Public color="primary" />
-                                <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
-                                    <Link underline="always">
-                                        <Msg id="pages.organizeCampaigns.linkGroup.public"/>
-                                    </Link>
-                                </NextLink>
-                            </Box>
-                            <Box display="flex" p={ 1 }>
-                                <Button onClick={ () => setEditCampaignDialogOpen(true) } startIcon={ <Settings color="primary" /> } variant="contained">
-                                    <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
-                                </Button>
-                            </Box>
-                        </Box>
-                    </Box>
+                { /* Action Buttons */ }
+                <Box alignItems="center" display="flex">
+                    { /* Public Page Link */ }
+                    <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
+                        <Button color="primary">
+                            <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+                        </Button>
+                    </NextLink>
+                    { /* Edit Campiagn Activator */ }
+                    <Button color="primary" onClick={ () => setEditCampaignDialogOpen(true) } variant="contained">
+                        <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
+                    </Button>
                 </Box>
             </Box>
             <ZetkinDialog

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -1,0 +1,136 @@
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { Avatar, Box, Button, Link, makeStyles, Typography } from '@material-ui/core';
+import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
+import { Public, Settings } from '@material-ui/icons';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+
+import CampaignForm from '../../CampaignForm';
+import ZetkinDialog from '../../ZetkinDialog';
+
+import getCampaignEvents from '../../../fetching/getCampaignEvents';
+import patchCampaign from '../../../fetching/patchCampaign';
+import { ZetkinCampaign } from '../../../types/zetkin';
+
+const useStyles = makeStyles((theme) => ({
+    responsiveFlexBox: {
+        display: 'flex',
+        [theme.breakpoints.down('sm')]: {
+            flexDirection: 'column',
+        },
+    },
+    responsiveText: {
+        width: '70%',
+        [theme.breakpoints.down('sm')]: {
+            width: '100%',
+        },
+    },
+}));
+
+interface CampaignDetailsHeaderProps {
+    campaign: ZetkinCampaign;
+}
+
+const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps> = ({ campaign }) => {
+    const intl = useIntl();
+    const queryClient = useQueryClient();
+    const [editCampaignDialogOpen, setEditCampaignDialogOpen] = useState(false);
+    const { campId, orgId } = useRouter().query;
+    const classes = useStyles();
+
+    const { data: events } = useQuery(
+        ['campaignEvents', orgId, campId],
+        getCampaignEvents(orgId as string, campId as string),
+    );
+
+    const sortedEvents = events ? [...events].sort((a, b) => {
+        return new Date(a.start_time).getTime() - new Date(b.start_time).getTime();
+    }): [];
+
+    const startDate = sortedEvents[0]?.start_time;
+    const endDate = sortedEvents[sortedEvents.length - 1]?.start_time;
+
+    const campaignMutation = useMutation(patchCampaign(orgId as string, campId as string), {
+        onSettled: () => queryClient.invalidateQueries('campaign'),
+    });
+
+    const handleEditCampaignFormSubmit = (data: Record<string, unknown>) => {
+        campaignMutation.mutate(data);
+        setEditCampaignDialogOpen(false);
+    };
+
+    return (
+        <>
+            <Box className={ classes.responsiveFlexBox }>
+                <Box flex={ 1 } p={ 1 }>
+                    <Box className={ classes.responsiveText } p={ 1 }>
+                        <Typography variant="body1">
+                            { campaign?.info_text }
+                        </Typography>
+                    </Box>
+                </Box>
+                <Box display="flex" flex={ 1 } p={ 1 }>
+                    <Box p={ 1 }>
+                        <Avatar
+                            src={ campaign?.manager ?
+                                `/api/orgs/${orgId}/people/${campaign?.manager.id}/avatar` : undefined }>
+                        </Avatar>
+                    </Box>
+                    <Box display="flex" flexDirection="column" p={ 1 }>
+                        <Typography variant="h6">
+                            { campaign?.manager?.name || <Msg id="pages.organizeCampaigns.noManager" /> }
+                        </Typography>
+                        <Typography variant="subtitle2">
+                            { startDate && endDate ? (
+                                <>
+                                    <FormattedDate
+                                        day="2-digit"
+                                        month="long"
+                                        value={ startDate }
+                                    />
+                                    { ` - ` }
+                                    <FormattedDate
+                                        day="2-digit"
+                                        month="long"
+                                        value={ endDate }
+                                        year="numeric"
+                                    />
+                                </>
+                            ) : (
+                                <Msg id="pages.organizeCampaigns.indefinite" />
+                            ) }
+                        </Typography>
+                        <Box display="flex" p={ 1 } pl={ 0 }>
+                            <Box display="flex" p={ 1 } pl={ 0 }>
+                                <Public color="primary" />
+                                <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
+                                    <Link underline="always">
+                                        <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+                                    </Link>
+                                </NextLink>
+                            </Box>
+                            <Box display="flex" p={ 1 }>
+                                <Button onClick={ () => setEditCampaignDialogOpen(true) } startIcon={ <Settings color="primary" /> } variant="contained">
+                                    <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
+                                </Button>
+                            </Box>
+                        </Box>
+                    </Box>
+                </Box>
+            </Box>
+            <ZetkinDialog
+                onClose={ () => setEditCampaignDialogOpen(false) }
+                open={ editCampaignDialogOpen }
+                title={ intl.formatMessage({ id: 'misc.formDialog.campaign.edit' }) }>
+                <CampaignForm
+                    campaign={ campaign }
+                    onCancel={ () => setEditCampaignDialogOpen(false) }
+                    onSubmit={ handleEditCampaignFormSubmit }
+                />
+            </ZetkinDialog>
+        </>
+    );
+};
+
+export default CampaignDetailsHeader;

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -61,43 +61,48 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
 
     return (
         <>
-            { /* First Row */ }
-            <Box className={ classes.responsiveFlexBox } p={ 5 }>
-                { /* Campaign Dates */ }
-                <Box flexGrow={ 1 }>
-                    <Typography variant="h4">
-                        { startDate && endDate ? (
-                            <>
-                                <FormattedDate
-                                    day="2-digit"
-                                    month="long"
-                                    value={ startDate }
-                                />
-                                { ` - ` }
-                                <FormattedDate
-                                    day="2-digit"
-                                    month="long"
-                                    value={ endDate }
-                                    year="numeric"
-                                />
-                            </>
-                        ) : (
-                            <Msg id="pages.organizeCampaigns.indefinite" />
-                        ) }
-                    </Typography>
-                </Box>
-                { /* Action Buttons */ }
-                <Box alignItems="center" display="flex">
-                    { /* Public Page Link */ }
-                    <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
-                        <Button color="primary">
-                            <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+            <Box p={ 5 }>
+                <Typography variant="body1">
+                    { campaign.info_text }
+                </Typography>
+                { /* First Row */ }
+                <Box className={ classes.responsiveFlexBox }>
+                    { /* Campaign Dates */ }
+                    <Box flexGrow={ 1 }>
+                        <Typography variant="h4">
+                            { startDate && endDate ? (
+                                <>
+                                    <FormattedDate
+                                        day="2-digit"
+                                        month="long"
+                                        value={ startDate }
+                                    />
+                                    { ` - ` }
+                                    <FormattedDate
+                                        day="2-digit"
+                                        month="long"
+                                        value={ endDate }
+                                        year="numeric"
+                                    />
+                                </>
+                            ) : (
+                                <Msg id="pages.organizeCampaigns.indefinite" />
+                            ) }
+                        </Typography>
+                    </Box>
+                    { /* Action Buttons */ }
+                    <Box alignItems="center" display="flex">
+                        { /* Public Page Link */ }
+                        <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
+                            <Button color="primary">
+                                <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+                            </Button>
+                        </NextLink>
+                        { /* Edit Campiagn Activator */ }
+                        <Button color="primary" onClick={ () => setEditCampaignDialogOpen(true) } variant="contained">
+                            <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
                         </Button>
-                    </NextLink>
-                    { /* Edit Campiagn Activator */ }
-                    <Button color="primary" onClick={ () => setEditCampaignDialogOpen(true) } variant="contained">
-                        <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
-                    </Button>
+                    </Box>
                 </Box>
             </Box>
             <ZetkinDialog

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -13,6 +13,12 @@ import patchCampaign from '../../../fetching/patchCampaign';
 import { ZetkinCampaign } from '../../../types/zetkin';
 
 const useStyles = makeStyles((theme) => ({
+    personContainer: {
+        '&:hover': {
+            cursor: 'pointer',
+            textDecoration: 'underline',
+        },
+    },
     responsiveFlexBox: {
         display: 'flex',
         [theme.breakpoints.down('sm')]: {
@@ -97,7 +103,7 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
                     { /* Action Buttons */ }
                     <Box alignItems="center" display="flex" mb={ 2 }>
                         { /* Public Page Link */ }
-                        <Box mr={ 1 }>
+                        <Box mr={ 2 }>
                             <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
                                 <Button color="primary">
                                     <Msg id="pages.organizeCampaigns.linkGroup.public"/>
@@ -113,7 +119,7 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
                 { /* Campaign Manager */ }
                 { campaign.manager ? (
                     <NextLink href={ `/organize/${orgId}/people/${campaign.manager.id}` }>
-                        <Box alignItems="center" display="flex">
+                        <Box alignItems="center" className={ classes.personContainer } display="flex">
                             <Box mr={ 2 }>
                                 <Avatar
                                     src={ `/api/orgs/${orgId}/people/${campaign.manager.id}/avatar` }

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -62,13 +62,14 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
     return (
         <>
             <Box p={ 4 }>
+                { /* Description */ }
                 { campaign.info_text && (
                     <Typography variant="body1">
                         { campaign.info_text }
                     </Typography>
                 ) }
 
-                { /* First Row */ }
+                { /* Dades / Buttons  */ }
                 <Box className={ classes.responsiveFlexBox } mt={ 2 }>
                     { /* Campaign Dates */ }
                     <Box flexGrow={ 1 } mb={ 2 }>
@@ -113,24 +114,23 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
                 { campaign.manager ? (
                     <NextLink href={ `/organize/${orgId}/people/${campaign.manager.id}` }>
                         <Box alignItems="center" display="flex">
-                            <Box mr={ 1 }>
+                            <Box mr={ 2 }>
                                 <Avatar
                                     src={ `/api/orgs/${orgId}/people/${campaign.manager.id}/avatar` }
                                 />
                             </Box>
                             <Box display="flex" flexDirection="column">
                                 <Typography variant="h6">{ campaign.manager.name }</Typography>
-                                <Typography variant="body2">Role</Typography>
+                                <Typography variant="body2"><Msg id="pages.organizeCampaigns.campaignManager" /></Typography>
                             </Box>
                         </Box>
                     </NextLink>
                 ) :
                     // If no campaign manager
                     <Typography variant="body1">
-                        <Msg id="No campaign manager" />
+                        <Msg id="pages.organizeCampaigns.noCampaignManager" />
                     </Typography>
                 }
-
             </Box>
 
             <ZetkinDialog

--- a/src/components/organize/campaigns/CampaignDetailsHeader.tsx
+++ b/src/components/organize/campaigns/CampaignDetailsHeader.tsx
@@ -1,7 +1,7 @@
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { Box, Button, makeStyles, Typography } from '@material-ui/core';
+import { Avatar, Box, Button, makeStyles, Typography } from '@material-ui/core';
 import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
@@ -61,14 +61,17 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
 
     return (
         <>
-            <Box p={ 5 }>
-                <Typography variant="body1">
-                    { campaign.info_text }
-                </Typography>
+            <Box p={ 4 }>
+                { campaign.info_text && (
+                    <Typography variant="body1">
+                        { campaign.info_text }
+                    </Typography>
+                ) }
+
                 { /* First Row */ }
-                <Box className={ classes.responsiveFlexBox }>
+                <Box className={ classes.responsiveFlexBox } mt={ 2 }>
                     { /* Campaign Dates */ }
-                    <Box flexGrow={ 1 }>
+                    <Box flexGrow={ 1 } mb={ 2 }>
                         <Typography variant="h4">
                             { startDate && endDate ? (
                                 <>
@@ -91,20 +94,45 @@ const CampaignDetailsHeader: React.FunctionComponent<CampaignDetailsHeaderProps>
                         </Typography>
                     </Box>
                     { /* Action Buttons */ }
-                    <Box alignItems="center" display="flex">
+                    <Box alignItems="center" display="flex" mb={ 2 }>
                         { /* Public Page Link */ }
-                        <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
-                            <Button color="primary">
-                                <Msg id="pages.organizeCampaigns.linkGroup.public"/>
-                            </Button>
-                        </NextLink>
+                        <Box mr={ 1 }>
+                            <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
+                                <Button color="primary">
+                                    <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+                                </Button>
+                            </NextLink>
+                        </Box>
                         { /* Edit Campiagn Activator */ }
                         <Button color="primary" onClick={ () => setEditCampaignDialogOpen(true) } variant="contained">
                             <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
                         </Button>
                     </Box>
                 </Box>
+                { /* Campaign Manager */ }
+                { campaign.manager ? (
+                    <NextLink href={ `/organize/${orgId}/people/${campaign.manager.id}` }>
+                        <Box alignItems="center" display="flex">
+                            <Box mr={ 1 }>
+                                <Avatar
+                                    src={ `/api/orgs/${orgId}/people/${campaign.manager.id}/avatar` }
+                                />
+                            </Box>
+                            <Box display="flex" flexDirection="column">
+                                <Typography variant="h6">{ campaign.manager.name }</Typography>
+                                <Typography variant="body2">Role</Typography>
+                            </Box>
+                        </Box>
+                    </NextLink>
+                ) :
+                    // If no campaign manager
+                    <Typography variant="body1">
+                        <Msg id="No campaign manager" />
+                    </Typography>
+                }
+
             </Box>
+
             <ZetkinDialog
                 onClose={ () => setEditCampaignDialogOpen(false) }
                 open={ editCampaignDialogOpen }

--- a/src/locale/pages/organizeCampaigns/en.yml
+++ b/src/locale/pages/organizeCampaigns/en.yml
@@ -1,6 +1,7 @@
 linkGroup:
     public: Public Page
     settings: Edit Settings
+campaignManager: Campaign Manager
 noManager: No Campaign Manager
 events: Events
 tasks: Tasks
@@ -14,5 +15,3 @@ feedback:
     heading: Feedback and Surveys (none configured)
     copy: Collecting feedback (during phonebanks or standalone) can help you work more efficiently
     create: Create survey
-campaignManager: Campaign Manager
-noCampaignManager: No campaign manager

--- a/src/locale/pages/organizeCampaigns/en.yml
+++ b/src/locale/pages/organizeCampaigns/en.yml
@@ -14,3 +14,5 @@ feedback:
     heading: Feedback and Surveys (none configured)
     copy: Collecting feedback (during phonebanks or standalone) can help you work more efficiently
     create: Create survey
+campaignManager: Campaign Manager
+noCampaignManager: No campaign manager

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -6,7 +6,7 @@ import { useQuery } from 'react-query';
 import { Box, Button, Link, makeStyles, Typography } from '@material-ui/core';
 import { Phone, PlaylistAddCheck } from '@material-ui/icons';
 
-import CampaignDetailsHeader from '../../../../../components/organize/campaigns/CampaignDetailsHeader';
+import CampaignDetailsHeader from '../../../../../components/organize/CampaignDetailsHeader';
 import EventList from '../../../../../components/organize/EventList';
 import getCampaign from '../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../fetching/getCampaignEvents';

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -1,14 +1,12 @@
 import { GetServerSideProps } from 'next';
 import { grey } from '@material-ui/core/colors';
+import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
-import { useRouter } from 'next/router';
-import { Avatar, Box, Button, Link, makeStyles, Typography } from '@material-ui/core';
-import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
-import { Phone, PlaylistAddCheck, Public, Settings } from '@material-ui/icons';
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
+import { Box, Button, Link, makeStyles, Typography } from '@material-ui/core';
+import { Phone, PlaylistAddCheck } from '@material-ui/icons';
 
-import CampaignForm from '../../../../../components/CampaignForm';
+import CampaignDetailsHeader from '../../../../../components/organize/campaigns/CampaignDetailsHeader';
 import EventList from '../../../../../components/organize/EventList';
 import getCampaign from '../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
@@ -16,10 +14,8 @@ import getCampaignTasks from '../../../../../fetching/tasks/getCampaignTasks';
 import getOrg from '../../../../../fetching/getOrg';
 import OrganizeTabbedLayout from '../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../types';
-import patchCampaign from '../../../../../fetching/patchCampaign';
 import { scaffold } from '../../../../../utils/next';
 import TaskList from '../../../../../components/organize/tasks/TaskList';
-import ZetkinDialog from '../../../../../components/ZetkinDialog';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
 
 const scaffoldOptions = {
@@ -92,9 +88,6 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId, campId }) => {
-    const intl = useIntl();
-    const queryClient = useQueryClient();
-    const router = useRouter();
     const classes = useStyles();
     const eventsQuery = useQuery(['campaignEvents', orgId, campId], getCampaignEvents(orgId, campId));
     const tasksQuery = useQuery(['campaignTasks', orgId, campId], getCampaignTasks(orgId, campId));
@@ -102,111 +95,14 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
     const events = eventsQuery.data || [];
     const tasks = tasksQuery.data || [];
     const campaign = campaignQuery.data;
-    const [formDialogOpen, setFormDialogOpen] = useState<null | string>(null);
-
-    const campaignMutation = useMutation(patchCampaign(orgId, campId), {
-        onSettled: () => queryClient.invalidateQueries('campaign'),
-    });
-
-    const sortedEvents = [...events].sort((a, b) => {
-        return new Date(a.start_time).getTime() - new Date(b.start_time).getTime();
-    });
-
-    const startDate = sortedEvents[0]?.start_time;
-    const endDate = sortedEvents[sortedEvents.length - 1]?.start_time;
-
-    const closeDialog = () => {
-        setFormDialogOpen(null);
-        router.push(`/organize/${orgId}/campaigns/${campId}`, undefined, { shallow: true });
-    };
-
-    const openEditCampaignDialog = () => {
-        router.push(`/organize/${orgId}/campaigns/${campId}#edit`, undefined, { shallow: true });
-        setFormDialogOpen('campaign');
-    };
-
-    const handleDialogClose = () => {
-        closeDialog();
-    };
-
-    const handleFormCancel = () => {
-        closeDialog();
-    };
-
-    const handleEditCampaignFormSubmit = (data: Record<string, unknown>) => {
-        campaignMutation.mutate(data);
-        closeDialog();
-    };
-
-    useEffect(() => {
-        const current = router.asPath.split('/').pop();
-        if (current?.includes('#new_campaign')) {
-            setFormDialogOpen('campaign');
-        }
-        else if (current?.includes('#new_event')) {
-            setFormDialogOpen('event');
-        }
-    }, [router.asPath]);
 
     return (
         <>
-            <Box className={ classes.responsiveFlexBox }>
-                <Box flex={ 1 } p={ 1 }>
-                    <Box className={ classes.responsiveText } p={ 1 }>
-                        <Typography variant="body1">
-                            { campaign?.info_text }
-                        </Typography>
-                    </Box>
-                </Box>
-                <Box display="flex" flex={ 1 } p={ 1 }>
-                    <Box p={ 1 }>
-                        <Avatar
-                            src={ campaign?.manager ?
-                                `/api/orgs/${orgId}/people/${campaign?.manager.id}/avatar` : undefined }>
-                        </Avatar>
-                    </Box>
-                    <Box display="flex" flexDirection="column" p={ 1 }>
-                        <Typography variant="h6">
-                            { campaign?.manager?.name || <Msg id="pages.organizeCampaigns.noManager" /> }
-                        </Typography>
-                        <Typography variant="subtitle2">
-                            { startDate && endDate ? (
-                                <>
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ startDate }
-                                    />
-                                    { ` - ` }
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ endDate }
-                                        year="numeric"
-                                    />
-                                </>
-                            ) : (
-                                <Msg id="pages.organizeCampaigns.indefinite" />
-                            ) }
-                        </Typography>
-                        <Box display="flex" p={ 1 } pl={ 0 }>
-                            <Box display="flex" p={ 1 } pl={ 0 }>
-                                <Public color="primary" />
-                                <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
-                                    <Link underline="always">
-                                        <Msg id="pages.organizeCampaigns.linkGroup.public"/>
-                                    </Link>
-                                </NextLink>
-                            </Box>
-                            <Box display="flex" p={ 1 }>
-                                <Button onClick={ openEditCampaignDialog } startIcon={ <Settings color="primary" /> } variant="contained">
-                                    <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
-                                </Button>
-                            </Box>
-                        </Box>
-                    </Box>
-                </Box>
-            </Box>
+            { /* Details Header */ }
+            { campaign && (
+                <CampaignDetailsHeader campaign={ campaign } />
+            ) }
+            { /* Page Content */ }
             <Box className={ classes.responsiveFlexBox }>
                 { /* Left Column */ }
                 <Box display="flex" flex={ 1 } flexDirection="column">
@@ -281,12 +177,6 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
                 </Box>
             </Box>
             { /* Edit Campaign Form */ }
-            <ZetkinDialog
-                onClose={ handleDialogClose }
-                open={ !!formDialogOpen }
-                title={ intl.formatMessage({ id: 'misc.formDialog.campaign.edit' }) }>
-                { formDialogOpen === 'campaign' && <CampaignForm campaign={ campaign } onCancel={ handleFormCancel } onSubmit={ handleEditCampaignFormSubmit }/> }
-            </ZetkinDialog>
             <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_TASK] }/>
         </>
     );


### PR DESCRIPTION
Resolves #288 

Implements a campaign page header which matches the style: https://www.figma.com/file/dnJiIWWZVLgcLILUnDOySa/Zetkin-Gen-3?node-id=101%3A3213

**Notes:**

Includes one fix to `CampaignForm` which allows descriptions to be deleted.

It's worth noting, currently our MUI styles override the capitalised buttons, and I thought I would leave this as the default style we have so far in case we decide to move everything over to capitalised. See actions buttons in figma & screenshot to see what I mean.

Also something to thing about: the current text for the runtime of a campaign shows dates in the past, which might not be so helpful. Might be worth thinking about what this should say if the campaign's last date is passed.

![header](https://user-images.githubusercontent.com/41007222/126045396-9bf11831-543c-488b-8d71-9d705240d2b5.png)
