### PR TITLE
Consistent spacing on instance sidebar

### DIFF
--- a/src/components/organize/journeys/JourneyInstanceSidebar.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSidebar.tsx
@@ -14,6 +14,12 @@ import {
   ZetkinTag,
 } from 'types/zetkin';
 
+const GridDivider = () => (
+  <Grid item xs={12}>
+    <Divider />
+  </Grid>
+);
+
 const JourneyInstanceSidebar = ({
   journeyInstance,
   onAddAssignee,
@@ -93,8 +99,8 @@ const JourneyInstanceSidebar = ({
             </ClickAwayListener>
           )}
         </ZetkinSection>
-        <Divider />
       </Grid>
+      <GridDivider />
       <Grid item xs={12}>
         <ZetkinSection
           data-testid="ZetkinSection-subjects"
@@ -144,8 +150,8 @@ const JourneyInstanceSidebar = ({
             </ClickAwayListener>
           )}
         </ZetkinSection>
-        <Divider />
       </Grid>
+      <GridDivider />
       <Grid item xs={12}>
         <TagManagerSection
           assignedTags={journeyInstance.tags}
@@ -153,22 +159,23 @@ const JourneyInstanceSidebar = ({
           onTagEdited={onTagEdited}
           onUnassignTag={onUnassignTag}
         />
-        <Divider />
       </Grid>
       {journeyInstance.milestones && (
-        <Grid item xs={12}>
-          <ZetkinSection
-            title={intl.formatMessage({
-              id: 'pages.organizeJourneyInstance.sections.milestones',
-            })}
-          >
-            <JourneyMilestoneProgress
-              milestones={journeyInstance.milestones}
-              next_milestone={journeyInstance.next_milestone}
-            />
-          </ZetkinSection>
-          <Divider />
-        </Grid>
+        <>
+          <GridDivider />
+          <Grid item xs={12}>
+            <ZetkinSection
+              title={intl.formatMessage({
+                id: 'pages.organizeJourneyInstance.sections.milestones',
+              })}
+            >
+              <JourneyMilestoneProgress
+                milestones={journeyInstance.milestones}
+                next_milestone={journeyInstance.next_milestone}
+              />
+            </ZetkinSection>
+          </Grid>
+        </>
       )}
     </Grid>
   );


### PR DESCRIPTION
## Description
This PR improves the consistency of spacing on the `JourneyInstanceSidebarComponent`. That's all!

## Screenshots
Before:
![ugly sidebar](https://user-images.githubusercontent.com/41007222/169645820-ec0ad2e1-75c1-4513-9f7e-1e6b25afa38b.png)
After:
![sidebar with spacing](https://user-images.githubusercontent.com/41007222/169645829-5dccc493-eb67-4f86-b4a4-b8324bf083ec.png)


## Changes

* Adds:
  * `<GridDivider />` component on the sidebar and uses it in place of the dividers inside each grid item
* Changes:
  * Divider is not shown beneath the last element  

## Related issues
Tracked in #666
