### PR TITLE
Calendar month render incorrectly

### DIFF
--- a/src/components/ZetkinCalendar/index.tsx
+++ b/src/components/ZetkinCalendar/index.tsx
@@ -51,7 +51,7 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleForwardButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, focusDate.getDate()));
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, 1, 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() + 7)));
@@ -60,7 +60,7 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleBackButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, focusDate.getDate()));
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, 1, 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() - 7)));


### PR DESCRIPTION
Resolves #419 

One thing every month has in common is that they all start from day 1. But not every month has the same number of days (e.g. February). So I set focusDate() to 12:00' on the 1st day of each month.