### PR TITLE
Issue 618/person view 404

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,43 +1,52 @@
 module.exports = {
-    async redirects() {
-        return [
-            {
-                source: '/:prevPath*/calendar/events',
-                destination: '/:prevPath*/calendar',
-                permanent: false,
-            },
-            {
-                source: '/:prevPath*/calendar/tasks',
-                destination: '/:prevPath*/calendar',
-                permanent: false,
-            },
-            // redirects to Gen2 for MVP August 2021
-            {
-                source: '/organize/:orgId(\\d{1,})',
-                destination: 'https://organize.zetk.in/?org=:orgId',
-                permanent: false,
-            },
-            {
-                source: '/organize/:orgId(\\d{1,})/areas',
-                destination: 'https://organize.zetk.in/maps?org=:orgId',
-                permanent: false,
-            },
-            {
-                source: '/organize/:orgId(\\d{1,})/campaigns/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
-                permanent: false,
-            },
-            {
-                source: '/organize/:orgId(\\d{1,})/campaigns/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
-                destination: 'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
-                permanent: false,
-            },
-            // all paths with /o redirected to Gen2
-            {
-                source: '/o/:path*',
-                destination: 'https://zetk.in/o/:path*',
-                permanent: false,
-            },
-        ]
-    },
+  async redirects() {
+    return [
+      {
+        source: '/:prevPath*/calendar/events',
+        destination: '/:prevPath*/calendar',
+        permanent: false,
+      },
+      {
+        source: '/:prevPath*/calendar/tasks',
+        destination: '/:prevPath*/calendar',
+        permanent: false,
+      },
+      {
+        source: `/:prevPath*/people/views`,
+        destination: '/:prevPath*/people',
+        permanent: true,
+      },
+      // redirects to Gen2 for MVP August 2021
+      {
+        source: '/organize/:orgId(\\d{1,})',
+        destination: 'https://organize.zetk.in/?org=:orgId',
+        permanent: false,
+      },
+      {
+        source: '/organize/:orgId(\\d{1,})/areas',
+        destination: 'https://organize.zetk.in/maps?org=:orgId',
+        permanent: false,
+      },
+      {
+        source:
+          '/organize/:orgId(\\d{1,})/campaigns/calendar/events/:eventId(\\d{1,})',
+        destination:
+          'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
+        permanent: false,
+      },
+      {
+        source:
+          '/organize/:orgId(\\d{1,})/campaigns/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
+        destination:
+          'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
+        permanent: false,
+      },
+      // all paths with /o redirected to Gen2
+      {
+        source: '/o/:path*',
+        destination: 'https://zetk.in/o/:path*',
+        permanent: false,
+      },
+    ];
+  },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -12,8 +12,8 @@ module.exports = {
         permanent: false,
       },
       {
-        source: `/:prevPath*/people/views`,
-        destination: '/:prevPath*/people',
+        source: `/organize/:orgId/people/views`,
+        destination: '/organize/:orgId/people',
         permanent: true,
       },
       // redirects to Gen2 for MVP August 2021

--- a/playwright/tests/organize/people/views/redirect.spec.ts
+++ b/playwright/tests/organize/people/views/redirect.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+import test from '../../../../fixtures/next';
+
+import KPD from '../../../../mockData/orgs/KPD';
+
+test('Navigating to /organize/:orgId/people/views redirects to views page', async ({
+  login,
+  page,
+  appUri,
+  moxy,
+}) => {
+  login();
+  moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+  moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
+
+  await page.goto(appUri + '/organize/1/people/views');
+
+  // Expect to have been redirected
+  expect(page.url()).not.toEqual(appUri + '/organize/1/people/views');
+  expect(page.url()).toEqual(appUri + '/organize/1/people');
+
+  moxy.teardown();
+});


### PR DESCRIPTION
## Description
This PR fixes the issue where navigating to `/organize/1/people/views` loaded the person page with the wrong data. Now the user is redirected to `/organize/1/people`

## Changes

* Adds
  * Redirect in `next.config.js` to redirect to the views url. 
    * A playwright test for this 

## Related issues
Resolves #618 
