### PR TITLE
Creating and assigning value tags (rebased)

### DIFF
--- a/playwright/mockData/orgs/KPD/tags/Occupation.ts
+++ b/playwright/mockData/orgs/KPD/tags/Occupation.ts
@@ -1,0 +1,16 @@
+import KPD from '..';
+import Skills from './groups/Skills';
+import { ZetkinTag } from '../../../../../src/types/zetkin';
+
+const OccupationTag: ZetkinTag = {
+  color: null,
+  description: 'What line of work are they in',
+  group: Skills,
+  hidden: false,
+  id: 1,
+  organization: { id: KPD.id, title: KPD.title },
+  title: 'Occupation',
+  value_type: 'text',
+};
+
+export default OccupationTag;

--- a/playwright/tests/organize/people/person/tags.spec.ts
+++ b/playwright/tests/organize/people/person/tags.spec.ts
@@ -5,6 +5,7 @@ import ActivistTag from '../../../../mockData/orgs/KPD/tags/Activist';
 import ClaraZetkin from '../../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../../mockData/orgs/KPD/tags/Coding';
 import KPD from '../../../../mockData/orgs/KPD';
+import OccupationTag from '../../../../mockData/orgs/KPD/tags/Occupation';
 import OrganizerTag from '../../../../mockData/orgs/KPD/tags/Organizer';
 import PlaysGuitarTag from '../../../../mockData/orgs/KPD/tags/PlaysGuitar';
 import SkillsGroup from '../../../../mockData/orgs/KPD/tags/groups/Skills';
