### PR TITLE
Gen2 redirect page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,26 +19,24 @@ module.exports = {
       // redirects to Gen2 for MVP August 2021
       {
         source: '/organize/:orgId(\\d{1,})',
-        destination: 'https://organize.zetk.in/?org=:orgId',
+        destination: '/legacy?orgId=:orgId',
         permanent: false,
       },
       {
         source: '/organize/:orgId(\\d{1,})/areas',
-        destination: 'https://organize.zetk.in/maps?org=:orgId',
+        destination: '/legacy?path=/maps&orgId=:orgId',
         permanent: false,
       },
       {
         source:
           '/organize/:orgId(\\d{1,})/campaigns/calendar/events/:eventId(\\d{1,})',
-        destination:
-          'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
+        destination: '/legacy?path=/campaign/action%3A:eventId&orgId=:orgId',
         permanent: false,
       },
       {
         source:
           '/organize/:orgId(\\d{1,})/campaigns/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
-        destination:
-          'https://organize.zetk.in/campaign/action%3A:eventId?org=:orgId',
+        destination: '/legacy?path=/campaign/action%3A:eventId&orgId=:orgId',
         permanent: false,
       },
       // all paths with /o redirected to Gen2

--- a/src/locale/pages/legacy/en.yml
+++ b/src/locale/pages/legacy/en.yml
@@ -1,0 +1,6 @@
+continueButton: Continue to old Zetkin
+header: You are being redirected
+info: |
+  You are using a prerelease version of Zetkin and the link you clicked has
+  not yet been implemented. You are being redirected to the equivalent page
+  in an older version of Zetkin.

--- a/src/pages/legacy.tsx
+++ b/src/pages/legacy.tsx
@@ -1,0 +1,102 @@
+import Head from 'next/head';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { Box, Button, Card, Link, Typography } from '@material-ui/core';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { GetServerSideProps, NextPage } from 'next';
+
+import { scaffold } from 'utils/next';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (context) => {
+    const path = context.query.path || '';
+    const orgQuerystring = context.query.orgId
+      ? `?org=${context.query.orgId}`
+      : '';
+    const destination = `https://organize.zetk.in/${path}${orgQuerystring}`;
+
+    return {
+      props: {
+        destination,
+      },
+    };
+  },
+  {
+    localeScope: ['pages.legacy'],
+  }
+);
+
+interface LegacyPageProps {
+  destination: string;
+}
+
+const LegacyPage: NextPage<LegacyPageProps> = ({ destination }) => {
+  const intl = useIntl();
+  const router = useRouter();
+
+  return (
+    <>
+      <Head>
+        <title>{intl.formatMessage({ id: 'pages.legacy.header' })}</title>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+            html, body, body > div { height: 100%; padding: 0; margin: 0; }
+            `,
+          }}
+        />
+      </Head>
+      <Box
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          height: '100%',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      >
+        <Card
+          style={{
+            margin: 10,
+            maxWidth: 600,
+            padding: 20,
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h3">
+            <FormattedMessage id="pages.legacy.header" />
+          </Typography>
+          <Typography
+            style={{ marginBottom: 20, marginTop: 20 }}
+            variant="body1"
+          >
+            <FormattedMessage id="pages.legacy.info" />
+          </Typography>
+          <NextLink href={destination} passHref>
+            <Button color="primary" component="a" variant="contained">
+              <FormattedMessage id="pages.legacy.continueButton" />
+            </Button>
+          </NextLink>
+          <Typography
+            color="textSecondary"
+            style={{ marginTop: 4 }}
+            variant="body2"
+          >
+            <NextLink href="/" passHref>
+              <Link
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  router.back();
+                }}
+              >
+                No, take me back!
+              </Link>
+            </NextLink>
+          </Typography>
+        </Card>
+      </Box>
+    </>
+  );
+};
+
+export default LegacyPage;


### PR DESCRIPTION
## Description
This PR creates a small page through which all gen2 redirects can happen, to avoid user confusion when being redirected to a completely different site.

## Screenshots
<img width="840" alt="image" src="https://user-images.githubusercontent.com/550212/170857890-fc952519-98ee-4544-8bc9-a68a14c7fe30.png">


## Changes
* Adds a new page
* Updates all redirects to use redirect page

## Notes to reviewer
I didn't add this for the frontend (`/o/*`) redirects since they are only used in cases where the user is expecting to leave the site (e.g. public page of campaigns).

## Related issues
Resolves #709