### PR TITLE
Issue 481/text search in view

### DIFF
--- a/src/components/organize/SearchDialog/index.tsx
+++ b/src/components/organize/SearchDialog/index.tsx
@@ -96,7 +96,7 @@ const SearchDialog: React.FunctionComponent = () => {
     <>
       {/* Activator */}
       <Button
-        data-testId="SearchDialog-activator"
+        data-testid="SearchDialog-activator"
         onClick={() => setOpen(true)}
         startIcon={<Search />}
       >

--- a/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
@@ -1,0 +1,106 @@
+import { FormattedMessage } from 'react-intl';
+import { makeStyles } from '@material-ui/styles';
+import {
+  Badge,
+  Box,
+  Button,
+  Fade,
+  IconButton,
+  Popover,
+  TextField,
+} from '@material-ui/core';
+import { Close, Search } from '@material-ui/icons';
+import { ReactEventHandler, SyntheticEvent, useState } from 'react';
+
+const useStyles = makeStyles({
+  popover: {
+    borderRadius: 0,
+    minWidth: 450,
+    padding: 24,
+  },
+});
+
+interface ViewDataTableSearchProps {
+  minSearchLength?: number;
+}
+
+const ViewDataTableSearch: React.FunctionComponent<
+  ViewDataTableSearchProps
+> = ({ minSearchLength = 3 }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const classes = useStyles();
+  const open = Boolean(anchorEl);
+  const [searchString, setSearchString] = useState<string>('');
+  const id = open ? 'sort-options' : undefined;
+  const active = searchString.length >= minSearchLength;
+
+  const handleSearchButtonClick = (
+    event: React.SyntheticEvent<HTMLButtonElement>
+  ) => setAnchorEl(event.currentTarget);
+  const handlePopoverClose = () => {
+    setAnchorEl(null);
+  };
+  const handleChange = (evt: SyntheticEvent<HTMLInputElement>) => {
+    setSearchString(evt.currentTarget.value);
+  };
+  const handleClear = () => {
+    setSearchString('');
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Badge
+        anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+        color="primary"
+        invisible={!active}
+        overlap="circular"
+        variant="dot"
+      >
+        <Button
+          data-testid="ViewDataTableToolbar-showSearch"
+          onClick={handleSearchButtonClick}
+          startIcon={<Search />}
+        >
+          <FormattedMessage id="misc.views.viewTableSearch.button" />
+        </Button>
+      </Badge>
+      <Popover
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          horizontal: 'left',
+          vertical: 'bottom',
+        }}
+        classes={{ paper: classes.popover }}
+        elevation={1}
+        id={id}
+        onClose={handlePopoverClose}
+        open={open}
+        transformOrigin={{
+          horizontal: 'center',
+          vertical: 'top',
+        }}
+      >
+        <Box display="flex" flexDirection="column">
+          <TextField
+            InputProps={{
+              endAdornment: (
+                <Fade in={active}>
+                  <IconButton onClick={handleClear}>
+                    <Close />
+                  </IconButton>
+                </Fade>
+              ),
+            }}
+            onChange={handleChange as ReactEventHandler<unknown>}
+            placeholder="Search this view"
+            value={searchString}
+            variant="outlined"
+          />
+        </Box>
+      </Popover>
+    </>
+  );
+};
+
+export default ViewDataTableSearch;

--- a/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
@@ -10,7 +10,7 @@ import {
   TextField,
 } from '@material-ui/core';
 import { Close, Search } from '@material-ui/icons';
