### PR TITLE
Journey instance timeline

### DIFF
--- a/src/components/TimelineWrapper.tsx
+++ b/src/components/TimelineWrapper.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from 'react-query';
+
+import { defaultFetch } from 'fetching';
+import handleResponseData from 'api/utils/handleResponseData';
+import Timeline from './Timeline';
+import ZetkinQuery from './ZetkinQuery';
+import { ZetkinUpdate } from 'types/updates';
+
+interface TimelineWrapperProps {
+  queryKey: string[];
+  itemApiPath: string;
+}
+
+const TimelineWrapper: React.FC<TimelineWrapperProps> = ({
+  queryKey,
+  itemApiPath,
+}) => {
+  const updatesQuery = useQuery(queryKey, async () => {
+    const res = await defaultFetch(itemApiPath + '/timeline/updates');
+    return handleResponseData<ZetkinUpdate[]>(res, 'GET');
+  });
+
+  return (
+    <ZetkinQuery queries={{ updatesQuery }}>
+      {({ queries }) => <Timeline updates={queries.updatesQuery.data} />}
+    </ZetkinQuery>
+  );
+};
+
+export default TimelineWrapper;

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -112,7 +112,7 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
           <JourneyInstanceSummary journeyInstance={journeyInstance} />
           <Divider style={{ marginTop: '2rem' }} />
           <TimelineWrapper
-            itemApiPath={`/api/orgs/${orgId}/journey_instances/${instanceId}`}
+            itemApiPath={`/orgs/${orgId}/journey_instances/${instanceId}`}
             queryKey={['journeyInstance', orgId, instanceId, 'timeline']}
           />
         </Grid>

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -11,6 +11,7 @@ import { organizationResource } from 'api/organizations';
 import { PageWithLayout } from 'types';
 import { scaffold } from 'utils/next';
 import SnackbarContext from 'hooks/SnackbarContext';
+import TimelineWrapper from 'components/TimelineWrapper';
 import { ZetkinJourneyInstance, ZetkinPerson } from 'types/zetkin';
 
 const scaffoldOptions = {
@@ -110,6 +111,10 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
         <Grid item md={6}>
           <JourneyInstanceSummary journeyInstance={journeyInstance} />
           <Divider style={{ marginTop: '2rem' }} />
+          <TimelineWrapper
+            itemApiPath={`/api/orgs/${orgId}/journey_instances/${instanceId}`}
+            queryKey={['journeyInstance', orgId, instanceId, 'timeline']}
+          />
         </Grid>
         <Grid item md={4}>
           <JourneyInstanceSidebar


### PR DESCRIPTION
## Description
This PR adds the `<Timeline/>` component created by @lowlandjuju to the journey instance page created by @ziggabyte, so that changes made to the journey instance can show up in the timeline.

I've done this in a way that can be reused on other "item" pages that should have timelines in the future, and in a way that can easily encapsulate code for things like submitting notes.

## Screenshots
https://user-images.githubusercontent.com/550212/167290427-3f2f042a-c240-481d-be68-a586222a4cf8.mov

## Changes
* Creates a new `TimelineWrapper` component to load timeline updates (and to encapsulate things like submitting notes, which is being introduced in #642)
* Adds the new component to the journey instance page

## Notes to reviewer
I have deployed the timeline feature branch of the Zetkin Platform API to the dev server, so running this should now work.

A lot of events types are still not working. Some of them are missing on the backend, and some are missing on the frontend (as tracked in #572).

## Related issues
Related to #572 but does not close any documented issues.
