### PR TITLE
Journeys on profile page

### DIFF
--- a/playwright/tests/organize/people/person/journeys.spec.ts
+++ b/playwright/tests/organize/people/person/journeys.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from '@playwright/test';
+
+import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
+import ClaraZetkin from '../../../../mockData/orgs/KPD/people/ClaraZetkin';
+import KPD from '../../../../mockData/orgs/KPD';
+import MarxistTraining from '../../../../mockData/orgs/KPD/journeys/MarxistTraining';
+import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';
+import test from '../../../../fixtures/next';
+
+test.describe('Person Profile Page Journeys', () => {
+  test.beforeEach(({ moxy, login }) => {
+    login();
+    moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+    moxy.setZetkinApiMock(
+      `/orgs/1/people/${ClaraZetkin.id}`,
+      'get',
+      ClaraZetkin
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPD.id}/people/${ClaraZetkin.id}/journey_instances`,
+      'get',
+      [ClarasOnboarding]
+    );
+
+    moxy.setZetkinApiMock(`/orgs/${KPD.id}/journeys`, 'get', [
+      MarxistTraining,
+      MemberOnboarding,
+    ]);
+  });
+
+  test.afterEach(({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test('displays relevant journey instances', async ({ appUri, page }) => {
+    await page.goto(appUri + `/organize/${KPD.id}/people/${ClaraZetkin.id}`);
+
+    await expect(
+      page.locator('data-testid=PersonJourneysCard-list')
+    ).toContainText(ClarasOnboarding.title!);
+  });
+
+  test('contains menu to start a journey', async ({ appUri, page }) => {
+    await page.goto(appUri + `/organize/${KPD.id}/people/${ClaraZetkin.id}`);
+
+    await page.locator('data-testid=PersonJourneysCard-addButton').click();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator(`text=${MarxistTraining.title}`).click(),
+    ]);
+
+    expect(page.url()).toMatch(/journeys\/2\/new/);
+    expect(page.url()).toMatch(/\?subject=1$/);
+  });
+});

--- a/src/api/people.ts
+++ b/src/api/people.ts
@@ -7,7 +7,7 @@ import {
 } from './utils/resourceHookFactories';
 
 import { PersonOrganization } from 'utils/organize/people';
-import { ZetkinPerson, ZetkinTag } from 'types/zetkin';
+import { ZetkinJourneyInstance, ZetkinPerson, ZetkinTag } from 'types/zetkin';
 
 export const personResource = (orgId: string, personId: string) => {
   const key = ['person', personId];
@@ -17,6 +17,15 @@ export const personResource = (orgId: string, personId: string) => {
     prefetch: createPrefetch<ZetkinPerson>(key, url),
     useQuery: createUseQuery<ZetkinPerson>(key, url),
     useRemove: createUseMutationDelete({ key, url }),
+  };
+};
+
+export const personJourneysResource = (orgId: string, personId: string) => {
+  const key = ['personJourneys', personId];
+  const url = `/orgs/${orgId}/people/${personId}/journey_instances`;
+
+  return {
+    useQuery: createUseQuery<ZetkinJourneyInstance[]>(key, url),
   };
 };
 

--- a/src/components/Timeline/updates/TimelineJourneyStart.stories.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyStart.stories.tsx
@@ -24,6 +24,10 @@ simple.args = {
           'This is the opening note with information about the journey',
       }),
     },
+    organization: {
+      id: 1,
+      title: 'KPD',
+    },
     target: mockJourneyInstance(),
     timestamp: new Date().toISOString(),
     type: UPDATE_TYPES.JOURNEYINSTANCE_CREATE,

--- a/src/components/Timeline/updates/TimelineJourneyStart.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyStart.tsx
@@ -23,7 +23,10 @@ const TimelineJourneyStart: React.FC<TimelineJourneyStartProps> = ({
       }
       update={update}
     >
-      <ZetkinJourneyInstanceCard instance={update.details.data} />
+      <ZetkinJourneyInstanceCard
+        instance={update.details.data}
+        orgId={update.organization.id}
+      />
       <Typography style={{ margin: '1em 0' }}>
         {update.details.data.opening_note}
       </Typography>

--- a/src/components/ZetkinDate.tsx
+++ b/src/components/ZetkinDate.tsx
@@ -1,0 +1,20 @@
+import { FormattedDate } from 'react-intl';
+
+interface ZetkinDateProps {
+  datetime: string; // iso datetime string
+}
+
+const ZetkinDate: React.FunctionComponent<ZetkinDateProps> = ({ datetime }) => {
+  return (
+    <>
+      <FormattedDate
+        day="numeric"
+        month="long"
+        value={datetime}
+        year="numeric"
+      />
+    </>
+  );
+};
+
+export default ZetkinDate;

--- a/src/components/ZetkinJourneyInstanceCard.stories.tsx
+++ b/src/components/ZetkinJourneyInstanceCard.stories.tsx
@@ -9,7 +9,7 @@ export default {
 } as ComponentMeta<typeof ZetkinJourneyInstanceCard>;
 
 const Template: ComponentStory<typeof ZetkinJourneyInstanceCard> = (args) => (
-  <ZetkinJourneyInstanceCard instance={args.instance} />
+  <ZetkinJourneyInstanceCard instance={args.instance} orgId={1} />
 );
 
 export const open = Template.bind({});

--- a/src/components/ZetkinJourneyInstanceCard.tsx
+++ b/src/components/ZetkinJourneyInstanceCard.tsx
@@ -1,11 +1,10 @@
-import { Grid, Typography } from '@material-ui/core';
-
 import ClickableCard from './views/SuggestedViews/ClickableCard';
-import JourneyStatusChip from './journeys/JourneyStatusChip';
-import { ZetkinJourneyInstance } from 'types/zetkin';
+import ZetkinJourneyInstanceItem, {
+  ZetkinJourneyInstanceItemProps,
+} from './ZetkinJourneyInstanceItem';
 
 interface ZetkinJourneyInstanceCardProps {
-  instance: Pick<ZetkinJourneyInstance, 'closed' | 'title' | 'journey' | 'id'>;
+  instance: ZetkinJourneyInstanceItemProps['instance'];
 }
 
 const ZetkinJourneyInstanceCard: React.FC<ZetkinJourneyInstanceCardProps> = ({
@@ -13,26 +12,7 @@ const ZetkinJourneyInstanceCard: React.FC<ZetkinJourneyInstanceCardProps> = ({
 }) => {
   return (
     <ClickableCard>
-      <Grid container justifyContent="space-between">
-        <Grid item>
-          <Typography
-            component="div"
-            data-testid="page-title"
-            noWrap
-            style={{ display: 'flex' }}
-            variant="h5"
-          >
-            {instance.title || instance.journey.title}
-            <Typography
-              color="textSecondary"
-              variant="h5"
-            >{`#${instance.id}`}</Typography>
-          </Typography>
-        </Grid>
-        <Grid item>
-          <JourneyStatusChip instance={instance} />
-        </Grid>
-      </Grid>
+      <ZetkinJourneyInstanceItem instance={instance} />
     </ClickableCard>
   );
 };

--- a/src/components/ZetkinJourneyInstanceCard.tsx
+++ b/src/components/ZetkinJourneyInstanceCard.tsx
@@ -5,14 +5,16 @@ import ZetkinJourneyInstanceItem, {
 
 interface ZetkinJourneyInstanceCardProps {
   instance: ZetkinJourneyInstanceItemProps['instance'];
+  orgId: number | string;
 }
 
 const ZetkinJourneyInstanceCard: React.FC<ZetkinJourneyInstanceCardProps> = ({
   instance,
+  orgId,
 }) => {
   return (
     <ClickableCard>
-      <ZetkinJourneyInstanceItem instance={instance} />
+      <ZetkinJourneyInstanceItem instance={instance} orgId={orgId} />
     </ClickableCard>
   );
 };

--- a/src/components/ZetkinJourneyInstanceItem.tsx
+++ b/src/components/ZetkinJourneyInstanceItem.tsx
@@ -1,0 +1,37 @@
+import { Grid, Typography } from '@material-ui/core';
+
+import JourneyStatusChip from './journeys/JourneyStatusChip';
+import { ZetkinJourneyInstance } from 'types/zetkin';
+
+export interface ZetkinJourneyInstanceItemProps {
+  instance: Pick<ZetkinJourneyInstance, 'closed' | 'title' | 'journey' | 'id'>;
+}
+
+const ZetkinJourneyInstanceItem: React.FC<ZetkinJourneyInstanceItemProps> = ({
+  instance,
+}) => {
+  return (
+    <Grid container justifyContent="space-between">
+      <Grid item>
+        <Typography
+          component="div"
+          data-testid="page-title"
+          noWrap
+          style={{ display: 'flex' }}
+          variant="h5"
+        >
+          {instance.title || instance.journey.title}
+          <Typography
+            color="textSecondary"
+            variant="h5"
+          >{`#${instance.id}`}</Typography>
+        </Typography>
+      </Grid>
+      <Grid item>
+        <JourneyStatusChip instance={instance} />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ZetkinJourneyInstanceItem;

--- a/src/components/ZetkinJourneyInstanceItem.tsx
+++ b/src/components/ZetkinJourneyInstanceItem.tsx
@@ -1,26 +1,43 @@
-import { Grid, Typography } from '@material-ui/core';
+import { AccessTime } from '@material-ui/icons';
+import NextLink from 'next/link';
+import { Grid, Link, Typography } from '@material-ui/core';
 
 import JourneyStatusChip from './journeys/JourneyStatusChip';
+import ZetkinDate from './ZetkinDate';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 
 export interface ZetkinJourneyInstanceItemProps {
-  instance: Pick<ZetkinJourneyInstance, 'closed' | 'title' | 'journey' | 'id'>;
+  instance:
+    | ZetkinJourneyInstance
+    | Pick<ZetkinJourneyInstance, 'closed' | 'title' | 'journey' | 'id'>;
+  orgId: number | string;
 }
 
 const ZetkinJourneyInstanceItem: React.FC<ZetkinJourneyInstanceItemProps> = ({
   instance,
+  orgId,
 }) => {
+  const isOpen = !instance.closed;
+  const hasMeta = 'next_milestone' in instance;
+
   return (
     <Grid container justifyContent="space-between">
       <Grid item>
         <Typography
-          component="div"
+          color={isOpen ? 'textPrimary' : 'textSecondary'}
           data-testid="page-title"
           noWrap
           style={{ display: 'flex' }}
           variant="h5"
         >
-          {instance.title || instance.journey.title}
+          <NextLink
+            href={`/organize/${orgId}/journeys/${instance.journey.id}/${instance.id}`}
+            passHref
+          >
+            <Link color="inherit">
+              {instance.title || instance.journey.title}
+            </Link>
+          </NextLink>
           <Typography
             color="textSecondary"
             variant="h5"
@@ -30,6 +47,32 @@ const ZetkinJourneyInstanceItem: React.FC<ZetkinJourneyInstanceItemProps> = ({
       <Grid item>
         <JourneyStatusChip instance={instance} />
       </Grid>
+      {isOpen && hasMeta && (
+        <>
+          <Grid item sm={12}>
+            <Typography variant="body2">{instance.journey.title}</Typography>
+          </Grid>
+          {instance.next_milestone && (
+            <Grid container item sm={12} style={{ marginTop: 8 }}>
+              <Typography
+                color="inherit"
+                style={{ display: 'flex' }}
+                variant="body2"
+              >
+                <AccessTime
+                  color="inherit"
+                  style={{ height: '1em', marginRight: 4 }}
+                />
+                {instance.next_milestone.title}
+                {instance.next_milestone.deadline && ': '}
+                {instance.next_milestone.deadline && (
+                  <ZetkinDate datetime={instance.next_milestone.deadline} />
+                )}
+              </Typography>
+            </Grid>
+          )}
+        </>
+      )}
     </Grid>
   );
 };

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -28,14 +28,16 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
       {({ queries }) => (
         <PersonCard titleId="pages.people.person.journeys.title">
           <List>
-            {queries.instancesQuery.data.map((instance) => (
-              <ListItem key={instance.id} divider>
-                <ZetkinJourneyInstanceItem
-                  instance={instance}
-                  orgId={instance.organization.id}
-                />
-              </ListItem>
-            ))}
+            {queries.instancesQuery.data
+              .sort((i0, i1) => Number(!!i0.closed) - Number(!!i1.closed))
+              .map((instance) => (
+                <ListItem key={instance.id} divider>
+                  <ZetkinJourneyInstanceItem
+                    instance={instance}
+                    orgId={instance.organization.id}
+                  />
+                </ListItem>
+              ))}
             <ListItem>
               <ZetkinQuery queries={{ journeysQuery }}>
                 {({ queries }) => (

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -1,8 +1,14 @@
+import { Add } from '@material-ui/icons';
+import { FormattedMessage } from 'react-intl';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Button, List, ListItem, Menu, MenuItem } from '@material-ui/core';
+
+import { journeysResource } from 'api/journeys';
 import PersonCard from '../PersonCard';
 import { personJourneysResource } from 'api/people';
 import ZetkinJourneyInstanceItem from 'components/ZetkinJourneyInstanceItem';
 import ZetkinQuery from 'components/ZetkinQuery';
-import { List, ListItem } from '@material-ui/core';
 
 interface PersonJourneysCardProps {
   orgId: string;
@@ -13,7 +19,9 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
   orgId,
   personId,
 }) => {
+  const [addMenuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
   const instancesQuery = personJourneysResource(orgId, personId).useQuery();
+  const journeysQuery = journeysResource(orgId).useQuery();
 
   return (
     <ZetkinQuery queries={{ instancesQuery }}>
@@ -28,6 +36,41 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
                 />
               </ListItem>
             ))}
+            <ListItem>
+              <ZetkinQuery queries={{ journeysQuery }}>
+                {({ queries }) => (
+                  <>
+                    <Button
+                      color="primary"
+                      onClick={(ev) => setMenuAnchorEl(ev.currentTarget)}
+                      startIcon={<Add />}
+                    >
+                      <FormattedMessage id="pages.people.person.journeys.addButton" />
+                    </Button>
+                    <Menu
+                      anchorEl={addMenuAnchorEl}
+                      onClose={() => setMenuAnchorEl(null)}
+                      open={Boolean(addMenuAnchorEl)}
+                    >
+                      {queries.journeysQuery.data.map((journey) => (
+                        <Link
+                          key={journey.id}
+                          href={`/organize/${journey.organization.id}/journeys/${journey.id}/new?subject=${personId}`}
+                          passHref
+                        >
+                          <MenuItem
+                            component="a"
+                            onClick={() => setMenuAnchorEl(null)}
+                          >
+                            {journey.title}
+                          </MenuItem>
+                        </Link>
+                      ))}
+                    </Menu>
+                  </>
+                )}
+              </ZetkinQuery>
+            </ListItem>
           </List>
         </PersonCard>
       )}

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -1,0 +1,35 @@
+import PersonCard from '../PersonCard';
+import { personJourneysResource } from 'api/people';
+import ZetkinJourneyInstanceItem from 'components/ZetkinJourneyInstanceItem';
+import ZetkinQuery from 'components/ZetkinQuery';
+import { List, ListItem } from '@material-ui/core';
+
+interface PersonJourneysCardProps {
+  orgId: string;
+  personId: string;
+}
+
+const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
+  orgId,
+  personId,
+}) => {
+  const instancesQuery = personJourneysResource(orgId, personId).useQuery();
+
+  return (
+    <ZetkinQuery queries={{ instancesQuery }}>
+      {({ queries }) => (
+        <PersonCard titleId="pages.people.person.journeys.title">
+          <List>
+            {queries.instancesQuery.data.map((instance) => (
+              <ListItem key={instance.id}>
+                <ZetkinJourneyInstanceItem instance={instance} />
+              </ListItem>
+            ))}
+          </List>
+        </PersonCard>
+      )}
+    </ZetkinQuery>
+  );
+};
+
+export default PersonJourneysCard;

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -27,7 +27,7 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
     <ZetkinQuery queries={{ instancesQuery }}>
       {({ queries }) => (
         <PersonCard titleId="pages.people.person.journeys.title">
-          <List>
+          <List data-testid="PersonJourneysCard-list">
             {queries.instancesQuery.data
               .sort((i0, i1) => Number(!!i0.closed) - Number(!!i1.closed))
               .map((instance) => (
@@ -44,6 +44,7 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
                   <>
                     <Button
                       color="primary"
+                      data-testid="PersonJourneysCard-addButton"
                       onClick={(ev) => setMenuAnchorEl(ev.currentTarget)}
                       startIcon={<Add />}
                     >

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -21,8 +21,11 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
         <PersonCard titleId="pages.people.person.journeys.title">
           <List>
             {queries.instancesQuery.data.map((instance) => (
-              <ListItem key={instance.id}>
-                <ZetkinJourneyInstanceItem instance={instance} />
+              <ListItem key={instance.id} divider>
+                <ZetkinJourneyInstanceItem
+                  instance={instance}
+                  orgId={instance.organization.id}
+                />
               </ListItem>
             ))}
           </List>

--- a/src/locale/pages/people/en.yml
+++ b/src/locale/pages/people/en.yml
@@ -9,6 +9,7 @@ person:
   editButton: Edit {title}
   editButtonClose: Stop editing {title}
   journeys:
+    addButton: Start new journey
     title: Journeys
   organizations:
     add: Add a new sub-organization

--- a/src/locale/pages/people/en.yml
+++ b/src/locale/pages/people/en.yml
@@ -8,6 +8,8 @@ person:
     title: Contact Details
   editButton: Edit {title}
   editButtonClose: Stop editing {title}
+  journeys:
+    title: Journeys
   organizations:
     add: Add a new sub-organization
     addError: This organization could not be added

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -10,6 +10,7 @@ import Header from 'layout/organize/elements/Header';
 import JourneyInstanceSidebar from 'components/organize/journeys/JourneyInstanceSidebar';
 import { organizationResource } from 'api/organizations';
 import { PageWithLayout } from 'types';
+import { personResource } from 'api/people';
 import { scaffold } from 'utils/next';
 import SnackbarContext from 'hooks/SnackbarContext';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
@@ -79,6 +80,25 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
   const intl = useIntl();
   const theme = useTheme();
   const router = useRouter();
+
+  const inputSubjectIds = router.query.subject
+    ? Array.isArray(router.query.subject)
+      ? router.query.subject
+      : [router.query.subject]
+    : [];
+
+  // Maybe in the future we can support multiple subjects added using
+  // the link, but for now a single subject (the first) is enough.
+  const subjectId = inputSubjectIds[0];
+  personResource(orgId, subjectId).useQuery({
+    // Only load if there is a subjectId and no subjects added already
+    enabled: !!subjectId && !subjects.length,
+    onSuccess: (person) => {
+      if (subjects.length == 0) {
+        setSubjects([...subjects, person]);
+      }
+    },
+  });
 
   const journeyQuery = journeyResource(orgId, journeyId).useQuery({
     onSuccess: (journey) => {

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 
 import { PageWithLayout } from 'types';
 import PersonDetailsCard from 'components/organize/people/PersonDetailsCard';
+import PersonJourneysCard from 'components/organize/people/PersonJourneysCard';
 import PersonOrganizationsCard from 'components/organize/people/PersonOrganizationsCard';
 import SinglePersonLayout from 'layout/organize/SinglePersonLayout';
 import SnackbarContext from 'hooks/SnackbarContext';
@@ -88,9 +89,6 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
           <PersonDetailsCard person={person} />
         </Grid>
         <Grid item lg={4} xs={12}>
-          <PersonOrganizationsCard {...props} />
-        </Grid>
-        <Grid item lg={4} xs={12}>
           <ZetkinQuery queries={{ personTagsQuery }}>
             {({ queries: { personTagsQuery } }) => (
               <TagManagerSection
@@ -111,6 +109,15 @@ const PersonProfilePage: PageWithLayout<PersonPageProps> = (props) => {
               />
             )}
           </ZetkinQuery>
+        </Grid>
+        <Grid item lg={4} xs={12}>
+          <PersonJourneysCard
+            orgId={orgId as string}
+            personId={personId as string}
+          />
+        </Grid>
+        <Grid item lg={4} xs={12}>
+          <PersonOrganizationsCard {...props} />
         </Grid>
       </Grid>
     </>

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -18,6 +18,7 @@ export enum UPDATE_TYPES {
 interface ZetkinUpdateBase<UpdateType, Target, Details = null> {
   actor: Pick<ZetkinPerson, 'id' | 'first_name' | 'last_name'>;
   details: Details;
+  organization: { id: number; title: string };
   target: Target;
   timestamp: string;
   type: UpdateType;

--- a/src/utils/testing/mocks/mockUpdate.ts
+++ b/src/utils/testing/mocks/mockUpdate.ts
@@ -9,6 +9,7 @@ import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
 
 const update: Partial<ZetkinUpdate> = {
   actor: mockPerson(),
+  organization: { id: 1, title: 'KPD' },
   timestamp: dayjs().subtract(5, 'hours').format(),
 };
 


### PR DESCRIPTION
## Description
This PR creates a card on the person profile page that contains a list of journey instances in which that person is a "subject".

## Screenshots
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/550212/169707828-bfa296ed-9925-4056-9223-a4ad199ccc86.png">
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/550212/169707842-b49a918e-f9bb-4406-93a2-268b9611394f.png">

## Changes
* Refactors `ZetkinJourneyInstanceCard` into reusable `ZetkinJourneyInstanceItem`
* Adds GUI to show more journey metadata in the `ZetkinJourneyInstanceItem`
* Creates new `PersonJourneysCard` on person profile page
* Adds support for `?subject=X` querystring parameter on the `new` page, to preset subject with ID X

## Notes to reviewer
Compared to designs, some information is missing (milestone count etc). It's not available in the instance list from the API and I don't think it's all that critical for the user needs, so in the interest of time I've tried to keep it simple.

## Related issues
Resolves #582