### PR TITLE
Load MUI-X license key from environment

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import dayjs from 'dayjs';
 import { Hydrate } from 'react-query/hydration';
 import { IntlProvider } from 'react-intl';
 import isoWeek from 'dayjs/plugin/isoWeek';
+import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import NProgress from 'nprogress';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -22,6 +23,11 @@ import { UserContext } from '../hooks';
 
 dayjs.extend(LocalTimeToJsonPlugin);
 dayjs.extend(isoWeek);
+
+// MUI-X license
+if (process.env.NEXT_PUBLIC_MUIX_LICENSE_KEY) {
+    LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUIX_LICENSE_KEY);
+}
 
 // Progress bar
 NProgress.configure({ showSpinner: false });


### PR DESCRIPTION
This PR loads an MUI-X license key from the environment and inserts it to get rid of the watermark and browser console warning. Developing without the key still works fine.

The key is added to an `.env.local` file, like this:

```env
NEXT_PUBLIC_MUIX_LICENSE_KEY=longalphanumerickeygoeshere
```

Staff can reach out to me to get a valid key.