### PR TITLE
Fix flaky tests

### DIFF
--- a/playwright/tests/organize/campaign-detail/action-buttons.spec.ts
+++ b/playwright/tests/organize/campaign-detail/action-buttons.spec.ts
@@ -108,9 +108,12 @@ test.describe('Campaign action buttons', async () => {
 
       await page.click('data-testid=EllipsisMenu-menuActivator');
       await page.click('data-testid=EllipsisMenu-item-deleteCampaign');
-      await page.click('button > :text("Confirm")');
 
-      await page.waitForNavigation();
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click('button > :text("Confirm")'),
+      ]);
+
       expect(page.url()).toEqual(appUri + '/organize/1/campaigns');
       expect(log().length).toEqual(1);
     });

--- a/playwright/tests/organize/campaigns-list/speed-dial.spec.ts
+++ b/playwright/tests/organize/campaigns-list/speed-dial.spec.ts
@@ -40,12 +40,17 @@ test.describe('All campaigns page speed dial', () => {
         'input:near(#visibility)',
         ReferendumSignatures.visibility
       );
-      await page.click('button > :text("Submit")');
+
+      await Promise.all([
+        (async () => {
+          await page.waitForNavigation();
+          await page.waitForNavigation();
+        })(),
+        page.click('button > :text("Submit")'),
+      ]);
 
       // Check for redirect
-      await page.waitForNavigation();
-      await page.waitForNavigation();
-      await expect(page.url()).toEqual(
+      expect(page.url()).toEqual(
         appUri + '/organize/1/campaigns/' + ReferendumSignatures.id
       );
     });

