### PR TITLE
issue-368/disable refetch on window focus

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,13 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 
 import { PageWithLayout } from '../types';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            refetchOnWindowFocus: false,
+        },
+    },
+});
 
 declare global {
     interface Window {


### PR DESCRIPTION
Resolves #368 

@richardolsson your assessment of the bug was correct, and I found these docs (https://react-query.tanstack.com/guides/window-focus-refetching) which gave ways to stop that behaviour. I tried the bottom-most solution on the page, but it didn't work, so I went with the global disable. Maybe this isn't ideal, however. I'm not sure. I can keep trying the non global way, but curious what you think.