### PR TITLE
Journey open & close updates

### DIFF
--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -130,6 +130,7 @@ _italic text_
 const updates = addAssigneeUpdates
   .concat(journeyMilestoneUpdates)
   .concat(journeyInstanceUpdates)
+  .concat([mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_CLOSE)])
   .concat(noteUpdates)
   .concat([
     mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_CREATE, {

--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -130,7 +130,10 @@ _italic text_
 const updates = addAssigneeUpdates
   .concat(journeyMilestoneUpdates)
   .concat(journeyInstanceUpdates)
-  .concat([mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_CLOSE)])
+  .concat([
+    mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_OPEN),
+    mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_CLOSE),
+  ])
   .concat(noteUpdates)
   .concat([
     mockUpdate(UPDATE_TYPES.JOURNEYINSTANCE_CREATE, {

--- a/src/components/Timeline/TimelineUpdate.tsx
+++ b/src/components/Timeline/TimelineUpdate.tsx
@@ -1,4 +1,5 @@
 import TimelineAssigned from './updates/TimelineAssigned';
+import TimelineGeneric from './updates/TimelineGeneric';
 import TimelineJourneyClose from './updates/TimelineJourneyClose';
 import TimelineJourneyInstance from './updates/TimelineJourneyInstance';
 import TimelineJourneyMilestone from './updates/TimelineJourneyMilestone';
@@ -9,6 +10,8 @@ import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
 interface Props {
   update: ZetkinUpdate;
 }
+
+const GENERIC_UPDATES = [UPDATE_TYPES.JOURNEYINSTANCE_OPEN];
 
 const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
   if (
@@ -26,6 +29,8 @@ const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
     return <TimelineJourneyMilestone update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_CREATE) {
     return <TimelineJourneyStart update={update} />;
+  } else if (GENERIC_UPDATES.includes(update.type)) {
+    return <TimelineGeneric update={update} />;
   } else {
     return <div />;
   }

--- a/src/components/Timeline/TimelineUpdate.tsx
+++ b/src/components/Timeline/TimelineUpdate.tsx
@@ -1,4 +1,5 @@
 import TimelineAssigned from './updates/TimelineAssigned';
+import TimelineJourneyClose from './updates/TimelineJourneyClose';
 import TimelineJourneyInstance from './updates/TimelineJourneyInstance';
 import TimelineJourneyMilestone from './updates/TimelineJourneyMilestone';
 import TimelineJourneyStart from './updates/TimelineJourneyStart';
@@ -17,6 +18,8 @@ const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
     return <TimelineAssigned update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE) {
     return <TimelineNoteAdded update={update} />;
+  } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_CLOSE) {
+    return <TimelineJourneyClose update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATE) {
     return <TimelineJourneyInstance update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATEMILESTONE) {

--- a/src/components/Timeline/updates/TimelineGeneric.stories.tsx
+++ b/src/components/Timeline/updates/TimelineGeneric.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
+import mockPerson from 'utils/testing/mocks/mockPerson';
+import TimelineGeneric from './TimelineGeneric';
+import { UPDATE_TYPES } from 'types/updates';
+
+export default {
+  component: TimelineGeneric,
+  title: 'Organisms/Timeline/Updates/TimelineGeneric',
+} as ComponentMeta<typeof TimelineGeneric>;
+
+const Template: ComponentStory<typeof TimelineGeneric> = (args) => (
+  <TimelineGeneric update={args.update} />
+);
+
+export const openJourney = Template.bind({});
+openJourney.args = {
+  update: {
+    actor: mockPerson(),
+    details: null,
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.JOURNEYINSTANCE_OPEN,
+  },
+};

--- a/src/components/Timeline/updates/TimelineGeneric.tsx
+++ b/src/components/Timeline/updates/TimelineGeneric.tsx
@@ -1,0 +1,23 @@
+import { FormattedMessage } from 'react-intl';
+
+import UpdateContainer from './elements/UpdateContainer';
+import ZetkinPersonLink from 'components/ZetkinPersonLink';
+import { ZetkinUpdate } from 'types/updates';
+
+interface TimelineGenericProps {
+  update: ZetkinUpdate;
+}
+
+const TimelineGeneric: React.FC<TimelineGenericProps> = ({ update }) => (
+  <UpdateContainer
+    headerContent={
+      <FormattedMessage
+        id={`misc.updates.${update.type}`}
+        values={{ actor: <ZetkinPersonLink person={update.actor} /> }}
+      />
+    }
+    update={update}
+  />
+);
+
+export default TimelineGeneric;

--- a/src/components/Timeline/updates/TimelineJourneyClose.stories.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyClose.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
+import mockPerson from 'utils/testing/mocks/mockPerson';
+import TimelineJourneyClose from './TimelineJourneyClose';
+import { UPDATE_TYPES } from 'types/updates';
+
+export default {
+  component: TimelineJourneyClose,
+  title: 'Organisms/Timeline/Updates/TimelineJourneyClose',
+} as ComponentMeta<typeof TimelineJourneyClose>;
+
+const Template: ComponentStory<typeof TimelineJourneyClose> = (args) => (
+  <TimelineJourneyClose update={args.update} />
+);
+
+export const withOutcome = Template.bind({});
+withOutcome.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      outcome: 'This is the outcome',
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.JOURNEYINSTANCE_CLOSE,
+  },
+};
+
+export const withoutOutcome = Template.bind({});
+withoutOutcome.args = {
+  update: {
+    actor: mockPerson(),
+    details: {
+      outcome: '',
+    },
+    target: mockJourneyInstance(),
+    timestamp: new Date().toISOString(),
+    type: UPDATE_TYPES.JOURNEYINSTANCE_CLOSE,
+  },
+};

--- a/src/components/Timeline/updates/TimelineJourneyClose.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyClose.tsx
@@ -1,0 +1,34 @@
+import { FormattedMessage } from 'react-intl';
+import { Typography } from '@material-ui/core';
+
+import UpdateContainer from './elements/UpdateContainer';
+import ZetkinJourneyInstanceCard from 'components/ZetkinJourneyInstanceCard';
+import ZetkinPersonLink from 'components/ZetkinPersonLink';
+import { ZetkinUpdateJourneyInstanceClose } from 'types/updates';
+
+interface TimelineJourneyCloseProps {
+  update: ZetkinUpdateJourneyInstanceClose;
+}
+
+const TimelineJourneyClose: React.FC<TimelineJourneyCloseProps> = ({
+  update,
+}) => {
+  return (
+    <UpdateContainer
+      headerContent={
+        <FormattedMessage
+          id="misc.updates.journeyinstance.close.header"
+          values={{ actor: <ZetkinPersonLink person={update.actor} /> }}
+        />
+      }
+      update={update}
+    >
+      <ZetkinJourneyInstanceCard instance={update.target} />
+      <Typography style={{ margin: '1em 0' }}>
+        {update.details.outcome}
+      </Typography>
+    </UpdateContainer>
+  );
+};
+
+export default TimelineJourneyClose;

--- a/src/locale/misc/updates/en.yml
+++ b/src/locale/misc/updates/en.yml
@@ -2,6 +2,8 @@
 journeyinstance:
   addassignee: '{actor} assigned {assignee}'
   addnote: '{actor} added a note'
+  close:
+    header: '{actor} closed the journey'
   create:
     header: '{actor} started a new journey'
   removeassignee: '{actor} unassigned {assignee}'

--- a/src/locale/misc/updates/en.yml
+++ b/src/locale/misc/updates/en.yml
@@ -6,6 +6,7 @@ journeyinstance:
     header: '{actor} closed the journey'
   create:
     header: '{actor} started a new journey'
+  open: '{actor} opened the journey again'
   removeassignee: '{actor} unassigned {assignee}'
   update:
     summary_text: '{actor} edited the summary'

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -9,6 +9,7 @@ import {
 export enum UPDATE_TYPES {
   JOURNEYINSTANCE_ADDASSIGNEE = 'journeyinstance.addassignee',
   JOURNEYINSTANCE_ADDNOTE = 'journeyinstance.addnote',
+  JOURNEYINSTANCE_CLOSE = 'journeyinstance.close',
   JOURNEYINSTANCE_CREATE = 'journeyinstance.create',
   JOURNEYINSTANCE_REMOVEASSIGNEE = 'journeyinstance.removeassignee',
   JOURNEYINSTANCE_UPDATE = 'journeyinstance.update',
@@ -70,6 +71,14 @@ export type ZetkinUpdateJourneyInstanceStart = ZetkinUpdateBase<
   }
 >;
 
+export type ZetkinUpdateJourneyInstanceClose = ZetkinUpdateBase<
+  UPDATE_TYPES.JOURNEYINSTANCE_CLOSE,
+  ZetkinJourneyInstance,
+  {
+    outcome: string;
+  }
+>;
+
 export type ZetkinUpdateJourneyInstanceAddNote = ZetkinUpdateBase<
   UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE,
   ZetkinJourneyInstance,
@@ -82,5 +91,6 @@ export type ZetkinUpdate =
   | ZetkinUpdateJourneyInstance
   | ZetkinUpdateJourneyInstanceAddNote
   | ZetkinUpdateJourneyInstanceAssignee
+  | ZetkinUpdateJourneyInstanceClose
   | ZetkinUpdateJourneyInstanceMilestone
   | ZetkinUpdateJourneyInstanceStart;

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -11,6 +11,7 @@ export enum UPDATE_TYPES {
   JOURNEYINSTANCE_ADDNOTE = 'journeyinstance.addnote',
   JOURNEYINSTANCE_CLOSE = 'journeyinstance.close',
   JOURNEYINSTANCE_CREATE = 'journeyinstance.create',
+  JOURNEYINSTANCE_OPEN = 'journeyinstance.open',
   JOURNEYINSTANCE_REMOVEASSIGNEE = 'journeyinstance.removeassignee',
   JOURNEYINSTANCE_UPDATE = 'journeyinstance.update',
   JOURNEYINSTANCE_UPDATEMILESTONE = 'journeyinstance.updatemilestone',
@@ -79,6 +80,12 @@ export type ZetkinUpdateJourneyInstanceClose = ZetkinUpdateBase<
   }
 >;
 
+export type ZetkinUpdateJourneyInstanceOpen = ZetkinUpdateBase<
+  UPDATE_TYPES.JOURNEYINSTANCE_OPEN,
+  ZetkinJourneyInstance,
+  null
+>;
+
 export type ZetkinUpdateJourneyInstanceAddNote = ZetkinUpdateBase<
   UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE,
   ZetkinJourneyInstance,
@@ -93,4 +100,5 @@ export type ZetkinUpdate =
   | ZetkinUpdateJourneyInstanceAssignee
   | ZetkinUpdateJourneyInstanceClose
   | ZetkinUpdateJourneyInstanceMilestone
+  | ZetkinUpdateJourneyInstanceOpen
   | ZetkinUpdateJourneyInstanceStart;

--- a/src/utils/testing/mocks/mockUpdate.ts
+++ b/src/utils/testing/mocks/mockUpdate.ts
@@ -46,6 +46,11 @@ const mockUpdate = (
       target: mockJourneyInstance(),
       type: 'journeyinstance.create',
     },
+    [UPDATE_TYPES.JOURNEYINSTANCE_OPEN]: {
+      details: {},
+      target: pick(mockJourneyInstance(), ['id', 'title']),
+      type: 'journeyinstance.open',
+    },
     [UPDATE_TYPES.JOURNEYINSTANCE_REMOVEASSIGNEE]: {
       details: { assignee: mockPerson() },
       target: pick(mockJourneyInstance(), ['id', 'title']),

--- a/src/utils/testing/mocks/mockUpdate.ts
+++ b/src/utils/testing/mocks/mockUpdate.ts
@@ -36,6 +36,11 @@ const mockUpdate = (
       target: pick(mockJourneyInstance(), ['id', 'title']),
       type: 'journeyinstance.addnote',
     },
+    [UPDATE_TYPES.JOURNEYINSTANCE_CLOSE]: {
+      details: { outcome: '' },
+      target: pick(mockJourneyInstance(), ['id', 'title']),
+      type: 'journeyinstance.close',
+    },
     [UPDATE_TYPES.JOURNEYINSTANCE_CREATE]: {
       details: { data: mockJourneyInstance() },
       target: mockJourneyInstance(),


### PR DESCRIPTION
## Description
This PR adds rendering capabilities for `journeyinstance.close` and `journeyinstance.open` timeline updates.


## Screenshots
![image](https://user-images.githubusercontent.com/550212/169776667-c30a1164-db0d-471b-abcb-cfdf9ffa3ddc.png)



## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a timeline update component for `journeyinstance.close` updates
* Creates a new "generic" timeline update components for those situations where the update is just rendered as a simple (localized) string
* Uses the new generic update component for `journeyinstance.open` updates
* Adds Storybook stories for the new components

## Notes to reviewer
This requires changes to the API to work, as these are new update types. Those changes are not deployed yet, so it will not be possible to test this against the dev server API.

## Related issues
Resolves #589
