### PR TITLE
Issue 612/edit tag

### DIFF
--- a/playwright/tests/organize/people/person/tags.spec.ts
+++ b/playwright/tests/organize/people/person/tags.spec.ts
@@ -360,13 +360,13 @@ test.describe('Person Profile Page Tags', () => {
       await page.click('data-testid=submit-button');
 
       // Check that request made to edit tag with correct values
-      await page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`);
-      const log = editTagRequest.log();
-      expect(log.length).toEqual(1);
-      expect(log[0].data).toEqual({
-        group_id: ActivistTag.group?.id,
-        title: 'New tag title',
-      });
+      await Promise.all([
+        page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`),
+        expect(editTagRequest.log()[0].data).toEqual({
+          group_id: ActivistTag.group?.id,
+          title: 'New tag title',
+        }),
+      ]);
     });
 
     test('shows error when editing tag fails', async ({ page, moxy }) => {
@@ -389,10 +389,12 @@ test.describe('Person Profile Page Tags', () => {
       await page.click('data-testid=submit-button');
 
       // Show error
-      await page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`);
-      expect(await page.locator('data-testid=Snackbar-error').count()).toEqual(
-        1
-      );
+      await Promise.all([
+        page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`),
+        expect(
+          await page.locator('data-testid=Snackbar-error').count()
+        ).toEqual(1),
+      ]);
     });
   });
 });

--- a/playwright/tests/organize/people/person/tags.spec.ts
+++ b/playwright/tests/organize/people/person/tags.spec.ts
@@ -357,16 +357,16 @@ test.describe('Person Profile Page Tags', () => {
         'New tag title'
       );
 
-      await page.click('data-testid=submit-button');
-
       // Check that request made to edit tag with correct values
       await Promise.all([
+        page.click('data-testid=submit-button'),
         page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`),
-        expect(editTagRequest.log()[0].data).toEqual({
-          group_id: ActivistTag.group?.id,
-          title: 'New tag title',
-        }),
       ]);
+
+      expect(editTagRequest.log()[0].data).toEqual({
+        group_id: ActivistTag.group?.id,
+        title: 'New tag title',
+      });
     });
 
     test('shows error when editing tag fails', async ({ page, moxy }) => {
@@ -386,15 +386,14 @@ test.describe('Person Profile Page Tags', () => {
         'New tag title'
       );
 
-      await page.click('data-testid=submit-button');
-
       // Show error
       await Promise.all([
+        page.click('data-testid=submit-button'),
         page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`),
-        expect(
-          await page.locator('data-testid=Snackbar-error').count()
-        ).toEqual(1),
       ]);
+      expect(await page.locator('data-testid=Snackbar-error').count()).toEqual(
+        1
+      );
     });
   });
 });

