### PR TITLE
Hide campaign field from event form when preconfigured

### DIFF
--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -204,11 +204,13 @@ const CreateEventForm = ({ onSubmit, onCancel, orgId }: CreateEventFormProps): J
             render={ ({ handleSubmit, submitting }) => (
                 <form noValidate onSubmit={ handleSubmit }>
                     <Grid alignItems="flex-start" container spacing={ 2 }>
-                        { formFields.map((item, idx) => item? (
-                            <Grid key={ idx } item xs={ item.size as GridSize }>
-                                { item.field }
-                            </Grid>
-                        ) : null) }
+                        { formFields.map((item, idx) => {
+                            if (item) {
+                                <Grid key={ idx } item xs={ item.size as GridSize }>
+                                    { item.field }
+                                </Grid>
+                            }
+                        } }
                         <Grid item style={{ marginTop: 16 }}>
                         </Grid>
                         <Box display="flex" justifyContent="flex-end" width={ 1 }>

--- a/src/components/CreateEventForm.tsx
+++ b/src/components/CreateEventForm.tsx
@@ -74,10 +74,9 @@ const CreateEventForm = ({ onSubmit, onCancel, orgId }: CreateEventFormProps): J
             ),
             size: 12,
         },
-        {
+        campId ? null : {
             field: (
                 <TextField
-                    disabled={ campId ? true : false }
                     fullWidth
                     id="camp"
                     label={ intl.formatMessage({ id: 'misc.formDialog.event.campaign' }) }
@@ -205,11 +204,11 @@ const CreateEventForm = ({ onSubmit, onCancel, orgId }: CreateEventFormProps): J
             render={ ({ handleSubmit, submitting }) => (
                 <form noValidate onSubmit={ handleSubmit }>
                     <Grid alignItems="flex-start" container spacing={ 2 }>
-                        { formFields.map((item, idx) => (
+                        { formFields.map((item, idx) => item? (
                             <Grid key={ idx } item xs={ item.size as GridSize }>
                                 { item.field }
                             </Grid>
-                        )) }
+                        ) : null) }
                         <Grid item style={{ marginTop: 16 }}>
                         </Grid>
                         <Box display="flex" justifyContent="flex-end" width={ 1 }>


### PR DESCRIPTION
This PR hides the campaign field of the `EventForm` when the campaign has already been configured, e.g. when opening the "Create event" dialog on the campaign page.

This is just to show @omidq our workflow. It's an ugly solution, and should not be merged.

Fixes #269 