### PR TITLE
issue-385/ show expired task status

### DIFF
--- a/src/components/organize/tasks/TaskActionButtons/PublishButton.tsx
+++ b/src/components/organize/tasks/TaskActionButtons/PublishButton.tsx
@@ -14,7 +14,9 @@ import PublishTaskForm from '../forms/PublishTaskForm';
 import validateTaskConfig from 'utils/validateTaskConfig';
 
 const getTooltipContents = (taskStatus: TASK_STATUS, isTaskConfigValid: boolean, hasAssignees: boolean): string | null => {
-    if (taskStatus === TASK_STATUS.ACTIVE || taskStatus === TASK_STATUS.CLOSED) {
+    if (taskStatus === TASK_STATUS.ACTIVE ||
+        taskStatus === TASK_STATUS.CLOSED ||
+        taskStatus === TASK_STATUS.EXPIRED) {
         return  'misc.tasks.publishButton.tooltip.alreadyPublished';
     }
 

--- a/src/components/organize/tasks/TaskList/index.tsx
+++ b/src/components/organize/tasks/TaskList/index.tsx
@@ -15,6 +15,7 @@ const TASK_STATUS_ORDER: {[key in TASK_STATUS]: number} = {
     [TASK_STATUS.ACTIVE]: 1,
     [TASK_STATUS.SCHEDULED]: 2,
     [TASK_STATUS.CLOSED]: 3,
+    [TASK_STATUS.EXPIRED]: 4,
 };
 
 const sortTasksByStatus = (firstTask: ZetkinTask, secondTask: ZetkinTask): number => {

--- a/src/components/organize/tasks/TaskStatusChip.tsx
+++ b/src/components/organize/tasks/TaskStatusChip.tsx
@@ -7,7 +7,7 @@ enum ChipColors {
     active = '#6CC551',
     closed = '#FF4242',
     draft = '',
-    expired= 'black',
+    expired= 'grey',
     scheduled = '#4A8FE7',
 }
 

--- a/src/components/organize/tasks/TaskStatusText.tsx
+++ b/src/components/organize/tasks/TaskStatusText.tsx
@@ -47,6 +47,13 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({ task }) 
                     values={{ time: <ZetkinRelativeTime datetime={ deadline } /> }}
                 />
             ) }
+            { /* Expired */ }
+            { taskStatus === TASK_STATUS.EXPIRED && expires && (
+                <FormattedMessage
+                    id="misc.tasks.taskListItem.relativeTimes.expired"
+                    values={{ time: <ZetkinRelativeTime datetime={ expires } /> }}
+                />
+            ) }
         </>
     );
 };

--- a/src/locale/misc/tasks/en.yml
+++ b/src/locale/misc/tasks/en.yml
@@ -3,6 +3,7 @@ statuses:
     closed: "Closed"
     draft: "Draft"
     scheduled: "Scheduled"
+    expired: "Expired"
 types:
     offline: Offline
     share_link: Share Link
@@ -15,6 +16,7 @@ taskListItem:
         closed: "Closed {time}"
         scheduled: "Will be published {time}"
         indefinite: "Published {time}"
+        expired: "Expired {time}"
 taskDetails:
     title: Task Details
     editButton: Edit

--- a/src/utils/getTaskStatus.ts
+++ b/src/utils/getTaskStatus.ts
@@ -1,32 +1,40 @@
 import dayjs from 'dayjs';
-import { ZetkinTask } from '../types/zetkin';
+import { ZetkinTask } from 'types/zetkin';
 
 export enum TASK_STATUS {
     ACTIVE= 'active',
     CLOSED= 'closed',
     DRAFT = 'draft',
+    EXPIRED = 'expired',
     SCHEDULED = 'scheduled',
 }
 
 const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
-    const { published, deadline } = task;
-
+    const { published, deadline, expires } = task;
     const now = dayjs();
-    const publishedDate = dayjs(published);
-    const deadlineDate = dayjs(deadline);
 
-    const isPublished = publishedDate.isBefore(now);
+    const expiresDate = dayjs(expires);
+    const isExpiresPassed = expiresDate.isBefore(now);
+
+    if (isExpiresPassed) {
+        return TASK_STATUS.EXPIRED;
+    }
+
+    const deadlineDate = dayjs(deadline);
     const isDeadlinePassed = deadlineDate.isBefore(now);
 
     if (isDeadlinePassed) {
         return TASK_STATUS.CLOSED;
     }
 
-    if (isPublished) {
+    const publishedDate = dayjs(published);
+    const isPublishedPassed = publishedDate.isBefore(now);
+
+    if (isPublishedPassed) {
         return TASK_STATUS.ACTIVE;
     }
 
-    if (published && !isPublished) {
+    if (published && !isPublishedPassed) {
         return TASK_STATUS.SCHEDULED;
     }
 


### PR DESCRIPTION
Changes:
* Adds new `TASK_STATUS.EXPIRED` which is returned from `getTaskStatus()` if the value `expires` is already past
* Adds text for `TaskStatusText` for expired status
* Adds localisation for expired status
* Publish button shows `Already published` in tooltip if expired 
* Add to sort for TaskList, expired tasks go at the bottom of the list
* `TaskStatusChip` is grey

Fixes #385 