### PR TITLE
Timeline tags updates

### DIFF
--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -128,6 +128,18 @@ _italic text_
 });
 
 const updates = addAssigneeUpdates
+  .concat([
+    mockUpdate(UPDATE_TYPES.ANY_ADDTAGS, {
+      timestamp: dayjs()
+        .subtract(Math.random() * 10, 'hours')
+        .format(),
+    }),
+    mockUpdate(UPDATE_TYPES.ANY_REMOVETAGS, {
+      timestamp: dayjs()
+        .subtract(Math.random() * 10, 'hours')
+        .format(),
+    }),
+  ])
   .concat(journeyMilestoneUpdates)
   .concat(journeyInstanceUpdates)
   .concat(noteUpdates)

--- a/src/components/Timeline/TimelineUpdate.tsx
+++ b/src/components/Timeline/TimelineUpdate.tsx
@@ -3,10 +3,31 @@ import TimelineJourneyInstance from './updates/TimelineJourneyInstance';
 import TimelineJourneyMilestone from './updates/TimelineJourneyMilestone';
 import TimelineJourneyStart from './updates/TimelineJourneyStart';
 import TimelineNoteAdded from './updates/TimelineNoteAdded';
+import TimelineTags from './updates/TimelineTags';
 import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
+
+import { ZetkinUpdateTags } from '../../types/updates';
 
 interface Props {
   update: ZetkinUpdate;
+}
+
+// Type predicate function that checks if the action (second part) of update type
+// matches any of the supplied types, and if so returns true indicating that
+// the update is of type T.
+function isWildcardType<T extends ZetkinUpdate>(
+  update: ZetkinUpdate,
+  types: Array<T['type']>
+): update is T {
+  const updateAction = update.type.split('.')[1];
+  for (const type of types) {
+    const typeAction = type.split('.')[1];
+    if (typeAction == updateAction) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
@@ -23,6 +44,13 @@ const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
     return <TimelineJourneyMilestone update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_CREATE) {
     return <TimelineJourneyStart update={update} />;
+  } else if (
+    isWildcardType<ZetkinUpdateTags>(update, [
+      UPDATE_TYPES.ANY_ADDTAGS,
+      UPDATE_TYPES.ANY_REMOVETAGS,
+    ])
+  ) {
+    return <TimelineTags update={update} />;
   } else {
     return <div />;
   }

--- a/src/components/Timeline/updates/TimelineTags.stories.tsx
+++ b/src/components/Timeline/updates/TimelineTags.stories.tsx
@@ -1,0 +1,68 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
+import mockPerson from 'utils/testing/mocks/mockPerson';
+import mockTag from 'utils/testing/mocks/mockTag';
+import TimelineTags from './TimelineTags';
+import { UPDATE_TYPES } from 'types/updates';
+
+export default {
+  component: TimelineTags,
+  title: 'Organisms/Timeline/Updates/TimelineTags',
+} as ComponentMeta<typeof TimelineTags>;
+
+const Template: ComponentStory<typeof TimelineTags> = (args) => (
+  <TimelineTags update={args.update} />
+);
+
+export const addSingle = Template.bind({});
+addSingle.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      tags: [mockTag()],
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.ANY_ADDTAGS,
+  },
+};
+
+export const addMultiple = Template.bind({});
+addMultiple.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      tags: [mockTag(), mockTag({ id: 1857, title: 'Another' })],
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.ANY_ADDTAGS,
+  },
+};
+
+export const removeSingle = Template.bind({});
+removeSingle.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      tags: [mockTag()],
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.ANY_REMOVETAGS,
+  },
+};
+
+export const removeMultiple = Template.bind({});
+removeMultiple.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      tags: [mockTag(), mockTag({ id: 1857, title: 'Another' })],
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.ANY_REMOVETAGS,
+  },
+};

--- a/src/components/Timeline/updates/TimelineTags.tsx
+++ b/src/components/Timeline/updates/TimelineTags.tsx
@@ -1,0 +1,35 @@
+import { FormattedMessage } from 'react-intl';
+
+import TagsList from 'components/organize/TagManager/components/TagsList';
+import UpdateContainer from './elements/UpdateContainer';
+import ZetkinPersonLink from 'components/ZetkinPersonLink';
+import { ZetkinUpdateTags } from 'types/updates';
+
+interface TimelineTagsProps {
+  update: ZetkinUpdateTags;
+}
+
+const TimelineTags: React.FC<TimelineTagsProps> = ({ update }) => {
+  const headerMessage = update.type.endsWith('addtags')
+    ? 'misc.updates.any.addtags'
+    : 'misc.updates.any.removetags';
+
+  return (
+    <UpdateContainer
+      headerContent={
+        <FormattedMessage
+          id={headerMessage}
+          values={{
+            actor: <ZetkinPersonLink person={update.actor} />,
+            count: update.details.tags.length,
+          }}
+        />
+      }
+      update={update}
+    >
+      <TagsList isGrouped={false} tags={update.details.tags} />
+    </UpdateContainer>
+  );
+};
+
+export default TimelineTags;

