### PR TITLE
Fix flaky tests

### DIFF
--- a/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
@@ -107,11 +107,7 @@ test.describe('Journey instance sidebar', () => {
       ).toBeTruthy();
     });
 
-    test('where you can remove assigned person from the journey instance.', async ({
-      appUri,
-      moxy,
-      page,
-    }) => {
+    test('where you can remove assigned person from the journey instance.', async ({ appUri, moxy, page }) => {
       moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
         'get',
@@ -130,39 +126,49 @@ test.describe('Journey instance sidebar', () => {
 
       await page.goto(appUri + '/organize/1/journeys/1/1');
 
-      //hover over Angela
-      await page
-        .locator(
-          `data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}`
-        )
-        .hover();
-
-      //GET journey instance again, with no assignees
-      moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
-        'get',
-        { ...ClarasOnboarding, assignees: [] }
-      );
-
-      //find x-icon and click it
-
+      // Set up two parallel async tracks
       await Promise.all([
-        page.waitForResponse(
-          (res) =>
-            res.request().method() === 'GET' &&
-            res
-              .request()
-              .url()
-              .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
-        ),
-        page
-          .locator(
-            `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
-          )
-          .click(),
+        // Track A waits for HTTP requests and updates mocks to reflect that
+        // an assignee has been deleted
+        (async () => {
+          await page.waitForRequest((res) => res.method() == 'DELETE');
+
+          // Update journey instance mock with no assignees
+          moxy.setZetkinApiMock(
+            `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+            'get',
+            { ...ClarasOnboarding, assignees: [] }
+          );
+
+          await page.waitForResponse(
+            (res) =>
+              res.request().method() === 'GET' &&
+              res
+                .request()
+                .url()
+                .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
+          );
+        })(),
+
+        // Track B performs UI interactions in parallel with track A
+        (async () => {
+          // Hover over Angela
+          await page
+            .locator(
+              `data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}`
+            )
+            .hover();
+
+          // Click X icon
+          await page
+            .locator(
+              `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
+            )
+            .click();
+        })(),
       ]);
 
-      // Wait a shot while for React to re-render after data has been retrieved
+      // Wait a short while for React to re-render after data has been retrieved
       await page.waitForTimeout(200);
 
       //there should be no Angela in list of assignees
@@ -290,35 +296,43 @@ test.describe('Journey instance sidebar', () => {
 
       await page.goto(appUri + '/organize/1/journeys/1/1');
 
-      //hover over Clara
-      await page
-        .locator(
-          `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
-        )
-        .hover();
-
-      //GET journey instance again, with no subjects
-      moxy.setZetkinApiMock(
-        `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
-        'get',
-        { ...ClarasOnboarding, subjects: [] }
-      );
-
-      //find x-icon and click it, then wait for re-fetch of invalidated instance data
+      // Set up two parallel async tracks
       await Promise.all([
-        page.waitForResponse(
-          (res) =>
-            res.request().method() === 'GET' &&
-            res
-              .request()
-              .url()
-              .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
-        ),
-        page
-          .locator(
-            `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
-          )
-          .click(),
+        (async () => {
+          await page.waitForRequest((req) => req.method() == 'DELETE');
+
+          // Update journey instance mocke, with no subjects
+          moxy.setZetkinApiMock(
+            `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
+            'get',
+            { ...ClarasOnboarding, subjects: [] }
+          );
+
+          await page.waitForResponse(
+            (res) =>
+              res.request().method() === 'GET' &&
+              res
+                .request()
+                .url()
+                .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
+          );
+        })(),
+
+        (async () => {
+          // Hover over Clara
+          await page
+            .locator(
+              `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+            )
+            .hover();
+
+          // Click X icon
+          await page
+            .locator(
+              `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
+            )
+            .click();
+        })(),
       ]);
 
       // Wait for React to re-render after response

--- a/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
@@ -162,6 +162,9 @@ test.describe('Journey instance sidebar', () => {
           .click(),
       ]);
 
+      // Wait a shot while for React to re-render after data has been retrieved
+      await page.waitForTimeout(200);
+
       //there should be no Angela in list of assignees
       expect(
         await page

--- a/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/sidebar.spec.ts
@@ -107,7 +107,11 @@ test.describe('Journey instance sidebar', () => {
       ).toBeTruthy();
     });
 
-    test('where you can remove assigned person from the journey instance.', async ({ appUri, moxy, page }) => {
+    test('where you can remove assigned person from the journey instance.', async ({
+      appUri,
+      moxy,
+      page,
+    }) => {
       moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journeys/${MemberOnboarding.id}`,
         'get',

--- a/playwright/tests/organize/people/views/columns/delete-column.spec.ts
+++ b/playwright/tests/organize/people/views/columns/delete-column.spec.ts
@@ -36,13 +36,18 @@ test.describe('Deleting a view column', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
 
     // Delete first column
-    await page.click(
-      'button[aria-label="Menu"]:right-of(:text("First Name"))',
-      { force: true }
-    );
-    await page.click(
-      `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
-    );
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'DELETE'),
+      (async () => {
+        await page.click(
+          'button[aria-label="Menu"]:right-of(:text("First Name"))',
+          { force: true }
+        );
+        await page.click(
+          `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
+        );
+      })(),
+    ]);
 
     // Check body of request
     const columnDeleteRequest = moxy
@@ -71,13 +76,20 @@ test.describe('Deleting a view column', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
 
     // Delete first column
-    await page.click(
-      'button[aria-label="Menu"]:right-of(:text("First Name"))',
-      { force: true }
-    );
-    await page.click(
-      `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
-    );
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'DELETE'),
+      (async () => {
+        await page.click(
+          'button[aria-label="Menu"]:right-of(:text("First Name"))',
+          { force: true }
+        );
+        await page.click(
+          `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
+        );
+      })(),
+    ]);
+
+    await page.locator('data-testid=Snackbar-error').waitFor();
 
     expect(await page.locator('data-testid=Snackbar-error').count()).toEqual(1);
   });
@@ -95,13 +107,21 @@ test.describe('Deleting a view column', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
 
     // Delete first column
-    await page.click('button[aria-label="Menu"]:right-of(:text("Active"))', {
-      force: true,
-    });
-    await page.click(
-      `data-testid=delete-column-button-col_${AllMembersColumns[2].id}`
-    );
-    await page.click('button > :text("Confirm")');
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'DELETE'),
+      (async () => {
+        await page.click(
+          'button[aria-label="Menu"]:right-of(:text("Active"))',
+          {
+            force: true,
+          }
+        );
+        await page.click(
+          `data-testid=delete-column-button-col_${AllMembersColumns[2].id}`
+        );
+        await page.click('button > :text("Confirm")');
+      })(),
+    ]);
 
     // Check body of request
     const columnDeleteRequest = moxy


### PR DESCRIPTION
## Description
This PR fixes a number of flaky tests. The method I use is this:

1. Discover a flaky test somewhere (e.g. `main` or another PR)
2. Figure out a fix for the flakiness
3. Push potential fix for that flakiness to this PR
4. See if complete test suite passes
  a. If a test fails, repeat steps 2-4 to fix that test
  b. If the suite passes, rerun it and go back to 4 (until confident that flakiness is gone)

## Screenshots
None

## Changes
* Waits for React to render after removing an assignee in the journey instance sidebar
* Waits for responses before checking the log in all tests for deleting view columns

## Notes to reviewer
No need to review.

## Related issues
None
