### PR TITLE
Page for opening a journey

### DIFF
--- a/playwright/mockData/orgs/KPD/journeys/MarxistTraining/index.ts
+++ b/playwright/mockData/orgs/KPD/journeys/MarxistTraining/index.ts
@@ -3,6 +3,7 @@ import { ZetkinJourney } from '../../../../../../src/types/zetkin';
 
 const MarxistTraining: ZetkinJourney = {
   id: 2,
+  opening_note_template: '',
   organization: KPD,
   plural_label: 'Marxist trainings',
   singular_label: 'Marxist training',

--- a/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/index.ts
+++ b/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/index.ts
@@ -3,6 +3,7 @@ import { ZetkinJourney } from '../../../../../../src/types/zetkin';
 
 const MemberOnboarding: ZetkinJourney = {
   id: 1,
+  opening_note_template: '',
   organization: KPD,
   plural_label: 'Onboardings',
   singular_label: 'Onboarding',

--- a/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding.ts
+++ b/playwright/mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding.ts
@@ -46,6 +46,7 @@ const ClarasOnboarding: ZetkinJourneyInstance = {
   },
   milestones: [AttendMeeting, AttendTraining, MeetBranchSec],
   next_milestone: AttendMeeting,
+  opening_note: '',
   organization: KPD,
   subjects: [ClaraZetkin],
   summary: `Nullam sagittis neque augue, vitae lacinia purus auctor eget. Mauris bibendum, 

--- a/playwright/tests/organize/journeys/create-journey-instance.spec.ts
+++ b/playwright/tests/organize/journeys/create-journey-instance.spec.ts
@@ -1,0 +1,129 @@
+import { expect } from '@playwright/test';
+
+import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
+import KPD from '../../../mockData/orgs/KPD';
+import MarxistTraining from '../../../mockData/orgs/KPD/journeys/MarxistTraining';
+import test from '../../../fixtures/next';
+import { ZetkinJourneyInstance } from '../../../../src/types/zetkin';
+
+test.describe('Creating a journey instance', () => {
+  test.beforeEach(async ({ moxy, login }) => {
+    login();
+    moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+    moxy.setZetkinApiMock('/orgs/1/journeys/1', 'get', MarxistTraining);
+  });
+
+  test.afterEach(async ({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test('shows correct labels', async ({ appUri, page }) => {
+    await page.goto(appUri + '/organize/1/journeys/1/new');
+
+    expect(await page.locator('data-testid=page-title').textContent()).toEqual(
+      'New Marxist training'
+    );
+
+    expect(
+      await page
+        .locator('data-testid=SubmitCancelButtons-submitButton')
+        .textContent()
+    ).toEqual('Create new Marxist training');
+  });
+
+  test('creates instance without subjects or assignees', async ({
+    appUri,
+    moxy,
+    page,
+  }) => {
+    const instMock = moxy.setZetkinApiMock(
+      '/orgs/1/journeys/1/instances',
+      'post',
+      { id: 1857 } as ZetkinJourneyInstance
+    );
+
+    await page.goto(appUri + '/organize/1/journeys/1/new');
+    await page.locator('[data-testid=page-title] input').type('My training');
+    await page.locator('[data-testid=page-title] input').press('Enter');
+    await page
+      .locator('data-testid=ZetkinAutoTextArea-textarea')
+      .type('Some info');
+
+    await Promise.all([
+      page.waitForResponse((res) => res.url().includes('api')),
+      page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
+    ]);
+
+    const requests = instMock.log<ZetkinJourneyInstance>();
+    expect(requests.length).toBe(1);
+    expect(requests[0].data?.title).toEqual('My training');
+    expect(requests[0].data?.opening_note).toEqual('Some info');
+  });
+
+  test('creates instance with subjects and assignees', async ({
+    appUri,
+    moxy,
+    page,
+  }) => {
+    const instMock = moxy.setZetkinApiMock(
+      '/orgs/1/journeys/1/instances',
+      'post',
+      {
+        id: 1857,
+      } as ZetkinJourneyInstance
+    );
+
+    // Mock search for Angela
+    moxy.setZetkinApiMock(`/orgs/${KPD.id}/search/person`, 'post', [
+      ClaraZetkin,
+    ]);
+    // Mock adding Angela as an assignee
+    const assigneeMock = moxy.setZetkinApiMock(
+      `/orgs/${KPD.id}/journey_instances/1857/assignees/${ClaraZetkin.id}`,
+      'put'
+    );
+    // Mock adding Angela as a subject
+    const subjectMock = moxy.setZetkinApiMock(
+      `/orgs/${KPD.id}/journey_instances/1857/subjects/${ClaraZetkin.id}`,
+      'put'
+    );
+    // Mock loading Angela's data
+    moxy.setZetkinApiMock(
+      `/orgs/${KPD.id}/people/${ClaraZetkin.id}`,
+      'get',
+      ClaraZetkin.id
+    );
+
+    await page.goto(appUri + '/organize/1/journeys/1/new');
+    await page
+      .locator('data-testid=ZetkinAutoTextArea-textarea')
+      .type('Some info');
+
+    // Add a subject
+    await page.locator('data-testid=Button-add-subject').click();
+    await page.locator('text=Add person').type('Clara');
+    await page
+      .locator('.MuiAutocomplete-popper li:has-text("Clara Zetkin")')
+      .click();
+
+    // Add an assignee
+    await page.locator('data-testid=Button-add-assignee').click();
+    await page.locator('text=Assign person').type('Clara');
+    await page
+      .locator('.MuiAutocomplete-popper li:has-text("Clara Zetkin")')
+      .click();
+
+    await Promise.all([
+      page.waitForResponse(async (res) => res.url().includes('createNew')),
+      page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
+    ]);
+
+    // Expect requests to have been made to:
+    // * POST to create journey instance
+    // * PUT to add assignee
+    // * PUT to add subject
+    expect(instMock.log().length).toBe(1);
+    expect(assigneeMock.log().length).toBe(1);
+    expect(subjectMock.log().length).toBe(1);
+  });
+});

--- a/playwright/tests/organize/journeys/create-journey-instance.spec.ts
+++ b/playwright/tests/organize/journeys/create-journey-instance.spec.ts
@@ -17,8 +17,15 @@ test.describe('Creating a journey instance', () => {
     moxy.teardown();
   });
 
-  test('shows correct labels', async ({ appUri, page }) => {
-    await page.goto(appUri + '/organize/1/journeys/1/new');
+  test('shows new page with correct labels', async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock('/orgs/1/journeys/1/instances', 'get', []);
+
+    await page.goto(appUri + '/organize/1/journeys/1');
+
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator('data-testid=JourneyInstanceOverviewPage-addFab').click(),
+    ]);
 
     expect(await page.locator('data-testid=page-title').textContent()).toEqual(
       'New Marxist training'

--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -7,7 +7,11 @@ import {
   createUseMutationPut,
   createUseQuery,
 } from './utils/resourceHookFactories';
-import { ZetkinJourney, ZetkinJourneyInstance } from 'types/zetkin';
+import {
+  ZetkinJourney,
+  ZetkinJourneyInstance,
+  ZetkinPerson,
+} from 'types/zetkin';
 
 export const journeysResource = (orgId: string) => {
   const key = ['journeys', orgId];
@@ -34,6 +38,15 @@ export const journeyInstancesResource = (orgId: string, journeyId: string) => {
   const url = `/organize/${orgId}/journeys/${journeyId}`;
 
   return {
+    useCreate: createUseMutation<
+      {
+        assignees: ZetkinPerson[];
+        note: string;
+        subjects: ZetkinPerson[];
+        title: string;
+      },
+      ZetkinJourneyInstance
+    >(key, `/journeyInstances/createNew?orgId=${orgId}&journeyId=${journeyId}`),
     useQuery: createUseQuery<{
       journeyInstances: ZetkinJourneyInstance[];
       tagMetadata: TagMetadata;

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -6,6 +6,7 @@ import {
   UseMutationResult,
   useQuery,
   useQueryClient,
+  UseQueryOptions,
   UseQueryResult,
 } from 'react-query';
 
@@ -19,14 +20,24 @@ export const createUseQuery = <Result>(
   key: string[],
   url: string,
   fetchOptions?: RequestInit
-): (() => UseQueryResult<Result>) => {
+): ((
+  options?: Omit<
+    UseQueryOptions<unknown, unknown, Result, string[]>,
+    'queryKey' | 'queryFn'
+  >
+) => UseQueryResult<Result>) => {
   const handler = async () => {
     const res = await defaultFetch(url, fetchOptions);
     return handleResponseData(res, fetchOptions?.method || 'GET');
   };
 
-  return () => {
-    return useQuery(key, handler);
+  return (
+    options?: Omit<
+      UseQueryOptions<unknown, unknown, Result, string[]>,
+      'queryKey' | 'queryFn'
+    >
+  ) => {
+    return useQuery(key, handler, options);
   };
 };
 

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -16,27 +16,22 @@ import { makeUseMutationOptions } from './makeUseMutationOptions';
 import { ScaffoldedContext } from 'utils/next';
 import { createDeleteHandler, createPutHandler } from './createDeleteHandler';
 
+type FactoryUseQueryOptions<Result> = Omit<
+  UseQueryOptions<unknown, unknown, Result, string[]>,
+  'queryKey' | 'queryFn'
+>;
+
 export const createUseQuery = <Result>(
   key: string[],
   url: string,
   fetchOptions?: RequestInit
-): ((
-  options?: Omit<
-    UseQueryOptions<unknown, unknown, Result, string[]>,
-    'queryKey' | 'queryFn'
-  >
-) => UseQueryResult<Result>) => {
+): ((options?: FactoryUseQueryOptions<Result>) => UseQueryResult<Result>) => {
   const handler = async () => {
     const res = await defaultFetch(url, fetchOptions);
     return handleResponseData(res, fetchOptions?.method || 'GET');
   };
 
-  return (
-    options?: Omit<
-      UseQueryOptions<unknown, unknown, Result, string[]>,
-      'queryKey' | 'queryFn'
-    >
-  ) => {
+  return (options?: FactoryUseQueryOptions<Result>) => {
     return useQuery(key, handler, options);
   };
 };

--- a/src/components/EditTextInPlace/index.spec.tsx
+++ b/src/components/EditTextInPlace/index.spec.tsx
@@ -70,6 +70,20 @@ describe('EditTextInPlace', () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
+  it('does trigger onChange with no text if explicitly allowed', async () => {
+    const onChange = jest.fn(props.onChange);
+    const { getByDisplayValue } = render(
+      <EditTextinPlace allowEmpty={true} {...{ ...props, onChange }} />
+    );
+    const inputEl = getByDisplayValue(props.value);
+    userEvent.click(inputEl);
+
+    // If user tries to save no text
+    userEvent.clear(inputEl);
+    userEvent.keyboard('{enter}');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it('resets when text is discarded with "escape"', async () => {
     const onChange = jest.fn(props.onChange);
     const { getByDisplayValue } = render(

--- a/src/components/EditTextInPlace/index.tsx
+++ b/src/components/EditTextInPlace/index.tsx
@@ -44,14 +44,18 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export interface EditTextinPlaceProps {
+  allowEmpty?: boolean;
   disabled?: boolean;
   onChange: (newValue: string) => Promise<void>;
+  placeholder?: string;
   value: string;
 }
 
 const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
+  allowEmpty = false,
   disabled,
   onChange,
+  placeholder,
   value,
 }) => {
   const [editing, setEditing] = useState<boolean>(false);
@@ -99,7 +103,7 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
   };
 
   const onKeyDown = (evt: React.KeyboardEvent) => {
-    if (evt.key === 'Enter' && !!text) {
+    if (evt.key === 'Enter' && (!!text || allowEmpty)) {
       // If user has not changed the text, do nothing
       if (text === value) {
         cancelEditing();
@@ -117,7 +121,7 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
         arrow
         disableHoverListener={editing}
         title={
-          text
+          text || allowEmpty
             ? intl.formatMessage({
                 id: `misc.components.editTextInPlace.tooltip.${
                   editing ? 'save' : 'edit'
@@ -130,7 +134,7 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
       >
         <FormControl style={{ overflow: 'hidden' }}>
           <span ref={spanRef} className={classes.span}>
-            {text}
+            {text || placeholder}
           </span>
           <InputBase
             classes={{
@@ -142,6 +146,7 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
             onChange={(e) => setText(e.target.value)}
             onFocus={startEditing}
             onKeyDown={onKeyDown}
+            placeholder={placeholder}
             readOnly={!editing}
             value={text}
           />

--- a/src/components/ZetkinAutoTextArea.tsx
+++ b/src/components/ZetkinAutoTextArea.tsx
@@ -30,6 +30,7 @@ const ZetkinAutoTextArea = React.forwardRef<
     <TextareaAutosize
       ref={ref}
       className={classes.textarea}
+      data-testid="ZetkinAutoTextArea-textarea"
       onChange={(e) => onChange(e.target.value)}
       value={value}
       {...restProps}

--- a/src/components/ZetkinAutoTextArea.tsx
+++ b/src/components/ZetkinAutoTextArea.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { lighten, makeStyles, TextareaAutosize } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  textarea: {
+    border: '2px dotted transparent',
+    borderColor: lighten(theme.palette.primary.main, 0.65),
+    borderRadius: 10,
+    fontFamily: theme.typography.fontFamily,
+    lineHeight: '1.5',
+    overflow: 'hidden',
+    padding: 10,
+    resize: 'none',
+    width: '100%',
+  },
+}));
+
+interface ZetkinAutoTextAreaProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const ZetkinAutoTextArea = React.forwardRef<
+  HTMLTextAreaElement,
+  ZetkinAutoTextAreaProps
+>(function ZetkinAutoTextArea({ onChange, value, ...restProps }, ref) {
+  const classes = useStyles();
+
+  return (
+    <TextareaAutosize
+      ref={ref}
+      className={classes.textarea}
+      onChange={(e) => onChange(e.target.value)}
+      value={value}
+      {...restProps}
+    />
+  );
+});
+
+export default ZetkinAutoTextArea;

--- a/src/components/forms/common/SubmitCancelButtons.tsx
+++ b/src/components/forms/common/SubmitCancelButtons.tsx
@@ -16,6 +16,7 @@ const SubmitCancelButtons: React.FunctionComponent<{
       <Box m={1}>
         <Button
           color="primary"
+          data-testid="SubmitCancelButtons-submitButton"
           disabled={submitDisabled}
           type="submit"
           variant="contained"

--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -19,7 +19,10 @@ const JourneyInstanceSidebar = ({
   onRemoveAssignee,
   onRemoveSubject,
 }: {
-  journeyInstance: ZetkinJourneyInstance;
+  journeyInstance: Pick<
+    ZetkinJourneyInstance,
+    'assignees' | 'milestones' | 'next_milestone' | 'subjects'
+  >;
   onAddAssignee: (person: ZetkinPersonType) => void;
   onAddSubject: (person: ZetkinPersonType) => void;
   onRemoveAssignee: (person: ZetkinPersonType) => void;

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -1,11 +1,5 @@
 import { useRouter } from 'next/router';
-import {
-  Button,
-  lighten,
-  makeStyles,
-  TextareaAutosize,
-  Typography,
-} from '@material-ui/core';
+import { Button, makeStyles, Typography } from '@material-ui/core';
 import { Edit, Save } from '@material-ui/icons';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
@@ -13,25 +7,15 @@ import { useContext, useEffect, useRef, useState } from 'react';
 
 import { journeyInstanceResource } from 'api/journeys';
 import SnackbarContext from 'hooks/SnackbarContext';
+import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 import ZetkinSection from 'components/ZetkinSection';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   collapsed: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-  },
-  editSummary: {
-    border: '2px dotted transparent',
-    borderColor: lighten(theme.palette.primary.main, 0.65),
-    borderRadius: 10,
-    fontFamily: theme.typography.fontFamily,
-    lineHeight: '1.5',
-    overflow: 'hidden',
-    padding: 10,
-    resize: 'none',
-    width: '100%',
   },
 }));
 
@@ -105,11 +89,10 @@ const JourneyInstanceSummary = ({
       })}
     >
       {editingSummary ? (
-        <TextareaAutosize
+        <ZetkinAutoTextArea
           ref={editingRef}
-          className={classes.editSummary}
           data-testid="JourneyInstanceSummary-textArea"
-          onChange={(e) => setSummary(e.target.value)}
+          onChange={(value) => setSummary(value)}
           value={summary}
         />
       ) : (

--- a/src/layout/organize/DefaultLayout.tsx
+++ b/src/layout/organize/DefaultLayout.tsx
@@ -1,8 +1,6 @@
 import { FunctionComponent } from 'react';
-import { grey } from '@material-ui/core/colors';
 import { Box, makeStyles } from '@material-ui/core';
 
-import BreadcrumbTrail from 'components/BreadcrumbTrail';
 import OrganizeSidebar from 'components/organize/OrganizeSidebar';
 
 const useStyles = makeStyles((theme) => ({
@@ -13,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
   },
   root: {
     [theme.breakpoints.down('xs')]: {
-      paddingTop: '4rem',
+      paddingTop: '3.5rem',
     },
   },
 }));
@@ -21,17 +19,17 @@ const useStyles = makeStyles((theme) => ({
 const DefaultLayout: FunctionComponent = ({ children }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.root} display="flex">
-      <Box bgcolor={grey[200]} height="100vh">
-        <OrganizeSidebar />
-      </Box>
-      <Box display="flex" flexDirection="column" width={1}>
-        <Box display="flex" m={1} mb={0}>
-          <Box className={classes.breadcrumbs} mt="0.5rem" width={1}>
-            <BreadcrumbTrail />
-          </Box>
-        </Box>
-        {children as JSX.Element}
+    <Box className={classes.root} display="flex" height="100vh">
+      <OrganizeSidebar />
+      <Box
+        display="flex"
+        flexDirection="column"
+        height="100vh"
+        overflow="auto"
+        position="relative"
+        width={1}
+      >
+        {children}
       </Box>
     </Box>
   );

--- a/src/layout/organize/TabbedLayout.tsx
+++ b/src/layout/organize/TabbedLayout.tsx
@@ -1,69 +1,28 @@
-import { ArrowUpward } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
 import { useRouter } from 'next/router';
 import {
-  Avatar,
   Box,
-  Button,
   Collapse,
   makeStyles,
   Tab,
   TabProps,
   Tabs,
   Theme,
-  Typography,
 } from '@material-ui/core';
 import { FunctionComponent, ReactElement, useState } from 'react';
 
-import BreadcrumbTrail from 'components/BreadcrumbTrail';
-import OrganizeSidebar from 'components/organize/OrganizeSidebar';
-import SearchDialog from 'components/organize/SearchDialog';
-import ZetkinEllipsisMenu, {
-  ZetkinEllipsisMenuProps,
-} from 'components/ZetkinEllipsisMenu';
+import DefaultLayout from './DefaultLayout';
+import Header from './elements/Header';
+import { ZetkinEllipsisMenuProps } from 'components/ZetkinEllipsisMenu';
 
 interface StyleProps {
-  collapsed: boolean;
   noPad?: boolean;
 }
 
-const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
-  avatar: {
-    height: 65,
-    marginRight: 20,
-    width: 'auto',
-  },
+const useStyles = makeStyles<Theme, StyleProps>(() => ({
   main: {
     overflowX: 'hidden',
     padding: ({ noPad }) => (noPad ? 0 : undefined),
-  },
-  root: {
-    [theme.breakpoints.down('xs')]: {
-      paddingTop: '3.5rem',
-    },
-    '& .collapse-button': {
-      '& svg': {
-        transform: ({ collapsed }) => (collapsed ? 'rotate(180deg)' : 'none'),
-        transition: 'transform 0.2s ease',
-      },
-      gridColumnEnd: 'none',
-    },
-  },
-  title: {
-    marginBottom: '8px',
-    transition: 'all 0.3s ease',
-  },
-  titleGrid: {
-    alignItems: 'center',
-    display: 'grid',
-    gap: '1rem',
-    gridTemplateColumns: '1fr auto',
-    gridTemplateRows: 'auto',
-    transition: 'font-size 0.2s ease',
-    width: '100%',
-    [theme.breakpoints.down('sm')]: {
-      gridTemplateColumns: '1fr',
-    },
   },
 }));
 
@@ -94,7 +53,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
   title,
 }) => {
   const [collapsed, setCollapsed] = useState(false);
-  const classes = useStyles({ collapsed, noPad });
+  const classes = useStyles({ noPad });
   const router = useRouter();
 
   const currentTab =
@@ -113,122 +72,58 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
     }
   };
 
