### PR TITLE
Issue 263/make tabbed layout configurable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,7 @@ module.exports = {
         'jsx-a11y/anchor-is-valid': 'off',
         'jsx-quotes': ['error', 'prefer-double'],
         'keyword-spacing': ['error', {}],
-        'no-console': 'error',
+        'no-console': ['error', { allow: ['warn'] }],
         'no-switch-statements/no-switch': 'error',
         'no-trailing-spaces': 'error',
         'object-curly-spacing': ['error', 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,7 +52,7 @@ module.exports = {
         'jsx-a11y/anchor-is-valid': 'off',
         'jsx-quotes': ['error', 'prefer-double'],
         'keyword-spacing': ['error', {}],
-        'no-console': ['error', { allow: ['warn'] }],
+        'no-console': 'error',
         'no-switch-statements/no-switch': 'error',
         'no-trailing-spaces': 'error',
         'object-curly-spacing': ['error', 'always'],

--- a/src/components/layout/organize/AllCampaignsLayout.tsx
+++ b/src/components/layout/organize/AllCampaignsLayout.tsx
@@ -15,12 +15,12 @@ const AllCampaignsLayout: FunctionComponent<AllCampaignsLayoutProps> = ({ childr
     return (
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns` }
-            defaultTab="summary"
+            defaultTab="/"
             fixedHeight={ fixedHeight }
             tabs={ [
-                { href: `/`, label: 'summary', messageId: 'layout.organize.campaigns.summary' },
-                { href: `/calendar`, label: 'calendar', messageId: 'layout.organize.campaigns.calendar' },
-                { href: `/archive`, label: 'archive', messageId: 'layout.organize.campaigns.archive' },
+                { href: `/`, messageId: 'layout.organize.campaigns.summary' },
+                { href: `/calendar`, messageId: 'layout.organize.campaigns.calendar' },
+                { href: `/archive`, messageId: 'layout.organize.campaigns.archive' },
             ] }
             title={ intl.formatMessage({ id: 'layout.organize.campaigns.allCampaigns' }) }>
             { children }

--- a/src/components/layout/organize/AllCampaignsLayout.tsx
+++ b/src/components/layout/organize/AllCampaignsLayout.tsx
@@ -16,7 +16,6 @@ const AllCampaignsLayout: FunctionComponent<AllCampaignsLayoutProps> = ({ childr
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns` }
             fixedHeight={ fixedHeight }
-            subtitle="subtitle for all campaigns tabs" //TODO: generate subtitle
             tabs={ [
                 {  defaultTab: true, href: `/`, label: 'summary' },
                 { href: `/calendar`, label: 'calendar' },

--- a/src/components/layout/organize/AllCampaignsLayout.tsx
+++ b/src/components/layout/organize/AllCampaignsLayout.tsx
@@ -15,11 +15,12 @@ const AllCampaignsLayout: FunctionComponent<AllCampaignsLayoutProps> = ({ childr
     return (
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns` }
+            defaultTab="summary"
             fixedHeight={ fixedHeight }
             tabs={ [
-                {  defaultTab: true, href: `/`, label: 'summary' },
-                { href: `/calendar`, label: 'calendar' },
-                { href: `/archive`, label: 'archive' },
+                { href: `/`, label: 'summary', messageId: 'layout.organize.campaigns.summary' },
+                { href: `/calendar`, label: 'calendar', messageId: 'layout.organize.campaigns.calendar' },
+                { href: `/archive`, label: 'archive', messageId: 'layout.organize.campaigns.archive' },
             ] }
             title={ intl.formatMessage({ id: 'layout.organize.campaigns.allCampaigns' }) }>
             { children }

--- a/src/components/layout/organize/AllCampaignsLayout.tsx
+++ b/src/components/layout/organize/AllCampaignsLayout.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent } from 'react';
+import { useIntl } from 'react-intl';
+import { useRouter } from 'next/router';
+
+import TabbedLayout from './TabbedLayout';
+
+interface AllCampaignsLayoutProps {
+    fixedHeight?: boolean;
+}
+
+const AllCampaignsLayout: FunctionComponent<AllCampaignsLayoutProps> = ({ children, fixedHeight }) => {
+    const { orgId } = useRouter().query;
+    const intl = useIntl();
+
+    return (
+        <TabbedLayout
+            baseHref={ `/organize/${orgId}/campaigns` }
+            fixedHeight={ fixedHeight }
+            subtitle="subtitle for all campaigns tabs" //TODO: generate subtitle
+            tabs={ [
+                {  defaultTab: true, href: `/`, label: 'summary' },
+                { href: `/calendar`, label: 'calendar' },
+                { href: `/archive`, label: 'archive' },
+            ] }
+            title={ intl.formatMessage({ id: 'layout.organize.campaigns.allCampaigns' }) }>
+            { children }
+        </TabbedLayout>
+    );
+};
+
+export default AllCampaignsLayout;

--- a/src/components/layout/organize/DefaultLayout.tsx
+++ b/src/components/layout/organize/DefaultLayout.tsx
@@ -2,9 +2,9 @@ import { FunctionComponent } from 'react';
 import { grey } from '@material-ui/core/colors';
 import { Box, makeStyles } from '@material-ui/core';
 
-import BreadcrumbTrail from '../BreadcrumbTrail';
-import OrganizeSidebar from '../OrganizeSidebar';
-import SearchDrawer from '../../components/SearchDrawer';
+import BreadcrumbTrail from '../../BreadcrumbTrail';
+import OrganizeSidebar from '../../OrganizeSidebar';
+import SearchDrawer from '../../SearchDrawer';
 
 const useStyles = makeStyles((theme) => ({
     breadcrumbs: {
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-const OrganizeLayout: FunctionComponent = ({ children }) => {
+const DefaultLayout: FunctionComponent = ({ children }) => {
     const classes = useStyles();
     return (
         <Box className={ classes.root } display="flex">
@@ -41,4 +41,4 @@ const OrganizeLayout: FunctionComponent = ({ children }) => {
     );
 };
 
-export default OrganizeLayout;
+export default DefaultLayout;

--- a/src/components/layout/organize/SingleCampaignLayout.tsx
+++ b/src/components/layout/organize/SingleCampaignLayout.tsx
@@ -31,7 +31,7 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ ch
     return (
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns/${campId}` }
-            defaultTab="summary"
+            defaultTab="/"
             fixedHeight={ fixedHeight }
             subtitle={ startDate && endDate ? (
                 <>
@@ -52,9 +52,9 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ ch
                 <Msg id="pages.organizeCampaigns.indefinite" />
             ) }
             tabs={ [
-                { href: `/`, label: 'summary', messageId: 'layout.organize.campaigns.summary' },
-                { href: `/calendar`, label: 'calendar', messageId: 'layout.organize.campaigns.calendar' },
-                { href: `/insights`, label: 'insights', messageId: 'layout.organize.campaigns.insights' },
+                { href: `/`, messageId: 'layout.organize.campaigns.summary' },
+                { href: `/calendar`, messageId: 'layout.organize.campaigns.calendar' },
+                { href: `/insights`, messageId: 'layout.organize.campaigns.insights' },
             ] }
             title={ campaign?.title }>
             { children }

--- a/src/components/layout/organize/SingleCampaignLayout.tsx
+++ b/src/components/layout/organize/SingleCampaignLayout.tsx
@@ -1,0 +1,32 @@
+import { FunctionComponent } from 'react';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
+
+import getCampaign from '../../../fetching/getCampaign';
+import TabbedLayout from './TabbedLayout';
+
+interface SingleCampaignLayoutProps {
+    fixedHeight?: boolean;
+}
+
+const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ children, fixedHeight }) => {
+    const { campId, orgId } = useRouter().query;
+    const campaignQuery = useQuery(['campaign', orgId, campId ], getCampaign(orgId  as string, campId as string));
+
+    return (
+        <TabbedLayout
+            baseHref={ `/organize/${orgId}/campaigns/${campId}` }
+            fixedHeight={ fixedHeight }
+            subtitle="subtitle for single campaign tabs" //TODO: generate subtitle
+            tabs={ [
+                {  defaultTab: true, href: `/`, label: 'summary' },
+                { href: `/calendar`, label: 'calendar' },
+                { href: `/insights`, label: 'insights' },
+            ] }
+            title={ campaignQuery.data?.title }>
+            { children }
+        </TabbedLayout>
+    );
+};
+
+export default SingleCampaignLayout;

--- a/src/components/layout/organize/SingleCampaignLayout.tsx
+++ b/src/components/layout/organize/SingleCampaignLayout.tsx
@@ -31,6 +31,7 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ ch
     return (
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns/${campId}` }
+            defaultTab="summary"
             fixedHeight={ fixedHeight }
             subtitle={ startDate && endDate ? (
                 <>
@@ -51,9 +52,9 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ ch
                 <Msg id="pages.organizeCampaigns.indefinite" />
             ) }
             tabs={ [
-                {  defaultTab: true, href: `/`, label: 'summary' },
-                { href: `/calendar`, label: 'calendar' },
-                { href: `/insights`, label: 'insights' },
+                { href: `/`, label: 'summary', messageId: 'layout.organize.campaigns.summary' },
+                { href: `/calendar`, label: 'calendar', messageId: 'layout.organize.campaigns.calendar' },
+                { href: `/insights`, label: 'insights', messageId: 'layout.organize.campaigns.insights' },
             ] }
             title={ campaign?.title }>
             { children }

--- a/src/components/layout/organize/SingleCampaignLayout.tsx
+++ b/src/components/layout/organize/SingleCampaignLayout.tsx
@@ -1,8 +1,11 @@
 import { FunctionComponent } from 'react';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
+import { FormattedDate, FormattedMessage as Msg } from 'react-intl';
 
 import getCampaign from '../../../fetching/getCampaign';
+import getCampaignEvents from '../../../fetching/getCampaignEvents';
+import { getNaiveDate } from '../../../utils/getNaiveDate';
 import TabbedLayout from './TabbedLayout';
 
 interface SingleCampaignLayoutProps {
@@ -12,18 +15,47 @@ interface SingleCampaignLayoutProps {
 const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ children, fixedHeight }) => {
     const { campId, orgId } = useRouter().query;
     const campaignQuery = useQuery(['campaign', orgId, campId ], getCampaign(orgId  as string, campId as string));
+    const campaignEventsQuery = useQuery(['campaignEvents', orgId, campId], getCampaignEvents(orgId as string, campId as string));
+
+    const campaign = campaignQuery.data;
+    const campaignEvents = campaignEventsQuery.data || [];
+
+    let endDate, startDate;
+    const firstEvent = campaignEvents[0];
+    const lastEvent = campaignEvents[campaignEvents.length - 1];
+    if (firstEvent && lastEvent) {
+        startDate = getNaiveDate(firstEvent.start_time) ;
+        endDate = getNaiveDate(lastEvent.end_time);
+    }
 
     return (
         <TabbedLayout
             baseHref={ `/organize/${orgId}/campaigns/${campId}` }
             fixedHeight={ fixedHeight }
-            subtitle="subtitle for single campaign tabs" //TODO: generate subtitle
+            subtitle={ startDate && endDate ? (
+                <>
+                    <FormattedDate
+                        day="2-digit"
+                        month="long"
+                        value={ startDate }
+                    />
+                    { ` - ` }
+                    <FormattedDate
+                        day="2-digit"
+                        month="long"
+                        value={ endDate }
+                        year="numeric"
+                    />
+                </>
+            ) : (
+                <Msg id="pages.organizeCampaigns.indefinite" />
+            ) }
             tabs={ [
                 {  defaultTab: true, href: `/`, label: 'summary' },
                 { href: `/calendar`, label: 'calendar' },
                 { href: `/insights`, label: 'insights' },
             ] }
-            title={ campaignQuery.data?.title }>
+            title={ campaign?.title }>
             { children }
         </TabbedLayout>
     );

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -26,7 +26,7 @@ interface TabbedLayoutProps {
     subtitle?: string | ReactElement;
     baseHref: string;
     defaultTab: string;
-    tabs: {href: string; label: string; messageId: string}[];
+    tabs: {href: string; messageId: string}[];
 }
 
 const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHeight, title, subtitle, tabs, baseHref, defaultTab }) => {
@@ -35,10 +35,10 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHei
     const router = useRouter();
 
     const currentTab = router.asPath === baseHref ? defaultTab :
-        router.pathname.split('/').pop();
+        `/${router.pathname.split('/').pop()}`;
 
     const selectTab = (selected: string) : void => {
-        const href = tabs.find(tab => tab.label === selected)?.href;
+        const href = tabs.find(tab => tab.href === selected)?.href;
         if (href) {
             router.push(baseHref + href);
         }
@@ -75,9 +75,9 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHei
                             value={ currentTab }>
                             { tabs.map(tab => {
                                 return (
-                                    <Tab key={ tab.label } label={ intl.formatMessage({
+                                    <Tab key={ tab.href } label={ intl.formatMessage({
                                         id: tab.messageId,
-                                    }) } value={ tab.label }
+                                    }) } value={ tab.href }
                                     />
                                 );
                             }) }

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -4,10 +4,10 @@ import { useRouter } from 'next/router';
 import { Box, makeStyles, Tab, Tabs, Typography } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
-import BreadcrumbTrail from '../BreadcrumbTrail';
-import getCampaign from '../../fetching/getCampaign';
-import OrganizeSidebar from '../OrganizeSidebar';
-import SearchDrawer from '../SearchDrawer';
+import BreadcrumbTrail from '../../BreadcrumbTrail';
+import getCampaign from '../../../fetching/getCampaign';
+import OrganizeSidebar from '../../OrganizeSidebar';
+import SearchDrawer from '../../SearchDrawer';
 
 const useStyles = makeStyles((theme) => ({
     breadcrumbs: {
@@ -22,11 +22,11 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-interface OrganizeTabbedLayoutProps {
+interface TabbedLayoutProps {
     fixedHeight?: boolean;
 }
 
-const OrganizeTabbedLayout: FunctionComponent<OrganizeTabbedLayoutProps> = ({ children, fixedHeight }) => {
+const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHeight }) => {
     const intl = useIntl();
     const classes = useStyles();
     const router = useRouter();
@@ -97,4 +97,4 @@ const OrganizeTabbedLayout: FunctionComponent<OrganizeTabbedLayoutProps> = ({ ch
     );
 };
 
-export default OrganizeTabbedLayout;
+export default TabbedLayout;

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -25,22 +25,17 @@ interface TabbedLayoutProps {
     title?: string;
     subtitle?: string | ReactElement;
     baseHref: string;
-    tabs: { defaultTab?:boolean; href: string; label: string}[];
+    defaultTab: string;
+    tabs: {href: string; label: string; messageId: string}[];
 }
 
-const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHeight, title, subtitle, tabs, baseHref }) => {
+const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHeight, title, subtitle, tabs, baseHref, defaultTab }) => {
     const intl = useIntl();
     const classes = useStyles();
     const router = useRouter();
 
-    let currentTab = router.pathname.split('/').pop();
-
-    if (router.asPath === baseHref) {
-        currentTab = tabs.find(tab => tab.defaultTab)?.label;
-        if (!currentTab && process.env.NODE_ENV === 'development') {
-            throw new Error('No default tab selected!');
-        }
-    }
+    const currentTab = router.asPath === baseHref ? defaultTab :
+        router.pathname.split('/').pop();
 
     const selectTab = (selected: string) : void => {
         const href = tabs.find(tab => tab.label === selected)?.href;
@@ -81,7 +76,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHei
                             { tabs.map(tab => {
                                 return (
                                     <Tab key={ tab.label } label={ intl.formatMessage({
-                                        id: `layout.organize.campaigns.${tab.label}`,
+                                        id: tab.messageId,
                                     }) } value={ tab.label }
                                     />
                                 );

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent } from 'react';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
 import { Box, makeStyles, Tab, Tabs, Typography } from '@material-ui/core';
+import { FunctionComponent, ReactElement } from 'react';
 
 import BreadcrumbTrail from '../../BreadcrumbTrail';
 import OrganizeSidebar from '../../OrganizeSidebar';
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
 interface TabbedLayoutProps {
     fixedHeight?: boolean;
     title?: string;
-    subtitle?: string;
+    subtitle?: string | ReactElement;
     baseHref: string;
     tabs: { defaultTab?:boolean; href: string; label: string}[];
 }

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -37,8 +37,8 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHei
 
     if (router.asPath === baseHref) {
         currentTab = tabs.find(tab => tab.defaultTab)?.label;
-        if (!currentTab) {
-            console.warn('No default tab selected.');
+        if (!currentTab && process.env.NODE_ENV === 'development') {
+            throw new Error('No default tab selected!');
         }
     }
 
@@ -47,8 +47,8 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({ children, fixedHei
         if (href) {
             router.push(baseHref + href);
         }
-        else {
-            console.warn(`Tab with label ${selected} wasn't found`);
+        else if (process.env.NODE_ENV === 'development') {
+            throw new Error (`Tab with label ${selected} wasn't found`);
         }
     };
 

--- a/src/pages/organize/[orgId]/areas.tsx
+++ b/src/pages/organize/[orgId]/areas.tsx
@@ -1,8 +1,8 @@
 import { GetServerSideProps } from 'next';
 import { Heading } from '@adobe/react-spectrum';
 
+import DefaultLayout from '../../../components/layout/organize/DefaultLayout';
 import getOrg from '../../../fetching/getOrg';
-import OrganizeLayout from '../../../components/layout/OrganizeLayout';
 import { PageWithLayout } from '../../../types';
 import { scaffold } from '../../../utils/next';
 
@@ -49,9 +49,9 @@ const OrganizeAreaPage : PageWithLayout<OrganizeAreaPageProps> = () => {
 
 OrganizeAreaPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeLayout>
+        <DefaultLayout>
             { page }
-        </OrganizeLayout>
+        </DefaultLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/events/[eventId]/index.tsx
@@ -1,9 +1,9 @@
 import { GetServerSideProps } from 'next';
 
 import getOrg from '../../../../../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../../../../types';
 import { scaffold } from '../../../../../../../../utils/next';
+import TabbedLayout from '../../../../../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -44,9 +44,9 @@ const EventPage: PageWithLayout = () => {
 
 EventPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/events/[eventId]/index.tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import getOrg from '../../../../../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../../../../../types';
 import { scaffold } from '../../../../../../../../utils/next';
-import TabbedLayout from '../../../../../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -44,9 +43,9 @@ const EventPage: PageWithLayout = () => {
 
 EventPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <>
             { page }
-        </TabbedLayout>
+        </>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
@@ -6,7 +6,7 @@ import getCampaignTasks from '../../../../../../fetching/tasks/getCampaignTasks'
 import getOrg from '../../../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../../../types';
 import { scaffold } from '../../../../../../utils/next';
-import TabbedLayout from '../../../../../../components/layout/organize/TabbedLayout';
+import SingleCampaignLayout from '../../../../../../components/layout/organize/SingleCampaignLayout';
 import { useQuery } from 'react-query';
 import ZetkinCalendar from '../../../../../../components/ZetkinCalendar';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../../components/ZetkinSpeedDial';
@@ -73,9 +73,9 @@ const CampaignCalendarPage : PageWithLayout<OrganizeCalendarPageProps> = ({ orgI
 
 CampaignCalendarPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout fixedHeight>
+        <SingleCampaignLayout fixedHeight>
             { page }
-        </TabbedLayout>
+        </SingleCampaignLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
@@ -4,9 +4,9 @@ import getCampaign from '../../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../../fetching/getCampaignEvents';
 import getCampaignTasks from '../../../../../../fetching/tasks/getCampaignTasks';
 import getOrg from '../../../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../../types';
 import { scaffold } from '../../../../../../utils/next';
+import TabbedLayout from '../../../../../../components/layout/organize/TabbedLayout';
 import { useQuery } from 'react-query';
 import ZetkinCalendar from '../../../../../../components/ZetkinCalendar';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../../components/ZetkinSpeedDial';
@@ -73,9 +73,9 @@ const CampaignCalendarPage : PageWithLayout<OrganizeCalendarPageProps> = ({ orgI
 
 CampaignCalendarPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout fixedHeight>
+        <TabbedLayout fixedHeight>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -17,7 +17,7 @@ import getOrg from '../../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../../types';
 import patchCampaign from '../../../../../fetching/patchCampaign';
 import { scaffold } from '../../../../../utils/next';
-import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
+import SingleCampaignLayout from '../../../../../components/layout/organize/SingleCampaignLayout';
 import TaskList from '../../../../../components/organize/tasks/TaskList';
 import ZetkinDialog from '../../../../../components/ZetkinDialog';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
@@ -294,9 +294,9 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
 
 CampaignSummaryPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <SingleCampaignLayout>
             { page }
-        </TabbedLayout>
+        </SingleCampaignLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -14,10 +14,10 @@ import getCampaign from '../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
 import getCampaignTasks from '../../../../../fetching/tasks/getCampaignTasks';
 import getOrg from '../../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../types';
 import patchCampaign from '../../../../../fetching/patchCampaign';
 import { scaffold } from '../../../../../utils/next';
+import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
 import TaskList from '../../../../../components/organize/tasks/TaskList';
 import ZetkinDialog from '../../../../../components/ZetkinDialog';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
@@ -294,9 +294,9 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
 
 CampaignSummaryPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/insights.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/insights.tsx
@@ -4,9 +4,9 @@ import { GetServerSideProps } from 'next';
 import getCampaign from '../../../../../fetching/getCampaign';
 import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
 import getOrg from '../../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../types';
 import { scaffold } from '../../../../../utils/next';
+import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -59,9 +59,9 @@ const CampaignInsightsPage: PageWithLayout<CampaignCalendarPageProps> = () => {
 
 CampaignInsightsPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/insights.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/insights.tsx
@@ -6,7 +6,7 @@ import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
 import getOrg from '../../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../../types';
 import { scaffold } from '../../../../../utils/next';
-import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
+import SingleCampaignLayout from '../../../../../components/layout/organize/SingleCampaignLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -59,9 +59,9 @@ const CampaignInsightsPage: PageWithLayout<CampaignCalendarPageProps> = () => {
 
 CampaignInsightsPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <SingleCampaignLayout>
             { page }
-        </TabbedLayout>
+        </SingleCampaignLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/calendar/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar/events/[eventId]/index.tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import getOrg from '../../../../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../../../../types';
 import { scaffold } from '../../../../../../../utils/next';
-import TabbedLayout from '../../../../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -43,9 +42,9 @@ const EventPage: PageWithLayout = () => {
 
 EventPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <>
             { page }
-        </TabbedLayout>
+        </>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/calendar/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar/events/[eventId]/index.tsx
@@ -1,9 +1,9 @@
 import { GetServerSideProps } from 'next';
 
 import getOrg from '../../../../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../../../types';
 import { scaffold } from '../../../../../../../utils/next';
+import TabbedLayout from '../../../../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -43,9 +43,9 @@ const EventPage: PageWithLayout = () => {
 
 EventPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
@@ -1,13 +1,13 @@
 import { GetServerSideProps } from 'next';
 import { useQuery } from 'react-query';
 
+import AllCampaignsLayout from '../../../../../components/layout/organize/AllCampaignsLayout';
 import getCampaigns from '../../../../../fetching/getCampaigns';
 import getEvents from '../../../../../fetching/getEvents';
 import getOrg from '../../../../../fetching/getOrg';
 import getOrganizationTasks from '../../../../../fetching/tasks/getOrganizationTasks';
 import { PageWithLayout } from '../../../../../types';
 import { scaffold } from '../../../../../utils/next';
-import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
 import ZetkinCalendar from '../../../../../components/ZetkinCalendar';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
 
@@ -70,9 +70,9 @@ const AllCampaignsCalendarPage : PageWithLayout<AllCampaignsCalendarPageProps> =
 
 AllCampaignsCalendarPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout fixedHeight>
+        <AllCampaignsLayout fixedHeight>
             { page }
-        </TabbedLayout>
+        </AllCampaignsLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
@@ -5,9 +5,9 @@ import getCampaigns from '../../../../../fetching/getCampaigns';
 import getEvents from '../../../../../fetching/getEvents';
 import getOrg from '../../../../../fetching/getOrg';
 import getOrganizationTasks from '../../../../../fetching/tasks/getOrganizationTasks';
-import OrganizeTabbedLayout from '../../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../../types';
 import { scaffold } from '../../../../../utils/next';
+import TabbedLayout from '../../../../../components/layout/organize/TabbedLayout';
 import ZetkinCalendar from '../../../../../components/ZetkinCalendar';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
 
@@ -70,9 +70,9 @@ const AllCampaignsCalendarPage : PageWithLayout<AllCampaignsCalendarPageProps> =
 
 AllCampaignsCalendarPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout fixedHeight>
+        <TabbedLayout fixedHeight>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/index.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { Box, Checkbox, Container, FormControl, FormControlLabel, FormGroup, FormLabel, Link, List, ListItem, Typography } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
+import AllCampaignsLayout from '../../../../components/layout/organize/AllCampaignsLayout';
 import CampaignCard from '../../../../components/CamapignCard';
 import getActivities from '../../../../fetching/getActivities';
 import getAllCallAssignments from '../../../../fetching/getAllCallAssignments';
@@ -18,7 +19,6 @@ import getSurveys from '../../../../fetching/getSurveys';
 import getUpcomingEvents from '../../../../fetching/getUpcomingEvents';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
-import TabbedLayout from '../../../../components/layout/organize/TabbedLayout';
 import ZetkinSection from '../../../../components/ZetkinSection';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../components/ZetkinSpeedDial';
 
@@ -190,9 +190,9 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
 
 AllCampaignsSummaryPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <AllCampaignsLayout>
             { page }
-        </TabbedLayout>
+        </AllCampaignsLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/index.tsx
@@ -16,9 +16,9 @@ import getLocations from '../../../../fetching/getLocations';
 import getOrg from '../../../../fetching/getOrg';
 import getSurveys from '../../../../fetching/getSurveys';
 import getUpcomingEvents from '../../../../fetching/getUpcomingEvents';
-import OrganizeTabbedLayout from '../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
+import TabbedLayout from '../../../../components/layout/organize/TabbedLayout';
 import ZetkinSection from '../../../../components/ZetkinSection';
 import ZetkinSpeedDial, { ACTIONS } from '../../../../components/ZetkinSpeedDial';
 
@@ -190,9 +190,9 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
 
 AllCampaignsSummaryPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/insights.tsx
+++ b/src/pages/organize/[orgId]/campaigns/insights.tsx
@@ -1,9 +1,9 @@
 import { GetServerSideProps } from 'next';
 
+import AllCampaignsLayout from '../../../../components/layout/organize/AllCampaignsLayout';
 import getOrg from '../../../../fetching/getOrg';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
-import TabbedLayout from '../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -47,9 +47,9 @@ const AllCampaignsInsightsPage: PageWithLayout<AllCampaignsInsightsPageProps> = 
 
 AllCampaignsInsightsPage.getLayout = function getLayout(page) {
     return (
-        <TabbedLayout>
+        <AllCampaignsLayout>
             { page }
-        </TabbedLayout>
+        </AllCampaignsLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/insights.tsx
+++ b/src/pages/organize/[orgId]/campaigns/insights.tsx
@@ -1,9 +1,9 @@
 import { GetServerSideProps } from 'next';
 
 import getOrg from '../../../../fetching/getOrg';
-import OrganizeTabbedLayout from '../../../../components/layout/OrganizeTabbedLayout';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
+import TabbedLayout from '../../../../components/layout/organize/TabbedLayout';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -47,9 +47,9 @@ const AllCampaignsInsightsPage: PageWithLayout<AllCampaignsInsightsPageProps> = 
 
 AllCampaignsInsightsPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeTabbedLayout>
+        <TabbedLayout>
             { page }
-        </OrganizeTabbedLayout>
+        </TabbedLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/index.tsx
+++ b/src/pages/organize/[orgId]/index.tsx
@@ -8,9 +8,9 @@ import { Public, Settings, SupervisorAccount } from '@material-ui/icons';
 import apiUrl from '../../../utils/apiUrl';
 import DashboardCampaigns from '../../../components/DashboardCampaigns';
 import DashboardPeople from '../../../components/DashboardPeople';
+import DefaultLayout from '../../../components/layout/organize/DefaultLayout';
 import getCampaigns from '../../../fetching/getCampaigns';
 import getOrg from '../../../fetching/getOrg';
-import OrganizeLayout from '../../../components/layout/OrganizeLayout';
 import { PageWithLayout } from '../../../types';
 import { scaffold } from '../../../utils/next';
 
@@ -115,9 +115,9 @@ const OrganizePage: PageWithLayout<OrganizePageProps> = ({ orgId }) => {
 
 OrganizePage.getLayout = function getLayout(page) {
     return (
-        <OrganizeLayout>
+        <DefaultLayout>
             { page }
-        </OrganizeLayout>
+        </DefaultLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/people.tsx
+++ b/src/pages/organize/[orgId]/people.tsx
@@ -1,8 +1,8 @@
 import { GetServerSideProps } from 'next';
 import { Heading } from '@adobe/react-spectrum';
 
+import DefaultLayout from '../../../components/layout/organize/DefaultLayout';
 import getOrg from '../../../fetching/getOrg';
-import OrganizeLayout from '../../../components/layout/OrganizeLayout';
 import { PageWithLayout } from '../../../types';
 import { scaffold } from '../../../utils/next';
 
@@ -49,9 +49,9 @@ const OrganizePeoplePage : PageWithLayout<OrganizePeoplePageProps> = () => {
 
 OrganizePeoplePage.getLayout = function getLayout(page) {
     return (
-        <OrganizeLayout>
+        <DefaultLayout>
             { page }
-        </OrganizeLayout>
+        </DefaultLayout>
     );
 };
 

--- a/src/pages/organize/[orgId]/people/[personId].tsx
+++ b/src/pages/organize/[orgId]/people/[personId].tsx
@@ -1,8 +1,8 @@
 import { GetServerSideProps } from 'next';
 import { Heading } from '@adobe/react-spectrum';
 
+import DefaultLayout from '../../../../components/layout/organize/DefaultLayout';
 import getOrg from '../../../../fetching/getOrg';
-import OrganizeLayout from '../../../../components/layout/OrganizeLayout';
 import { PageWithLayout } from '../../../../types';
 import { scaffold } from '../../../../utils/next';
 
@@ -49,9 +49,9 @@ const OrganizePersonPage : PageWithLayout<OrganizePersonPageProps> = () => {
 
 OrganizePersonPage.getLayout = function getLayout(page) {
     return (
-        <OrganizeLayout>
+        <DefaultLayout>
             { page }
-        </OrganizeLayout>
+        </DefaultLayout>
     );
 };
 


### PR DESCRIPTION
Resolves #263 and Resolves #296

Renaming: OrganizeLayout and OrganizeTabbedLayout are now DefaultLayout and TabbedLayout and lie in `layout/organize`