### PR TITLE
Issue 682/submit button summary

### DIFF
--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -55,13 +55,18 @@ const JourneyInstanceSummary = ({
   }, [editingSummary]);
 
   const saveEditedSummary = async () => {
-    await patchJourneyInstanceMutation.mutateAsync(
+    return await patchJourneyInstanceMutation.mutateAsync(
       { summary },
       {
         onError: () => showSnackbar('error'),
         onSuccess: () => setEditingSummary(false),
       }
     );
+  };
+
+  const cancelEditingSummary = () => {
+    setEditingSummary(false);
+    setSummary(journeyInstance.summary);
   };
 
   return (
@@ -89,8 +94,9 @@ const JourneyInstanceSummary = ({
           onSubmit={async (e) => {
             e.stopPropagation();
             e.preventDefault();
-            await saveEditedSummary();
+            const patchedInstance = await saveEditedSummary();
             setEditingSummary(false);
+            setSummary(patchedInstance.summary);
           }}
         >
           <ZetkinAutoTextArea
@@ -100,7 +106,10 @@ const JourneyInstanceSummary = ({
             placeholder={summaryPlaceholder}
             value={summary}
           />
-          <SubmitCancelButtons onCancel={() => setEditingSummary(false)} />
+          <SubmitCancelButtons
+            onCancel={cancelEditingSummary}
+            submitDisabled={patchJourneyInstanceMutation.isLoading}
+          />
         </form>
       ) : (
         // Not editing

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -1,12 +1,13 @@
+import { Edit } from '@material-ui/icons';
 import { useRouter } from 'next/router';
 import { Button, makeStyles, Typography } from '@material-ui/core';
-import { Edit, Save } from '@material-ui/icons';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import { journeyInstanceResource } from 'api/journeys';
 import SnackbarContext from 'hooks/SnackbarContext';
+import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 import ZetkinSection from 'components/ZetkinSection';
@@ -42,11 +43,10 @@ const JourneyInstanceSummary = ({
     { journeyTitle: journeyInstance.journey.title.toLowerCase() }
   );
 
-  const journeyInstanceHooks = journeyInstanceResource(
+  const patchJourneyInstanceMutation = journeyInstanceResource(
     orgId as string,
     journeyInstance.id.toString()
-  );
-  const patchJourneyInstanceMutation = journeyInstanceHooks.useUpdate();
+  ).useUpdate();
 
   useEffect(() => {
     if (editingRef.current) {
@@ -54,8 +54,8 @@ const JourneyInstanceSummary = ({
     }
   }, [editingSummary]);
 
-  const saveEditedSummary = (summary: string) => {
-    patchJourneyInstanceMutation.mutateAsync(
+  const saveEditedSummary = async () => {
+    await patchJourneyInstanceMutation.mutateAsync(
       { summary },
       {
         onError: () => showSnackbar('error'),
@@ -64,51 +64,53 @@ const JourneyInstanceSummary = ({
     );
   };
 
-  const submitChange = () => {
-    setEditingSummary(false);
-    saveEditedSummary(summary);
-  };
-
   return (
     <ZetkinSection
       action={
-        <Button
-          color="primary"
-          data-testid="JourneyInstanceSummary-saveEditButton"
-          onClick={
-            editingSummary ? submitChange : () => setEditingSummary(true)
-          }
-          startIcon={editingSummary ? <Save /> : <Edit />}
-          style={{ textTransform: 'uppercase' }}
-        >
-          <Msg
-            id={
-              editingSummary
-                ? 'pages.organizeJourneyInstance.saveButton'
-                : 'pages.organizeJourneyInstance.editButton'
-            }
-          />
-        </Button>
+        editingSummary ? null : (
+          <Button
+            color="primary"
+            data-testid="JourneyInstanceSummary-editButton"
+            onClick={() => setEditingSummary(true)}
+            startIcon={<Edit />}
+            style={{ textTransform: 'uppercase' }}
+          >
+            <Msg id={'pages.organizeJourneyInstance.editButton'} />
+          </Button>
+        )
       }
       title={intl.formatMessage({
         id: 'pages.organizeJourneyInstance.sections.summary',
       })}
     >
       {editingSummary ? (
-        <ZetkinAutoTextArea
-          ref={editingRef}
-          data-testid="JourneyInstanceSummary-textArea"
-          onChange={(value) => setSummary(value)}
-          placeholder={summaryPlaceholder}
-          value={summary}
-        />
+        // Editing
+        <form
+          onSubmit={async (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            await saveEditedSummary();
+            setEditingSummary(false);
+          }}
+        >
+          <ZetkinAutoTextArea
+            ref={editingRef}
+            data-testid="JourneyInstanceSummary-textArea"
+            onChange={(value) => setSummary(value)}
+            placeholder={summaryPlaceholder}
+            value={summary}
+          />
+          <SubmitCancelButtons onCancel={() => setEditingSummary(false)} />
+        </form>
       ) : (
+        // Not editing
         <>
           {journeyInstance.summary.length > 0 ? (
             <Typography
               className={summaryCollapsed ? classes.collapsed : ''}
+              onClick={() => setEditingSummary(true)}
               style={{
-                padding: '1rem 0 1rem 0',
+                padding: '0.75rem 0',
               }}
               variant="body1"
             >

--- a/src/locale/misc/updates/en.yml
+++ b/src/locale/misc/updates/en.yml
@@ -14,7 +14,7 @@ journeyinstance:
   removeassignee: '{actor} unassigned {assignee}'
   removesubject: '{actor} removed {subject}'
   update:
-    summary_text: '{actor} edited the summary'
+    summary: '{actor} edited the summary'
     title: '{actor} edited the title'
   updatemilestone:
     complete: '{actor} completed a milestone'

--- a/src/locale/pages/organizeJourneyInstance/en.yml
+++ b/src/locale/pages/organizeJourneyInstance/en.yml
@@ -12,7 +12,6 @@ expandButton: Expand
 markedCompleteLabel: Marked complete {relativeTime}
 noMilestones: There are no milestones.
 percentComplete: '{percentComplete}% complete'
-saveButton: Save
 sections:
   assigned: Assigned to
   members: Members


### PR DESCRIPTION
## Description
This PR implements the `<SubmitCancelButtons />` component on the journey summary. It also updates locale strings!


## Screenshots
![Screenshot from 2022-05-26 14-00-31](https://user-images.githubusercontent.com/41007222/170494670-3e4f044c-8446-4da2-9178-e84d003f3c81.png)


## Changes

* Changes
  * The edit button in the summary section header no longer becomes a save button when editing. It disappears when editing.
  * `<SubmitCancelButtons />` are used to save and cancel editing.
  * Padding is changed so the summary is roughly in the same place when editing.
  * Clicking the summary also allows the user to edit on a short summary, which was already supported for a long summary 


## Notes to reviewer
Try editing, cancelling, and cancelling after typing in text to check that it's working as expected.


## Related issues
Resolves #682
