### PR TITLE
Eslint curly brace rule & consistent use of `attr?: SomeType` 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,8 @@ module.exports = {
             interfaces: ['signature', 'method', 'constructor', 'field'],
           },
         ],
+        curly: 'error',
+        'brace-style': 'error',
         'jsx-a11y/anchor-is-valid': 'off',
         'no-console': 'error',
         'no-switch-statements/no-switch': 'error',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "build": "next build",
         "start": "next start -p 80",
         "devserver": "next dev -p 3000",
-        "lint": "yarn eslint src && prettier --check src playwright",
+        "lint": "yarn eslint src playwright && prettier --check src playwright",
         "check-types": "yarn tsc --noEmit",
         "test": "jest",
         "suite": "yarn lint && yarn check-types && yarn test && yarn playwright:ci",

--- a/playwright/fixtures/next.ts
+++ b/playwright/fixtures/next.ts
@@ -61,7 +61,9 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
           handle(req, res, parsedUrl);
         });
         server.listen((error: unknown) => {
-          if (error) throw error;
+          if (error) {
+            throw error;
+          }
           resolve(server);
         });
       });

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -108,8 +108,8 @@ export const createPrefetch = <Result>(
   url: string,
   fetchOptions?: RequestInit
 ): ((scaffoldContext: ScaffoldedContext) => Promise<{
-  data: Result | undefined;
-  state: QueryState<Result> | undefined;
+  data?: Result;
+  state?: QueryState<Result>;
 }>) => {
   return async (scaffoldContext) => {
     // Build get handler

--- a/src/components/ZetkinDialog.tsx
+++ b/src/components/ZetkinDialog.tsx
@@ -12,7 +12,7 @@ interface ZetkinDialogProps {
   open: boolean;
   onClose: () => void;
   title?: string;
-  maxWidth?: false | 'sm' | 'md' | 'lg' | 'xl' | undefined;
+  maxWidth?: false | 'sm' | 'md' | 'lg' | 'xl';
 }
 
 const ZetkinDialog: FunctionComponent<ZetkinDialogProps> = ({

--- a/src/components/ZetkinList.tsx
+++ b/src/components/ZetkinList.tsx
@@ -33,7 +33,9 @@ const ZetkinList: React.FunctionComponent<ZetkinListProps> = ({
     <List disablePadding>
       {childrenArray.map((child, index) => {
         // Show more results if the user clicks the show more button
-        if (index < numResultsToDisplay) return child;
+        if (index < numResultsToDisplay) {
+          return child;
+        }
       })}
       {childrenArray.length > numResultsToDisplay && (
         <ListItem

--- a/src/components/forms/TaskDetailsForm/utils.ts
+++ b/src/components/forms/TaskDetailsForm/utils.ts
@@ -76,7 +76,9 @@ export const configForTaskType = (
   type: TASK_TYPE | undefined,
   config: AnyTaskTypeConfig | undefined
 ): AnyTaskTypeConfig => {
-  if (type === undefined || config === undefined) return {};
+  if (type === undefined || config === undefined) {
+    return {};
+  }
 
   if (type === TASK_TYPE.COLLECT_DEMOGRAPHICS) {
     const collectDemographicsConfig = config as CollectDemographicsConfig;

--- a/src/components/forms/TaskDetailsForm/utils.ts
+++ b/src/components/forms/TaskDetailsForm/utils.ts
@@ -73,8 +73,8 @@ export const isExpiresThird = (values: ZetkinTaskRequestBody): boolean => {
  * Returns a task config object with only the fields which exist on that type's config, and only fields with values
  */
 export const configForTaskType = (
-  type: TASK_TYPE | undefined,
-  config: AnyTaskTypeConfig | undefined
+  type?: TASK_TYPE,
+  config?: AnyTaskTypeConfig
 ): AnyTaskTypeConfig => {
   if (type === undefined || config === undefined) {
     return {};

--- a/src/components/organize/people/PersonCard.tsx
+++ b/src/components/organize/people/PersonCard.tsx
@@ -38,7 +38,9 @@ const PersonCard: React.FunctionComponent<{
 
   const onToggleEdit = (evt: SyntheticEvent) => {
     setEditable(!editable);
-    if (onClickEdit) onClickEdit(evt);
+    if (onClickEdit) {
+      onClickEdit(evt);
+    }
   };
 
   return (

--- a/src/components/organize/people/PersonOrganizationsCard/OrganizationSelect.tsx
+++ b/src/components/organize/people/PersonOrganizationsCard/OrganizationSelect.tsx
@@ -64,7 +64,9 @@ const OrganizationSelect: React.FunctionComponent<OrganizationSelectProps> = ({
           color="primary"
           disabled={!selected}
           onClick={() => {
-            if (selected) onSubmit(selected);
+            if (selected) {
+              onSubmit(selected);
+            }
           }}
           style={{ height: '100%', marginLeft: 10 }}
           variant="contained"

--- a/src/components/organize/people/PersonOrganizationsCard/OrganizationsTree.tsx
+++ b/src/components/organize/people/PersonOrganizationsCard/OrganizationsTree.tsx
@@ -49,9 +49,15 @@ export const OrganizationsTree: React.FunctionComponent<OrganizationProps> = ({
   const classes = useStyles({ level });
 
   const getIcon = () => {
-    if (level === 0) return <AccountTree />;
-    if (level === 1) return <SubdirectoryArrowRight />;
-    if (level === 2) return <ArrowRight />;
+    if (level === 0) {
+      return <AccountTree />;
+    }
+    if (level === 1) {
+      return <SubdirectoryArrowRight />;
+    }
+    if (level === 2) {
+      return <ArrowRight />;
+    }
   };
 
   return (

--- a/src/components/organize/people/PersonOrganizationsCard/index.tsx
+++ b/src/components/organize/people/PersonOrganizationsCard/index.tsx
@@ -49,7 +49,7 @@ const PersonOrganizationsCard: React.FunctionComponent<PersonPageProps> = ({
   };
 
   const submitSubOrg = () => {
-    if (selected)
+    if (selected) {
       addOrgMutation.mutate(selected.id, {
         onError: () =>
           showSnackbar(
@@ -60,6 +60,7 @@ const PersonOrganizationsCard: React.FunctionComponent<PersonPageProps> = ({
           ),
         onSuccess: () => setSelected(undefined),
       });
+    }
   };
 
   const removeSubOrg = (subOrgId: PersonOrganization['id']) => {
@@ -79,7 +80,9 @@ const PersonOrganizationsCard: React.FunctionComponent<PersonPageProps> = ({
     });
   };
 
-  if (!data?.organizationTree) return null;
+  if (!data?.organizationTree) {
+    return null;
+  }
 
   return (
     <PersonCard

--- a/src/components/organize/tasks/TaskAssigneesList/utils.ts
+++ b/src/components/organize/tasks/TaskAssigneesList/utils.ts
@@ -12,23 +12,27 @@ export const sortAssignedTasks = (
   if (
     first.status === ASSIGNED_STATUS.COMPLETED &&
     second.status !== ASSIGNED_STATUS.COMPLETED
-  )
+  ) {
     return -1;
+  }
   if (
     first.status !== ASSIGNED_STATUS.COMPLETED &&
     second.status === ASSIGNED_STATUS.COMPLETED
-  )
+  ) {
     return 1;
+  }
   if (
     first.status === ASSIGNED_STATUS.ASSIGNED &&
     second.status === ASSIGNED_STATUS.IGNORED
-  )
+  ) {
     return 1;
+  }
   if (
     first.status === ASSIGNED_STATUS.IGNORED &&
     second.status === ASSIGNED_STATUS.ASSIGNED
-  )
+  ) {
     return -1;
+  }
 
   let firstDate;
   if (first.completed) {

--- a/src/components/organize/tasks/TaskTypeDetailsSection/index.tsx
+++ b/src/components/organize/tasks/TaskTypeDetailsSection/index.tsx
@@ -19,7 +19,9 @@ interface TaskTypeDetailsProps {
 const TaskTypeDetailsSection: React.FunctionComponent<TaskTypeDetailsProps> = ({
   task,
 }) => {
-  if (task.type === TASK_TYPE.OFFLINE) return null;
+  if (task.type === TASK_TYPE.OFFLINE) {
+    return null;
+  }
 
   return (
     <>

--- a/src/components/smartSearch/SmartSearchDialog/index.tsx
+++ b/src/components/smartSearch/SmartSearchDialog/index.tsx
@@ -108,9 +108,8 @@ const SmartSearchDialog = ({
     // If editing existing filter
     if ('id' in filter) {
       editFilter(filter.id, filter);
-    }
-    // If creating a new filter
-    else {
+    } else {
+      // If creating a new filter
       addFilter(filter);
     }
   };

--- a/src/components/smartSearch/filters/PersonTags/index.tsx
+++ b/src/components/smartSearch/filters/PersonTags/index.tsx
@@ -55,8 +55,9 @@ const PersonTags = ({
   );
 
   useEffect(() => {
-    if (filter.config.condition === CONDITION_OPERATOR.ANY)
+    if (filter.config.condition === CONDITION_OPERATOR.ANY) {
       setConfig({ ...filter.config, min_matching: minMatching });
+    }
   }, [minMatching]);
 
   // preserve the order of the tag array

--- a/src/components/smartSearch/filters/SubQuery/index.tsx
+++ b/src/components/smartSearch/filters/SubQuery/index.tsx
@@ -98,7 +98,9 @@ const SubQuery = ({
     let newQuery = queries.find(
       (q) => q.type === type && selectedQuery?.title === q.title
     );
-    if (!newQuery) newQuery = queries.find((q) => q.type === type);
+    if (!newQuery) {
+      newQuery = queries.find((q) => q.type === type);
+    }
     setSelectedQuery(newQuery);
   };
 

--- a/src/components/views/SuggestedViews/index.tsx
+++ b/src/components/views/SuggestedViews/index.tsx
@@ -63,7 +63,9 @@ const SuggestedViews: React.FunctionComponent = () => {
         const suggestedViews = getSuggestedViews(viewsQuery.data, member?.id);
 
         // if fewer than 3 views supplied, render nothing
-        if (viewsQuery.data.length < 3) return null;
+        if (viewsQuery.data.length < 3) {
+          return null;
+        }
 
         return (
           <ZetkinSection

--- a/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableSearch.tsx
@@ -45,7 +45,9 @@ const ViewDataTableSearch: React.FunctionComponent<
     setSearchString(evt.currentTarget.value);
   };
   const handleClear = (override?: boolean) => {
-    if (!isActive || override) setSearchString('');
+    if (!isActive || override) {
+      setSearchString('');
+    }
     setAnchorEl(null);
   };
   useEffect(() => {

--- a/src/components/views/ViewDataTable/cells/SurveySubmittedViewCell.tsx
+++ b/src/components/views/ViewDataTable/cells/SurveySubmittedViewCell.tsx
@@ -13,7 +13,9 @@ export type SurveySubmittedParams = ViewGridCellParams<Submission[] | null>;
 export const getNewestSubmission = (
   submissions: Submission[]
 ): string | null => {
-  if (!submissions.length) return null;
+  if (!submissions.length) {
+    return null;
+  }
   const subsWithDates = submissions.map((sub) => ({
     ...sub,
     submitted: new Date(sub.submitted),

--- a/src/components/views/ViewDataTable/utils.tsx
+++ b/src/components/views/ViewDataTable/utils.tsx
@@ -106,7 +106,9 @@ export const viewQuickSearch = (
   columns: ZetkinViewColumn[],
   quickSearch: string
 ): ZetkinViewRow[] => {
-  if (!quickSearch) return rows;
+  if (!quickSearch) {
+    return rows;
+  }
 
   const searchableStringFields = ['person_field'];
   const searchableObjectFields = ['survey_response', 'person_notes'];

--- a/src/hooks/useSmartSearch.ts
+++ b/src/hooks/useSmartSearch.ts
@@ -47,8 +47,11 @@ const useSmartSearch = (
 
   const editFilter = (id: number, newFilterValue: SmartSearchFilterWithId) => {
     const filtersWithEditedFilter = filtersWithIds.map((filter) => {
-      if (id === filter.id) return newFilterValue;
-      else return filter;
+      if (id === filter.id) {
+        return newFilterValue;
+      } else {
+        return filter;
+      }
     });
     setFiltersWithIds(filtersWithEditedFilter);
   };

--- a/src/layout/organize/SingleCampaignLayout.tsx
+++ b/src/layout/organize/SingleCampaignLayout.tsx
@@ -32,7 +32,9 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({
 
   const [firstEvent, lastEvent] = getFirstAndLastEvent(campaignEvents);
 
-  if (!campaign) return null;
+  if (!campaign) {
+    return null;
+  }
 
   return (
     <TabbedLayout

--- a/src/layout/organize/SinglePersonLayout.tsx
+++ b/src/layout/organize/SinglePersonLayout.tsx
@@ -18,7 +18,9 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
     personId as string
   ).useQuery();
 
-  if (!person) return null;
+  if (!person) {
+    return null;
+  }
 
   return (
     <TabbedLayout

--- a/src/layout/organize/SingleTaskLayout.tsx
+++ b/src/layout/organize/SingleTaskLayout.tsx
@@ -14,7 +14,9 @@ const SingleTaskLayout: FunctionComponent = ({ children }) => {
     taskId as string
   ).useQuery();
 
-  if (!task) return null;
+  if (!task) {
+    return null;
+  }
 
   return (
     <TabbedLayout

--- a/src/layout/organize/TabbedLayout.tsx
+++ b/src/layout/organize/TabbedLayout.tsx
@@ -101,7 +101,9 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
   const selectTab = (selected: string): void => {
     const href = tabs.find((tab) => tab.href === selected)?.href;
     if (href) {
-      if (href !== currentTab) router.push(baseHref + href);
+      if (href !== currentTab) {
+        router.push(baseHref + href);
+      }
     } else if (process.env.NODE_ENV === 'development') {
       throw new Error(`Tab with label ${selected} wasn't found`);
     }

--- a/src/pages/api/organize/[orgId]/people/[personId]/organizations/index.ts
+++ b/src/pages/api/organize/[orgId]/people/[personId]/organizations/index.ts
@@ -42,7 +42,9 @@ const getOrganizationTrees = async (
       await connectionsRes.json();
 
     // If orgId refers to an org that is itself a sub-org, then nullify the parent prop
-    if (requestOrg.parent) requestOrg.parent = null;
+    if (requestOrg.parent) {
+      requestOrg.parent = null;
+    }
 
     // Assemble tree
     const orgTree = { ...requestOrg, sub_orgs: subOrgs };

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/assignees.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/assignees.tsx
@@ -70,9 +70,8 @@ const getQueryStatus = (
     if (!task?.target.filter_spec.length) {
       queryStatus = QUERY_STATUS.NEW;
     }
-  }
-  // we don't want 'publishing' state to appear on page load while the data is being fetched
-  else if (assignedTasks && !assignedTasks.length) {
+  } else if (assignedTasks && !assignedTasks.length) {
+    // we don't want 'publishing' state to appear on page load while the data is being fetched
     queryStatus = QUERY_STATUS.PUBLISHED;
   }
   return queryStatus;

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/index.tsx
@@ -45,7 +45,9 @@ const TaskDetailPage: PageWithLayout<TaskDetailPageProps> = ({
 }) => {
   const { data: task } = taskResource(orgId, taskId).useQuery();
 
-  if (!task) return null;
+  if (!task) {
+    return null;
+  }
 
   return (
     <>

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -52,7 +52,9 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
     props.personId
   ).useQuery();
 
-  if (!person) return null;
+  if (!person) {
+    return null;
+  }
 
   return (
     <>

--- a/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/manage/index.tsx
@@ -24,7 +24,9 @@ const PersonManagePage: PageWithLayout<PersonPageProps> = (props) => {
     props.personId
   ).useQuery();
 
-  if (!person) return null;
+  if (!person) {
+    return null;
+  }
 
   return (
     <>

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -13,7 +13,9 @@ function stringToBool(str: string | undefined): boolean {
 }
 
 const getEllipsedString = (string: string, maxLength: number): string => {
-  if (maxLength >= string.length) return string;
+  if (maxLength >= string.length) {
+    return string;
+  }
   const matches = Array.from(string.matchAll(/(\s)/g));
   const ellipseIndex = matches.find(
     (m) => (m.index as number) >= maxLength

--- a/src/utils/validateTaskConfig.ts
+++ b/src/utils/validateTaskConfig.ts
@@ -1,7 +1,9 @@
 import { TASK_TYPE, ZetkinTask } from 'types/tasks';
 
 const validateTaskConfig = (task: ZetkinTask): boolean => {
-  if (typeof task.config !== 'object') return false;
+  if (typeof task.config !== 'object') {
+    return false;
+  }
 
   const configLength = Object.values(task.config).length;
 


### PR DESCRIPTION
## Description
This PR implements ESLint rule for enforcing curly braces after if statements, and multi line braces. This had to be handled in 2 rules because the `curly` rule only enforced the use of braces after if, not that they were on a new line. 

It also adds playwright to the linting check in CI.

Also replaces `attr: string | undefined` with `attr?: string` where that was used. Except in ONE location where this broke types with an external dependency