### PR TITLE
Issue 504 / Add confirm modal when deleting local view

### DIFF
--- a/playwright/tests/organize/people/views/columns/delete-column.spec.ts
+++ b/playwright/tests/organize/people/views/columns/delete-column.spec.ts
@@ -20,7 +20,6 @@ test.describe('Deleting a view column', () => {
         moxy.teardown();
     });
 
-
     test('the user can delete an existing column', async ({ page, appUri, moxy }) => {
         moxy.setZetkinApiMock(`/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`, 'delete');
 
@@ -38,7 +37,7 @@ test.describe('Deleting a view column', () => {
         expect(columnDeleteRequest).not.toEqual(undefined);
     });
 
-    test('shows an error modal if there is an error renaming the column', async ({ page, appUri, moxy }) => {
+    test('shows an error modal if there is an error deleting the column', async ({ page, appUri, moxy }) => {
         moxy.setZetkinApiMock(`/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`, 'delete', undefined, 400);
 
         await page.goto(appUri + '/organize/1/people/views/1');
@@ -50,4 +49,21 @@ test.describe('Deleting a view column', () => {
         expect(await page.locator('data-testid=Snackbar-error').count()).toEqual(1);
     });
 
+    test('the user must confirm deletion of a column with local data', async ({ page, appUri, moxy }) => {
+        moxy.setZetkinApiMock(`/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`, 'delete');
+
+        await page.goto(appUri + '/organize/1/people/views/1');
+
+        // Delete first column
+        await page.click('button[aria-label="Menu"]:right-of(:text("Active"))', { force: true });
+        await page.click(`data-testid=delete-column-button-col_${AllMembersColumns[2].id}`);
+        await page.click('button > :text("Confirm")');
+
+        // Check body of request
+        const columnDeleteRequest = moxy.log().find(mock =>
+            mock.method === 'DELETE' &&
+            mock.path === `/v1/orgs/1/people/views/1/columns/${AllMembersColumns[2].id}`,
+        );
+        expect(columnDeleteRequest).not.toEqual(undefined);
+    });
 });

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -28,6 +28,9 @@ createFromSelection: Create view from selection
 columnMenu:
     configure: Configure column
     delete: Delete column
+    confirmDelete: >-
+        Are you sure you want to remove this column? It contains data 
+        that will be permanently deleted. This action can not be undone.
     rename: Rename column
 columnRenameDialog:
     title: Title


### PR DESCRIPTION
## Description
Shows a confirm modal when deleting a column with local data. 
## Screenshots
![dialog](https://user-images.githubusercontent.com/41007222/151995542-0c25e96e-280d-49a9-af99-bb073d595286.png)


## Changes
* Adds: Confirm modal when deleting a column with local data
* Adds: New localised string for the warning text
* Adds: Test that user must click "confirm" and that delete request is made


## Notes to reviewer
* Check that deleting a local column shows the confirm modal and confirming deletes the column
* Check that deleting any other type of column just deletes automatically.


## Related issues
Resolves #504 
