### PR TITLE
issue-387/ task form clears on submit

### DIFF
--- a/src/components/ZetkinSpeedDial/actions/createTask.tsx
+++ b/src/components/ZetkinSpeedDial/actions/createTask.tsx
@@ -18,6 +18,7 @@ const DialogContent: React.FunctionComponent<DialogContentBaseProps> = ({ closeD
 
     const handleFormSubmit = async (task: ZetkinTaskRequestBody) => {
         const newTask = await eventMutation.mutateAsync(task);
+        closeDialog();
         // Redirect to task page
         router.push(`/organize/${orgId}/campaigns/${campId}/calendar/tasks/${newTask.id}`);
     };

--- a/src/components/organize/tasks/forms/TaskDetailsForm.tsx
+++ b/src/components/organize/tasks/forms/TaskDetailsForm.tsx
@@ -96,6 +96,7 @@ const TaskDetailsForm = ({ onSubmit, onCancel, task }: TaskDetailsFormProps): JS
                 title: task?.title,
                 type: task?.type,
             }}
+            keepDirtyOnReinitialize
             onSubmit={ submit }
             render={ ({ handleSubmit, submitting, valid, values }) => (
                 <form noValidate onSubmit={ handleSubmit }>


### PR DESCRIPTION
Resolves #387 

When submitting the task form, values aren't cleared. Previously they were cleared, causing the validation to show errors, also closes modal after submitting like on `createCampaign` speed dial task. 