### PR TITLE
issue-369/remove gender option

### DIFF
--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -20,7 +20,6 @@ export interface VisitLinkConfig {
 
 export enum DEMOGRAPHICS_FIELD {
     EMAIL= 'email',
-    GENDER= 'gender',
     STREET_ADDRESS= 'street_address',
     CITY= 'city',
     COUNTRY= 'country',


### PR DESCRIPTION
Resolves #369 

Very simply removes the gender field from the enum that generates the demographics field options.