### PR TITLE
View column for assigned journeys

### DIFF
--- a/src/components/views/ViewColumnDialog/index.tsx
+++ b/src/components/views/ViewColumnDialog/index.tsx
@@ -10,6 +10,7 @@ import { COLUMN_TYPE, SelectedViewColumn } from 'types/views';
 
 // These column types will auto save and not open the ColumnEditor
 export const AUTO_SAVE_TYPES = [
+  COLUMN_TYPE.JOURNEY_ASSIGNEE,
   COLUMN_TYPE.LOCAL_BOOL,
   COLUMN_TYPE.LOCAL_PERSON,
   COLUMN_TYPE.PERSON_NOTES,

--- a/src/components/views/ViewDataTable/utils.spec.ts
+++ b/src/components/views/ViewDataTable/utils.spec.ts
@@ -1,3 +1,5 @@
+import { GridValueGetterParams } from '@mui/x-data-grid-pro';
+
 import { COLUMN_TYPE } from 'types/views';
 import mockPersonNote from 'utils/testing/mocks/mockPersonNote';
 import mockViewCol from 'utils/testing/mocks/mockViewCol';
@@ -97,6 +99,22 @@ describe('makeGridColDef', () => {
       1
     );
     expect(colDef.renderCell).toBeTruthy();
+  });
+
+  it('returns number cell for journey_assignee', () => {
+    const colDef = makeGridColDef(
+      mockViewCol({
+        type: COLUMN_TYPE.JOURNEY_ASSIGNEE,
+      }),
+      1
+    );
+    expect(colDef.type).toEqual('number');
+    expect(colDef.valueGetter).toBeTruthy();
+    expect(
+      colDef.valueGetter!({
+        value: [{}, {}],
+      } as GridValueGetterParams)
+    ).toEqual(2);
   });
 });
 

--- a/src/components/views/ViewDataTable/utils.tsx
+++ b/src/components/views/ViewDataTable/utils.tsx
@@ -96,6 +96,9 @@ export function makeGridColDef(
       const submissions = (params as SurveySubmittedParams).value;
       return submissions?.length ? getNewestSubmission(submissions) : null;
     };
+  } else if (viewCol.type == COLUMN_TYPE.JOURNEY_ASSIGNEE) {
+    colDef.type = 'number';
+    colDef.valueGetter = (params) => (params.value as unknown[]).length;
   }
 
   return colDef;

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -16,6 +16,7 @@ columnDialog:
     configureColumn: Configure column
     header: Add column to view
   types:
+    journey_assignee: Assigned journeys
     local_bool: On/off toggle in this view
     local_person: Reference to another person
     person_field: Basic person data (name, e-mail etc)
@@ -40,6 +41,7 @@ dataTableErrors:
   modify_column: There was an error editing the column
   remove_rows: There was an error removing one or more rows
 defaultColumnTitles:
+  journey_assignee: Assigned journeys
   local_bool: Toggle
   local_person: Person reference
   person_notes: Notes

--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -28,6 +28,7 @@ export interface ZetkinViewColumnBase {
 }
 
 export enum COLUMN_TYPE {
+  JOURNEY_ASSIGNEE = 'journey_assignee',
   LOCAL_BOOL = 'local_bool',
   LOCAL_PERSON = 'local_person',
   PERSON_FIELD = 'person_field',
@@ -36,6 +37,13 @@ export enum COLUMN_TYPE {
   PERSON_TAG = 'person_tag',
   SURVEY_RESPONSE = 'survey_response',
   SURVEY_SUBMITTED = 'survey_submitted',
+}
+
+export interface JourneyAssigneeViewColumn extends ZetkinViewColumnBase {
+  type: COLUMN_TYPE.JOURNEY_ASSIGNEE;
+  config: {
+    journey_id?: number;
+  };
 }
 
 export interface LocalBoolViewColumn extends ZetkinViewColumnBase {
@@ -89,6 +97,7 @@ export interface SurveySubmittedViewColumn extends ZetkinViewColumnBase {
 }
 
 export type ZetkinViewColumn =
+  | JourneyAssigneeViewColumn
   | LocalBoolViewColumn
   | LocalPersonViewColumn
   | PersonNotesViewColumn


### PR DESCRIPTION
## Description
This PR implements the new view column type called `journey_assignee`. This is an MVP version of the column, with no configuration, with the purpose of being able to get a hint of "workload" for case workers in a union.

A future iteration will need to further develop this to include filtering by open/closed journey instances, instances of specific journeys, etc.

## Screenshots
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/550212/167344253-b680ae56-e78e-46ce-9621-44b4bfae5fdc.png">

## Changes
* Adds a `JOURNEY_ASSIGNEE` view column type
* Adds a test to verify that what's being displayed in the view column is the count

## Notes to reviewer
This requires changes on the backend, which have been implemented but not deployed to the dev server. Hence, it's currently not possible to test this live.

I took some shortcuts with regards to testing, especially not declaring an explicit type for the data being returned for this column. There is no obvious place to declare those types right now, but will be once we add more features and create a custom renderer and configuration UI.

## Related issues
Undocumented
