### PR TITLE
Configurable column widths and order in data grids

### DIFF
--- a/src/components/UserConfigurableDataGrid/index.tsx
+++ b/src/components/UserConfigurableDataGrid/index.tsx
@@ -1,0 +1,43 @@
+import { DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
+
+import useConfigurableDataGridColumns from './useConfigurableDataGridColumns';
+
+type UserConfigurableDataGridProps = DataGridProProps & {
+  storageKey: string;
+};
+
+const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
+  storageKey,
+  ...gridProps
+}) => {
+  const { columns, setColumnOrder, setColumnWidth } =
+    useConfigurableDataGridColumns(storageKey, gridProps.columns);
+
+  return (
+    <DataGridPro
+      {...gridProps}
+      columns={columns}
+      onColumnOrderChange={(params, event, details) => {
+        // Subtract one for selection column, if it's visible
+        const targetIndex = gridProps.checkboxSelection
+          ? params.targetIndex - 1
+          : params.targetIndex;
+
+        setColumnOrder(params.colDef.field, targetIndex);
+
+        if (gridProps.onColumnOrderChange) {
+          gridProps.onColumnOrderChange(params, event, details);
+        }
+      }}
+      onColumnResize={(params, event, details) => {
+        setColumnWidth(params.colDef.field, params.width);
+
+        if (gridProps.onColumnResize) {
+          gridProps.onColumnResize(params, event, details);
+        }
+      }}
+    />
+  );
+};
+
+export default UserConfigurableDataGrid;

