### PR TITLE
localise and improve journey card style

### DIFF
--- a/src/components/organize/journeys/JourneyCard.tsx
+++ b/src/components/organize/journeys/JourneyCard.tsx
@@ -1,14 +1,7 @@
 import { FormattedMessage as Msg } from 'react-intl';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import {
-  Box,
-  Card,
-  CardActions,
-  CardContent,
-  Link,
-  Typography,
-} from '@material-ui/core';
+import { Box, Card, CardActionArea, Link, Typography } from '@material-ui/core';
 
 import { ZetkinJourney } from 'types/zetkin';
 
@@ -18,31 +11,36 @@ interface JourneyCardProps {
 
 const JourneyCard = ({ journey }: JourneyCardProps): JSX.Element => {
   const { orgId } = useRouter().query;
-  const { id, singular_label, stats } = journey;
+  const { id, title, stats } = journey;
 
   return (
     <Card data-testid="journey-card">
-      <CardContent>
-        <Typography gutterBottom noWrap variant="h5">
-          {singular_label}
-        </Typography>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'row',
-          }}
-        >
-          <Typography>{`${stats.open} open`}</Typography>
-          <Typography color="secondary">{`${stats.closed} closed`}</Typography>
-        </Box>
-      </CardContent>
-      <CardActions>
-        <NextLink href={`/organize/${orgId}/journeys/${id}`} passHref>
-          <Link variant="button">
-            <Msg id="pages.organizeJourneys.cardCTA" />
-          </Link>
-        </NextLink>
-      </CardActions>
+      <NextLink href={`/organize/${orgId}/journeys/${id}`} passHref>
+        <CardActionArea>
+          <Box p={1.5}>
+            <Typography gutterBottom variant="h5">
+              {title}
+            </Typography>
+            <Typography component="span">
+              <Msg
+                id="pages.organizeJourneys.openCount"
+                values={{ numberOpen: stats.open }}
+              />{' '}
+              <Typography color="secondary" component="span">
+                <Msg
+                  id="pages.organizeJourneys.closedCount"
+                  values={{ numberClosed: stats.closed }}
+                />
+              </Typography>
+            </Typography>
+            <Box mt={3}>
+              <Link variant="button">
+                <Msg id="pages.organizeJourneys.cardCTA" />
+              </Link>
+            </Box>
+          </Box>
+        </CardActionArea>
+      </NextLink>
     </Card>
   );
 };

--- a/src/locale/pages/organizeJourneys/en.yml
+++ b/src/locale/pages/organizeJourneys/en.yml
@@ -1,1 +1,3 @@
 cardCTA: View all
+closedCount: '{numberClosed} closed'
+openCount: '{numberOpen} open'

--- a/src/pages/organize/[orgId]/journeys/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
+import { Grid } from '@material-ui/core';
 import Head from 'next/head';
 import { useIntl } from 'react-intl';
-import { Box, Grid } from '@material-ui/core';
 
 import JourneyCard from 'components/organize/journeys/JourneyCard';
 import JourneysLayout from 'layout/organize/JourneysLayout';
@@ -70,17 +70,13 @@ const AllJourneysOverviewPage: PageWithLayout<AllJourneysOverviewPageProps> = ({
           id: 'misc.journeys.overview.overviewTitle',
         })}
       >
-        <Box
-          display="grid"
-          gridGap={20}
-          gridTemplateColumns="repeat( auto-fit, minmax(450px, 1fr) )"
-        >
+        <Grid container spacing={2}>
           {journeys.map((journey: ZetkinJourney) => (
-            <Grid key={journey.id} item>
+            <Grid key={journey.id} item lg={4} md={6} xl={3} xs={12}>
               <JourneyCard journey={journey} />
             </Grid>
           ))}
-        </Box>
+        </Grid>
       </ZetkinSection>
     </>
   );


### PR DESCRIPTION
## Description
This PR improves the style of the `JourneyCard`.

## Screenshots
![Screenshot from 2022-05-25 11-15-44](https://user-images.githubusercontent.com/41007222/170239726-89406dbd-4bd2-4623-8885-8adaa191290d.png)


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds
  * Locale strings for localising the number of open and closed journeys 
* Changes
  * Unifies padding inside the carad
  * Improves spacing between open and closed labels
  * The entire card is now clickable 
  * Uses the journey title instead of singular label
  * Improves the breakpoints of the grid on the journeys page.

## Related issues
Resolves #678 
