### PR TITLE
Edit journey instance title in place.

### DIFF
--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -1,6 +1,9 @@
 conversionSnackbar:
   error: Something went wrong in converting the journey.
   success: Journey conversion successful!
+editJourneyTitleAlert:
+  error: Error. Title not updated.
+  success: Updated title!
 journeyInstanceCloseButton:
   dialog:
     outcomeFieldPlaceholder: Describe the outcome of the case


### PR DESCRIPTION
## Description
Makes the title of a journey instance editable in place.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/170033920-2286938d-520d-4b0d-b059-4e86406bbe6e.png)

## Changes
* Adds an EditTextInPlace to the journey instance layout title.

## Related issues
Resolves #674 
