### PR TITLE
Recurring tasks

### DIFF
--- a/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend.ts
+++ b/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend.ts
@@ -23,6 +23,8 @@ const SpeakToFriendAboutReferendum: ZetkinTask = {
     reducing homelessness.
     `,
   organization: KPD,
+  reassign_interval: null,
+  reassign_limit: null,
   target: {
     filter_spec: [],
     id: 1,

--- a/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
+++ b/playwright/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
@@ -26,6 +26,8 @@ const VisitReferendumWebsite: ZetkinTask<VisitLinkConfig> = {
     Visit this website to learn more about the referendum
     `,
   organization: KPD,
+  reassign_interval: null,
+  reassign_limit: null,
   target: {
     filter_spec: [],
     id: 2,

--- a/src/components/forms/TaskDetailsForm/constants.ts
+++ b/src/components/forms/TaskDetailsForm/constants.ts
@@ -7,10 +7,13 @@ export enum TASK_DETAILS_FIELDS {
   PUBLISHED = 'published',
   DEADLINE = 'deadline',
   EXPIRES = 'expires',
+  REASSIGN_INTERVAL = 'reassign_interval',
+  REASSIGN_LIMIT = 'reassign_limit',
   TIME_ESTIMATE = 'time_estimate',
 }
 
 export const DEFAULT_TIME_ESTIMATE = 'noEstimate'; // Gets mapped to null when saving if this is selected value
+export const DEFAULT_REASSIGN_INTERVAL = 'noInterval'; // Gets mapped to null when saving if this is selected value
 
 export enum SHARE_LINK_FIELDS {
   DEFAULT_MESSAGE = 'config.default_message',

--- a/src/components/forms/TaskDetailsForm/fields/ReassignFields.tsx
+++ b/src/components/forms/TaskDetailsForm/fields/ReassignFields.tsx
@@ -1,0 +1,84 @@
+import { MenuItem } from '@material-ui/core';
+import { TextField } from 'mui-rff';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
+
+import { DEFAULT_REASSIGN_INTERVAL, TASK_DETAILS_FIELDS } from '../constants';
+
+const ReassignFields: React.FunctionComponent = () => {
+  const intl = useIntl();
+  return (
+    <>
+      <TextField
+        fullWidth
+        id="reassign-interval"
+        label={intl.formatMessage({
+          id: 'misc.tasks.forms.createTask.fields.reassign_interval',
+        })}
+        margin="normal"
+        name={TASK_DETAILS_FIELDS.REASSIGN_INTERVAL}
+        required
+        select
+      >
+        <MenuItem value={DEFAULT_REASSIGN_INTERVAL}>
+          <Msg id="misc.tasks.forms.createTask.fields.reassign_interval_options.noReassign" />
+        </MenuItem>
+        <MenuItem value={1}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.hours"
+            values={{ hours: 1 }}
+          />
+        </MenuItem>
+        <MenuItem value={6}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.hours"
+            values={{ hours: 3 }}
+          />
+        </MenuItem>
+        <MenuItem value={12}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.hours"
+            values={{ hours: 6 }}
+          />
+        </MenuItem>
+        <MenuItem value={24}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.days"
+            values={{ days: 1 }}
+          />
+        </MenuItem>
+        <MenuItem value={48}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.days"
+            values={{ days: 2 }}
+          />
+        </MenuItem>
+        <MenuItem value={72}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.days"
+            values={{ days: 3 }}
+          />
+        </MenuItem>
+        <MenuItem value={168}>
+          <Msg
+            id="misc.tasks.forms.createTask.fields.reassign_interval_options.days"
+            values={{ days: 7 }}
+          />
+        </MenuItem>
+      </TextField>
+
+      <TextField
+        fullWidth
+        id="reassign-limit"
+        label={intl.formatMessage({
+          id: 'misc.tasks.forms.createTask.fields.reassign_limit',
+        })}
+        margin="normal"
+        name={TASK_DETAILS_FIELDS.REASSIGN_LIMIT}
+        required
+        type="number"
+      />
+    </>
+  );
+};
+
+export default ReassignFields;

--- a/src/components/forms/TaskDetailsForm/fields/ReassignFields.tsx
+++ b/src/components/forms/TaskDetailsForm/fields/ReassignFields.tsx
@@ -16,7 +16,6 @@ const ReassignFields: React.FunctionComponent = () => {
         })}
         margin="normal"
         name={TASK_DETAILS_FIELDS.REASSIGN_INTERVAL}
-        required
         select
       >
         <MenuItem value={DEFAULT_REASSIGN_INTERVAL}>
@@ -74,7 +73,6 @@ const ReassignFields: React.FunctionComponent = () => {
         })}
         margin="normal"
         name={TASK_DETAILS_FIELDS.REASSIGN_LIMIT}
-        required
         type="number"
       />
     </>

