### PR TITLE
Issue 724/firefox file upload

### DIFF
--- a/src/components/Timeline/TextEditor/index.tsx
+++ b/src/components/Timeline/TextEditor/index.tsx
@@ -1,7 +1,7 @@
 import { isEqual } from 'lodash';
 import { makeStyles } from '@material-ui/styles';
 import { withHistory } from 'slate-history';
-import { Box, Collapse } from '@material-ui/core';
+import { Box, ClickAwayListener, Collapse } from '@material-ui/core';
 import { createEditor, Descendant, Editor, Transforms } from 'slate';
 import { Editable, ReactEditor, Slate, withReact } from 'slate-react';
 import React, {
@@ -83,49 +83,50 @@ const TextEditor: React.FunctionComponent<TextEditorProps> = ({
   }, [clear]);
 
   return (
-    <Box
-      className={classes.container}
-      onClick={() => ReactEditor.focus(editor)}
-    >
-      <Slate
-        editor={editor}
-        onChange={(slateArray) => onChange(slateToMarkdown(slateArray))}
-        value={initialValue}
+    <ClickAwayListener onClickAway={onClickAway}>
+      <Box
+        className={classes.container}
+        onClick={() => ReactEditor.focus(editor)}
       >
-        <Editable
-          onBlur={onBlur}
-          onFocus={() => setActive(true)}
-          onKeyDown={onKeyDown}
-          placeholder={placeholder}
-          renderElement={renderElement}
-          renderLeaf={renderLeaf}
-          spellCheck
-        />
-        <Collapse in={active}>
-          <Toolbar onClickAttach={onClickAttach} />
-        </Collapse>
-      </Slate>
-      {fileUploads.map((fileUpload) => {
-        return (
-          <ZetkinFileUploadChip
-            key={fileUpload.key}
-            fileUpload={fileUpload}
-            onDelete={() => {
-              if (onCancelFile) {
-                onCancelFile(fileUpload);
-              }
-            }}
+        <Slate
+          editor={editor}
+          onChange={(slateArray) => onChange(slateToMarkdown(slateArray))}
+          value={initialValue}
+        >
+          <Editable
+            onFocus={() => setActive(true)}
+            onKeyDown={onKeyDown}
+            placeholder={placeholder}
+            renderElement={renderElement}
+            renderLeaf={renderLeaf}
+            spellCheck
           />
-        );
-      })}
-    </Box>
+          <Collapse in={active}>
+            <Toolbar onClickAttach={onClickAttach} />
+          </Collapse>
+        </Slate>
+        {fileUploads.map((fileUpload) => {
+          return (
+            <ZetkinFileUploadChip
+              key={fileUpload.key}
+              fileUpload={fileUpload}
+              onDelete={() => {
+                if (onCancelFile) {
+                  onCancelFile(fileUpload);
+                }
+              }}
+            />
+          );
+        })}
+      </Box>
+    </ClickAwayListener>
   );
 
   function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     keyDownHandler(editor, event);
   }
 
-  function onBlur() {
+  function onClickAway() {
     if (isEqual(editor.children, initialValue)) {
       setActive(false);
       clearEditor();

--- a/src/hooks/useFileUploads.ts
+++ b/src/hooks/useFileUploads.ts
@@ -44,6 +44,38 @@ export default function useFileUploads(props?: {
 
   const fileKeyRef = useRef<number>(1);
   const filesRef = useRef(fileUploads);
+  const fileInput = useRef<HTMLInputElement>();
+
+  const addFiles = (files: File[]) => {
+    setFileUploads([
+      ...filesRef.current,
+      ...files.map((file) => {
+        const fileUpload: FileUpload = {
+          apiData: null,
+          file: file,
+          key: fileKeyRef.current++,
+          name: file.name,
+          state: FileUploadState.UPLOADING,
+        };
+
+        postFile(fileUpload);
+
+        return fileUpload;
+      }),
+    ]);
+  };
+
+  // Creates input element for uploading files that works across browsers
+  if (!fileInput.current) {
+    fileInput.current = document.createElement('input');
+    fileInput.current.setAttribute('type', 'file');
+    fileInput.current.onchange = (ev) => {
+      const files = (ev.target as HTMLInputElement)?.files;
+      if (files) {
+        addFiles(Array.from(files));
+      }
+    };
+  }
 
   async function postFile(upload: FileUpload): Promise<void> {
     const formData = new FormData();
@@ -80,25 +112,10 @@ export default function useFileUploads(props?: {
   }, [fileUploads]);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
-    setFileUploads([
-      ...filesRef.current,
-      ...acceptedFiles.map((file) => {
-        const fileUpload: FileUpload = {
-          apiData: null,
-          file: file,
-          key: fileKeyRef.current++,
-          name: file.name,
-          state: FileUploadState.UPLOADING,
-        };
-
-        postFile(fileUpload);
-
-        return fileUpload;
-      }),
-    ]);
+    addFiles(acceptedFiles);
   }, []);
 
-  const { getRootProps, open } = useDropzone({
+  const { getRootProps } = useDropzone({
     accept: props?.accept,
     multiple: props?.multiple,
     noClick: true,
@@ -113,7 +130,9 @@ export default function useFileUploads(props?: {
     },
     fileUploads,
     getDropZoneProps: getRootProps,
-    openFilePicker: open,
+    openFilePicker: () => {
+      fileInput.current?.click();
+    },
     reset: () => {
       setFileUploads([]);
     },

--- a/src/hooks/useFileUploads.ts
+++ b/src/hooks/useFileUploads.ts
@@ -66,7 +66,7 @@ export default function useFileUploads(props?: {
   };
 
   // Creates input element for uploading files that works across browsers
-  if (!fileInput.current) {
+  if (!fileInput.current && typeof document === 'object') {
     fileInput.current = document.createElement('input');
     fileInput.current.setAttribute('type', 'file');
     fileInput.current.onchange = (ev) => {


### PR DESCRIPTION
## Description
This PR replaces the dropzone implementation of opening the native filepicker with a custom solution. It also makes the text editor only close when clicking outside of it.


## Changes
* Changes
  * Uses a custom input component for uploading files. This works on firefox and hopefully chrome
  * Only close text editor on clickaway 


## Notes to reviewer
Try uploading files in firefox and chrome on tasks and journeys

## Related issues
Resolves #724
