### PR TITLE
Enable linebreaks in marked().

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -9,7 +9,7 @@ interface MarkdownProps {
 }
 
 const Markdown: React.FC<MarkdownProps> = ({ BoxProps, markdown }) => {
-  const dirtyHtml = marked(markdown);
+  const dirtyHtml = marked(markdown, { breaks: true });
   return <CleanHtml BoxProps={BoxProps} dirtyHtml={dirtyHtml} />;
 };
 


### PR DESCRIPTION
## Description
This PR enables rendering of linebreaks (\n) when using marked()


## Changes
- Adds option to render linebreaks.

## Related issues
Resolves #721 
