### PR TITLE
Move views to People, remove redirect, change urls.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,46 +3,41 @@ module.exports = {
         return [
             {
                 source: '/:prevPath*/calendar/events',
-                destination: '/:prevPath*/calendar', 
+                destination: '/:prevPath*/calendar',
                 permanent: false,
             },
             {
                 source: '/:prevPath*/calendar/tasks',
-                destination: '/:prevPath*/calendar', 
+                destination: '/:prevPath*/calendar',
                 permanent: false,
             },
             // redirects to Gen2 for MVP August 2021
             {
                 source: '/organize/:orgId(\\d{1,})',
-                destination: 'https://organize.zetk.in/?org=:orgId', 
-                permanent: false,
-            }, 
-            {
-                source: '/organize/:orgId(\\d{1,})/areas',
-                destination: 'https://organize.zetk.in/maps?org=:orgId', 
+                destination: 'https://organize.zetk.in/?org=:orgId',
                 permanent: false,
             },
             {
-                source: '/organize/:orgId(\\d{1,})/people',
-                destination: 'https://organize.zetk.in/people?org=:orgId', 
+                source: '/organize/:orgId(\\d{1,})/areas',
+                destination: 'https://organize.zetk.in/maps?org=:orgId',
                 permanent: false,
-            }, 
+            },
             {
                 source: '/organize/:orgId(\\d{1,})/campaigns/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId', 
+                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
                 permanent: false,
-            }, 
+            },
             {
                 source: '/organize/:orgId(\\d{1,})/campaigns/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId', 
+                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
                 permanent: false,
             },
             // all paths with /o redirected to Gen2
             {
                 source: '/o/:path*',
-                destination: 'https://zetk.in/o/:path*', 
+                destination: 'https://zetk.in/o/:path*',
                 permanent: false,
-            }, 
+            },
         ]
     },
 };

--- a/playwright/tests/organize/people/views/create-new-view.spec.ts
+++ b/playwright/tests/organize/people/views/create-new-view.spec.ts
@@ -23,7 +23,7 @@ test.describe('Views list page', () => {
     moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/people/views', 'post', undefined, 500);
 
-    await page.goto(appUri + '/organize/1/people/views');
+    await page.goto(appUri + '/organize/1/people');
     await page.click('data-testid=create-view-action-button');
 
     // Expect error dialog to exist on page
@@ -51,7 +51,7 @@ test.describe('Views list page', () => {
       NewViewColumns
     );
 
-    await page.goto(appUri + '/organize/1/people/views');
+    await page.goto(appUri + '/organize/1/people');
     await page.click('data-testid=create-view-action-button');
 
     await page.waitForNavigation();

--- a/playwright/tests/organize/people/views/delete-view.spec.ts
+++ b/playwright/tests/organize/people/views/delete-view.spec.ts
@@ -54,7 +54,7 @@ test.describe('Delete view from view list page', () => {
       204
     );
 
-    await page.goto(appUri + '/organize/1/people/views');
+    await page.goto(appUri + '/organize/1/people');
 
     await deleteView(page);
     expectDeleteViewSuccess(moxy);
@@ -73,7 +73,7 @@ test.describe('Delete view from view list page', () => {
       405
     );
 
-    await page.goto(appUri + '/organize/1/people/views');
+    await page.goto(appUri + '/organize/1/people');
 
     await deleteView(page);
     await expectDeleteViewError(page);

--- a/playwright/tests/organize/people/views/views-list.spec.ts
+++ b/playwright/tests/organize/people/views/views-list.spec.ts
@@ -22,7 +22,7 @@ test.describe('Views list page', () => {
     }) => {
       moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
 
-      await page.goto(appUri + '/organize/1/people/views');
+      await page.goto(appUri + '/organize/1/people');
       expect(
         await page.locator('data-testid=empty-views-list-indicator').count()
       ).toEqual(1);
@@ -46,7 +46,7 @@ test.describe('Views list page', () => {
         },
       ]);
 
-      await page.goto(appUri + '/organize/1/people/views');
+      await page.goto(appUri + '/organize/1/people');
       expect(await page.locator('.MuiDataGrid-row').count()).toEqual(2);
     });
 
@@ -57,7 +57,7 @@ test.describe('Views list page', () => {
     }) => {
       moxy.setZetkinApiMock('/orgs/1/people/views', 'get', [AllMembers]);
 
-      await page.goto(appUri + '/organize/1/people/views');
+      await page.goto(appUri + '/organize/1/people');
       await page.click(`text=${AllMembers.title}`);
       await page.waitForNavigation();
 

--- a/src/components/organize/OrganizeSidebar.tsx
+++ b/src/components/organize/OrganizeSidebar.tsx
@@ -107,7 +107,7 @@ const OrganizeSidebar = (): JSX.Element => {
             </NextLink>
           </ListItem>
           <ListItem disableGutters>
-            <NextLink href={`/organize/${orgId}/people/views`} passHref>
+            <NextLink href={`/organize/${orgId}/people`} passHref>
               <IconButton
                 aria-label="People"
                 className={classes.roundButton}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -84,7 +84,7 @@ export default function Home(): JSX.Element {
               size="large"
               variant="text"
             >
-              <Button href="organize/1/people/views">People / views</Button>
+              <Button href="organize/1/people">People</Button>
               <Button href="organize/1/campaigns">Campaigns</Button>
             </ButtonGroup>
           </div>

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -50,11 +50,7 @@ const PeopleViewsPage: PageWithLayout<PeopleViewsPageProps> = () => {
         <title>
           {intl.formatMessage({
             id: 'layout.organize.people.title',
-          }) +
-            ' - ' +
-            intl.formatMessage({
-              id: 'layout.organize.people.tabs.views',
-            })}
+          })}
         </title>
       </Head>
       <SuggestedViews />


### PR DESCRIPTION
## Description
This PR restructures the paths from organize/{orgId}/people/views to be just organize/{orgId}/people, and updates urls in links accordingly, and removes the redirect to gen2 for organize/{orgId}/people. 

## Changes
* Changes: Moves files, changes urls, removes redirect

## Related issues
Resolves #569 
