### PR TITLE
Allow absolute imports

### DIFF
--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
   },
   "include": [
     "next-env.d.ts",

--- a/tsconfig.cypress.json
+++ b/tsconfig.cypress.json
@@ -19,7 +19,7 @@
     "isolatedModules": true,
     "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
     "jsx": "react-jsx",
-    "baseUrl": "./src",
+    "baseUrl": "./src"
   },
   "include": [
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "isolatedModules": true,
     "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
     "jsx": "preserve",
-    "baseUrl": "./src",
+    "baseUrl": "./src"
   },
   "include": [
     "next-env.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "types": ["cypress", "@testing-library/cypress", "./cypress/support"],
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "baseUrl": "./src",
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Allow absolute imports so instead of import getTask from `../../../../../../../../fetching/tasks/getTask` we can do `import getTask from 'fetching/tasks/getTask` and autocomplete/clicking the link to navigate to the file and all features will still work :thumbsup: And when you allow VSCode to autoimport it automatically uses the absolute import.