@@ -89,6 +90,44 @@ test.describe('Person Profile Page Tags', () => {
 
       // Expect to have made request to put tag
       expect(putTagLog().length).toEqual(1);
+    });
+
+    test('can add value tag to person', async ({ page, appUri, moxy }) => {
+      moxy.setZetkinApiMock(`/orgs/${KPD.id}/people/tags`, 'get', [
+        ActivistTag,
+        CodingSkillsTag,
+        OccupationTag,
+      ]);
+      moxy.setZetkinApiMock(
+        `/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags`,
+        'get',
+        []
+      );
+      const { log: putTagLog } = moxy.setZetkinApiMock(
+        `/orgs/1/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`,
+        'put'
+      );
+
+      await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+
+      await page.locator('text=Add tag').click();
+
+      // Select tag
+      await page.click('text=Occupation');
+
+      await page
+        .locator('data-testid=TagManager-TagSelect-searchField')
+        .type('Revolutionary');
+
+      await Promise.all([
+        page.waitForResponse((res) => res.request().method() == 'PUT'),
+        page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
+      ]);
+
+      // Expect to have made request to put tag
+      expect(putTagLog()[0].data).toEqual({
+        value: 'Revolutionary',
+      });
     });
 
     test('shows error when adding tag fails', async ({

--- a/src/api/people.ts
+++ b/src/api/people.ts
@@ -3,6 +3,7 @@ import {
   createPrefetch,
   createUseMutationDelete,
   createUseMutationPut,
+  createUseMutationPutWithBody,
   createUseQuery,
 } from './utils/resourceHookFactories';
 
@@ -46,7 +47,10 @@ export const personTagsResource = (orgId: string, personId: string) => {
 
   return {
     key,
-    useAssign: createUseMutationPut({ key, url }),
+    useAssign: createUseMutationPutWithBody<Pick<ZetkinTag, 'id' | 'value'>>({
+      key,
+      url,
+    }),
     useQuery: createUseQuery<ZetkinTag[]>(key, url),
     useUnassign: createUseMutationDelete({ key, url }),
   };

--- a/src/api/utils/resourceHookFactories.ts
+++ b/src/api/utils/resourceHookFactories.ts
@@ -10,6 +10,7 @@ import {
   UseQueryResult,
 } from 'react-query';
 
+import APIError from 'utils/apiError';
 import { defaultFetch } from 'fetching';
 import handleResponseData from './handleResponseData';
 import { makeUseMutationOptions } from './makeUseMutationOptions';
@@ -107,6 +108,38 @@ export const createUseMutationPut = (
       handler,
       makeUseMutationOptions(queryClient, props.key, props.mutationOptions)
     );
+  };
+};
+
+export const createUseMutationPutWithBody = <
+  Input extends { id: number }
+>(props: {
+  key: string[];
+  url: string;
+}): (() => UseMutationResult<null, unknown, Input, unknown>) => {
+  const handler = async (resource: Input): Promise<null> => {
+    const { id, ...body } = resource;
+    const requestOptions: RequestInit = {
+      method: 'PUT',
+    };
+    if (body) {
+      requestOptions.body = JSON.stringify(body);
+      requestOptions.headers = {
+        'Content-Type': 'application/json',
+      };
+    }
+
+    const res = await defaultFetch(`${props.url}/${id}`, requestOptions);
+
+    if (!res.ok) {
+      throw new APIError('PUT', res.url);
+    }
+    return null;
+  };
+
+  return () => {
+    const queryClient = useQueryClient();
+    return useMutation(handler, makeUseMutationOptions(queryClient, props.key));
   };
 };
 

--- a/src/components/organize/TagManager/TagManagerController.spec.tsx
+++ b/src/components/organize/TagManager/TagManagerController.spec.tsx
@@ -132,6 +132,56 @@ describe('<TagManagerController />', () => {
     // Check that callback has been called
     expect(onAssignTag).toHaveBeenCalledWith(tag1);
   });
+  it('can add a value tag', () => {
+    const onAssignTag = jest.fn((tag: ZetkinTag) => tag);
+
+    const tag = mockTag({
+      group: null,
+      id: 1857,
+      title: 'Age',
+      value_type: 'text',
+    });
+
+    const { getByText, getByTestId } = render(
+      <TagManagerController
+        assignedTags={[]}
+        availableGroups={[]}
+        availableTags={[tag]}
+        onAssignTag={onAssignTag}
+        onCreateTag={createTagCallback}
+        onEditTag={editTagCallback}
+        onUnassignTag={unassignTagCallback}
+      />
+    );
+    const addTagButton = getByText('misc.tags.tagManager.addTag');
+    click(addTagButton);
+
+    // Typing searches for tag
+    keyboard(tag.title);
+
+    // Select an option
+    const tagOption = getByText(tag.title);
+    click(tagOption);
+
+    // Check that callback has not been called yet
+    expect(onAssignTag).not.toHaveBeenCalled();
+
+    // Check that we're in value mode
+    const input = getByTestId('TagManager-TagSelect-searchField');
+    expect(input.getAttribute('placeholder')).toEqual(
+      'misc.tags.tagManager.addValue'
+    );
+
+    // Add value
+    click(input);
+    keyboard('75{Enter}');
+
+    // Check that tag was assigned with value
+    expect(onAssignTag).toHaveBeenCalledWith({
+      ...tag,
+      value: '75',
+    });
+  });
   it('can remove a tag', () => {
     const onUnassignTag = jest.fn((tag: ZetkinTag) => tag);
 

--- a/src/components/organize/TagManager/TagManagerController.spec.tsx
+++ b/src/components/organize/TagManager/TagManagerController.spec.tsx
@@ -13,7 +13,9 @@ import { EditTag, NewTag } from './types';
 jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 const assignTagCallback = jest.fn((tag: ZetkinTag) => tag);
-const createTagCallback = jest.fn((tag: NewTag) => tag);
+const createTagCallback = jest.fn<Promise<ZetkinTag>, [NewTag]>((tag) =>
+  Promise.resolve({ ...tag, id: 1 } as ZetkinTag)
+);
 const unassignTagCallback = jest.fn((tag: ZetkinTag) => tag);
 const editTagCallback = jest.fn((tag: EditTag) => tag);
 
@@ -168,10 +170,10 @@ describe('<TagManagerController />', () => {
   });
 
   describe('creating a tag', () => {
-    let onCreateTag: jest.Mock<NewTag, [tag: NewTag]>;
+    let onCreateTag: jest.Mock<Promise<ZetkinTag>, [tag: NewTag]>;
 
     beforeEach(() => {
-      onCreateTag = jest.fn((tag: NewTag) => tag);
+      onCreateTag = jest.fn((tag: NewTag) => Promise.resolve(tag as ZetkinTag));
       singletonRouter.query = {
         orgId: '1',
       };
@@ -208,10 +210,10 @@ describe('<TagManagerController />', () => {
   });
 
   describe('editing a tag', () => {
-    let onCreateTag: jest.Mock<NewTag, [tag: NewTag]>;
+    let onCreateTag: jest.Mock<Promise<ZetkinTag>, [tag: NewTag]>;
 
     beforeEach(() => {
-      onCreateTag = jest.fn((tag: NewTag) => tag);
+      onCreateTag = jest.fn((tag: NewTag) => Promise.resolve(tag as ZetkinTag));
       singletonRouter.query = {
         orgId: '1',
       };

--- a/src/components/organize/TagManager/TagManagerController.spec.tsx
+++ b/src/components/organize/TagManager/TagManagerController.spec.tsx
@@ -236,6 +236,12 @@ describe('<TagManagerController />', () => {
 
       await waitFor(() => expect(onCreateTag).toBeCalled());
       expect(assignTagCallback).toBeCalled();
+
+      const input = getByTestId('TagManager-TagSelect-searchField');
+      expect(input.getAttribute('value')).toEqual('');
+      expect(input.getAttribute('placeholder')).toEqual(
+        'misc.tags.tagManager.addTag'
+      );
     });
   });
 

--- a/src/components/organize/TagManager/TagManagerController.spec.tsx
+++ b/src/components/organize/TagManager/TagManagerController.spec.tsx
@@ -3,6 +3,7 @@ import { hover } from '@testing-library/user-event/dist/hover';
 import { keyboard } from '@testing-library/user-event/dist/keyboard';
 import { render } from 'utils/testing';
 import singletonRouter from 'next/router';
+import { waitFor } from '@testing-library/react';
 
 import { TagManagerController } from './TagManagerController';
 
@@ -206,6 +207,35 @@ describe('<TagManagerController />', () => {
 
       const titleField = getByTestId('TagManager-TagDialog-titleField');
       expect((titleField as HTMLInputElement).value).toEqual("Jerry's family");
+    });
+
+    it('invokes onCreateTag() and onAssignTag() when creating a tag', async () => {
+      const { getByTestId, getByText } = render(
+        <TagManagerController
+          assignedTags={[]}
+          availableGroups={[]}
+          availableTags={[]}
+          onAssignTag={assignTagCallback}
+          onCreateTag={onCreateTag}
+          onEditTag={editTagCallback}
+          onUnassignTag={unassignTagCallback}
+        />
+      );
+
+      // Open create dialog
+      click(getByText('misc.tags.tagManager.addTag'));
+      click(getByTestId('TagManager-TagSelect-createTagOption'));
+
+      // Fill in dialog
+      const titleField = getByTestId('TagManager-TagDialog-titleField');
+      click(titleField);
+      keyboard('Spongeworthy');
+
+      const submit = getByTestId('SubmitCancelButtons-submitButton');
+      click(submit);
+
+      await waitFor(() => expect(onCreateTag).toBeCalled());
+      expect(assignTagCallback).toBeCalled();
     });
   });
 

--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -66,9 +66,10 @@ export const TagManagerController: React.FunctionComponent<
             onCreateTag={async (tag) => {
               const newTag = await onCreateTag(tag);
               if (!newTag.value_type) {
+                // If not a value tag, assign to resource directly
                 onAssignTag(newTag);
               }
-
+              // New tag is accessible in TagSelect
               return newTag;
             }}
             onEditTag={onEditTag}

--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -62,6 +62,7 @@ export const TagManagerController: React.FunctionComponent<
             disabledTags={disabledTags || assignedTags}
             disableEditTags={disableEditTags}
             groups={availableGroups}
+            onClose={() => setAddTagButton(null)}
             onCreateTag={onCreateTag}
             onEditTag={onEditTag}
             onSelect={onAssignTag}

--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -56,6 +56,7 @@ export const TagManagerController: React.FunctionComponent<
           anchorEl={addTagButton}
           onClose={() => setAddTagButton(null)}
           open={Boolean(addTagButton)}
+          PaperProps={{ style: { minWidth: '300px' } }}
         >
           <TagSelect
             disabledTags={disabledTags || assignedTags}

--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -63,7 +63,14 @@ export const TagManagerController: React.FunctionComponent<
             disableEditTags={disableEditTags}
             groups={availableGroups}
             onClose={() => setAddTagButton(null)}
-            onCreateTag={onCreateTag}
+            onCreateTag={async (tag) => {
+              const newTag = await onCreateTag(tag);
+              if (!newTag.value_type) {
+                onAssignTag(newTag);
+              }
+
+              return newTag;
+            }}
             onEditTag={onEditTag}
             onSelect={onAssignTag}
             tags={availableTags}

--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -16,7 +16,7 @@ export interface TagManagerControllerProps {
   disabledTags?: ZetkinTag[];
   groupTags?: boolean;
   onAssignTag: (tag: ZetkinTag) => void;
-  onCreateTag: (tag: NewTag) => void;
+  onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
   onEditTag: (tag: EditTag) => void;
   onUnassignTag: (tag: ZetkinTag) => void;
 }

--- a/src/components/organize/TagManager/components/TagDialog/TagDialog.spec.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/TagDialog.spec.tsx
@@ -149,4 +149,20 @@ describe('<TagDialog />', () => {
       title: title,
     });
   });
+
+  it('disables TypeSelect when editing a tag', () => {
+    const { getByTestId } = render(
+      <TagDialog
+        groups={[]}
+        onClose={() => undefined}
+        onSubmit={onSubmit}
+        open={true}
+        tag={mockTag({ id: 1000, title: 'Value tag', value_type: 'text' })}
+      />
+    );
+
+    const radioGroup = getByTestId('TypeSelect-formControl');
+    const input = radioGroup.querySelector('input');
+    expect(input?.getAttribute('disabled')).not.toBeNull();
+  });
 });

--- a/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
@@ -1,0 +1,44 @@
+import { useIntl } from 'react-intl';
+import { ZetkinTag } from 'types/zetkin';
+import { Box, MenuItem, TextField } from '@material-ui/core';
+
+const TypeSelect: React.FC<{
+  onChange: (value: ZetkinTag['value_type']) => void;
+  value: ZetkinTag['value_type'];
+}> = ({ onChange, value }) => {
+  const intl = useIntl();
+
+  return (
+    <Box mb={0.8} mt={1.5}>
+      <TextField
+        label={intl.formatMessage({
+          id: 'misc.tags.tagManager.tagDialog.typeLabel',
+        })}
+        onChange={(ev) =>
+          onChange(
+            ev.target.value == 'none'
+              ? null
+              : (ev.target.value as ZetkinTag['value_type'])
+          )
+        }
+        select
+        style={{ width: '100%' }}
+        value={value || 'none'}
+        variant="outlined"
+      >
+        <MenuItem value="none">
+          {intl.formatMessage({
+            id: 'misc.tags.tagManager.tagDialog.types.none',
+          })}
+        </MenuItem>
+        <MenuItem value="text">
+          {intl.formatMessage({
+            id: 'misc.tags.tagManager.tagDialog.types.text',
+          })}
+        </MenuItem>
+      </TextField>
+    </Box>
+  );
+};
+
+export default TypeSelect;

--- a/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
@@ -11,14 +11,15 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { ZetkinTag } from 'types/zetkin';
 
 const TypeSelect: React.FC<{
+  disabled?: boolean;
   onChange: (value: ZetkinTag['value_type']) => void;
   value: ZetkinTag['value_type'];
-}> = ({ onChange, value }) => {
+}> = ({ disabled, onChange, value }) => {
   const intl = useIntl();
 
   return (
     <Box mb={0.8} mt={1.5}>
-      <FormControl data-testid="TypeSelect-formControl">
+      <FormControl data-testid="TypeSelect-formControl" disabled={disabled}>
         <FormLabel>
           <FormattedMessage id={'misc.tags.tagManager.tagDialog.typeLabel'} />
         </FormLabel>

--- a/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/TypeSelect.tsx
@@ -1,6 +1,14 @@
-import { useIntl } from 'react-intl';
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+} from '@material-ui/core';
+import { FormattedMessage, useIntl } from 'react-intl';
+
 import { ZetkinTag } from 'types/zetkin';
-import { Box, MenuItem, TextField } from '@material-ui/core';
 
 const TypeSelect: React.FC<{
   onChange: (value: ZetkinTag['value_type']) => void;
@@ -10,33 +18,36 @@ const TypeSelect: React.FC<{
 
   return (
     <Box mb={0.8} mt={1.5}>
-      <TextField
-        label={intl.formatMessage({
-          id: 'misc.tags.tagManager.tagDialog.typeLabel',
-        })}
-        onChange={(ev) =>
-          onChange(
-            ev.target.value == 'none'
-              ? null
-              : (ev.target.value as ZetkinTag['value_type'])
-          )
-        }
-        select
-        style={{ width: '100%' }}
-        value={value || 'none'}
-        variant="outlined"
-      >
-        <MenuItem value="none">
-          {intl.formatMessage({
-            id: 'misc.tags.tagManager.tagDialog.types.none',
-          })}
-        </MenuItem>
-        <MenuItem value="text">
-          {intl.formatMessage({
-            id: 'misc.tags.tagManager.tagDialog.types.text',
-          })}
-        </MenuItem>
-      </TextField>
+      <FormControl data-testid="TypeSelect-formControl">
+        <FormLabel>
+          <FormattedMessage id={'misc.tags.tagManager.tagDialog.typeLabel'} />
+        </FormLabel>
+        <RadioGroup
+          onChange={(ev) =>
+            onChange(
+              ev.target.value == 'none'
+                ? null
+                : (ev.target.value as ZetkinTag['value_type'])
+            )
+          }
+          value={value || 'none'}
+        >
+          <FormControlLabel
+            control={<Radio />}
+            label={intl.formatMessage({
+              id: 'misc.tags.tagManager.tagDialog.types.none',
+            })}
+            value="none"
+          />
+          <FormControlLabel
+            control={<Radio />}
+            label={intl.formatMessage({
+              id: 'misc.tags.tagManager.tagDialog.types.text',
+            })}
+            value="text"
+          />
+        </RadioGroup>
+      </FormControl>
     </Box>
   );
 };

--- a/src/components/organize/TagManager/components/TagDialog/index.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import ColorPicker from './ColorPicker';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import TagGroupSelect from './TagGroupSelect';
+import TypeSelect from './TypeSelect';
 import ZetkinDialog from 'components/ZetkinDialog';
 import { EditTag, NewTag, NewTagGroup } from '../../types';
 import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
@@ -36,6 +37,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
   const [group, setGroup] = useState<
     ZetkinTagGroup | NewTagGroup | null | undefined
   >();
+  const [type, setType] = useState<ZetkinTag['value_type']>(null);
 
   const editingTag = tag && 'id' in tag;
 
@@ -54,6 +56,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     setColor({ valid: true, value: '' });
     setGroup(undefined);
     setTitleEdited(false);
+    setType(null);
     onClose();
   };
 
@@ -76,6 +79,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           const tagBody = {
             ...(color.value && { color: `#${color.value}` }),
             ...(tag && 'id' in tag && { id: tag.id }),
+            ...(type && { value_type: type }),
             title,
           };
           if (group && 'id' in group) {
@@ -132,6 +136,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           onChange={(value) => setColor(value)}
           value={color.value}
         />
+        <TypeSelect onChange={(value) => setType(value)} value={type} />
         <SubmitCancelButtons
           onCancel={closeAndClear}
           submitDisabled={!title || !color.valid}

--- a/src/components/organize/TagManager/components/TagDialog/index.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/index.tsx
@@ -49,6 +49,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
         : { valid: true, value: '' }
     );
     setGroup(tag && 'group' in tag ? tag.group : undefined);
+    setType(tag && 'value_type' in tag ? tag.value_type : null);
   }, [tag]);
 
   const closeAndClear = () => {

--- a/src/components/organize/TagManager/components/TagDialog/index.tsx
+++ b/src/components/organize/TagManager/components/TagDialog/index.tsx
@@ -137,7 +137,11 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           onChange={(value) => setColor(value)}
           value={color.value}
         />
-        <TypeSelect onChange={(value) => setType(value)} value={type} />
+        <TypeSelect
+          disabled={tag && 'id' in tag}
+          onChange={(value) => setType(value)}
+          value={type}
+        />
         <SubmitCancelButtons
           onCancel={closeAndClear}
           submitDisabled={!title || !color.valid}

--- a/src/components/organize/TagManager/components/TagSelect.tsx
+++ b/src/components/organize/TagManager/components/TagSelect.tsx
@@ -76,84 +76,15 @@ const TagSelect: React.FunctionComponent<{
         variant="outlined"
       />
       {/* Options */}
-      <List
-        {...getListboxProps()}
-        style={{ maxHeight: '400px', overflowY: 'scroll' }}
-      >
-        {groupedFilteredTags.map((group) => {
-          // Groups
-          return (
-            <List
-              key={group.title}
-              subheader={
-                <ListSubheader disableSticky>{group.title}</ListSubheader>
-              }
-              title={group.title}
-            >
-              {/* Tags */}
-              {group.tags.map((tag) => {
-                return (
-                  <ListItem key={tag.id} dense={!disableEditTags}>
-                    <Box
-                      alignItems="center"
-                      display="flex"
-                      justifyContent="space-between"
-                      width="100%"
-                    >
-                      <TagChip
-                        disabled={disabledTags
-                          .map((disabledTags) => disabledTags.id)
-                          .includes(tag.id)}
-                        onClick={() => onSelect(tag)}
-                        tag={tag}
-                      />
-                      {/* Edit tag button, only show if enabled (it's enabled by default) */}
-                      {!disableEditTags && (
-                        <IconButton
-                          data-testid={`TagManager-TagSelect-editTag-${tag.id}`}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setTagToEdit(tag);
-                          }}
-                        >
-                          <EditIcon fontSize="small" />
-                        </IconButton>
-                      )}
-                    </Box>
-                  </ListItem>
-                );
-              })}
-            </List>
-          );
-        })}
-        <ListItem
-          button
-          data-testid="TagManager-TagSelect-createTagOption"
-          dense
-          onClick={() =>
-            setTagToEdit({
-              title: inputValue,
-            })
-          }
-        >
-          <Add />
-          {inputValue ? (
-            <FormattedMessage
-              id="misc.tags.tagManager.createNamedTag"
-              values={{
-                b: (...chunks: string[]) => (
-                  <>
-                    &nbsp;<b>{chunks}</b>
-                  </>
-                ),
-                name: inputValue,
-              }}
-            />
-          ) : (
-            <FormattedMessage id="misc.tags.tagManager.createTag" />
-          )}
-        </ListItem>
-      </List>
+      <TagSelectList
+        disabledTags={disabledTags}
+        disableEditTags={!!disableEditTags}
+        groupedTags={groupedFilteredTags}
+        inputValue={inputValue}
+        listProps={getListboxProps()}
+        onEdit={(tag) => setTagToEdit(tag)}
+        onSelect={onSelect}
+      />
       <TagDialog
         groups={groups}
         onClose={() => setTagToEdit(undefined)}
@@ -170,6 +101,102 @@ const TagSelect: React.FunctionComponent<{
         tag={tagToEdit}
       />
     </Box>
+  );
+};
+
+const TagSelectList: React.FC<{
+  disableEditTags: boolean;
+  disabledTags: ZetkinTag[];
+  groupedTags: { id: number | 'ungrouped'; tags: ZetkinTag[]; title: string }[];
+  inputValue: string;
+  listProps: Record<string, unknown>;
+  onEdit: (tag: ZetkinTag | Pick<ZetkinTag, 'title'>) => void;
+  onSelect: (tag: ZetkinTag) => void;
+}> = ({
+  disableEditTags,
+  disabledTags,
+  groupedTags,
+  inputValue,
+  listProps,
+  onEdit,
+  onSelect,
+}) => {
+  return (
+    <List {...listProps} style={{ maxHeight: '400px', overflowY: 'scroll' }}>
+      {groupedTags.map((group) => {
+        // Groups
+        return (
+          <List
+            key={group.title}
+            subheader={
+              <ListSubheader disableSticky>{group.title}</ListSubheader>
+            }
+            title={group.title}
+          >
+            {/* Tags */}
+            {group.tags.map((tag) => {
+              return (
+                <ListItem key={tag.id} dense={!disableEditTags}>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                    width="100%"
+                  >
+                    <TagChip
+                      disabled={disabledTags
+                        .map((disabledTags) => disabledTags.id)
+                        .includes(tag.id)}
+                      onClick={() => onSelect(tag)}
+                      tag={tag}
+                    />
+                    {/* Edit tag button, only show if enabled (it's enabled by default) */}
+                    {!disableEditTags && (
+                      <IconButton
+                        data-testid={`TagManager-TagSelect-editTag-${tag.id}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEdit(tag);
+                        }}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                  </Box>
+                </ListItem>
+              );
+            })}
+          </List>
+        );
+      })}
+      <ListItem
+        button
+        data-testid="TagManager-TagSelect-createTagOption"
+        dense
+        onClick={() =>
+          onEdit({
+            title: inputValue,
+          })
+        }
+      >
+        <Add />
+        {inputValue ? (
+          <FormattedMessage
+            id="misc.tags.tagManager.createNamedTag"
+            values={{
+              b: (...chunks: string[]) => (
+                <>
+                  &nbsp;<b>{chunks}</b>
+                </>
+              ),
+              name: inputValue,
+            }}
+          />
+        ) : (
+          <FormattedMessage id="misc.tags.tagManager.createTag" />
+        )}
+      </ListItem>
+    </List>
   );
 };
 

--- a/src/components/organize/TagManager/components/TagSelect/TagSelectList.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/TagSelectList.tsx
@@ -1,108 +1,16 @@
-/* eslint-disable jsx-a11y/no-autofocus */
 import { Add } from '@material-ui/icons';
 import EditIcon from '@material-ui/icons/Edit';
-import { useAutocomplete } from '@material-ui/lab';
-import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
 import {
   Box,
   IconButton,
   List,
   ListItem,
   ListSubheader,
-  TextField,
 } from '@material-ui/core';
-import { FormattedMessage, useIntl } from 'react-intl';
 
-import { groupTags } from '../utils';
-import TagChip from './TagChip';
-import TagDialog from './TagDialog';
-import { EditTag, NewTag } from '../types';
-import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
-
-const TagSelect: React.FunctionComponent<{
-  disableEditTags?: boolean;
-  disabledTags: ZetkinTag[];
-  groups: ZetkinTagGroup[];
-  onCreateTag: (tag: NewTag) => void;
-  onEditTag: (tag: EditTag) => void;
-  onSelect: (tag: ZetkinTag) => void;
-  tags: ZetkinTag[];
-}> = ({
-  disableEditTags,
-  disabledTags,
-  groups,
-  onCreateTag,
-  onEditTag,
-  onSelect,
-  tags,
-}) => {
-  const intl = useIntl();
-
-  const [tagToEdit, setTagToEdit] = useState<
-    ZetkinTag | Pick<ZetkinTag, 'title'> | undefined
-  >(undefined);
-
-  const {
-    inputValue,
-    getInputProps,
-    getListboxProps,
-    getRootProps,
-    groupedOptions,
-  } = useAutocomplete({
-    getOptionLabel: (option) => option.title,
-    open: true,
-    options: tags,
-  });
-
-  const groupedFilteredTags = groupTags(
-    groupedOptions,
-    intl.formatMessage({
-      id: 'misc.tags.tagManager.ungroupedHeader',
-    })
-  );
-
-  return (
-    <Box {...getRootProps()}>
-      <TextField
-        {...getInputProps()}
-        autoFocus
-        fullWidth
-        inputProps={{
-          'data-testid': 'TagManager-TagSelect-searchField',
-        }}
-        placeholder={intl.formatMessage({
-          id: 'misc.tags.tagManager.addTag',
-        })}
-        variant="outlined"
-      />
-      {/* Options */}
-      <TagSelectList
-        disabledTags={disabledTags}
-        disableEditTags={!!disableEditTags}
-        groupedTags={groupedFilteredTags}
-        inputValue={inputValue}
-        listProps={getListboxProps()}
-        onEdit={(tag) => setTagToEdit(tag)}
-        onSelect={onSelect}
-      />
-      <TagDialog
-        groups={groups}
-        onClose={() => setTagToEdit(undefined)}
-        onSubmit={(tag) => {
-          if ('id' in tag) {
-            // If existing tag
-            onEditTag(tag);
-          } else {
-            // If new tag
-            onCreateTag(tag);
-          }
-        }}
-        open={Boolean(tagToEdit)}
-        tag={tagToEdit}
-      />
-    </Box>
-  );
-};
+import TagChip from '../TagChip';
+import { ZetkinTag } from 'types/zetkin';
 
 const TagSelectList: React.FC<{
   disableEditTags: boolean;
@@ -200,4 +108,4 @@ const TagSelectList: React.FC<{
   );
 };
 
-export default TagSelect;
+export default TagSelectList;

--- a/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -1,10 +1,16 @@
+import { FormattedMessage } from 'react-intl';
+import { Box, Typography } from '@material-ui/core';
+
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
+import TagChip from '../TagChip';
+import { ZetkinTag } from 'types/zetkin';
 
 const ValueTagForm: React.FC<{
   inputValue: string;
   onCancel: () => void;
   onSubmit: (value: string | number) => void;
-}> = ({ inputValue, onCancel, onSubmit }) => {
+  tag: ZetkinTag;
+}> = ({ inputValue, onCancel, onSubmit, tag }) => {
   return (
     <form
       onSubmit={(ev) => {
@@ -12,6 +18,22 @@ const ValueTagForm: React.FC<{
         onSubmit(inputValue);
       }}
     >
+      <Box display="flex" flexDirection="column" p={1}>
+        <Typography variant="body2">
+          <FormattedMessage
+            id="misc.tags.tagManager.valueTagForm.typeHint"
+            values={{ type: tag.value_type }}
+          />
+        </Typography>
+        <Box
+          alignItems="flex-start"
+          display="flex"
+          flexDirection="column"
+          marginTop={1}
+        >
+          <TagChip tag={{ ...tag, value: inputValue }} />
+        </Box>
+      </Box>
       <SubmitCancelButtons onCancel={onCancel} />
     </form>
   );

--- a/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -1,0 +1,20 @@
+import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
+
+const ValueTagForm: React.FC<{
+  inputValue: string;
+  onCancel: () => void;
+  onSubmit: (value: string | number) => void;
+}> = ({ inputValue, onCancel, onSubmit }) => {
+  return (
+    <form
+      onSubmit={(ev) => {
+        ev.preventDefault();
+        onSubmit(inputValue);
+      }}
+    >
+      <SubmitCancelButtons onCancel={onCancel} />
+    </form>
+  );
+};
+
+export default ValueTagForm;

--- a/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+import { useEffect } from 'react';
 import { Box, Typography } from '@material-ui/core';
 
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
@@ -8,14 +9,23 @@ import { ZetkinTag } from 'types/zetkin';
 const ValueTagForm: React.FC<{
   inputValue: string;
   onCancel: () => void;
-  onSubmit: (value: string | number) => void;
+  onChange: (value: string | number | null) => void;
+  onSubmit: () => void;
   tag: ZetkinTag;
-}> = ({ inputValue, onCancel, onSubmit, tag }) => {
+}> = ({ inputValue, onCancel, onChange, onSubmit, tag }) => {
+  useEffect(() => {
+    if (inputValue == '') {
+      onChange(null);
+    } else {
+      onChange(inputValue);
+    }
+  }, [inputValue]);
+
   return (
     <form
       onSubmit={(ev) => {
         ev.preventDefault();
-        onSubmit(inputValue);
+        onSubmit();
       }}
     >
       <Box display="flex" flexDirection="column" p={1}>

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -81,7 +81,12 @@ const TagSelect: React.FunctionComponent<{
             setPendingTag(null);
             setInputValue('');
           }}
-          onSubmit={(value) => onSelect({ ...pendingTag, value })}
+          onSubmit={(value) => {
+            onSelect({ ...pendingTag, value });
+            setPendingTag(null);
+            setInputValue('');
+          }}
+          tag={pendingTag}
         />
       ) : (
         <TagSelectList

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -141,7 +141,9 @@ const TagSelect: React.FunctionComponent<{
           } else {
             // If new tag
             const createdTag = await onCreateTag(tag);
-            setPendingTag(createdTag);
+            if (createdTag.value_type) {
+              setPendingTag(createdTag);
+            }
             setInputValue('');
           }
         }}

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -62,9 +62,16 @@ const TagSelect: React.FunctionComponent<{
           'data-testid': 'TagManager-TagSelect-searchField',
         }}
         onChange={(ev) => setInputValue(ev.target.value)}
-        placeholder={intl.formatMessage({
-          id: 'misc.tags.tagManager.addTag',
-        })}
+        placeholder={
+          pendingTag
+            ? intl.formatMessage(
+                { id: 'misc.tags.tagManager.addValue' },
+                { tag: pendingTag.title }
+              )
+            : intl.formatMessage({
+                id: 'misc.tags.tagManager.addTag',
+              })
+        }
         variant="outlined"
       />
       {pendingTag ? (

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable jsx-a11y/no-autofocus */
+import { useAutocomplete } from '@material-ui/lab';
+import { useIntl } from 'react-intl';
+import { useState } from 'react';
+import { Box, TextField } from '@material-ui/core';
+
+import { groupTags } from '../../utils';
+import TagDialog from '../TagDialog';
+import TagSelectList from './TagSelectList';
+import { EditTag, NewTag } from '../../types';
+import { ZetkinTag, ZetkinTagGroup } from 'types/zetkin';
+
+const TagSelect: React.FunctionComponent<{
+  disableEditTags?: boolean;
+  disabledTags: ZetkinTag[];
+  groups: ZetkinTagGroup[];
+  onCreateTag: (tag: NewTag) => void;
+  onEditTag: (tag: EditTag) => void;
+  onSelect: (tag: ZetkinTag) => void;
+  tags: ZetkinTag[];
+}> = ({
+  disableEditTags,
+  disabledTags,
+  groups,
+  onCreateTag,
+  onEditTag,
+  onSelect,
+  tags,
+}) => {
+  const intl = useIntl();
+
+  const [tagToEdit, setTagToEdit] = useState<
+    ZetkinTag | Pick<ZetkinTag, 'title'> | undefined
+  >(undefined);
+
+  const {
+    inputValue,
+    getInputProps,
+    getListboxProps,
+    getRootProps,
+    groupedOptions,
+  } = useAutocomplete({
+    getOptionLabel: (option) => option.title,
+    open: true,
+    options: tags,
+  });
+
+  const groupedFilteredTags = groupTags(
+    groupedOptions,
+    intl.formatMessage({
+      id: 'misc.tags.tagManager.ungroupedHeader',
+    })
+  );
+
+  return (
+    <Box {...getRootProps()}>
+      <TextField
+        {...getInputProps()}
+        autoFocus
+        fullWidth
+        inputProps={{
+          'data-testid': 'TagManager-TagSelect-searchField',
+        }}
+        placeholder={intl.formatMessage({
+          id: 'misc.tags.tagManager.addTag',
+        })}
+        variant="outlined"
+      />
+      {/* Options */}
+      <TagSelectList
+        disabledTags={disabledTags}
+        disableEditTags={!!disableEditTags}
+        groupedTags={groupedFilteredTags}
+        inputValue={inputValue}
+        listProps={getListboxProps()}
+        onEdit={(tag) => setTagToEdit(tag)}
+        onSelect={onSelect}
+      />
+      <TagDialog
+        groups={groups}
+        onClose={() => setTagToEdit(undefined)}
+        onSubmit={(tag) => {
+          if ('id' in tag) {
+            // If existing tag
+            onEditTag(tag);
+          } else {
+            // If new tag
+            onCreateTag(tag);
+          }
+        }}
+        open={Boolean(tagToEdit)}
+        tag={tagToEdit}
+      />
+    </Box>
+  );
+};
+
+export default TagSelect;

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -16,7 +16,7 @@ const TagSelect: React.FunctionComponent<{
   disabledTags: ZetkinTag[];
   groups: ZetkinTagGroup[];
   onClose: () => void;
-  onCreateTag: (tag: NewTag) => void;
+  onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
   onEditTag: (tag: EditTag) => void;
   onSelect: (tag: ZetkinTag) => void;
   tags: ZetkinTag[];
@@ -134,13 +134,15 @@ const TagSelect: React.FunctionComponent<{
       <TagDialog
         groups={groups}
         onClose={() => setTagToEdit(undefined)}
-        onSubmit={(tag) => {
+        onSubmit={async (tag) => {
           if ('id' in tag) {
             // If existing tag
             onEditTag(tag);
           } else {
             // If new tag
-            onCreateTag(tag);
+            const createdTag = await onCreateTag(tag);
+            setPendingTag(createdTag);
+            setInputValue('');
           }
         }}
         open={Boolean(tagToEdit)}

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -15,6 +15,7 @@ const TagSelect: React.FunctionComponent<{
   disableEditTags?: boolean;
   disabledTags: ZetkinTag[];
   groups: ZetkinTagGroup[];
+  onClose: () => void;
   onCreateTag: (tag: NewTag) => void;
   onEditTag: (tag: EditTag) => void;
   onSelect: (tag: ZetkinTag) => void;
@@ -23,6 +24,7 @@ const TagSelect: React.FunctionComponent<{
   disableEditTags,
   disabledTags,
   groups,
+  onClose,
   onCreateTag,
   onEditTag,
   onSelect,
@@ -73,6 +75,21 @@ const TagSelect: React.FunctionComponent<{
           'data-testid': 'TagManager-TagSelect-searchField',
         }}
         onChange={(ev) => setInputValue(ev.target.value)}
+        onKeyUp={(ev) => {
+          if (ev.key == 'Enter') {
+            if (pendingTag) {
+              handleSubmit();
+            }
+          } else if (ev.key == 'Escape') {
+            if (pendingTag) {
+              setPendingTag(null);
+            } else if (inputValue) {
+              setInputValue('');
+            } else {
+              onClose();
+            }
+          }
+        }}
         placeholder={
           pendingTag
             ? intl.formatMessage(

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -57,7 +57,7 @@ const TagSelect: React.FunctionComponent<{
     })
   );
 
-  const handleSubmit = () => {
+  const handleSubmitValue = () => {
     if (pendingTag) {
       onSelect({ ...pendingTag, value: pendingValue || undefined });
       setPendingTag(null);
@@ -78,7 +78,7 @@ const TagSelect: React.FunctionComponent<{
         onKeyUp={(ev) => {
           if (ev.key == 'Enter') {
             if (pendingTag) {
-              handleSubmit();
+              handleSubmitValue();
             }
           } else if (ev.key == 'Escape') {
             if (pendingTag) {
@@ -110,7 +110,7 @@ const TagSelect: React.FunctionComponent<{
             setInputValue('');
           }}
           onChange={(value) => setPendingValue(value)}
-          onSubmit={handleSubmit}
+          onSubmit={handleSubmitValue}
           tag={pendingTag}
         />
       ) : (

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -32,6 +32,9 @@ const TagSelect: React.FunctionComponent<{
 
   const [pendingTag, setPendingTag] = useState<ZetkinTag | null>(null);
   const [inputValue, setInputValue] = useState('');
+  const [pendingValue, setPendingValue] = useState<number | string | null>(
+    null
+  );
 
   const [tagToEdit, setTagToEdit] = useState<
     ZetkinTag | Pick<ZetkinTag, 'title'> | undefined
@@ -51,6 +54,14 @@ const TagSelect: React.FunctionComponent<{
       id: 'misc.tags.tagManager.ungroupedHeader',
     })
   );
+
+  const handleSubmit = () => {
+    if (pendingTag) {
+      onSelect({ ...pendingTag, value: pendingValue || undefined });
+      setPendingTag(null);
+      setInputValue('');
+    }
+  };
 
   return (
     <Box {...getRootProps()}>
@@ -81,11 +92,8 @@ const TagSelect: React.FunctionComponent<{
             setPendingTag(null);
             setInputValue('');
           }}
-          onSubmit={(value) => {
-            onSelect({ ...pendingTag, value });
-            setPendingTag(null);
-            setInputValue('');
-          }}
+          onChange={(value) => setPendingValue(value)}
+          onSubmit={handleSubmit}
           tag={pendingTag}
         />
       ) : (

--- a/src/components/organize/TagManager/components/TagSelect/index.tsx
+++ b/src/components/organize/TagManager/components/TagSelect/index.tsx
@@ -32,11 +32,11 @@ const TagSelect: React.FunctionComponent<{
 }) => {
   const intl = useIntl();
 
-  const [pendingTag, setPendingTag] = useState<ZetkinTag | null>(null);
   const [inputValue, setInputValue] = useState('');
-  const [pendingValue, setPendingValue] = useState<number | string | null>(
+  const [selectedValueTag, setSelectedValueTag] = useState<ZetkinTag | null>(
     null
   );
+  const [tagValue, setTagValue] = useState<number | string | null>(null);
 
   const [tagToEdit, setTagToEdit] = useState<
     ZetkinTag | Pick<ZetkinTag, 'title'> | undefined
@@ -58,9 +58,9 @@ const TagSelect: React.FunctionComponent<{
   );
 
   const handleSubmitValue = () => {
-    if (pendingTag) {
-      onSelect({ ...pendingTag, value: pendingValue || undefined });
-      setPendingTag(null);
+    if (selectedValueTag) {
+      onSelect({ ...selectedValueTag, value: tagValue || undefined });
+      setSelectedValueTag(null);
       setInputValue('');
     }
   };
@@ -77,12 +77,12 @@ const TagSelect: React.FunctionComponent<{
         onChange={(ev) => setInputValue(ev.target.value)}
         onKeyUp={(ev) => {
           if (ev.key == 'Enter') {
-            if (pendingTag) {
+            if (selectedValueTag) {
               handleSubmitValue();
             }
           } else if (ev.key == 'Escape') {
-            if (pendingTag) {
-              setPendingTag(null);
+            if (selectedValueTag) {
+              setSelectedValueTag(null);
             } else if (inputValue) {
               setInputValue('');
             } else {
@@ -91,10 +91,10 @@ const TagSelect: React.FunctionComponent<{
           }
         }}
         placeholder={
-          pendingTag
+          selectedValueTag
             ? intl.formatMessage(
                 { id: 'misc.tags.tagManager.addValue' },
-                { tag: pendingTag.title }
+                { tag: selectedValueTag.title }
               )
             : intl.formatMessage({
                 id: 'misc.tags.tagManager.addTag',
@@ -102,16 +102,16 @@ const TagSelect: React.FunctionComponent<{
         }
         variant="outlined"
       />
-      {pendingTag ? (
+      {selectedValueTag ? (
         <ValueTagForm
           inputValue={inputValue}
           onCancel={() => {
-            setPendingTag(null);
+            setSelectedValueTag(null);
             setInputValue('');
           }}
-          onChange={(value) => setPendingValue(value)}
+          onChange={(value) => setTagValue(value)}
           onSubmit={handleSubmitValue}
-          tag={pendingTag}
+          tag={selectedValueTag}
         />
       ) : (
         <TagSelectList
@@ -123,7 +123,7 @@ const TagSelect: React.FunctionComponent<{
           onEdit={(tag) => setTagToEdit(tag)}
           onSelect={(tag) => {
             if (tag.value_type) {
-              setPendingTag(tag);
+              setSelectedValueTag(tag);
               setInputValue('');
             } else {
               onSelect(tag);
@@ -142,7 +142,7 @@ const TagSelect: React.FunctionComponent<{
             // If new tag
             const createdTag = await onCreateTag(tag);
             if (createdTag.value_type) {
-              setPendingTag(createdTag);
+              setSelectedValueTag(createdTag);
             }
             setInputValue('');
           }

--- a/src/components/organize/TagManager/index.tsx
+++ b/src/components/organize/TagManager/index.tsx
@@ -34,10 +34,6 @@ const TagManager: React.FunctionComponent<TagManagerProps> = (props) => {
           availableTags={tagsQuery.data}
           onCreateTag={async (tagToCreate) => {
             const newTag = await createTag(tagToCreate);
-            if (!newTag.value_type) {
-              props.onAssignTag(newTag);
-            }
-
             return newTag;
           }}
           onEditTag={editTag}

--- a/src/components/organize/TagManager/index.tsx
+++ b/src/components/organize/TagManager/index.tsx
@@ -32,10 +32,7 @@ const TagManager: React.FunctionComponent<TagManagerProps> = (props) => {
         <TagManagerController
           availableGroups={tagGroupsQuery.data}
           availableTags={tagsQuery.data}
-          onCreateTag={async (tagToCreate) => {
-            const newTag = await createTag(tagToCreate);
-            return newTag;
-          }}
+          onCreateTag={createTag}
           onEditTag={editTag}
           {...props}
         />
@@ -61,7 +58,7 @@ export const TagManagerSection: React.FunctionComponent<
       }
       title={intl.formatMessage({ id: 'misc.tags.tagManager.title' })}
     >
-      <TagManager groupTags={isGrouped} {...props} />{' '}
+      <TagManager groupTags={isGrouped} {...props} />
     </ZetkinSection>
   );
 };

--- a/src/components/organize/TagManager/index.tsx
+++ b/src/components/organize/TagManager/index.tsx
@@ -34,7 +34,11 @@ const TagManager: React.FunctionComponent<TagManagerProps> = (props) => {
           availableTags={tagsQuery.data}
           onCreateTag={async (tagToCreate) => {
             const newTag = await createTag(tagToCreate);
-            props.onAssignTag(newTag);
+            if (!newTag.value_type) {
+              props.onAssignTag(newTag);
+            }
+
+            return newTag;
           }}
           onEditTag={editTag}
           {...props}

--- a/src/locale/misc/tags/en.yml
+++ b/src/locale/misc/tags/en.yml
@@ -16,6 +16,10 @@ tagManager:
     groupSelectPlaceholder: Type to search or create a group
     titleErrorText: Tag name is required
     titleLabel: Tag name
+    typeLabel: Type
+    types:
+      none: None (simple tag)
+      text: Text value
   title: Tags
   ungroupedHeader: No group
   valueTagForm:

--- a/src/locale/misc/tags/en.yml
+++ b/src/locale/misc/tags/en.yml
@@ -1,5 +1,6 @@
 tagManager:
   addTag: Add tag
+  addValue: 'Add value for "{tag}"'
   createNamedTag: 'Create tag: <b>{name}</b>'
   createTag: New Tag
   groupTags: Group tags

--- a/src/locale/misc/tags/en.yml
+++ b/src/locale/misc/tags/en.yml
@@ -18,3 +18,5 @@ tagManager:
     titleLabel: Tag name
   title: Tags
   ungroupedHeader: No group
+  valueTagForm:
+    typeHint: '{type, select, text {Enter some text} other {Enter a value}} to go along with the tag.'

--- a/src/locale/misc/tags/en.yml
+++ b/src/locale/misc/tags/en.yml
@@ -16,10 +16,10 @@ tagManager:
     groupSelectPlaceholder: Type to search or create a group
     titleErrorText: Tag name is required
     titleLabel: Tag name
-    typeLabel: Type
+    typeLabel: Tag type
     types:
-      none: None (simple tag)
-      text: Text value
+      none: Basic (no values)
+      text: Text values
   title: Tags
   ungroupedHeader: No group
   valueTagForm:

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -95,11 +95,12 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
             {({ queries: { personTagsQuery } }) => (
               <TagManagerSection
                 assignedTags={personTagsQuery.data}
-                onAssignTag={(tag) =>
-                  assignTagMutation.mutate(tag.id, {
+                onAssignTag={(tag) => {
+                  const tagBody = { id: tag.id, value: tag.value };
+                  assignTagMutation.mutate(tagBody, {
                     onError: () => showSnackbar('error'),
-                  })
-                }
+                  });
+                }}
                 onTagEdited={() => {
                   queryClient.invalidateQueries(personTagsKey);
                 }}


### PR DESCRIPTION
## Description
This PR implements GUI for adding value tags using the `TagManager`.

## Screenshots
<img width="1403" alt="image" src="https://user-images.githubusercontent.com/550212/169681844-17d07fd0-071b-4931-8860-5cf83bd6d06d.png">

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/550212/169681826-56f6964b-66f4-47b3-a0b6-2acc560a976c.png">

## Changes
* Adds UI to the `TagDialog` to allow for creating value tags (but not changing their value setting once created)
* Changes `TagSelect` to have two states
  * The old state for picking a tag remains, and most of the GUI is broken out into a separate component, `TagSelectList`
  * A new state for entering the value of a value tag is introduced. This state is only activated when a value tag is picked in the first state.
* Adds basic support for keyboard interaction – enter to submit and escape to clear/go back/close the select, depending on state
* Adds tests for all of the above

## Notes to reviewer
This UI will work both on person profile pages, and on journey instances. However, the backend support for value tags is not implemented for journey instances yet, so using the UI there will apply the tag but without the value.

## Related issues
Resolves #632 
