### PR TITLE
Issue 713/link journey instance item

### DIFF
--- a/src/components/ZetkinJourneyInstanceItem.tsx
+++ b/src/components/ZetkinJourneyInstanceItem.tsx
@@ -21,63 +21,66 @@ const ZetkinJourneyInstanceItem: React.FC<ZetkinJourneyInstanceItemProps> = ({
   const hasMeta = 'next_milestone' in instance;
 
   return (
-    <Grid container direction="column">
-      <Grid item>
-        <Box
-          alignItems="center"
-          display="flex"
-          flexWrap="wrap-reverse"
-          justifyContent="space-between"
-          style={{ gap: 5 }}
-        >
-          <Typography
-            color={isOpen ? 'textPrimary' : 'textSecondary'}
-            component="span"
-            data-testid="page-title"
-            variant="h5"
+    <NextLink
+      href={`/organize/${orgId}/journeys/${instance.journey.id}/${instance.id}`}
+    >
+      <Grid container direction="column" style={{ cursor: 'pointer' }}>
+        <Grid item>
+          <Box
+            alignItems="center"
+            display="flex"
+            flexWrap="wrap-reverse"
+            justifyContent="space-between"
+            style={{ gap: 5 }}
           >
-            <NextLink
-              href={`/organize/${orgId}/journeys/${instance.journey.id}/${instance.id}`}
-              passHref
+            <Typography
+              color={isOpen ? 'textPrimary' : 'textSecondary'}
+              component="span"
+              data-testid="page-title"
+              variant="h5"
             >
               <Link color="inherit">
                 {instance.title || instance.journey.title}
               </Link>
-            </NextLink>
-            <Typography color="textSecondary" component="span" variant="h5">
-              {' '}
-              {`#${instance.id}`}
-            </Typography>
-          </Typography>
-          <JourneyStatusChip instance={instance} />
-        </Box>
-      </Grid>
-      {isOpen && hasMeta && (
-        <>
-          <Grid item>
-            <Typography variant="body2">{instance.journey.title}</Typography>
-          </Grid>
-          {instance.next_milestone && (
-            <Grid container item>
-              <Typography
-                color="inherit"
-                style={{ alignItems: 'center', display: 'flex', marginTop: 8 }}
-                variant="body2"
-              >
-                <AccessTime color="inherit" style={{ marginRight: 4 }} />
-                {instance.next_milestone.title}
-                {instance.next_milestone.deadline && (
-                  <>
-                    {': '}
-                    <ZetkinDate datetime={instance.next_milestone.deadline} />
-                  </>
-                )}
+              <Typography color="textSecondary" component="span" variant="h5">
+                {' '}
+                {`#${instance.id}`}
               </Typography>
+            </Typography>
+            <JourneyStatusChip instance={instance} />
+          </Box>
+        </Grid>
+        {isOpen && hasMeta && (
+          <>
+            <Grid item>
+              <Typography variant="body2">{instance.journey.title}</Typography>
             </Grid>
-          )}
-        </>
-      )}
-    </Grid>
+            {instance.next_milestone && (
+              <Grid container item>
+                <Typography
+                  color="inherit"
+                  style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    marginTop: 8,
+                  }}
+                  variant="body2"
+                >
+                  <AccessTime color="inherit" style={{ marginRight: 4 }} />
+                  {instance.next_milestone.title}
+                  {instance.next_milestone.deadline && (
+                    <>
+                      {': '}
+                      <ZetkinDate datetime={instance.next_milestone.deadline} />
+                    </>
+                  )}
+                </Typography>
+              </Grid>
+            )}
+          </>
+        )}
+      </Grid>
+    </NextLink>
   );
 };
 

--- a/src/components/organize/people/PersonJourneysCard/index.tsx
+++ b/src/components/organize/people/PersonJourneysCard/index.tsx
@@ -27,11 +27,11 @@ const PersonJourneysCard: React.FC<PersonJourneysCardProps> = ({
     <ZetkinQuery queries={{ instancesQuery }}>
       {({ queries }) => (
         <PersonCard titleId="pages.people.person.journeys.title">
-          <List data-testid="PersonJourneysCard-list">
+          <List data-testid="PersonJourneysCard-list" disablePadding>
             {queries.instancesQuery.data
               .sort((i0, i1) => Number(!!i0.closed) - Number(!!i1.closed))
               .map((instance) => (
-                <ListItem key={instance.id} divider>
+                <ListItem key={instance.id} button divider>
                   <ZetkinJourneyInstanceItem
                     instance={instance}
                     orgId={instance.organization.id}

--- a/src/components/views/SuggestedViews/ClickableCard.tsx
+++ b/src/components/views/SuggestedViews/ClickableCard.tsx
@@ -1,39 +1,21 @@
 import { ReactEventHandler } from 'react';
-import { Card, CardActionArea, makeStyles } from '@material-ui/core';
+import { Box, Card, CardActionArea } from '@material-ui/core';
 
 interface ZetkinCardProps {
   onClick?: ReactEventHandler;
   value?: string | number;
 }
 
-const useStyles = makeStyles((theme) => ({
-  card: ({ hasClickHandler }: { hasClickHandler: boolean }) => ({
-    padding: theme.spacing(hasClickHandler ? 0 : 2),
-  }),
-  cardActionArea: {
-    padding: theme.spacing(2),
-  },
-}));
-
 const ClickableCard: React.FunctionComponent<ZetkinCardProps> = ({
   children,
   onClick,
   value,
 }) => {
-  const classes = useStyles({ hasClickHandler: !!onClick });
-
   return (
-    <Card className={classes.card}>
-      {!onClick && children}
-      {onClick && (
-        <CardActionArea
-          className={classes.cardActionArea}
-          onClick={onClick}
-          value={value}
-        >
-          {children}
-        </CardActionArea>
-      )}
+    <Card>
+      <CardActionArea onClick={onClick} value={value}>
+        <Box p={2}>{children}</Box>
+      </CardActionArea>
     </Card>
   );
 };


### PR DESCRIPTION
## Description
This PR makes the `<JourneyInstanceItem />` component so that clicking anywhere on it links to that journey. It also implements hover styles so that the item is highlighted when hovered wherever it is used.


## Changes
* Changes
  * [make entire journey instance item a link](https://github.com/zetkin/app.zetkin.org/commit/9427a8e86d6c205a5a87f7fc66b5cc1a0d2753d8) 
  * [highlights the journey instance in the journey list on the person page](https://github.com/zetkin/app.zetkin.org/pull/715/commits/6a967d3401dc3042ec02c5f0bef7c94705f43c2d)
   * [clickable card always shows action buttons](https://github.com/zetkin/app.zetkin.org/pull/715/commits/83a725492f955f6b5a977c757717c55052d0c2a3)

## Notes to reviewer
* Hover journey instance on person page, check it is highlighted.
* Click on journey instance on person page, check it redirects

* Hover journey instance in journey timeline, check it is highlighted
* Clicking on it redirects to...... same page.

## Related issues
Resolves #713
