### PR TITLE
Create Markdown component and use where marked() or CleanHtml was used.

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -8,7 +8,7 @@ interface MarkdownProps {
   markdown: string;
 }
 
-const Markdown = ({ BoxProps, markdown }: MarkdownProps): JSX.Element => {
+const Markdown: React.FC<MarkdownProps> = ({ BoxProps, markdown }) => {
   const dirtyHtml = marked(markdown);
   return <CleanHtml BoxProps={BoxProps} dirtyHtml={dirtyHtml} />;
 };

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,16 @@
+import { BoxProps } from '@material-ui/core';
+import { marked } from 'marked';
+
+import CleanHtml from './CleanHtml';
+
+interface MarkdownProps {
+  BoxProps?: BoxProps;
+  markdown: string;
+}
+
+const Markdown = ({ BoxProps, markdown }: MarkdownProps): JSX.Element => {
+  const dirtyHtml = marked(markdown);
+  return <CleanHtml BoxProps={BoxProps} dirtyHtml={dirtyHtml} />;
+};
+
+export default Markdown;

--- a/src/components/Timeline/updates/TimelineJourneyStart.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyStart.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
-import { Typography } from '@material-ui/core';
 
+import Markdown from 'components/Markdown';
 import UpdateContainer from './elements/UpdateContainer';
 import ZetkinJourneyInstanceCard from 'components/ZetkinJourneyInstanceCard';
 import ZetkinPersonLink from 'components/ZetkinPersonLink';
@@ -27,9 +27,10 @@ const TimelineJourneyStart: React.FC<TimelineJourneyStartProps> = ({
         instance={update.details.data}
         orgId={update.organization.id}
       />
-      <Typography style={{ margin: '1em 0' }}>
-        {update.details.data.opening_note}
-      </Typography>
+      <Markdown
+        BoxProps={{ margin: '1rem 0' }}
+        markdown={update.details.data.opening_note}
+      />
     </UpdateContainer>
   );
 };

--- a/src/components/Timeline/updates/TimelineNoteAdded.tsx
+++ b/src/components/Timeline/updates/TimelineNoteAdded.tsx
@@ -1,9 +1,8 @@
 import { FormattedMessage } from 'react-intl';
-import { marked } from 'marked';
 import { Box, makeStyles } from '@material-ui/core';
 
-import CleanHtml from 'components/CleanHtml';
 import EmailLoader from './elements/EmailLoader';
+import Markdown from 'components/Markdown';
 import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinFile } from 'types/zetkin';
 import { ZetkinFileObjectChip } from 'components/ZetkinFileChip';
@@ -46,12 +45,12 @@ const TimelineNoteAdded: React.FC<Props> = ({ update }) => {
       }
       update={update}
     >
-      <CleanHtml
+      <Markdown
         BoxProps={{
           className: classes.note,
           component: 'div',
         }}
-        dirtyHtml={marked(update.details.note.text)}
+        markdown={update.details.note.text}
       />
       {!!miscFiles.length && (
         <Box pt={2}>

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -15,7 +15,7 @@ import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { LetterparserNode, parse } from 'letterparser';
 import { useCallback, useEffect, useState } from 'react';
 
-import Markdown from 'components/Markdown';
+import CleanHtml from 'components/CleanHtml';
 
 interface PrettyEmailProps {
   emailStr: string;
@@ -124,9 +124,9 @@ const EmailBody: React.FC<{
     const content = typeof body == 'string' ? body : body.toString();
 
     return (
-      <Markdown
+      <CleanHtml
         BoxProps={{ className: classes.body, component: 'div' }}
-        markdown={content}
+        dirtyHtml={content}
       />
     );
   }

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -15,7 +15,7 @@ import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { LetterparserNode, parse } from 'letterparser';
 import { useCallback, useEffect, useState } from 'react';
 
-import CleanHtml from 'components/CleanHtml';
+import Markdown from 'components/Markdown';
 
 interface PrettyEmailProps {
   emailStr: string;
@@ -124,9 +124,9 @@ const EmailBody: React.FC<{
     const content = typeof body == 'string' ? body : body.toString();
 
     return (
-      <CleanHtml
+      <Markdown
         BoxProps={{ className: classes.body, component: 'div' }}
-        dirtyHtml={content}
+        markdown={content}
       />
     );
   }

--- a/src/components/organize/tasks/TaskPreviewSection.tsx
+++ b/src/components/organize/tasks/TaskPreviewSection.tsx
@@ -1,11 +1,10 @@
-import { marked } from 'marked';
 import { useState } from 'react';
 import { AccessTime, Image as ImageIcon } from '@material-ui/icons';
 import { Box, Button, Card, Typography } from '@material-ui/core';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import CleanHtml from 'components/CleanHtml';
 import ImageSelectDialog from 'components/ImageSelectDialog';
+import Markdown from 'components/Markdown';
 import { taskResource } from 'api/tasks';
 import ZetkinEditableImage from 'components/ZetkinEditableImage';
 import ZetkinSection from 'components/ZetkinSection';
@@ -72,9 +71,9 @@ const TaskPreviewSection: React.FC<TaskPreviewSectionProps> = ({ task }) => {
               />
             </Typography>
           )}
-          <CleanHtml
+          <Markdown
             BoxProps={{ component: 'div' }}
-            dirtyHtml={marked(task.instructions)}
+            markdown={task.instructions}
           />
         </Box>
       </Card>


### PR DESCRIPTION
## Description
This PR adds a Markdown component that turns strings into markdown and runs them through the CleanHtml component for added security and comfort.

* Adds…
- Markdown component, and uses it where CleanHtml was used.
 
## Related issues
Resolves #721 
