### PR TITLE
adddayjs plugin globally instead of locally

### DIFF
--- a/src/components/ZetkinCalendar/index.tsx
+++ b/src/components/ZetkinCalendar/index.tsx
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import isoWeek from 'dayjs/plugin/isoWeek';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { Box, Button, makeStyles, MenuItem, TextField, Tooltip, Typography } from '@material-ui/core';
@@ -11,8 +10,6 @@ import { useIntl } from 'react-intl';
 import WeekCalendar from './WeekCalendar';
 import { CALENDAR_RANGES, getViewRange } from './utils';
 import { ZetkinCampaign, ZetkinEvent, ZetkinTask } from '../../types/zetkin';
-
-dayjs.extend(isoWeek);
 
 interface ZetkinCalendarProps {
     baseHref: string;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import DateUtils from '@date-io/dayjs';
 import dayjs from 'dayjs';
 import { Hydrate } from 'react-query/hydration';
 import { IntlProvider } from 'react-intl';
+import isoWeek from 'dayjs/plugin/isoWeek';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { ThemeProvider } from '@material-ui/core/styles';
@@ -18,6 +19,7 @@ import theme from '../theme';
 import { UserContext } from '../hooks';
 
 dayjs.extend(LocalTimeToJsonPlugin);
+dayjs.extend(isoWeek);
 
 const queryClient = new QueryClient({
     defaultOptions: {


### PR DESCRIPTION
Fixes #403 


I extended dajs plugin globally instead of on one page, and it makes sense that this is best practice, but I can't guarantee it fixes the bug since I couldn't reproduce. 