-  const toggleCollapse = () => setCollapsed(!collapsed);
+  const onToggleCollapsed = fixedHeight
+    ? (value: boolean) => setCollapsed(value)
+    : undefined;
 
   return (
-    <Box className={classes.root} display="flex" height="100vh">
-      <OrganizeSidebar />
+    <DefaultLayout>
       <Box
-        display="flex"
+        display={fixedHeight ? 'flex' : 'block'}
         flexDirection="column"
-        height="100vh"
-        overflow="auto"
-        position="relative"
-        width={1}
+        height={fixedHeight ? 1 : 'auto'}
       >
-        <Box
-          display={fixedHeight ? 'flex' : 'block'}
-          flexDirection="column"
-          height={fixedHeight ? 1 : 'auto'}
-        >
-          <Box component="header" flexGrow={0} flexShrink={0}>
-            <Box mb={collapsed ? 1 : 2} pt={3} px={3}>
-              <Box
-                display="flex"
-                flexDirection="row"
-                justifyContent="space-between"
-              >
-                <BreadcrumbTrail highlight={collapsed} />
-                {/* Search and collapse buttons */}
-                <Box display="flex" flexDirection="row">
-                  {fixedHeight && (
-                    <Box className="collapse-button">
-                      <Button
-                        onClick={toggleCollapse}
-                        startIcon={<ArrowUpward />}
-                      >
-                        <FormattedMessage
-                          id={`layout.organize.header.collapseButton.${
-                            collapsed ? 'expand' : 'collapse'
-                          }`}
-                        />
-                      </Button>
-                    </Box>
-                  )}
-                  <SearchDialog />
-                </Box>
-              </Box>
-              {/* Title, subtitle, and action buttons */}
-              <Collapse in={!collapsed}>
-                <Box className={classes.titleGrid} mt={2}>
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    flexDirection="row"
-                    overflow="hidden"
-                  >
-                    {avatar && (
-                      <Avatar className={classes.avatar} src={avatar} />
-                    )}
-                    <Box>
-                      <Typography
-                        className={classes.title}
-                        component="div"
-                        data-testid="page-title"
-                        noWrap
-                        style={{ display: 'flex' }}
-                        variant="h3"
-                      >
-                        {title}
-                      </Typography>
-                      <Typography color="secondary" component="h2" variant="h5">
-                        {subtitle}
-                      </Typography>
-                    </Box>
-                  </Box>
-                  <Box display="flex" flexDirection="row">
-                    <Box>{actionButtons}</Box>
-                    {!!ellipsisMenuItems?.length && (
-                      <ZetkinEllipsisMenu items={ellipsisMenuItems} />
-                    )}
-                  </Box>
-                </Box>
-              </Collapse>
-            </Box>
-            <Collapse in={!collapsed}>
-              <Tabs
-                aria-label="campaign tabs"
-                onChange={(_, selected) => selectTab(selected)}
-                value={currentTab}
-              >
-                {tabs.map((tab) => {
-                  return (
-                    <Tab
-                      {...tab.tabProps}
-                      key={tab.href}
-                      label={<FormattedMessage id={tab.messageId} />}
-                      value={tab.href}
-                    />
-                  );
-                })}
-              </Tabs>
-            </Collapse>
-          </Box>
-          {/* Page Content */}
-          <Box
-            className={classes.main}
-            component="main"
-            flexGrow={1}
-            minHeight={0}
-            p={fixedHeight ? 0 : 3}
-            position="relative"
-            role="tabpanel"
+        <Header
+          actionButtons={actionButtons}
+          avatar={avatar}
+          collapsed={collapsed}
+          ellipsisMenuItems={ellipsisMenuItems}
+          onToggleCollapsed={onToggleCollapsed}
+          subtitle={subtitle}
+          title={title}
+        />
+        <Collapse in={!collapsed}>
+          <Tabs
+            aria-label="campaign tabs"
+            onChange={(_, selected) => selectTab(selected)}
+            value={currentTab}
           >
-            {children}
-          </Box>
+            {tabs.map((tab) => {
+              return (
+                <Tab
+                  {...tab.tabProps}
+                  key={tab.href}
+                  label={<FormattedMessage id={tab.messageId} />}
+                  value={tab.href}
+                />
+              );
+            })}
+          </Tabs>
+        </Collapse>
+        {/* Page Content */}
+        <Box
+          className={classes.main}
+          component="main"
+          flexGrow={1}
+          minHeight={0}
+          p={fixedHeight ? 0 : 3}
+          position="relative"
+          role="tabpanel"
+        >
+          {children}
         </Box>
       </Box>
-    </Box>
+    </DefaultLayout>
   );
 };
 

