### PR TITLE
Issue 681/avoid confusion summary

### DIFF
--- a/src/components/ZetkinAutoTextArea.tsx
+++ b/src/components/ZetkinAutoTextArea.tsx
@@ -18,12 +18,16 @@ const useStyles = makeStyles((theme) => ({
 interface ZetkinAutoTextAreaProps {
   value: string;
   onChange: (value: string) => void;
+  placeholder?: string;
 }
 
 const ZetkinAutoTextArea = React.forwardRef<
   HTMLTextAreaElement,
   ZetkinAutoTextAreaProps
->(function ZetkinAutoTextArea({ onChange, value, ...restProps }, ref) {
+>(function ZetkinAutoTextArea(
+  { onChange, value, placeholder, ...restProps },
+  ref
+) {
   const classes = useStyles();
 
   return (
@@ -32,6 +36,7 @@ const ZetkinAutoTextArea = React.forwardRef<
       className={classes.textarea}
       data-testid="ZetkinAutoTextArea-textarea"
       onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
       value={value}
       {...restProps}
     />

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -120,6 +120,7 @@ const JourneyInstanceSummary = ({
               color="secondary"
               onClick={() => setEditingSummary(true)}
               style={{
+                cursor: 'pointer',
                 padding: '1rem 0 1rem 0',
               }}
               variant="body1"

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -35,6 +35,12 @@ const JourneyInstanceSummary = ({
 
   const [editingSummary, setEditingSummary] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>(journeyInstance.summary);
+  const summaryPlaceholder = intl.formatMessage(
+    {
+      id: 'pages.organizeJourneyInstance.summaryPlaceholder',
+    },
+    { journeyTitle: journeyInstance.journey.title.toLowerCase() }
+  );
 
   const journeyInstanceHooks = journeyInstanceResource(
     orgId as string,
@@ -93,25 +99,34 @@ const JourneyInstanceSummary = ({
           ref={editingRef}
           data-testid="JourneyInstanceSummary-textArea"
           onChange={(value) => setSummary(value)}
-          placeholder={intl.formatMessage(
-            {
-              id: 'pages.organizeJourneyInstance.summaryPlaceholder',
-            },
-            { journeyTitle: journeyInstance.journey.title.toLowerCase() }
-          )}
+          placeholder={summaryPlaceholder}
           value={summary}
         />
       ) : (
         <>
-          <Typography
-            className={summaryCollapsed ? classes.collapsed : ''}
-            style={{
-              padding: '1rem 0 1rem 0',
-            }}
-            variant="body1"
-          >
-            {journeyInstance.summary}
-          </Typography>
+          {journeyInstance.summary.length > 0 ? (
+            <Typography
+              className={summaryCollapsed ? classes.collapsed : ''}
+              style={{
+                padding: '1rem 0 1rem 0',
+              }}
+              variant="body1"
+            >
+              {journeyInstance.summary}
+            </Typography>
+          ) : (
+            <Typography
+              className={summaryCollapsed ? classes.collapsed : ''}
+              color="secondary"
+              onClick={() => setEditingSummary(true)}
+              style={{
+                padding: '1rem 0 1rem 0',
+              }}
+              variant="body1"
+            >
+              {summaryPlaceholder}
+            </Typography>
+          )}
           {journeyInstance.summary.length > 100 && (
             <Button
               color="primary"

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -93,6 +93,12 @@ const JourneyInstanceSummary = ({
           ref={editingRef}
           data-testid="JourneyInstanceSummary-textArea"
           onChange={(value) => setSummary(value)}
+          placeholder={intl.formatMessage(
+            {
+              id: 'pages.organizeJourneyInstance.summaryPlaceholder',
+            },
+            { journeyTitle: journeyInstance.journey.title.toLowerCase() }
+          )}
           value={summary}
         />
       ) : (

--- a/src/locale/pages/organizeJourneyInstance/en.yml
+++ b/src/locale/pages/organizeJourneyInstance/en.yml
@@ -17,3 +17,4 @@ sections:
   milestones: Milestones
   summary: Summary
   timeline: Notes
+summaryPlaceholder: Enter a brief description of the status of this {journeyTitle}.

--- a/src/locale/pages/organizeNewJourneyInstance/en.yml
+++ b/src/locale/pages/organizeNewJourneyInstance/en.yml
@@ -1,3 +1,4 @@
 draft: Draft
+openingNote: Opening note
 submitLabel: Create new {journey}
 title: New {journey}

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { useIntl } from 'react-intl';
-import { Box, Chip, Grid, useTheme } from '@material-ui/core';
+import { Box, Chip, Grid, Typography, useTheme } from '@material-ui/core';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useState } from 'react';
 
 import DefaultLayout from 'layout/organize/DefaultLayout';
@@ -161,6 +161,13 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
             <Box p={3}>
               <Grid container justifyContent="space-between" spacing={2}>
                 <Grid item md={6}>
+                  <Typography
+                    color="secondary"
+                    style={{ marginBottom: '1.5rem' }}
+                    variant="h6"
+                  >
+                    <Msg id="pages.organizeNewJourneyInstance.openingNote" />
+                  </Typography>
                   <ZetkinAutoTextArea
                     onChange={(value) => {
                       setNote(value);


### PR DESCRIPTION
## Description
Adds a header to the opening note, and a placeholder to the journey instance summary, to solve confusion. 

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/170100990-350a04f8-45b5-4f1f-8b91-0f08ba66c755.png)
![bild](https://user-images.githubusercontent.com/58265097/170101023-91259e94-6f99-4a69-815c-7c28c1610842.png)

## Changes
* Adds "Opening note" header
* Adds placeholder in journey instance summary 
* Makes ZetkinAutoTextArea take an optional placeholder prop

## Related issues
Resolves #681 
