### PR TITLE
Dark mode

### DIFF
--- a/src/components/views/ViewColumnDialog/index.tsx
+++ b/src/components/views/ViewColumnDialog/index.tsx
@@ -4,7 +4,7 @@ import { FunctionComponent, useState } from 'react';
 
 import ColumnEditor from './ColumnEditor';
 import ColumnGallery from './ColumnGallery';
-import theme from 'theme';
+import { lightTheme } from 'theme';
 import ZetkinDialog from 'components/ZetkinDialog';
 import { COLUMN_TYPE, SelectedViewColumn } from 'types/views';
 
@@ -22,7 +22,7 @@ interface ViewColumnDialogProps {
 }
 
 const ViewColumnDialog : FunctionComponent<ViewColumnDialogProps> = ({ selectedColumn, onCancel, onSave }) => {
-    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const isMobile = useMediaQuery(lightTheme.breakpoints.down('sm'));
     const intl = useIntl();
     const [column, setColumn] = useState<SelectedViewColumn>(selectedColumn || {});
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,9 +16,9 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
+import { lightTheme } from '../theme';
 import { LocalTimeToJsonPlugin } from '../utils/dateUtils';
 import { PageWithLayout } from '../types';
-import theme from '../theme';
 import { UserContext } from '../hooks';
 
 dayjs.extend(LocalTimeToJsonPlugin);
@@ -68,7 +68,7 @@ function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
 
     return (
         <UserContext.Provider value={ pageProps.user }>
-            <ThemeProvider theme={ theme }>
+            <ThemeProvider theme={ lightTheme }>
                 <MuiPickersUtilsProvider libInstance={ dayjs } utils={ DateUtils }>
                     <IntlProvider
                         defaultLocale="en"

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,10 +16,11 @@ import { ThemeProvider } from '@material-ui/core/styles';
 import { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { lightTheme } from '../theme';
 import { LocalTimeToJsonPlugin } from '../utils/dateUtils';
 import { PageWithLayout } from '../types';
+import { useMediaQuery } from '@material-ui/core';
 import { UserContext } from '../hooks';
+import { darkTheme, lightTheme } from '../theme';
 
 dayjs.extend(LocalTimeToJsonPlugin);
 dayjs.extend(isoWeek);
@@ -58,6 +59,8 @@ function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
         window.__reactRendered = true;
     }
 
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
     useEffect(() => {
         // Remove the server-side injected CSS.
         const jssStyles = document.querySelector('#jss-server-side');
@@ -68,7 +71,7 @@ function MyApp({ Component, pageProps } : AppProps) : JSX.Element {
 
     return (
         <UserContext.Provider value={ pageProps.user }>
-            <ThemeProvider theme={ lightTheme }>
+            <ThemeProvider theme={ prefersDarkMode? darkTheme : lightTheme }>
                 <MuiPickersUtilsProvider libInstance={ dayjs } utils={ DateUtils }>
                     <IntlProvider
                         defaultLocale="en"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,6 @@
 import { Children } from 'react';
+import { lightTheme } from '../theme';
 import { ServerStyleSheets } from '@material-ui/core/styles';
-import theme from '../theme';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
 // boilerplate page taken from https://github.com/mui-org/material-ui/tree/master/examples/nextjs
@@ -11,7 +11,7 @@ export default class MyDocument extends Document {
             <Html lang="en">
                 <Head>
                     { /* PWA primary color */ }
-                    <meta content={ theme.palette.primary.main } name="theme-color" />
+                    <meta content={ lightTheme.palette.primary.main } name="theme-color" />
                     <script src="https://use.typekit.net/tqq3ylv.js"></script>
                     <script>{ 'try{Typekit.load({ async: true })}catch(e){}' }</script>
                     <link href="/logo-zetkin.png" rel="shortcut icon" />

--- a/src/test-utils/index.tsx
+++ b/src/test-utils/index.tsx
@@ -8,9 +8,9 @@ import { FC, ReactElement } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
 
+import { lightTheme } from 'theme';
 import { LocalTimeToJsonPlugin } from 'utils/dateUtils';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import theme from 'theme';
 import { UserContext } from 'hooks';
 
 dayjs.extend(LocalTimeToJsonPlugin);
@@ -27,7 +27,7 @@ const ZetkinAppProviders: FC = ({ children }) => {
 
     return (
         <UserContext.Provider value={ null }>
-            <ThemeProvider theme={ theme }>
+            <ThemeProvider theme={ lightTheme }>
                 <MuiPickersUtilsProvider libInstance={ dayjs } utils={ DateUtils }>
                     <IntlProvider
                         defaultLocale="en"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,7 @@
 import { createElement } from 'react';
-import { createTheme } from '@material-ui/core/styles';
+import { createTheme, ThemeOptions } from '@material-ui/core/styles';
 
-// Create a theme instance.
-const theme = createTheme({
+const baseTheme: ThemeOptions = {
     overrides: {
         MuiButton: {
             root: {
@@ -105,6 +104,19 @@ const theme = createTheme({
             fontWeight: 'lighter',
         },
     },
+};
+
+const lightTheme = createTheme(baseTheme);
+const darkTheme = createTheme(baseTheme, {
+    palette: {
+        background: {
+            default: '#222222',
+        },
+        text: {
+            secondary: '#eeeeee',
+        },
+        type: 'dark',
+    },
 });
 
-export default theme;
+export { darkTheme, lightTheme };


### PR DESCRIPTION
## Description
This PR adds dark mode, using a second theme and a media query to automatically switch between the two based on browser/OS settings.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/147450362-2fc23157-eb89-4342-a606-d258832b474f.png)
![image](https://user-images.githubusercontent.com/550212/147450396-36bf4cac-ad71-49ae-84f0-95001072c978.png)

## Changes
* Create separate `lightTheme` and `darkTheme`, both based on a common `baseTheme`
* Use `useMediaQuery()` to automatically switch between the two

## Notes to reviewer
This can be tested using the emulation setting in Chrome (probably other browsers as well), enabled like this: https://stackoverflow.com/a/59223868/229824
