### PR TITLE
use ZetkinDateTime to display date and time for created column

### DIFF
--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -1,8 +1,8 @@
-import dayjs from 'dayjs';
 import { GridColDef } from '@mui/x-data-grid-pro';
 
 import JourneyInstanceTitle from 'components/journeys/JourneyInstanceTitle';
 import PersonHoverCard from 'components/PersonHoverCard';
+import ZetkinDateTime from 'components/ZetkinDateTime';
 import ZetkinPerson from 'components/ZetkinPerson';
 import ZetkinRelativeTime from 'components/ZetkinRelativeTime';
 import {
@@ -29,9 +29,10 @@ export const getStaticColumns = (): GridColDef[] => [
   },
   {
     field: 'created',
+    renderCell: (params) => (
+      <ZetkinDateTime datetime={params.value as string} />
+    ),
     type: 'date',
-    valueFormatter: (params) =>
-      dayjs(params.value as string).format('MMMM D, YYYY'),
   },
   {
     field: 'updated',


### PR DESCRIPTION
## Description
This PR changes the journey view list so that the Created column shows the date and time that it was created. Previously it only showed the date. This helps users see which journey instance was created first and at what time of day.

## Screenshots
![Screenshot from 2022-05-30 15-31-40](https://user-images.githubusercontent.com/41007222/171013819-7fece84e-5244-463b-b354-f2d9decfb783.png)

## Changes

* Changes
  * Column "Created" renders the cell with the date and time 

