### PR TITLE
Fix env APP_HOST and USE_TLS

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,3 @@
-# Client settings
-NEXT_PUBLIC_APP_USE_TLS=0
-
 # Zetkin API settings
 ZETKIN_API_DOMAIN=dev.zetkin.org
 ZETKIN_API_HOST=localhost

--- a/src/fetching/index.ts
+++ b/src/fetching/index.ts
@@ -1,6 +1,3 @@
-import apiUrl from '../utils/apiUrl';
-
 export function defaultFetch(path : string, init? : RequestInit) : Promise<Response> {
-    const url = apiUrl(path);
-    return fetch(url, init);
+    return fetch(`/api${path}`, init);
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps : GetServerSideProps = scaffold(async (context) 
     const code = query?.code;
 
     if (code) {
-        const protocol = stringToBool(process.env.NEXT_PUBLIC_APP_USE_TLS)? 'https' : 'http';
+        const protocol = stringToBool(process.env.ZETKIN_USE_TLS)? 'https' : 'http';
         const host = process.env.ZETKIN_APP_HOST;
 
         let destination = '/';

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -14,7 +14,7 @@ export const getServerSideProps : GetServerSideProps = async (context) => {
         zetkinDomain: process.env.ZETKIN_API_DOMAIN,
     });
 
-    const protocol = stringToBool(process.env.NEXT_PUBLIC_APP_USE_TLS)? 'https' : 'http';
+    const protocol = stringToBool(process.env.ZETKIN_USE_TLS)? 'https' : 'http';
     const host = process.env.ZETKIN_APP_HOST;
 
     let scopes;

--- a/src/utils/apiFetch.ts
+++ b/src/utils/apiFetch.ts
@@ -1,11 +1,13 @@
-import apiUrl from './apiUrl';
 import { IncomingHttpHeaders } from 'node:http';
+import { stringToBool } from './stringUtils';
 
 export type ApiFetch = (path: string, init?: RequestInit) => Promise<Response>;
 
 export const createApiFetch = (headers: IncomingHttpHeaders): ApiFetch => {
     return (path,init) => {
-        return fetch(apiUrl(path), {
+        const protocol = stringToBool(process.env.ZETKIN_USE_TLS) ? 'https' : 'http';
+        const apiUrl = `${protocol}://${process.env.ZETKIN_APP_HOST}/api${path}`;
+        return fetch(apiUrl, {
             ...init,
             headers: {
                 cookie: headers.cookie ||'',

--- a/src/utils/apiUrl.ts
+++ b/src/utils/apiUrl.ts
@@ -1,6 +1,0 @@
-import { stringToBool } from './stringUtils';
-
-export default function apiUrl(path : string) : string {
-    const protocol = stringToBool(process.env.NEXT_PUBLIC_APP_USE_TLS)? 'https' : 'http';
-    return `${protocol}://${process.env.ZETKIN_APP_HOST}/api${path}`;
-}


### PR DESCRIPTION
Changes:
* remove `apiUrl()` util
* default fetch automatically just uses the default host and prepends `/api` to the path
* `apiFetch()`
  * Builds url for api endpoint directly (previously done in `apiUrl()`)
  * Replaces `NEXT_PUBLIC_USE_TLS` with `ZETKIN_USE_TLS`
* `NEXT_PUBLIC_USE_TLS` 
  * is replaced with `ZETKIN_USE_TLS` since this env var is only used server side
  * Removed from `.env.test` & `.env.development.