-import { ReactEventHandler, SyntheticEvent, useState } from 'react';
+import { ReactEventHandler, SyntheticEvent, useEffect, useState } from 'react';
 
 const useStyles = makeStyles({
   popover: {
@@ -22,17 +22,18 @@ const useStyles = makeStyles({
 
 interface ViewDataTableSearchProps {
   minSearchLength?: number;
+  onChange: (searchString: string) => void;
 }
 
 const ViewDataTableSearch: React.FunctionComponent<
   ViewDataTableSearchProps
-> = ({ minSearchLength = 3 }) => {
+> = ({ minSearchLength = 3, onChange }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const classes = useStyles();
   const open = Boolean(anchorEl);
   const [searchString, setSearchString] = useState<string>('');
   const id = open ? 'sort-options' : undefined;
-  const active = searchString.length >= minSearchLength;
+  const isActive = searchString.length >= minSearchLength;
 
   const handleSearchButtonClick = (
     event: React.SyntheticEvent<HTMLButtonElement>
@@ -43,17 +44,20 @@ const ViewDataTableSearch: React.FunctionComponent<
   const handleChange = (evt: SyntheticEvent<HTMLInputElement>) => {
     setSearchString(evt.currentTarget.value);
   };
-  const handleClear = () => {
-    setSearchString('');
+  const handleClear = (override?: boolean) => {
+    if (!isActive || override) setSearchString('');
     setAnchorEl(null);
   };
+  useEffect(() => {
+    onChange(isActive ? searchString : '');
+  }, [searchString]);
 
   return (
     <>
       <Badge
         anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
         color="primary"
-        invisible={!active}
+        invisible={!isActive}
         overlap="circular"
         variant="dot"
       >
@@ -80,13 +84,24 @@ const ViewDataTableSearch: React.FunctionComponent<
           horizontal: 'center',
           vertical: 'top',
         }}
+        TransitionProps={{ onExited: () => handleClear() }}
       >
         <Box display="flex" flexDirection="column">
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <TextField
+            helperText={
+              minSearchLength > 1 &&
+              searchString.length < 3 && (
+                <FormattedMessage
+                  id="misc.views.viewTableSearch.helpText"
+                  values={{ minSearchLength }}
+                />
+              )
+            }
             InputProps={{
               endAdornment: (
-                <Fade in={active}>
-                  <IconButton onClick={handleClear}>
+                <Fade in={isActive}>
+                  <IconButton onClick={() => handleClear(true)}>
                     <Close />
                   </IconButton>
                 </Fade>

--- a/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
@@ -17,6 +17,7 @@ export interface ViewDataTableToolbarProps {
   onRowsRemove: () => void;
   onViewCreate: () => void;
   selection: number[];
+  setQuickSearch: (quickSearch: string) => void;
   setSortModel: (model: GridSortModel) => void;
   sortModel: GridSortModel;
 }
@@ -41,6 +42,7 @@ const ViewDataTableToolbar: React.FunctionComponent<
   onRowsRemove,
   onViewCreate,
   selection,
+  setQuickSearch,
   setSortModel,
   sortModel,
 }) => {
@@ -108,7 +110,9 @@ const ViewDataTableToolbar: React.FunctionComponent<
       >
         <FormattedMessage id="misc.views.toolbar.createColumn" />
       </Button>
-      <ViewDataTableSearch />
+      <ViewDataTableSearch
+        onChange={(searchString) => setQuickSearch(searchString)}
+      />
     </Box>
   );
 };

--- a/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableToolbar.tsx
@@ -5,6 +5,7 @@ import { Box, Button, makeStyles, Slide, Tooltip } from '@material-ui/core';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { ConfirmDialogContext } from 'hooks/ConfirmDialogProvider';
+import ViewDataTableSearch from './ViewDataTableSearch';
 import ViewDataTableSorting from './ViewDataTableSorting';
 import { GridColDef, GridSortModel } from '@mui/x-data-grid-pro';
 
@@ -25,6 +26,7 @@ const useStyles = makeStyles({
     '& > *': {
       margin: '0 4px',
     },
+    marginRight: 15,
     marginTop: 5,
   },
 });
@@ -64,7 +66,7 @@ const ViewDataTableToolbar: React.FunctionComponent<
           onClick={onViewCreate}
           startIcon={<Launch />}
         >
-          <FormattedMessage id="misc.views.createFromSelection" />
+          <FormattedMessage id="misc.views.toolbar.createFromSelection" />
         </Button>
       </Slide>
       <Slide direction="left" in={!!selection.length} timeout={100}>
@@ -72,7 +74,7 @@ const ViewDataTableToolbar: React.FunctionComponent<
           title={
             isSmartSearch
               ? intl.formatMessage({
-                  id: 'misc.views.removeTooltip',
+                  id: 'misc.views.toolbar.removeTooltip',
                 })
               : ''
           }
@@ -85,7 +87,7 @@ const ViewDataTableToolbar: React.FunctionComponent<
               startIcon={<RemoveCircleOutline />}
             >
               <FormattedMessage
-                id="misc.views.removeFromSelection"
+                id="misc.views.toolbar.removeFromSelection"
                 values={{ numSelected: selection.length }}
               />
             </Button>
@@ -104,8 +106,9 @@ const ViewDataTableToolbar: React.FunctionComponent<
         onClick={onColumnCreate}
         startIcon={<Add />}
       >
-        <FormattedMessage id="misc.views.createColumn" />
+        <FormattedMessage id="misc.views.toolbar.createColumn" />
       </Button>
+      <ViewDataTableSearch />
     </Box>
   );
 };

--- a/src/components/views/ViewDataTable/cells/PersonNotesViewCell.tsx
+++ b/src/components/views/ViewDataTable/cells/PersonNotesViewCell.tsx
@@ -4,7 +4,7 @@ import { Typography } from '@material-ui/core';
 
 import { ViewGridCellParams } from '.';
 
-interface PersonNote {
+export interface PersonNote {
   created: string;
   id: number;
   text: string;

--- a/src/components/views/ViewDataTable/index.tsx
+++ b/src/components/views/ViewDataTable/index.tsx
@@ -22,7 +22,7 @@ import SnackbarContext from 'hooks/SnackbarContext';
 import ViewRenameColumnDialog from '../ViewRenameColumnDialog';
 import { viewRowsResource } from 'api/viewRows';
 import { viewsResource } from 'api/views';
-import { colIdFromFieldName, makeGridColDef } from './utils';
+import { colIdFromFieldName, makeGridColDef, viewQuickSearch } from './utils';
 import { SelectedViewColumn, ZetkinView } from 'types/views';
 import { VIEW_CONTENT_SOURCE, VIEW_DATA_TABLE_ERROR } from './constants';
 import ViewColumnDialog, {
@@ -76,6 +76,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const [selection, setSelection] = useState<number[]>([]);
   const [waiting, setWaiting] = useState(false);
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
+  const [quickSearch, setQuickSearch] = useState('');
   const router = useRouter();
   const { orgId } = router.query;
   const queryClient = useQueryClient();
@@ -292,7 +293,9 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     ...columns.map((col) => makeGridColDef(col, orgId as string)),
   ];
 
-  const gridRows = rows.map((input) => {
+  const rowsWithSearch = viewQuickSearch(rows, columns, quickSearch);
+
+  const gridRows = rowsWithSearch.map((input) => {
     const output: Record<string, unknown> = {
       id: input.id,
     };
@@ -356,6 +359,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       onRowsRemove,
       onViewCreate,
       selection,
+      setQuickSearch,
       setSortModel,
       sortModel,
     },

--- a/src/components/views/ViewDataTable/utils.spec.ts
+++ b/src/components/views/ViewDataTable/utils.spec.ts
@@ -1,6 +1,9 @@
 import { COLUMN_TYPE } from 'types/views';
-import { makeGridColDef } from './utils';
+import mockPersonNote from 'utils/testing/mocks/mockPersonNote';
 import mockViewCol from 'utils/testing/mocks/mockViewCol';
+import mockViewRow from 'utils/testing/mocks/mockViewRow';
+import { PersonNote } from './cells/PersonNotesViewCell';
+import { makeGridColDef, viewQuickSearch } from './utils';
 
 describe('makeGridColDef', () => {
   it('returns common fields correctly', () => {
@@ -94,5 +97,59 @@ describe('makeGridColDef', () => {
       1
     );
     expect(colDef.renderCell).toBeTruthy();
+  });
+});
+
+describe('viewQuickSearch', () => {
+  const columns = [
+    mockViewCol({
+      config: {
+        field: 'first_name',
+      },
+      type: COLUMN_TYPE.PERSON_FIELD,
+    }),
+    mockViewCol({
+      config: {
+        field: 'last_name',
+      },
+      type: COLUMN_TYPE.PERSON_FIELD,
+    }),
+    mockViewCol({
+      type: COLUMN_TYPE.PERSON_NOTES,
+    }),
+  ];
+
+  const rows = [
+    mockViewRow({
+      content: ['Angela', 'Davis', [mockPersonNote({ text: 'Note text A' })]],
+    }),
+    mockViewRow({
+      content: ['Clara', 'Zetkin', [mockPersonNote({ text: 'Note text B' })]],
+    }),
+  ];
+
+  it('Correctly returns rows when searching for a string field', () => {
+    const matchedRows = viewQuickSearch(rows, columns, 'Zetki');
+
+    expect(matchedRows.length).toEqual(1);
+    expect(matchedRows[0].content[0]).toEqual('Clara');
+  });
+  it('Searches case-insensitively', () => {
+    const matchedRows = viewQuickSearch(rows, columns, 'zetkin');
+
+    expect(matchedRows.length).toEqual(1);
+  });
+  it('Correctly returns rows when searching for an object field', () => {
+    const matchedRows = viewQuickSearch(rows, columns, 'text a');
+    const matchedNotes = matchedRows[0].content[2] as PersonNote[];
+
+    expect(matchedRows.length).toEqual(1);
+    expect(matchedNotes).toHaveLength(1);
+    expect(matchedNotes[0].text).toEqual('Note text A');
+  });
+  it('Returns an empty array if no rows match the search', () => {
+    const matchedRows = viewQuickSearch(rows, columns, 'text c');
+
+    expect(matchedRows).toEqual([]);
   });
 });

--- a/src/components/views/ViewDataTable/utils.tsx
+++ b/src/components/views/ViewDataTable/utils.tsx
@@ -113,7 +113,9 @@ export const viewQuickSearch = (
 
   const getColIdxByFieldType = (fields: string[]) =>
     columns.reduce((output: number[], input, idx) => {
-      if (fields.includes(input.type)) output.push(idx);
+      if (fields.includes(input.type)) {
+        output.push(idx);
+      }
       return output;
     }, []);
 

--- a/src/components/views/ViewDataTable/utils.tsx
+++ b/src/components/views/ViewDataTable/utils.tsx
@@ -106,6 +106,8 @@ export const viewQuickSearch = (
   columns: ZetkinViewColumn[],
   quickSearch: string
 ): ZetkinViewRow[] => {
+  if (!quickSearch) return rows;
+
   const getColIdxByFieldType = (fields: string[]) =>
     columns.reduce((output: number[], input, idx) => {
       if (fields.includes(input.type)) output.push(idx);

--- a/src/components/views/ViewDataTable/utils.tsx
+++ b/src/components/views/ViewDataTable/utils.tsx
@@ -108,27 +108,28 @@ export const viewQuickSearch = (
 ): ZetkinViewRow[] => {
   if (!quickSearch) return rows;
 
+  const searchableStringFields = ['person_field'];
+  const searchableObjectFields = ['survey_response', 'person_notes'];
+
   const getColIdxByFieldType = (fields: string[]) =>
     columns.reduce((output: number[], input, idx) => {
       if (fields.includes(input.type)) output.push(idx);
       return output;
     }, []);
-  const stringIndexes = getColIdxByFieldType(['person_field']);
-  const objectArrayIndexes = getColIdxByFieldType([
-    'survey_response',
-    'person_notes',
-  ]);
+
+  const stringIndexes = getColIdxByFieldType(searchableStringFields);
+  const objectArrayIndexes = getColIdxByFieldType(searchableObjectFields);
 
   const getSearchableString = (row: { content: unknown[] }) => {
     const rowContent = row.content;
     let searchable = '';
 
-    // Add string fields
+    // Add string field values directly to searchable string
     stringIndexes.forEach((idx) => {
       searchable = [searchable, rowContent[idx]].join(',');
     });
 
-    // Add object array fields
+    // Extract string values from object fields and add to searchable string
     objectArrayIndexes.forEach((idx) => {
       const content = rowContent[idx];
       if (content instanceof Array) {

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -34,8 +34,6 @@ columnMenu:
 columnRenameDialog:
   save: Save
   title: Title
-createColumn: New column
-createFromSelection: Create view from selection
 dataTableErrors:
   create_column: There was an error creating the column
   delete_column: There was an error deleting the column
@@ -67,16 +65,22 @@ newViewFields:
 removeDialog:
   action: Are you sure you want to remove these rows from this view?
   title: Remove people from view
-removeFromSelection: Remove {numSelected, plural,
-  one {1 person}
-  other {{numSelected} people}
-  } from view
-removeTooltip: Smart search views do not currently support removing rows
 suggested:
   created: Created by {name}
   sectionTitle: Suggested
+toolbar:
+  createColumn: New column
+  createFromSelection: Create view from selection
+  removeFromSelection: Remove {numSelected, plural,
+    one {1 person}
+    other {{numSelected} people}
+    } from view
+  removeTooltip: Smart search views do not currently support removing rows
 viewTableSort:
   addButton: Add sorting column
   button: Sort
   hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
   title: Sort
+viewTableSearch:
+  button: Search
+  title: Search

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -76,11 +76,12 @@ toolbar:
     other {{numSelected} people}
     } from view
   removeTooltip: Smart search views do not currently support removing rows
+viewTableSearch:
+  button: Search
+  helpText: Type at least {minSearchLength} characters
+  title: Search
 viewTableSort:
   addButton: Add sorting column
   button: Sort
   hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
   title: Sort
-viewTableSearch:
-  button: Search
-  title: Search

--- a/src/utils/testing/mocks/mockPersonNote.ts
+++ b/src/utils/testing/mocks/mockPersonNote.ts
@@ -1,0 +1,14 @@
+import { mockObject } from '.';
+import { PersonNote } from 'components/views/ViewDataTable/cells/PersonNotesViewCell';
+
+const personNote: PersonNote = {
+  created: new Date().toISOString(),
+  id: 1,
+  text: 'person note text',
+};
+
+const mockPersonNote = (overrides?: Partial<PersonNote>): PersonNote => {
+  return mockObject<PersonNote>(personNote, overrides);
+};
+
+export default mockPersonNote;

--- a/src/utils/testing/mocks/mockViewRow.ts
+++ b/src/utils/testing/mocks/mockViewRow.ts
@@ -1,0 +1,13 @@
+import { mockObject } from '.';
+import { ZetkinViewRow } from 'types/views';
+
+const viewRow: ZetkinViewRow = {
+  content: [],
+  id: 1,
+};
+
+const mockViewRow = (overrides?: Partial<ZetkinViewRow>): ZetkinViewRow => {
+  return mockObject<ZetkinViewRow>(viewRow, overrides);
+};
+
+export default mockViewRow;


### PR DESCRIPTION
## Description
Fixes #481 


## Screen recording
![issue-481-text-search](https://user-images.githubusercontent.com/4164774/155882899-62814e3f-fc9a-44a7-bded-9fd5e75f1647.gif)


## Changes
- Adds the UI for free text searching a view
- Adds a simple case insensitive text search function to filter rows based on the text search input. Works on any `person_field` as well as `survey_response` and `person_notes`

