### PR TITLE
extends issue-231/smart search - hook and improve typing

### DIFF
--- a/src/components/smartSearch/EditTargetDialog.tsx
+++ b/src/components/smartSearch/EditTargetDialog.tsx
@@ -8,9 +8,10 @@ import { isFilterWithId } from './utils';
 import MostActive from './filters/MostActive';
 import patchTaskTarget from 'fetching/tasks/patchTaskTarget';
 import { useRouter } from 'next/router';
-import { ZetkinSmartSearchFilter } from 'types/zetkin';
-import { FILTER_TYPE, ZetkinSmartSearchFilterWithId } from 'types/smartSearch';
+import { FILTER_TYPE, SelectedSmartSearchFilter, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
 import { useMutation, useQueryClient } from 'react-query';
+
+import useSmartSearch from 'hooks/useSmartSearch';
 
 interface EditTargetDialogProps {
     filterSpec: ZetkinSmartSearchFilter[];
@@ -21,42 +22,32 @@ interface EditTargetDialogProps {
 const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogProps) : JSX.Element => {
     const queryClient = useQueryClient();
     const { orgId, taskId } = useRouter().query;
-    const filtersWithIds = filterSpec.map((filter, index) => ({ ...filter, id: index }));
-    const [filterArray, setFilterArray] = useState<ZetkinSmartSearchFilterWithId[]>(filtersWithIds);
-    const [selectedType, setSelectedType] = useState<FILTER_TYPE | null>(null);
-    const [selectedFilter, setSelectedFilter] = useState<ZetkinSmartSearchFilterWithId| null>(null);
+
+    const [filterArray, addFilter, editFilter, deleteFilter ] = useSmartSearch(filterSpec);
+    const [selectedFilter, setSelectedFilter] = useState<SelectedSmartSearchFilter>(null);
 
     const taskMutation = useMutation(patchTaskTarget(orgId as string, taskId as string),{
         onSettled: () => queryClient.invalidateQueries(['filter_spec', orgId, taskId]),
     } );
 
     const handleDialogClose = () => {
-        setSelectedType(null);
+        setSelectedFilter(null);
         onDialogClose();
     };
 
-    const handleCancelFilter = () => setSelectedType(null);
+    const handleCancelFilter = () => setSelectedFilter(null);
 
-    const handleSubmitFilter = (filter:ZetkinSmartSearchFilterWithId | ZetkinSmartSearchFilter) => {
+    const handleSubmitFilter = (filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter) => {
+        // If editing a filter
         if (isFilterWithId(filter)) {
-            setFilterArray(filterArray.map(f => {
-                if (f.id === filter.id) {
-                    return filter;
-                }
-                else {
-                    return f;
-                }
-            }));
+            editFilter((filter as SmartSearchFilterWithId).id, filter as SmartSearchFilterWithId);
         }
+        // If creating a new filter
         else {
-            const newId = 1 + (filterArray.length ? Math.max(...filterArray.map(f => f.id)) : 0);
-            setFilterArray(filterArray.concat({ ...filter, id: newId }));
+            addFilter(filter);
         }
         setSelectedFilter(null);
-        setSelectedType(null);
     };
-
-    const handleSelectedTypeChange = (type: FILTER_TYPE) => setSelectedType(type);
 
     const handleSave = () => {
         taskMutation.mutate(filterArray.map(filter => ({
@@ -65,19 +56,18 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
         onDialogClose();
     };
 
-    const handleDeleteButtonClick = (filter: ZetkinSmartSearchFilterWithId) => {
-        setFilterArray(filterArray.filter(f => f.id !== filter.id));
+    const handleDeleteButtonClick = (filter: SmartSearchFilterWithId) => {
+        deleteFilter(filter.id);
     };
 
-    const handleEditButtonClick = (filter: ZetkinSmartSearchFilterWithId) => {
+    const handleEditButtonClick = (filter: SmartSearchFilterWithId) => {
         setSelectedFilter(filter);
-        setSelectedType(filter.type as FILTER_TYPE);
     };
 
     return (
         <Dialog fullWidth maxWidth="xl" onClose={ handleDialogClose } open={ open }>
             <DialogContent>
-                { !selectedType && (
+                { !selectedFilter && (
                     <>
                         <Box p={ 1 }>
                             <Typography variant="h6">
@@ -93,11 +83,12 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
                             <Typography variant="h6">
                                 <Msg id="misc.smartSearch.headers.add"/>
                             </Typography>
+                            { /* Buttons to add new filter */ }
                             { Object.values(FILTER_TYPE).map(value => (
                                 <ButtonBase
                                     key={ value }
                                     disableRipple
-                                    onClick={ () => handleSelectedTypeChange(value) }>
+                                    onClick={ () => setSelectedFilter({ type: value }) }>
                                     <Card style={{ margin: '1rem', width: '250px' }}>
                                         <CardContent>
                                             <Typography>
@@ -118,8 +109,8 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
                         </Box>
                     </>
                 ) }
-                { selectedType === FILTER_TYPE.ALL && <All onCancel={ handleCancelFilter } onSubmit={ handleSubmitFilter }/> }
-                { selectedType === FILTER_TYPE.MOST_ACTIVE && <MostActive filter={ selectedFilter } onCancel={ handleCancelFilter } onSubmit={ handleSubmitFilter }/> }
+                { selectedFilter?.type === FILTER_TYPE.ALL && <All onCancel={ handleCancelFilter } onSubmit={ handleSubmitFilter }/> }
+                { selectedFilter?.type === FILTER_TYPE.MOST_ACTIVE && <MostActive filter={ selectedFilter } onCancel={ handleCancelFilter } onSubmit={ handleSubmitFilter }/> }
             </DialogContent>
         </Dialog>
     );

--- a/src/components/smartSearch/EditTargetDialog.tsx
+++ b/src/components/smartSearch/EditTargetDialog.tsx
@@ -23,7 +23,7 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
     const queryClient = useQueryClient();
     const { orgId, taskId } = useRouter().query;
 
-    const [filterArray, addFilter, editFilter, deleteFilter ] = useSmartSearch(filterSpec);
+    const { filtersWithIds: filterArray, filters, addFilter, editFilter, deleteFilter } = useSmartSearch(filterSpec);
     const [selectedFilter, setSelectedFilter] = useState<SelectedSmartSearchFilter>(null);
 
     const taskMutation = useMutation(patchTaskTarget(orgId as string, taskId as string),{
@@ -50,9 +50,7 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
     };
 
     const handleSave = () => {
-        taskMutation.mutate(filterArray.map(filter => ({
-            config: filter.config, op: filter.op, type: filter.type,
-        })));
+        taskMutation.mutate(filters);
         onDialogClose();
     };
 

--- a/src/components/smartSearch/EditTargetDialog.tsx
+++ b/src/components/smartSearch/EditTargetDialog.tsx
@@ -38,9 +38,9 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
     const handleCancelFilter = () => setSelectedFilter(null);
 
     const handleSubmitFilter = (filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter) => {
-        // If editing a filter
-        if (isFilterWithId(filter)) {
-            editFilter((filter as SmartSearchFilterWithId).id, filter as SmartSearchFilterWithId);
+        // If editing existing filter
+        if ('id' in filter) {
+            editFilter(filter.id, filter);
         }
         // If creating a new filter
         else {

--- a/src/components/smartSearch/EditTargetDialog.tsx
+++ b/src/components/smartSearch/EditTargetDialog.tsx
@@ -4,7 +4,6 @@ import { Box, Button, ButtonBase, Card, CardContent, Dialog, DialogContent, Typo
 
 import All from './filters/All';
 import Filter from './Filter';
-import { isFilterWithId } from './utils';
 import MostActive from './filters/MostActive';
 import patchTaskTarget from 'fetching/tasks/patchTaskTarget';
 import { useRouter } from 'next/router';
@@ -37,7 +36,7 @@ const EditTargetDialog = ({ onDialogClose, open, filterSpec }: EditTargetDialogP
 
     const handleCancelFilter = () => setSelectedFilter(null);
 
-    const handleSubmitFilter = (filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter) => {
+    const handleSubmitFilter = (filter: ZetkinSmartSearchFilter | SmartSearchFilterWithId) => {
         // If editing existing filter
         if ('id' in filter) {
             editFilter(filter.id, filter);

--- a/src/components/smartSearch/Filter.tsx
+++ b/src/components/smartSearch/Filter.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardActions, IconButton, Typography } from '@material-ui/cor
 import { Delete, Edit } from '@material-ui/icons';
 
 import { getTimeFrame } from './utils';
-import { SmartSearchFilterWithId } from 'types/smartSearch';
+import { FILTER_TYPE, OPERATION, SmartSearchFilterWithId } from 'types/smartSearch';
 
 interface FilterProps {
     filter: SmartSearchFilterWithId;
@@ -14,7 +14,7 @@ interface FilterProps {
 
 const Filter = ({ filter, onDelete, onEdit }:FilterProps): JSX.Element => {
     const { config, type } = filter;
-    const op = filter.op || 'add';
+    const op = filter.op || OPERATION.ADD;
     const timeFrame = getTimeFrame({ after: config?.after, before: config?.before });
 
     return (
@@ -46,7 +46,7 @@ const Filter = ({ filter, onDelete, onEdit }:FilterProps): JSX.Element => {
                     />
                 </Typography>
                 <CardActions>
-                    { filter.type !== 'all' && (
+                    { filter.type !== FILTER_TYPE.ALL && (
                         <IconButton
                             onClick={ () => onEdit(filter) }>
                             <Edit />

--- a/src/components/smartSearch/Filter.tsx
+++ b/src/components/smartSearch/Filter.tsx
@@ -3,12 +3,12 @@ import { Box, Card, CardActions, IconButton, Typography } from '@material-ui/cor
 import { Delete, Edit } from '@material-ui/icons';
 
 import { getTimeFrame } from './utils';
-import { ZetkinSmartSearchFilterWithId } from 'types/smartSearch';
+import { SmartSearchFilterWithId } from 'types/smartSearch';
 
 interface FilterProps {
-    filter: ZetkinSmartSearchFilterWithId;
-    onDelete: (filter: ZetkinSmartSearchFilterWithId) => void;
-    onEdit: (filter: ZetkinSmartSearchFilterWithId) => void;
+    filter: SmartSearchFilterWithId;
+    onDelete: (filter: SmartSearchFilterWithId) => void;
+    onEdit: (filter: SmartSearchFilterWithId) => void;
 }
 
 

--- a/src/components/smartSearch/filters/All.tsx
+++ b/src/components/smartSearch/filters/All.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
 import { Box, Button, Divider, Typography } from '@material-ui/core';
-import { FILTER_TYPE, ZetkinSmartSearchFilter } from 'types/smartSearch';
+import { FILTER_TYPE, OPERATION, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 interface AllProps {
     onSubmit: (filter: ZetkinSmartSearchFilter) => void;
@@ -12,7 +12,7 @@ const All = ({ onSubmit, onCancel }: AllProps): JSX.Element => {
 
     const handleSubmitFilter = (e: FormEvent) => {
         e.preventDefault();
-        onSubmit({ op: 'add', type: FILTER_TYPE.ALL  });
+        onSubmit({ op: OPERATION.ADD, type: FILTER_TYPE.ALL  });
     };
 
     return (

--- a/src/components/smartSearch/filters/All.tsx
+++ b/src/components/smartSearch/filters/All.tsx
@@ -1,7 +1,7 @@
 import { FormEvent } from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
-import { ZetkinSmartSearchFilter } from 'types/zetkin';
 import { Box, Button, Divider, Typography } from '@material-ui/core';
+import { FILTER_TYPE, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 interface AllProps {
     onSubmit: (filter: ZetkinSmartSearchFilter) => void;
@@ -12,7 +12,7 @@ const All = ({ onSubmit, onCancel }: AllProps): JSX.Element => {
 
     const handleSubmitFilter = (e: FormEvent) => {
         e.preventDefault();
-        onSubmit({ op: 'add', type: 'all'  });
+        onSubmit({ op: 'add', type: FILTER_TYPE.ALL  });
     };
 
     return (

--- a/src/components/smartSearch/filters/MostActive.tsx
+++ b/src/components/smartSearch/filters/MostActive.tsx
@@ -6,10 +6,10 @@ import { isFilterWithId } from '../utils';
 import StyledNumberInput from '../inputs/StyledNumberInput';
 import StyledSelect from '../inputs/StyledSelect';
 import TimeFrame from './TimeFrame';
-import { FILTER_TYPE, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
+import { FILTER_TYPE, OPERATION, SelectedSmartSearchFilter, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 interface MostActiveProps {
-    filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter | { type: FILTER_TYPE };
+    filter: SelectedSmartSearchFilter;
     onSubmit: (filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter) => void;
     onCancel: () => void;
 }
@@ -17,7 +17,7 @@ interface MostActiveProps {
 const MostActive = ({ onSubmit, onCancel, filter }: MostActiveProps): JSX.Element => {
     const [numPeople, setNumPeople] = useState(filter?.config?.size || 10);
     const [timeFrame, setTimeFrame] = useState({});
-    const [op, setOp] = useState<'add' | 'sub'>(filter?.op || 'add');
+    const [op, setOp] = useState<OPERATION>(filter?.op || OPERATION.ADD);
 
     const handleAddFilter = (e: FormEvent) => {
         e.preventDefault();
@@ -41,12 +41,12 @@ const MostActive = ({ onSubmit, onCancel, filter }: MostActiveProps): JSX.Elemen
             <Typography style={{ lineHeight: 'unset', marginBottom: '2rem' }} variant="h4">
                 <Msg id="misc.smartSearch.most_active.inputString" values={{
                     addRemoveSelect: (
-                        <StyledSelect onChange={ e => setOp(e.target.value as 'add' | 'sub') }
+                        <StyledSelect onChange={ e => setOp(e.target.value as OPERATION) }
                             value={ op }>
-                            <MenuItem key="add" value="add">
+                            <MenuItem key={ OPERATION.ADD } value={ OPERATION.ADD }>
                                 <Msg id="misc.smartSearch.most_active.addRemoveSelect.add"/>
                             </MenuItem>
-                            <MenuItem key="sub" value="sub">
+                            <MenuItem key={ OPERATION.SUB } value={ OPERATION.SUB }>
                                 <Msg id="misc.smartSearch.most_active.addRemoveSelect.sub" />
                             </MenuItem>
                         </StyledSelect>

--- a/src/components/smartSearch/filters/MostActive.tsx
+++ b/src/components/smartSearch/filters/MostActive.tsx
@@ -9,7 +9,7 @@ import useSmartSearchFilter from 'hooks/useSmartSearchFilter';
 import { MostActiveFilterConfig, NewSmartSearchFilter, OPERATION, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 interface MostActiveProps {
-    filter:  ZetkinSmartSearchFilter<MostActiveFilterConfig> | SmartSearchFilterWithId<MostActiveFilterConfig> |  NewSmartSearchFilter ;
+    filter:  SmartSearchFilterWithId<MostActiveFilterConfig> |  NewSmartSearchFilter ;
     onSubmit: (filter: SmartSearchFilterWithId<MostActiveFilterConfig> | ZetkinSmartSearchFilter<MostActiveFilterConfig>) => void;
     onCancel: () => void;
 }

--- a/src/components/smartSearch/filters/MostActive.tsx
+++ b/src/components/smartSearch/filters/MostActive.tsx
@@ -6,12 +6,11 @@ import { isFilterWithId } from '../utils';
 import StyledNumberInput from '../inputs/StyledNumberInput';
 import StyledSelect from '../inputs/StyledSelect';
 import TimeFrame from './TimeFrame';
-import { ZetkinSmartSearchFilter } from 'types/zetkin';
-import { ZetkinSmartSearchFilterWithId } from 'types/smartSearch';
+import { FILTER_TYPE, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 interface MostActiveProps {
-    filter: ZetkinSmartSearchFilterWithId | ZetkinSmartSearchFilter | null;
-    onSubmit: (filter: ZetkinSmartSearchFilterWithId | ZetkinSmartSearchFilter) => void;
+    filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter | { type: FILTER_TYPE };
+    onSubmit: (filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter) => void;
     onCancel: () => void;
 }
 
@@ -29,7 +28,7 @@ const MostActive = ({ onSubmit, onCancel, filter }: MostActiveProps): JSX.Elemen
             },
             ...(filter && isFilterWithId(filter) && { id: filter.id }),
             op,
-            type: 'most_active',
+            type: FILTER_TYPE.MOST_ACTIVE,
         });
     };
 
@@ -83,7 +82,7 @@ const MostActive = ({ onSubmit, onCancel, filter }: MostActiveProps): JSX.Elemen
                     <Msg id="misc.smartSearch.buttonLabels.cancel"/>
                 </Button>
                 <Button color="primary" type="submit" variant="contained">
-                    { filter ? <Msg id="misc.smartSearch.buttonLabels.edit"/>: <Msg id="misc.smartSearch.buttonLabels.add"/> }
+                    { filter.config ? <Msg id="misc.smartSearch.buttonLabels.edit"/>: <Msg id="misc.smartSearch.buttonLabels.add"/> }
                 </Button>
             </Box>
         </form>

--- a/src/components/smartSearch/utils.ts
+++ b/src/components/smartSearch/utils.ts
@@ -1,9 +1,8 @@
 import { TIME_FRAME } from 'types/smartSearch';
-import { ZetkinSmartSearchFilter } from 'types/zetkin';
-import { ZetkinSmartSearchFilterWithId } from 'types/smartSearch';
+import { SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
 
-export function isFilterWithId(filter: ZetkinSmartSearchFilterWithId | ZetkinSmartSearchFilter): filter is ZetkinSmartSearchFilterWithId {
-    return (filter as ZetkinSmartSearchFilterWithId).id !== undefined;
+export function isFilterWithId(filter: SmartSearchFilterWithId | ZetkinSmartSearchFilter): filter is SmartSearchFilterWithId {
+    return (filter as SmartSearchFilterWithId).id !== undefined;
 }
 
 export const getTimeFrame = (config: {after?: string; before?: string }): TIME_FRAME => {

--- a/src/fetching/tasks/getTaskFilterSpec.ts
+++ b/src/fetching/tasks/getTaskFilterSpec.ts
@@ -1,5 +1,5 @@
 import { defaultFetch } from '..';
-import { ZetkinSmartSearchFilter } from '../../types/zetkin';
+import { ZetkinSmartSearchFilter } from 'types/smartSearch';
 
 export default function getTaskFilterSpec(orgId : string, taskId: string, fetch = defaultFetch) {
     return async () : Promise<ZetkinSmartSearchFilter[]> => {

--- a/src/fetching/tasks/patchTaskTarget.ts
+++ b/src/fetching/tasks/patchTaskTarget.ts
@@ -1,5 +1,6 @@
 import { defaultFetch } from '..';
-import { ZetkinSmartSearchFilter, ZetkinTask } from '../../types/zetkin';
+import { ZetkinSmartSearchFilter } from 'types/smartSearch';
+import { ZetkinTask } from 'types/zetkin';
 
 const patchTaskTarget = (orgId : string, taskId: string, fetch = defaultFetch) => {
     return async (data: ZetkinSmartSearchFilter[]):Promise<ZetkinTask> => {

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
+
+type InitialFilters = ZetkinSmartSearchFilter[] | SmartSearchFilterWithId[]
+
+type UseSmartSearch = [
+    SmartSearchFilterWithId[],
+    (filter: ZetkinSmartSearchFilter) => void, // addSmartSearchFilter
+    (id: number, newFilterValue: SmartSearchFilterWithId) => void, // editSmartSearchFilter
+    (id: number) => void // removeSmartSearchFilter
+]
+
+const useSmartSearch = (initialFilters: InitialFilters = []): UseSmartSearch => {
+    const filtersWithIds = initialFilters.map((filter, index) => ({ ...filter, id: index }));
+    const [smartSearchFilters, setSmartSearchFilters] = useState<SmartSearchFilterWithId[]>(filtersWithIds);
+
+    const addSmartSearchFilter = (filter: ZetkinSmartSearchFilter) => {
+        const newFilterWithId: SmartSearchFilterWithId = {
+            ...filter,
+            id: smartSearchFilters.length,
+        };
+        setSmartSearchFilters([
+            ...smartSearchFilters,
+            newFilterWithId,
+        ]);
+    };
+
+    const editSmartSearchFilter = (id: number, newFilterValue: SmartSearchFilterWithId) => {
+        const filtersWithEditedFilter = smartSearchFilters.map(filter => {
+            if (id === filter.id) return newFilterValue;
+            else return filter;
+        });
+        setSmartSearchFilters(filtersWithEditedFilter);
+    };
+
+    const removeSmartSearchFilter = (id: number) => {
+        const filtersWithoutSelected = smartSearchFilters.filter(filter => filter.id !== id);
+        setSmartSearchFilters(filtersWithoutSelected);
+    };
+
+
+    return [
+        smartSearchFilters,
+        addSmartSearchFilter,
+        editSmartSearchFilter,
+        removeSmartSearchFilter,
+    ];
+};
+
+export default useSmartSearch;

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -3,48 +3,56 @@ import { SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSea
 
 type InitialFilters = ZetkinSmartSearchFilter[] | SmartSearchFilterWithId[]
 
-type UseSmartSearch = [
-    SmartSearchFilterWithId[],
-    (filter: ZetkinSmartSearchFilter) => void, // addSmartSearchFilter
-    (id: number, newFilterValue: SmartSearchFilterWithId) => void, // editSmartSearchFilter
-    (id: number) => void // removeSmartSearchFilter
-]
+type UseSmartSearch = {
+    addFilter: (filter: ZetkinSmartSearchFilter) => void; // addSmartSearchFilter
+    editFilter: (id: number, newFilterValue: SmartSearchFilterWithId) => void; // editSmartSearchFilter
+    filters: ZetkinSmartSearchFilter[];
+    filtersWithIds: SmartSearchFilterWithId[];
+    deleteFilter: (id: number) => void; // removeSmartSearchFilter
+}
 
 const useSmartSearch = (initialFilters: InitialFilters = []): UseSmartSearch => {
-    const filtersWithIds = initialFilters.map((filter, index) => ({ ...filter, id: index }));
-    const [smartSearchFilters, setSmartSearchFilters] = useState<SmartSearchFilterWithId[]>(filtersWithIds);
+    const intialFiltersWithIds = initialFilters.map((filter, index) => ({ ...filter, id: index }));
+    const [filtersWithIds, setFiltersWithIds] = useState<SmartSearchFilterWithId[]>(intialFiltersWithIds);
 
-    const addSmartSearchFilter = (filter: ZetkinSmartSearchFilter) => {
+    const addFilter = (filter: ZetkinSmartSearchFilter) => {
         const newFilterWithId: SmartSearchFilterWithId = {
             ...filter,
-            id: smartSearchFilters.length,
+            id: filtersWithIds.length,
         };
-        setSmartSearchFilters([
-            ...smartSearchFilters,
+        setFiltersWithIds([
+            ...filtersWithIds,
             newFilterWithId,
         ]);
     };
 
-    const editSmartSearchFilter = (id: number, newFilterValue: SmartSearchFilterWithId) => {
-        const filtersWithEditedFilter = smartSearchFilters.map(filter => {
+    const editFilter = (id: number, newFilterValue: SmartSearchFilterWithId) => {
+        const filtersWithEditedFilter = filtersWithIds.map(filter => {
             if (id === filter.id) return newFilterValue;
             else return filter;
         });
-        setSmartSearchFilters(filtersWithEditedFilter);
+        setFiltersWithIds(filtersWithEditedFilter);
     };
 
-    const removeSmartSearchFilter = (id: number) => {
-        const filtersWithoutSelected = smartSearchFilters.filter(filter => filter.id !== id);
-        setSmartSearchFilters(filtersWithoutSelected);
+    const deleteFilter = (id: number) => {
+        const filtersWithoutSelected = filtersWithIds.filter(filter => filter.id !== id);
+        setFiltersWithIds(filtersWithoutSelected);
     };
 
+    const filters = filtersWithIds.map(filterWithId => {
+        const { config, op, type } = filterWithId;
+        return {
+            config, op, type,
+        };
+    });
 
-    return [
-        smartSearchFilters,
-        addSmartSearchFilter,
-        editSmartSearchFilter,
-        removeSmartSearchFilter,
-    ];
+    return {
+        addFilter,
+        editFilter,
+        filters,
+        filtersWithIds,
+        deleteFilter,
+    };
 };
 
 export default useSmartSearch;

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -12,8 +12,8 @@ type UseSmartSearch = {
 }
 
 const useSmartSearch = (initialFilters: InitialFilters = []): UseSmartSearch => {
-    const intialFiltersWithIds = initialFilters.map((filter, index) => ({ ...filter, id: index }));
-    const [filtersWithIds, setFiltersWithIds] = useState<SmartSearchFilterWithId[]>(intialFiltersWithIds);
+    const initialFiltersWithIds = initialFilters.map((filter, index) => ({ ...filter, id: index }));
+    const [filtersWithIds, setFiltersWithIds] = useState<SmartSearchFilterWithId[]>(initialFiltersWithIds);
 
     const addFilter = (filter: ZetkinSmartSearchFilter) => {
         const newFilterWithId: SmartSearchFilterWithId = {

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -48,10 +48,10 @@ const useSmartSearch = (initialFilters: InitialFilters = []): UseSmartSearch => 
 
     return {
         addFilter,
+        deleteFilter,
         editFilter,
         filters,
         filtersWithIds,
-        deleteFilter,
     };
 };
 

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -5,10 +5,10 @@ type InitialFilters = ZetkinSmartSearchFilter[] | SmartSearchFilterWithId[]
 
 type UseSmartSearch = {
     addFilter: (filter: ZetkinSmartSearchFilter) => void; // addSmartSearchFilter
+    deleteFilter: (id: number) => void; // removeSmartSearchFilter
     editFilter: (id: number, newFilterValue: SmartSearchFilterWithId) => void; // editSmartSearchFilter
     filters: ZetkinSmartSearchFilter[];
     filtersWithIds: SmartSearchFilterWithId[];
-    deleteFilter: (id: number) => void; // removeSmartSearchFilter
 }
 
 const useSmartSearch = (initialFilters: InitialFilters = []): UseSmartSearch => {

--- a/src/hooks/useSmartSearchFilter.ts
+++ b/src/hooks/useSmartSearchFilter.ts
@@ -1,0 +1,35 @@
+import { Dispatch } from 'react';
+import { DefaultFilterConfig, FilterConfig, NewSmartSearchFilter, OPERATION, SmartSearchFilterWithId, ZetkinSmartSearchFilter } from 'types/smartSearch';
+import { SetStateAction, useState } from 'react';
+
+interface UseSmartSearchFilter<T extends FilterConfig> {
+    filter: ZetkinSmartSearchFilter<T> | SmartSearchFilterWithId<T>;
+    setConfig: Dispatch<SetStateAction<T>>;
+    setOp: Dispatch<SetStateAction<OPERATION>>;
+}
+
+type InitialFilter<T extends FilterConfig> = ZetkinSmartSearchFilter<T> | SmartSearchFilterWithId<T> | NewSmartSearchFilter;
+
+export const useSmartSearchFilter = <C extends FilterConfig>(initialFilter: InitialFilter<C>): UseSmartSearchFilter<C> => {
+    // Set config to initial value, or empty
+    const [config, setConfig] = useState<C | DefaultFilterConfig>('config' in initialFilter && initialFilter.config || {});
+    // Set operation to initial value or ADD
+    const [op, setOp] = useState('op' in initialFilter && initialFilter.op || OPERATION.ADD);
+
+    // Build filter object
+    const filter: ZetkinSmartSearchFilter<C> = {
+        config: config as C,
+        op,
+        type: initialFilter.type,
+        // Keep id if already in filter
+        ...('id' in initialFilter && { id: initialFilter.id }),
+    };
+
+    return {
+        filter,
+        setConfig: setConfig as Dispatch<SetStateAction<C>>, // Only allow setting config to typed config
+        setOp,
+    };
+};
+
+export default useSmartSearchFilter;

--- a/src/types/smartSearch.ts
+++ b/src/types/smartSearch.ts
@@ -1,8 +1,3 @@
-import { ZetkinSmartSearchFilter } from './zetkin';
-
-export interface ZetkinSmartSearchFilterWithId extends ZetkinSmartSearchFilter {
-    id: number;
-}
 
 export enum FILTER_TYPE {
     ALL ='all',
@@ -18,3 +13,26 @@ export enum TIME_FRAME {
     BETWEEN='between',
     LAST_FEW_DAYS='lastFew',
 }
+
+export interface ZetkinSmartSearchFilter {
+    config?: {
+        after?: string;
+        before?: string;
+        size?: number;
+    };
+    op: 'sub' | 'add';
+    type: FILTER_TYPE;
+}
+
+export interface SmartSearchFilterWithId extends ZetkinSmartSearchFilter {
+    id: number;
+}
+
+export interface NewSmartSearchFilter {
+    type: FILTER_TYPE;
+}
+
+export type SelectedSmartSearchFilter =
+    SmartSearchFilterWithId | // When existing filter is being edited
+    NewSmartSearchFilter | // When a new filter is being created
+    null // When no filter selected

--- a/src/types/smartSearch.ts
+++ b/src/types/smartSearch.ts
@@ -19,17 +19,27 @@ export enum TIME_FRAME {
     LAST_FEW_DAYS='lastFew',
 }
 
-export interface ZetkinSmartSearchFilter {
-    config?: {
-        after?: string;
-        before?: string;
-        size?: number;
-    };
+// Filter Configs are objects
+export type FilterConfig = Record<string, unknown>
+
+// Default filter config is an empty object
+export type DefaultFilterConfig = Record<string, never>
+
+export type AnyFilterConfig = DefaultFilterConfig | MostActiveFilterConfig
+
+export interface MostActiveFilterConfig extends FilterConfig {
+    after?: string;
+    before?: string;
+    size?: number;
+}
+
+export interface ZetkinSmartSearchFilter<C extends FilterConfig = AnyFilterConfig> {
+    config?: C;
     op: OPERATION;
     type: FILTER_TYPE;
 }
 
-export interface SmartSearchFilterWithId extends ZetkinSmartSearchFilter {
+export interface SmartSearchFilterWithId<C extends FilterConfig = AnyFilterConfig> extends ZetkinSmartSearchFilter<C> {
     id: number;
 }
 
@@ -37,7 +47,7 @@ export interface NewSmartSearchFilter {
     type: FILTER_TYPE;
 }
 
-export type SelectedSmartSearchFilter =
-    SmartSearchFilterWithId | // When existing filter is being edited
+export type SelectedSmartSearchFilter<C extends FilterConfig = AnyFilterConfig> =
+    SmartSearchFilterWithId<C> | // When existing filter is being edited
     NewSmartSearchFilter | // When a new filter is being created
     null // When no filter selected

--- a/src/types/smartSearch.ts
+++ b/src/types/smartSearch.ts
@@ -19,13 +19,12 @@ export enum TIME_FRAME {
     LAST_FEW_DAYS='lastFew',
 }
 
-// Filter Configs are objects
-export type FilterConfig = Record<string, unknown>
+/**
+ * Filter Configs
+ */
+export type FilterConfig = Record<string, unknown> // Filter Configs are objects
 
-// Default filter config is an empty object
-export type DefaultFilterConfig = Record<string, never>
-
-export type AnyFilterConfig = DefaultFilterConfig | MostActiveFilterConfig
+export type DefaultFilterConfig = Record<string, never> // Default filter config is an empty object
 
 export interface MostActiveFilterConfig extends FilterConfig {
     after?: string;
@@ -33,6 +32,9 @@ export interface MostActiveFilterConfig extends FilterConfig {
     size?: number;
 }
 
+export type AnyFilterConfig = DefaultFilterConfig | MostActiveFilterConfig // Add all filter objects here
+
+/** Filters */
 export interface ZetkinSmartSearchFilter<C extends FilterConfig = AnyFilterConfig> {
     config?: C;
     op: OPERATION;
@@ -47,6 +49,7 @@ export interface NewSmartSearchFilter {
     type: FILTER_TYPE;
 }
 
+// Used for `selectedFilter` handling
 export type SelectedSmartSearchFilter<C extends FilterConfig = AnyFilterConfig> =
     SmartSearchFilterWithId<C> | // When existing filter is being edited
     NewSmartSearchFilter | // When a new filter is being created

--- a/src/types/smartSearch.ts
+++ b/src/types/smartSearch.ts
@@ -4,6 +4,11 @@ export enum FILTER_TYPE {
     MOST_ACTIVE ='most_active',
 }
 
+export enum OPERATION {
+    ADD = 'add',
+    SUB = 'sub'
+}
+
 export enum TIME_FRAME {
     EVER='ever',
     FUTURE='future',
@@ -20,7 +25,7 @@ export interface ZetkinSmartSearchFilter {
         before?: string;
         size?: number;
     };
-    op: 'sub' | 'add';
+    op: OPERATION;
     type: FILTER_TYPE;
 }
 

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -1,3 +1,5 @@
+import { ZetkinSmartSearchFilter } from './smartSearch';
+
 export interface ZetkinCampaign {
     color: string;
     info_text: string;
@@ -170,16 +172,6 @@ export interface ZetkinActivity {
     id: number;
     title: string;
     info_text: string | null;
-}
-
-export interface ZetkinSmartSearchFilter {
-    config?: {
-        after?: string;
-        before?: string;
-        size?: number;
-    };
-    op: 'sub' | 'add';
-    type: string;
 }
 
 //  Tasks


### PR DESCRIPTION
Changes:
* Creates `useSmartSearch` which is a hook that handles adding, editing, and deleting filters from the list.
* creates `useSmartSearchFilter` which is a hook that handles creating filters and modifying their properties in a type safe way.
* `selectedFilter` now handles the current open filter state, rather than using a `setFilterType`.
* All filters have generic configs, with the default as `AnyFilterConfig` :D 

Other little things:
* Uses the `FILTER_TYPE` enum where needed
* Moves around imports so that `FILTER_TYPE` can be used without circular import.
