### PR TITLE
Issue 577/journey assignees and members

### DIFF
--- a/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding.ts
+++ b/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding.ts
@@ -1,4 +1,5 @@
 import ActivistTag from '../../../tags/Activist';
+import AngelaDavis from '../../../people/AngelaDavis';
 import ClaraZetkin from '../../../people/ClaraZetkin';
 import KPD from '../../..';
 import MemberOnboarding from '../../MemberOnboarding';
@@ -35,7 +36,7 @@ const MeetBranchSec: ZetkinJourneyMilestoneStatus = {
 
 // Journey Instance
 const ClarasOnboarding: ZetkinJourneyInstance = {
-  assignees: [ClaraZetkin],
+  assignees: [AngelaDavis],
   closed: null,
   created: '2022-02-01T14:53:15',
   id: 1,

--- a/playwright/mockData/orgs/KPD/people/AngelaDavis.ts
+++ b/playwright/mockData/orgs/KPD/people/AngelaDavis.ts
@@ -1,0 +1,20 @@
+import { ZetkinPerson } from '../../../../../src/types/zetkin';
+
+const AngelaDavis: ZetkinPerson = {
+  alt_phone: '',
+  city: 'Oakland',
+  co_address: '',
+  country: 'USA',
+  email: 'angela@blackpanthers.org',
+  ext_id: '74',
+  first_name: 'Angela',
+  gender: 'f',
+  id: 2,
+  is_user: false,
+  last_name: 'Davis',
+  phone: '0018493298448',
+  street_address: '45 Main Street',
+  zip_code: '34910',
+};
+
+export default AngelaDavis;

--- a/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
@@ -59,7 +59,7 @@ test.describe('Journey instance sidebar', () => {
         ClarasOnboarding.assignees[0],
       ]);
       //Add Angela as assignee
-      moxy.setZetkinApiMock(
+      const { log: putTagLog } = moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
         'put'
       );
@@ -90,20 +90,12 @@ test.describe('Journey instance sidebar', () => {
         )
         .click();
 
-      //expect Angela to be in list of assignees
-      expect(
-        await page
-          .locator(
-            `[data-testid=ZetkinSection-assignees] [data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}]`
-          )
-          .count()
-      ).toEqual(1);
+      //wait for response
+      await page.waitForResponse(
+        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`
+      );
 
       //Expect PUT-request to be done
-      const { log: putTagLog } = moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
-        'put'
-      );
       expect(putTagLog().length).toEqual(1);
 
       //Expect Add assignee-button to be visible
@@ -212,7 +204,7 @@ test.describe('Journey instance sidebar', () => {
         ClarasOnboarding.subjects[0],
       ]);
       //Add Clara as subject
-      moxy.setZetkinApiMock(
+      const { log: putTagLog } = moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
         'put'
       );
@@ -243,20 +235,12 @@ test.describe('Journey instance sidebar', () => {
         )
         .click();
 
-      //expect Clara to be in list of assignees
-      expect(
-        await page
-          .locator(
-            `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
-          )
-          .count()
-      ).toEqual(1);
+      //wait for response
+      await page.waitForResponse(
+        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`
+      );
 
       //Expect PUT-request to be done
-      const { log: putTagLog } = moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
-        'put'
-      );
       expect(putTagLog().length).toEqual(1);
 
       //Expect Add subject-button to be visible

--- a/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
@@ -1,0 +1,313 @@
+import { expect } from '@playwright/test';
+import test from '../../../fixtures/next';
+
+import AngelaDavis from '../../../mockData/orgs/KPD/people/AngelaDavis';
+import ClarasOnboarding from '../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
+import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
+import KPD from '../../../mockData/orgs/KPD';
+import MemberOnboarding from '../../../mockData/orgs/KPD/journeys/MemberOnboarding';
+
+test.describe('Journey instance sidebar', () => {
+  test.beforeEach(async ({ moxy, login }) => {
+    login();
+    moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+  });
+
+  test.afterEach(async ({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test.describe('has a section for assignees', () => {
+    test('with a list of assigned people.', async ({ appUri, moxy, page }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-assignees] [data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}]`
+          )
+          .count()
+      ).toEqual(1);
+    });
+
+    test('where you can assign new person to the journey instance.', async ({
+      appUri,
+      moxy,
+      page,
+    }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, assignees: [] }
+      );
+      //Angela appears in search results in PersonSelect
+      moxy.setZetkinApiMock(`/orgs/${KPD.id}/search/person`, 'post', [
+        AngelaDavis,
+      ]);
+      //Add Angela as assignee
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${AngelaDavis.id}`,
+        'put'
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      //Open PersonSelect and search for Angela
+      await page.locator('data-testid=Button-add-assignee').click();
+      await page.locator('text=Assign person').type('Angela');
+
+      //click Angela in search results
+      await page
+        .locator(
+          `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
+        )
+        .click();
+
+      //GET the journeyInstance with Angela as assignee
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, assignees: [AngelaDavis] }
+      );
+
+      //expect Angela to be in list of assignees
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-assignees] [data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}]`
+          )
+          .count()
+      ).toEqual(1);
+
+      //Expect PUT-request to be done
+      const { log: putTagLog } = moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${AngelaDavis.id}`,
+        'put'
+      );
+      expect(putTagLog().length).toEqual(1);
+
+      //Expect Add assignee-button to be visible
+      expect(
+        await page.locator(`data-testid=Button-add-assignee`).isVisible()
+      ).toBeTruthy();
+    });
+
+    test('where you can remove assigned person from the journey instance.', async ({
+      appUri,
+      moxy,
+      page,
+    }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+      //DELETE Angela from list of assignees
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
+        'delete'
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      //hover over Angela
+      await page
+        .locator(
+          `data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}`
+        )
+        .hover();
+
+      //find x-icon and click it
+      await page
+        .locator(
+          `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
+        )
+        .click();
+
+      //GET journey instance again, with no assignees
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, assignees: [] }
+      );
+
+      //there should be no Angela in list of assignees
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-assignees] [data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}]`
+          )
+          .isVisible()
+      ).toBeFalsy();
+    });
+  });
+
+  test.describe('has a section for members', () => {
+    test('with a list of subjects.', async ({ appUri, moxy, page }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+          )
+          .count()
+      ).toEqual(1);
+    });
+
+    //put request works
+    test('where you can add new subject to the journey instance.', async ({
+      appUri,
+      moxy,
+      page,
+    }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, subjects: [] }
+      );
+      //Clara appears in search results in PersonSelect
+      moxy.setZetkinApiMock(`/orgs/${KPD.id}/search/person`, 'post', [
+        ClaraZetkin,
+      ]);
+      //Add Clara as subject
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClaraZetkin.id}`,
+        'put'
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      //Open PersonSelect and search for Clara
+      await page.locator('data-testid=Button-add-subject').click();
+      await page.locator('text=Add person').type('Clara');
+
+      //click Clara in search results
+      await page
+        .locator(
+          `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
+        )
+        .click();
+
+      //GET the journeyInstance with Clara as assignee
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, subjects: [ClaraZetkin] }
+      );
+
+      //expect Clara to be in list of assignees
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+          )
+          .count()
+      ).toEqual(1);
+
+      //Expect PUT-request to be done
+      const { log: putTagLog } = moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClaraZetkin.id}`,
+        'put'
+      );
+      expect(putTagLog().length).toEqual(1);
+
+      //Expect Add subject-button to be visible
+      expect(
+        await page.locator(`data-testid=Button-add-subject`).isVisible()
+      ).toBeTruthy();
+    });
+
+    //delete request works
+    test('where you can remove a member from the journey instance.', async ({
+      appUri,
+      moxy,
+      page,
+    }) => {
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
+        'get',
+        MemberOnboarding
+      );
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+      //DELETE Angela from list of assignees
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
+        'delete'
+      );
+
+      await page.goto(appUri + '/organize/1/journeys/1/1');
+
+      //hover over Clara
+      await page
+        .locator(
+          `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+        )
+        .hover();
+
+      //find x-icon and click it
+      await page
+        .locator(
+          `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
+        )
+        .click();
+
+      //GET journey instance again, with no subjects
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        { ...ClarasOnboarding, subjects: [] }
+      );
+
+      //there should be no Clara in list of subejcts
+      expect(
+        await page
+          .locator(
+            `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+          )
+          .isVisible()
+      ).toBeFalsy();
+    });
+  });
+});

