### PR TITLE
Make orgId dynamic in avatar url

### DIFF
--- a/src/components/views/ViewDataTable/index.tsx
+++ b/src/components/views/ViewDataTable/index.tsx
@@ -161,7 +161,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({ columns, rows, v
         filterable: false,
         headerName: ' ',
         renderCell: (params) => {
-            const url = `/api/orgs/1/people/${params.value}/avatar`;
+            const url = `/api/orgs/${orgId}/people/${params.value}/avatar`;
             return (
                 <img
                     alt="Avatar"


### PR DESCRIPTION
## Description
Fixes a very small bug which hardcoded the org id in the URL for the avatar in a view data table.

## Related issues
Resolves #527 