--- a/src/layout/organize/elements/Header.tsx
+++ b/src/layout/organize/elements/Header.tsx
@@ -1,0 +1,142 @@
+import { ArrowUpward } from '@material-ui/icons';
+import BreadcrumbTrail from 'components/BreadcrumbTrail';
+import { FormattedMessage } from 'react-intl';
+import { ReactElement } from 'react';
+import {
+  Avatar,
+  Box,
+  Button,
+  Collapse,
+  makeStyles,
+  Theme,
+  Typography,
+} from '@material-ui/core';
+
+import SearchDialog from 'components/organize/SearchDialog';
+import ZetkinEllipsisMenu, {
+  ZetkinEllipsisMenuProps,
+} from 'components/ZetkinEllipsisMenu';
+
+interface StyleProps {
+  collapsed: boolean;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
+  avatar: {
+    height: 65,
+    marginRight: 20,
+    width: 'auto',
+  },
+  collapseButton: {
+    '& svg': {
+      transform: ({ collapsed }) => (collapsed ? 'rotate(180deg)' : 'none'),
+      transition: 'transform 0.2s ease',
+    },
+    gridColumnEnd: 'none',
+  },
+  title: {
+    marginBottom: '8px',
+    transition: 'all 0.3s ease',
+  },
+  titleGrid: {
+    alignItems: 'center',
+    display: 'grid',
+    gap: '1rem',
+    gridTemplateColumns: '1fr auto',
+    gridTemplateRows: 'auto',
+    transition: 'font-size 0.2s ease',
+    width: '100%',
+    [theme.breakpoints.down('sm')]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+}));
+
+interface HeaderProps {
+  actionButtons?: React.ReactElement | React.ReactElement[];
+  avatar?: string;
+  collapsed?: boolean;
+  ellipsisMenuItems?: ZetkinEllipsisMenuProps['items'];
+  onToggleCollapsed?: (collapsed: boolean) => void;
+  subtitle?: string | ReactElement;
+  title?: string | ReactElement;
+}
+
+const Header: React.FC<HeaderProps> = ({
+  actionButtons,
+  avatar,
+  collapsed = false,
+  ellipsisMenuItems,
+  onToggleCollapsed,
+  subtitle,
+  title,
+}) => {
+  const classes = useStyles({ collapsed });
+
+  const toggleCollapsed = () => {
+    if (onToggleCollapsed) {
+      onToggleCollapsed(!collapsed);
+    }
+  };
+
+  return (
+    <Box component="header" flexGrow={0} flexShrink={0}>
+      <Box mb={collapsed ? 1 : 2} pt={3} px={3}>
+        <Box display="flex" flexDirection="row" justifyContent="space-between">
+          <BreadcrumbTrail highlight={collapsed} />
+          {/* Search and collapse buttons */}
+          <Box display="flex" flexDirection="row">
+            {!!onToggleCollapsed && (
+              <Box className={classes.collapseButton}>
+                <Button onClick={toggleCollapsed} startIcon={<ArrowUpward />}>
+                  <FormattedMessage
+                    id={`layout.organize.header.collapseButton.${
+                      collapsed ? 'expand' : 'collapse'
+                    }`}
+                  />
+                </Button>
+              </Box>
+            )}
+            <SearchDialog />
+          </Box>
+        </Box>
+        {/* Title, subtitle, and action buttons */}
+        <Collapse in={!collapsed}>
+          <Box className={classes.titleGrid} mt={2}>
+            <Box
+              alignItems="center"
+              display="flex"
+              flexDirection="row"
+              overflow="hidden"
+            >
+              {avatar && <Avatar className={classes.avatar} src={avatar} />}
+              <Box>
+                <Typography
+                  className={classes.title}
+                  component="div"
+                  data-testid="page-title"
+                  noWrap
+                  style={{ display: 'flex' }}
+                  variant="h3"
+                >
+                  {title}
+                </Typography>
+                <Typography color="secondary" component="h2" variant="h5">
+                  {subtitle}
+                </Typography>
+              </Box>
+            </Box>
+            <Box display="flex" flexDirection="row">
+              <Box>{actionButtons}</Box>
+              {!!ellipsisMenuItems?.length && (
+                <ZetkinEllipsisMenu items={ellipsisMenuItems} />
+              )}
+            </Box>
+          </Box>
+        </Collapse>
+      </Box>
+    </Box>
+  );
+};
+
+export default Header;