--- a/src/locale/misc/updates/en.yml
+++ b/src/locale/misc/updates/en.yml
@@ -1,4 +1,7 @@
 # eslint-disable yml/key-name-casing
+any:
+  addtags: '{actor} added {count, plural, =1 {a tag} other {# tags}}'
+  removetags: '{actor} removed {count, plural, =1 {a tag} other {# tags}}'
 journeyinstance:
   addassignee: '{actor} assigned {assignee}'
   addnote: '{actor} added a note'

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -4,9 +4,12 @@ import {
   ZetkinJourneyMilestoneStatus,
   ZetkinNote,
   ZetkinPerson,
+  ZetkinTag,
 } from './zetkin';
 
 export enum UPDATE_TYPES {
+  ANY_ADDTAGS = '*.addtags',
+  ANY_REMOVETAGS = '*.removetags',
   JOURNEYINSTANCE_ADDASSIGNEE = 'journeyinstance.addassignee',
   JOURNEYINSTANCE_ADDNOTE = 'journeyinstance.addnote',
   JOURNEYINSTANCE_CREATE = 'journeyinstance.create',
@@ -70,6 +73,14 @@ export type ZetkinUpdateJourneyInstanceStart = ZetkinUpdateBase<
   }
 >;
 
+export type ZetkinUpdateTags = ZetkinUpdateBase<
+  UPDATE_TYPES.ANY_ADDTAGS | UPDATE_TYPES.ANY_REMOVETAGS,
+  unknown,
+  {
+    tags: ZetkinTag[];
+  }
+>;
+
 export type ZetkinUpdateJourneyInstanceAddNote = ZetkinUpdateBase<
   UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE,
   ZetkinJourneyInstance,
@@ -79,6 +90,7 @@ export type ZetkinUpdateJourneyInstanceAddNote = ZetkinUpdateBase<
 >;
 
 export type ZetkinUpdate =
+  | ZetkinUpdateTags
   | ZetkinUpdateJourneyInstance
   | ZetkinUpdateJourneyInstanceAddNote
   | ZetkinUpdateJourneyInstanceAssignee

--- a/src/utils/testing/mocks/mockUpdate.ts
+++ b/src/utils/testing/mocks/mockUpdate.ts
@@ -5,6 +5,7 @@ import mockJourneyInstance from './mockJourneyInstance';
 import mockNote from './mockNote';
 import { mockObject } from 'utils/testing/mocks';
 import mockPerson from './mockPerson';
+import mockTag from './mockTag';
 import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
 
 const update: Partial<ZetkinUpdate> = {
@@ -17,6 +18,20 @@ const mockUpdate = (
   overrides?: Partial<ZetkinUpdate>
 ): ZetkinUpdate => {
   const updateData = {
+    [UPDATE_TYPES.ANY_ADDTAGS]: {
+      details: {
+        tags: [mockTag()],
+      },
+      target: pick(mockJourneyInstance(), ['id', 'title']),
+      type: 'journeyinstance.addtags',
+    },
+    [UPDATE_TYPES.ANY_REMOVETAGS]: {
+      details: {
+        tags: [mockTag()],
+      },
+      target: pick(mockJourneyInstance(), ['id', 'title']),
+      type: 'journeyinstance.removetags',
+    },
     [UPDATE_TYPES.JOURNEYINSTANCE_UPDATE]: {
       details: {
         changes: {


### PR DESCRIPTION
## Description
This PR adds support for rendering `*.addtags` and `*.removetags` timeline update types.

## Screenshots
![timelinetags](https://user-images.githubusercontent.com/550212/169689709-f883c520-ceac-4525-8299-b6c3c4958f1f.gif)

## Changes
* Create component for rendering tags updates (and storybook stories to preview)
* Add example updates to main timeline story

## Notes to reviewer
None

## Related issues
Resolves #590 
