### PR TITLE
Optional environment variable for playwright worker count

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ const config: PlaywrightTestConfig = {
     globalSetup: './playwright/globalSetup.ts',
     globalTeardown: './playwright/globalTeardown.ts',
     testDir: './playwright',
-    workers: 4,
+    workers: parseInt(process.env.PLAYWRIGHT_WORKERS as string) || 4,
 };
 
 export default config;


### PR DESCRIPTION
## Description
This PR adds an environment variable that can be used to change the number of workers used when running the playwright tests. On my machine, which is quite slow, running 4 tests in parallel causes many tests to time out, so I need to run a smaller number of workers (1 or 2).

This change will let me (and others) do that, without manually modifying the `playwright.config.ts` configuration ahead of each run.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/147816385-90390fe9-9ebb-492c-b767-693e86b6e34d.png)


## Changes
* Add an optional environment variable `PLAYWRIGHT_WORKERS` to configure worker count

## Notes to reviewer
Test it by running `PLAYWRIGHT_WORKERS=3 yarn playwright` and make sure that the number of workers is 3.
