### PR TITLE
Issue 670/ Show open and closed journey instances using tabs

### DIFF
--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { TagMetadata } from '../utils/getTagMetadata';
+import { JourneyInstancesData } from 'pages/api/organize/[orgId]/journeys/[journeyId]';
 import {
   createPrefetch,
   createUseMutation,
@@ -50,10 +50,7 @@ export const journeyInstancesResource = (orgId: string, journeyId: string) => {
       },
       ZetkinJourneyInstance
     >(key, `/journeyInstances/createNew?orgId=${orgId}&journeyId=${journeyId}`),
-    useQuery: createUseQuery<{
-      journeyInstances: ZetkinJourneyInstance[];
-      tagMetadata: TagMetadata;
-    }>(key, url),
+    useQuery: createUseQuery<JourneyInstancesData>(key, url),
   };
 };
 

--- a/src/components/journeys/JourneyInstanceCreateFab.tsx
+++ b/src/components/journeys/JourneyInstanceCreateFab.tsx
@@ -1,0 +1,31 @@
+import { Add } from '@material-ui/icons';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Fab, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  fab: {
+    bottom: theme.spacing(10),
+    position: 'fixed',
+    right: theme.spacing(4),
+  },
+}));
+
+const JourneyInstanceCreateFab: React.FunctionComponent = () => {
+  const classes = useStyles();
+  const { orgId, journeyId } = useRouter().query;
+
+  return (
+    <Link href={`/organize/${orgId}/journeys/${journeyId}/new`} passHref>
+      <Fab
+        className={classes.fab}
+        color="primary"
+        data-testid="JourneyInstanceOverviewPage-addFab"
+      >
+        <Add />
+      </Fab>
+    </Link>
+  );
+};
+
+export default JourneyInstanceCreateFab;

--- a/src/components/journeys/JourneyInstancesDataTable/index.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.tsx
@@ -15,12 +15,14 @@ interface JourneysDataTableProps {
   dataGridProps?: Partial<DataGridProProps>;
   tagMetadata: TagMetadata;
   journeyInstances: ZetkinJourneyInstance[];
+  storageKey?: string;
 }
 
 const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
   dataGridProps,
   tagMetadata,
   journeyInstances,