--- a/src/api/people.ts
+++ b/src/api/people.ts
@@ -45,6 +45,7 @@ export const personTagsResource = (orgId: string, personId: string) => {
   const url = `/orgs/${orgId}/people/${personId}/tags`;
 
   return {
+    key,
     useAssign: createUseMutationPut({ key, url }),
     useQuery: createUseQuery<ZetkinTag[]>(key, url),
     useUnassign: createUseMutationDelete({ key, url }),

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,17 +1,27 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import {
   createUseMutation,
+  createUseMutationPatch,
   createUseQuery,
 } from './utils/resourceHookFactories';
 
 import { NewTagGroup } from 'components/organize/TagsManager/types';
-import { ZetkinTag, ZetkinTagGroup, ZetkinTagPostBody } from 'types/zetkin';
+import {
+  ZetkinTag,
+  ZetkinTagGroup,
+  ZetkinTagPatchBody,
+  ZetkinTagPostBody,
+} from 'types/zetkin';
 
 export const tagsResource = (orgId: string) => {
   const key = ['tags', orgId];
   const url = `/orgs/${orgId}/people/tags`;
   return {
     useCreate: createUseMutation<ZetkinTagPostBody, ZetkinTag>(key, url),
+    useEdit: createUseMutationPatch<ZetkinTagPatchBody, ZetkinTag>({
+      key,
+      url,
+    }),
     useQuery: createUseQuery<ZetkinTag[]>(key, url),
   };
 };

--- a/src/api/utils/createHandlers.ts
+++ b/src/api/utils/createHandlers.ts
@@ -1,5 +1,6 @@
 import APIError from 'utils/apiError';
 import { defaultFetch } from 'fetching';
+import handleResponseData from './handleResponseData';
 
 export const createPutOrDeleteHandler =
   (method: RequestInit['method']) =>
@@ -17,3 +18,17 @@ export const createPutOrDeleteHandler =
 
 export const createDeleteHandler = createPutOrDeleteHandler('DELETE');
 export const createPutHandler = createPutOrDeleteHandler('PUT');
+
+export const createPatchHandler =
+  <Input extends { id: number }, Result>(url: string) =>
+  async (resource: Input): Promise<Result> => {
+    const { id, ...resourceWithoutId } = resource;
+    const res = await defaultFetch(`${url}/${id}`, {
+      body: JSON.stringify(resourceWithoutId),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    });
+    return handleResponseData<Result>(res, 'PATCH');
+  };

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -13,7 +13,11 @@ import { defaultFetch } from 'fetching';
 import handleResponseData from './handleResponseData';
 import { makeUseMutationOptions } from './makeUseMutationOptions';
 import { ScaffoldedContext } from 'utils/next';
-import { createDeleteHandler, createPutHandler } from './createDeleteHandler';
+import {
+  createDeleteHandler,
+  createPatchHandler,
+  createPutHandler,
+} from './createHandlers';
 
 export const createUseQuery = <Result>(
   key: string[],
@@ -62,7 +66,7 @@ export const createUseMutation = <Input, Result>(
   };
 };
 
-interface MutationDeleteOrPutProps {
+interface MutationProps {
   key: string[];
   url: string;
   fetchOptions?: RequestInit;
@@ -73,7 +77,7 @@ interface MutationDeleteOrPutProps {
 }
 
 export const createUseMutationDelete = (
-  props: MutationDeleteOrPutProps
+  props: MutationProps
 ): (() => UseMutationResult<null, unknown, number | undefined, unknown>) => {
   const handler = createDeleteHandler(props.url, props.fetchOptions);
 
@@ -87,7 +91,7 @@ export const createUseMutationDelete = (
 };
 
 export const createUseMutationPut = (
-  props: MutationDeleteOrPutProps
+  props: MutationProps
 ): (() => UseMutationResult<null, unknown, number | undefined, unknown>) => {
   const handler = createPutHandler(props.url, props.fetchOptions);
 
@@ -97,6 +101,21 @@ export const createUseMutationPut = (
       handler,
       makeUseMutationOptions(queryClient, props.key, props.mutationOptions)
     );
+  };
+};
+
+export const createUseMutationPatch = <
+  Input extends { id: number },
+  Result
+>(props: {
+  key: string[];
+  url: string;
+}): (() => UseMutationResult<Result, unknown, Input, unknown>) => {
+  const handler = createPatchHandler<Input, Result>(props.url);
+
+  return () => {
+    const queryClient = useQueryClient();
+    return useMutation(handler, makeUseMutationOptions(queryClient, props.key));
   };
 };
 

--- a/src/api/viewRows.ts
+++ b/src/api/viewRows.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { createDeleteHandler } from './utils/createDeleteHandler';
+import { createDeleteHandler } from './utils/createHandlers';
 import { defaultFetch } from 'fetching';
 import handleResponseData from './utils/handleResponseData';
 import { makeUseMutationOptions } from './utils/makeUseMutationOptions';

--- a/src/components/organize/TagsManager/TagDialog/TagDialog.spec.tsx
+++ b/src/components/organize/TagsManager/TagDialog/TagDialog.spec.tsx
@@ -11,10 +11,10 @@ import TagDialog from '.';
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('<TagDialog />', () => {
-  let onCreateTag: jest.Mock<NewTag | EditTag, [tag: NewTag | EditTag]>;
+  let onSubmit: jest.Mock<NewTag | EditTag, [tag: NewTag | EditTag]>;
 
   beforeEach(() => {
-    onCreateTag = jest.fn((tag: NewTag | EditTag) => tag);
+    onSubmit = jest.fn((tag: NewTag | EditTag) => tag);
     singletonRouter.query = {
       orgId: '1',
     };
@@ -25,7 +25,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
-        onSubmit={onCreateTag}
+        onSubmit={onSubmit}
         open={true}
       />
     );
@@ -39,7 +39,7 @@ describe('<TagDialog />', () => {
     click(submit);
 
     // Check new group object created
-    expect(onCreateTag).toBeCalledWith({
+    expect(onSubmit).toBeCalledWith({
       color: undefined,
       group_id: null,
       title: 'Spongeworthy',
@@ -48,13 +48,13 @@ describe('<TagDialog />', () => {
 
   it(`
       When creating a new group, sends the new group properties
-      to the onCreateTag callback instead of groupId
+      to the onSubmit callback instead of groupId
     `, () => {
     const { getByTestId, getByText } = render(
       <TagDialog
         groups={[]}
         onClose={() => undefined}
-        onSubmit={onCreateTag}
+        onSubmit={onSubmit}
         open={true}
       />
     );
@@ -76,7 +76,7 @@ describe('<TagDialog />', () => {
     click(submit);
 
     // Check new group object created
-    expect(onCreateTag).toBeCalledWith({
+    expect(onSubmit).toBeCalledWith({
       color: undefined,
       group: { title: 'New Group' },
       title: 'Tag Title',
@@ -88,7 +88,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
-        onSubmit={onCreateTag}
+        onSubmit={onSubmit}
         open={true}
       />
     );
@@ -125,7 +125,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
-        onSubmit={onCreateTag}
+        onSubmit={onSubmit}
         open={true}
         tag={mockTag({ id: 1000, title })}
       />
@@ -140,7 +140,7 @@ describe('<TagDialog />', () => {
     click(submit);
 
     // Check correct fields returned with tag id.
-    expect(onCreateTag).toBeCalledWith({
+    expect(onSubmit).toBeCalledWith({
       color: `#${color}`,
       group_id: null,
       id: 1000,

--- a/src/components/organize/TagsManager/TagDialog/TagDialog.spec.tsx
+++ b/src/components/organize/TagsManager/TagDialog/TagDialog.spec.tsx
@@ -131,10 +131,6 @@ describe('<TagDialog />', () => {
       />
     );
 
-    // Title is passed in from existing tag
-    const titleField = getByTestId('TagManager-TagDialog-titleField');
-    expect((titleField as HTMLInputElement).value).toEqual(title);
-
     // Modify color field
     const colorField = getByTestId('TagManager-TagDialog-colorField');
     click(colorField);

--- a/src/components/organize/TagsManager/TagDialog/index.tsx
+++ b/src/components/organize/TagsManager/TagDialog/index.tsx
@@ -37,6 +37,8 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     ZetkinTagGroup | NewTagGroup | null | undefined
   >();
 
+  const editingTag = tag && 'id' in tag;
+
   useEffect(() => {
     setTitle(tag?.title || '');
     setColor(
@@ -59,9 +61,13 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     <ZetkinDialog
       onClose={closeAndClear}
       open={open}
-      title={intl.formatMessage({
-        id: 'misc.tags.tagsManager.tagDialog.dialogTitle',
-      })}
+      title={
+        editingTag
+          ? 'Edit tag'
+          : intl.formatMessage({
+              id: 'misc.tags.tagsManager.tagDialog.dialogTitle',
+            })
+      }
     >
       <form
         onSubmit={(e) => {
@@ -129,11 +135,11 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           onCancel={closeAndClear}
           submitDisabled={!title || !color.valid}
           submitText={
-            !tag || !('id' in tag)
-              ? intl.formatMessage({
+            editingTag
+              ? undefined
+              : intl.formatMessage({
                   id: 'misc.tags.tagsManager.submitCreateTagButton',
                 })
-              : undefined
           }
         />
       </form>

--- a/src/components/organize/TagsManager/TagDialog/index.tsx
+++ b/src/components/organize/TagsManager/TagDialog/index.tsx
@@ -73,25 +73,25 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
         onSubmit={(e) => {
           e.preventDefault();
           const tagBody = {
-            color: color.value ? `#${color.value}` : undefined,
-            id: tag && 'id' in tag ? tag.id : undefined, // Attach id when editing an existing tag
+            ...(color.value && { color: `#${color.value}` }),
+            ...(tag && 'id' in tag && { id: tag.id }),
             title,
           };
           if (group && 'id' in group) {
-            // If existing group, submit with POST body
+            // If selecting existing group, submit with group_id
             onSubmit({
               group_id: group.id,
               ...tagBody,
             });
           } else if (group && !('id' in group)) {
-            // If new group, submit with group object
+            // If selecting new group, submit with group object
             onSubmit({
               group,
               ...tagBody,
             });
           } else {
             // If no group
-            onSubmit(tagBody);
+            onSubmit({ ...tagBody, group_id: null });
           }
           closeAndClear();
         }}

--- a/src/components/organize/TagsManager/TagDialog/index.tsx
+++ b/src/components/organize/TagsManager/TagDialog/index.tsx
@@ -7,27 +7,27 @@ import ColorPicker from './ColorPicker';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import TagGroupSelect from './TagGroupSelect';
 import ZetkinDialog from 'components/ZetkinDialog';
-import { ZetkinTagGroup } from 'types/zetkin';
 import { NewTagGroup, OnCreateTagHandler } from '../types';
+import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
 
 interface TagDialogProps {
   groups: ZetkinTagGroup[];
   open: boolean;
   onClose: () => void;
   onSubmit: OnCreateTagHandler;
-  defaultTitle?: string;
+  tag?: ZetkinTag | Pick<ZetkinTag, 'title'>;
 }
 
 const TagDialog: React.FunctionComponent<TagDialogProps> = ({
-  defaultTitle,
   groups,
   open,
   onClose,
   onSubmit,
+  tag,
 }) => {
   const intl = useIntl();
 
-  const [title, setTitle] = useState(defaultTitle || '');
+  const [title, setTitle] = useState('');
   const [titleEdited, setTitleEdited] = useState(false);
   const [color, setColor] = useState<{ valid: boolean; value: string }>({
     valid: true,
@@ -37,11 +37,15 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     ZetkinTagGroup | NewTagGroup | null | undefined
   >();
 
-  const titleValid = !!title;
-
   useEffect(() => {
-    setTitle(defaultTitle || '');
-  }, [defaultTitle]);
+    setTitle(tag?.title || '');
+    setColor(
+      tag && 'color' in tag && tag.color
+        ? { valid: true, value: tag.color.slice(1) }
+        : { valid: true, value: '' }
+    );
+    setGroup(tag && 'group' in tag ? tag.group : undefined);
+  }, [tag]);
 
   const closeAndClear = () => {
     setTitle('');
@@ -86,11 +90,11 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
         }}
       >
         <TextField
-          error={titleEdited && !titleValid}
+          error={titleEdited && !title}
           fullWidth
           helperText={
             titleEdited &&
-            !titleValid &&
+            !title &&
             intl.formatMessage({
               id: 'misc.tags.tagsManager.tagDialog.titleErrorText',
             })
@@ -122,10 +126,14 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
         />
         <SubmitCancelButtons
           onCancel={closeAndClear}
-          submitDisabled={!titleValid || !color.valid}
-          submitText={intl.formatMessage({
-            id: 'misc.tags.tagsManager.submitCreateTagButton',
-          })}
+          submitDisabled={!title || !color.valid}
+          submitText={
+            !tag || !('id' in tag)
+              ? intl.formatMessage({
+                  id: 'misc.tags.tagsManager.submitCreateTagButton',
+                })
+              : undefined
+          }
         />
       </form>
     </ZetkinDialog>

--- a/src/components/organize/TagsManager/TagDialog/index.tsx
+++ b/src/components/organize/TagsManager/TagDialog/index.tsx
@@ -7,14 +7,14 @@ import ColorPicker from './ColorPicker';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import TagGroupSelect from './TagGroupSelect';
 import ZetkinDialog from 'components/ZetkinDialog';
-import { NewTagGroup, OnCreateTagHandler } from '../types';
+import { EditTag, NewTag, NewTagGroup } from '../types';
 import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
 
 interface TagDialogProps {
   groups: ZetkinTagGroup[];
   open: boolean;
   onClose: () => void;
-  onSubmit: OnCreateTagHandler;
+  onSubmit: (tag: NewTag | EditTag) => void;
   tag?: ZetkinTag | Pick<ZetkinTag, 'title'>;
 }
 
@@ -66,25 +66,26 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          const tag = {
+          const tagBody = {
             color: color.value ? `#${color.value}` : undefined,
+            id: tag && 'id' in tag ? tag.id : undefined, // Attach id when editing an existing tag
             title,
           };
           if (group && 'id' in group) {
             // If existing group, submit with POST body
             onSubmit({
               group_id: group.id,
-              ...tag,
+              ...tagBody,
             });
           } else if (group && !('id' in group)) {
             // If new group, submit with group object
             onSubmit({
               group,
-              ...tag,
+              ...tagBody,
             });
           } else {
             // If no group
-            onSubmit(tag);
+            onSubmit(tagBody);
           }
           closeAndClear();
         }}

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -77,7 +77,7 @@ const TagSelect: React.FunctionComponent<{
             <List
               key={group.title}
               subheader={
-                <ListSubheader component="div">{group.title}</ListSubheader>
+                <ListSubheader disableSticky>{group.title}</ListSubheader>
               }
               title={group.title}
             >

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -71,7 +71,7 @@ const TagSelect: React.FunctionComponent<{
         {...getListboxProps()}
         style={{ maxHeight: '400px', overflowY: 'scroll' }}
       >
-        {Object.values(groupedFilteredTags).map((group) => {
+        {groupedFilteredTags.map((group) => {
           // Groups
           return (
             <List
@@ -106,7 +106,7 @@ const TagSelect: React.FunctionComponent<{
                           setTagToEdit(tag);
                         }}
                       >
-                        <EditIcon />
+                        <EditIcon fontSize="small" />
                       </IconButton>
                     </Box>
                   </ListItem>

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -101,6 +101,7 @@ const TagSelect: React.FunctionComponent<{
                         tag={tag}
                       />
                       <IconButton
+                        data-testid={`TagManager-TagSelect-editTag-${tag.id}`}
                         onClick={(e) => {
                           e.stopPropagation();
                           setTagToEdit(tag);

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import { Add } from '@material-ui/icons';
+import EditIcon from '@material-ui/icons/Edit';
 import { useAutocomplete } from '@material-ui/lab';
 import { useState } from 'react';
 import {
   Box,
+  IconButton,
   List,
   ListItem,
   ListSubheader,
@@ -26,13 +28,9 @@ const TagSelect: React.FunctionComponent<{
 }> = ({ disabledTags, groups, onCreateTag, onSelect, tags }) => {
   const intl = useIntl();
 
-  const [dialogOpen, setDialogOpen] = useState<{
-    defaultTitle: string;
-    open: boolean;
-  }>({
-    defaultTitle: '',
-    open: false,
-  });
+  const [tagToEdit, setTagToEdit] = useState<
+    ZetkinTag | Pick<ZetkinTag, 'title'> | undefined
+  >(undefined);
 
   const {
     inputValue,
@@ -90,16 +88,32 @@ const TagSelect: React.FunctionComponent<{
                   <ListItem
                     key={tag.id}
                     button
+                    dense
                     disabled={disabledTags
                       .map((disabledTags) => disabledTags.id)
                       .includes(tag.id)}
                     onClick={() => onSelect(tag)}
                     tabIndex={-1}
                   >
-                    <TagChip
-                      chipProps={{ style: { cursor: 'pointer' } }}
-                      tag={tag}
-                    />
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="space-between"
+                      width="100%"
+                    >
+                      <TagChip
+                        chipProps={{ style: { cursor: 'pointer' } }}
+                        tag={tag}
+                      />
+                      <IconButton
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTagToEdit(tag);
+                        }}
+                      >
+                        <EditIcon />
+                      </IconButton>
+                    </Box>
                   </ListItem>
                 );
               })}
@@ -109,10 +123,10 @@ const TagSelect: React.FunctionComponent<{
         <ListItem
           button
           data-testid="TagManager-TagSelect-createTagOption"
+          dense
           onClick={() =>
-            setDialogOpen({
-              defaultTitle: inputValue,
-              open: true,
+            setTagToEdit({
+              title: inputValue,
             })
           }
         >
@@ -135,11 +149,11 @@ const TagSelect: React.FunctionComponent<{
         </ListItem>
       </List>
       <TagDialog
-        defaultTitle={dialogOpen.defaultTitle}
         groups={groups}
-        onClose={() => setDialogOpen({ defaultTitle: '', open: false })}
+        onClose={() => setTagToEdit(undefined)}
         onSubmit={onCreateTag}
-        open={dialogOpen.open}
+        open={Boolean(tagToEdit)}
+        tag={tagToEdit}
       />
     </Box>
   );

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -14,18 +14,19 @@ import {
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { groupTags } from './utils';
-import { OnCreateTagHandler } from './types';
 import TagChip from './TagChip';
 import TagDialog from './TagDialog';
+import { EditTag, NewTag } from './types';
 import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
 
 const TagSelect: React.FunctionComponent<{
   disabledTags: ZetkinTag[];
   groups: ZetkinTagGroup[];
-  onCreateTag: OnCreateTagHandler;
+  onCreateTag: (tag: NewTag) => void;
+  onEditTag: (tag: EditTag) => void;
   onSelect: (tag: ZetkinTag) => void;
   tags: ZetkinTag[];
-}> = ({ disabledTags, groups, onCreateTag, onSelect, tags }) => {
+}> = ({ disabledTags, groups, onCreateTag, onEditTag, onSelect, tags }) => {
   const intl = useIntl();
 
   const [tagToEdit, setTagToEdit] = useState<
@@ -151,7 +152,13 @@ const TagSelect: React.FunctionComponent<{
       <TagDialog
         groups={groups}
         onClose={() => setTagToEdit(undefined)}
-        onSubmit={onCreateTag}
+        onSubmit={(tag) => {
+          if ('id' in tag) {
+            onEditTag(tag);
+          } else {
+            onCreateTag(tag);
+          }
+        }}
         open={Boolean(tagToEdit)}
         tag={tagToEdit}
       />

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -152,8 +152,10 @@ const TagSelect: React.FunctionComponent<{
         onClose={() => setTagToEdit(undefined)}
         onSubmit={(tag) => {
           if ('id' in tag) {
+            // If existing tag
             onEditTag(tag);
           } else {
+            // If new tag
             onCreateTag(tag);
           }
         }}

--- a/src/components/organize/TagsManager/TagSelect.tsx
+++ b/src/components/organize/TagsManager/TagSelect.tsx
@@ -84,16 +84,7 @@ const TagSelect: React.FunctionComponent<{
               {/* Tags */}
               {group.tags.map((tag) => {
                 return (
-                  <ListItem
-                    key={tag.id}
-                    button
-                    dense
-                    disabled={disabledTags
-                      .map((disabledTags) => disabledTags.id)
-                      .includes(tag.id)}
-                    onClick={() => onSelect(tag)}
-                    tabIndex={-1}
-                  >
+                  <ListItem key={tag.id} dense>
                     <Box
                       alignItems="center"
                       display="flex"
@@ -101,7 +92,12 @@ const TagSelect: React.FunctionComponent<{
                       width="100%"
                     >
                       <TagChip
-                        chipProps={{ style: { cursor: 'pointer' } }}
+                        chipProps={{
+                          disabled: disabledTags
+                            .map((disabledTags) => disabledTags.id)
+                            .includes(tag.id),
+                          onClick: () => onSelect(tag),
+                        }}
                         tag={tag}
                       />
                       <IconButton

--- a/src/components/organize/TagsManager/TagsList.tsx
+++ b/src/components/organize/TagsManager/TagsList.tsx
@@ -32,8 +32,10 @@ const TagsList: React.FunctionComponent<{
               flexWrap="wrap"
               style={{ gap: 8 }}
             >
-              {group.tags.map((tag, i) => {
-                return <TagChip key={i} onDelete={onUnassignTag} tag={tag} />;
+              {group.tags.map((tag) => {
+                return (
+                  <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />
+                );
               })}
             </Box>
           </Box>
@@ -45,8 +47,8 @@ const TagsList: React.FunctionComponent<{
   //   Flat list of tags
   return (
     <Box display="flex" flexWrap="wrap" style={{ gap: 8 }}>
-      {tags.map((tag, i) => {
-        return <TagChip key={i} onDelete={onUnassignTag} tag={tag} />;
+      {tags.map((tag) => {
+        return <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />;
       })}
     </Box>
   );

--- a/src/components/organize/TagsManager/TagsList.tsx
+++ b/src/components/organize/TagsManager/TagsList.tsx
@@ -23,11 +23,11 @@ const TagsList: React.FunctionComponent<{
 
     return (
       <>
-        {Object.entries(groupedTags).map(([id, group], i) => (
+        {groupedTags.map((group, i) => (
           <Box key={i} mb={1}>
             <Typography variant="overline">{group.title}</Typography>
             <Box
-              data-testid={`TagsManager-groupedTags-${id}`}
+              data-testid={`TagsManager-groupedTags-${group.id}`}
               display="flex"
               flexWrap="wrap"
               style={{ gap: 8 }}
@@ -47,9 +47,11 @@ const TagsList: React.FunctionComponent<{
   //   Flat list of tags
   return (
     <Box display="flex" flexWrap="wrap" style={{ gap: 8 }}>
-      {tags.map((tag) => {
-        return <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />;
-      })}
+      {tags
+        .sort((tag0, tag1) => tag0.title.localeCompare(tag1.title))
+        .map((tag) => {
+          return <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />;
+        })}
     </Box>
   );
 };

--- a/src/components/organize/TagsManager/TagsManager.spec.tsx
+++ b/src/components/organize/TagsManager/TagsManager.spec.tsx
@@ -221,4 +221,42 @@ describe('<TagsManager />', () => {
       expect((titleField as HTMLInputElement).value).toEqual("Jerry's family");
     });
   });
+
+  describe('editing a tag', () => {
+    let onCreateTag: jest.Mock<NewTag, [tag: NewTag]>;
+
+    beforeEach(() => {
+      onCreateTag = jest.fn((tag: NewTag) => tag);
+      singletonRouter.query = {
+        orgId: '1',
+      };
+    });
+
+    it('can edit an existing tag in the tag dialog', () => {
+      const tagToEdit = mockTag();
+
+      const { getByTestId, getByText } = render(
+        <TagsManager
+          assignedTags={[]}
+          availableGroups={[]}
+          availableTags={[tagToEdit]}
+          onAssignTag={assignTagCallback}
+          onCreateTag={onCreateTag}
+          onEditTag={editTagCallback}
+          onUnassignTag={unassignTagCallback}
+        />
+      );
+
+      const addTagButton = getByText('misc.tags.tagsManager.addTag');
+      click(addTagButton);
+
+      const editTagButton = getByTestId(
+        `TagManager-TagSelect-editTag-${tagToEdit.id}`
+      );
+      click(editTagButton);
+
+      const titleField = getByTestId('TagManager-TagDialog-titleField');
+      expect((titleField as HTMLInputElement).value).toEqual(tagToEdit.title);
+    });
+  });
 });

--- a/src/components/organize/TagsManager/TagsManager.spec.tsx
+++ b/src/components/organize/TagsManager/TagsManager.spec.tsx
@@ -4,16 +4,18 @@ import { keyboard } from '@testing-library/user-event/dist/keyboard';
 import { render } from 'utils/testing';
 import singletonRouter from 'next/router';
 
-import mockTag from 'utils/testing/mocks/mockTag';
-import { NewTag } from './types';
 import TagsManager from '.';
+
+import mockTag from 'utils/testing/mocks/mockTag';
 import { ZetkinTag } from 'types/zetkin';
+import { EditTag, NewTag } from './types';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 const assignTagCallback = jest.fn((tag: ZetkinTag) => tag);
 const createTagCallback = jest.fn((tag: NewTag) => tag);
 const unassignTagCallback = jest.fn((tag: ZetkinTag) => tag);
+const editTagCallback = jest.fn((tag: EditTag) => tag);
 
 describe('<TagsManager />', () => {
   describe('Renders list of tags passed in', () => {
@@ -25,6 +27,7 @@ describe('<TagsManager />', () => {
           availableTags={[]}
           onAssignTag={assignTagCallback}
           onCreateTag={createTagCallback}
+          onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
       );
@@ -40,6 +43,7 @@ describe('<TagsManager />', () => {
           availableTags={[tag1, tag2]}
           onAssignTag={assignTagCallback}
           onCreateTag={createTagCallback}
+          onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
       );
@@ -89,6 +93,7 @@ describe('<TagsManager />', () => {
         availableTags={tags}
         onAssignTag={assignTagCallback}
         onCreateTag={createTagCallback}
+        onEditTag={editTagCallback}
         onUnassignTag={unassignTagCallback}
       />
     );
@@ -124,6 +129,7 @@ describe('<TagsManager />', () => {
         availableTags={[tag1]}
         onAssignTag={onAssignTag}
         onCreateTag={createTagCallback}
+        onEditTag={editTagCallback}
         onUnassignTag={unassignTagCallback}
       />
     );
@@ -156,6 +162,7 @@ describe('<TagsManager />', () => {
         availableTags={[tag1]}
         onAssignTag={assignTagCallback}
         onCreateTag={createTagCallback}
+        onEditTag={editTagCallback}
         onUnassignTag={onUnassignTag}
       />
     );
@@ -193,6 +200,7 @@ describe('<TagsManager />', () => {
           availableTags={[]}
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
       );

--- a/src/components/organize/TagsManager/index.tsx
+++ b/src/components/organize/TagsManager/index.tsx
@@ -6,9 +6,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import ZetkinSection from 'components/ZetkinSection';
 
 import GroupToggle from './GroupToggle';
-import { OnCreateTagHandler } from './types';
 import TagSelect from './TagSelect';
 import TagsList from './TagsList';
+import { EditTag, NewTag } from './types';
 import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
 
 const TagsManager: React.FunctionComponent<{
@@ -16,7 +16,8 @@ const TagsManager: React.FunctionComponent<{
   availableGroups: ZetkinTagGroup[];
   availableTags: ZetkinTag[];
   onAssignTag: (tag: ZetkinTag) => void;
-  onCreateTag: OnCreateTagHandler;
+  onCreateTag: (tag: NewTag) => void;
+  onEditTag: (tag: EditTag) => void;
   onUnassignTag: (tag: ZetkinTag) => void;
 }> = ({
   assignedTags,
@@ -24,6 +25,7 @@ const TagsManager: React.FunctionComponent<{
   availableTags,
   onAssignTag,
   onCreateTag,
+  onEditTag,
   onUnassignTag,
 }) => {
   const intl = useIntl();
@@ -72,6 +74,7 @@ const TagsManager: React.FunctionComponent<{
             disabledTags={assignedTags}
             groups={availableGroups}
             onCreateTag={onCreateTag}
+            onEditTag={onEditTag}
             onSelect={onAssignTag}
             tags={availableTags}
           />

--- a/src/components/organize/TagsManager/types.ts
+++ b/src/components/organize/TagsManager/types.ts
@@ -1,13 +1,15 @@
-import { ZetkinTag, ZetkinTagGroup, ZetkinTagPostBody } from 'types/zetkin';
+import {
+  ZetkinTag,
+  ZetkinTagGroup,
+  ZetkinTagPatchBody,
+  ZetkinTagPostBody,
+} from 'types/zetkin';
 
 export type NewTagGroup = { title: string };
+export type TagWithNewGroup<Tag> = Tag & { group: NewTagGroup };
 
-interface TagWithNewGroup
-  extends Partial<Omit<ZetkinTag, 'group' | 'organization'>> {
-  group: NewTagGroup;
-}
-
-export type NewTag = ZetkinTagPostBody | TagWithNewGroup;
+export type NewTag = ZetkinTagPostBody | TagWithNewGroup<ZetkinTagPostBody>;
+export type EditTag = ZetkinTagPatchBody | TagWithNewGroup<ZetkinTagPatchBody>;
 
 export interface ZetkinTagGroupPostBody
   extends Partial<Omit<ZetkinTagGroup, 'id'>> {

--- a/src/components/organize/TagsManager/types.ts
+++ b/src/components/organize/TagsManager/types.ts
@@ -1,5 +1,4 @@
 import {
-  ZetkinTag,
   ZetkinTagGroup,
   ZetkinTagPatchBody,
   ZetkinTagPostBody,
@@ -17,10 +16,3 @@ export interface ZetkinTagGroupPostBody
 }
 
 export type OnCreateTagHandler = (tag: NewTag) => void;
-
-export interface TagsGroups {
-  [key: string]: {
-    tags: ZetkinTag[];
-    title: string;
-  };
-}

--- a/src/components/organize/TagsManager/utils.ts
+++ b/src/components/organize/TagsManager/utils.ts
@@ -58,7 +58,10 @@ export const groupTags = (
     group0.title.localeCompare(group1.title)
   );
 
-  return [...sortedGroupedTags, ungrouped];
+  if (ungrouped) {
+    return [...sortedGroupedTags, ungrouped];
+  }
+  return sortedGroupedTags;
 };
 
 export const randomColor = (): string => {

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -61,6 +61,7 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
   const { showSnackbar } = useContext(SnackbarContext);
 
   const {
+    key: personTagsKey,
     useAssign,
     useQuery: usePersonTagsQuery,
     useUnassign,
@@ -80,7 +81,7 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
   const tagsGroupsQuery = useTagGroupsQuery();
 
   const createTag = useCreateTag();
-  const editTag = useEditTag();
+  const editTag = useEditTag(personTagsKey);
 
   if (!person) {
     return null;

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -10,11 +10,14 @@ import PersonOrganizationsCard from 'components/organize/people/PersonOrganizati
 import SinglePersonLayout from 'layout/organize/SinglePersonLayout';
 import SnackbarContext from 'hooks/SnackbarContext';
 import TagsManager from 'components/organize/TagsManager';
-import { useCreateTag } from 'components/organize/TagsManager/utils';
 import ZetkinQuery from 'components/ZetkinQuery';
 import { personResource, personTagsResource } from 'api/people';
 import { scaffold, ScaffoldedGetServerSideProps } from 'utils/next';
 import { tagGroupsResource, tagsResource } from 'api/tags';
+import {
+  useCreateTag,
+  useEditTag,
+} from 'components/organize/TagsManager/utils';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
@@ -62,11 +65,8 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
     useQuery: usePersonTagsQuery,
     useUnassign,
   } = personTagsResource(orgId as string, personId as string);
-  const { useQuery: useAvailableTagsQuery, useEdit } = tagsResource(
-    orgId as string
-  );
+  const { useQuery: useAvailableTagsQuery } = tagsResource(orgId as string);
   const assignTagMutation = useAssign();
-  const editTagMutation = useEdit();
   const unassignTagMutation = useUnassign();
   const personTagsQuery = usePersonTagsQuery();
   const organizationTagsQuery = useAvailableTagsQuery();
@@ -80,6 +80,7 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
   const tagsGroupsQuery = useTagGroupsQuery();
 
   const createTag = useCreateTag();
+  const editTag = useEditTag();
 
   if (!person) {
     return null;
@@ -116,9 +117,7 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
                   onError: () => showSnackbar('error'),
                 });
               }}
-              onEditTag={async (tag) => {
-                await editTagMutation.mutateAsync(tag);
-              }}
+              onEditTag={editTag}
               onUnassignTag={(tag) =>
                 unassignTagMutation.mutate(tag.id, {
                   onError: () => showSnackbar('error'),

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -62,8 +62,11 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
     useQuery: usePersonTagsQuery,
     useUnassign,
   } = personTagsResource(orgId as string, personId as string);
-  const { useQuery: useAvailableTagsQuery } = tagsResource(orgId as string);
+  const { useQuery: useAvailableTagsQuery, useEdit } = tagsResource(
+    orgId as string
+  );
   const assignTagMutation = useAssign();
+  const editTagMutation = useEdit();
   const unassignTagMutation = useUnassign();
   const personTagsQuery = usePersonTagsQuery();
   const organizationTagsQuery = useAvailableTagsQuery();
@@ -112,6 +115,9 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
                 assignTagMutation.mutate(newTag.id, {
                   onError: () => showSnackbar('error'),
                 });
+              }}
+              onEditTag={async (tag) => {
+                await editTagMutation.mutateAsync(tag);
               }}
               onUnassignTag={(tag) =>
                 unassignTagMutation.mutate(tag.id, {

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -217,13 +217,13 @@ export interface ZetkinTag {
 export interface ZetkinTagPostBody
   extends Partial<Omit<ZetkinTag, 'id' | 'group' | 'organization'>> {
   title: string;
-  group_id?: number;
+  group_id?: number | null;
 }
 
 export interface ZetkinTagPatchBody
   extends Partial<Omit<ZetkinTag, 'group' | 'organization'>> {
   id: number;
-  group_id?: number;
+  group_id?: number | null;
 }
 
 export enum CUSTOM_FIELD_TYPE {

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -220,6 +220,12 @@ export interface ZetkinTagPostBody
   group_id?: number;
 }
 
+export interface ZetkinTagPatchBody
+  extends Partial<Omit<ZetkinTag, 'group' | 'organization'>> {
+  id: number;
+  group_id?: number;
+}
+
 export enum CUSTOM_FIELD_TYPE {
   URL = 'url',
   DATE = 'date',


### PR DESCRIPTION
## Description
This PR adds the ability to edit and existing tag from within the `<TagsManager />` component


## Screenshots
![Screenshot from 2022-05-10 16-08-46](https://user-images.githubusercontent.com/41007222/167661685-ed306d77-237b-473c-946a-fa5fa2ad6fe9.png)

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds
  * Playwright tests for editing a tag and error handling
  * Unit tests for features around editing a tag
  * `createPatchMutation` method for handling patch requests to use with `createMutation` helpers
  * `useEdit` on tags resource to edit tags 
  * `useEditTag` hook to handle the update of tags and possibly creating a new group in the process.
* Changes
  * Refactor `TagDialog` to take an existing tag for editing
  * Refactor `TagSelect`
    * to include buttons for opening the `TagDialog` to edit a tag
    * styles are improved
  * Improve tags sorting so all groups and tags are alphabetical 

## Notes to reviewer
* Test editing an existing tag.
* Change all fields
* Try with an existing group, no group, removing a group, and creating a group.

## Related issues
Resolves #612