--- a/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance-sidebar.spec.ts
@@ -83,17 +83,17 @@ test.describe('Journey instance sidebar', () => {
         ClarasOnboarding
       );
 
-      //click Angela in search results
-      await page
-        .locator(
-          `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
-        )
-        .click();
-
-      //wait for response
-      await page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`
-      );
+      //click Angela in search results and wait for response
+      await Promise.all([
+        page.waitForResponse(
+          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`
+        ),
+        page
+          .locator(
+            `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
+          )
+          .click(),
+      ]);
 
       //Expect PUT-request to be done
       expect(putTagLog().length).toEqual(1);
@@ -228,17 +228,17 @@ test.describe('Journey instance sidebar', () => {
         ClarasOnboarding
       );
 
-      //click Clara in search results
-      await page
-        .locator(
-          `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
-        )
-        .click();
-
-      //wait for response
-      await page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`
-      );
+      //click Clara in search results and awit for response
+      await Promise.all([
+        page.waitForResponse(
+          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`
+        ),
+        page
+          .locator(
+            `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
+          )
+          .click(),
+      ]);
 
       //Expect PUT-request to be done
       expect(putTagLog().length).toEqual(1);

--- a/playwright/tests/organize/people/person/tags.spec.ts
+++ b/playwright/tests/organize/people/person/tags.spec.ts
@@ -219,16 +219,18 @@ test.describe('Person Profile Page Tags', () => {
         [ActivistTag, CodingSkillsTag, ActivistTag]
       );
 
-      await page.click('data-testid=submit-button');
+      await Promise.all([
+        page.waitForResponse('**/orgs/1/people/tags'),
+        page.waitForResponse(
+          `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
+        ),
+        page.click('data-testid=submit-button'),
+      ]);
 
       // Check that request made to create tag
-      await page.waitForResponse('**/orgs/1/people/tags');
       expect(createTagRequest.log().length).toEqual(1);
 
       // Check that request made to apply tag
-      await page.waitForResponse(
-        `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
-      );
       expect(assignNewTagRequest.log().length).toEqual(1);
     });
 
@@ -266,20 +268,22 @@ test.describe('Person Profile Page Tags', () => {
         );
         await page.click(`text=Add "${SkillsGroup.title}"`);
 
-        await page.click('data-testid=submit-button');
+        await Promise.all([
+          page.waitForResponse(`**/orgs/1/tag_groups`),
+          page.waitForResponse('**/orgs/1/people/tags'),
+          page.waitForResponse(
+            `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
+          ),
+          page.click('data-testid=submit-button'),
+        ]);
 
         // Check that request made to create group
-        await page.waitForResponse(`**/orgs/1/tag_groups`);
         expect(createTagGroupRequest.log().length).toEqual(1);
 
         // Check that request made to create tag
-        await page.waitForResponse('**/orgs/1/people/tags');
         expect(createTagRequest.log().length).toEqual(1);
 
         // Check that request made to apply tag
-        await page.waitForResponse(
-          `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
-        );
         expect(assignNewTagRequest.log().length).toEqual(1);
       });
       test('shows error when creating group fails', async ({ page, moxy }) => {

--- a/playwright/tests/organize/people/views/create-new-view.spec.ts
+++ b/playwright/tests/organize/people/views/create-new-view.spec.ts
@@ -52,9 +52,11 @@ test.describe('Views list page', () => {
     );
 
     await page.goto(appUri + '/organize/1/people');
-    await page.click('data-testid=create-view-action-button');
 
-    await page.waitForNavigation();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('data-testid=create-view-action-button'),
+    ]);
 
     // Get POST requests for creating new view and columns
     const columnPostLogs = moxy

--- a/playwright/tests/organize/people/views/create-view-from-selection.spec.ts
+++ b/playwright/tests/organize/people/views/create-view-from-selection.spec.ts
@@ -47,9 +47,11 @@ test.describe('View detail page', () => {
 
     await page.locator('[role=cell] >> input[type=checkbox]').nth(0).click();
     await page.locator('[role=cell] >> input[type=checkbox]').nth(1).click();
-    await page.click('data-testid=ViewDataTableToolbar-createFromSelection');
 
-    await page.waitForNavigation();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('data-testid=ViewDataTableToolbar-createFromSelection'),
+    ]);
 
     // Get POST requests for creating new view and columns
     const moxyLog = moxy.log<{ title: string }>();

--- a/playwright/tests/organize/people/views/delete-view.spec.ts
+++ b/playwright/tests/organize/people/views/delete-view.spec.ts
@@ -102,11 +102,18 @@ test.describe('Delete view from view detail page', () => {
 
     await page.goto(appUri + '/organize/1/people/views/1');
 
-    await deleteView(page);
-    expectDeleteViewSuccess(moxy);
+    // Wait for navigation after deleting
+    await Promise.all([
+      (async () => {
+        // Check that the request to delete was made successfully
+        await page.waitForResponse(`**/orgs/1/people/views/${AllMembers.id}`);
+        expectDeleteViewSuccess(moxy);
+      })(),
+      page.waitForNavigation(),
+      deleteView(page),
+    ]);
 
     // Check navigates back to views list
-    await page.waitForNavigation();
     await expect(page.url()).toEqual(
       appUri + `/organize/${KPD.id}/people/views`
     );

--- a/playwright/tests/organize/people/views/rows/add-row.spec.ts
+++ b/playwright/tests/organize/people/views/rows/add-row.spec.ts
@@ -58,8 +58,11 @@ test.describe('View detail page', () => {
     // Add person statically
     await page.click('[name=person]');
     await page.fill('[name=person]', `${NewPerson.last_name}`);
-    await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
-    await page.waitForResponse('**/orgs/1/people/views/1/rows');
+
+    await Promise.all([
+      page.waitForResponse('**/orgs/1/people/views/1/rows'),
+      page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`),
+    ]);
 
     // Make sure the row was added
     expect(
@@ -107,8 +110,11 @@ test.describe('View detail page', () => {
     // Add person statically
     await page.click('[name=person]');
     await page.fill('[name=person]', `${NewPerson.last_name}`);
-    await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
-    await page.waitForTimeout(200);
+
+    await Promise.all([
+      page.waitForResponse(`**/orgs/1/people/views/1/rows/${NewPerson.id}`),
+      page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`),
+    ]);
 
     // Make sure the row was added
     expect(

--- a/playwright/tests/organize/people/views/view-detail.spec.ts
+++ b/playwright/tests/organize/people/views/view-detail.spec.ts
@@ -46,8 +46,10 @@ test.describe('View detail page', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
     await page.click(inputSelector);
     await page.fill(inputSelector, 'Friends of Zetkin');
-    await page.keyboard.press('Enter');
-    await page.waitForResponse('**/orgs/1/people/views/1');
+    await Promise.all([
+      page.waitForResponse('**/orgs/1/people/views/1'),
+      page.keyboard.press('Enter'),
+    ]);
 
     // Check body of request
     const titleUpdateRequest = moxy
@@ -76,10 +78,10 @@ test.describe('View detail page', () => {
 
     // Press down to select view and enter to navigate
     await page.keyboard.press('ArrowDown');
-    await page.keyboard.press('Enter');
+
+    await Promise.all([page.waitForNavigation(), page.keyboard.press('Enter')]);
 
     // Assert that we navigate away to the new view
-    await page.waitForNavigation();
     await expect(page.url()).toEqual(
       appUri + `/organize/1/people/views/${NewView.id}`
     );
@@ -109,8 +111,11 @@ test.describe('View detail page', () => {
     await page.click('data-testid=StartsWith-select');
     await page.click('data-testid=StartsWith-select-all');
     await page.click('data-testid=FilterForm-saveButton');
-    await page.click('data-testid=QueryOverview-saveButton');
-    await page.waitForResponse('**/orgs/1/people/views/1/rows');
+
+    await Promise.all([
+      page.waitForResponse('**/orgs/1/people/views/1/rows'),
+      page.click('data-testid=QueryOverview-saveButton'),
+    ]);
 
     // Make sure previous content query was deleted
     expect(

--- a/playwright/tests/organize/people/views/views-list.spec.ts
+++ b/playwright/tests/organize/people/views/views-list.spec.ts
@@ -58,8 +58,11 @@ test.describe('Views list page', () => {
       moxy.setZetkinApiMock('/orgs/1/people/views', 'get', [AllMembers]);
 
       await page.goto(appUri + '/organize/1/people');
-      await page.click(`text=${AllMembers.title}`);
-      await page.waitForNavigation();
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(`text=${AllMembers.title}`),
+      ]);
 
       await expect(page.url()).toEqual(
         appUri + `/organize/1/people/views/${AllMembers.id}`

--- a/playwright/tests/organize/task-detail/action-buttons.spec.ts
+++ b/playwright/tests/organize/task-detail/action-buttons.spec.ts
@@ -89,9 +89,12 @@ test.describe('Task action buttons', async () => {
 
       await page.click('data-testid=EllipsisMenu-menuActivator');
       await page.click('data-testid=EllipsisMenu-item-deleteTask');
-      await page.click('button > :text("Confirm")');
 
-      await page.waitForNavigation();
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click('button > :text("Confirm")'),
+      ]);
+
       expect(page.url()).toEqual(appUri + '/organize/1/campaigns/1');
       expect(log().length).toEqual(1);
     });


### PR DESCRIPTION
## Description
This PR (hopefully) fixes flaky Playwright tests by consistently using `await Promise.all()` to wait and interact in parallel in those cases where an interaction triggers something that should be waited for.

## Screenshots
None

## Changes
* Uses `Promise.all()` for all occurrences of `waitForNavigation()`, `waitForRequest()` and `waitForResponse()`
* Replaces `waitForTimeout()` with correct `waitForResponse()` in one or two places

## Notes to reviewer
Please have a look at the code, and if all tests pass that should be enough.

## Related issues
Resolves #649 