--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
@@ -1,0 +1,307 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import useConfigurableDataGridColumns, {
+  StorageBackend,
+} from './useConfigurableDataGridColumns';
+
+const mockSetState = jest.fn();
+
+jest.mock('react', () => ({
+  useState: <T>(initial: T) => [initial, mockSetState],
+}));
+
+class MockStorage implements StorageBackend {
+  public data: Record<string, string> = {};
+
+  getItem(key: string): string | null {
+    return this.data[key] || null;
+  }
+  setItem(key: string, value: string): void {
+    this.data[key] = value;
+  }
+}
+
+function mockColumns(count: number, widths: number[] = []): GridColDef[] {
+  const columns: GridColDef[] = [];
+  for (let i = 0; i < count; i++) {
+    columns.push({
+      field: `field${i}`,
+      width: i < widths.length ? widths[0] : 100,
+    });
+  }
+
+  return columns;
+}
+
+describe('useConfigurableDataGridColumns', () => {
+  let mockStorage: StorageBackend;
+
+  beforeEach(() => {
+    mockStorage = new MockStorage();
+    mockSetState.mockReset();
+  });
+
+  describe('columns', () => {
+    test('are untouched nothing by default', () => {
+      const inputColumns = mockColumns(3);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns).toEqual(inputColumns);
+    });
+
+    test('reads widths from storage', () => {
+      mockStorage.setItem(
+        'dataGridConfig-key',
+        JSON.stringify({
+          fieldWidths: {
+            field0: 200,
+            field1: 250,
+            field2: 300,
+          },
+        })
+      );
+
+      const inputColumns = mockColumns(3);
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0].width).toEqual(200);
+      expect(columns[1].width).toEqual(250);
+      expect(columns[2].width).toEqual(300);
+    });
+
+    test('removes flex when width is set', () => {
+      mockStorage.setItem(
+        'dataGridConfig-key',
+        JSON.stringify({
+          fieldWidths: {
+            field0: 200,
+          },
+        })
+      );
+
+      const inputColumns = [{ field: 'field0', flex: 1 }];
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+      expect(columns[0]).toEqual({
+        field: 'field0',
+        width: 200,
+      });
+    });
+
+    test('reads order from storage', () => {
+      mockStorage.setItem(
+        'dataGridConfig-key',
+        JSON.stringify({
+          fieldOrder: ['field2', 'field0', 'field1'],
+        })
+      );
+
+      const inputColumns = mockColumns(3);
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0].field).toEqual('field2');
+      expect(columns[1].field).toEqual('field0');
+      expect(columns[2].field).toEqual('field1');
+    });
+
+    test('puts unknown columns last', () => {
+      mockStorage.setItem(
+        'dataGridConfig-key',
+        JSON.stringify({
+          fieldOrder: ['field2', 'field0', 'field1'],
+        })
+      );
+
+      const inputColumns = mockColumns(6);
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0].field).toEqual('field2');
+      expect(columns[1].field).toEqual('field0');
+      expect(columns[2].field).toEqual('field1');
+      expect(columns[3].field).toEqual('field3');
+      expect(columns[4].field).toEqual('field4');
+      expect(columns[5].field).toEqual('field5');
+    });
+  });
+
+  describe('setColumnOrder()', () => {
+    test('correctly updates storage when reordering left to right', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field0', 1);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[1]);
+      expect(columns[1]).toEqual(inputColumns[0]);
+      expect(columns[2]).toEqual(inputColumns[2]);
+    });
+
+    test('correctly updates storage when reordering right to left', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field1', 0);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[1]);
+      expect(columns[1]).toEqual(inputColumns[0]);
+      expect(columns[2]).toEqual(inputColumns[2]);
+    });
+
+    test('correctly updates storage when reordering end to start', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field2', 0);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[2]);
+      expect(columns[1]).toEqual(inputColumns[0]);
+      expect(columns[2]).toEqual(inputColumns[1]);
+    });
+
+    test('correctly updates storage when reordering start to end', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field0', 2);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[1]);
+      expect(columns[1]).toEqual(inputColumns[2]);
+      expect(columns[2]).toEqual(inputColumns[0]);
+    });
+
+    test('does not trigger re-render using state', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field0', 0);
+      expect(mockSetState).toHaveBeenCalledTimes(0);
+    });
+
+    test('correctly updates storage when several times in a row', () => {
+      const inputColumns = mockColumns(4);
+      const { setColumnOrder } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      // Reorder as field1, field0, field2, field3
+      setColumnOrder('field0', 1);
+
+      // Reorder as field1, field2, field0, field3
+      setColumnOrder('field0', 2);
+
+      // Reorder as field1, field2, field3, field0
+      setColumnOrder('field3', 2);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[1]);
+      expect(columns[1]).toEqual(inputColumns[2]);
+      expect(columns[2]).toEqual(inputColumns[3]);
+      expect(columns[3]).toEqual(inputColumns[0]);
+    });
+  });
+
+  describe('setColumnWidth()', () => {
+    test('stores updated width in storage', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnWidth } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnWidth('field1', 500);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual(inputColumns[0]);
+      expect(columns[1].width).toEqual(500);
+      expect(columns[2]).toEqual(inputColumns[2]);
+    });
+
+    test('triggers re-render using state', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnWidth } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnWidth('field1', 500);
+      expect(mockSetState).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
@@ -304,4 +304,28 @@ describe('useConfigurableDataGridColumns', () => {
       expect(mockSetState).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Complex interactions', () => {
+    test('handles reorder followed by resize', () => {
+      const inputColumns = mockColumns(3);
+      const { setColumnOrder, setColumnWidth } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      setColumnOrder('field0', 1);
+      setColumnWidth('field1', 200);
+
+      const { columns } = useConfigurableDataGridColumns(
+        'key',
+        inputColumns,
+        mockStorage
+      );
+
+      expect(columns[0]).toEqual({ field: 'field1', width: 200 });
+      expect(columns[1]).toEqual({ field: 'field0', width: 100 });
+      expect(columns[2]).toEqual({ field: 'field2', width: 100 });
+    });
+  });
 });