--- a/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
@@ -1,9 +1,7 @@
 import { expect } from '@playwright/test';
 import test from '../../../fixtures/next';
 
-import AngelaDavis from '../../../mockData/orgs/KPD/people/AngelaDavis';
 import ClarasOnboarding from '../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
-import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import KPD from '../../../mockData/orgs/KPD';
 import MemberOnboarding from '../../../mockData/orgs/KPD/journeys/MemberOnboarding';
 
@@ -58,12 +56,18 @@ test.describe('Journey instance sidebar', () => {
       );
       //Angela appears in search results in PersonSelect
       moxy.setZetkinApiMock(`/orgs/${KPD.id}/search/person`, 'post', [
-        AngelaDavis,
+        ClarasOnboarding.assignees[0],
       ]);
       //Add Angela as assignee
       moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${AngelaDavis.id}`,
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
         'put'
+      );
+      //GET data for Angela to render her info
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/people/${ClarasOnboarding.assignees[0].id}`,
+        'get',
+        ClarasOnboarding.assignees[0]
       );
 
       await page.goto(appUri + '/organize/1/journeys/1/1');
@@ -72,19 +76,19 @@ test.describe('Journey instance sidebar', () => {
       await page.locator('data-testid=Button-add-assignee').click();
       await page.locator('text=Assign person').type('Angela');
 
+      //GET the journeyInstance with Angela as assignee
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+
       //click Angela in search results
       await page
         .locator(
           `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
         )
         .click();
-
-      //GET the journeyInstance with Angela as assignee
-      moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
-        'get',
-        { ...ClarasOnboarding, assignees: [AngelaDavis] }
-      );
 
       //expect Angela to be in list of assignees
       expect(
@@ -97,7 +101,7 @@ test.describe('Journey instance sidebar', () => {
 
       //Expect PUT-request to be done
       const { log: putTagLog } = moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${AngelaDavis.id}`,
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
         'put'
       );
       expect(putTagLog().length).toEqual(1);
@@ -138,19 +142,19 @@ test.describe('Journey instance sidebar', () => {
         )
         .hover();
 
-      //find x-icon and click it
-      await page
-        .locator(
-          `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
-        )
-        .click();
-
       //GET journey instance again, with no assignees
       moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
         'get',
         { ...ClarasOnboarding, assignees: [] }
       );
+
+      //find x-icon and click it
+      await page
+        .locator(
+          `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
+        )
+        .click();
 
       //there should be no Angela in list of assignees
       expect(
@@ -205,12 +209,18 @@ test.describe('Journey instance sidebar', () => {
       );
       //Clara appears in search results in PersonSelect
       moxy.setZetkinApiMock(`/orgs/${KPD.id}/search/person`, 'post', [
-        ClaraZetkin,
+        ClarasOnboarding.subjects[0],
       ]);
       //Add Clara as subject
       moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClaraZetkin.id}`,
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
         'put'
+      );
+      //GET data for Clara to render her info
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/people/${ClarasOnboarding.subjects[0].id}`,
+        'get',
+        ClarasOnboarding.subjects[0]
       );
 
       await page.goto(appUri + '/organize/1/journeys/1/1');
@@ -219,19 +229,19 @@ test.describe('Journey instance sidebar', () => {
       await page.locator('data-testid=Button-add-subject').click();
       await page.locator('text=Add person').type('Clara');
 
+      //GET the journeyInstance with Clara as assignee
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+        'get',
+        ClarasOnboarding
+      );
+
       //click Clara in search results
       await page
         .locator(
           `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
         )
         .click();
-
-      //GET the journeyInstance with Clara as assignee
-      moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
-        'get',
-        { ...ClarasOnboarding, subjects: [ClaraZetkin] }
-      );
 
       //expect Clara to be in list of assignees
       expect(
@@ -244,7 +254,7 @@ test.describe('Journey instance sidebar', () => {
 
       //Expect PUT-request to be done
       const { log: putTagLog } = moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClaraZetkin.id}`,
+        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
         'put'
       );
       expect(putTagLog().length).toEqual(1);
@@ -286,19 +296,19 @@ test.describe('Journey instance sidebar', () => {
         )
         .hover();
 
-      //find x-icon and click it
-      await page
-        .locator(
-          `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
-        )
-        .click();
-
       //GET journey instance again, with no subjects
       moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
         'get',
         { ...ClarasOnboarding, subjects: [] }
       );
+
+      //find x-icon and click it
+      await page
+        .locator(
+          `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
+        )
+        .click();
 
       //there should be no Clara in list of subejcts
       expect(

--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -48,13 +48,13 @@ export const journeyInstanceResource = (orgId: string, instanceId: string) => {
   return {
     prefetch: createPrefetch<ZetkinJourneyInstance>(key, url),
     useAddAssignee: createUseMutationPut({ key, url: `${url}/assignees` }),
-    useAddMember: createUseMutationPut({ key, url: `${url}/subjects` }),
+    useAddSubject: createUseMutationPut({ key, url: `${url}/subjects` }),
     useQuery: createUseQuery<ZetkinJourneyInstance>(key, url),
     useRemoveAssignee: createUseMutationDelete({
       key,
       url: `${url}/assignees`,
     }),
-    useRemoveMember: createUseMutationDelete({ key, url: `${url}/subjects` }),
+    useRemoveSubject: createUseMutationDelete({ key, url: `${url}/subjects` }),
     useUpdate: createUseMutation<
       Partial<ZetkinJourneyInstance>,
       ZetkinJourneyInstance

--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -48,11 +48,13 @@ export const journeyInstanceResource = (orgId: string, instanceId: string) => {
   return {
     prefetch: createPrefetch<ZetkinJourneyInstance>(key, url),
     useAddAssignee: createUseMutationPut({ key, url: `${url}/assignees` }),
+    useAddMember: createUseMutationPut({ key, url: `${url}/subjects` }),
     useQuery: createUseQuery<ZetkinJourneyInstance>(key, url),
     useRemoveAssignee: createUseMutationDelete({
       key,
       url: `${url}/assignees`,
     }),
+    useRemoveMember: createUseMutationDelete({ key, url: `${url}/subjects` }),
     useUpdate: createUseMutation<
       Partial<ZetkinJourneyInstance>,
       ZetkinJourneyInstance

--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -3,6 +3,7 @@ import { TagMetadata } from '../utils/getTagMetadata';
 import {
   createPrefetch,
   createUseMutation,
+  createUseMutationPut,
   createUseQuery,
 } from './utils/resourceHookFactories';
 import { ZetkinJourney, ZetkinJourneyInstance } from 'types/zetkin';
@@ -45,6 +46,7 @@ export const journeyInstanceResource = (orgId: string, instanceId: string) => {
 
   return {
     prefetch: createPrefetch<ZetkinJourneyInstance>(key, url),
+    useAddAssignee: createUseMutationPut({ key, url: `${url}/assignees` }),
     useQuery: createUseQuery<ZetkinJourneyInstance>(key, url),
     useUpdate: createUseMutation<
       Partial<ZetkinJourneyInstance>,

--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -3,6 +3,7 @@ import { TagMetadata } from '../utils/getTagMetadata';
 import {
   createPrefetch,
   createUseMutation,
+  createUseMutationDelete,
   createUseMutationPut,
   createUseQuery,
 } from './utils/resourceHookFactories';
@@ -48,6 +49,10 @@ export const journeyInstanceResource = (orgId: string, instanceId: string) => {
     prefetch: createPrefetch<ZetkinJourneyInstance>(key, url),
     useAddAssignee: createUseMutationPut({ key, url: `${url}/assignees` }),
     useQuery: createUseQuery<ZetkinJourneyInstance>(key, url),
+    useRemoveAssignee: createUseMutationDelete({
+      key,
+      url: `${url}/assignees`,
+    }),
     useUpdate: createUseMutation<
       Partial<ZetkinJourneyInstance>,
       ZetkinJourneyInstance

--- a/src/components/ZetkinPerson.tsx
+++ b/src/components/ZetkinPerson.tsx
@@ -9,7 +9,17 @@ const ZetkinPerson: React.FunctionComponent<{
   showText?: boolean;
   size?: number;
   subtitle?: string | React.ReactNode;
-}> = ({ containerProps, id, link, name, showText = true, size, subtitle }) => {
+  tooltip?: boolean;
+}> = ({
+  containerProps,
+  id,
+  link,
+  name,
+  showText = true,
+  size,
+  subtitle,
+  tooltip = true,
+}) => {
   const router = useRouter();
   const { orgId } = router.query;
   const linkProps = {
@@ -19,14 +29,21 @@ const ZetkinPerson: React.FunctionComponent<{
 
   return (
     <Box display="flex" {...containerProps}>
-      <Tooltip title={name}>
+      {tooltip ? (
+        <Tooltip title={name}>
+          <Avatar
+            {...(link ? linkProps : {})}
+            src={orgId ? `/api/orgs/${orgId}/people/${id}/avatar` : ''}
+            style={size ? { height: size, width: size } : {}}
+          />
+        </Tooltip>
+      ) : (
         <Avatar
           {...(link ? linkProps : {})}
           src={orgId ? `/api/orgs/${orgId}/people/${id}/avatar` : ''}
           style={size ? { height: size, width: size } : {}}
         />
-      </Tooltip>
-
+      )}
       {showText && (
         <Box
           alignItems="start"

--- a/src/components/ZetkinSection.tsx
+++ b/src/components/ZetkinSection.tsx
@@ -10,9 +10,10 @@ const ZetkinSection: FunctionComponent<ZetkinSectionProps> = ({
   children,
   title,
   action,
+  ...restProps
 }) => {
   return (
-    <Box>
+    <Box {...restProps}>
       <Box
         alignItems="center"
         display="flex"

--- a/src/components/forms/common/PersonSelect.tsx
+++ b/src/components/forms/common/PersonSelect.tsx
@@ -53,7 +53,10 @@ interface UsePersonSelectReturn {
 
 type UsePersonSelect = (props: UsePersonSelectProps) => UsePersonSelectReturn;
 
-type PersonSelectProps = UsePersonSelectProps;
+type PersonSelectProps = UsePersonSelectProps & {
+  size?: 'small' | 'medium';
+  variant?: 'filled' | 'outlined' | 'standard';
+};
 
 const usePersonSelect: UsePersonSelect = ({
   getOptionDisabled,
@@ -159,7 +162,8 @@ const PersonSelect: FunctionComponent<PersonSelectProps & { name: string }> = (
 export default PersonSelect;
 
 const MUIOnlyPersonSelect: FunctionComponent<PersonSelectProps> = (props) => {
-  const { autoCompleteProps } = usePersonSelect(props);
+  const { label, size, variant, ...restComponentProps } = props;
+  const { autoCompleteProps } = usePersonSelect(restComponentProps);
 
   const { name, placeholder, inputRef, ...restProps } = autoCompleteProps;
 
@@ -175,9 +179,11 @@ const MUIOnlyPersonSelect: FunctionComponent<PersonSelectProps> = (props) => {
             ...params.inputProps,
           }}
           inputRef={inputRef}
+          label={label}
           name={name}
           placeholder={placeholder}
-          variant="outlined"
+          size={size}
+          variant={variant}
         />
       )}
     />

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -1,0 +1,60 @@
+import { useIntl } from 'react-intl';
+import { Divider, Grid } from '@material-ui/core';
+
+import JourneyMilestoneProgress from 'components/organize/journeys/JourneyMilestoneProgress';
+import { ZetkinJourneyInstance } from 'types/zetkin';
+import ZetkinSection from 'components/ZetkinSection';
+
+const JourneyInstanceSidebar = ({
+  journeyInstance,
+}: {
+  journeyInstance: ZetkinJourneyInstance;
+}): JSX.Element => {
+  const intl = useIntl();
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={12}>
+        <ZetkinSection
+          title={intl.formatMessage({
+            id: 'pages.organizeJourneyInstance.assignedTo',
+          })}
+        ></ZetkinSection>
+        <Divider />
+      </Grid>
+      <Grid item xs={12}>
+        <ZetkinSection
+          title={intl.formatMessage({
+            id: 'pages.organizeJourneyInstance.members',
+          })}
+        ></ZetkinSection>
+        <Divider />
+      </Grid>
+      <Grid item xs={12}>
+        <ZetkinSection
+          title={intl.formatMessage({
+            id: 'pages.organizeJourneyInstance.tags',
+          })}
+        ></ZetkinSection>
+        <Divider />
+      </Grid>
+      {journeyInstance.milestones && (
+        <Grid item xs={12}>
+          <ZetkinSection
+            title={intl.formatMessage({
+              id: 'pages.organizeJourneyInstance.milestones',
+            })}
+          >
+            <JourneyMilestoneProgress
+              milestones={journeyInstance.milestones}
+              next_milestone={journeyInstance.next_milestone}
+            />
+          </ZetkinSection>
+          <Divider />
+        </Grid>
+      )}
+    </Grid>
+  );
+};
+
+export default JourneyInstanceSidebar;

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -1,18 +1,11 @@
-import { grey } from '@material-ui/core/colors';
+import { Add } from '@material-ui/icons';
 import { useState } from 'react';
-import { Add, Close } from '@material-ui/icons';
-import {
-  Box,
-  Button,
-  ClickAwayListener,
-  Divider,
-  Grid,
-} from '@material-ui/core';
+import { Button, ClickAwayListener, Divider, Grid } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import JourneyMilestoneProgress from 'components/organize/journeys/JourneyMilestoneProgress';
+import JourneyPerson from './JourneyPerson';
 import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
-import ZetkinPerson from 'components/ZetkinPerson';
 import ZetkinSection from 'components/ZetkinSection';
 import {
   ZetkinJourneyInstance,
@@ -22,16 +15,20 @@ import {
 const JourneyInstanceSidebar = ({
   journeyInstance,
   onAddAssignee,
+  onAddMember,
   onRemoveAssignee,
+  onRemoveMember,
 }: {
   journeyInstance: ZetkinJourneyInstance;
   onAddAssignee: (person: ZetkinPersonType) => void;
+  onAddMember: (person: ZetkinPersonType) => void;
   onRemoveAssignee: (person: ZetkinPersonType) => void;
+  onRemoveMember: (person: ZetkinPersonType) => void;
 }): JSX.Element => {
   const intl = useIntl();
 
   const [addingAssignee, setAddingAssignee] = useState<boolean>(false);
-  const [hover, setHover] = useState<boolean>(false);
+  const [addingMember, setAddingMember] = useState<boolean>(false);
 
   return (
     <Grid container spacing={2}>
@@ -42,23 +39,11 @@ const JourneyInstanceSidebar = ({
           })}
         >
           {journeyInstance.assignees.map((assignee, index) => (
-            <Box
+            <JourneyPerson
               key={index}
-              alignItems="center"
-              bgcolor={hover ? grey[200] : ''}
-              display="flex"
-              justifyContent="space-between"
-              onClick={() => onRemoveAssignee(assignee)}
-              onMouseEnter={() => setHover(true)}
-              onMouseLeave={() => setHover(false)}
-              p={1}
-            >
-              <ZetkinPerson
-                id={assignee.id}
-                name={`${assignee.first_name} ${assignee.last_name}`}
-              />
-              {hover && <Close color="secondary" />}
-            </Box>
+              onRemove={onRemoveAssignee}
+              person={assignee}
+            />
           ))}
           {!addingAssignee && (
             <Button
@@ -75,11 +60,9 @@ const JourneyInstanceSidebar = ({
               <div>
                 <PersonSelect
                   getOptionDisabled={(option) => {
-                    if (journeyInstance.assignees.length > 0) {
-                      return !journeyInstance.assignees.includes(option);
-                    } else {
-                      return false;
-                    }
+                    return journeyInstance.assignees
+                      .map((a) => a.id)
+                      .includes(option.id);
                   }}
                   label={intl.formatMessage({
                     id: 'pages.organizeJourneyInstance.assignPersonLabel',
@@ -104,6 +87,46 @@ const JourneyInstanceSidebar = ({
             id: 'pages.organizeJourneyInstance.members',
           })}
         ></ZetkinSection>
+        {journeyInstance.subjects.map((member, index) => (
+          <JourneyPerson
+            key={index}
+            onRemove={onRemoveMember}
+            person={member}
+          />
+        ))}
+        {!addingMember && (
+          <Button
+            color="primary"
+            onClick={() => setAddingMember(true)}
+            startIcon={<Add />}
+            style={{ textTransform: 'uppercase' }}
+          >
+            <Msg id="pages.organizeJourneyInstance.addMemberButton" />
+          </Button>
+        )}
+        {addingMember && (
+          <ClickAwayListener onClickAway={() => setAddingMember(false)}>
+            <div>
+              <PersonSelect
+                getOptionDisabled={(option) => {
+                  return journeyInstance.subjects
+                    .map((s) => s.id)
+                    .includes(option.id);
+                }}
+                label={intl.formatMessage({
+                  id: 'pages.organizeJourneyInstance.addMemberLabel',
+                })}
+                name="person_id"
+                onChange={(person) => {
+                  setAddingMember(false);
+                  onAddMember(person);
+                }}
+                selectedPerson={null}
+                size="small"
+              />
+            </div>
+          </ClickAwayListener>
+        )}
         <Divider />
       </Grid>
       <Grid item xs={12}>

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -15,20 +15,20 @@ import {
 const JourneyInstanceSidebar = ({
   journeyInstance,
   onAddAssignee,
-  onAddMember,
+  onAddSubject,
   onRemoveAssignee,
-  onRemoveMember,
+  onRemoveSubject,
 }: {
   journeyInstance: ZetkinJourneyInstance;
   onAddAssignee: (person: ZetkinPersonType) => void;
-  onAddMember: (person: ZetkinPersonType) => void;
+  onAddSubject: (person: ZetkinPersonType) => void;
   onRemoveAssignee: (person: ZetkinPersonType) => void;
-  onRemoveMember: (person: ZetkinPersonType) => void;
+  onRemoveSubject: (person: ZetkinPersonType) => void;
 }): JSX.Element => {
   const intl = useIntl();
 
   const [addingAssignee, setAddingAssignee] = useState<boolean>(false);
-  const [addingMember, setAddingMember] = useState<boolean>(false);
+  const [addingSubject, setAddingSubject] = useState<boolean>(false);
 
   return (
     <Grid container spacing={2}>
@@ -90,22 +90,22 @@ const JourneyInstanceSidebar = ({
         {journeyInstance.subjects.map((member, index) => (
           <JourneyPerson
             key={index}
-            onRemove={onRemoveMember}
+            onRemove={onRemoveSubject}
             person={member}
           />
         ))}
-        {!addingMember && (
+        {!addingSubject && (
           <Button
             color="primary"
-            onClick={() => setAddingMember(true)}
+            onClick={() => setAddingSubject(true)}
             startIcon={<Add />}
             style={{ textTransform: 'uppercase' }}
           >
-            <Msg id="pages.organizeJourneyInstance.addMemberButton" />
+            <Msg id="pages.organizeJourneyInstance.addSubjectButton" />
           </Button>
         )}
-        {addingMember && (
-          <ClickAwayListener onClickAway={() => setAddingMember(false)}>
+        {addingSubject && (
+          <ClickAwayListener onClickAway={() => setAddingSubject(false)}>
             <div>
               <PersonSelect
                 getOptionDisabled={(option) => {
@@ -114,12 +114,12 @@ const JourneyInstanceSidebar = ({
                     .includes(option.id);
                 }}
                 label={intl.formatMessage({
-                  id: 'pages.organizeJourneyInstance.addMemberLabel',
+                  id: 'pages.organizeJourneyInstance.addSubjectLabel',
                 })}
                 name="person_id"
                 onChange={(person) => {
-                  setAddingMember(false);
-                  onAddMember(person);
+                  setAddingSubject(false);
+                  onAddSubject(person);
                 }}
                 selectedPerson={null}
                 size="small"

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -1,10 +1,17 @@
 import { Add } from '@material-ui/icons';
 import { useState } from 'react';
-import { Button, ClickAwayListener, Divider, Grid } from '@material-ui/core';
+import {
+  Box,
+  Button,
+  ClickAwayListener,
+  Divider,
+  Grid,
+} from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import JourneyMilestoneProgress from 'components/organize/journeys/JourneyMilestoneProgress';
 import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
+import ZetkinPerson from 'components/ZetkinPerson';
 import ZetkinSection from 'components/ZetkinSection';
 import {
   ZetkinJourneyInstance,
@@ -30,6 +37,19 @@ const JourneyInstanceSidebar = ({
             id: 'pages.organizeJourneyInstance.assignedTo',
           })}
         >
+          {journeyInstance.assignees.map((assignee, index) => (
+            <Box
+              key={index}
+              alignItems="center"
+              display="flex"
+              justifyContent="space-between"
+            >
+              <ZetkinPerson
+                id={assignee.id}
+                name={`${assignee.first_name} ${assignee.last_name}`}
+              />
+            </Box>
+          ))}
           {!addingAssignee && (
             <Button
               color="primary"

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -64,6 +64,9 @@ const JourneyInstanceSidebar = ({
             <ClickAwayListener onClickAway={() => setAddingAssignee(false)}>
               <div>
                 <PersonSelect
+                  getOptionDisabled={(option) =>
+                    !journeyInstance.assignees.includes(option)
+                  }
                   label={intl.formatMessage({
                     id: 'pages.organizeJourneyInstance.assignPersonLabel',
                   })}

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -1,16 +1,26 @@
-import { useIntl } from 'react-intl';
-import { Divider, Grid } from '@material-ui/core';
+import { Add } from '@material-ui/icons';
+import { useState } from 'react';
+import { Button, ClickAwayListener, Divider, Grid } from '@material-ui/core';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import JourneyMilestoneProgress from 'components/organize/journeys/JourneyMilestoneProgress';
-import { ZetkinJourneyInstance } from 'types/zetkin';
+import { MUIOnlyPersonSelect as PersonSelect } from 'components/forms/common/PersonSelect';
 import ZetkinSection from 'components/ZetkinSection';
+import {
+  ZetkinJourneyInstance,
+  ZetkinPerson as ZetkinPersonType,
+} from 'types/zetkin';
 
 const JourneyInstanceSidebar = ({
   journeyInstance,
+  onAddAssignee,
 }: {
   journeyInstance: ZetkinJourneyInstance;
+  onAddAssignee: (person: ZetkinPersonType) => void;
 }): JSX.Element => {
   const intl = useIntl();
+
+  const [addingAssignee, setAddingAssignee] = useState<boolean>(false);
 
   return (
     <Grid container spacing={2}>
@@ -19,7 +29,36 @@ const JourneyInstanceSidebar = ({
           title={intl.formatMessage({
             id: 'pages.organizeJourneyInstance.assignedTo',
           })}
-        ></ZetkinSection>
+        >
+          {!addingAssignee && (
+            <Button
+              color="primary"
+              onClick={() => setAddingAssignee(true)}
+              startIcon={<Add />}
+              style={{ textTransform: 'uppercase' }}
+            >
+              <Msg id="pages.organizeJourneyInstance.addAssigneeButton" />
+            </Button>
+          )}
+          {addingAssignee && (
+            <ClickAwayListener onClickAway={() => setAddingAssignee(false)}>
+              <div>
+                <PersonSelect
+                  label={intl.formatMessage({
+                    id: 'pages.organizeJourneyInstance.assignPersonLabel',
+                  })}
+                  name="person_id"
+                  onChange={(person) => {
+                    setAddingAssignee(false);
+                    onAddAssignee(person);
+                  }}
+                  selectedPerson={null}
+                  size="small"
+                />
+              </div>
+            </ClickAwayListener>
+          )}
+        </ZetkinSection>
         <Divider />
       </Grid>
       <Grid item xs={12}>

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -1,5 +1,6 @@
-import { Add } from '@material-ui/icons';
+import { grey } from '@material-ui/core/colors';
 import { useState } from 'react';
+import { Add, Close } from '@material-ui/icons';
 import {
   Box,
   Button,
@@ -21,13 +22,16 @@ import {
 const JourneyInstanceSidebar = ({
   journeyInstance,
   onAddAssignee,
+  onRemoveAssignee,
 }: {
   journeyInstance: ZetkinJourneyInstance;
   onAddAssignee: (person: ZetkinPersonType) => void;
+  onRemoveAssignee: (person: ZetkinPersonType) => void;
 }): JSX.Element => {
   const intl = useIntl();
 
   const [addingAssignee, setAddingAssignee] = useState<boolean>(false);
+  const [hover, setHover] = useState<boolean>(false);
 
   return (
     <Grid container spacing={2}>
@@ -41,13 +45,19 @@ const JourneyInstanceSidebar = ({
             <Box
               key={index}
               alignItems="center"
+              bgcolor={hover ? grey[200] : ''}
               display="flex"
               justifyContent="space-between"
+              onClick={() => onRemoveAssignee(assignee)}
+              onMouseEnter={() => setHover(true)}
+              onMouseLeave={() => setHover(false)}
+              p={1}
             >
               <ZetkinPerson
                 id={assignee.id}
                 name={`${assignee.first_name} ${assignee.last_name}`}
               />
+              {hover && <Close color="secondary" />}
             </Box>
           ))}
           {!addingAssignee && (
@@ -64,9 +74,13 @@ const JourneyInstanceSidebar = ({
             <ClickAwayListener onClickAway={() => setAddingAssignee(false)}>
               <div>
                 <PersonSelect
-                  getOptionDisabled={(option) =>
-                    !journeyInstance.assignees.includes(option)
-                  }
+                  getOptionDisabled={(option) => {
+                    if (journeyInstance.assignees.length > 0) {
+                      return !journeyInstance.assignees.includes(option);
+                    } else {
+                      return false;
+                    }
+                  }}
                   label={intl.formatMessage({
                     id: 'pages.organizeJourneyInstance.assignPersonLabel',
                   })}

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -34,6 +34,7 @@ const JourneyInstanceSidebar = ({
     <Grid container spacing={2}>
       <Grid item xs={12}>
         <ZetkinSection
+          data-testid="ZetkinSection-assignees"
           title={intl.formatMessage({
             id: 'pages.organizeJourneyInstance.assignedTo',
           })}
@@ -48,6 +49,7 @@ const JourneyInstanceSidebar = ({
           {!addingAssignee && (
             <Button
               color="primary"
+              data-testid="Button-add-assignee"
               onClick={() => setAddingAssignee(true)}
               startIcon={<Add />}
               style={{ textTransform: 'uppercase' }}
@@ -59,6 +61,7 @@ const JourneyInstanceSidebar = ({
             <ClickAwayListener onClickAway={() => setAddingAssignee(false)}>
               <div>
                 <PersonSelect
+                  data-testid="PersonSelect-add-assignee"
                   getOptionDisabled={(option) => {
                     return journeyInstance.assignees
                       .map((a) => a.id)
@@ -83,50 +86,53 @@ const JourneyInstanceSidebar = ({
       </Grid>
       <Grid item xs={12}>
         <ZetkinSection
+          data-testid="ZetkinSection-subjects"
           title={intl.formatMessage({
             id: 'pages.organizeJourneyInstance.members',
           })}
-        ></ZetkinSection>
-        {journeyInstance.subjects.map((member, index) => (
-          <JourneyPerson
-            key={index}
-            onRemove={onRemoveSubject}
-            person={member}
-          />
-        ))}
-        {!addingSubject && (
-          <Button
-            color="primary"
-            onClick={() => setAddingSubject(true)}
-            startIcon={<Add />}
-            style={{ textTransform: 'uppercase' }}
-          >
-            <Msg id="pages.organizeJourneyInstance.addSubjectButton" />
-          </Button>
-        )}
-        {addingSubject && (
-          <ClickAwayListener onClickAway={() => setAddingSubject(false)}>
-            <div>
-              <PersonSelect
-                getOptionDisabled={(option) => {
-                  return journeyInstance.subjects
-                    .map((s) => s.id)
-                    .includes(option.id);
-                }}
-                label={intl.formatMessage({
-                  id: 'pages.organizeJourneyInstance.addSubjectLabel',
-                })}
-                name="person_id"
-                onChange={(person) => {
-                  setAddingSubject(false);
-                  onAddSubject(person);
-                }}
-                selectedPerson={null}
-                size="small"
-              />
-            </div>
-          </ClickAwayListener>
-        )}
+        >
+          {journeyInstance.subjects.map((member, index) => (
+            <JourneyPerson
+              key={index}
+              onRemove={onRemoveSubject}
+              person={member}
+            />
+          ))}
+          {!addingSubject && (
+            <Button
+              color="primary"
+              data-testid="Button-add-subject"
+              onClick={() => setAddingSubject(true)}
+              startIcon={<Add />}
+              style={{ textTransform: 'uppercase' }}
+            >
+              <Msg id="pages.organizeJourneyInstance.addSubjectButton" />
+            </Button>
+          )}
+          {addingSubject && (
+            <ClickAwayListener onClickAway={() => setAddingSubject(false)}>
+              <div>
+                <PersonSelect
+                  getOptionDisabled={(option) => {
+                    return journeyInstance.subjects
+                      .map((s) => s.id)
+                      .includes(option.id);
+                  }}
+                  label={intl.formatMessage({
+                    id: 'pages.organizeJourneyInstance.addSubjectLabel',
+                  })}
+                  name="person_id"
+                  onChange={(person) => {
+                    setAddingSubject(false);
+                    onAddSubject(person);
+                  }}
+                  selectedPerson={null}
+                  size="small"
+                />
+              </div>
+            </ClickAwayListener>
+          )}
+        </ZetkinSection>
         <Divider />
       </Grid>
       <Grid item xs={12}>

--- a/src/components/organize/journeys/JourneyPerson.tsx
+++ b/src/components/organize/journeys/JourneyPerson.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
+import { grey } from '@material-ui/core/colors';
+import { useState } from 'react';
+
+import ZetkinPerson from 'components/ZetkinPerson';
+import { ZetkinPerson as ZetkinPersonType } from 'types/zetkin';
+
+const JourneyPerson = ({
+  person,
+  onRemove,
+}: {
+  onRemove: (person: ZetkinPersonType) => void;
+  person: ZetkinPersonType;
+}): JSX.Element => {
+  const [hover, setHover] = useState<boolean>(false);
+  return (
+    <Box
+      alignItems="center"
+      bgcolor={hover ? grey[200] : ''}
+      display="flex"
+      justifyContent="space-between"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      p={1}
+    >
+      <ZetkinPerson
+        id={person.id}
+        name={`${person.first_name} ${person.last_name}`}
+      />
+      {hover && <Close color="secondary" onClick={() => onRemove(person)} />}
+    </Box>
+  );
+};
+
+export default JourneyPerson;

--- a/src/components/organize/journeys/JourneyPerson.tsx
+++ b/src/components/organize/journeys/JourneyPerson.tsx
@@ -28,7 +28,13 @@ const JourneyPerson = ({
         id={person.id}
         name={`${person.first_name} ${person.last_name}`}
       />
-      {hover && <Close color="secondary" onClick={() => onRemove(person)} />}
+      {hover && (
+        <Close
+          color="secondary"
+          onClick={() => onRemove(person)}
+          style={{ cursor: 'pointer' }}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/organize/journeys/JourneyPerson.tsx
+++ b/src/components/organize/journeys/JourneyPerson.tsx
@@ -18,6 +18,7 @@ const JourneyPerson = ({
     <Box
       alignItems="center"
       bgcolor={hover ? grey[200] : ''}
+      data-testid={`JourneyPerson-${person.id}`}
       display="flex"
       justifyContent="space-between"
       onMouseEnter={() => setHover(true)}
@@ -31,6 +32,7 @@ const JourneyPerson = ({
       {hover && (
         <Close
           color="secondary"
+          data-testid={`JourneyPerson-remove-${person.id}`}
           onClick={() => onRemove(person)}
           style={{ cursor: 'pointer' }}
         />

--- a/src/components/organize/journeys/JourneyPerson.tsx
+++ b/src/components/organize/journeys/JourneyPerson.tsx
@@ -3,6 +3,7 @@ import { Close } from '@material-ui/icons';
 import { grey } from '@material-ui/core/colors';
 import { useState } from 'react';
 
+import PersonHoverCard from 'components/PersonHoverCard';
 import ZetkinPerson from 'components/ZetkinPerson';
 import { ZetkinPerson as ZetkinPersonType } from 'types/zetkin';
 
@@ -25,10 +26,13 @@ const JourneyPerson = ({
       onMouseLeave={() => setHover(false)}
       p={1}
     >
-      <ZetkinPerson
-        id={person.id}
-        name={`${person.first_name} ${person.last_name}`}
-      />
+      <PersonHoverCard personId={person.id}>
+        <ZetkinPerson
+          id={person.id}
+          name={`${person.first_name} ${person.last_name}`}
+          tooltip={false}
+        />
+      </PersonHoverCard>
       {hover && (
         <Close
           color="secondary"

--- a/src/components/views/EmptyView.tsx
+++ b/src/components/views/EmptyView.tsx
@@ -82,6 +82,7 @@ const EmptyView: FunctionComponent<EmptyViewProps> = ({ orgId, view }) => {
                     addFirstRowMutation.mutate(person);
                   }}
                   selectedPerson={null}
+                  variant="outlined"
                 />
               </Box>
             </CardContent>

--- a/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/components/views/ViewDataTable/ViewDataTableFooter.tsx
@@ -52,6 +52,7 @@ const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({
           id: 'misc.views.footer.addPlaceholder',
         })}
         selectedPerson={null}
+        variant="outlined"
       />
     </Box>
   );

--- a/src/locale/pages/organizeJourneyInstance/en.yml
+++ b/src/locale/pages/organizeJourneyInstance/en.yml
@@ -1,3 +1,5 @@
+addAssigneeButton: Add assignee
+assignPersonLabel: Assign person
 assignedTo: Assigned to
 collapseButton: Collapse
 complete: Complete

--- a/src/locale/pages/organizeJourneyInstance/en.yml
+++ b/src/locale/pages/organizeJourneyInstance/en.yml
@@ -1,4 +1,6 @@
 addAssigneeButton: Add assignee
+addMemberButton: Add member
+addMemberLabel: Add member
 assignPersonLabel: Assign person
 assignedTo: Assigned to
 collapseButton: Collapse

--- a/src/locale/pages/organizeJourneyInstance/en.yml
+++ b/src/locale/pages/organizeJourneyInstance/en.yml
@@ -1,6 +1,6 @@
 addAssigneeButton: Add assignee
-addMemberButton: Add member
-addMemberLabel: Add member
+addSubjectButton: Add person
+addSubjectLabel: Add person
 assignPersonLabel: Assign person
 assignedTo: Assigned to
 collapseButton: Collapse

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -1,17 +1,15 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { useIntl } from 'react-intl';
 import { Divider, Grid } from '@material-ui/core';
 
 import JourneyInstanceLayout from 'layout/organize/JourneyInstanceLayout';
 import { journeyInstanceResource } from 'api/journeys';
+import JourneyInstanceSidebar from 'components/organize/journeys/JourneyInstanceSidebar';
 import JourneyInstanceSummary from 'components/organize/journeys/JourneyInstanceSummary';
-import JourneyMilestoneProgress from 'components/organize/journeys/JourneyMilestoneProgress';
 import { organizationResource } from 'api/organizations';
 import { PageWithLayout } from 'types';
 import { scaffold } from 'utils/next';
 import { ZetkinJourneyInstance } from 'types/zetkin';
-import ZetkinSection from 'components/ZetkinSection';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -62,8 +60,6 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
   ).useQuery();
   const journeyInstance = journeyInstanceQuery.data as ZetkinJourneyInstance;
 
-  const intl = useIntl();
-
   return (
     <>
       <Head>
@@ -79,47 +75,7 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
           <Divider style={{ marginTop: '2rem' }} />
         </Grid>
         <Grid item md={4}>
-          <Grid container spacing={2}>
-            <Grid item xs={12}>
-              <ZetkinSection
-                title={intl.formatMessage({
-                  id: 'pages.organizeJourneyInstance.assignedTo',
-                })}
-              ></ZetkinSection>
-              <Divider />
-            </Grid>
-            <Grid item xs={12}>
-              <ZetkinSection
-                title={intl.formatMessage({
-                  id: 'pages.organizeJourneyInstance.members',
-                })}
-              ></ZetkinSection>
-              <Divider />
-            </Grid>
-            <Grid item xs={12}>
-              <ZetkinSection
-                title={intl.formatMessage({
-                  id: 'pages.organizeJourneyInstance.tags',
-                })}
-              ></ZetkinSection>
-              <Divider />
-            </Grid>
-            {journeyInstance.milestones && (
-              <Grid item xs={12}>
-                <ZetkinSection
-                  title={intl.formatMessage({
-                    id: 'pages.organizeJourneyInstance.milestones',
-                  })}
-                >
-                  <JourneyMilestoneProgress
-                    milestones={journeyInstance.milestones}
-                    next_milestone={journeyInstance.next_milestone}
-                  />
-                </ZetkinSection>
-                <Divider />
-              </Grid>
-            )}
-          </Grid>
+          <JourneyInstanceSidebar journeyInstance={journeyInstance} />
         </Grid>
       </Grid>
     </>

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -56,12 +56,11 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
   instanceId,
   orgId,
 }) => {
-  const { useAddAssignee, useQuery } = journeyInstanceResource(
-    orgId,
-    instanceId
-  );
+  const { useAddAssignee, useQuery, useRemoveAssignee } =
+    journeyInstanceResource(orgId, instanceId);
   const journeyInstanceQuery = useQuery();
   const addAssigneeMutation = useAddAssignee();
+  const removeAssigneeMutation = useRemoveAssignee();
 
   const journeyInstance = journeyInstanceQuery.data as ZetkinJourneyInstance;
 
@@ -69,6 +68,12 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
 
   const onAddAssignee = (person: ZetkinPerson) => {
     addAssigneeMutation.mutate(person.id, {
+      onError: () => showSnackbar('error'),
+    });
+  };
+
+  const onRemoveAssignee = (person: ZetkinPerson) => {
+    removeAssigneeMutation.mutate(person.id, {
       onError: () => showSnackbar('error'),
     });
   };
@@ -91,6 +96,7 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
           <JourneyInstanceSidebar
             journeyInstance={journeyInstance}
             onAddAssignee={onAddAssignee}
+            onRemoveAssignee={onRemoveAssignee}
           />
         </Grid>
       </Grid>

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -56,11 +56,18 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
   instanceId,
   orgId,
 }) => {
-  const { useAddAssignee, useQuery, useRemoveAssignee } =
-    journeyInstanceResource(orgId, instanceId);
+  const {
+    useAddAssignee,
+    useAddMember,
+    useQuery,
+    useRemoveAssignee,
+    useRemoveMember,
+  } = journeyInstanceResource(orgId, instanceId);
   const journeyInstanceQuery = useQuery();
   const addAssigneeMutation = useAddAssignee();
   const removeAssigneeMutation = useRemoveAssignee();
+  const addMemberMutation = useAddMember();
+  const removeMemberMutation = useRemoveMember();
 
   const journeyInstance = journeyInstanceQuery.data as ZetkinJourneyInstance;
 
@@ -74,6 +81,18 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
 
   const onRemoveAssignee = (person: ZetkinPerson) => {
     removeAssigneeMutation.mutate(person.id, {
+      onError: () => showSnackbar('error'),
+    });
+  };
+
+  const onAddMember = (person: ZetkinPerson) => {
+    addMemberMutation.mutate(person.id, {
+      onError: () => showSnackbar('error'),
+    });
+  };
+
+  const onRemoveMember = (person: ZetkinPerson) => {
+    removeMemberMutation.mutate(person.id, {
       onError: () => showSnackbar('error'),
     });
   };
@@ -96,7 +115,9 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
           <JourneyInstanceSidebar
             journeyInstance={journeyInstance}
             onAddAssignee={onAddAssignee}
+            onAddMember={onAddMember}
             onRemoveAssignee={onRemoveAssignee}
+            onRemoveMember={onRemoveMember}
           />
         </Grid>
       </Grid>

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -58,16 +58,16 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
 }) => {
   const {
     useAddAssignee,
-    useAddMember,
+    useAddSubject,
     useQuery,
     useRemoveAssignee,
-    useRemoveMember,
+    useRemoveSubject,
   } = journeyInstanceResource(orgId, instanceId);
   const journeyInstanceQuery = useQuery();
   const addAssigneeMutation = useAddAssignee();
   const removeAssigneeMutation = useRemoveAssignee();
-  const addMemberMutation = useAddMember();
-  const removeMemberMutation = useRemoveMember();
+  const addMemberMutation = useAddSubject();
+  const removeMemberMutation = useRemoveSubject();
 
   const journeyInstance = journeyInstanceQuery.data as ZetkinJourneyInstance;
 
@@ -85,13 +85,13 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
     });
   };
 
-  const onAddMember = (person: ZetkinPerson) => {
+  const onAddSubject = (person: ZetkinPerson) => {
     addMemberMutation.mutate(person.id, {
       onError: () => showSnackbar('error'),
     });
   };
 
-  const onRemoveMember = (person: ZetkinPerson) => {
+  const onRemoveSubject = (person: ZetkinPerson) => {
     removeMemberMutation.mutate(person.id, {
       onError: () => showSnackbar('error'),
     });
@@ -115,9 +115,9 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
           <JourneyInstanceSidebar
             journeyInstance={journeyInstance}
             onAddAssignee={onAddAssignee}
-            onAddMember={onAddMember}
+            onAddSubject={onAddSubject}
             onRemoveAssignee={onRemoveAssignee}
-            onRemoveMember={onRemoveMember}
+            onRemoveSubject={onRemoveSubject}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Description
This PR creates a JourneyInstanceSidebar component, and adds logic to display, add and remove people as members and assignees of that journey instance.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/166701703-8218bcc3-7615-47b2-8132-adf466837c56.png)

## Changes
Changes the MUIOnlyPersonSelect component to take label, size and variant props.

* Adds…
* JourneyInstanceSidebar component 
* JourneyPerson component that (POTENTIAL BAD NAME-ALERT!!) which is a ZetkinPerson with an x-icon that appears when hovering.

## Notes to reviewer
- Suggestions for tests? 
- Suggestion for how to think about the naming of the JourneyPerson-component? This could be something that is useful in other areas of the code, maybe, and should maybe have a more generic name? Would love input on this please :)

## Related issues
Resolves #577 
