### PR TITLE
Issues 538 & 539:  hide watch video task type, fix bug not sending config

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "jest": "^27.2.4",
-        "moxy": "^0.1.1",
+        "moxy": "^0.1.2",
         "next-compose-plugins": "^2.2.0",
         "next-router-mock": "^0.5.2",
         "next-transpile-modules": "^4.1.0",

--- a/playwright/fixtures/next.ts
+++ b/playwright/fixtures/next.ts
@@ -8,7 +8,7 @@ import next from 'next';
 import { parse } from 'url';
 import path from 'path';
 import { createServer, Server } from 'http';
-import moxy, { HTTPMethod, MockResponseSetter, Moxy } from 'moxy';
+import moxy, { HTTPMethod, LoggedRequest, MockResponseSetter, Moxy } from 'moxy';
 
 import RosaLuxemburg from '../mockData/users/RosaLuxemburg';
 import { ZetkinSession, ZetkinUser } from '../../src/types/zetkin';
@@ -28,7 +28,10 @@ export interface NextWorkerFixtures {
             data?: G,
             status?: MockResponseSetter['status'],
             headers?: MockResponseSetter['headers'],
-        ) => () => void;
+        ) => {
+            log: <T>() => LoggedRequest<T, { data: G }>[];
+            removeMock: () => void;
+        };
         teardown: () => void;
     } & Omit<Moxy, 'start' | 'stop'>;
 }

--- a/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
+++ b/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
@@ -1,0 +1,35 @@
+import { ZetkinTask } from '../../../../../../../src/types/zetkin';
+import { TASK_TYPE, VisitLinkConfig } from '../../../../../../../src/types/tasks';
+
+import KPD from '../../..';
+import ReferendumSignatureCollection from '..';
+
+/**
+ * ZetkinTask
+ *
+ * - Visit Link Task
+ * - No publish date, no expires and no deadline
+ */
+const VisitReferendumWebsite: ZetkinTask<VisitLinkConfig> = {
+    campaign: {
+        id: ReferendumSignatureCollection.id,
+        title: ReferendumSignatureCollection.title,
+    },
+    config: {
+        url: 'https://meingrundeinkommen.de',
+    },
+    id: 2,
+    instructions: `
+    Visit this website to learn more about the referendum
+    `,
+    organization: KPD,
+    target: {
+        filter_spec: [],
+        id: 2,
+    },
+    time_estimate: null,
+    title: 'Learn more about the referrendum',
+    type: TASK_TYPE.VISIT_LINK,
+};
+
+export default VisitReferendumWebsite;

--- a/playwright/tests/organize/campaign-detail/action-buttons.spec.ts
+++ b/playwright/tests/organize/campaign-detail/action-buttons.spec.ts
@@ -68,7 +68,7 @@ test.describe('Campaign action buttons', async () => {
         });
 
         test('shows error alert if server error on request', async ({ appUri, page, moxy }) => {
-            const removePatchTaskMock =  moxy.setZetkinApiMock('/orgs/1/campaigns/1', 'patch', {}, 401);
+            moxy.setZetkinApiMock('/orgs/1/campaigns/1', 'patch', {}, 401);
 
             await page.goto(appUri + '/organize/1/campaigns/1');
 
@@ -82,8 +82,6 @@ test.describe('Campaign action buttons', async () => {
 
             // Check that alert shows
             await expect(page.locator('data-testid=error-alert')).toBeVisible();
-
-            await removePatchTaskMock();
         });
     });
 });

--- a/playwright/tests/organize/campaign-detail/speed-dial.spec.ts
+++ b/playwright/tests/organize/campaign-detail/speed-dial.spec.ts
@@ -4,7 +4,7 @@ import test from '../../../fixtures/next';
 import KPD from '../../../mockData/orgs/KPD';
 import ReferendumSignatures  from '../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import SpeakToFriend from '../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
-import { VisitLinkConfig } from 'types/tasks';
+import { VisitLinkConfig } from '../../../../src/types/tasks';
 import VisitReferendumWebsite from '../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite';
 
 test.describe('Single campaign page speed dial', () => {
@@ -76,7 +76,7 @@ test.describe('Single campaign page speed dial', () => {
         });
 
         test('shows error alert when response error', async ({ page, moxy, appUri }) => {
-            moxy.setZetkinApiMock('/orgs/1/tasks', 'post', {}, 400);
+            moxy.setZetkinApiMock('/orgs/1/tasks', 'post', undefined, 400);
 
             await page.goto(appUri + '/organize/1/campaigns/1#create-task');
 

--- a/src/components/ZetkinSpeedDial/actions/createTask.tsx
+++ b/src/components/ZetkinSpeedDial/actions/createTask.tsx
@@ -21,7 +21,6 @@ const DialogContent: React.FunctionComponent<DialogContentBaseProps> = ({ closeD
         // Set defaults for config and target_filters
         const body: ZetkinTaskRequestBody = {
             ...task,
-            config: {},
             target_filters: [],
         };
         await sendTaskRequest(body, {

--- a/src/components/forms/TaskDetailsForm/index.tsx
+++ b/src/components/forms/TaskDetailsForm/index.tsx
@@ -174,9 +174,9 @@ const TaskDetailsForm = ({ onSubmit, onCancel, task }: TaskDetailsFormProps): JS
                         <MenuItem value={ TASK_TYPE.VISIT_LINK }>
                             <FormattedMessage id="misc.tasks.forms.createTask.fields.types.visit_link" />
                         </MenuItem>
-                        <MenuItem value={ TASK_TYPE.WATCH_VIDEO }>
+                        { /* <MenuItem value={ TASK_TYPE.WATCH_VIDEO }>
                             <FormattedMessage id="misc.tasks.forms.createTask.fields.types.watch_video" />
-                        </MenuItem>
+                        </MenuItem> */ }
                         <MenuItem value={ TASK_TYPE.COLLECT_DEMOGRAPHICS }>
                             <FormattedMessage id="misc.tasks.forms.createTask.fields.types.demographic" />
                         </MenuItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4903,10 +4903,10 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-moxy@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/moxy/-/moxy-0.1.1.tgz#b486ad4a318a1f4b0a36fe1350f406c0d29b4cf8"
-  integrity sha512-a7fMfbtfS7peyqut3w0KCo2SFY4lgupe4Jy8NNLUWqCP5b3S9XlSEDM7O0oA6n/NU0h6LohbKaRyYsoQbA08hQ==
+moxy@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/moxy/-/moxy-0.1.2.tgz#d8a25ec03c4531a83d0f1f3b01a85319244257b4"
+  integrity sha512-383YEqihqO1ZpW+6HYf3ErIeO58PtVX+H+PKopu4clGC3LQEGdkut0u3GtrZe2aNYqV/w7eTxB5iDhEeScArDg==
   dependencies:
     body-parser "^1.19.0"
     command-line-args "^5.1.1"


### PR DESCRIPTION
## Changes
- Removes `TASK_TYPE.WATCH_VIDEO` from list of available task types in the task details form
- Fixes bug that sends an empty config when creating a new task
  - Adds playwright test to confirm that config is sent in the post request when creating a task.
  - Uses updated moxy. This moxy PR has been merged and published: https://github.com/zetkin/moxy/pull/9

## Related issues
Resolves #539, #538 
