### PR TITLE
Month calendar renders wrong month

### DIFF
--- a/src/components/ZetkinCalendar/index.tsx
+++ b/src/components/ZetkinCalendar/index.tsx
@@ -51,7 +51,7 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleForwardButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, focusDate.getDate()));
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, focusDate.getDate(), 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() + 7)));
@@ -60,13 +60,12 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleBackButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, focusDate.getDate()));
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, focusDate.getDate(), 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() - 7)));
         }
     };
-
 
     const today = new Date();
     const { firstDayInView, lastDayInView } = getViewRange(focusDate, range);

--- a/src/components/ZetkinCalendar/index.tsx
+++ b/src/components/ZetkinCalendar/index.tsx
@@ -51,7 +51,9 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleForwardButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, focusDate.getDate(), 12));
+            //Instead of determining day of the month based on focusDate.getDate()
+            //Hardcode it to remain day 1. To avoid error in months less than 31 days.
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, 1, 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() + 7)));
@@ -60,7 +62,8 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const handleBackButtonClick = () => {
         if (range === CALENDAR_RANGES.MONTH) {
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, focusDate.getDate(), 12));
+            //Hardcode day 1 of the month, then hour.
+            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, 1, 12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
             setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() - 7)));

--- a/src/components/ZetkinCalendar/index.tsx
+++ b/src/components/ZetkinCalendar/index.tsx
@@ -49,25 +49,29 @@ const ZetkinCalendar = ({ baseHref, events, campaigns , tasks }: ZetkinCalendarP
 
     const tasksWithDeadlines = tasks.filter(task => task.deadline);
 
-    const handleForwardButtonClick = () => {
+    const navigateCalendar = (step : 1 | -1) => {
         if (range === CALENDAR_RANGES.MONTH) {
-            //Instead of determining day of the month based on focusDate.getDate()
-            //Hardcode it to remain day 1. To avoid error in months less than 31 days.
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, 1, 12));
+            setFocusDate(new Date(
+                focusDate.getFullYear(),
+                focusDate.getMonth() + step,
+                // Always use day 1 of the month to avoid error when navigating between
+                // months with different number of days, ex: Aug = 31, Sep = 30, Feb = 28
+                1,
+                // Always use 12' noon to avoid timezone issues, ex: September 1st
+                // midnight in Sweden is interpreted as 31 of August in UTC
+                12));
         }
         else if (range === CALENDAR_RANGES.WEEK) {
-            setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() + 7)));
+            setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() + step * 7)));
         }
     };
 
+    const handleForwardButtonClick = () => {
+        navigateCalendar(1);
+    };
+
     const handleBackButtonClick = () => {
-        if (range === CALENDAR_RANGES.MONTH) {
-            //Hardcode day 1 of the month, then hour.
-            setFocusDate(new Date(focusDate.getFullYear(), focusDate.getMonth() - 1, 1, 12));
-        }
-        else if (range === CALENDAR_RANGES.WEEK) {
-            setFocusDate(new Date(new Date(focusDate).setDate(focusDate.getDate() - 7)));
-        }
+        navigateCalendar(-1);
     };
 
     const today = new Date();


### PR DESCRIPTION
Resolves #419 

When the current month (e.g. September) has fewer days in total (=30) than the previous month (August = 31), the bug occurred on handling NEXT or PREV events. It happened when the current date of the month is either the 31st or the midnight of the 1st day of the month. 

When the current date was 30 and the user clicked NEXT all the way to January, on NEXT, the calendar didn't render February (which normally has 28 days).