### PR TITLE
issue-396/remove createEvent actions

### DIFF
--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/index.tsx
@@ -66,7 +66,7 @@ const CampaignCalendarPage : PageWithLayout<OrganizeCalendarPageProps> = ({ orgI
     return (
         <>
             <ZetkinCalendar baseHref={ `/organize/${orgId}/campaigns/${campId}/calendar` } campaigns={ campaigns } events={ events } tasks={ tasks } />
-            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_TASK] }/>
+            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_TASK] }/>
         </>
     );
 };

--- a/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/index.tsx
@@ -118,7 +118,7 @@ const CampaignSummaryPage: PageWithLayout<CampaignCalendarPageProps> = ({ orgId,
                     </ZetkinSection>
                 </Grid>
             </Grid>
-            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_TASK] }/>
+            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_TASK] }/>
         </Box>
     );
 };

--- a/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/calendar/index.tsx
@@ -63,7 +63,7 @@ const AllCampaignsCalendarPage : PageWithLayout<AllCampaignsCalendarPageProps> =
     return (
         <>
             <ZetkinCalendar baseHref={ `/organize/${orgId}/campaigns/calendar` } campaigns={ campaigns } events={ events } tasks={ tasks } />
-            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_EVENT, ACTIONS.CREATE_CAMPAIGN] } />
+            <ZetkinSpeedDial actions={ [ACTIONS.CREATE_CAMPAIGN] } />
         </>
     );
 };


### PR DESCRIPTION
Resolves #396 

Removes `ACTIONS.CREATE_EVENT` from wherever it's implemented in the MVP