### PR TITLE
View jump menu

### DIFF
--- a/playwright/tests/organize/people/views/view-detail.spec.ts
+++ b/playwright/tests/organize/people/views/view-detail.spec.ts
@@ -5,6 +5,7 @@ import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';
 import KPD from '../../../../mockData/orgs/KPD';
+import NewView from '../../../../mockData/orgs/KPD/people/views/NewView';
 
 test.describe('View detail page', () => {
 
@@ -49,6 +50,55 @@ test.describe('View detail page', () => {
         expect(await page.locator('text=Rosa').count()).toEqual(1);
 
         await removeViewsMock();
+        await removeRowsMock();
+        await removeColsMock();
+    });
+
+    test('jumps between views using jump menu', async ({ page, appUri, moxy }) => {
+        const removeViewsMock = await moxy.setMock('/orgs/1/people/views', 'get', {
+            data: {
+                data: [ AllMembers, NewView ],
+            },
+            status: 200,
+        });
+        const removeViewMock = await moxy.setMock('/orgs/1/people/views/1', 'get', {
+            data: {
+                data: AllMembers,
+            },
+            status: 200,
+        });
+        const removeRowsMock = await moxy.setMock('/orgs/1/people/views/1/rows', 'get', {
+            data: {
+                data: AllMembersRows,
+            },
+            status: 200,
+        });
+        const removeColsMock = await moxy.setMock('/orgs/1/people/views/1/columns', 'get', {
+            data: {
+                data: AllMembersColumns,
+            },
+            status: 200,
+        });
+
+        await page.goto(appUri + '/organize/1/people/views/1');
+
+        // Click to open the jump menu
+        await page.click('data-testid=view-jump-menu-button');
+
+        // Assert that the input is automatically focused, and type in part of the title of NewView
+        expect(await page.locator('data-testid=view-jump-menu-popover >> input')).toBeFocused();
+        await page.fill('data-testid=view-jump-menu-popover >> input', NewView.title.slice(0, 3));
+
+        // Press down to select view and enter to navigate
+        await page.keyboard.press('ArrowDown');
+        await page.keyboard.press('Enter');
+
+        // Assert that we navigate away to the new view
+        await page.waitForNavigation();
+        await expect(page.url()).toEqual(appUri + `/organize/1/people/views/${NewView.id}`);
+
+        await removeViewsMock();
+        await removeViewMock();
         await removeRowsMock();
         await removeColsMock();
     });

--- a/src/components/layout/organize/SingleViewLayout.tsx
+++ b/src/components/layout/organize/SingleViewLayout.tsx
@@ -8,7 +8,7 @@ import TabbedLayout from './TabbedLayout';
 
 const SingleViewLayout: FunctionComponent = ({ children }) => {
     const { orgId, viewId } = useRouter().query;
-    const viewQuery = useQuery(['views', orgId, viewId ], getView(orgId as string, viewId as string));
+    const viewQuery = useQuery(['view', viewId ], getView(orgId as string, viewId as string));
 
     const view = viewQuery.data;
 

--- a/src/components/layout/organize/SingleViewLayout.tsx
+++ b/src/components/layout/organize/SingleViewLayout.tsx
@@ -1,16 +1,28 @@
+import { Box } from '@material-ui/core';
 import { FunctionComponent } from 'react';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
 
 import getView from 'fetching/views/getView';
 import TabbedLayout from './TabbedLayout';
+import ViewJumpMenu from 'components/views/ViewJumpMenu';
 
 
 const SingleViewLayout: FunctionComponent = ({ children }) => {
-    const { orgId, viewId } = useRouter().query;
+    const router = useRouter();
+    const { orgId, viewId } = router.query;
     const viewQuery = useQuery(['view', viewId ], getView(orgId as string, viewId as string));
 
     const view = viewQuery.data;
+
+    const title = (
+        <Box>
+            { view?.title }
+            <ViewJumpMenu
+                onViewSelect={ view => router.push(`/organize/${orgId}/people/views/${view.id}`) }
+            />
+        </Box>
+    );
 
     return (
         <TabbedLayout
@@ -20,7 +32,7 @@ const SingleViewLayout: FunctionComponent = ({ children }) => {
             tabs={ [
                 { href: `/`, messageId: 'layout.organize.view.tabs.view' },
             ] }
-            title={ view?.title }>
+            title={ title }>
             { children }
         </TabbedLayout>
     );

--- a/src/components/layout/organize/SingleViewLayout.tsx
+++ b/src/components/layout/organize/SingleViewLayout.tsx
@@ -18,9 +18,7 @@ const SingleViewLayout: FunctionComponent = ({ children }) => {
     const title = (
         <Box>
             { view?.title }
-            <ViewJumpMenu
-                onViewSelect={ view => router.push(`/organize/${orgId}/people/views/${view.id}`) }
-            />
+            <ViewJumpMenu/>
         </Box>
     );
 

--- a/src/components/layout/organize/TabbedLayout.tsx
+++ b/src/components/layout/organize/TabbedLayout.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
 interface TabbedLayoutProps {
     actionButtons?: React.ReactElement | React.ReactElement[];
     fixedHeight?: boolean;
-    title?: string;
+    title?: string | ReactElement;
     subtitle?: string | ReactElement;
     baseHref: string;
     defaultTab: string;

--- a/src/components/views/ViewJumpMenu.tsx
+++ b/src/components/views/ViewJumpMenu.tsx
@@ -1,0 +1,58 @@
+import { ExpandMore } from '@material-ui/icons';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
+import { FunctionComponent, useState } from 'react';
+import { IconButton, Menu, MenuItem } from '@material-ui/core';
+
+import getViews from 'fetching/views/getViews';
+import ZetkinQuery from 'components/ZetkinQuery';
+import { ZetkinView } from 'types/views';
+
+interface ViewJumpMenuProps {
+    onViewSelect: (view: ZetkinView) => void;
+}
+
+const ViewJumpMenu : FunctionComponent<ViewJumpMenuProps> = ({ onViewSelect }) => {
+    const router = useRouter();
+    const { orgId, viewId } = router.query;
+    const viewsQuery = useQuery(['views', orgId], getViews(orgId as string));
+    const [jumpMenuAnchor, setJumpMenuAnchor] = useState<Element | null>(null);
+
+    return (
+        <>
+            <IconButton onClick={ (ev) => setJumpMenuAnchor(ev.target as Element) }>
+                <ExpandMore/>
+            </IconButton>
+            <Menu
+                anchorEl={ jumpMenuAnchor }
+                onClose={ () => setJumpMenuAnchor(null) }
+                open={ !!jumpMenuAnchor }
+                PaperProps={{
+                    style: {
+                        maxHeight: '40vh',
+                    },
+                }}>
+                <ZetkinQuery
+                    queries={{ viewsQuery }}>
+                    { ({ queries: { viewsQuery } }) => {
+                        return viewsQuery.data.map(view => {
+                            if (view.id.toString() != viewId as string) {
+                                return (
+                                    <MenuItem key={ view.id }
+                                        onClick={ () => {
+                                            setJumpMenuAnchor(null);
+                                            onViewSelect(view);
+                                        } }>
+                                        { view.title }
+                                    </MenuItem>
+                                );
+                            }
+                        });
+                    } }
+                </ZetkinQuery>
+            </Menu>
+        </>
+    );
+};
+
+export default ViewJumpMenu;

--- a/src/components/views/ViewJumpMenu.tsx
+++ b/src/components/views/ViewJumpMenu.tsx
@@ -66,11 +66,14 @@ const ViewJumpMenu : FunctionComponent = () => {
 
     return (
         <>
-            <IconButton onClick={ (ev) => setJumpMenuAnchor(ev.target as Element) }>
+            <IconButton
+                data-testid="view-jump-menu-button"
+                onClick={ (ev) => setJumpMenuAnchor(ev.target as Element) }>
                 <ExpandMore/>
             </IconButton>
             <Popover
                 anchorEl={ jumpMenuAnchor }
+                data-testid="view-jump-menu-popover"
                 onClose={ () => setJumpMenuAnchor(null) }
                 onKeyDown={ ev => {
                     if (ev.code == 'ArrowUp') {

--- a/src/components/views/ViewJumpMenu.tsx
+++ b/src/components/views/ViewJumpMenu.tsx
@@ -28,6 +28,7 @@ const ViewJumpMenu : FunctionComponent = () => {
         groupedOptions,
         inputValue,
     } = useAutocomplete({
+        clearOnBlur: true,
         getOptionLabel: option => option.title,
         options: viewsQuery.data || [],
     });
@@ -124,7 +125,7 @@ const ViewJumpMenu : FunctionComponent = () => {
                                         pathname: `/organize/${orgId}/people/views/${view.id}`,
                                     }}
                                     passHref>
-                                    <ListItem button component="a" selected={ idx == activeIndex }>
+                                    <ListItem button component="a" selected={ idx == activeIndex } tabIndex={ -1 }>
                                         <ListItemText>
                                             { view.title }
                                         </ListItemText>

--- a/src/components/views/ViewJumpMenu.tsx
+++ b/src/components/views/ViewJumpMenu.tsx
@@ -1,8 +1,9 @@
 import { ExpandMore } from '@material-ui/icons';
+import { useAutocomplete } from '@material-ui/lab';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
+import { Box, IconButton, MenuItem, Popover, TextField } from '@material-ui/core';
 import { FunctionComponent, useState } from 'react';
-import { IconButton, Menu, MenuItem } from '@material-ui/core';
 
 import getViews from 'fetching/views/getViews';
 import ZetkinQuery from 'components/ZetkinQuery';
@@ -17,40 +18,64 @@ const ViewJumpMenu : FunctionComponent<ViewJumpMenuProps> = ({ onViewSelect }) =
     const { orgId, viewId } = router.query;
     const viewsQuery = useQuery(['views', orgId], getViews(orgId as string));
     const [jumpMenuAnchor, setJumpMenuAnchor] = useState<Element | null>(null);
+    const {
+        getInputProps,
+        getListboxProps,
+        getRootProps,
+        groupedOptions,
+        inputValue,
+    } = useAutocomplete({
+        getOptionLabel: option => option.title,
+        options: viewsQuery.data || [],
+    });
 
     return (
         <>
             <IconButton onClick={ (ev) => setJumpMenuAnchor(ev.target as Element) }>
                 <ExpandMore/>
             </IconButton>
-            <Menu
+            <Popover
                 anchorEl={ jumpMenuAnchor }
                 onClose={ () => setJumpMenuAnchor(null) }
                 open={ !!jumpMenuAnchor }
                 PaperProps={{
                     style: {
+                        display: 'flex',
+                        flexDirection: 'column',
                         maxHeight: '40vh',
+                        width: '30ch',
                     },
                 }}>
                 <ZetkinQuery
                     queries={{ viewsQuery }}>
                     { ({ queries: { viewsQuery } }) => {
-                        return viewsQuery.data.map(view => {
-                            if (view.id.toString() != viewId as string) {
-                                return (
-                                    <MenuItem key={ view.id }
-                                        onClick={ () => {
-                                            setJumpMenuAnchor(null);
-                                            onViewSelect(view);
-                                        } }>
-                                        { view.title }
-                                    </MenuItem>
-                                );
-                            }
-                        });
+                        const options = inputValue.length? groupedOptions : viewsQuery.data;
+
+                        return (
+                            <>
+                                <Box { ...getRootProps() }>
+                                    <TextField { ...getInputProps() } />
+                                </Box>
+                                <Box { ...getListboxProps() } style={{ overflowY: 'scroll' }}>
+                                    { options.map(view => {
+                                        if (view.id.toString() != viewId as string) {
+                                            return (
+                                                <MenuItem key={ view.id }
+                                                    onClick={ () => {
+                                                        setJumpMenuAnchor(null);
+                                                        onViewSelect(view);
+                                                    } }>
+                                                    { view.title }
+                                                </MenuItem>
+                                            );
+                                        }
+                                    }) }
+                                </Box>
+                            </>
+                        );
                     } }
                 </ZetkinQuery>
-            </Menu>
+            </Popover>
         </>
     );
 };

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -9,3 +9,6 @@ viewsList:
         title: Title
         created: Date created
         owner: Owner
+layout:
+    jumpMenu:
+        placeholder: Start typing to find view

--- a/src/pages/organize/[orgId]/people/views/[viewId].tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId].tsx
@@ -30,11 +30,11 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
     const orgState = ctx.queryClient.getQueryState(['org', orgId]);
 
     await ctx.queryClient.prefetchQuery(
-        ['views', viewId],
+        ['view', viewId],
         getView(orgId as string, viewId as string, ctx.apiFetch),
     );
 
-    const viewState = ctx.queryClient.getQueryState(['views', viewId]);
+    const viewState = ctx.queryClient.getQueryState(['view', viewId]);
 
     if (orgState?.data && viewState?.data) {
         return {
@@ -59,9 +59,9 @@ type SingleViewPageProps = {
 const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({ orgId, viewId }) => {
     return (
         <ZetkinQuery queries={{
-            colsQuery: useQuery(['views', viewId, 'columns'], getViewColumns(orgId, viewId)),
-            rowsQuery: useQuery(['views', viewId, 'rows'], getViewRows(orgId, viewId)),
-            viewQuery: useQuery(['views', viewId], getView(orgId, viewId)),
+            colsQuery: useQuery(['view', viewId, 'columns'], getViewColumns(orgId, viewId)),
+            rowsQuery: useQuery(['view', viewId, 'rows'], getViewRows(orgId, viewId)),
+            viewQuery: useQuery(['view', viewId], getView(orgId, viewId)),
         }}>
             { ({ queries: { colsQuery, rowsQuery, viewQuery } }) => (
                 <>


### PR DESCRIPTION
## Description
This PR adds a menu which allows the user to quickly jump from one view page to another, without going via the views list page.

Fixes #478

## Screenshots
![image](https://user-images.githubusercontent.com/550212/146410938-837d03f4-d531-4fb9-ada0-942263dd986d.png)

## Changes
* Adds a `ViewJumpMenu` component to the single-view page
  * Click to open menu containing all views (except current one)
  * Type to filter list
  * Click or navigate with keyboard and press enter on view to navigate to that view's page
* Adds a playwright test for the full keyboard navigation workflow
* Changes react-query keys to avoid collisions between single views (`'view', viewId`) and views lists (`'views', orgId`)

## Notes to reviewer
Although we previously discussed to just use the tab key to navigate the list using keyboard, I eventually decided against that, for two reasons. First, navigating out of the `input` caused the auto-complete filter to reset. There may be ways against this that I could have research more thoroughly if it wasn't for the second thing, which is this:

While I was developing and playing with this, I repeatedly pressed the up/down keys to navigate. It's just in muscle memory somehow, and I think it will be for a lot of people, because that's how many components like this one work.