### PR TITLE
Pretty email rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "final-form": "^4.20.2",
     "fuse.js": "^6.5.3",
     "leaflet": "^1.7.1",
+    "letterparser": "^0.0.8",
     "lodash": "^4.17.21",
     "mui-rff": "^3.0.9",
     "negotiator": "^0.6.2",

--- a/src/components/Timeline/updates/elements/PrettyEmail.stories.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import {
+  MULTIPART,
+  MULTIPART_WITH_REPLY,
+  PLAINTEXT,
+  PLAINTEXT_MULTI_CC,
+} from 'utils/testing/mocks/email';
+
+import PrettyEmail from './PrettyEmail';
+
+export default {
+  component: PrettyEmail,
+  title: 'Example/Timeline/Elements/PrettyEmail',
+} as ComponentMeta<typeof PrettyEmail>;
+
+const Template: ComponentStory<typeof PrettyEmail> = (args) => (
+  <PrettyEmail emailStr={args.emailStr} />
+);
+
+export const plaintext = Template.bind({});
+plaintext.args = {
+  emailStr: PLAINTEXT,
+};
+
+export const plaintextMultiCc = Template.bind({});
+plaintextMultiCc.args = {
+  emailStr: PLAINTEXT_MULTI_CC,
+};
+
+export const html = Template.bind({});
+html.args = {
+  emailStr: MULTIPART,
+};
+
+export const htmlReply = Template.bind({});
+htmlReply.args = {
+  emailStr: MULTIPART_WITH_REPLY,
+};

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -64,8 +64,10 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
         </Collapse>
         {needsCollapse && (
           <Button
+            color="primary"
             onClick={() => setCollapsed(!collapsed)}
             startIcon={collapsed ? <ExpandMore /> : <ExpandLess />}
+            style={{ textTransform: 'uppercase' }}
           >
             <FormattedMessage
               id={collapsed ? 'misc.email.expand' : 'misc.email.collapse'}

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -51,7 +51,9 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
     return (
       <Box>
         <EmailHeader headers={emailData.headers} />
-        <Typography style={{ fontWeight: 'bold', marginBottom: 8 }}>
+        <Typography
+          style={{ fontWeight: 'bold', marginBottom: 8, marginTop: 8 }}
+        >
           {emailData.headers.Subject}
         </Typography>
         <Collapse
@@ -132,7 +134,7 @@ const EmailHeader: React.FC<{ headers: LetterparserNode['headers'] }> = ({
 }) => {
   const RELEVANT_HEADERS = ['from', 'to', 'cc'];
   return (
-    <Grid container direction="column">
+    <Grid container direction="column" spacing={1}>
       {RELEVANT_HEADERS.map((headerName) => {
         const matchedHeader = Object.entries(headers).find(
           ([key]) => key.toLowerCase() == headerName.toLowerCase()
@@ -142,24 +144,22 @@ const EmailHeader: React.FC<{ headers: LetterparserNode['headers'] }> = ({
           const values = matchedHeader[1].split(',');
 
           return (
-            <Grid key={headerName} item style={{ marginBottom: 8 }}>
-              <Grid container direction="row" wrap="nowrap">
-                <Grid item style={{ paddingRight: 12, paddingTop: '0.2em' }}>
-                  <Typography>
-                    <FormattedMessage id={`misc.email.headers.${headerName}`} />
-                  </Typography>
-                </Grid>
-                <Grid item>
-                  {values.map((value) => (
-                    <Link key={value} href={`mailto:${value}`} passHref>
-                      <Chip
-                        component="a"
-                        label={value}
-                        style={{ marginBottom: 4, marginRight: 4 }}
-                      />
-                    </Link>
-                  ))}
-                </Grid>
+            <Grid key={headerName} container direction="row" item wrap="nowrap">
+              <Grid item style={{ marginRight: 12, marginTop: '0.2em' }}>
+                <Typography>
+                  <FormattedMessage id={`misc.email.headers.${headerName}`} />
+                </Typography>
+              </Grid>
+              <Grid item>
+                {values.map((value) => (
+                  <Link key={value} href={`mailto:${value}`} passHref>
+                    <Chip
+                      component="a"
+                      label={value}
+                      style={{ marginBottom: 4, marginRight: 4 }}
+                    />
+                  </Link>
+                ))}
               </Grid>
             </Grid>
           );

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   Grid,
   makeStyles,
+  Theme,
   Typography,
 } from '@material-ui/core';
 import { LetterparserNode, parse } from 'letterparser';
@@ -41,7 +42,7 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
   }
 };
 
-const useBodyStyles = makeStyles((theme) => ({
+const useBodyStyles = makeStyles<Theme, { plain: boolean }>((theme) => ({
   body: {
     '& blockquote': {
       borderColor: theme.palette.text.disabled,
@@ -53,11 +54,16 @@ const useBodyStyles = makeStyles((theme) => ({
       paddingLeft: 10,
     },
     fontFamily: 'sans-serif',
+    whiteSpace: ({ plain }) => (plain ? 'pre' : 'normal'),
   },
 }));
 
-const EmailBody: React.FC<{ body: LetterparserNode['body'] }> = ({ body }) => {
-  const classes = useBodyStyles();
+const EmailBody: React.FC<{
+  body: LetterparserNode['body'];
+  forcePlain?: boolean;
+}> = ({ body, forcePlain = false }) => {
+  const plain = forcePlain || typeof body == 'string';
+  const classes = useBodyStyles({ plain });
 
   if (Array.isArray(body)) {
     let bodyToRender = body.find(
@@ -68,9 +74,10 @@ const EmailBody: React.FC<{ body: LetterparserNode['body'] }> = ({ body }) => {
       bodyToRender = body[0];
     }
 
-    return <EmailBody body={bodyToRender.body} />;
+    return <EmailBody body={bodyToRender.body} forcePlain />;
   } else {
     const content = typeof body == 'string' ? body : body.toString();
+
     // TODO: Sanitize content before rendering
     return (
       <div

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import Link from 'next/link';
 import {
   Box,
   Button,
@@ -148,11 +149,13 @@ const EmailHeader: React.FC<{ headers: LetterparserNode['headers'] }> = ({
                 </Grid>
                 <Grid item>
                   {values.map((value) => (
-                    <Chip
-                      key={value}
-                      label={value}
-                      style={{ marginBottom: 4, marginRight: 4 }}
-                    />
+                    <Link key={value} href={`mailto:${value}`} passHref>
+                      <Chip
+                        component="a"
+                        label={value}
+                        style={{ marginBottom: 4, marginRight: 4 }}
+                      />
+                    </Link>
                   ))}
                 </Grid>
               </Grid>

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -1,0 +1,126 @@
+import { FormattedMessage } from 'react-intl';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  Grid,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+import { LetterparserNode, parse } from 'letterparser';
+import { useEffect, useState } from 'react';
+
+interface PrettyEmailProps {
+  emailStr: string;
+}
+
+const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
+  const [emailData, setEmailData] = useState<LetterparserNode | null>(null);
+
+  useEffect(() => {
+    async function parseEmailStr() {
+      const data = await parse(emailStr);
+      setEmailData(data);
+    }
+
+    parseEmailStr();
+  }, [emailStr]);
+
+  if (emailData) {
+    return (
+      <Box>
+        <EmailHeader headers={emailData.headers} />
+        <Typography style={{ fontWeight: 'bold', marginBottom: 8 }}>
+          {emailData.headers.Subject}
+        </Typography>
+        <EmailBody body={emailData.body} />
+      </Box>
+    );
+  } else {
+    return <CircularProgress />;
+  }
+};
+
+const useBodyStyles = makeStyles((theme) => ({
+  body: {
+    '& blockquote': {
+      borderColor: theme.palette.text.disabled,
+      borderLeftWidth: 4,
+      borderStyle: 'solid',
+      borderWidth: 0,
+      marginLeft: 2,
+      opacity: 0.8,
+      paddingLeft: 10,
+    },
+    fontFamily: 'sans-serif',
+  },
+}));
+
+const EmailBody: React.FC<{ body: LetterparserNode['body'] }> = ({ body }) => {
+  const classes = useBodyStyles();
+
+  if (Array.isArray(body)) {
+    let bodyToRender = body.find(
+      (bodyCandidate) => bodyCandidate.contentType.type === 'text/html'
+    );
+
+    if (!bodyToRender) {
+      bodyToRender = body[0];
+    }
+
+    return <EmailBody body={bodyToRender.body} />;
+  } else {
+    const content = typeof body == 'string' ? body : body.toString();
+    // TODO: Sanitize content before rendering
+    return (
+      <div
+        className={classes.body}
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    );
+  }
+};
+
+const EmailHeader: React.FC<{ headers: LetterparserNode['headers'] }> = ({
+  headers,
+}) => {
+  const RELEVANT_HEADERS = ['from', 'to', 'cc'];
+  return (
+    <Grid container direction="column">
+      {RELEVANT_HEADERS.map((headerName) => {
+        const matchedHeader = Object.entries(headers).find(
+          ([key]) => key.toLowerCase() == headerName.toLowerCase()
+        );
+
+        if (matchedHeader && matchedHeader[1]) {
+          const values = matchedHeader[1].split(',');
+
+          return (
+            <Grid key={headerName} item style={{ marginBottom: 8 }}>
+              <Grid container direction="row" wrap="nowrap">
+                <Grid item style={{ paddingRight: 12, paddingTop: '0.2em' }}>
+                  <Typography>
+                    <FormattedMessage id={`misc.email.headers.${headerName}`} />
+                  </Typography>
+                </Grid>
+                <Grid item>
+                  {values.map((value) => (
+                    <Chip
+                      key={value}
+                      label={value}
+                      style={{ marginBottom: 4, marginRight: 4 }}
+                    />
+                  ))}
+                </Grid>
+              </Grid>
+            </Grid>
+          );
+        } else {
+          return null;
+        }
+      })}
+    </Grid>
+  );
+};
+
+export default PrettyEmail;

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -24,6 +24,8 @@ dataTable:
     hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
     title: Sort
 email:
+  collapse: Show less
+  expand: Show more
   headers:
     cc: CC
     from: From

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -23,6 +23,11 @@ dataTable:
     button: Sort
     hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
     title: Sort
+email:
+  headers:
+    cc: CC
+    from: From
+    to: To
 errorLoading: There was an error loading the data.
 nativePersonFields:
   alt_phone: Alt Phone number

--- a/src/utils/testing/mocks/email.ts
+++ b/src/utils/testing/mocks/email.ts
@@ -1,0 +1,126 @@
+export const PLAINTEXT = `From: Richard Olsson <richard@zetkin.org>
+Content-Type: text/plain
+Subject: A test e-mail for rendering
+Date: Sat, 14 May 2022 15:42:48 +0200
+To: Richard Olsson <info@zetkin.org>
+
+This is a plain text e-mail.
+`;
+
+export const PLAINTEXT_MULTI_CC = `From: Richard Olsson <richard@zetkin.org>
+Content-Type: text/plain
+Subject: A test e-mail for rendering
+Date: Sat, 14 May 2022 15:42:48 +0200
+To: Richard Olsson <info@zetkin.org>
+CC: Clara Zetkin <clara@zetkin.org>,
+ clara@zetk.in,
+ Clara <clara.zetkin@zetkin.org>
+
+This is a plain text e-mail.
+`;
+
+export const MULTIPART = `Return-Path: <richard@zetkin.org>
+Delivered-To: info@zetkin.org
+From: Richard Olsson <richard@zetkin.org>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_B2FFAF6E-F5DA-49E5-9BB9-1E6807C89884"
+Mime-Version: 1.0 (Mac OS X Mail 13.4 \\(3608.120.23.2.4\\))
+Subject: A test e-mail for rendering
+Date: Sat, 14 May 2022 15:42:48 +0200
+To: Richard Olsson <info@zetkin.org>
+X-Mailer: Apple Mail (2.3608.120.23.2.4)
+
+
+--Apple-Mail=_B2FFAF6E-F5DA-49E5-9BB9-1E6807C89884
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain;
+	charset=us-ascii
+
+This is a test e-mail.
+
+With a little bit of formatting.
+Including a list
+And also formatting in the signature
+
+
+Richard Olsson, tech lead
+
+Zetkin Foundation
+www.zetkin.org/en
+info@zetkin.org
+
+
+
+
+
+
+--Apple-Mail=_B2FFAF6E-F5DA-49E5-9BB9-1E6807C89884
+Content-Transfer-Encoding: 7bit
+Content-Type: text/html;
+	charset=us-ascii
+
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=us-ascii"></head><body style="word-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;" class="">This is a test e-mail.<div class=""><br class=""></div><div class=""><ul class="MailOutline"><li class="">With a <i class="">little bit</i> of formatting.</li><li class="">Including a list</li><li class="">And also formatting in the signature</li></ul></div><br class=""><div class="">
+<div><br class="">Richard Olsson, tech lead<br class=""><br class=""><b class="">Zetkin Foundation<br class=""></b><a href="http://www.zetkin.org/en" class="">www.zetkin.org/en</a><br class="">info@zetkin.org<br class=""><br class=""><br class=""><br class=""><br class=""></div>
+
+</div>
+<br class=""></body></html>
+--Apple-Mail=_B2FFAF6E-F5DA-49E5-9BB9-1E6807C89884--
+`;
+
+export const MULTIPART_WITH_REPLY = `Return-Path: <info@zetkin.org>
+Delivered-To: richard@zetkin.org
+From: Richard Olsson <info@zetkin.org>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_19D75894-132F-4CB0-B342-B0A60D9F68B7"
+Mime-Version: 1.0 (Mac OS X Mail 13.4 \\(3608.120.23.2.4\\))
+Subject: Re: A test e-mail for rendering
+Date: Sat, 14 May 2022 16:14:49 +0200
+To: Richard Olsson <richard@zetkin.org>
+X-Mailer: Apple Mail (2.3608.120.23.2.4)
+
+
+--Apple-Mail=_19D75894-132F-4CB0-B342-B0A60D9F68B7
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain;
+	charset=us-ascii
+
+A reply
+
+
+> On 14 May 2022, at 15:42, Richard Olsson <richard@zetkin.org> wrote:
+> 
+> This is a test e-mail.
+> 
+> With a little bit of formatting.
+> Including a list
+> And also formatting in the signature
+> 
+> 
+> Richard Olsson, tech lead
+> 
+> Zetkin Foundation
+> www.zetkin.org/en <http://www.zetkin.org/en>
+> info@zetkin.org
+> 
+> 
+> 
+> 
+> 
+
+
+--Apple-Mail=_19D75894-132F-4CB0-B342-B0A60D9F68B7
+Content-Transfer-Encoding: 7bit
+Content-Type: text/html;
+	charset=us-ascii
+
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=us-ascii"></head><body style="word-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;" class="">A reply<br class=""><div class=""><div><br class=""></div>
+
+</div>
+<div style=""><br class=""><blockquote type="cite" class=""><div class="">On 14 May 2022, at 15:42, Richard Olsson &lt;<a href="mailto:richard@zetkin.org" class="">richard@zetkin.org</a>&gt; wrote:</div><br class="Apple-interchange-newline"><div class=""><meta http-equiv="Content-Type" content="text/html; charset=us-ascii" class=""><div style="word-wrap: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;" class="">This is a test e-mail.<div class=""><br class=""></div><div class=""><ul class="MailOutline"><li class="">With a <i class="">little bit</i> of formatting.</li><li class="">Including a list</li><li class="">And also formatting in the signature</li></ul></div><br class=""><div class="">
+<div class=""><br class="">Richard Olsson, tech lead<br class=""><br class=""><b class="">Zetkin Foundation<br class=""></b><a href="http://www.zetkin.org/en" class="">www.zetkin.org/en</a><br class=""><a href="mailto:info@zetkin.org" class="">info@zetkin.org</a><br class=""><br class=""><br class=""><br class=""><br class=""></div>
+
+</div>
+<br class=""></div></div></blockquote></div><br class=""></body></html>
+--Apple-Mail=_19D75894-132F-4CB0-B342-B0A60D9F68B7--
+
+`;

--- a/src/utils/testing/mocks/email.ts
+++ b/src/utils/testing/mocks/email.ts
@@ -5,6 +5,8 @@ Date: Sat, 14 May 2022 15:42:48 +0200
 To: Richard Olsson <info@zetkin.org>
 
 This is a plain text e-mail.
+
+It has two lines.
 `;
 
 export const PLAINTEXT_MULTI_CC = `From: Richard Olsson <richard@zetkin.org>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4938,7 +4938,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -9861,6 +9861,21 @@ leaflet@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
   integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
+
+lettercoder@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/lettercoder/-/lettercoder-0.0.4.tgz#7593c7aa0ba2a077019f960058a7f62fa16acdef"
+  integrity sha512-mBhgv/zXcF3B/6+up4YYm1l2cuf/b7CjKr895ydUBUzI+OhQ1NMl8JZBv1KUIPsPEamziAZ4242b7LoUWI9Lfg==
+  dependencies:
+    base64-js "^1.3.1"
+
+letterparser@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/letterparser/-/letterparser-0.0.8.tgz#d40bf83a744918f60a6934f9b3800e65c5d1b7b5"
+  integrity sha512-SH7cb7Yi9KvtMzOeHGu7HWjFjLuZgADyJS3L9vbIGAisgudcdfrx9T1FzK2DTWiVPnMpdvYg9N2MspmLtNMUSg==
+  dependencies:
+    base64-js "^1.3.1"
+    lettercoder "^0.0.4"
 
 leven@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
## Description
This PR creates a component, `<PrettyEmail>`, that parses the contents of an e-mail file (a string) and renders a pretty e-mail preview.

## Screenshots
<img width="844" alt="image" src="https://user-images.githubusercontent.com/550212/168439833-e49a82e7-1f27-45b1-81cb-5be0a34ee614.png">

## Changes
* Adds the `letterparser` package which does low-level parsing of e-mail
* Creates `<PrettyEmail>` component to render e-mail
  * Renders plaintext and HTML e-mail
  * Shows an expand button only if the e-mail body when rendered is taller than 150px
  * E-mail addresses in header are clickable chips
  * Adds storybook stories for the component

## Notes to reviewer
I have only built _the component_. It will still need to be implemented on timeline notes once they support attachments containing e-mail.

## Related issues
Resolves #593 