### PR TITLE
Prettier tag rendering

### DIFF
--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -21,7 +21,7 @@ const getTagColumns = (tagMetadata: TagMetadata): GridColDef[] => {
     renderCell: (params) => {
       if (group) {
         return getGroupTags(params.row, group.id).map((tag) => (
-          <TagChip key={tag.id} tag={tag as ZetkinTag} />
+          <TagChip key={tag.id} size="small" tag={tag as ZetkinTag} />
         ));
       }
     },
@@ -50,7 +50,7 @@ const getTagColumns = (tagMetadata: TagMetadata): GridColDef[] => {
       const rowTags = params.row.tags as ZetkinJourneyInstance['tags'];
       const freeTags = rowTags.filter((tag) => !tag.group && !('value' in tag));
       return freeTags.map((tag) => (
-        <TagChip key={tag.id} tag={tag as ZetkinTag} />
+        <TagChip key={tag.id} size="small" tag={tag as ZetkinTag} />
       ));
     },
     renderHeader: () => (

--- a/src/components/organize/TagsManager/TagChip.tsx
+++ b/src/components/organize/TagsManager/TagChip.tsx
@@ -53,8 +53,13 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
       deletable && hover ? 'transform 0.1s 0.1s' : 'transform 0.1s',
   },
   deleteContainer: {
-    padding: ({ deletable, hover }) =>
-      deletable && hover ? '0.2em 1.6em 0.2em 0.4em' : '0.2em 1em',
+    padding: ({ deletable, hover }) => {
+      if (deletable) {
+        return hover ? '0.2em 1.6em 0.2em 0.4em' : '0.2em 1em';
+      } else {
+        return '0.2em 0.6em';
+      }
+    },
     position: 'relative',
     transition: 'padding 0.1s',
   },

--- a/src/components/organize/TagsManager/TagChip.tsx
+++ b/src/components/organize/TagsManager/TagChip.tsx
@@ -13,11 +13,14 @@ import { DEFAULT_TAG_COLOR } from './utils';
 import { getContrastColor } from 'utils/colorUtils';
 import { ZetkinTag } from 'types/zetkin';
 
+type TagChipSize = 'small' | 'medium' | 'large';
+
 interface StyleProps {
   clickable: boolean;
   deletable: boolean;
   disabled: boolean;
   hover: boolean;
+  size: TagChipSize;
   tag: ZetkinTag;
 }
 
@@ -27,6 +30,12 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
     cursor: ({ clickable, disabled }) =>
       clickable && !disabled ? 'pointer' : 'default',
     display: 'flex',
+    fontSize: ({ size }) =>
+      ({
+        large: '1.2em',
+        medium: '1.0em',
+        small: '0.8em',
+      }[size]),
     lineHeight: 'normal',
     marginRight: '0.1em',
     opacity: ({ disabled }) => (disabled ? 0.5 : 1.0),
@@ -74,14 +83,16 @@ const TagChip: React.FunctionComponent<{
   disabled?: boolean;
   onClick?: (tag: ZetkinTag) => void;
   onDelete?: (tag: ZetkinTag) => void;
+  size?: TagChipSize;
   tag: ZetkinTag;
-}> = ({ disabled = false, onClick, onDelete, tag }) => {
+}> = ({ disabled = false, onClick, onDelete, size = 'medium', tag }) => {
   const [hover, setHover] = useState(false);
   const classes = useStyles({
     clickable: !!onClick,
     deletable: !!onDelete,
     disabled,
     hover,
+    size,
     tag,
   });
 

--- a/src/components/organize/TagsManager/TagChip.tsx
+++ b/src/components/organize/TagsManager/TagChip.tsx
@@ -73,7 +73,10 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
   label: {
     backgroundColor: ({ tag }) => tag.color || DEFAULT_TAG_COLOR,
     color: ({ tag }) => getContrastColor(tag.color || DEFAULT_TAG_COLOR),
+    maxWidth: '100%',
+    overflow: 'hidden',
     padding: '0.2em 0.4em 0.2em 1em',
+    textOverflow: 'ellipsis',
   },
   value: {
     backgroundColor: ({ tag }) => lighten(tag.color || DEFAULT_TAG_COLOR, 0.7),

--- a/src/components/organize/TagsManager/TagChip.tsx
+++ b/src/components/organize/TagsManager/TagChip.tsx
@@ -87,6 +87,24 @@ const useStyles = makeStyles<Theme, StyleProps>(() => ({
   },
 }));
 
+const TagToolTip: React.FunctionComponent<{
+  children: JSX.Element;
+  tag: ZetkinTag;
+}> = ({ children, tag }) => {
+  return (
+    <Tooltip
+      arrow
+      title={
+        <>
+          {tag.title} <br /> {tag.description || ''}
+        </>
+      }
+    >
+      {children}
+    </Tooltip>
+  );
+};
+
 const TagChip: React.FunctionComponent<{
   disabled?: boolean;
   onClick?: (tag: ZetkinTag) => void;
@@ -127,9 +145,9 @@ const TagChip: React.FunctionComponent<{
     >
       {tag.value_type && (
         <>
-          <Tooltip arrow title={tag.description || ''}>
+          <TagToolTip tag={tag}>
             <Box className={classes.label}>{tag.title}</Box>
-          </Tooltip>
+          </TagToolTip>
           <Tooltip arrow title={tag.value || ''}>
             <Box
               className={classes.value + ' ' + classes.deleteContainer}
@@ -142,12 +160,12 @@ const TagChip: React.FunctionComponent<{
         </>
       )}
       {!tag.value_type && (
-        <Tooltip arrow title={tag.description || ''}>
+        <TagToolTip tag={tag}>
           <Box className={classes.label + ' ' + classes.deleteContainer}>
             {tag.title}
             {deleteButton}
           </Box>
-        </Tooltip>
+        </TagToolTip>
       )}
     </Box>
   );


### PR DESCRIPTION
## Description
This PR makes some additional improvements (on top of #653) to how tags are rendered in various places.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/168082868-e84da28c-c835-4c3a-8dc2-a516c58114fd.png)

## Changes
* Shows ellipsis when the label of a tag can't fit in the tag as it's rendered (which happens in the journey instance table)
* Adds a tooltip when hovering the label of a tag
* Tweaks the padding of tags when deleting is disabled (less padding needed)
* Makes the size of tags configurable (three sizes, which are all relative to the font size)

## Notes to reviewer
Tags should look ok in all places where they're used.

I had originally planned to tweak the column width in the journey instance table depending on how many tags are shown in a column, but I couldn't quite make that happen easily enough to warrant spending time on it. It's something we could improve further down the line if we want to.

## Related issues
Related to #632 but only barely