--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
@@ -1,0 +1,126 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { useState } from 'react';
+
+export interface StorageBackend {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface ConfigurableDataGridColumns {
+  columns: GridColDef[];
+  setColumnOrder: (field: string, newIndex: number) => void;
+  setColumnWidth: (field: string, width: number) => void;
+}
+
+interface ColumnConfig {
+  fieldOrder: string[];
+  fieldWidths: Record<string, number>;
+}
+
+function orderColumns(
+  columns: GridColDef[],
+  fieldOrder: string[]
+): GridColDef[] {
+  return columns.concat().sort((c0, c1) => {
+    const idx0 = fieldOrder.indexOf(c0.field);
+    const idx1 = fieldOrder.indexOf(c1.field);
+
+    if (idx0 === -1 && idx1 === -1) {
+      return 0;
+    } else if (idx0 === -1) {
+      return 1;
+    } else if (idx1 === -1) {
+      return -1;
+    } else {
+      return idx0 - idx1;
+    }
+  });
+}
+
+export default function useConfigurableDataGridColumns(
+  storageKey: string,
+  inputColumns: GridColDef[],
+  storage: StorageBackend = localStorage
+): ConfigurableDataGridColumns {
+  const key = `dataGridConfig-${storageKey}`;
+
+  const [config, setConfig] = useState<ColumnConfig>(loadConfig(storage, key));
+
+  return {
+    columns: orderColumns(inputColumns, config.fieldOrder).map((colDef) => {
+      if (config.fieldWidths[colDef.field]) {
+        const modified = {
+          ...colDef,
+          width: config.fieldWidths[colDef.field],
+        };
+        delete modified.flex;
+        return modified;
+      } else {
+        return colDef;
+      }
+    }),
+    setColumnOrder: (field, newIndex) => {
+      // Use the stored config and not the config from state when reordering.
+      // Changing the order does not require a re-render (because the grid
+      // already re-renders internally), so we don't update state when the
+      // order changes, instead just updating the storage, which is why that's
+      // where we have to go to find the most recent order config.
+      const storedConfig = loadConfig(storage, key);
+      const sortedFields = orderColumns(
+        inputColumns,
+        storedConfig.fieldOrder
+      ).map((colDef) => colDef.field);
+
+      const originalIndex = sortedFields.indexOf(field);
+      sortedFields.splice(originalIndex, 1);
+
+      const before = sortedFields.slice(0, newIndex);
+      const after = sortedFields.slice(newIndex);
+
+      const newConfig = {
+        ...config,
+        fieldOrder: [...before, field, ...after],
+      };
+
+      storage.setItem(key, JSON.stringify(newConfig));
+    },
+    setColumnWidth: (field, width) => {
+      const newConfig = {
+        ...config,
+        fieldWidths: {
+          ...config.fieldWidths,
+          [field]: width,
+        },
+      };
+
+      storage.setItem(key, JSON.stringify(newConfig));
+
+      setConfig(newConfig);
+    },
+  };
+}
+
+function loadConfig(storage: StorageBackend, key: string): ColumnConfig {
+  let fieldOrder: string[] = [];
+  let fieldWidths: Record<string, number> = {};
+  try {
+    const configStr = storage.getItem(key);
+    if (configStr) {
+      const config = JSON.parse(configStr);
+      if (Array.isArray(config.fieldOrder)) {
+        fieldOrder = config.fieldOrder;
+      }
+      if (config.fieldWidths) {
+        fieldWidths = config.fieldWidths;
+      }
+    } else {
+      throw new Error('Config not found in storage');
+    }
+  } catch (err) {
+    // Do nothing, use default values
+  }
+  return {
+    fieldOrder,
+    fieldWidths,
+  };
+}

--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
@@ -85,10 +85,11 @@ export default function useConfigurableDataGridColumns(
       storage.setItem(key, JSON.stringify(newConfig));
     },
     setColumnWidth: (field, width) => {
+      const storedConfig = loadConfig(storage, key);
       const newConfig = {
-        ...config,
+        ...storedConfig,
         fieldWidths: {
-          ...config.fieldWidths,
+          ...storedConfig.fieldWidths,
           [field]: width,
         },
       };

--- a/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
+++ b/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
@@ -13,8 +13,8 @@ const getColumns = (tagMetadata: TagMetadata): GridColDef[] => {
       // Add/override common props
       .concat(staticColumns)
       .map((col) => ({
-        flex: 1,
-        minWidth: 200,
+        minWidth: 50,
+        width: 200,
         ...col,
       }))
   );

--- a/src/components/journeys/JourneyInstancesDataTable/index.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.tsx
@@ -1,10 +1,6 @@
 import { isEqual } from 'lodash';
 import { useIntl } from 'react-intl';
-import {
-  DataGridPro,
-  DataGridProProps,
-  GridSortModel,
-} from '@mui/x-data-grid-pro';
+import { DataGridProProps, GridSortModel } from '@mui/x-data-grid-pro';
 
 import getColumns from './getColumns';
 import { getRows } from './getRows';
@@ -12,6 +8,8 @@ import { TagMetadata } from 'utils/getTagMetadata';
 import Toolbar from './Toolbar';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 import { FunctionComponent, useState } from 'react';
+
+import UserConfigurableDataGrid from 'components/UserConfigurableDataGrid';
 
 interface JourneysDataTableProps {
   dataGridProps?: Partial<DataGridProProps>;
@@ -41,8 +39,7 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
 
   return (
     <>
-      <DataGridPro
-        autoHeight={rows.length === 0}
+      <UserConfigurableDataGrid
         checkboxSelection
         columns={columnsWithHeaderTitles}
         components={{ Toolbar: Toolbar }}
@@ -65,6 +62,7 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
         pagination
         rows={rows}
         sortModel={sortModel}
+        storageKey="journeyInstances"
         {...dataGridProps}
       />
     </>

--- a/src/components/views/ViewDataTable/index.tsx
+++ b/src/components/views/ViewDataTable/index.tsx
@@ -3,13 +3,8 @@ import NextLink from 'next/link';
 import NProgress from 'nprogress';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
-import {
-  DataGridPro,
-  GridColDef,
-  GridSortModel,
-  useGridApiRef,
-} from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';
+import { GridColDef, GridSortModel, useGridApiRef } from '@mui/x-data-grid-pro';
 import { Link, makeStyles } from '@material-ui/core';
 import { useMutation, useQueryClient } from 'react-query';
 
@@ -20,6 +15,7 @@ import patchViewColumn from 'fetching/views/patchViewColumn';
 import PersonHoverCard from 'components/PersonHoverCard';
 import postViewColumn from 'fetching/views/postViewColumn';
 import SnackbarContext from 'hooks/SnackbarContext';
+import UserConfigurableDataGrid from 'components/UserConfigurableDataGrid';
 import ViewRenameColumnDialog from '../ViewRenameColumnDialog';
 import { viewRowsResource } from 'api/viewRows';
 import { viewsResource } from 'api/views';
@@ -375,7 +371,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   return (
     <>
-      <DataGridPro
+      <UserConfigurableDataGrid
         apiRef={gridApiRef}
         autoHeight={empty}
         checkboxSelection={true}
@@ -404,6 +400,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         }}
         rows={gridRows}
         sortModel={sortModel}
+        storageKey={`personView_${viewId}`}
         style={{
           border: 'none',
         }}


### PR DESCRIPTION
## Description
This PR implements a new hook and wrapper component to very easily enable storage of `DataGrid` column orders and widths in `LocalStorage`, so that user changes are persisted across page refreshes.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/168384829-dd844567-8797-4a36-9392-59d337b674b6.png)

## Changes
* Adds a new hook called `useConfigurableDataGridColumns()` and tests
* Adds a new component called `<UserConfigurableDataGrid/>` that is a drop-in replacement for `DataGridPro` but uses the new hook to store configs
* Replaces the regular `DataGridProp` with the new component in the journey instance list
* Replaces the regular `DataGridProp` with the new component in views

## Notes to reviewer
To test it:

1. Navigate to either the journey instance list or any view
2. Change the width of columns
3. Reorder some columns
4. Refresh the page

The order and width changes should persist across refreshes

## Related issues
Resolves #535
