### PR TITLE
update urls to say campaign and not campaigns

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,12 +29,12 @@ module.exports = {
             }, 
             {
                 source: '/organize/:orgId(\\d{1,})/campaigns/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaigns/action%3A:eventId?org=:orgId', 
+                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId', 
                 permanent: false,
             }, 
             {
                 source: '/organize/:orgId(\\d{1,})/campaigns/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaigns/action%3A:eventId?org=:orgId', 
+                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId', 
                 permanent: false,
             },
             // all paths with /o redirected to Gen2


### PR DESCRIPTION
This pr changes the urls in the redirects to events so they say "campaign" and not "campaignS". Solves #434 