### PR TITLE
Issue 558/delete person

### DIFF
--- a/src/api/people.ts
+++ b/src/api/people.ts
@@ -16,6 +16,7 @@ export const personResource = (orgId: string, personId: string) => {
   return {
     prefetch: createPrefetch<ZetkinPerson>(key, url),
     useQuery: createUseQuery<ZetkinPerson>(key, url),
+    useRemove: createUseMutationDelete({ key, url }),
   };
 };
 

--- a/src/api/utils/createDeleteHandler.ts
+++ b/src/api/utils/createDeleteHandler.ts
@@ -4,8 +4,8 @@ import { defaultFetch } from 'fetching';
 export const createPutOrDeleteHandler =
   (method: RequestInit['method']) =>
   (url: string, fetchOptions?: RequestInit) =>
-  async (id: number): Promise<null> => {
-    const res = await defaultFetch(`${url}/${id}`, {
+  async (id?: number): Promise<null> => {
+    const res = await defaultFetch(`${url}/${id ? id : ''}`, {
       method,
       ...fetchOptions,
     });

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -67,14 +67,14 @@ interface MutationDeleteOrPutProps {
   url: string;
   fetchOptions?: RequestInit;
   mutationOptions?: Omit<
-    UseMutationOptions<null, unknown, number, unknown>,
+    UseMutationOptions<null, unknown, number | undefined, unknown>,
     'mutationFn'
   >;
 }
 
 export const createUseMutationDelete = (
   props: MutationDeleteOrPutProps
-): (() => UseMutationResult<null, unknown, number, unknown>) => {
+): (() => UseMutationResult<null, unknown, number | undefined, unknown>) => {
   const handler = createDeleteHandler(props.url, props.fetchOptions);
 
   return () => {
@@ -88,7 +88,7 @@ export const createUseMutationDelete = (
 
 export const createUseMutationPut = (
   props: MutationDeleteOrPutProps
-): (() => UseMutationResult<null, unknown, number, unknown>) => {
+): (() => UseMutationResult<null, unknown, number | undefined, unknown>) => {
   const handler = createPutHandler(props.url, props.fetchOptions);
 
   return () => {

--- a/src/components/organize/people/PersonCard.tsx
+++ b/src/components/organize/people/PersonCard.tsx
@@ -45,24 +45,30 @@ const PersonCard: React.FunctionComponent<{
     <ZetkinSection title={title}>
       <Card>
         {children}
-        <List disablePadding>
-          <ListItem button disabled={!onClickEdit} onClick={onToggleEdit}>
-            <ListItemIcon>
-              {editable ? <Close color="primary" /> : <Edit color="primary" />}
-            </ListItemIcon>
-            <ListItemText
-              className={classes.editButton}
-              primary={intl.formatMessage(
-                {
-                  id: `pages.people.person.${
-                    editable ? 'editButtonClose' : 'editButton'
-                  }`,
-                },
-                { title }
-              )}
-            />
-          </ListItem>
-        </List>
+        {onClickEdit && (
+          <List disablePadding>
+            <ListItem button disabled={!onClickEdit} onClick={onToggleEdit}>
+              <ListItemIcon>
+                {editable ? (
+                  <Close color="primary" />
+                ) : (
+                  <Edit color="primary" />
+                )}
+              </ListItemIcon>
+              <ListItemText
+                className={classes.editButton}
+                primary={intl.formatMessage(
+                  {
+                    id: `pages.people.person.${
+                      editable ? 'editButtonClose' : 'editButton'
+                    }`,
+                  },
+                  { title }
+                )}
+              />
+            </ListItem>
+          </List>
+        )}
       </Card>
     </ZetkinSection>
   );

--- a/src/components/organize/people/PersonDeleteCard.tsx
+++ b/src/components/organize/people/PersonDeleteCard.tsx
@@ -1,0 +1,69 @@
+import { NewReleases } from '@material-ui/icons';
+import { useContext } from 'react';
+import { useRouter } from 'next/router';
+import { Box, Button, Typography } from '@material-ui/core';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { ConfirmDialogContext } from 'hooks/ConfirmDialogProvider';
+import PersonCard from './PersonCard';
+import { PersonPageProps } from 'pages/organize/[orgId]/people/[personId]';
+import { personResource } from 'api/people';
+import SnackbarContext from 'hooks/SnackbarContext';
+import { ZetkinPerson } from 'types/zetkin';
+
+const PersonDeleteCard: React.FunctionComponent<{
+  orgId: PersonPageProps['orgId'];
+  person: ZetkinPerson;
+}> = ({ orgId, person }) => {
+  const intl = useIntl();
+  const router = useRouter();
+  const { showConfirmDialog } = useContext(ConfirmDialogContext);
+  const { showSnackbar } = useContext(SnackbarContext);
+  const useRemoveMutation = personResource(
+    orgId.toString(),
+    person.id.toString()
+  ).useRemove();
+
+  const deletePerson = () => {
+    showConfirmDialog({
+      onSubmit: () =>
+        useRemoveMutation.mutate(undefined, {
+          onError: () => showSnackbar('error'),
+          onSuccess: () => router.push(`/organize/${orgId}/people/views`),
+        }),
+      warningText: intl.formatMessage(
+        { id: 'pages.people.person.delete.confirm' },
+        { name: person.first_name + ' ' + person.last_name }
+      ),
+    });
+  };
+
+  return (
+    <PersonCard titleId="pages.people.person.delete.title">
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+        minHeight={125}
+        p={2}
+      >
+        <Box display="flex" flexDirection="row">
+          <NewReleases color="primary" style={{ marginRight: 10 }} />
+          <Typography color="primary" variant="h5">
+            <FormattedMessage id="pages.people.person.delete.warning" />
+          </Typography>
+        </Box>
+        <Button
+          color="primary"
+          fullWidth
+          onClick={deletePerson}
+          variant="contained"
+        >
+          <FormattedMessage id="pages.people.person.delete.button" />
+        </Button>
+      </Box>
+    </PersonCard>
+  );
+};
+
+export default PersonDeleteCard;

--- a/src/components/organize/people/PersonDetailsCard.tsx
+++ b/src/components/organize/people/PersonDetailsCard.tsx
@@ -25,7 +25,10 @@ const PersonDetailsCard: React.FunctionComponent<{ person: ZetkinPerson }> = ({
   ].filter((detail) => !!detail.value);
 
   return (
-    <PersonCard titleId="pages.people.person.details.title">
+    <PersonCard
+      onClickEdit={() => null}
+      titleId="pages.people.person.details.title"
+    >
       <List disablePadding>
         {details.map((detail, idx) => (
           <div key={idx}>

--- a/src/components/organize/people/PersonOrganizationsCard/index.tsx
+++ b/src/components/organize/people/PersonOrganizationsCard/index.tsx
@@ -16,12 +16,13 @@ import { OrganizationsTree } from './OrganizationsTree';
 import PersonCard from '../PersonCard';
 import { PersonOrganization } from 'utils/organize/people';
 import { personOrganizationsResource } from 'api/people';
-import { PersonProfilePageProps } from 'pages/organize/[orgId]/people/[personId]';
+import { PersonPageProps } from 'pages/organize/[orgId]/people/[personId]';
 import SnackbarContext from 'hooks/SnackbarContext';
 
-const PersonOrganizationsCard: React.FunctionComponent<
-  PersonProfilePageProps
-> = ({ orgId, personId }) => {
+const PersonOrganizationsCard: React.FunctionComponent<PersonPageProps> = ({
+  orgId,
+  personId,
+}) => {
   const [editable, setEditable] = useState<boolean>(false);
   const [addable, setAddable] = useState<boolean>(false);
   const [selected, setSelected] = useState<PersonOrganization>();

--- a/src/hooks/SnackbarContext.tsx
+++ b/src/hooks/SnackbarContext.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Snackbar } from '@material-ui/core';
+import { useIntl } from 'react-intl';
 import { Alert, Color } from '@material-ui/lab';
 import { createContext, useState } from 'react';
 
 interface SnackbarContextProps {
   isOpen: boolean;
   hideSnackbar: () => void;
-  showSnackbar: (severity: Color, message: string) => void;
+  showSnackbar: (severity: Color, message?: string) => void;
 }
 
 const SnackbarContext = createContext<SnackbarContextProps>({
@@ -16,6 +17,7 @@ const SnackbarContext = createContext<SnackbarContextProps>({
 });
 
 const SnackbarProvider: React.FunctionComponent = ({ children }) => {
+  const intl = useIntl();
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarState, setSnackbarState] = useState<{
     message: string;
@@ -24,8 +26,10 @@ const SnackbarProvider: React.FunctionComponent = ({ children }) => {
 
   const showSnackbar: SnackbarContextProps['showSnackbar'] = (
     severity,
-    message
+    customMessage?
   ) => {
+    const message =
+      customMessage || intl.formatMessage({ id: `misc.snackbar.${severity}` });
     setSnackbarOpen(true);
     setSnackbarState({
       message,

--- a/src/layout/organize/SinglePersonLayout.tsx
+++ b/src/layout/organize/SinglePersonLayout.tsx
@@ -33,6 +33,10 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
           messageId: 'layout.organize.person.tabs.timeline',
           tabProps: { disabled: true },
         },
+        {
+          href: `/manage`,
+          messageId: 'layout.organize.person.tabs.manage',
+        },
       ]}
       title={`${person?.first_name} ${person?.last_name}`}
     >

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -23,6 +23,7 @@ people:
   title: People
 person:
   tabs:
+    manage: Manage
     profile: Profile
     timeline: Timeline
 search:

--- a/src/locale/misc/breadcrumbs/en.yml
+++ b/src/locale/misc/breadcrumbs/en.yml
@@ -4,6 +4,7 @@ calendar: Calendar
 campaigns: Campaigns
 events: Events
 insights: Insights
+manage: Manage
 organize: Organize
 people: People
 projects: Projects

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -23,3 +23,5 @@ nativePersonFields:
   phone: Phone number
   street_address: Street address
   zip_code: Zip code
+snackbar:
+  error: Oh dear, something went wrong

--- a/src/locale/pages/people/en.yml
+++ b/src/locale/pages/people/en.yml
@@ -3,6 +3,9 @@ person:
     title: Contact Details
   editButton: Edit {title}
   editButtonClose: Stop editing {title}
+  delete:
+    title: Delete account
+    confirm: Are you sure you want to delete {name}? This is a permanent action.
   organizations:
     add: Add a new sub-organization
     addError: This organization could not be added

--- a/src/locale/pages/people/en.yml
+++ b/src/locale/pages/people/en.yml
@@ -1,11 +1,13 @@
 person:
+  delete:
+    button: Remove person
+    confirm: Are you sure you want to delete {name}? This is a permanent action.
+    title: Delete account
+    warning: This cannot be undone!
   details:
     title: Contact Details
   editButton: Edit {title}
   editButtonClose: Stop editing {title}
-  delete:
-    title: Delete account
-    confirm: Are you sure you want to delete {name}? This is a permanent action.
   organizations:
     add: Add a new sub-organization
     addError: This organization could not be added

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -6,15 +6,17 @@ import { PageWithLayout } from 'types';
 import PersonDetailsCard from 'components/organize/people/PersonDetailsCard';
 import PersonOrganizationsCard from 'components/organize/people/PersonOrganizationsCard';
 import { personResource } from 'api/people';
-import { scaffold } from 'utils/next';
 import SinglePersonLayout from 'layout/organize/SinglePersonLayout';
+import { scaffold, ScaffoldedGetServerSideProps } from 'utils/next';
 
-const scaffoldOptions = {
+export const scaffoldOptions = {
   authLevelRequired: 2,
   localeScope: ['layout.organize', 'pages.people', 'misc'],
 };
 
-export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+export const getPersonScaffoldProps: ScaffoldedGetServerSideProps = async (
+  ctx
+) => {
   const { orgId, personId } = ctx.params!;
 
   const { prefetch } = personResource(orgId as string, personId as string);
@@ -32,14 +34,19 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
       notFound: true,
     };
   }
-}, scaffoldOptions);
+};
 
-export type PersonProfilePageProps = {
+export const getServerSideProps: GetServerSideProps = scaffold(
+  getPersonScaffoldProps,
+  scaffoldOptions
+);
+
+export type PersonPageProps = {
   orgId: string;
   personId: string;
 };
 
-const PersonProfilePage: PageWithLayout<PersonProfilePageProps> = (props) => {
+const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
   const { data: person } = personResource(
     props.orgId,
     props.personId

--- a/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
@@ -1,0 +1,49 @@
+import { GetServerSideProps } from 'next';
+import { Grid } from '@material-ui/core';
+import Head from 'next/head';
+
+import { PageWithLayout } from 'types';
+import PersonDeleteCard from 'components/organize/people/PersonDeleteCard';
+import { personResource } from 'api/people';
+import { scaffold } from 'utils/next';
+import SinglePersonLayout from 'layout/organize/SinglePersonLayout';
+import {
+  getPersonScaffoldProps,
+  PersonPageProps,
+  scaffoldOptions,
+} from '../index';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  getPersonScaffoldProps,
+  scaffoldOptions
+);
+
+const PersonManagePage: PageWithLayout<PersonPageProps> = (props) => {
+  const { data: person } = personResource(
+    props.orgId,
+    props.personId
+  ).useQuery();
+
+  if (!person) return null;
+
+  return (
+    <>
+      <Head>
+        <title>
+          {person?.first_name} {person?.last_name}
+        </title>
+      </Head>
+      <Grid container direction="row" spacing={6}>
+        <Grid item lg={4}>
+          <PersonDeleteCard person={person} />
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+PersonManagePage.getLayout = function getLayout(page) {
+  return <SinglePersonLayout>{page}</SinglePersonLayout>;
+};
+
+export default PersonManagePage;

--- a/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
@@ -35,7 +35,7 @@ const PersonManagePage: PageWithLayout<PersonPageProps> = (props) => {
       </Head>
       <Grid container direction="row" spacing={6}>
         <Grid item lg={4}>
-          <PersonDeleteCard person={person} />
+          <PersonDeleteCard orgId={props.orgId} person={person} />
         </Grid>
       </Grid>
     </>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -106,8 +106,12 @@ const theme = createTheme({
       fontWeight: 400,
     },
     h5: {
-      fontSize: '1.2rem',
+      fontSize: '1.1rem',
       fontWeight: 500,
+    },
+    h6: {
+      fontSize: '1rem',
+      fontWeight: 600,
     },
   },
 });


### PR DESCRIPTION
## Description
Fixes #558 


## Screen recording
![issue-558-delete-person](https://user-images.githubusercontent.com/4164774/155580712-e545c16a-e85a-45b7-9176-54fdcf708003.gif)



## Changes
- Adds a new 'manage' tab to the person page layout
- Adds a delete card and mounts it on the manage tab
- Uses confirm dialog provider with the delete button to warn the user
- Redirects after deletion to `/organize/${orgId}/people/views`

