### PR TITLE
Create `mockObject` test util and implement in `mockEvent`

### DIFF
--- a/src/test-utils/mockObject.ts
+++ b/src/test-utils/mockObject.ts
@@ -1,8 +1,0 @@
-const mockObject = <G>(object: G, overrides?: Partial<G>): G => {
-    return {
-        ...object,
-        ...overrides,
-    };
-};
-
-export default mockObject;

--- a/src/test-utils/mocks/index.spec.ts
+++ b/src/test-utils/mocks/index.spec.ts
@@ -1,4 +1,4 @@
-import mockObject from './mockObject';
+import { mockObject } from './index';
 
 describe('mockObject', () => {
     it('if only object given, returns object', () => {

--- a/src/test-utils/mocks/index.ts
+++ b/src/test-utils/mocks/index.ts
@@ -1,0 +1,6 @@
+export const mockObject = <G >(object: G, overrides?: Partial<G>): G => {
+    return {
+        ...object,
+        ...overrides,
+    };
+};

--- a/src/test-utils/mocks/mockEvent.ts
+++ b/src/test-utils/mocks/mockEvent.ts
@@ -1,7 +1,7 @@
-import mockObject from 'test-utils/mockObject';
+import { mockObject } from 'test-utils/mocks';
 import { ZetkinEvent } from 'types/zetkin';
 
-const dummyEvent: ZetkinEvent = {
+const event: ZetkinEvent = {
     activity: {
         title: 'Active activity',
     },
@@ -31,6 +31,10 @@ const dummyEvent: ZetkinEvent = {
 };
 
 
-export const createMockEvent = (overrides: Partial<ZetkinEvent>): ZetkinEvent => {
-    return mockObject(dummyEvent, overrides);
+const mockEvent = (overrides?: Partial<ZetkinEvent>): ZetkinEvent => {
+    return mockObject(event, overrides);
 };
+
+export default mockEvent;
+
+export { event };

--- a/src/utils/dateUtils.spec.ts
+++ b/src/utils/dateUtils.spec.ts
@@ -1,19 +1,20 @@
-import { createMockEvent } from './testing';
-import { ZetkinEvent } from '../types/zetkin';
+import mockEvent from 'test-utils/mocks/mockEvent';
+import { ZetkinEvent } from 'types/zetkin';
+
 import { getFirstAndLastEvent, removeOffset } from './dateUtils';
 
 describe('getFirstAndLastEvent()', () => {
-    const firstEvent = createMockEvent({
+    const firstEvent = mockEvent({
         end_time: '2022-06-16T09:00:00+00:00',
         start_time: '2022-06-16T09:00:00+00:00',
     });
 
-    const secondEvent = createMockEvent({
+    const secondEvent = mockEvent({
         end_time: '2022-06-17T09:00:00+00:00',
         start_time: '2022-06-17T09:00:00+00:00',
     });
 
-    const thirdEvent = createMockEvent({
+    const thirdEvent = mockEvent({
         end_time: '2022-06-18T09:00:00+00:00',
         start_time: '2022-06-18T09:00:00+00:00',
     });


### PR DESCRIPTION
* Creates a new util in `test-utils` called `mockObject` which takes a base object and allows the developer to override any of the properties of that object.
  * Includes type checking so the override properties must be in the original object's type.
  * Unit tests for this function
* Implements this function in `createMockEvent` which now accepts any property from `ZetkinEvent` in the overrides object. 
  * Allows dev to simply call `mockEvent` and return a mock event with default settings. Just in case they need a quick event :) 
* Moves the `mockEvent` to a new folder for mocks in `test-utils` where we will put mock objects.