### PR TITLE
Create view from selection

### DIFF
--- a/playwright/tests/organize/people/views/columns/create-column.spec.ts
+++ b/playwright/tests/organize/people/views/columns/create-column.spec.ts
@@ -77,7 +77,7 @@ test.describe('Creating a view column', () => {
         });
 
         // Create new toggle column
-        await page.click('data-testid=create-column-button');
+        await page.click('data-testid=ViewDataTableToolbar-createColumn');
         await page.click('data-testid=column-type-selector-local_bool');
 
         // Check body of request
@@ -95,7 +95,7 @@ test.describe('Creating a view column', () => {
         await page.goto(appUri + '/organize/1/people/views/1');
 
         // Create new toggle column
-        await page.click('data-testid=create-column-button');
+        await page.click('data-testid=ViewDataTableToolbar-createColumn');
         await page.click('data-testid=column-type-selector-local_bool');
 
         expect(await page.locator('data-testid=data-table-error-indicator').count()).toEqual(1);

--- a/playwright/tests/organize/people/views/view-detail.spec.ts
+++ b/playwright/tests/organize/people/views/view-detail.spec.ts
@@ -6,6 +6,7 @@ import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMem
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';
 import KPD from '../../../../mockData/orgs/KPD';
 import NewView from '../../../../mockData/orgs/KPD/people/views/NewView';
+import NewViewColumns from '../../../../mockData/orgs/KPD/people/views/NewView/columns';
 
 test.describe('View detail page', () => {
 
@@ -101,5 +102,102 @@ test.describe('View detail page', () => {
         await removeViewMock();
         await removeRowsMock();
         await removeColsMock();
+    });
+
+    test('create view from selection', async ({ appUri, moxy, page }) => {
+        const removeViewsMock = await moxy.setMock('/orgs/1/people/views', 'get', {
+            data: {
+                data: [ AllMembers, NewView ],
+            },
+            status: 200,
+        });
+        const removeViewMock = await moxy.setMock('/orgs/1/people/views/1', 'get', {
+            data: {
+                data: AllMembers,
+            },
+            status: 200,
+        });
+        const removeRowsMock = await moxy.setMock('/orgs/1/people/views/1/rows', 'get', {
+            data: {
+                data: AllMembersRows,
+            },
+            status: 200,
+        });
+        const removeColsMock = await moxy.setMock('/orgs/1/people/views/1/columns', 'get', {
+            data: {
+                data: AllMembersColumns,
+            },
+            status: 200,
+        });
+        const removePostViewMock = await moxy.setMock('/orgs/1/people/views', 'post', {
+            data: {
+                data: NewView,
+            },
+            status: 203,
+        });
+        const removePostColumnMock = await moxy.setMock(`/orgs/1/people/views/${NewView.id}/columns`, 'post', {
+            data: {
+                data: NewViewColumns[0],
+            },
+            status: 200,
+        });
+        const removePutRow1Mock = await moxy.setMock(`/orgs/1/people/views/${NewView.id}/rows/1`, 'put', {
+            data: {
+                data: {
+                    content: ['Clara', 'Zetkin'],
+                    id: 1,
+                },
+            },
+            status: 200,
+        });
+        const removePutRow2Mock = await moxy.setMock(`/orgs/1/people/views/${NewView.id}/rows/2`, 'put', {
+            data: {
+                data: {
+                    content: ['Clara', 'Zetkin'],
+                    id: 1,
+                },
+            },
+            status: 200,
+        });
+
+
+        await page.goto(appUri + '/organize/1/people/views/1');
+
+        await page.locator('[role=cell] >> input[type=checkbox]').nth(0).click();
+        await page.locator('[role=cell] >> input[type=checkbox]').nth(1).click();
+        await page.click('data-testid=ViewDataTableToolbar-createFromSelection');
+
+        await page.waitForNavigation();
+
+        // Get POST requests for creating new view and columns
+        const { log } = await moxy.logRequests<{title: string}>();
+        const columnPostLogs = log.filter(log => log.path == `/v1/orgs/1/people/views/${NewView.id}/columns` && log.method == 'POST');
+        const viewPostLogs = log.filter(log => log.path == '/v1/orgs/1/people/views' && log.method == 'POST');
+        const rowPutLogs = log.filter(log => log.path.startsWith(`/v1/orgs/1/people/views/${NewView.id}/rows/`) && log.method == 'PUT');
+
+        // Expect requests to be made
+        expect(viewPostLogs).toHaveLength(1);
+        expect(columnPostLogs).toHaveLength(2);
+
+        // Expect that correctly localised strings sent when posting
+        expect(viewPostLogs[0].data?.title).toEqual('New View');
+        expect(columnPostLogs[0].data?.title).toEqual('First name');
+        expect(columnPostLogs[1].data?.title).toEqual('Last name');
+
+        // Expect that the correct rows were added
+        expect(rowPutLogs[0].path).toMatch(/1$/);
+        expect(rowPutLogs[1].path).toMatch(/2$/);
+
+        // Expect that user is navigated to new view's page
+        await expect(page.url()).toEqual(appUri + `/organize/1/people/views/${NewView.id}`);
+
+        await removeViewsMock();
+        await removeViewMock();
+        await removeRowsMock();
+        await removeColsMock();
+        await removePostViewMock();
+        await removePostColumnMock();
+        await removePutRow1Mock();
+        await removePutRow2Mock();
     });
 });

--- a/src/components/views/CreateViewActionButton.tsx
+++ b/src/components/views/CreateViewActionButton.tsx
@@ -45,7 +45,7 @@ const CreateViewActionButton: React.FunctionComponent = () => {
                     data-testid="create-view-action-button"
                     onClick={ () => {
                         NProgress.start();
-                        createNewViewMutation.mutate(undefined);
+                        createNewViewMutation.mutate();
                     } }>
                     <Add />
                 </Fab>

--- a/src/components/views/CreateViewActionButton.tsx
+++ b/src/components/views/CreateViewActionButton.tsx
@@ -45,7 +45,7 @@ const CreateViewActionButton: React.FunctionComponent = () => {
                     data-testid="create-view-action-button"
                     onClick={ () => {
                         NProgress.start();
-                        createNewViewMutation.mutate();
+                        createNewViewMutation.mutate(undefined);
                     } }>
                     <Add />
                 </Fab>
@@ -61,7 +61,7 @@ const CreateViewActionButton: React.FunctionComponent = () => {
                         e.preventDefault();
                         NProgress.start();
                         setErrorDialogOpen(false);
-                        createNewViewMutation.mutate();
+                        createNewViewMutation.mutate(undefined);
                     } }>
                         <SubmitCancelButtons
                             onCancel={ () => setErrorDialogOpen(false) }

--- a/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
@@ -1,16 +1,28 @@
-import { Add } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
+import { Add, Launch } from '@material-ui/icons';
 import { Box, Button } from '@material-ui/core';
+
 
 export interface ViewDataTableToolbarProps {
     onColumnCreate: () => void;
+    onViewCreate: () => void;
+    selection: number[];
 }
 
-const ViewDataTableToolbar: React.FunctionComponent<ViewDataTableToolbarProps> = ({ onColumnCreate }) => {
+const ViewDataTableToolbar: React.FunctionComponent<ViewDataTableToolbarProps> = ({
+    onColumnCreate,
+    onViewCreate,
+    selection,
+}) => {
     return (
         <Box display="flex" justifyContent="flex-end">
-            <Button data-testid="create-column-button" onClick={ onColumnCreate }>
-                <Add /><FormattedMessage id="misc.views.createColumn" />
+            { !!selection.length && (
+                <Button onClick={ onViewCreate } startIcon={ <Launch/> }>
+                    <FormattedMessage id="misc.views.createFromSelection" />
+                </Button>
+            ) }
+            <Button data-testid="create-column-button" onClick={ onColumnCreate } startIcon={ <Add /> }>
+                <FormattedMessage id="misc.views.createColumn" />
             </Button>
         </Box>
     );

--- a/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
@@ -17,7 +17,10 @@ const ViewDataTableToolbar: React.FunctionComponent<ViewDataTableToolbarProps> =
     return (
         <Box display="flex" justifyContent="flex-end">
             { !!selection.length && (
-                <Button onClick={ onViewCreate } startIcon={ <Launch/> }>
+                <Button
+                    data-testid="ViewDataTableToolbar-createFromSelection"
+                    onClick={ onViewCreate }
+                    startIcon={ <Launch/> }>
                     <FormattedMessage id="misc.views.createFromSelection" />
                 </Button>
             ) }

--- a/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
@@ -24,7 +24,10 @@ const ViewDataTableToolbar: React.FunctionComponent<ViewDataTableToolbarProps> =
                     <FormattedMessage id="misc.views.createFromSelection" />
                 </Button>
             ) }
-            <Button data-testid="create-column-button" onClick={ onColumnCreate } startIcon={ <Add /> }>
+            <Button
+                data-testid="ViewDataTableToolbar-createColumn"
+                onClick={ onColumnCreate }
+                startIcon={ <Add /> }>
                 <FormattedMessage id="misc.views.createColumn" />
             </Button>
         </Box>

--- a/src/fetching/views/createNewView.ts
+++ b/src/fetching/views/createNewView.ts
@@ -5,7 +5,7 @@ import { ZetkinView } from 'types/zetkin';
 import { defaultFetch } from '..';
 
 export default function createNewView(orgId: string, fetch = defaultFetch) {
-    return async (rows?: number[]) : Promise<ZetkinView> => {
+    return async (rows?: number[] | void) : Promise<ZetkinView> => {
         const url = `/views/createNew?orgId=${orgId}`;
 
         const res = await fetch(url, {

--- a/src/fetching/views/createNewView.ts
+++ b/src/fetching/views/createNewView.ts
@@ -5,10 +5,13 @@ import { ZetkinView } from 'types/zetkin';
 import { defaultFetch } from '..';
 
 export default function createNewView(orgId: string, fetch = defaultFetch) {
-    return async () : Promise<ZetkinView> => {
+    return async (rows?: number[]) : Promise<ZetkinView> => {
         const url = `/views/createNew?orgId=${orgId}`;
 
         const res = await fetch(url, {
+            body: JSON.stringify({
+                rows: rows || [],
+            }),
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/src/fetching/views/putViewRow.ts
+++ b/src/fetching/views/putViewRow.ts
@@ -1,0 +1,18 @@
+import APIError from 'utils/apiError';
+import { ZetkinViewColumn } from 'types/zetkin';
+
+import { defaultFetch } from '..';
+
+export default function putViewRow(orgId: string, viewId: string | number, fetch = defaultFetch) {
+    return async (personId: string | number) : Promise<ZetkinViewColumn> => {
+        const url = `/orgs/${orgId}/people/views/${viewId}/rows/${personId}`;
+        const res = await fetch(url, {
+            method: 'PUT',
+        });
+        if (!res.ok) {
+            throw new APIError('PUT', url);
+        }
+        const resData = await res.json();
+        return resData.data;
+    };
+}

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -24,6 +24,7 @@ columnDialog:
         survey_response: Response to survey question
         survey_submitted: Date of survey submission
 createColumn: New column
+createFromSelection: Create view from selection
 columnMenu:
     configure: Configure column
     delete: Delete column

--- a/src/pages/api/views/createNew.ts
+++ b/src/pages/api/views/createNew.ts
@@ -5,6 +5,7 @@ import { createApiFetch } from 'utils/apiFetch';
 import { NATIVE_PERSON_FIELDS } from 'types/views';
 import postView from 'fetching/views/postView';
 import postViewColumn from 'fetching/views/postViewColumn';
+import putViewRow from 'fetching/views/putViewRow';
 import { getBrowserLanguage, getMessages } from 'utils/locale';
 
 export default async (
@@ -14,6 +15,7 @@ export default async (
     const {
         query: { orgId },
         method,
+        body,
     } = req;
 
     // Return error if method other than POST
@@ -49,6 +51,14 @@ export default async (
             title: messages['misc.nativePersonFields.last_name'],
             type: COLUMN_TYPE.PERSON_FIELD,
         });
+
+        const { rows } = body;
+        if (rows.length) {
+            const rowsPutMethod = putViewRow(orgId as string, newViewId, apiFetch);
+            for await (const personId of rows) {
+                await rowsPutMethod(personId);
+            }
+        }
 
         res.status(200).json({ data: newView });
     }


### PR DESCRIPTION
## Description
This PR adds functionality to select people in a view and create a new view that will contain the selected people.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/147296394-7985b43b-1465-4c9f-be72-740dfaedd0a1.png)

## Changes
* Augment the `createView` API endpoint to accept a list of rows to add to the created view
* Enable checkbox selection on the view data grid
* Add button to view toolbar to trigger request to `createView` API along with selection
* Integration test for this flow

## Notes to reviewer
Test like this:

1. Navigate to a view with people in it
2. Select at least one person – check that "Create view from selection" button appears in toolbar
3. Click the button and wait for navigation to page of new view – check that selected people are in view

## Related issues
Resolves #476 