### PR TITLE
Issue 331/campain manager description

### DIFF
--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -2,17 +2,18 @@ import { useRouter } from 'next/router';
 import { Avatar, Box, Typography } from '@material-ui/core';
 
 const ZetkinPerson: React.FunctionComponent<{
-  person: {first_name: string; id: number; last_name: string };
+    id: number;
+  name: string;
   subtitle?: string | React.ReactNode;
-}> = ({ person, subtitle  }) => {
+}> = ({ id, name, subtitle  }) => {
     const router = useRouter();
     const { orgId } = router.query;
 
     return (
         <Box display="flex">
-            <Avatar src={ orgId ? `/api/orgs/${orgId}/people/${person.id}/avatar` : '' } />
+            <Avatar src={ orgId ? `/api/orgs/${orgId}/people/${id}/avatar` : '' } />
             <Box alignItems="start" display="flex" flexDirection="column" justifyContent="center" ml={ 1 }>
-                <Typography variant="body1">{ person.first_name } { person.last_name }</Typography>
+                <Typography variant="body1">{ name }</Typography>
                 { subtitle && (
                     <Typography variant="body2">{ subtitle }</Typography>
                 ) }

--- a/src/components/ZetkinSection.tsx
+++ b/src/components/ZetkinSection.tsx
@@ -7,7 +7,7 @@ interface ZetkinSectionProps {
 
 const ZetkinSection:FunctionComponent<ZetkinSectionProps> = ({ children, title }) => {
     return (
-        <Box height={ 1 } p={ 1 } width={ 1 }>
+        <Box height={ 1 } width={ 1 }>
             <Box mb={ 2 }>
                 <Typography color="secondary" component="h2" variant="h6">
                     { title }

--- a/src/components/ZetkinSpeedDial/actions/createCampaign.tsx
+++ b/src/components/ZetkinSpeedDial/actions/createCampaign.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/display-name */
-import { ACTIONS } from '../constants';
-import CampaignForm from '../../CampaignForm';
 import { Flag } from '@material-ui/icons';
-import postCampaign from '../../../fetching/postCampaign';
 import { useRouter } from 'next/router';
-import { ActionConfig, DialogContentBaseProps } from './types';
 import { useMutation, useQueryClient } from 'react-query';
 
+import CampaignForm from 'components/organize/campaigns/forms/CampaignForm';
+import postCampaign from 'fetching/postCampaign';
+
+import { ACTIONS } from '../constants';
+import { ActionConfig, DialogContentBaseProps } from './types';
 
 const DialogContent: React.FunctionComponent<DialogContentBaseProps> = ({ closeDialog }) => {
     const queryClient = useQueryClient();

--- a/src/components/layout/organize/SingleCampaignLayout.tsx
+++ b/src/components/layout/organize/SingleCampaignLayout.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
 import { FormattedDate, FormattedMessage as Msg } from 'react-intl';
 
+import CampaignActionButtons from 'components/organize/campaigns/CampaignActionButtons';
 import getCampaign from '../../../fetching/getCampaign';
 import getCampaignEvents from '../../../fetching/getCampaignEvents';
 import { getNaiveDate } from '../../../utils/dateUtils';
@@ -28,8 +29,13 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({ ch
         endDate = getNaiveDate(lastEvent.end_time);
     }
 
+    if (!campaign) return null;
+
     return (
         <TabbedLayout
+            actionButtons={
+                <CampaignActionButtons campaign={ campaign } />
+            }
             baseHref={ `/organize/${orgId}/campaigns/${campId}` }
             defaultTab="/"
             fixedHeight={ fixedHeight }

--- a/src/components/organize/campaigns/CampaignActionButtons.tsx
+++ b/src/components/organize/campaigns/CampaignActionButtons.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Box, Button, Menu, MenuItem } from '@material-ui/core';
 import { Delete, Settings } from '@material-ui/icons';
@@ -55,7 +56,11 @@ const CampaignActionButtons: React.FunctionComponent<CampaignActionButtonsProps>
     return (
         <Box display="flex">
             <Box mr={ 1 }>
-                <Button color="primary">Public Page</Button>
+                <Link href={ `/o/${orgId}/campaigns/${campaign.id}` } passHref>
+                    <Button color="primary">
+                        <Msg id="pages.organizeCampaigns.linkGroup.public"/>
+                    </Button>
+                </Link>
             </Box>
             <Box>
                 <Button color="secondary" disableElevation onClick={ (e) => setMenuActivator(e.currentTarget) } variant="contained">

--- a/src/components/organize/campaigns/CampaignActionButtons.tsx
+++ b/src/components/organize/campaigns/CampaignActionButtons.tsx
@@ -1,0 +1,108 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useRouter } from 'next/router';
+import { Box, Button, Menu, MenuItem } from '@material-ui/core';
+import { Delete, Settings } from '@material-ui/icons';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
+import React, { useState } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+
+import CampaignForm from 'components/organize/campaigns/forms/CampaignForm';
+import deleteCampaign from 'fetching/campaigns/deleteCampaign';
+import DeleteCampaignForm from './forms/DeleteCampaignForm';
+import patchCampaign from 'fetching/campaigns/patchCampaign';
+import { ZetkinCampaign } from 'types/zetkin';
+import ZetkinDialog from 'components/ZetkinDialog';
+
+enum CAMPAIGN_MENU_ITEMS {
+    EDIT_CAMPAIGN = 'editCampaign',
+    DELETE_CAMPAIGN = 'deleteCampaign'
+}
+
+interface CampaignActionButtonsProps {
+    campaign: ZetkinCampaign;
+}
+
+const CampaignActionButtons: React.FunctionComponent<CampaignActionButtonsProps> = ({ campaign }) => {
+    const intl = useIntl();
+    const queryClient = useQueryClient();
+    const router = useRouter();
+    const { orgId } = router.query;
+    // Menu
+    const [menuActivator, setMenuActivator] = React.useState<null | HTMLElement>(null);
+    // Dialogs
+    const [currentOpenDialog, setCurrentOpenDialog] = useState<CAMPAIGN_MENU_ITEMS>();
+    const closeDialog = () => setCurrentOpenDialog(undefined);
+
+    // Mutations
+    const patchCampaignMutation = useMutation(patchCampaign(orgId as string, campaign.id), {
+        onSettled: () => queryClient.invalidateQueries(['campaign' ]),
+    });
+    const deleteCampaignMutation = useMutation(deleteCampaign(orgId as string, campaign.id));
+
+    // Event Handlers
+    const handleEditCampaign = (campaign: Partial<ZetkinCampaign>) => {
+        patchCampaignMutation.mutate(campaign);
+        closeDialog();
+    };
+    const handleDeleteCampaign = () => {
+        deleteCampaignMutation.mutate();
+        closeDialog();
+        // Navigate back to campaign page
+        router.push(`/organize/${orgId as string}/campaigns`);
+    };
+
+    return (
+        <Box display="flex">
+            <Box mr={ 1 }>
+                <Button color="primary">Public Page</Button>
+            </Box>
+            <Box>
+                <Button color="secondary" disableElevation onClick={ (e) => setMenuActivator(e.currentTarget) } variant="contained">
+                    <Settings />
+                </Button>
+            </Box>
+            <Menu
+                anchorEl={ menuActivator }
+                keepMounted
+                onClose={ () => setMenuActivator(null) }
+                open={ Boolean(menuActivator) }>
+                { /* Edit Campaign */ }
+                <MenuItem
+                    key={ CAMPAIGN_MENU_ITEMS.EDIT_CAMPAIGN }
+                    onClick={ () => {
+                        setMenuActivator(null);
+                        setCurrentOpenDialog(CAMPAIGN_MENU_ITEMS.EDIT_CAMPAIGN);
+                    } }>
+                    <Box mr={ 1 }><Settings /></Box>
+                    <Msg id="misc.formDialog.campaign.edit" />
+                </MenuItem>
+                { /* Delete Task */ }
+                <MenuItem
+                    key={ CAMPAIGN_MENU_ITEMS.DELETE_CAMPAIGN }
+                    onClick={ () => {
+                        setMenuActivator(null);
+                        setCurrentOpenDialog(CAMPAIGN_MENU_ITEMS.DELETE_CAMPAIGN);
+                    } }>
+                    <Box mr={ 1 }><Delete /></Box>
+                    <Msg id="misc.formDialog.campaign.deleteCampaign.title" />
+                </MenuItem>
+            </Menu>
+            { /* Dialogs */ }
+            <ZetkinDialog
+                onClose={ closeDialog }
+                open={ currentOpenDialog === CAMPAIGN_MENU_ITEMS.EDIT_CAMPAIGN }
+                title={ intl.formatMessage({ id: 'misc.formDialog.campaign.edit' }) }>
+                <CampaignForm campaign={ campaign } onCancel={ closeDialog } onSubmit={ handleEditCampaign }/>
+            </ZetkinDialog>
+            <ZetkinDialog
+                onClose={ closeDialog }
+                open={ currentOpenDialog === CAMPAIGN_MENU_ITEMS.DELETE_CAMPAIGN }
+                title={ intl.formatMessage({ id: 'misc.formDialog.campaign.deleteCampaign.title' }) }>
+                <DeleteCampaignForm onCancel={ closeDialog } onSubmit={ handleDeleteCampaign } />
+            </ZetkinDialog>
+        </Box>
+    );
+};
+
+export default CampaignActionButtons;

--- a/src/components/organize/campaigns/forms/CampaignForm.tsx
+++ b/src/components/organize/campaigns/forms/CampaignForm.tsx
@@ -52,7 +52,7 @@ const CampaignForm = ({ onSubmit, onCancel, campaign }: CampaignFormProps): JSX.
 
     const initialValues = {
         info_text: campaign?.info_text,
-        status: campaign?.published,
+        status: campaign?.published ? 'published' : 'draft',
         title: campaign?.title,
         visibility: campaign?.visibility,
     };

--- a/src/components/organize/campaigns/forms/CampaignForm.tsx
+++ b/src/components/organize/campaigns/forms/CampaignForm.tsx
@@ -7,9 +7,9 @@ import { Grid, GridSize } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useEffect, useState } from 'react';
 
-import getPeopleSearchResults from '../fetching/getPeopleSearchResults';
-import useDebounce from '../hooks/useDebounce';
-import { ZetkinCampaign, ZetkinPerson } from '../types/zetkin';
+import getPeopleSearchResults from 'fetching/getPeopleSearchResults';
+import useDebounce from 'hooks/useDebounce';
+import { ZetkinCampaign, ZetkinPerson } from 'types/zetkin';
 
 interface CampaignFormProps {
     campaign?: ZetkinCampaign;

--- a/src/components/organize/campaigns/forms/DeleteCampaignForm.tsx
+++ b/src/components/organize/campaigns/forms/DeleteCampaignForm.tsx
@@ -1,0 +1,29 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { Box, Button, Typography } from '@material-ui/core';
+
+interface DeleteCampaignFormProps {
+    onSubmit: () => void;
+    onCancel: () => void;
+}
+
+const DeleteCampaignForm: React.FunctionComponent<DeleteCampaignFormProps> = ({ onCancel, onSubmit }) => {
+    return (
+        <>
+            <Typography variant="body1">
+                <Msg id="misc.formDialog.campaign.deleteCampaign.warning" />
+            </Typography>
+            <Box mt={ 4 }>
+                <Button color="secondary" fullWidth onClick={ onCancel } variant="contained">
+                    <Msg id="misc.formDialog.campaign.deleteCampaign.cancel" />
+                </Button>
+            </Box>
+            <Box mt={ 2 }>
+                <Button color="primary" fullWidth onClick={ onSubmit } variant="contained">
+                    <Msg id="misc.formDialog.campaign.deleteCampaign.submitButton" />
+                </Button>
+            </Box>
+        </>
+    );
+};
+
+export default DeleteCampaignForm;

--- a/src/components/organize/tasks/TaskAssigneesList.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList.tsx
@@ -50,7 +50,11 @@ const TaskAssigneesList: React.FunctionComponent<{
                         <Grid key={ task.id } item lg={ 3 } md={ 4 } sm={ 6 } xs={ 12 }>
                             <Card>
                                 <Box p={ 3 }>
-                                    <ZetkinPerson person={ task.assignee } subtitle={ completedText } />
+                                    <ZetkinPerson
+                                        id={ task.assignee.id }
+                                        name={ `${task.assignee.first_name} ${task.assignee.last_name}` }
+                                        subtitle={ completedText }
+                                    />
                                 </Box>
                             </Card>
                         </Grid>

--- a/src/fetching/campaigns/deleteCampaign.ts
+++ b/src/fetching/campaigns/deleteCampaign.ts
@@ -1,0 +1,12 @@
+import { defaultFetch } from '..';
+
+const deleteCampaign = (orgId : string | number, campaignId: string | number, fetch = defaultFetch) => {
+    return async (): Promise<void> => {
+        const url = `/orgs/${orgId}/campaigns/${campaignId}`;
+        await fetch(url, {
+            method: 'DELETE',
+        });
+    };
+};
+
+export default deleteCampaign;

--- a/src/fetching/campaigns/patchCampaign.ts
+++ b/src/fetching/campaigns/patchCampaign.ts
@@ -1,5 +1,5 @@
-import { defaultFetch } from '.';
-import { ZetkinCampaign } from '../types/zetkin';
+import { defaultFetch } from '..';
+import { ZetkinCampaign } from 'types/zetkin';
 
 export default function patchCampaign(orgId: string | number, campId: string | number, fetch = defaultFetch) {
     return async (campaign: Record<string, unknown>):Promise<ZetkinCampaign> => {

--- a/src/fetching/campaigns/patchCampaign.ts
+++ b/src/fetching/campaigns/patchCampaign.ts
@@ -1,7 +1,7 @@
 import { defaultFetch } from '.';
 import { ZetkinCampaign } from '../types/zetkin';
 
-export default function patchCampaign(orgId: string, campId: string, fetch = defaultFetch) {
+export default function patchCampaign(orgId: string | number, campId: string | number, fetch = defaultFetch) {
     return async (campaign: Record<string, unknown>):Promise<ZetkinCampaign> => {
         const url = `/orgs/${orgId}/campaigns/${campId}`;
         const res = await fetch(url, {

--- a/src/locale/misc/formDialog/campaign/en.yml
+++ b/src/locale/misc/formDialog/campaign/en.yml
@@ -15,3 +15,8 @@ status:
     heading: Status
     published: Published
     draft: Draft
+deleteCampaign:
+    title: Delete campaign
+    warning: Are you sure you want to delete this campiagn? This action is permanent.
+    cancel: Cancel
+    submitButton: Confirm deletion

--- a/src/locale/pages/organizeCampaigns/en.yml
+++ b/src/locale/pages/organizeCampaigns/en.yml
@@ -16,3 +16,4 @@ feedback:
     heading: Feedback and Surveys (none configured)
     copy: Collecting feedback (during phonebanks or standalone) can help you work more efficiently
     create: Create survey
+campaignManager: Campaign Manager

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -82,24 +82,26 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
 
     return (
         <Box p={ 4 }>
-            <Grid container spacing={ 2 }>
-                { campaign?.info_text && (
-                    <Grid item lg={ 6 } md={ 12 } xs={ 12 }>
-                        <Typography variant="body1">
-                            { campaign?.info_text }
-                        </Typography>
-                    </Grid>
-                ) }
-                { campaign?.manager && (
-                    <Grid item xs={ 12 }>
-                        <ZetkinPerson
-                            id={ campaign.manager.id }
-                            name={ campaign.manager.name }
-                            subtitle={ intl.formatMessage({ id: 'pages.organizeCampaigns.campaignManager' }) }
-                        />
-                    </Grid>
-                ) }
-            </Grid>
+            <Box mb={ campaign?.info_text || campaign?.manager ? 2 : 0 }>
+                <Grid container spacing={ 2 }>
+                    { campaign?.info_text && (
+                        <Grid item lg={ 6 } md={ 12 } xs={ 12 }>
+                            <Typography variant="body1">
+                                { campaign?.info_text }
+                            </Typography>
+                        </Grid>
+                    ) }
+                    { campaign?.manager && (
+                        <Grid item xs={ 12 }>
+                            <ZetkinPerson
+                                id={ campaign.manager.id }
+                                name={ campaign.manager.name }
+                                subtitle={ intl.formatMessage({ id: 'pages.organizeCampaigns.campaignManager' }) }
+                            />
+                        </Grid>
+                    ) }
+                </Grid>
+            </Box>
 
             <Grid container spacing={ 2 }>
                 { /* Events */ }

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -1,26 +1,20 @@
 import { GetServerSideProps } from 'next';
-import NextLink from 'next/link';
-import { useRouter } from 'next/router';
-import { Avatar, Box, Button, Grid, Link, makeStyles, Typography } from '@material-ui/core';
-import { FormattedDate, FormattedMessage as Msg, useIntl } from 'react-intl';
-import { Public, Settings } from '@material-ui/icons';
-import { useEffect, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useIntl } from 'react-intl';
+import { useQuery } from 'react-query';
+import { Box, Grid, Typography } from '@material-ui/core';
 
-import CampaignForm from '../../../../../components/CampaignForm';
-import EventList from '../../../../../components/organize/EventList';
-import getCampaign from '../../../../../fetching/getCampaign';
-import getCampaignEvents from '../../../../../fetching/getCampaignEvents';
-import getCampaignTasks from '../../../../../fetching/tasks/getCampaignTasks';
-import getOrg from '../../../../../fetching/getOrg';
-import { PageWithLayout } from '../../../../../types';
-import patchCampaign from '../../../../../fetching/patchCampaign';
-import { scaffold } from '../../../../../utils/next';
-import SingleCampaignLayout from '../../../../../components/layout/organize/SingleCampaignLayout';
-import TaskList from '../../../../../components/organize/tasks/TaskList';
-import ZetkinDialog from '../../../../../components/ZetkinDialog';
-import ZetkinSection from '../../../../../components/ZetkinSection';
-import ZetkinSpeedDial, { ACTIONS } from '../../../../../components/ZetkinSpeedDial';
+import EventList from 'components/organize/EventList';
+import getCampaign from 'fetching/getCampaign';
+import getCampaignEvents from 'fetching/getCampaignEvents';
+import getCampaignTasks from 'fetching/tasks/getCampaignTasks';
+import getOrg from 'fetching/getOrg';
+import { PageWithLayout } from 'types';
+import { scaffold } from 'utils/next';
+import SingleCampaignLayout from 'components/layout/organize/SingleCampaignLayout';
+import TaskList from 'components/organize/tasks/TaskList';
+import ZetkinPerson from 'components/ZetkinPerson';
+import ZetkinSection from 'components/ZetkinSection';
+import ZetkinSpeedDial, { ACTIONS } from 'components/ZetkinSpeedDial';
 
 const scaffoldOptions = {
     authLevelRequired: 2,
@@ -76,163 +70,52 @@ type CampaignCalendarPageProps = {
     orgId: string;
 };
 
-const useStyles = makeStyles((theme) => ({
-    responsiveFlexBox: {
-        display: 'flex',
-        [theme.breakpoints.down('sm')]: {
-            flexDirection: 'column',
-        },
-    },
-    responsiveText: {
-        width: '70%',
-        [theme.breakpoints.down('sm')]: {
-            width: '100%',
-        },
-    },
-}));
-
 const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId, campId }) => {
     const intl = useIntl();
-    const queryClient = useQueryClient();
-    const router = useRouter();
-    const classes = useStyles();
+
     const eventsQuery = useQuery(['campaignEvents', orgId, campId], getCampaignEvents(orgId, campId));
     const tasksQuery = useQuery(['campaignTasks', orgId, campId], getCampaignTasks(orgId, campId));
     const campaignQuery = useQuery(['campaign', orgId, campId], getCampaign(orgId, campId));
     const events = eventsQuery.data || [];
     const tasks = tasksQuery.data || [];
     const campaign = campaignQuery.data;
-    const [formDialogOpen, setFormDialogOpen] = useState<null | string>(null);
-
-    const campaignMutation = useMutation(patchCampaign(orgId, campId), {
-        onSettled: () => queryClient.invalidateQueries('campaign'),
-    });
-
-    const sortedEvents = [...events].sort((a, b) => {
-        return new Date(a.start_time).getTime() - new Date(b.start_time).getTime();
-    });
-
-    const startDate = sortedEvents[0]?.start_time;
-    const endDate = sortedEvents[sortedEvents.length - 1]?.start_time;
-
-    const closeDialog = () => {
-        setFormDialogOpen(null);
-        router.push(`/organize/${orgId}/campaigns/${campId}`, undefined, { shallow: true });
-    };
-
-    const openEditCampaignDialog = () => {
-        router.push(`/organize/${orgId}/campaigns/${campId}#edit`, undefined, { shallow: true });
-        setFormDialogOpen('campaign');
-    };
-
-    const handleDialogClose = () => {
-        closeDialog();
-    };
-
-    const handleFormCancel = () => {
-        closeDialog();
-    };
-
-    const handleEditCampaignFormSubmit = (data: Record<string, unknown>) => {
-        campaignMutation.mutate(data);
-        closeDialog();
-    };
-
-    useEffect(() => {
-        const current = router.asPath.split('/').pop();
-        if (current?.includes('#new_campaign')) {
-            setFormDialogOpen('campaign');
-        }
-        else if (current?.includes('#new_event')) {
-            setFormDialogOpen('event');
-        }
-    }, [router.asPath]);
 
     return (
-        <>
-            <Box className={ classes.responsiveFlexBox }>
-                <Box flex={ 1 } p={ 1 }>
-                    <Box className={ classes.responsiveText } p={ 1 }>
-                        <Typography variant="body1">
-                            { campaign?.info_text }
-                        </Typography>
-                    </Box>
-                </Box>
-                <Box display="flex" flex={ 1 } p={ 1 }>
-                    <Box p={ 1 }>
-                        <Avatar
-                            src={ campaign?.manager ?
-                                `/api/orgs/${orgId}/people/${campaign?.manager.id}/avatar` : undefined }>
-                        </Avatar>
-                    </Box>
-                    <Box display="flex" flexDirection="column" p={ 1 }>
-                        <Typography variant="h6">
-                            { campaign?.manager?.name || <Msg id="pages.organizeCampaigns.noManager" /> }
-                        </Typography>
-                        <Typography variant="subtitle2">
-                            { startDate && endDate ? (
-                                <>
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ startDate }
-                                    />
-                                    { ` - ` }
-                                    <FormattedDate
-                                        day="2-digit"
-                                        month="long"
-                                        value={ endDate }
-                                        year="numeric"
-                                    />
-                                </>
-                            ) : (
-                                <Msg id="pages.organizeCampaigns.indefinite" />
-                            ) }
-                        </Typography>
-                        <Box display="flex" p={ 1 } pl={ 0 }>
-                            <Box display="flex" p={ 1 } pl={ 0 }>
-                                <Public color="primary" />
-                                <NextLink href={ `/o/${orgId}/campaigns/${campId}` } passHref>
-                                    <Link underline="always">
-                                        <Msg id="pages.organizeCampaigns.linkGroup.public"/>
-                                    </Link>
-                                </NextLink>
-                            </Box>
-                            <Box display="flex" p={ 1 }>
-                                <Button onClick={ openEditCampaignDialog } startIcon={ <Settings color="primary" /> } variant="contained">
-                                    <Msg id="pages.organizeCampaigns.linkGroup.settings"/>
-                                </Button>
-                            </Box>
-                        </Box>
-                    </Box>
-                </Box>
-            </Box>
-            <Box p={ 4 }>
-                <Grid container spacing={ 2 }>
-                    { /* Events */ }
-                    <Grid item md={ 6 } sm={ 12 } xs={ 12 }>
-                        <ZetkinSection title={ intl.formatMessage({ id: 'pages.organizeCampaigns.events' }) }>
-                            <EventList events={ events ?? [] } hrefBase={ `/organize/${orgId}/campaigns/${campId}` } />
-                        </ZetkinSection>
-                    </Grid>
-
-                    { /* Tasks */ }
-                    <Grid item md={ 6 } sm={ 12 } xs={ 12 }>
-                        <ZetkinSection title={ intl.formatMessage({ id: 'pages.organizeCampaigns.tasks' }) }>
-                            <TaskList hrefBase={ `/organize/${orgId}/campaigns/${campId}` } tasks={ tasks ?? [] } />
-                        </ZetkinSection>
-                    </Grid>
+        <Box p={ 4 }>
+            <Grid container spacing={ 2 }>
+                <Grid item xs={ 12 }>
+                    <Typography variant="body1">
+                        { campaign?.info_text }
+                    </Typography>
                 </Grid>
-            </Box>
-            { /* Edit Campaign Form */ }
-            <ZetkinDialog
-                onClose={ handleDialogClose }
-                open={ !!formDialogOpen }
-                title={ intl.formatMessage({ id: 'misc.formDialog.campaign.edit' }) }>
-                { formDialogOpen === 'campaign' && <CampaignForm campaign={ campaign } onCancel={ handleFormCancel } onSubmit={ handleEditCampaignFormSubmit }/> }
-            </ZetkinDialog>
+                { campaign?.manager && (
+                    <Grid item xs={ 12 }>
+                        <ZetkinPerson
+                            id={ campaign.manager.id }
+                            name={ campaign.manager.name }
+                            subtitle="Campaign Manager"
+                        />
+                    </Grid>
+                ) }
+            </Grid>
+
+            <Grid container spacing={ 2 }>
+                { /* Events */ }
+                <Grid item md={ 6 } sm={ 12 } xs={ 12 }>
+                    <ZetkinSection title={ intl.formatMessage({ id: 'pages.organizeCampaigns.events' }) }>
+                        <EventList events={ events ?? [] } hrefBase={ `/organize/${orgId}/campaigns/${campId}` } />
+                    </ZetkinSection>
+                </Grid>
+
+                { /* Tasks */ }
+                <Grid item md={ 6 } sm={ 12 } xs={ 12 }>
+                    <ZetkinSection title={ intl.formatMessage({ id: 'pages.organizeCampaigns.tasks' }) }>
+                        <TaskList hrefBase={ `/organize/${orgId}/campaigns/${campId}` } tasks={ tasks ?? [] } />
+                    </ZetkinSection>
+                </Grid>
+            </Grid>
             <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_TASK] }/>
-        </>
+        </Box>
     );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -83,7 +83,7 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
     return (
         <Box p={ 4 }>
             <Grid container spacing={ 2 }>
-                <Grid item xs={ 12 }>
+                <Grid item lg={ 6 } md={ 12 } xs={ 12 }>
                     <Typography variant="body1">
                         { campaign?.info_text }
                     </Typography>
@@ -93,7 +93,7 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
                         <ZetkinPerson
                             id={ campaign.manager.id }
                             name={ campaign.manager.name }
-                            subtitle="Campaign Manager"
+                            subtitle={ intl.formatMessage({ id: 'pages.organizeCampaigns.campaignManager' }) }
                         />
                     </Grid>
                 ) }

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -83,11 +83,13 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
     return (
         <Box p={ 4 }>
             <Grid container spacing={ 2 }>
-                <Grid item lg={ 6 } md={ 12 } xs={ 12 }>
-                    <Typography variant="body1">
-                        { campaign?.info_text }
-                    </Typography>
-                </Grid>
+                { campaign?.info_text && (
+                    <Grid item lg={ 6 } md={ 12 } xs={ 12 }>
+                        <Typography variant="body1">
+                            { campaign?.info_text }
+                        </Typography>
+                    </Grid>
+                ) }
                 { campaign?.manager && (
                     <Grid item xs={ 12 }>
                         <ZetkinPerson

--- a/src/pages/organize/[orgId]/campaigns/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/index.tsx
@@ -3,7 +3,7 @@ import { grey } from '@material-ui/core/colors';
 import NextLink from 'next/link';
 import { useQuery } from 'react-query';
 import { useState } from 'react';
-import { Box, Checkbox, Container, FormControl, FormControlLabel, FormGroup, FormLabel, Link, List, ListItem, Typography } from '@material-ui/core';
+import { Box, Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel, Link, List, ListItem, Typography } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import AllCampaignsLayout from '../../../../components/layout/organize/AllCampaignsLayout';
@@ -121,7 +121,7 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
 
     return (
         <>
-            <Container maxWidth={ false }>
+            <Box p={ 4 }>
                 <ZetkinSection title={ intl.formatMessage({ id: 'pages.organizeAllCampaigns.heading' }) }>
                     <Box display="grid" gridGap={ 20 } gridTemplateColumns="repeat( auto-fit, minmax(450px, 1fr) )">
                         { campaigns.map(campaign => (
@@ -182,7 +182,7 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
                         </FormControl>
                     </Box>
                 </Box>
-            </Container>
+            </Box>
             <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_CAMPAIGN] } />
         </>
     );


### PR DESCRIPTION
Resolves #331 and #332

Implements new styles for Campaign Manager and Description, AND implements action buttons for Campaign page.



**Action Button Changes**
- [x] Add CampaignActionButtons to SingleCampaignLayout
  - [x] Uses `CampaignForm` to edit campaign
  - [x] Creates `deleteCampaign` handler and implements it in `DeleteCampaignForm`
  - [x] Button to redirect to campaign in old zetkin (just need to find link format)

**Campaign Manager Changes**
- [x] Changes ZetkinPerson to take the name and ID as props
- [x] Uses ZetkinPerson to show campaign manager
- [x] Sets max width on description

**Other Changes**
- [x] Removes padding on ZetkinSection
  - [x] Fixes the layouts impacted by this (All Campaigns View, any more?)
- [x] Moves CampaignForm to campaign folder in components, moves patchCampaign to campaign folder in fetching
- [x] Fix CampaignForm to correctly show value of `published`