### PR TITLE
Basic view rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
         "@material-ui/pickers": "^3.3.10",
+        "@mui/x-data-grid-pro": "^4.0.2",
         "date-fns": "^2.22.1",
         "dayjs": "^1.10.6",
         "final-form": "^4.20.2",

--- a/playwright/mockData/orgs/KPD/people/views/AllMembers/columns.ts
+++ b/playwright/mockData/orgs/KPD/people/views/AllMembers/columns.ts
@@ -1,0 +1,18 @@
+import { ZetkinViewColumn } from '../../../../../../../src/types/zetkin';
+
+const AllMembersColumns: ZetkinViewColumn[] = [
+    {
+        id: 1,
+        title: 'First name',
+    },
+    {
+        id: 2,
+        title: 'Last name',
+    },
+    {
+        id: 3,
+        title: 'Active',
+    },
+];
+
+export default AllMembersColumns;

--- a/playwright/mockData/orgs/KPD/people/views/AllMembers/index.ts
+++ b/playwright/mockData/orgs/KPD/people/views/AllMembers/index.ts
@@ -1,6 +1,6 @@
-import KPD from '../..';
-import RosaLuxemburg from '../../../../users/RosaLuxemburg';
-import { ZetkinView } from '../../../../../../src/types/zetkin';
+import KPD from '../../..';
+import RosaLuxemburg from '../../../../../users/RosaLuxemburg';
+import { ZetkinView } from '../../../../../../../src/types/zetkin';
 
 const AllMembers: ZetkinView = {
     created: '2021-11-21T12:53:15',

--- a/playwright/mockData/orgs/KPD/people/views/AllMembers/rows.ts
+++ b/playwright/mockData/orgs/KPD/people/views/AllMembers/rows.ts
@@ -1,0 +1,14 @@
+import { ZetkinViewRow } from '../../../../../../../src/types/zetkin';
+
+const AllMembersRows: ZetkinViewRow[] = [
+    {
+        content: [ 'Clara', 'Zetkin', true ],
+        id: 1,
+    },
+    {
+        content: [ 'Rosa', 'Luxemburg', false ],
+        id: 2,
+    },
+];
+
+export default AllMembersRows;

--- a/playwright/tests/organize/people/views/view-detail.spec.ts
+++ b/playwright/tests/organize/people/views/view-detail.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from '@playwright/test';
+import test from '../../../../fixtures/next';
+
+import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
+import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
+import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';
+import KPD from '../../../../mockData/orgs/KPD';
+
+test.describe('View detail page', () => {
+
+    test.beforeAll(async ({ moxy, login }) => {
+        await moxy.removeMock();
+        await login();
+
+        await moxy.setMock( '/orgs/1', 'get', {
+            data: {
+                data: KPD,
+            },
+        });
+    });
+
+    test.afterAll(async ({ moxy }) => {
+        await moxy.removeMock();
+    });
+
+    test('displays view title and content to the user', async ({ page, appUri, moxy }) => {
+        const removeViewsMock = await moxy.setMock('/orgs/1/people/views/1', 'get', {
+            data: {
+                data: AllMembers,
+            },
+            status: 200,
+        });
+        const removeRowsMock = await moxy.setMock('/orgs/1/people/views/1/rows', 'get', {
+            data: {
+                data: AllMembersRows,
+            },
+            status: 200,
+        });
+        const removeColsMock = await moxy.setMock('/orgs/1/people/views/1/columns', 'get', {
+            data: {
+                data: AllMembersColumns,
+            },
+            status: 200,
+        });
+
+        await page.goto(appUri + '/organize/1/people/views/1');
+        expect(await page.locator('data-testid=page-title >> text=All KPD members').count()).toEqual(1);
+        expect(await page.locator('text=Clara').count()).toEqual(1);
+        expect(await page.locator('text=Rosa').count()).toEqual(1);
+
+        await removeViewsMock();
+        await removeRowsMock();
+        await removeColsMock();
+    });
+});

--- a/playwright/tests/organize/people/views/views-list.spec.ts
+++ b/playwright/tests/organize/people/views/views-list.spec.ts
@@ -37,7 +37,7 @@ test.describe('Views list page', () => {
             await removeViewsMock();
         });
 
-        test.only('displays available views to the user', async ({ page, appUri, moxy }) => {
+        test('displays available views to the user', async ({ page, appUri, moxy }) => {
             const removeViewsMock = await moxy.setMock('/orgs/1/people/views', 'get', {
                 data: {
                     data: [

--- a/src/components/ZetkinQuery.spec.tsx
+++ b/src/components/ZetkinQuery.spec.tsx
@@ -6,77 +6,79 @@ import ZetkinQuery from './ZetkinQuery';
 
 describe('<ZetkinQuery />', () => {
 
-    describe('when loading', () => {
+    describe('when single query is passed', () => {
+        describe('when loading', () => {
 
-        it('renders the loading indicator', () => {
-            const mockLoadingQuery = mockUseQueryResult('loading');
-            const { getByTestId } = render(<ZetkinQuery query={ mockLoadingQuery } />);
-            expect(getByTestId('loading-indicator')).toBeTruthy();
-        });
-
-        it('renders a custom loading indicator if provided', () => {
-            const mockLoadingQuery = mockUseQueryResult('loading');
-            const { getByTestId } = render(<ZetkinQuery
-                loadingIndicator={
-                    <LinearProgress data-testid="custom-loading-indicator" />
-                }
-                query={ mockLoadingQuery }
-            />);
-            expect(getByTestId('custom-loading-indicator')).toBeTruthy();
-        });
-    });
-
-    describe('when there is an error', () => {
-
-        it('renders the error indicator', () => {
-            const mockErrorQuery = mockUseQueryResult('error');
-            const { getByTestId } = render(<ZetkinQuery query={ mockErrorQuery } />);
-            expect(getByTestId('error-indicator')).toBeTruthy();
-        });
-
-        it('renders a custom error indicator if provided', () => {
-            const mockErrorQuery = mockUseQueryResult('error');
-            const { getByTestId } = render(<ZetkinQuery
-                errorIndicator={
-                    <Typography data-testid="custom-error-indicator" variant="h1">THERE WAS AN ERROR!!!</Typography>
-                }
-                query={ mockErrorQuery }
-            />);
-            expect(getByTestId('custom-error-indicator')).toBeTruthy();
-        });
-    });
-
-    describe('when query successfully resolves', () => {
-
-        it('renders the children', () => {
-            const mockSuccessQuery = mockUseQueryResult('success');
-            const { getByTestId } = render(
-                <ZetkinQuery query={ mockSuccessQuery }>
-                    <Typography data-testid="success-state-child">
-                        When you control the mail, you control EVERYTHING!
-                    </Typography>
-                </ZetkinQuery>,
-            );
-            expect(getByTestId('success-state-child')).toBeTruthy();
-        });
-
-        it('exposes the query result to the children', () => {
-            const mockSuccessQuery = mockUseQueryResult('success', {
-                text: 'These pretzels are making me thirsty',
+            it('renders the loading indicator', () => {
+                const mockLoadingQuery = mockUseQueryResult('loading');
+                const { getByTestId } = render(<ZetkinQuery queries={{ mockLoadingQuery }} />);
+                expect(getByTestId('loading-indicator')).toBeTruthy();
             });
-            const { getByText } = render(
-                <ZetkinQuery query={ mockSuccessQuery }>
-                    { ({ query }) => {
-                        const { data } = query;
-                        return (
-                            <Typography>
-                                { data.text }
-                            </Typography>
-                        );
-                    } }
-                </ZetkinQuery>,
-            );
-            expect(getByText('These pretzels are making me thirsty')).toBeTruthy();
+
+            it('renders a custom loading indicator if provided', () => {
+                const mockLoadingQuery = mockUseQueryResult('loading');
+                const { getByTestId } = render(<ZetkinQuery
+                    loadingIndicator={
+                        <LinearProgress data-testid="custom-loading-indicator" />
+                    }
+                    queries={{ mockLoadingQuery }}
+                />);
+                expect(getByTestId('custom-loading-indicator')).toBeTruthy();
+            });
+        });
+
+        describe('when there is an error', () => {
+
+            it('renders the error indicator', () => {
+                const mockErrorQuery = mockUseQueryResult('error');
+                const { getByTestId } = render(<ZetkinQuery queries={{ mockErrorQuery }} />);
+                expect(getByTestId('error-indicator')).toBeTruthy();
+            });
+
+            it('renders a custom error indicator if provided', () => {
+                const mockErrorQuery = mockUseQueryResult('error');
+                const { getByTestId } = render(<ZetkinQuery
+                    errorIndicator={
+                        <Typography data-testid="custom-error-indicator" variant="h1">THERE WAS AN ERROR!!!</Typography>
+                    }
+                    queries={{ mockErrorQuery }}
+                />);
+                expect(getByTestId('custom-error-indicator')).toBeTruthy();
+            });
+        });
+
+        describe('when query successfully resolves', () => {
+
+            it('renders the children', () => {
+                const mockSuccessQuery = mockUseQueryResult('success');
+                const { getByTestId } = render(
+                    <ZetkinQuery queries={{ mockSuccessQuery }}>
+                        <Typography data-testid="success-state-child">
+                            When you control the mail, you control EVERYTHING!
+                        </Typography>
+                    </ZetkinQuery>,
+                );
+                expect(getByTestId('success-state-child')).toBeTruthy();
+            });
+
+            it('exposes the query result to the children', () => {
+                const mockSuccessQuery = mockUseQueryResult('success', {
+                    text: 'These pretzels are making me thirsty',
+                });
+                const { getByText } = render(
+                    <ZetkinQuery queries={{ mockSuccessQuery }}>
+                        { ({ queries }) => {
+                            const { data } = queries.mockSuccessQuery;
+                            return (
+                                <Typography>
+                                    { data.text }
+                                </Typography>
+                            );
+                        } }
+                    </ZetkinQuery>,
+                );
+                expect(getByText('These pretzels are making me thirsty')).toBeTruthy();
+            });
         });
     });
 });

--- a/src/components/ZetkinQuery.spec.tsx
+++ b/src/components/ZetkinQuery.spec.tsx
@@ -81,4 +81,65 @@ describe('<ZetkinQuery />', () => {
             });
         });
     });
+
+    describe('when multiple queries are passed', () => {
+        it('renders the error indicator if any query resolves to error', () => {
+            const mockSuccessQuery = mockUseQueryResult('success');
+            const mockErrorQuery = mockUseQueryResult('error');
+            const mockLoadingQuery = mockUseQueryResult('loading');
+
+            const { getByTestId } = render(
+                <ZetkinQuery queries={{
+                    mockErrorQuery,
+                    mockLoadingQuery,
+                    mockSuccessQuery,
+                }}
+                />,
+            );
+            expect(getByTestId('error-indicator')).toBeTruthy();
+        });
+
+        it('renders the loading indicator if any query is loading and none have errors', () => {
+            const mockSuccessQuery = mockUseQueryResult('success');
+            const mockLoadingQuery = mockUseQueryResult('loading');
+
+            const { getByTestId } = render(
+                <ZetkinQuery queries={{
+                    mockLoadingQuery,
+                    mockSuccessQuery,
+                }}
+                />,
+            );
+            expect(getByTestId('loading-indicator')).toBeTruthy();
+        });
+
+        it('exposes the query result to the children', () => {
+            const pretzelQuery = mockUseQueryResult('success', {
+                text: 'These pretzels are making me thirsty',
+            });
+            const movieQuery = mockUseQueryResult('success', {
+                title: 'Rochelle, Rochelle',
+            });
+
+            const { getByText } = render(
+                <ZetkinQuery queries={{ movieQuery, pretzelQuery }}>
+                    { ({ queries: { movieQuery, pretzelQuery } }) => {
+                        const { data: pretzelData } = pretzelQuery;
+                        const { data: movieData } = movieQuery;
+                        return (
+                            <>
+                                <Typography>
+                                    { pretzelData.text }
+                                </Typography>
+                                <Typography>
+                                    { movieData.title }
+                                </Typography>
+                            </>
+                        );
+                    } }
+                </ZetkinQuery>,
+            );
+            expect(getByText('These pretzels are making me thirsty')).toBeTruthy();
+        });
+    });
 });

--- a/src/components/ZetkinViewTable/index.tsx
+++ b/src/components/ZetkinViewTable/index.tsx
@@ -1,0 +1,31 @@
+import { DataGridPro } from '@mui/x-data-grid-pro';
+
+import { ZetkinViewColumn, ZetkinViewRow } from 'types/zetkin';
+
+
+interface ZetkinViewTableProps {
+    columns: ZetkinViewColumn[];
+    rows: ZetkinViewRow[];
+}
+
+const ZetkinViewTable = ({ columns, rows }: ZetkinViewTableProps): JSX.Element => {
+    const gridColumns = columns.map((col, index) => ({
+        field: index.toString(),
+        headerName: col.title,
+        minWidth: 200,
+    }));
+
+    const gridRows = rows.map(row => ({
+        id: row.id,
+        ...row.content,
+    }));
+
+    return (
+        <DataGridPro
+            columns={ gridColumns }
+            rows={ gridRows }
+        />
+    );
+};
+
+export default ZetkinViewTable;

--- a/src/components/ZetkinViewTable/index.tsx
+++ b/src/components/ZetkinViewTable/index.tsx
@@ -1,5 +1,5 @@
 import { Person } from '@material-ui/icons';
-import { DataGridPro, GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 
 import { ZetkinViewColumn, ZetkinViewRow } from 'types/zetkin';
 
@@ -44,7 +44,7 @@ const ZetkinViewTable = ({ columns, rows }: ZetkinViewTableProps): JSX.Element =
             field: index.toString(),
             headerName: col.title,
             minWidth: 200,
-        }))
+        })),
     ];
 
     const gridRows = rows.map(row => ({

--- a/src/components/ZetkinViewTable/index.tsx
+++ b/src/components/ZetkinViewTable/index.tsx
@@ -1,4 +1,5 @@
-import { DataGridPro } from '@mui/x-data-grid-pro';
+import { Person } from '@material-ui/icons';
+import { DataGridPro, GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
 
 import { ZetkinViewColumn, ZetkinViewRow } from 'types/zetkin';
 
@@ -9,11 +10,42 @@ interface ZetkinViewTableProps {
 }
 
 const ZetkinViewTable = ({ columns, rows }: ZetkinViewTableProps): JSX.Element => {
-    const gridColumns = columns.map((col, index) => ({
-        field: index.toString(),
-        headerName: col.title,
-        minWidth: 200,
-    }));
+    const avatarColumn : GridColDef = {
+        disableColumnMenu: true,
+        disableExport: true,
+        disableReorder: true,
+        field: 'id',
+        filterable: false,
+        headerName: ' ',
+        renderCell: (params) => {
+            const url = `/api/orgs/1/people/${params.value}/avatar`;
+            return (
+                <img
+                    alt="Avatar"
+                    src={ url }
+                    style={{
+                        maxHeight: '100%',
+                        maxWidth: '100%',
+                    }}
+                />
+            );
+        },
+        renderHeader: () => {
+            return <Person/>;
+        },
+        resizable: false,
+        sortable: false,
+        width: 50,
+    };
+
+    const gridColumns = [
+        avatarColumn,
+        ...columns.map((col, index) => ({
+            field: index.toString(),
+            headerName: col.title,
+            minWidth: 200,
+        }))
+    ];
 
     const gridRows = rows.map(row => ({
         id: row.id,

--- a/src/components/layout/organize/SingleViewLayout.tsx
+++ b/src/components/layout/organize/SingleViewLayout.tsx
@@ -1,0 +1,29 @@
+import { FunctionComponent } from 'react';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
+
+import getView from 'fetching/views/getView';
+import TabbedLayout from './TabbedLayout';
+
+
+const SingleViewLayout: FunctionComponent = ({ children }) => {
+    const { orgId, viewId } = useRouter().query;
+    const viewQuery = useQuery(['views', orgId, viewId ], getView(orgId as string, viewId as string));
+
+    const view = viewQuery.data;
+
+    return (
+        <TabbedLayout
+            baseHref={ `/organize/${orgId}/people/views/${viewId}` }
+            defaultTab="/"
+            fixedHeight={ true }
+            tabs={ [
+                { href: `/`, messageId: 'layout.organize.view.tabs.view' },
+            ] }
+            title={ view?.title }>
+            { children }
+        </TabbedLayout>
+    );
+};
+
+export default SingleViewLayout;

--- a/src/components/organize/people/ViewsListTable.tsx
+++ b/src/components/organize/people/ViewsListTable.tsx
@@ -30,8 +30,8 @@ const ViewsListTable: React.FunctionComponent = () => {
             </TableHead>
             <TableBody>
                 <ZetkinQuery
-                    query={ viewsQuery }>
-                    { ({ query: { data: views } }) => {
+                    queries={{ viewsQuery }}>
+                    { ({ queries: { viewsQuery: { data: views } } }) => {
                         if (views.length === 0) {
                             return (
                                 <TableRow data-testid="empty-views-list-row">

--- a/src/fetching/views/getView.ts
+++ b/src/fetching/views/getView.ts
@@ -1,10 +1,15 @@
+import APIError from 'utils/apiError';
 import { defaultFetch } from '..';
 import { ZetkinView } from '../../types/zetkin';
 
 export default function getView(orgId : string, viewId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinView> => {
-        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}`);
-        const oData = await oRes.json();
-        return oData.data;
+        const url = `/orgs/${orgId}/people/views/${viewId}`;
+        const res = await fetch(url);
+        if (!res.ok) {
+            throw new APIError('GET', url);
+        }
+        const resData = await res.json();
+        return resData.data;
     };
 }

--- a/src/fetching/views/getView.ts
+++ b/src/fetching/views/getView.ts
@@ -1,0 +1,10 @@
+import { defaultFetch } from '..';
+import { ZetkinView } from '../../types/zetkin';
+
+export default function getView(orgId : string, viewId : string, fetch = defaultFetch) {
+    return async () : Promise<ZetkinView> => {
+        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}`);
+        const oData = await oRes.json();
+        return oData.data;
+    };
+}

--- a/src/fetching/views/getViewColumns.ts
+++ b/src/fetching/views/getViewColumns.ts
@@ -1,10 +1,15 @@
+import APIError from 'utils/apiError';
 import { defaultFetch } from '..';
 import { ZetkinViewColumn } from '../../types/zetkin';
 
 export default function getViewColumns(orgId : string, viewId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinViewColumn[]> => {
-        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}/columns`);
-        const oData = await oRes.json();
-        return oData.data;
+        const url = `/orgs/${orgId}/people/views/${viewId}/columns`;
+        const res = await fetch(url);
+        if (!res.ok) {
+            throw new APIError('GET', url);
+        }
+        const resData = await res.json();
+        return resData.data;
     };
 }

--- a/src/fetching/views/getViewColumns.ts
+++ b/src/fetching/views/getViewColumns.ts
@@ -1,0 +1,10 @@
+import { defaultFetch } from '..';
+import { ZetkinViewColumn } from '../../types/zetkin';
+
+export default function getViewColumns(orgId : string, viewId : string, fetch = defaultFetch) {
+    return async () : Promise<ZetkinViewColumn[]> => {
+        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}/columns`);
+        const oData = await oRes.json();
+        return oData.data;
+    };
+}

--- a/src/fetching/views/getViewRows.ts
+++ b/src/fetching/views/getViewRows.ts
@@ -1,0 +1,10 @@
+import { defaultFetch } from '..';
+import { ZetkinViewRow } from '../../types/zetkin';
+
+export default function getViewRows(orgId : string, viewId : string, fetch = defaultFetch) {
+    return async () : Promise<ZetkinViewRow[]> => {
+        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}/rows`);
+        const oData = await oRes.json();
+        return oData.data;
+    };
+}

--- a/src/fetching/views/getViewRows.ts
+++ b/src/fetching/views/getViewRows.ts
@@ -1,10 +1,15 @@
+import APIError from 'utils/apiError';
 import { defaultFetch } from '..';
 import { ZetkinViewRow } from '../../types/zetkin';
 
 export default function getViewRows(orgId : string, viewId : string, fetch = defaultFetch) {
     return async () : Promise<ZetkinViewRow[]> => {
-        const oRes = await fetch(`/orgs/${orgId}/people/views/${viewId}/rows`);
-        const oData = await oRes.json();
-        return oData.data;
+        const url = `/orgs/${orgId}/people/views/${viewId}/rows`;
+        const res = await fetch(url);
+        if (!res.ok) {
+            throw new APIError('GET', url);
+        }
+        const resData = await res.json();
+        return resData.data;
     };
 }

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -32,3 +32,6 @@ people:
     title: People
     tabs:
         views: Views
+view:
+    tabs:
+        view: View

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -82,6 +82,12 @@ async function fetchLabel(
         ).then((res) => res.json());
         return campaign.data.title;
     }
+    if (fieldName == 'viewId') {
+        const view = await apiFetch(
+            `/orgs/${orgId}/people/views/${fieldValue}`,
+        ).then((res) => res.json());
+        return view.data.title;
+    }
     return fieldValue;
 }
 

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -77,10 +77,10 @@ async function fetchLabel(
         return campaign.data.title;
     }
     if (fieldName === 'taskId') {
-        const campaign = await apiFetch(
+        const task = await apiFetch(
             `/orgs/${orgId}/tasks/${fieldValue}`,
         ).then((res) => res.json());
-        return campaign.data.title;
+        return task.data.title;
     }
     if (fieldName == 'viewId') {
         const view = await apiFetch(

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/assignees.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/assignees.tsx
@@ -102,11 +102,11 @@ const TaskAssigneesPage: PageWithLayout = () => {
                     openDialog={ () => setDialogOpen(true) }
                     status={ queryStatus }
                 />
-                <ZetkinQuery query={ assignedTasksQuery }>
-                    { ({ query }) => {
+                <ZetkinQuery queries={{ assignedTasksQuery }}>
+                    { ({ queries }) => {
                         return (
                             <Box mt={ 3 }>
-                                <TaskAssigneesList assignedTasks={ query.data } />
+                                <TaskAssigneesList assignedTasks={ queries.assignedTasksQuery.data } />
                             </Box>
                         );
                     } }

--- a/src/pages/organize/[orgId]/people/views/[viewId].tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId].tsx
@@ -1,0 +1,67 @@
+import getOrg from 'fetching/getOrg';
+import { GetServerSideProps } from 'next';
+import getView from 'fetching/views/getView';
+
+import { PageWithLayout } from 'types';
+import { scaffold } from 'utils/next';
+import SingleViewLayout from 'components/layout/organize/SingleViewLayout';
+
+
+const scaffoldOptions = {
+    authLevelRequired: 2,
+    localeScope: [
+    ],
+};
+
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { orgId, viewId } = ctx.params!;
+
+    await ctx.queryClient.prefetchQuery(
+        ['org', orgId],
+        getOrg(orgId as string, ctx.apiFetch),
+    );
+    const orgState = ctx.queryClient.getQueryState(['org', orgId]);
+
+    await ctx.queryClient.prefetchQuery(
+        ['views', viewId],
+        getView(orgId as string, viewId as string, ctx.apiFetch),
+    );
+
+    const viewState = ctx.queryClient.getQueryState(['views', viewId]);
+
+    if (orgState?.data && viewState?.data) {
+        return {
+            props: {
+                orgId,
+                viewId,
+            },
+        };
+    }
+    else {
+        return {
+            notFound: true,
+        };
+    }
+}, scaffoldOptions);
+
+type SingleViewPageProps = {
+    orgId: string;
+};
+
+const SingleViewPage: PageWithLayout<SingleViewPageProps> = () => {
+    return (
+        <>
+        </>
+    );
+};
+
+SingleViewPage.getLayout = function getLayout(page) {
+    return (
+        <SingleViewLayout>
+            { page }
+        </SingleViewLayout>
+    );
+};
+
+export default SingleViewPage;

--- a/src/pages/organize/[orgId]/people/views/[viewId].tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId].tsx
@@ -9,6 +9,7 @@ import getViewRows from 'fetching/views/getViewRows';
 import { PageWithLayout } from 'types';
 import { scaffold } from 'utils/next';
 import SingleViewLayout from 'components/layout/organize/SingleViewLayout';
+import ZetkinQuery from 'components/ZetkinQuery';
 import ZetkinViewTable from 'components/ZetkinViewTable';
 
 
@@ -56,30 +57,26 @@ type SingleViewPageProps = {
 };
 
 const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({ orgId, viewId }) => {
-    const viewQuery = useQuery(['views', viewId], getView(orgId, viewId));
-    const colsQuery = useQuery(['views', viewId, 'columns'], getViewColumns(orgId, viewId));
-    const rowsQuery = useQuery(['views', viewId, 'rows'], getViewRows(orgId, viewId));
 
-    if (viewQuery.data && colsQuery.data && rowsQuery.data) {
-        const view = viewQuery.data;
-        const cols = colsQuery.data;
-        const rows = rowsQuery.data;
-
-        return (
-            <>
-                <Head>
-                    <title>{ view.title || '' }</title>
-                </Head>
-                <ZetkinViewTable
-                    columns={ cols }
-                    rows={ rows }
-                />
-            </>
-        );
-    }
-    else {
-        return <></>;
-    }
+    return (
+        <ZetkinQuery queries={{
+            colsQuery: useQuery(['views', viewId, 'columns'], getViewColumns(orgId, viewId)),
+            rowsQuery: useQuery(['views', viewId, 'rows'], getViewRows(orgId, viewId)),
+            viewQuery: useQuery(['views', viewId], getView(orgId, viewId)),
+        }}>
+            { ({ queries: { colsQuery, rowsQuery, viewQuery } }) => (
+                <>
+                    <Head>
+                        <title>{ viewQuery.data.title }</title>
+                    </Head>
+                    <ZetkinViewTable
+                        columns={ colsQuery.data }
+                        rows={ rowsQuery.data }
+                    />
+                </>
+            ) }
+        </ZetkinQuery>
+    );
 };
 
 SingleViewPage.getLayout = function getLayout(page) {

--- a/src/pages/organize/[orgId]/people/views/[viewId].tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId].tsx
@@ -1,10 +1,15 @@
-import getOrg from 'fetching/getOrg';
 import { GetServerSideProps } from 'next';
-import getView from 'fetching/views/getView';
+import Head from 'next/head';
+import { useQuery } from 'react-query';
 
+import getOrg from 'fetching/getOrg';
+import getView from 'fetching/views/getView';
+import getViewColumns from 'fetching/views/getViewColumns';
+import getViewRows from 'fetching/views/getViewRows';
 import { PageWithLayout } from 'types';
 import { scaffold } from 'utils/next';
 import SingleViewLayout from 'components/layout/organize/SingleViewLayout';
+import ZetkinViewTable from 'components/ZetkinViewTable';
 
 
 const scaffoldOptions = {
@@ -47,13 +52,34 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 
 type SingleViewPageProps = {
     orgId: string;
+    viewId: string;
 };
 
-const SingleViewPage: PageWithLayout<SingleViewPageProps> = () => {
-    return (
-        <>
-        </>
-    );
+const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({ orgId, viewId }) => {
+    const viewQuery = useQuery(['views', viewId], getView(orgId, viewId));
+    const colsQuery = useQuery(['views', viewId, 'columns'], getViewColumns(orgId, viewId));
+    const rowsQuery = useQuery(['views', viewId, 'rows'], getViewRows(orgId, viewId));
+
+    if (viewQuery.data && colsQuery.data && rowsQuery.data) {
+        const view = viewQuery.data;
+        const cols = colsQuery.data;
+        const rows = rowsQuery.data;
+
+        return (
+            <>
+                <Head>
+                    <title>{ view.title || '' }</title>
+                </Head>
+                <ZetkinViewTable
+                    columns={ cols }
+                    rows={ rows }
+                />
+            </>
+        );
+    }
+    else {
+        return <></>;
+    }
 };
 
 SingleViewPage.getLayout = function getLayout(page) {

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -229,3 +229,14 @@ export interface ZetkinView {
     };
     organization: ZetkinOrganization;
 }
+
+export interface ZetkinViewColumn {
+    id: number;
+    title: string;
+    // TODO: Add all fields when implementing proper support for column types
+}
+
+export interface ZetkinViewRow {
+    id: number;
+    content: unknown[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -451,6 +451,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.8":
+  version "7.16.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
+  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
@@ -929,6 +936,37 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
+"@material-ui/utils@^5.0.0-beta.4":
+  version "5.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-5.0.0-beta.5.tgz#de492037e1f1f0910fda32e6f11b66dfcde2a1c2"
+  integrity sha512-wtJ3ovXWZdTAz5eLBqvMpYH/IBJb3qMQbGCyL1i00+sf7AUlAuv4QLx+QtX/siA6L7IpxUQVfqpoCpQH1eYRpQ==
+  dependencies:
+    "@babel/runtime" "^7.14.8"
+    "@types/prop-types" "^15.7.4"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
+
+"@mui/x-data-grid-pro@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid-pro/-/x-data-grid-pro-4.0.2.tgz#3ec31bea8be5d1f4306520df0dc647e67f2dff25"
+  integrity sha512-BK/zXY/lOVP3IUHm4wcbTcJM/9O+jeOSv4NDG3gemeB0G0wL1rq5czOuZvjVaOhs5MUlULOqUq72k5oMNwmJjQ==
+  dependencies:
+    "@material-ui/utils" "^5.0.0-beta.4"
+    "@mui/x-license-pro" "4.0.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    reselect "^4.0.0"
+
+"@mui/x-license-pro@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-4.0.2.tgz#0bd7b016d63d1f712b559844e7962b7f846dbe17"
+  integrity sha512-e9qXJDoAKiB/IQ7m7o7is5DcQpEVvvuQOtZIdhRmyl78wYVvgjLIJfZM6pBnE7UYsAbSnhE0E8yeWQfjamczaw==
+  dependencies:
+    "@material-ui/utils" "^5.0.0-beta.4"
+    esm "^3.2.25"
+    yargs "^17.0.1"
+
 "@napi-rs/triples@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@napi-rs/triples/-/triples-1.0.3.tgz#76d6d0c3f4d16013c61e45dfca5ff1e6c31ae53c"
@@ -1321,7 +1359,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
   integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.4":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
@@ -1340,6 +1378,13 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/react-is@^16.7.1 || ^17.0.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-transition-group@^4.2.0":
   version "4.4.3"
@@ -3068,6 +3113,11 @@ eslint@^7.15.0:
     table "^6.0.9"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^7.3.0, espree@^7.3.1:
   version "7.3.1"
@@ -5822,7 +5872,7 @@ react-intl@^5.13.2:
     intl-messageformat "9.9.2"
     tslib "^2.1.0"
 
-react-is@17.0.2, "react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1:
+react-is@17.0.2, "react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -5942,6 +5992,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.4.tgz#66df0aff41b6ee0f51e2cc17cfaf2c1995916f32"
+  integrity sha512-i1LgXw8DKSU5qz1EV0ZIKz4yIUHJ7L3bODh+Da6HmVSm9vdL/hG7IpbgzQ3k2XSirzf8/eI7OMEs81gb1VV2fQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -7047,6 +7102,19 @@ yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
+yargs@^17.0.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
This PR implements a very crude single-view page that displays the title of a view and renders it's content using the MUI-X data grid.

Changes
* Adds a single-view page to render view
* Refactors `ZetkinQuery` to support multiple queries (pair-programmed with @djbusstop)

Supersedes #492
Fixes #486 

![image](https://user-images.githubusercontent.com/550212/142668194-50897028-49df-4926-be2a-6e6720f96feb.png)

