### PR TITLE
Issue 679/local time

### DIFF
--- a/src/components/Timeline/updates/elements/UpdateHeader.tsx
+++ b/src/components/Timeline/updates/elements/UpdateHeader.tsx
@@ -14,7 +14,7 @@ const UpdateHeader: React.FC<UpdateHeaderProps> = ({ children, timestamp }) => {
         {children}
       </Typography>
       <Typography color="textSecondary" component={Grid} item variant="body2">
-        <ZetkinRelativeTime convertToLocal datetime={timestamp} />
+        <ZetkinRelativeTime convertToLocal datetime={timestamp} forcePast />
       </Typography>
     </Grid>
   );

--- a/src/components/Timeline/updates/elements/UpdateHeader.tsx
+++ b/src/components/Timeline/updates/elements/UpdateHeader.tsx
@@ -14,7 +14,7 @@ const UpdateHeader: React.FC<UpdateHeaderProps> = ({ children, timestamp }) => {
         {children}
       </Typography>
       <Typography color="textSecondary" component={Grid} item variant="body2">
-        <ZetkinRelativeTime datetime={timestamp} />
+        <ZetkinRelativeTime convertToLocal datetime={timestamp} />
       </Typography>
     </Grid>
   );

--- a/src/components/ZetkinDateTime.tsx
+++ b/src/components/ZetkinDateTime.tsx
@@ -1,10 +1,12 @@
 import { FormattedDate, FormattedTime } from 'react-intl';
 
 interface ZetkinDateTimeProps {
+  convertToLocal?: boolean;
   datetime: string; // iso datetime string
 }
 
 const ZetkinDateTime: React.FunctionComponent<ZetkinDateTimeProps> = ({
+  convertToLocal,
   datetime,
 }) => {
   return (
@@ -12,10 +14,12 @@ const ZetkinDateTime: React.FunctionComponent<ZetkinDateTimeProps> = ({
       <FormattedDate
         day="numeric"
         month="long"
-        value={datetime}
+        value={convertToLocal ? new Date(datetime + 'Z') : datetime}
         year="numeric"
       />{' '}
-      <FormattedTime value={datetime} />
+      <FormattedTime
+        value={convertToLocal ? new Date(datetime + 'Z') : datetime}
+      />
     </>
   );
 };

--- a/src/components/ZetkinDateTime.tsx
+++ b/src/components/ZetkinDateTime.tsx
@@ -9,17 +9,11 @@ const ZetkinDateTime: React.FunctionComponent<ZetkinDateTimeProps> = ({
   convertToLocal,
   datetime,
 }) => {
+  const value = convertToLocal ? new Date(datetime + 'Z') : datetime;
   return (
     <>
-      <FormattedDate
-        day="numeric"
-        month="long"
-        value={convertToLocal ? new Date(datetime + 'Z') : datetime}
-        year="numeric"
-      />{' '}
-      <FormattedTime
-        value={convertToLocal ? new Date(datetime + 'Z') : datetime}
-      />
+      <FormattedDate day="numeric" month="long" value={value} year="numeric" />{' '}
+      <FormattedTime value={value} />
     </>
   );
 };

--- a/src/components/ZetkinRelativeTime.spec.tsx
+++ b/src/components/ZetkinRelativeTime.spec.tsx
@@ -1,0 +1,15 @@
+import { render } from 'utils/testing';
+import ZetkinRelativeTime from './ZetkinRelativeTime';
+
+describe('<ZetkinRelativeTime />', () => {
+  it('does not display time in the future if forcePast is set.', () => {
+    const mockDatetime = new Date();
+    mockDatetime.setDate(new Date().getDate() + 1);
+
+    const { getByText } = render(
+      <ZetkinRelativeTime datetime={mockDatetime.toISOString()} forcePast />
+    );
+
+    expect(getByText('now')).toBeTruthy();
+  });
+});

--- a/src/components/ZetkinRelativeTime.tsx
+++ b/src/components/ZetkinRelativeTime.tsx
@@ -5,14 +5,19 @@ import { Tooltip } from '@material-ui/core';
 import ZetkinDateTime from './ZetkinDateTime';
 
 interface ZetkinRelativeTimeProps {
+  convertToLocal?: boolean;
   datetime: string; // iso datetime string
 }
 
 const ZetkinRelativeTime: React.FunctionComponent<ZetkinRelativeTimeProps> = ({
+  convertToLocal,
   datetime,
 }) => {
   const now = dayjs();
-  const absoluteDatetime = dayjs(datetime);
+  const absoluteDatetime = dayjs(
+    convertToLocal ? new Date(datetime + 'Z') : datetime
+  );
+
   const difference: number = absoluteDatetime.unix() - now.unix();
 
   if (isNaN(difference)) {
@@ -20,7 +25,10 @@ const ZetkinRelativeTime: React.FunctionComponent<ZetkinRelativeTimeProps> = ({
   }
 
   return (
-    <Tooltip arrow title={<ZetkinDateTime datetime={datetime} />}>
+    <Tooltip
+      arrow
+      title={<ZetkinDateTime convertToLocal datetime={datetime} />}
+    >
       <span>
         <FormattedRelativeTime
           numeric="auto"

--- a/src/components/ZetkinRelativeTime.tsx
+++ b/src/components/ZetkinRelativeTime.tsx
@@ -7,18 +7,24 @@ import ZetkinDateTime from './ZetkinDateTime';
 interface ZetkinRelativeTimeProps {
   convertToLocal?: boolean;
   datetime: string; // iso datetime string
+  forcePast?: boolean;
 }
 
 const ZetkinRelativeTime: React.FunctionComponent<ZetkinRelativeTimeProps> = ({
   convertToLocal,
   datetime,
+  forcePast,
 }) => {
   const now = dayjs();
   const absoluteDatetime = dayjs(
     convertToLocal ? new Date(datetime + 'Z') : datetime
   );
 
-  const difference: number = absoluteDatetime.unix() - now.unix();
+  //if forcePast is set and datetime is in the future, set time to "now"
+  const difference: number =
+    forcePast && absoluteDatetime.unix() - now.unix() > 0
+      ? 0
+      : absoluteDatetime.unix() - now.unix();
 
   if (isNaN(difference)) {
     return null;


### PR DESCRIPTION
## Description
This PR adds properties convertToLocal to ZetkinRelativeTime and ZetkinDateTime, and forcePast to ZetkinRelativeTime. convertToLocal localises time, and is to be used where timestamps are set by the server. forcePast is used to make sure events we *KNOW* are always in the past does not accidentaly display as being in the future, if fx someone's computer clock is off by a few mins.


## Changes
- convertToLocal prop on ZetkinRelativeTime and ZetkinDateTime
- forcePast prop on ZetkinRelativeTime
- test for forcePast
- apply these on the UpdateHeader in the timeline


## Related issues
Resolves #679 