+  storageKey = 'journeyInstances',
 }) => {
   const columns = getColumns(tagMetadata);
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
@@ -62,7 +64,7 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
         pagination
         rows={rows}
         sortModel={sortModel}
-        storageKey="journeyInstances"
+        storageKey={storageKey}
         {...dataGridProps}
       />
     </>

--- a/src/layout/organize/AllJourneyInstancesLayout.tsx
+++ b/src/layout/organize/AllJourneyInstancesLayout.tsx
@@ -27,7 +27,8 @@ const AllJourneyInstancesLayout: FunctionComponent<LayoutProps> = ({
       fixedHeight={fixedHeight}
       noPad
       tabs={[
-        { href: `/`, messageId: 'layout.organize.journeys.tabs.overview' },
+        { href: `/`, messageId: 'layout.organize.journeys.tabs.open' },
+        { href: `/closed`, messageId: 'layout.organize.journeys.tabs.closed' },
         {
           href: `/manage`,
           messageId: 'layout.organize.journeys.tabs.manage',

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -16,8 +16,10 @@ journeys:
   statusClosed: Closed
   statusOpen: Open
   tabs:
+    closed: Closed
     manage: Manage
     milestones: Milestones
+    open: Open
     overview: Overview
     timeline: Timeline
   title: Journeys

--- a/src/locale/misc/breadcrumbs/en.yml
+++ b/src/locale/misc/breadcrumbs/en.yml
@@ -2,6 +2,7 @@ areas: Areas
 assignees: Assignees
 calendar: Calendar
 campaigns: Campaigns
+closed: Closed
 events: Events
 insights: Insights
 instances: Instances

--- a/src/pages/api/organize/[orgId]/journeys/[journeyId]/index.ts
+++ b/src/pages/api/organize/[orgId]/journeys/[journeyId]/index.ts
@@ -1,12 +1,20 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { createApiFetch } from 'utils/apiFetch';
-import { getMessages } from 'utils/locale';
-import { getTagMetadata } from 'utils/getTagMetadata';
+import { ZetkinApiSuccessResponse } from 'api/utils/handleResponseData';
+import { ZetkinJourneyInstance } from 'types/zetkin';
+import { getTagMetadata, TagMetadata } from 'utils/getTagMetadata';
+
+export interface JourneyInstancesData {
+  journeyInstances: ZetkinJourneyInstance[];
+  tagMetadata: TagMetadata;
+}
 
 const getJourneyTableData = async (
   req: NextApiRequest & { query: Record<string, string> },
-  res: NextApiResponse
+  res: NextApiResponse<
+    ZetkinApiSuccessResponse<JourneyInstancesData> | { error: string }
+  >
 ): Promise<void> => {
   const {
     query: { orgId, journeyId },
@@ -27,17 +35,9 @@ const getJourneyTableData = async (
     );
     const { data: journeyInstances } = await journeyInstancesRes.json();
 
-    // Retrieve column names
-    const columnNames = Object.fromEntries(
-      Object.entries(
-        await getMessages('en', ['pages.organizeJourneyInstances'])
-      ).map(([key, value]) => [key.split('.').pop(), value])
-    );
     const tagMetadata = getTagMetadata(journeyInstances);
 
-    res
-      .status(200)
-      .json({ data: { columnNames, journeyInstances, tagMetadata } });
+    res.status(200).json({ data: { journeyInstances, tagMetadata } });
   } catch (e) {
     res.status(500).json({ error: (e as Error).message });
   }

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
@@ -1,0 +1,96 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+
+import AllJourneyInstancesLayout from 'layout/organize/AllJourneyInstancesLayout';
+import getOrg from 'fetching/getOrg';
+import JourneyInstanceCreateFab from 'components/journeys/JourneyInstanceCreateFab';
+import JourneyInstancesDataTable from 'components/journeys/JourneyInstancesDataTable';
+import { PageWithLayout } from 'types';
+import { scaffold } from 'utils/next';
+import { ZetkinJourney } from 'types/zetkin';
+import ZetkinQuery from 'components/ZetkinQuery';
+import { journeyInstancesResource, journeyResource } from 'api/journeys';
+
+const scaffoldOptions = {
+  authLevelRequired: 2,
+  localeScope: ['layout.organize', 'pages.organizeJourney'],
+};
+
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+  const { orgId, journeyId } = ctx.params!;
+
+  await ctx.queryClient.prefetchQuery(
+    ['org', orgId],
+    getOrg(orgId as string, ctx.apiFetch)
+  );
+  const orgState = ctx.queryClient.getQueryState(['org', orgId]);
+
+  const { state: journeyQueryState } = await journeyResource(
+    orgId as string,
+    journeyId as string
+  ).prefetch(ctx);
+
+  if (
+    orgState?.status === 'success' &&
+    journeyQueryState?.status === 'success'
+  ) {
+    return {
+      props: {
+        journeyId,
+        orgId,
+      },
+    };
+  } else {
+    return {
+      notFound: true,
+    };
+  }
+}, scaffoldOptions);
+
+type ClosedJourneyInstancesPageProps = {
+  journeyId: string;
+  orgId: string;
+};
+
+const ClosedJourneyInstancesPage: PageWithLayout<
+  ClosedJourneyInstancesPageProps
+> = ({ orgId, journeyId }) => {
+  const journeyQuery = journeyResource(orgId, journeyId).useQuery();
+  const journeyInstancesQuery = journeyInstancesResource(
+    orgId,
+    journeyId
+  ).useQuery();
+  const journey = journeyQuery.data as ZetkinJourney;
+
+  return (
+    <>
+      <Head>
+        <title>{journey.plural_label}</title>
+      </Head>
+      <ZetkinQuery queries={{ journeyInstancesQuery }}>
+        {({ queries: { journeyInstancesQuery } }) => {
+          const openJourneyInstances =
+            journeyInstancesQuery.data.journeyInstances.filter(
+              (journeyInstance) => Boolean(journeyInstance.closed)
+            );
+
+          return (
+            <JourneyInstancesDataTable
+              journeyInstances={openJourneyInstances}
+              tagMetadata={journeyInstancesQuery.data.tagMetadata}
+            />
+          );
+        }}
+      </ZetkinQuery>
+      <JourneyInstanceCreateFab />
+    </>
+  );
+};
+
+ClosedJourneyInstancesPage.getLayout = function getLayout(page) {
+  return (
+    <AllJourneyInstancesLayout fixedHeight>{page}</AllJourneyInstancesLayout>
+  );
+};
+
+export default ClosedJourneyInstancesPage;

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
@@ -77,6 +77,7 @@ const ClosedJourneyInstancesPage: PageWithLayout<
           return (
             <JourneyInstancesDataTable
               journeyInstances={openJourneyInstances}
+              storageKey="journeyInstances-closed"
               tagMetadata={journeyInstancesQuery.data.tagMetadata}
             />
           );

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
@@ -77,6 +77,7 @@ const OpenJourneyInstancesPage: PageWithLayout<
           return (
             <JourneyInstancesDataTable
               journeyInstances={openJourneyInstances}
+              storageKey="journeyInstances-open"
               tagMetadata={journeyInstancesQuery.data.tagMetadata}
             />
           );

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
@@ -1,18 +1,15 @@
-import { Add } from '@material-ui/icons';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import NextLink from 'next/link';
-import { Fab, makeStyles } from '@material-ui/core';
 
 import AllJourneyInstancesLayout from 'layout/organize/AllJourneyInstancesLayout';
 import getOrg from 'fetching/getOrg';
+import JourneyInstanceCreateFab from 'components/journeys/JourneyInstanceCreateFab';
 import JourneyInstancesDataTable from 'components/journeys/JourneyInstancesDataTable';
 import { PageWithLayout } from 'types';
 import { scaffold } from 'utils/next';
-import { TagMetadata } from 'utils/getTagMetadata';
+import { ZetkinJourney } from 'types/zetkin';
 import ZetkinQuery from 'components/ZetkinQuery';
 import { journeyInstancesResource, journeyResource } from 'api/journeys';
-import { ZetkinJourney, ZetkinJourneyInstance } from 'types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -50,26 +47,13 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   }
 }, scaffoldOptions);
 
-type JourneyInstancesOverviewPageProps = {
+type OpenJourneyInstancesPageProps = {
   journeyId: string;
   orgId: string;
 };
 
-interface JourneyInstancesData {
-  journeyInstances: ZetkinJourneyInstance[];
-  tagMetadata: TagMetadata;
-}
-
-const useStyles = makeStyles((theme) => ({
-  fab: {
-    bottom: theme.spacing(10),
-    position: 'fixed',
-    right: theme.spacing(4),
-  },
-}));
-
-const JourneyInstancesOverviewPage: PageWithLayout<
-  JourneyInstancesOverviewPageProps
+const OpenJourneyInstancesPage: PageWithLayout<
+  OpenJourneyInstancesPageProps
 > = ({ orgId, journeyId }) => {
   const journeyQuery = journeyResource(orgId, journeyId).useQuery();
   const journeyInstancesQuery = journeyInstancesResource(
@@ -78,35 +62,35 @@ const JourneyInstancesOverviewPage: PageWithLayout<
   ).useQuery();
   const journey = journeyQuery.data as ZetkinJourney;
 
-  const classes = useStyles();
-
   return (
     <>
       <Head>
         <title>{journey.plural_label}</title>
       </Head>
       <ZetkinQuery queries={{ journeyInstancesQuery }}>
-        <JourneyInstancesDataTable
-          {...(journeyInstancesQuery.data as JourneyInstancesData)}
-        />
+        {({ queries: { journeyInstancesQuery } }) => {
+          const openJourneyInstances =
+            journeyInstancesQuery.data.journeyInstances.filter(
+              (journeyInstance) => journeyInstance.closed == null
+            );
+
+          return (
+            <JourneyInstancesDataTable
+              journeyInstances={openJourneyInstances}
+              tagMetadata={journeyInstancesQuery.data.tagMetadata}
+            />
+          );
+        }}
       </ZetkinQuery>
-      <NextLink href={`/organize/${orgId}/journeys/${journeyId}/new`} passHref>
-        <Fab
-          className={classes.fab}
-          color="primary"
-          data-testid="JourneyInstanceOverviewPage-addFab"
-        >
-          <Add />
-        </Fab>
-      </NextLink>
+      <JourneyInstanceCreateFab />
     </>
   );
 };
 
-JourneyInstancesOverviewPage.getLayout = function getLayout(page) {
+OpenJourneyInstancesPage.getLayout = function getLayout(page) {
   return (
     <AllJourneyInstancesLayout fixedHeight>{page}</AllJourneyInstancesLayout>
   );
 };
 
-export default JourneyInstancesOverviewPage;
+export default OpenJourneyInstancesPage;


### PR DESCRIPTION
## Description
This PR allows the user to see only open or closed journey instances using tabs on the journey instance list pages.


## Screenshots
![Screenshot from 2022-05-21 09-59-08](https://user-images.githubusercontent.com/41007222/169644237-2c3fa7a7-db83-44f7-b800-06ff87e1dc49.png)


## Changes
* Adds
  * Tab for closed journey instances which only shows closed instances. 
  * Breadcrumb label for closed journey instances
  * Prop `storageKey` on `JourneyInstancesDataTable` which is used for storing column configuration. Uses different keys for open and closed journey tables
* Changes
  * "Overview" tab for journey instance list renamed to "open" and it only shows open journeys 
  * Moves the FAB to create a new journey instance in to it's own component 
  * Improves types on `journeyInstances` api response page and uses these types in the API handler
  * Removes unused property `columnNames` from the journey instances API response 
    * @richardolsson can you please confirm nothing else depends on this property? I looked all over and didn't see it being used anywhere so I think it's safely removed. Check this commit: [d9a98d5](https://github.com/zetkin/app.zetkin.org/pull/671/commits/d9a98d5f11461e763e381c43400b0f2239079889)

## Related issues
Resolves #670 
