### PR TITLE
Saves on blur + no tooltip when editing.

### DIFF
--- a/src/components/EditTextInPlace/index.spec.tsx
+++ b/src/components/EditTextInPlace/index.spec.tsx
@@ -8,7 +8,7 @@ const props: EditTextinPlaceProps = {
   value: 'Current Text',
 };
 
-describe.only('EditTextInPlace', () => {
+describe('EditTextInPlace', () => {
   it('shows the current text', () => {
     const { getByDisplayValue } = render(<EditTextinPlace {...props} />);
     const inputEl = getByDisplayValue(props.value);

--- a/src/components/EditTextInPlace/index.spec.tsx
+++ b/src/components/EditTextInPlace/index.spec.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act, render } from 'utils/testing';
 import EditTextinPlace, { EditTextinPlaceProps } from '.';
@@ -7,7 +8,7 @@ const props: EditTextinPlaceProps = {
   value: 'Current Text',
 };
 
-describe('EditTextInPlace', () => {
+describe.only('EditTextInPlace', () => {
   it('shows the current text', () => {
     const { getByDisplayValue } = render(<EditTextinPlace {...props} />);
     const inputEl = getByDisplayValue(props.value);
@@ -26,17 +27,15 @@ describe('EditTextInPlace', () => {
     expect(tooltip).not.toBeNull();
   });
 
-  it('shows a tooltip informing the user to press enter to save when focussed', async () => {
-    const { getByDisplayValue, findByText } = render(
+  it('shows no tooltip when editing.', async () => {
+    const { getByDisplayValue, queryByRole } = render(
       <EditTextinPlace {...props} />
     );
     const inputEl = getByDisplayValue(props.value);
-    userEvent.hover(inputEl);
     userEvent.click(inputEl);
-    const tooltip = await findByText(
-      'misc.components.editTextInPlace.tooltip.save'
-    );
-    expect(tooltip).not.toBeNull();
+    userEvent.hover(inputEl);
+    const tooltip = queryByRole('tooltip');
+    expect(tooltip).toBeNull();
   });
 
   it('shows a tooltip informing the user the field must not be empty when no text', async () => {
@@ -44,9 +43,9 @@ describe('EditTextInPlace', () => {
       <EditTextinPlace {...props} />
     );
     const inputEl = getByDisplayValue(props.value);
-    userEvent.hover(inputEl);
     userEvent.click(inputEl);
     userEvent.clear(inputEl);
+    userEvent.hover(inputEl);
     const tooltip = await findByText(
       'misc.components.editTextInPlace.tooltip.noEmpty'
     );
@@ -109,5 +108,21 @@ describe('EditTextInPlace', () => {
       userEvent.keyboard('{enter}');
     });
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers onChange when text is submitted with click away', async () => {
+    const onChange = jest.fn(props.onChange);
+    const { getByDisplayValue } = render(
+      <EditTextinPlace {...{ ...props, onChange }} />
+    );
+    const inputEl = getByDisplayValue(props.value);
+    userEvent.click(inputEl);
+    userEvent.clear(inputEl);
+    userEvent.paste(inputEl, 'New Text');
+
+    fireEvent.blur(inputEl);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('New Text');
   });
 });

--- a/src/components/EditTextInPlace/index.tsx
+++ b/src/components/EditTextInPlace/index.tsx
@@ -1,10 +1,5 @@
 import { useIntl } from 'react-intl';
-import {
-  ClickAwayListener,
-  FormControl,
-  InputBase,
-  Tooltip,
-} from '@material-ui/core';
+import { FormControl, InputBase, Tooltip } from '@material-ui/core';
 import { lighten, makeStyles } from '@material-ui/core/styles';
 import { useEffect, useRef, useState } from 'react';
 
@@ -84,20 +79,25 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
     }
   }, [spanRef.current, inputRef.current, editing, text]);
 
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+    } else {
+      inputRef.current?.blur();
+    }
+  }, [editing]);
+
   const startEditing = () => {
     setEditing(true);
-    inputRef?.current?.focus();
   };
 
   const cancelEditing = () => {
     setEditing(false);
-    inputRef?.current?.blur();
     // Set text back to value passed in props
     setText(value);
   };
 
   const submitChange = () => {
-    inputRef?.current?.blur();
     setEditing(false);
     onChange(text);
   };
@@ -115,44 +115,57 @@ const EditTextinPlace: React.FunctionComponent<EditTextinPlaceProps> = ({
     }
   };
 
-  return (
-    <ClickAwayListener onClickAway={cancelEditing}>
-      <Tooltip
-        arrow
-        disableHoverListener={editing}
-        title={
-          text || allowEmpty
-            ? intl.formatMessage({
-                id: `misc.components.editTextInPlace.tooltip.${
-                  editing ? 'save' : 'edit'
-                }`,
-              })
-            : intl.formatMessage({
-                id: 'misc.components.editTextInPlace.tooltip.noEmpty',
-              })
+  const onBlur = () => {
+    if (editing) {
+      if (!!text || allowEmpty) {
+        if (text === value) {
+          cancelEditing();
+        } else {
+          submitChange();
         }
-      >
-        <FormControl style={{ overflow: 'hidden' }}>
-          <span ref={spanRef} className={classes.span}>
-            {text || placeholder}
-          </span>
-          <InputBase
-            classes={{
-              input: classes.input,
-              root: classes.inputRoot,
-            }}
-            disabled={disabled}
-            inputRef={inputRef}
-            onChange={(e) => setText(e.target.value)}
-            onFocus={startEditing}
-            onKeyDown={onKeyDown}
-            placeholder={placeholder}
-            readOnly={!editing}
-            value={text}
-          />
-        </FormControl>
-      </Tooltip>
-    </ClickAwayListener>
+      }
+    }
+  };
+
+  const tooltipText = () => {
+    if (text || allowEmpty) {
+      if (editing) {
+        return '';
+      } else {
+        return intl.formatMessage({
+          id: 'misc.components.editTextInPlace.tooltip.edit',
+        });
+      }
+    } else {
+      return intl.formatMessage({
+        id: 'misc.components.editTextInPlace.tooltip.noEmpty',
+      });
+    }
+  };
+
+  return (
+    <Tooltip arrow disableHoverListener={editing} title={tooltipText()}>
+      <FormControl style={{ overflow: 'hidden' }}>
+        <span ref={spanRef} className={classes.span}>
+          {text || placeholder}
+        </span>
+        <InputBase
+          classes={{
+            input: classes.input,
+            root: classes.inputRoot,
+          }}
+          disabled={disabled}
+          inputRef={inputRef}
+          onBlur={onBlur}
+          onChange={(e) => setText(e.target.value)}
+          onFocus={startEditing}
+          onKeyDown={onKeyDown}
+          placeholder={placeholder}
+          readOnly={!editing}
+          value={text}
+        />
+      </FormControl>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
## Description
This PR makes EditTextInPlace save on blur = when clicking away, tabbing away etc.

## Changes
Removes ClickAwayListener in favor of good ol' onBlur
Sets blur and focus in a useEffect

## Related issues
Resolves #675 