--- a/src/components/forms/TaskDetailsForm/index.tsx
+++ b/src/components/forms/TaskDetailsForm/index.tsx
@@ -17,6 +17,7 @@ import {
 import getTaskStatus, { TASK_STATUS } from 'utils/getTaskStatus';
 
 import CollectDemographicsFields from './fields/CollectDemographicsFields';
+import ReassignFields from './fields/ReassignFields';
 import ShareLinkFields from './fields/ShareLinkFields';
 import TimeEstimateField from './fields/TimeEstimateField';
 import VisitLinkFields from './fields/VisitLinkFields';
@@ -29,7 +30,11 @@ import {
   isExpiresThird,
   isPublishedFirst,
 } from './utils';
-import { DEFAULT_TIME_ESTIMATE, TASK_DETAILS_FIELDS } from './constants';
+import {
+  DEFAULT_REASSIGN_INTERVAL,
+  DEFAULT_TIME_ESTIMATE,
+  TASK_DETAILS_FIELDS,
+} from './constants';
 
 interface TaskDetailsFormProps {
   onSubmit: (task: ZetkinTaskRequestBody) => void;
@@ -132,9 +137,24 @@ const TaskDetailsForm = ({
         ? null
         : newTaskValues.time_estimate;
 
+    const reassign_interval =
+      (newTaskValues.reassign_interval as number | string) ===
+      DEFAULT_REASSIGN_INTERVAL
+        ? null
+        : newTaskValues.reassign_interval;
+
+    // Value from widget is string, but typed as number. So convert to int
+    // or null, depending on whether interval was set or not.
+    const reassign_limit =
+      reassign_interval && newTaskValues.reassign_limit
+        ? parseInt(newTaskValues.reassign_limit.toString())
+        : null;
+
     onSubmit({
       ...newTaskValues,
       config,
+      reassign_interval,
+      reassign_limit,
       time_estimate,
     });
   };
@@ -156,6 +176,8 @@ const TaskDetailsForm = ({
         expires: task?.expires,
         instructions: task?.instructions,
         published: task?.published,
+        reassign_interval: task?.reassign_interval,
+        reassign_limit: task?.reassign_limit,
         time_estimate: task?.time_estimate || DEFAULT_TIME_ESTIMATE,
         title: task?.title,
         type: task?.type,
@@ -291,6 +313,8 @@ const TaskDetailsForm = ({
             margin="normal"
             name={TASK_DETAILS_FIELDS.EXPIRES}
           />
+
+          <ReassignFields />
 
           <SubmitCancelButtons
             onCancel={onCancel}

--- a/src/components/organize/tasks/TaskDetailsSection.tsx
+++ b/src/components/organize/tasks/TaskDetailsSection.tsx
@@ -82,6 +82,34 @@ const TaskDetailsCard: React.FunctionComponent<TaskDetailsCardProps> = ({
         })}
         value={task.expires && <ZetkinDateTime datetime={task.expires} />}
       />
+      <TaskProperty
+        title={intl.formatMessage({
+          id: 'misc.tasks.taskDetails.reassignInterval.label',
+        })}
+        value={
+          task.reassign_interval &&
+          intl.formatMessage(
+            { id: 'misc.tasks.taskDetails.reassignInterval.value' },
+            { value: task.reassign_interval }
+          )
+        }
+      />
+      <TaskProperty
+        title={intl.formatMessage({
+          id: 'misc.tasks.taskDetails.reassignLimit.label',
+        })}
+        value={
+          task.reassign_limit &&
+          intl.formatMessage(
+            {
+              id: 'misc.tasks.taskDetails.reassignLimit.value',
+            },
+            {
+              value: task.reassign_limit,
+            }
+          )
+        }
+      />
     </>
   );
 };

--- a/src/locale/misc/tasks/en.yml
+++ b/src/locale/misc/tasks/en.yml
@@ -24,6 +24,12 @@ taskDetails:
   expiresTime: Expires Time
   instructionsLabel: Instructions
   publishedTime: Publish Time
+  reassignInterval:
+    label: Reassign interval
+    value: Reassigns {value, plural, =1{one hour} other{# hours}} after completion
+  reassignLimit:
+    label: Reassign limit
+    value: Repeats at most {value, plural, =1{one time} other{# times}} per person
   statusLabel: Status
   timeEstimateLabel: Estimated time to complete
   title: Task Details

--- a/src/locale/misc/tasks/forms/en.yml
+++ b/src/locale/misc/tasks/forms/en.yml
@@ -19,6 +19,12 @@ createTask:
     expires: Expiration Date
     instructions: Instructions
     published: Publish Time
+    reassign_interval: Reassign after completion
+    reassign_interval_options:
+      days: '{days, plural, =1 {The next day} other {after # days}}'
+      hours: After {hours, plural, =1 {one hour} other {# hours}}
+      noReassign: Never reassign
+    reassign_limit: 'Maximum number of (re)assigns:'
     timeValidationErrors:
       deadlineNotSecond: This must be scheduled after the Published Date, and before the Expiry Date
       expiresNotThird: This must be scheduled last

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -51,6 +51,8 @@ export interface ZetkinTask<TaskTypeConfig = AnyTaskTypeConfig> {
   time_estimate?: number | null; // Time in minutes to complete
   type: TASK_TYPE;
   config: TaskTypeConfig;
+  reassign_interval: number | null;
+  reassign_limit: number | null;
   target: ZetkinQuery;
   campaign: {
     id: number;


### PR DESCRIPTION
## Description
This PR adds the `reassign_interval` and `reassign_limit` fields to the task form and summary page.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/154491498-468cee9e-e748-404e-b86e-5e9485916805.png)

## Changes
* Adds `reassign_interval` and `reassign_limit` to the task summary page
* Adds `reassign_interval` and `reassign_limit` fields to the task form


## Notes to reviewer
I think it works fine, but it's not perfect. I set the bar based on the assumption that we will likely be remaking the editing anyway, moving towards "edit in place" rather than the modal approach, but that will not happen until more UX research has been done.

## Related issues
Resolves #510 
