### PR TITLE
Issue 370/add ignore to assigned tasks

### DIFF
--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -14,9 +14,7 @@ const ZetkinPerson: React.FunctionComponent<{
             <Avatar src={ orgId ? `/api/orgs/${orgId}/people/${id}/avatar` : '' } />
             <Box alignItems="start" display="flex" flexDirection="column" justifyContent="center" ml={ 1 }>
                 <Typography variant="body1">{ name }</Typography>
-                { subtitle && (
-                    <span className="MuiTypography-root MuiTypography-body2">{ subtitle }</span>
-                ) }
+                { typeof subtitle === 'string' ? <Typography>{ subtitle }</Typography> : <Box alignItems="center" display="flex">{ subtitle }</Box> }
             </Box>
         </Box>
     );

--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -15,9 +15,8 @@ const ZetkinPerson: React.FunctionComponent<{
             <Box alignItems="start" display="flex" flexDirection="column" justifyContent="center" ml={ 1 }>
                 <Typography variant="body1">{ name }</Typography>
                 { typeof subtitle === 'string' ?
-                    <Typography>{ subtitle }</Typography>
-                    :
-                    <>{ subtitle }</>
+                    <Typography variant="body2">{ subtitle }</Typography> :
+                    subtitle
                 }
             </Box>
         </Box>

--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -15,7 +15,7 @@ const ZetkinPerson: React.FunctionComponent<{
             <Box alignItems="start" display="flex" flexDirection="column" justifyContent="center" ml={ 1 }>
                 <Typography variant="body1">{ name }</Typography>
                 { subtitle && (
-                    <Typography variant="body2">{ subtitle }</Typography>
+                    <span className="MuiTypography-root MuiTypography-body2">{ subtitle }</span>
                 ) }
             </Box>
         </Box>

--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -14,7 +14,11 @@ const ZetkinPerson: React.FunctionComponent<{
             <Avatar src={ orgId ? `/api/orgs/${orgId}/people/${id}/avatar` : '' } />
             <Box alignItems="start" display="flex" flexDirection="column" justifyContent="center" ml={ 1 }>
                 <Typography variant="body1">{ name }</Typography>
-                { typeof subtitle === 'string' ? <Typography>{ subtitle }</Typography> : <Box alignItems="center" display="flex">{ subtitle }</Box> }
+                { typeof subtitle === 'string' ?
+                    <Typography>{ subtitle }</Typography>
+                    :
+                    <>{ subtitle }</>
+                }
             </Box>
         </Box>
     );

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -1,38 +1,23 @@
+import mockAssignedTask from 'test-utils/mocks/mockAssignedTask';
 import { render } from 'test-utils';
 import singletonRouter from 'next/router';
 import TaskAssigneesList from '.';
-import {  ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
-
-const tasks : ZetkinAssignedTask[] = [
-    {
-        assigned: '2021-08-20T12:55:01.469207',
-        assignee: {
-            first_name: 'Dolly',
-            id: 2,
-            last_name: 'Parton',
-        },
-        completed: null,
-        id: 1,
-        status: ASSIGNED_STATUS.COMPLETED,
-        task: {
-            deadline: '2021-012-20T12:55:01.469207',
-            expires: '2021-012-20T12:55:01.469207',
-            id: 1,
-            title: 'Fake title',
-        },
-    },
-];
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('TaskAssigneesList', () => {
     it('renders a list of assignees.', async () => {
+        const task = mockAssignedTask();
+        const task2 = mockAssignedTask({
+            id: 2,
+        });
+
         singletonRouter.query = {
             orgId: '1',
         };
-        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ tasks } />);
+        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ [task, task2] } />);
         const assignees = await findAllByTestId('task-assignee');
-        expect(assignees.length).toEqual(1);
+        expect(assignees.length).toEqual(2);
     });
     it.skip('correctly sorts cards.', () => {
         //todo

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -1,0 +1,40 @@
+import { render } from 'test-utils';
+import singletonRouter from 'next/router';
+import TaskAssigneesList from '.';
+import {  ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+
+const tasks : ZetkinAssignedTask[] = [
+    {
+        assigned: '2021-08-20T12:55:01.469207',
+        assignee: {
+            first_name: 'Dolly',
+            id: 2,
+            last_name: 'Parton',
+        },
+        completed: null,
+        id: 1,
+        status: ASSIGNED_STATUS.COMPLETED,
+        task: {
+            deadline: '2021-012-20T12:55:01.469207',
+            expires: '2021-012-20T12:55:01.469207',
+            id: 1,
+            title: 'Fake title',
+        },
+    },
+];
+
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+
+describe('TaskAssigneesList', () => {
+    it('renders a list of assignees.', async () => {
+        singletonRouter.query = {
+            orgId: '1',
+        };
+        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ tasks } />);
+        const assignees = await findAllByTestId('task-assignee');
+        expect(assignees.length).toEqual(1);
+    });
+    it.skip('correctly sorts cards.', () => {
+        //todo
+    });
+});

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -52,6 +52,7 @@ describe('TaskAssigneesList', () => {
                 last_name: 'Smith',
             },
             id: 3,
+            ignored: '2021-11-21T12:50:01.469207',
             status: ASSIGNED_STATUS.IGNORED,
         });
         const task4 = mockAssignedTask({
@@ -62,6 +63,7 @@ describe('TaskAssigneesList', () => {
                 last_name: 'Paytas',
             },
             id: 4,
+            ignored: '2021-11-19T12:50:01.469207',
             status: ASSIGNED_STATUS.IGNORED,
         });
         const task5 = mockAssignedTask({

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 });
 
 describe('TaskAssigneesList', () => {
-    it('renders a list of assignees.', async () => {
+    it.skip('renders a list of assignees.', async () => {
         const task = mockAssignedTask();
         const task2 = mockAssignedTask({
             id: 2,
@@ -24,21 +24,73 @@ describe('TaskAssigneesList', () => {
         expect(assignees.length).toEqual(2);
     });
     it('correctly sorts assignees.', async () => {
-        const task = mockAssignedTask();
+        const task1 = mockAssignedTask({
+            assignee: {
+                first_name: 'Pamela',
+                id: 1,
+                last_name: 'Anderson',
+            },
+            completed: '2021-12-18T12:50:01.469207',
+            id: 1,
+            status: ASSIGNED_STATUS.COMPLETED,
+        });
         const task2 = mockAssignedTask({
-            completed: '2021-012-18T12:50:01.469207',
+            assignee: {
+                first_name: 'Dolly',
+                id: 2,
+                last_name: 'Parton',
+            },
+            completed: '2021-12-16T12:50:01.469207',
             id: 2,
             status: ASSIGNED_STATUS.COMPLETED,
         });
         const task3 = mockAssignedTask({
+            assigned: '2021-11-18T12:50:01.469207',
+            assignee: {
+                first_name: 'Anna Nicole',
+                id: 3,
+                last_name: 'Smith',
+            },
             id: 3,
             status: ASSIGNED_STATUS.IGNORED,
         });
+        const task4 = mockAssignedTask({
+            assigned: '2021-11-16T12:50:01.469207',
+            assignee: {
+                first_name: 'Trisha',
+                id: 4,
+                last_name: 'Paytas',
+            },
+            id: 4,
+            status: ASSIGNED_STATUS.IGNORED,
+        });
+        const task5 = mockAssignedTask({
+            assigned: '2021-11-20T12:50:01.469207',
+            assignee: {
+                first_name: 'Barb',
+                id: 5,
+                last_name: 'Wire',
+            },
+            id: 5,
+        });
+        const task6 = mockAssignedTask({
+            assigned: '2021-11-19T12:50:01.469207',
+            assignee: {
+                first_name: 'Nicholas',
+                id: 6,
+                last_name: 'Cage',
+            },
+            id: 6,
+        });
 
-        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ [task, task2, task3] } />);
+        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ [task2, task5, task4,  task1, task6, task3] } />);
         const assignees = await findAllByTestId('task-assignee');
-        const status = ['completed', 'ignored', 'notCompleted'];
 
-        assignees.forEach((assignee, index) => expect(assignee.innerHTML).toContain(status[index]));
+        expect(assignees[0].innerHTML).toContain('Pamela Anderson');
+        expect(assignees[1].innerHTML).toContain('Dolly Parton');
+        expect(assignees[2].innerHTML).toContain('Nina Ricci');
+        expect(assignees[3].innerHTML).toContain('John Lennon');
+        expect(assignees[4].innerHTML).toContain('Barb Wire');
+        expect(assignees[5].innerHTML).toContain('Nicholas Cage');
     });
 });

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 });
 
 describe('TaskAssigneesList', () => {
-    it.skip('renders a list of assignees.', async () => {
+    it('renders a list of assignees.', async () => {
         const task = mockAssignedTask();
         const task2 = mockAssignedTask({
             id: 2,
@@ -88,8 +88,8 @@ describe('TaskAssigneesList', () => {
 
         expect(assignees[0].innerHTML).toContain('Pamela Anderson');
         expect(assignees[1].innerHTML).toContain('Dolly Parton');
-        expect(assignees[2].innerHTML).toContain('Nina Ricci');
-        expect(assignees[3].innerHTML).toContain('John Lennon');
+        expect(assignees[2].innerHTML).toContain('Anna Nicole Smith');
+        expect(assignees[3].innerHTML).toContain('Trisha Paytas');
         expect(assignees[4].innerHTML).toContain('Barb Wire');
         expect(assignees[5].innerHTML).toContain('Nicholas Cage');
     });

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -1,3 +1,4 @@
+import { ASSIGNED_STATUS } from 'types/tasks';
 import mockAssignedTask from 'test-utils/mocks/mockAssignedTask';
 import { render } from 'test-utils';
 import singletonRouter from 'next/router';
@@ -22,7 +23,22 @@ describe('TaskAssigneesList', () => {
         const assignees = await findAllByTestId('task-assignee');
         expect(assignees.length).toEqual(2);
     });
-    it.skip('correctly sorts cards.', () => {
-        //todo
+    it('correctly sorts assignees.', async () => {
+        const task = mockAssignedTask();
+        const task2 = mockAssignedTask({
+            completed: '2021-012-18T12:50:01.469207',
+            id: 2,
+            status: ASSIGNED_STATUS.COMPLETED,
+        });
+        const task3 = mockAssignedTask({
+            id: 3,
+            status: ASSIGNED_STATUS.IGNORED,
+        });
+
+        const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ [task, task2, task3] } />);
+        const assignees = await findAllByTestId('task-assignee');
+        const status = ['completed', 'ignored', 'notCompleted'];
+
+        assignees.forEach((assignee, index) => expect(assignee.innerHTML).toContain(status[index]));
     });
 });

--- a/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -5,6 +5,12 @@ import TaskAssigneesList from '.';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
+beforeEach(() => {
+    singletonRouter.query = {
+        orgId: '1',
+    };
+});
+
 describe('TaskAssigneesList', () => {
     it('renders a list of assignees.', async () => {
         const task = mockAssignedTask();
@@ -12,9 +18,6 @@ describe('TaskAssigneesList', () => {
             id: 2,
         });
 
-        singletonRouter.query = {
-            orgId: '1',
-        };
         const { findAllByTestId } = render(<TaskAssigneesList assignedTasks={ [task, task2] } />);
         const assignees = await findAllByTestId('task-assignee');
         expect(assignees.length).toEqual(2);

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
@@ -27,8 +27,8 @@ describe('TaskStatusSubtitle', () => {
         });
 
         const { getByText } = render(<TaskStatusSubtitle task={ task } />);
-        const notCompletedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.ignored');
-        expect(notCompletedSubtitle).not.toBeNull();
+        const ignoredSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.ignored');
+        expect(ignoredSubtitle).not.toBeNull();
     });
     it('shows completed status.', () => {
         const task = mockAssignedTask({
@@ -37,7 +37,7 @@ describe('TaskStatusSubtitle', () => {
         });
 
         const { getByText } = render(<TaskStatusSubtitle task={ task } />);
-        const notCompletedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.completed');
-        expect(notCompletedSubtitle).not.toBeNull();
+        const completedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.completed');
+        expect(completedSubtitle).not.toBeNull();
     });
 });

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
@@ -1,0 +1,20 @@
+import mockAssignedTask from 'test-utils/mocks/mockAssignedTask';
+import { render } from 'test-utils';
+import singletonRouter from 'next/router';
+import TaskStatusSubtitle from './TaskStatusSubtitle';
+
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+
+describe('TaskStatusSubtitle', () => {
+    it('shows correct task status.', () => {
+        const task = mockAssignedTask();
+
+        singletonRouter.query = {
+            orgId: '1',
+        };
+
+        const { getByText } = render(<TaskStatusSubtitle task={ task } />);
+        const statusSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.notCompleted');
+        expect(statusSubtitle).not.toBeNull();
+    });
+});

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
@@ -1,3 +1,4 @@
+import { ASSIGNED_STATUS } from 'types/tasks';
 import mockAssignedTask from 'test-utils/mocks/mockAssignedTask';
 import { render } from 'test-utils';
 import singletonRouter from 'next/router';
@@ -5,16 +6,38 @@ import TaskStatusSubtitle from './TaskStatusSubtitle';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
+beforeEach(() => {
+    singletonRouter.query = {
+        orgId: '1',
+    };
+});
+
 describe('TaskStatusSubtitle', () => {
-    it('shows correct task status.', () => {
+    it('shows not completed status.', () => {
         const task = mockAssignedTask();
 
-        singletonRouter.query = {
-            orgId: '1',
-        };
+        const { getByText } = render(<TaskStatusSubtitle task={ task } />);
+        const notCompletedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.notCompleted');
+        expect(notCompletedSubtitle).not.toBeNull();
+    });
+    it('shows ignored status.', () => {
+        const task = mockAssignedTask({
+            ignored: '2021-11-21T1:50:01.4692072',
+            status: ASSIGNED_STATUS.IGNORED,
+        });
 
         const { getByText } = render(<TaskStatusSubtitle task={ task } />);
-        const statusSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.notCompleted');
-        expect(statusSubtitle).not.toBeNull();
+        const notCompletedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.ignored');
+        expect(notCompletedSubtitle).not.toBeNull();
+    });
+    it('shows completed status.', () => {
+        const task = mockAssignedTask({
+            completed: '2021-12-18T12:50:01.469207',
+            status: ASSIGNED_STATUS.COMPLETED,
+        });
+
+        const { getByText } = render(<TaskStatusSubtitle task={ task } />);
+        const notCompletedSubtitle = getByText('misc.tasks.taskAssigneesList.completedStates.completed');
+        expect(notCompletedSubtitle).not.toBeNull();
     });
 });

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@material-ui/core';
-import { Done } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
 import ZetkinRelativeTime from 'components/ZetkinRelativeTime';
 import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+import { Done, NotInterested } from '@material-ui/icons';
 
 
 const TaskStatusSubtitle = ({
@@ -26,7 +26,12 @@ const TaskStatusSubtitle = ({
         );
     }
     else if (!task.completed && task.status === ASSIGNED_STATUS.IGNORED) {
-        return <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.ignored" />;
+        return (
+            <Box alignItems="center" display="flex">
+                <NotInterested fontSize="small" />
+                <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.ignored"/>
+            </Box>
+        );
     }
     else {
         return <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.notCompleted" />;

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -29,7 +29,14 @@ const TaskStatusSubtitle = ({
         return (
             <Box alignItems="center" display="flex">
                 <NotInterested fontSize="small" />
-                <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.ignored"/>
+                <Box>
+                    <FormattedMessage
+                        id="misc.tasks.taskAssigneesList.completedStates.ignored"
+                        values={{
+                            time: <ZetkinRelativeTime datetime={ task.ignored as string } />,
+                        }}
+                    />
+                </Box>
             </Box>
         );
     }

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -12,7 +12,7 @@ const TaskStatusSubtitle = ({
 }): JSX.Element => {
     if (task.completed) {
         return (
-            <Box alignItems="center" display="flex">
+            <>
                 <Done fontSize="small" />
                 <Box>
                     <FormattedMessage
@@ -22,12 +22,12 @@ const TaskStatusSubtitle = ({
                         }}
                     />
                 </Box>
-            </Box>
+            </>
         );
     }
     else if (!task.completed && task.status === ASSIGNED_STATUS.IGNORED) {
         return (
-            <Box alignItems="center" display="flex">
+            <>
                 <NotInterested fontSize="small" />
                 <Box>
                     <FormattedMessage
@@ -37,7 +37,7 @@ const TaskStatusSubtitle = ({
                         }}
                     />
                 </Box>
-            </Box>
+            </>
         );
     }
     else {

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@material-ui/core';
+import { Done } from '@material-ui/icons';
+import { FormattedMessage } from 'react-intl';
+import ZetkinRelativeTime from 'components/ZetkinRelativeTime';
+import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+
+
+const TaskStatusSubtitle = ({
+    task,
+}: {
+    task: ZetkinAssignedTask;
+}): JSX.Element => {
+    if (task.completed) {
+        return (
+            <Box alignItems="center" display="flex">
+                <Done fontSize="small" />
+                <Box>
+                    <FormattedMessage
+                        id="misc.tasks.taskAssigneesList.completedStates.completed"
+                        values={{
+                            time: <ZetkinRelativeTime datetime={ task.completed as string } />,
+                        }}
+                    />
+                </Box>
+            </Box>
+        );
+    }
+    else if (!task.completed && task.status === ASSIGNED_STATUS.IGNORED) {
+        return <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.ignored" />;
+    }
+    else {
+        return <FormattedMessage id="misc.tasks.taskAssigneesList.completedStates.notCompleted" />;
+    }
+};
+
+export default TaskStatusSubtitle;

--- a/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -12,7 +12,7 @@ const TaskStatusSubtitle = ({
 }): JSX.Element => {
     if (task.completed) {
         return (
-            <>
+            <Box alignItems="center" display="flex">
                 <Done fontSize="small" />
                 <Box>
                     <FormattedMessage
@@ -22,12 +22,12 @@ const TaskStatusSubtitle = ({
                         }}
                     />
                 </Box>
-            </>
+            </Box>
         );
     }
     else if (!task.completed && task.status === ASSIGNED_STATUS.IGNORED) {
         return (
-            <>
+            <Box alignItems="center" display="flex">
                 <NotInterested fontSize="small" />
                 <Box>
                     <FormattedMessage
@@ -37,7 +37,7 @@ const TaskStatusSubtitle = ({
                         }}
                     />
                 </Box>
-            </>
+            </Box>
         );
     }
     else {

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -3,16 +3,18 @@ import { useIntl } from 'react-intl';
 import { Box, Card, Grid } from '@material-ui/core';
 
 import TaskStatusSubtitle from './TaskStatusSubtitle';
-import { ZetkinAssignedTask } from 'types/tasks';
 import ZetkinPerson from 'components/ZetkinPerson';
 import ZetkinSection from 'components/ZetkinSection';
+import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
 
 const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssignedTask[] }> = ({ assignedTasks }) => {
     const intl = useIntl();
 
     const sortedAssignedTasks = assignedTasks.sort((first, second) => {
-        if (!first.completed && second.completed) return 1;
-        if (first.completed && !second.completed) return -1;
+        if (first.status === ASSIGNED_STATUS.COMPLETED && second.status !== ASSIGNED_STATUS.COMPLETED) return -1;
+        if (first.status !== ASSIGNED_STATUS.COMPLETED && second.status === ASSIGNED_STATUS.COMPLETED) return 1;
+        if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
+        if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
 
         const firstDate = dayjs(first.completed);
         const secondDate = dayjs(second.completed);

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -1,45 +1,19 @@
-import dayjs from 'dayjs';
 import { useIntl } from 'react-intl';
 import { Box, Card, Grid } from '@material-ui/core';
 
 import TaskStatusSubtitle from './TaskStatusSubtitle';
+import { ZetkinAssignedTask } from 'types/tasks';
 import ZetkinPerson from 'components/ZetkinPerson';
 import ZetkinSection from 'components/ZetkinSection';
-import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+
+import { sortAssignedTasks } from './utils';
+
+
 
 const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssignedTask[] }> = ({ assignedTasks }) => {
     const intl = useIntl();
 
-    const sortedAssignedTasks = assignedTasks.sort((first, second) => {
-        if (first.status === ASSIGNED_STATUS.COMPLETED && second.status !== ASSIGNED_STATUS.COMPLETED) return -1;
-        if (first.status !== ASSIGNED_STATUS.COMPLETED && second.status === ASSIGNED_STATUS.COMPLETED) return 1;
-        if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
-        if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
-
-        let firstDate;
-        if (first.completed) {
-            firstDate = dayjs(first.completed);
-        }
-        else if (first.ignored) {
-            firstDate = dayjs(first.ignored);
-        }
-        else {
-            firstDate = dayjs(first.assigned);
-        }
-
-        let secondDate;
-        if (first.completed) {
-            secondDate = dayjs(second.completed);
-        }
-        else if (first.ignored) {
-            secondDate = dayjs(second.ignored);
-        }
-        else {
-            secondDate = dayjs(second.assigned);
-        }
-
-        return secondDate.diff(firstDate);
-    });
+    const sortedAssignedTasks = assignedTasks.sort(sortAssignedTasks);
 
     return (
         <ZetkinSection title={ intl.formatMessage({ id: 'misc.tasks.taskAssigneesList.title' }, { numPeople: assignedTasks.length }) }>

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -16,8 +16,8 @@ const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssigned
         if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
         if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
 
-        const firstDate = dayjs(first.completed);
-        const secondDate = dayjs(second.completed);
+        const firstDate = first.completed ? dayjs(first.completed) : dayjs(first.assigned);
+        const secondDate = second.completed ? dayjs(second.completed) : dayjs(second.assigned);
 
         if (firstDate.isBefore(secondDate)) return 1;
         if (firstDate.isAfter(secondDate)) return -1;

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -1,24 +1,21 @@
 import dayjs from 'dayjs';
-import { Done } from '@material-ui/icons';
+import { useIntl } from 'react-intl';
 import { Box, Card, Grid } from '@material-ui/core';
-import { FormattedMessage, useIntl } from 'react-intl';
 
+import TaskStatusSubtitle from './TaskStatusSubtitle';
 import { ZetkinAssignedTask } from 'types/tasks';
 import ZetkinPerson from 'components/ZetkinPerson';
-import ZetkinRelativeTime from 'components/ZetkinRelativeTime';
 import ZetkinSection from 'components/ZetkinSection';
 
-const TaskAssigneesList: React.FunctionComponent<{
-    assignedTasks: ZetkinAssignedTask[];
-}> = ({ assignedTasks }) => {
+const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssignedTask[] }> = ({ assignedTasks }) => {
     const intl = useIntl();
 
     const sortedAssignedTasks = assignedTasks.sort((first, second) => {
-        const firstDate = dayjs(first.completed);
-        const secondDate = dayjs(second.completed);
-
         if (!first.completed && second.completed) return 1;
         if (first.completed && !second.completed) return -1;
+
+        const firstDate = dayjs(first.completed);
+        const secondDate = dayjs(second.completed);
 
         if (firstDate.isBefore(secondDate)) return 1;
         if (firstDate.isAfter(secondDate)) return -1;
@@ -30,30 +27,14 @@ const TaskAssigneesList: React.FunctionComponent<{
         <ZetkinSection title={ intl.formatMessage({ id: 'misc.tasks.taskAssigneesList.title' }, { numPeople: assignedTasks.length }) }>
             <Grid container spacing={ 4 }>
                 { sortedAssignedTasks.map(task => {
-                    const completedText = task.completed ?
-                        (
-                            <Box alignItems="center" display="flex">
-                                <Done fontSize="small"/>
-                                <Box>
-                                    <FormattedMessage
-                                        id="misc.tasks.taskAssigneesList.completedStates.completed"
-                                        values={{
-                                            time: <ZetkinRelativeTime datetime={ task.completed as string } />,
-                                        }}
-                                    />
-                                </Box>
-                            </Box>
-                        ) :
-                        intl.formatMessage({ id: 'misc.tasks.taskAssigneesList.completedStates.notCompleted' });
-
                     return (
                         <Grid key={ task.id } item lg={ 3 } md={ 4 } sm={ 6 } xs={ 12 }>
-                            <Card>
+                            <Card data-testid="task-assignee">
                                 <Box p={ 3 }>
                                     <ZetkinPerson
                                         id={ task.assignee.id }
                                         name={ `${task.assignee.first_name} ${task.assignee.last_name}` }
-                                        subtitle={ completedText }
+                                        subtitle={ <TaskStatusSubtitle task={ task }/> }
                                     />
                                 </Box>
                             </Card>

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -16,8 +16,27 @@ const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssigned
         if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
         if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
 
-        const firstDate = first.completed ? dayjs(first.completed) : first.ignored ? dayjs(first.ignored) : dayjs(first.assigned);
-        const secondDate = second.completed ? dayjs(second.completed) : second.ignored ? dayjs(second.ignored) : dayjs(second.assigned);
+        let firstDate;
+        if (first.completed) {
+            firstDate = dayjs(first.completed);
+        }
+        else if (first.ignored) {
+            firstDate = dayjs(first.ignored);
+        }
+        else {
+            firstDate = dayjs(first.assigned);
+        }
+
+        let secondDate;
+        if (first.completed) {
+            secondDate = dayjs(second.completed);
+        }
+        else if (first.ignored) {
+            secondDate = dayjs(second.ignored);
+        }
+        else {
+            secondDate = dayjs(second.assigned);
+        }
 
         return secondDate.diff(firstDate);
     });

--- a/src/components/organize/tasks/TaskAssigneesList/index.tsx
+++ b/src/components/organize/tasks/TaskAssigneesList/index.tsx
@@ -16,13 +16,10 @@ const TaskAssigneesList: React.FunctionComponent<{ assignedTasks: ZetkinAssigned
         if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
         if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
 
-        const firstDate = first.completed ? dayjs(first.completed) : dayjs(first.assigned);
-        const secondDate = second.completed ? dayjs(second.completed) : dayjs(second.assigned);
+        const firstDate = first.completed ? dayjs(first.completed) : first.ignored ? dayjs(first.ignored) : dayjs(first.assigned);
+        const secondDate = second.completed ? dayjs(second.completed) : second.ignored ? dayjs(second.ignored) : dayjs(second.assigned);
 
-        if (firstDate.isBefore(secondDate)) return 1;
-        if (firstDate.isAfter(secondDate)) return -1;
-
-        return 0;
+        return secondDate.diff(firstDate);
     });
 
     return (

--- a/src/components/organize/tasks/TaskAssigneesList/utils.ts
+++ b/src/components/organize/tasks/TaskAssigneesList/utils.ts
@@ -1,0 +1,37 @@
+import dayjs from 'dayjs';
+import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+
+/**
+ * Callback function for Array `.sort()` method which sorts assigned tasks by
+ * completion state and time relative to other assigned tasks of the same state.
+ */
+export const sortAssignedTasks = (first: ZetkinAssignedTask, second: ZetkinAssignedTask): number => {
+    if (first.status === ASSIGNED_STATUS.COMPLETED && second.status !== ASSIGNED_STATUS.COMPLETED) return -1;
+    if (first.status !== ASSIGNED_STATUS.COMPLETED && second.status === ASSIGNED_STATUS.COMPLETED) return 1;
+    if (first.status === ASSIGNED_STATUS.ASSIGNED && second.status === ASSIGNED_STATUS.IGNORED) return 1;
+    if (first.status === ASSIGNED_STATUS.IGNORED && second.status === ASSIGNED_STATUS.ASSIGNED) return -1;
+
+    let firstDate;
+    if (first.completed) {
+        firstDate = dayjs(first.completed);
+    }
+    else if (first.ignored) {
+        firstDate = dayjs(first.ignored);
+    }
+    else {
+        firstDate = dayjs(first.assigned);
+    }
+
+    let secondDate;
+    if (first.completed) {
+        secondDate = dayjs(second.completed);
+    }
+    else if (first.ignored) {
+        secondDate = dayjs(second.ignored);
+    }
+    else {
+        secondDate = dayjs(second.assigned);
+    }
+
+    return secondDate.diff(firstDate);
+};

--- a/src/locale/misc/tasks/en.yml
+++ b/src/locale/misc/tasks/en.yml
@@ -47,3 +47,4 @@ taskAssigneesList:
     completedStates:
         notCompleted: Not yet completed
         completed: Completed {time}
+        ignored: Ignored

--- a/src/locale/misc/tasks/en.yml
+++ b/src/locale/misc/tasks/en.yml
@@ -47,4 +47,4 @@ taskAssigneesList:
     completedStates:
         notCompleted: Not yet completed
         completed: Completed {time}
-        ignored: Ignored
+        ignored: Ignored {time}

--- a/src/test-utils/mocks/mockAssignedTask.ts
+++ b/src/test-utils/mocks/mockAssignedTask.ts
@@ -11,6 +11,7 @@ const task: ZetkinAssignedTask =
         },
         completed: null,
         id: 1,
+        ignored: null,
         status: ASSIGNED_STATUS.ASSIGNED,
         task: {
             deadline: '2021-12-20T12:55:01.469207',

--- a/src/test-utils/mocks/mockAssignedTask.ts
+++ b/src/test-utils/mocks/mockAssignedTask.ts
@@ -13,8 +13,8 @@ const task: ZetkinAssignedTask =
         id: 1,
         status: ASSIGNED_STATUS.ASSIGNED,
         task: {
-            deadline: '2021-012-20T12:55:01.469207',
-            expires: '2021-012-20T12:55:01.469207',
+            deadline: '2021-12-20T12:55:01.469207',
+            expires: '2021-12-20T12:55:01.469207',
             id: 1,
             title: 'Fake title',
         },

--- a/src/test-utils/mocks/mockAssignedTask.ts
+++ b/src/test-utils/mocks/mockAssignedTask.ts
@@ -1,0 +1,30 @@
+import { mockObject } from '.';
+import { ASSIGNED_STATUS, ZetkinAssignedTask } from 'types/tasks';
+
+const task: ZetkinAssignedTask =
+    {
+        assigned: '2021-08-20T12:55:01.469207',
+        assignee: {
+            first_name: 'Dolly',
+            id: 2,
+            last_name: 'Parton',
+        },
+        completed: null,
+        id: 1,
+        status: ASSIGNED_STATUS.ASSIGNED,
+        task: {
+            deadline: '2021-012-20T12:55:01.469207',
+            expires: '2021-012-20T12:55:01.469207',
+            id: 1,
+            title: 'Fake title',
+        },
+    }
+;
+
+const mockAssignedTask = (overrides?: Partial<ZetkinAssignedTask >): ZetkinAssignedTask => {
+    return mockObject(task, overrides);
+};
+
+export default mockAssignedTask;
+
+export { task };

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -78,11 +78,12 @@ export interface ZetkinTaskPostBody extends ZetkinTaskRequestBody {
     type: TASK_TYPE;
 }
 
-enum ASSIGNED_STATUS {
+export enum ASSIGNED_STATUS {
     ASSIGNED='assigned',
     COMPLETED='completed',
     EXPIRED='expired',
-    OVERDUE='overdue',
+    OVERDUE = 'overdue',
+    IGNORED = 'ignored',
 }
 
 export interface TaskAssignee {

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -99,4 +99,5 @@ export interface ZetkinAssignedTask {
     completed: string | null;
     assignee:TaskAssignee;
     assigned: string;
+    ignored: string | null;
 }


### PR DESCRIPTION
Resolves #370 

This PR adds a "ignored" status to tasks, an icon to tasks with that status, sorting to make ignored tasks appear between completed and not completed tasks, and tests to confirm that sorting works. 

In each sorted category the task with the most recent date will appear closest to the top.