### PR TITLE
Fix remaining flaky tests

### DIFF
--- a/playwright/tests/organize/campaigns-list/speed-dial.spec.ts
+++ b/playwright/tests/organize/campaigns-list/speed-dial.spec.ts
@@ -42,10 +42,11 @@ test.describe('All campaigns page speed dial', () => {
       );
 
       await Promise.all([
-        (async () => {
-          await page.waitForNavigation();
-          await page.waitForNavigation();
-        })(),
+        // Page may navigate away from modal (#createCampaign) before it
+        // navigates to the new campaign, so wait for specific URL
+        page.waitForNavigation({
+          url: `**/organize/1/campaigns/${ReferendumSignatures.id}`,
+        }),
         page.click('button > :text("Submit")'),
       ]);
 

--- a/playwright/tests/organize/journeys/journey-instance/milestones.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/milestones.spec.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { expect } from '@playwright/test';
 import test from '../../../../fixtures/next';
 
@@ -194,9 +193,15 @@ test.describe('Journey instance Milestones tab', () => {
           .click(),
       ]);
 
+      const submittedDate = new Date(
+        patchReqLog<ZetkinJourneyMilestoneStatus>()[0].data!.completed!
+      );
+      const nowDate = new Date();
+
+      // Check that submitted time is within 10 seconds of now
       expect(
-        patchReqLog<ZetkinJourneyMilestoneStatus>()[0].data?.completed
-      ).toMatch(dayjs().toJSON());
+        Math.abs(submittedDate.getTime() - nowDate.getTime())
+      ).toBeLessThan(10000);
     });
 
     test('lets you mark a completed milestone as not completed.', async ({

--- a/playwright/tests/organize/journeys/journey-instance/page.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/page.spec.ts
@@ -30,9 +30,23 @@ test.describe('Journey instance page', () => {
 
     await page.goto(appUri + '/organize/1/journeys/1/1');
 
+    // Check that the title is visible in the right place
     expect(
-      await page.locator(`text=${ClarasOnboarding.title}`).count()
-    ).toEqual(2);
+      await page
+        .locator(
+          `[data-testid=page-title]:has-text("${ClarasOnboarding.title}")`
+        )
+        .count()
+    ).toEqual(1);
+
+    // Check that the title is also in the breadcrumbs
+    expect(
+      await page
+        .locator(
+          `[aria-label=breadcrumb]:has-text("${ClarasOnboarding.title}")`
+        )
+        .count()
+    ).toEqual(1);
   });
 
   test('navigates to Milestones page when clicking tab', async ({

--- a/playwright/tests/organize/journeys/journey-instance/page.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/page.spec.ts
@@ -103,7 +103,12 @@ test.describe('Journey instance page', () => {
         newSummaryText
       );
 
-      await page.click('data-testid=JourneyInstanceSummary-saveEditButton');
+      await Promise.all([
+        page.waitForResponse(
+          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`
+        ),
+        page.click('data-testid=JourneyInstanceSummary-saveEditButton'),
+      ]);
 
       // Makes request with correct data
       expect(

--- a/playwright/tests/organize/people/views/delete-view.spec.ts
+++ b/playwright/tests/organize/people/views/delete-view.spec.ts
@@ -99,6 +99,7 @@ test.describe('Delete view from view detail page', () => {
       AllMembersColumns
     );
     moxy.setZetkinApiMock('/orgs/1/people/views/1', 'delete', undefined, 204);
+    moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
 
     await page.goto(appUri + '/organize/1/people/views/1');
 

--- a/playwright/tests/organize/people/views/delete-view.spec.ts
+++ b/playwright/tests/organize/people/views/delete-view.spec.ts
@@ -107,7 +107,14 @@ test.describe('Delete view from view detail page', () => {
     await Promise.all([
       (async () => {
         // Check that the request to delete was made successfully
-        await page.waitForResponse(`**/orgs/1/people/views/${AllMembers.id}`);
+        await page.waitForResponse(
+          (res) =>
+            res.request().method() === 'DELETE' &&
+            res
+              .request()
+              .url()
+              .includes(`/orgs/1/people/views/${AllMembers.id}`)
+        );
         expectDeleteViewSuccess(moxy);
       })(),
       page.waitForNavigation(),


### PR DESCRIPTION
## Description
This PR fixes a number of flaky playwright tests. I went back and looked at all failures on `main` (i.e. tests that have failed after passing in a PR before it was merged) over the last week and analyzed what made them flaky.

## Screenshots
None

## Changes
Fixes the following tests

* `All campaigns page speed dial › allows user to create a campiagn › user can create a new campaign `
  * Previously waited for two navigations (the first of which was expected to be the `#createCampaign`) but now waits for the relevant navigation to campaign details instead
* `Delete view from view detail page › successfully deletes a view`
  * Not sure what's causing this, but added a mock to make sure the navigation succeeds, and now waiting specifically for the `DELETE` request in case the cause for the flakiness was that another request to the same URL is being made causing the wait to resolve too soon
* `Journey instance Milestones tab › JourneyMilestoneCard › lets you mark a milestone as completed. `
  * Made date comparison fuzzy (10 seconds margin)
* `Journey instance page › shows journey instance `
  * Previously searched for two text nodes with `"Clara's on-boarding"` in it, one being the page title and the other being the breadcrumb. I think the flakiness is because one may be rendered milliseconds before the other one, causing the `locator.count()` to resolve when there is just one visible. Fixed by looking for the two texts separately in breadcrumbs and title.
* `Journey instance page › Editing the journey summary › User can edit summary `
  * Was not waiting for response after save before asserting

## Notes to reviewer
No action needed except code review and make sure CI passes.

## Related issues
Undocumented
