### PR TITLE
Adding people to view

### DIFF
--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import nProgress from 'nprogress';
 import { QueryState } from 'react-query/types/core/query';
 import { QueryClient, useMutation, UseMutationOptions, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from 'react-query';
@@ -8,7 +9,7 @@ import handleResponseData from './handleResponseData';
 import { ScaffoldedContext } from 'utils/next';
 
 
-const makeUseMutationOptions = <Input, Result>(
+export const makeUseMutationOptions = <Input, Result>(
     queryClient: QueryClient,
     key: string[],
     mutationOptions?: UseMutationOptions<Result, unknown, Input, unknown>,

--- a/src/api/viewRows.ts
+++ b/src/api/viewRows.ts
@@ -1,0 +1,37 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { defaultFetch } from 'fetching';
+import handleResponseData from './utils/handleResponseData';
+import { makeUseMutationOptions } from './utils/resourceHookFactories';
+import { useMutation, useQueryClient } from 'react-query';
+import { ZetkinPerson, ZetkinViewRow } from 'types/zetkin';
+
+
+export const viewRowsResource = (orgId: number, viewId: string) => {
+    const key = ['view', viewId, 'rows'];
+    const rowsUrl = `/orgs/${orgId}/people/views/${viewId}/rows`;
+
+    return {
+        useAdd: () => {
+            const queryClient = useQueryClient();
+
+            const handler = async (personId: ZetkinPerson['id']): Promise<ZetkinViewRow> => {
+                const res = await defaultFetch(`${rowsUrl}/${personId}`, {
+                    method: 'PUT',
+                });
+                return handleResponseData(res, 'PUT');
+            };
+
+            return useMutation(handler, makeUseMutationOptions(queryClient, key, {
+                onSuccess: (newRow) => {
+                    if (newRow) {
+                        // Add created row directly to view, to avoid waiting for entire collection to reload
+                        const prevRows: ZetkinViewRow[] = queryClient.getQueryData<ZetkinViewRow[]>(key) || [];
+                        const allRows = prevRows.concat([newRow as ZetkinViewRow]);
+                        queryClient.setQueryData(key, allRows);
+                    }
+                },
+            }));
+        },
+    };
+};

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
 import { Avatar, Box, TextField, Typography } from '@material-ui/core';
-import React, { FunctionComponent, ReactElement, useEffect, useState } from 'react';
+import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useState } from 'react';
 
 import getPeopleSearchResults from 'fetching/getPeopleSearchResults';
 import useDebounce from 'hooks/useDebounce';
@@ -12,6 +12,7 @@ import { ZetkinPerson } from 'types/zetkin';
 
 
 interface UsePersonSelectProps {
+    inputRef?: MutableRefObject<HTMLInputElement | undefined> | undefined;
     label?: string;
     name?: string;
     onChange: (person: ZetkinPerson) => void;
@@ -25,6 +26,7 @@ interface UsePersonSelectReturn {
         getOptionLabel: (person: ZetkinPerson) => string;
         getOptionSelected: (option: ZetkinPerson, value: ZetkinPerson) => boolean;
         getOptionValue: (person: ZetkinPerson) => unknown;
+        inputRef: MutableRefObject<HTMLInputElement | undefined> | undefined;
         label: string | undefined;
         name: string;
         noOptionsText: string;
@@ -42,6 +44,7 @@ type UsePersonSelect = (props: UsePersonSelectProps) => UsePersonSelectReturn;
 type PersonSelectProps = UsePersonSelectProps;
 
 const usePersonSelect: UsePersonSelect = ({
+    inputRef,
     label,
     name,
     onChange,
@@ -91,6 +94,7 @@ const usePersonSelect: UsePersonSelect = ({
             getOptionLabel: (person: ZetkinPerson) => person.first_name? `${person.first_name} ${person.last_name}` : '',
             getOptionSelected: (option: ZetkinPerson, value: ZetkinPerson) => option?.id == value?.id,
             getOptionValue: (person: ZetkinPerson) => person.id || null,
+            inputRef,
             label,
             name: name || '',
             noOptionsText: searchLabel,
@@ -142,6 +146,7 @@ const MUIOnlyPersonSelect: FunctionComponent<PersonSelectProps> = (props) => {
     const {
         name,
         placeholder,
+        inputRef,
         ...restProps
     } = autoCompleteProps;
 
@@ -154,6 +159,7 @@ const MUIOnlyPersonSelect: FunctionComponent<PersonSelectProps> = (props) => {
                     inputProps={{
                         ...params.inputProps,
                     }}
+                    inputRef={ inputRef }
                     name={ name }
                     placeholder={ placeholder }
                     variant="outlined"

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -29,7 +29,7 @@ interface UsePersonSelectReturn {
         getOptionDisabled?: (option: ZetkinPerson) => boolean;
         getOptionLabel: (person: ZetkinPerson) => string;
         getOptionSelected: (option: ZetkinPerson, value: ZetkinPerson) => boolean;
-        getOptionValue: (person: ZetkinPerson) => unknown;
+        getOptionValue?: (person: ZetkinPerson) => unknown;
         inputRef: MutableRefObject<HTMLInputElement | undefined> | undefined;
         label: string | undefined;
         name: string;
@@ -155,6 +155,8 @@ const MUIOnlyPersonSelect: FunctionComponent<PersonSelectProps> = (props) => {
         inputRef,
         ...restProps
     } = autoCompleteProps;
+
+    delete restProps.getOptionValue;
 
     return (
         <MUIAutocomplete

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -1,14 +1,15 @@
 import { Autocomplete as MUIAutocomplete } from '@material-ui/lab';
 import { Autocomplete as RFFAutocomplete } from 'mui-rff';
+import { TextField } from '@material-ui/core';
 import { useIntl } from 'react-intl';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
-import { Avatar, Box, TextField, Typography } from '@material-ui/core';
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useState } from 'react';
 
 import getPeopleSearchResults from 'fetching/getPeopleSearchResults';
 import useDebounce from 'hooks/useDebounce';
 import { ZetkinPerson } from 'types/zetkin';
+import ZetkinPersonComponent from 'components/ZetkinPerson';
 
 
 interface UsePersonSelectProps {
@@ -116,23 +117,11 @@ const usePersonSelect: UsePersonSelect = ({
                 const extraLabel = getOptionExtraLabel? getOptionExtraLabel(person) : null;
 
                 return (
-                    <Box alignItems="center" display="flex">
-                        <Box m={ 1 }>
-                            <Avatar
-                                src={ `/api/orgs/${orgId}/people/${person.id}/avatar` }>
-                            </Avatar>
-                        </Box>
-                        <Box display="flex" flexDirection="column" justifyContent="center">
-                            <Typography>
-                                { `${ person.first_name } ${ person.last_name }` }
-                            </Typography>
-                            { extraLabel && (
-                                <Typography variant="caption">
-                                    { extraLabel }
-                                </Typography>
-                            ) }
-                        </Box>
-                    </Box>
+                    <ZetkinPersonComponent
+                        id={ person.id }
+                        name={ `${ person.first_name } ${ person.last_name }` }
+                        subtitle={ extraLabel }
+                    />
                 );
             },
             value: selectedPerson,

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -12,6 +12,7 @@ import { ZetkinPerson } from 'types/zetkin';
 
 
 interface UsePersonSelectProps {
+    getOptionDisabled?: (option: ZetkinPerson) => boolean;
     inputRef?: MutableRefObject<HTMLInputElement | undefined> | undefined;
     label?: string;
     name?: string;
@@ -23,6 +24,7 @@ interface UsePersonSelectProps {
 interface UsePersonSelectReturn {
     autoCompleteProps: {
         filterOptions: (options: ZetkinPerson[]) => ZetkinPerson[];
+        getOptionDisabled?: (option: ZetkinPerson) => boolean;
         getOptionLabel: (person: ZetkinPerson) => string;
         getOptionSelected: (option: ZetkinPerson, value: ZetkinPerson) => boolean;
         getOptionValue: (person: ZetkinPerson) => unknown;
@@ -44,6 +46,7 @@ type UsePersonSelect = (props: UsePersonSelectProps) => UsePersonSelectReturn;
 type PersonSelectProps = UsePersonSelectProps;
 
 const usePersonSelect: UsePersonSelect = ({
+    getOptionDisabled,
     inputRef,
     label,
     name,
@@ -91,6 +94,7 @@ const usePersonSelect: UsePersonSelect = ({
     return {
         autoCompleteProps: {
             filterOptions: options => options,
+            getOptionDisabled,
             getOptionLabel: (person: ZetkinPerson) => person.first_name? `${person.first_name} ${person.last_name}` : '',
             getOptionSelected: (option: ZetkinPerson, value: ZetkinPerson) => option?.id == value?.id,
             getOptionValue: (person: ZetkinPerson) => person.id || null,

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -13,6 +13,7 @@ import { ZetkinPerson } from 'types/zetkin';
 
 interface UsePersonSelectProps {
     getOptionDisabled?: (option: ZetkinPerson) => boolean;
+    getOptionExtraLabel?: (option: ZetkinPerson) => string;
     inputRef?: MutableRefObject<HTMLInputElement | undefined> | undefined;
     label?: string;
     name?: string;
@@ -47,6 +48,7 @@ type PersonSelectProps = UsePersonSelectProps;
 
 const usePersonSelect: UsePersonSelect = ({
     getOptionDisabled,
+    getOptionExtraLabel,
     inputRef,
     label,
     name,
@@ -110,18 +112,29 @@ const usePersonSelect: UsePersonSelect = ({
             },
             options: personOptions,
             placeholder,
-            renderOption: (person: ZetkinPerson) => (
-                <Box alignItems="center" display="flex">
-                    <Box m={ 1 }>
-                        <Avatar
-                            src={ `/api/orgs/${orgId}/people/${person.id}/avatar` }>
-                        </Avatar>
+            renderOption: (person: ZetkinPerson) => {
+                const extraLabel = getOptionExtraLabel? getOptionExtraLabel(person) : null;
+
+                return (
+                    <Box alignItems="center" display="flex">
+                        <Box m={ 1 }>
+                            <Avatar
+                                src={ `/api/orgs/${orgId}/people/${person.id}/avatar` }>
+                            </Avatar>
+                        </Box>
+                        <Box display="flex" flexDirection="column" justifyContent="center">
+                            <Typography>
+                                { `${ person.first_name } ${ person.last_name }` }
+                            </Typography>
+                            { extraLabel && (
+                                <Typography variant="caption">
+                                    { extraLabel }
+                                </Typography>
+                            ) }
+                        </Box>
                     </Box>
-                    <Typography>
-                        { `${ person.first_name } ${ person.last_name }` }
-                    </Typography>
-                </Box>
-            ),
+                );
+            },
             value: selectedPerson,
         },
     };

--- a/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@material-ui/core';
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useRef } from 'react';
 
 import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
 import { useIntl } from 'react-intl';
@@ -12,18 +12,20 @@ export interface ViewDataTableFooterProps {
 
 const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({ onRowAdd }) => {
     const intl = useIntl();
-    const [key, setKey] = useState(1);
+    const selectInputRef = useRef<HTMLInputElement>();
 
     return (
         <Box p={ 1 }>
             <PersonSelect
-                key={ key }
+                inputRef={ selectInputRef }
                 name="person"
                 onChange={ person => {
                     onRowAdd(person);
 
-                    // Change the key to force the PersonSelect to reset
-                    setKey(key + 1);
+                    // Blur and re-focus input to reset, so that user can type again to
+                    // add another person, without taking their hands off the keyboard.
+                    selectInputRef?.current?.blur();
+                    selectInputRef?.current?.focus();
                 } }
                 placeholder={ intl.formatMessage({ id: 'misc.views.footer.addPlaceholder' }) }
                 selectedPerson={ null }

--- a/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
@@ -1,22 +1,35 @@
 import { Box } from '@material-ui/core';
 import { FunctionComponent, useRef } from 'react';
 
+import getViewRows from 'fetching/views/getViewRows';
 import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
 import { useIntl } from 'react-intl';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
 import { ZetkinPerson } from 'types/zetkin';
 
 
 export interface ViewDataTableFooterProps {
     onRowAdd: (person: ZetkinPerson) => void;
+    viewId: string;
 }
 
-const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({ onRowAdd }) => {
+const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({ onRowAdd, viewId }) => {
+    const { orgId } = useRouter().query;
     const intl = useIntl();
     const selectInputRef = useRef<HTMLInputElement>();
+
+    const rowsQuery = useQuery(['view', viewId, 'rows'], getViewRows(orgId as string, viewId));
+    const rows = rowsQuery.data || [];
 
     return (
         <Box p={ 1 }>
             <PersonSelect
+                getOptionDisabled={ option => rows.some(row => row.id == option.id) }
+                getOptionExtraLabel={ option => {
+                    return (rows.some(row => row.id == option.id))?
+                        intl.formatMessage({ id: 'misc.views.footer.alreadyInView' }) : '';
+                } }
                 inputRef={ selectInputRef }
                 name="person"
                 onChange={ person => {

--- a/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
@@ -1,0 +1,35 @@
+import { Box } from '@material-ui/core';
+import { FunctionComponent, useState } from 'react';
+
+import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
+import { useIntl } from 'react-intl';
+import { ZetkinPerson } from 'types/zetkin';
+
+
+export interface ViewDataTableFooterProps {
+    onRowAdd: (person: ZetkinPerson) => void;
+}
+
+const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({ onRowAdd }) => {
+    const intl = useIntl();
+    const [key, setKey] = useState(1);
+
+    return (
+        <Box p={ 1 }>
+            <PersonSelect
+                key={ key }
+                name="person"
+                onChange={ person => {
+                    onRowAdd(person);
+
+                    // Change the key to force the PersonSelect to reset
+                    setKey(key + 1);
+                } }
+                placeholder={ intl.formatMessage({ id: 'misc.views.footer.addPlaceholder' }) }
+                selectedPerson={ null }
+            />
+        </Box>
+    );
+};
+
+export default ViewDataTableFooter;

--- a/src/components/views/ViewDataTable/index.tsx
+++ b/src/components/views/ViewDataTable/index.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react';
 import NProgress from 'nprogress';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColDef, useGridApiRef } from '@mui/x-data-grid-pro';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { makeStyles, Snackbar } from '@material-ui/core';
 import { useMutation, useQueryClient } from 'react-query';
@@ -48,6 +48,7 @@ interface ViewDataTableProps {
 const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({ columns, rows, view }) => {
     const intl = useIntl();
     const classes = useStyles();
+    const gridApiRef = useGridApiRef();
     const [addedId, setAddedId] = useState(0);
     const [columnToConfigure, setColumnToConfigure] = useState<SelectedViewColumn | null>(null);
     const [columnToRename, setColumnToRename] = useState<ZetkinViewColumn | null>(null);
@@ -114,6 +115,18 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({ columns, rows, v
 
             // Store ID for highlighting the new row
             setAddedId(person.id);
+
+            // Remove ID again after 2 seconds, unless the state has changed
+            setTimeout(() => {
+                setAddedId(curState => (curState == person.id)? 0 : curState);
+            }, 2000);
+
+            // Scroll (jump) to row after short delay
+            setTimeout(() => {
+                const gridApi = gridApiRef.current;
+                const rowIndex = gridApi.getRowIndex(person.id);
+                gridApi.scrollToIndexes({ rowIndex });
+            }, 200);
         },
     });
 
@@ -277,6 +290,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({ columns, rows, v
     return (
         <>
             <DataGridPro
+                apiRef={ gridApiRef }
                 autoHeight={ empty }
                 checkboxSelection={ true }
                 columns={ gridColumns }

--- a/src/components/views/ViewDataTable/index.tsx
+++ b/src/components/views/ViewDataTable/index.tsx
@@ -276,6 +276,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({ columns, rows, v
             onRowAdd: person => {
                 addRowMutation.mutate(person);
             },
+            viewId,
         },
         toolbar: {
             onColumnCreate,

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -47,6 +47,8 @@ empty:
     static:
         description: Add the first person to create a static view where people are added and removed manually.
         headline: Add people manually
+footer:
+    addPlaceholder: Start typing to add person to view
 newViewFields:
     title: New View
 dataTableErrors:

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -49,6 +49,7 @@ empty:
         headline: Add people manually
 footer:
     addPlaceholder: Start typing to add person to view
+    alreadyInView: Already in view
 newViewFields:
     title: New View
 dataTableErrors:


### PR DESCRIPTION
## Description
This PR adds UI to append rows to a static, non-empty view. It builds on the functionality introduced in #518 for adding the first row to an empty view, and uses the same widget in the footer of a view to add more rows after the first one.

## Screenshots
![addtoview](https://user-images.githubusercontent.com/550212/148074743-0d3b53cd-fdee-41a1-ae4b-618aa1bccaa0.gif)

## Changes
* Add widget to bottom of views for adding people to the view
  * Reuse `PersonSelect` (introduced in #518)
  * Only show widget on static views
  * Disable options (people) that are already in the view
  * Highlight and scroll to recently added row
  * Re-focus widget after adding (which is nice for adding multiple people in rapid succession)
* Add test to confirm that adding people to view works

## Notes to reviewer
Test by navigating to view 1 from the dummy data ("My View", [link to localhost](http://localhost:3000/organize/1/people/views/1)). Because it's a "static view", at the bottom there will be a `PersonSelect` widget to pick a person to be added to the view.

A dynamic view (e.g. "My View", [link to localhost](http://localhost:3000/organize/1/people/views/1)) will not have the widget, since people can not be added manually to such a view.

## Related issues
Resolves #475 