--- a/src/locale/misc/breadcrumbs/en.yml
+++ b/src/locale/misc/breadcrumbs/en.yml
@@ -7,6 +7,7 @@ insights: Insights
 instances: Instances
 journeys: Journeys
 manage: Manage
+new: New
 organize: Organize
 people: People
 projects: Projects

--- a/src/locale/pages/organizeNewJourneyInstance/en.yml
+++ b/src/locale/pages/organizeNewJourneyInstance/en.yml
@@ -1,0 +1,3 @@
+draft: Draft
+submitLabel: Create new {journey}
+title: New {journey}

--- a/src/pages/api/journeyInstances/createNew.ts
+++ b/src/pages/api/journeyInstances/createNew.ts
@@ -40,7 +40,10 @@ const createNewInstance = async (
     const instData = await instRes.json();
     const instId = instData.data.id;
 
-    const putPeople = async (field: string, people: ZetkinPerson[]) => {
+    const putPeople = async (
+      field: 'assignees' | 'subjects',
+      people: ZetkinPerson[]
+    ) => {
       await Promise.all(
         people.map((person: ZetkinPerson) =>
           apiFetch(

--- a/src/pages/api/journeyInstances/createNew.ts
+++ b/src/pages/api/journeyInstances/createNew.ts
@@ -1,0 +1,68 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { createApiFetch } from 'utils/apiFetch';
+import { ZetkinPerson } from 'types/zetkin';
+
+const createNewInstance = async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const {
+    query: { orgId, journeyId },
+    method,
+    body,
+  } = req;
+
+  // Return error if method other than POST
+  if (method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).end(`Method ${method} Not Allowed`);
+    return;
+  }
+
+  const apiFetch = createApiFetch(req.headers);
+
+  try {
+    const instRes = await apiFetch(
+      `/orgs/${orgId}/journeys/${journeyId}/instances`,
+      {
+        body: JSON.stringify({
+          opening_note: body.note,
+          title: body.title,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      }
+    );
+
+    const instData = await instRes.json();
+    const instId = instData.data.id;
+
+    const putPeople = async (field: string, people: ZetkinPerson[]) => {
+      await Promise.all(
+        people.map((person: ZetkinPerson) =>
+          apiFetch(
+            `/orgs/${orgId}/journey_instances/${instId}/${field}/${person.id}`,
+            { method: 'PUT' }
+          )
+        )
+      );
+    };
+
+    if (body.assignees) {
+      await putPeople('assignees', body.assignees);
+    }
+
+    if (body.subjects) {
+      await putPeople('subjects', body.subjects);
+    }
+
+    res.status(200).json(instData);
+  } catch (e) {
+    res.status(500).json({ error: (e as Error).message });
+  }
+};
+
+export default createNewInstance;

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
@@ -1,5 +1,8 @@
+import { Add } from '@material-ui/icons';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
+import NextLink from 'next/link';
+import { Fab, makeStyles } from '@material-ui/core';
 
 import AllJourneyInstancesLayout from 'layout/organize/AllJourneyInstancesLayout';
 import getOrg from 'fetching/getOrg';
@@ -57,6 +60,14 @@ interface JourneyInstancesData {
   tagMetadata: TagMetadata;
 }
 
+const useStyles = makeStyles((theme) => ({
+  fab: {
+    bottom: theme.spacing(10),
+    position: 'fixed',
+    right: theme.spacing(4),
+  },
+}));
+
 const JourneyInstancesOverviewPage: PageWithLayout<
   JourneyInstancesOverviewPageProps
 > = ({ orgId, journeyId }) => {
@@ -66,6 +77,8 @@ const JourneyInstancesOverviewPage: PageWithLayout<
     journeyId
   ).useQuery();
   const journey = journeyQuery.data as ZetkinJourney;
+
+  const classes = useStyles();
 
   return (
     <>
@@ -77,6 +90,15 @@ const JourneyInstancesOverviewPage: PageWithLayout<
           {...(journeyInstancesQuery.data as JourneyInstancesData)}
         />
       </ZetkinQuery>
+      <NextLink href={`/organize/${orgId}/journeys/${journeyId}/new`} passHref>
+        <Fab
+          className={classes.fab}
+          color="primary"
+          data-testid="JourneyInstanceOverviewPage-addFab"
+        >
+          <Add />
+        </Fab>
+      </NextLink>
     </>
   );
 };

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -87,7 +87,10 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
     },
   });
 
-  const mutation = journeyInstancesResource(orgId, journeyId).useCreate();
+  const createInstanceMutation = journeyInstancesResource(
+    orgId,
+    journeyId
+  ).useCreate();
 
   return (
     <ZetkinQuery queries={{ journeyQuery }}>
@@ -147,7 +150,7 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
                   <form
                     onSubmit={async (ev) => {
                       ev.preventDefault();
-                      mutation.mutate(
+                      createInstanceMutation.mutate(
                         { assignees, note, subjects, title },
                         {
                           onError: () => {
@@ -167,7 +170,9 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
                         router.push(`/organize/${orgId}/journeys/${journeyId}`);
                       }}
                       submitDisabled={
-                        !editedNote || mutation.isLoading || mutation.isSuccess
+                        !editedNote ||
+                        createInstanceMutation.isLoading ||
+                        createInstanceMutation.isSuccess
                       }
                       submitText={intl.formatMessage(
                         {

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -1,0 +1,208 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { useIntl } from 'react-intl';
+import { Box, Chip, Grid, useTheme } from '@material-ui/core';
+import { useContext, useEffect, useState } from 'react';
+
+import DefaultLayout from 'layout/organize/DefaultLayout';
+import EditTextinPlace from 'components/EditTextInPlace';
+import Header from 'layout/organize/elements/Header';
+import JourneyInstanceSidebar from 'components/organize/journeys/JourneyInstanceSidebar';
+import { organizationResource } from 'api/organizations';
+import { PageWithLayout } from 'types';
+import { scaffold } from 'utils/next';
+import SnackbarContext from 'hooks/SnackbarContext';
+import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
+import { useRouter } from 'next/router';
+import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
+import { journeyInstancesResource, journeyResource } from 'api/journeys';
+import { ZetkinJourney, ZetkinPerson } from 'types/zetkin';
+
+const scaffoldOptions = {
+  authLevelRequired: 2,
+  localeScope: [
+    'layout.organize',
+    'misc',
+    'pages.organizeJourneyInstance',
+    'pages.organizeNewJourneyInstance',
+  ],
+};
+
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+  const { orgId, journeyId } = ctx.params!;
+
+  const { state: orgQueryState } = await organizationResource(
+    orgId as string
+  ).prefetch(ctx);
+
+  const { state: journeyQueryState } = await journeyResource(
+    orgId as string,
+    journeyId as string
+  ).prefetch(ctx);
+
+  if (
+    orgQueryState?.status === 'success' &&
+    journeyQueryState?.status === 'success'
+  ) {
+    return {
+      props: {
+        journeyId,
+        orgId,
+      },
+    };
+  } else {
+    return {
+      notFound: true,
+    };
+  }
+}, scaffoldOptions);
+
+interface NewJourneyPageProps {
+  journeyId: string;
+  orgId: string;
+}
+
+const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
+  journeyId,
+  orgId,
+}) => {
+  const [assignees, setAssignees] = useState<ZetkinPerson[]>([]);
+  const [subjects, setSubjects] = useState<ZetkinPerson[]>([]);
+  const [note, setNote] = useState('');
+  const [editedNote, setEditedNote] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const { showSnackbar } = useContext(SnackbarContext);
+
+  const intl = useIntl();
+  const theme = useTheme();
+  const router = useRouter();
+
+  const journeyQuery = journeyResource(orgId, journeyId).useQuery();
+  const journey = journeyQuery.data as ZetkinJourney;
+
+  useEffect(() => {
+    if (journey && !editedNote) {
+      setNote(journey.opening_note_template);
+    }
+  }, [editedNote, journey, setNote]);
+
+  const mutation = journeyInstancesResource(orgId, journeyId).useCreate();
+
+  return (
+    <>
+      <Head>
+        <title>
+          {intl.formatMessage(
+            { id: 'pages.organizeNewJourneyInstance.title' },
+            { journey: journey.singular_label }
+          )}
+        </title>
+      </Head>
+      <Header
+        subtitle={
+          <Box
+            style={{
+              alignItems: 'center',
+              display: 'flex',
+            }}
+          >
+            <Chip
+              label={intl.formatMessage({
+                id: 'pages.organizeNewJourneyInstance.draft',
+              })}
+              style={{
+                backgroundColor: theme.palette.grey['300'],
+                fontWeight: 'bold',
+              }}
+            />
+          </Box>
+        }
+        title={
+          <EditTextinPlace
+            allowEmpty={true}
+            onChange={async (value) => setTitle(value)}
+            placeholder={intl.formatMessage(
+              { id: 'pages.organizeNewJourneyInstance.title' },
+              { journey: journey.singular_label }
+            )}
+            value={title}
+          />
+        }
+      />
+      <Box p={3}>
+        <Grid container justifyContent="space-between" spacing={2}>
+          <Grid item md={6}>
+            <ZetkinAutoTextArea
+              onChange={(value) => {
+                setNote(value);
+                setEditedNote(true);
+              }}
+              value={note}
+            />
+            <form
+              onSubmit={async (ev) => {
+                ev.preventDefault();
+                mutation.mutate(
+                  { assignees, note, subjects, title },
+                  {
+                    onError: () => {
+                      showSnackbar('error');
+                    },
+                    onSuccess: (newInstance) => {
+                      router.push(
+                        `/organize/${orgId}/journeys/${journeyId}/${newInstance.id}`
+                      );
+                    },
+                  }
+                );
+              }}
+            >
+              <SubmitCancelButtons
+                onCancel={() => {
+                  router.push(`/organize/${orgId}/journeys/${journeyId}`);
+                }}
+                submitDisabled={
+                  !editedNote || mutation.isLoading || mutation.isSuccess
+                }
+                submitText={intl.formatMessage(
+                  {
+                    id: 'pages.organizeNewJourneyInstance.submitLabel',
+                  },
+                  { journey: journey.singular_label }
+                )}
+              />
+            </form>
+          </Grid>
+          <Grid item md={4}>
+            <JourneyInstanceSidebar
+              journeyInstance={{
+                assignees,
+                next_milestone: null,
+                subjects,
+              }}
+              onAddAssignee={(person) => setAssignees([...assignees, person])}
+              onAddSubject={(person) => setSubjects([...subjects, person])}
+              onRemoveAssignee={(person) =>
+                setAssignees(
+                  assignees.filter((assignee) => assignee.id != person.id)
+                )
+              }
+              onRemoveSubject={(person) =>
+                setSubjects(
+                  subjects.filter((subject) => subject.id != person.id)
+                )
+              }
+            />
+          </Grid>
+        </Grid>
+      </Box>
+    </>
+  );
+};
+
+NewJourneyPage.getLayout = function getLayout(page) {
+  return <DefaultLayout>{page}</DefaultLayout>;
+};
+
+export default NewJourneyPage;

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -256,6 +256,7 @@ export interface ZetkinJourneyInstance {
   // as item, not when retrieved as collection
   milestones?: ZetkinJourneyMilestoneStatus[] | null;
   next_milestone: ZetkinJourneyMilestoneStatus | null;
+  opening_note: string;
   organization: {
     id: number;
     title: string;

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -233,6 +233,7 @@ export type { ZetkinView, ZetkinViewColumn, ZetkinViewRow };
 
 export interface ZetkinJourney {
   id: number;
+  opening_note_template: string;
   organization: ZetkinOrganization;
   plural_label: string;
   singular_label: string;

--- a/src/utils/testing/mocks/mockJourney.ts
+++ b/src/utils/testing/mocks/mockJourney.ts
@@ -3,6 +3,7 @@ import { ZetkinJourney } from 'types/zetkin';
 
 const journey: ZetkinJourney = {
   id: 2,
+  opening_note_template: '',
   organization: {
     id: 1,
     title: 'Kommunistiche Partei Deutschlands',

--- a/src/utils/testing/mocks/mockJourneyInstance.ts
+++ b/src/utils/testing/mocks/mockJourneyInstance.ts
@@ -15,6 +15,7 @@ const journeyInstance: ZetkinJourneyInstance = {
   },
   milestones: [milestone],
   next_milestone: milestone,
+  opening_note: '',
   organization: KPD,
   subjects: [person],
   summary: 'Haohrez uhca evo fup fonruh do vafeesa lida penco rillesven.',


### PR DESCRIPTION
## Description
This PR creates a page where a new journey instance can be opened.

## Screenshots
https://user-images.githubusercontent.com/550212/167681554-494c9e7a-4f82-4ccd-9478-2f19b5bff364.mov

## Change
* Adds a new page where journey instances can be opened from
* Creates NEXT API route used to open a journey instance against the Zetkin API, while adding assignees and subjects
* Also a number of changes to existing code to support this:
  * Refactors layouts to use use common components
  * Adds placeholder to `EditTextInPlace`
  * Breaks out `ZetkinAutoTextArea` into it's own component

## Notes to reviewer

### Deviations from design
* The FAB on the journey instance list page is at the bottom of the screen, contrary to the designs. The designs do not include the "collapse" option in the header, which complicates having the FAB there. Instead, I've put it in the bottom right, above the table footer
* On the new page, there were a lot of elements in the designs that do not make sense on this page where the journey has not yet been started, e.g. ellipsis menu, "last updated" label, tabs and milestones
* The tags have not been implemented yet, and are tracked separately in #578 

### How to test
1. Go to cases list, http://localhost:3000/organize/1/journeys/1
2. Click FAB navigate to new page
3. Add title and opening note text
4. Optionally add an assignee
5. Optionally add a member
6. Click create button

A new case should be opened and you should be taken to it's instance page.

## Related issues
Resolves #580 
