### PR TITLE
Exclude value tags from other columns in journey table

### DIFF
--- a/src/utils/journeyInstanceUtils.spec.ts
+++ b/src/utils/journeyInstanceUtils.spec.ts
@@ -1,0 +1,67 @@
+import mockTag from './testing/mocks/mockTag';
+import { ZetkinTagGroup } from 'types/zetkin';
+import {
+  getTagColumns,
+  JourneyTagColumnType,
+  JourneyTagGroupColumn,
+  JourneyUnsortedTagsColumn,
+  JourneyValueTagColumn,
+} from './journeyInstanceUtils';
+
+describe('journeyInstanceUtils', () => {
+  describe('getTagColumns()', () => {
+    const tagMock = mockTag();
+    const groupMock: ZetkinTagGroup = {
+      id: 1,
+      organization: {
+        id: 1,
+        title: 'KPD',
+      },
+      title: 'Group',
+    };
+
+    it('separates tags by group', () => {
+      const columns = getTagColumns([
+        {
+          tags: [
+            { ...tagMock, group: groupMock, id: 1 },
+            { ...tagMock, group: { ...groupMock, id: 2 }, id: 2 },
+          ],
+        },
+      ]) as JourneyTagGroupColumn[];
+
+      expect(columns.length).toBe(2);
+      expect(columns[0].type).toBe(JourneyTagColumnType.TAG_GROUP);
+      expect(columns[1].type).toBe(JourneyTagColumnType.TAG_GROUP);
+
+      expect(columns[0].group.id).toBe(1);
+      expect(columns[1].group.id).toBe(2);
+    });
+
+    it('separates value tags from other columns', () => {
+      const instance = {
+        tags: [
+          { ...tagMock, id: 1, value: 'Clara', value_type: 'string' },
+          { ...tagMock, id: 2 },
+        ],
+      };
+
+      const columns = getTagColumns([instance]);
+
+      expect(columns.length).toBe(2);
+      expect(columns[0].type).toBe(JourneyTagColumnType.VALUE_TAG);
+      expect(columns[1].type).toBe(JourneyTagColumnType.UNSORTED);
+
+      // Check that the value is correct
+      const valueCol = columns[0] as JourneyValueTagColumn;
+      expect(valueCol.tag.id).toBe(1);
+      expect(valueCol.valueGetter(instance)).toBe('Clara');
+
+      // There should be only one tag in unsorted
+      const unsortedTags = (columns[1] as JourneyUnsortedTagsColumn).tagsGetter(
+        instance
+      );
+      expect(unsortedTags.map((tag) => tag.id)).toEqual([2]);
+    });
+  });
+});

--- a/src/utils/journeyInstanceUtils.ts
+++ b/src/utils/journeyInstanceUtils.ts
@@ -6,32 +6,34 @@ export enum JourneyTagColumnType {
   UNSORTED = 'UNSORTED',
 }
 
-interface JourneyValueTagColumnData {
+export interface JourneyValueTagColumnData {
   type: JourneyTagColumnType.VALUE_TAG;
   tag: ZetkinTag;
   header: string;
 }
 
-interface JourneyTagGroupColumnData {
+export interface JourneyTagGroupColumnData {
   type: JourneyTagColumnType.TAG_GROUP;
   group: ZetkinTagGroup;
   header: string;
 }
 
-interface JourneyUnsortedTagsColumnData {
+export interface JourneyUnsortedTagsColumnData {
   type: JourneyTagColumnType.UNSORTED;
 }
 
-type JourneyUnsortedTagsColumn = JourneyUnsortedTagsColumnData & {
-  tagsGetter: (instance: ZetkinJourneyInstance) => ZetkinTag[];
+export type JourneyUnsortedTagsColumn = JourneyUnsortedTagsColumnData & {
+  tagsGetter: (instance: Pick<ZetkinJourneyInstance, 'tags'>) => ZetkinTag[];
 };
 
-type JourneyTagGroupColumn = JourneyTagGroupColumnData & {
-  tagsGetter: (instance: ZetkinJourneyInstance) => ZetkinTag[];
+export type JourneyTagGroupColumn = JourneyTagGroupColumnData & {
+  tagsGetter: (instance: Pick<ZetkinJourneyInstance, 'tags'>) => ZetkinTag[];
 };
 
-type JourneyValueTagColumn = JourneyValueTagColumnData & {
-  valueGetter: (instance: ZetkinJourneyInstance) => string | number | null;
+export type JourneyValueTagColumn = JourneyValueTagColumnData & {
+  valueGetter: (
+    instance: Pick<ZetkinJourneyInstance, 'tags'>
+  ) => string | number | null;
 };
 
 export type JourneyTagColumnData =
@@ -50,27 +52,29 @@ export function makeJourneyTagColumn(
   if (colData.type == JourneyTagColumnType.TAG_GROUP) {
     return {
       ...colData,
-      tagsGetter: (instance: ZetkinJourneyInstance) =>
-        instance.tags.filter((tag) => tag.group?.id == colData.group.id),
+      tagsGetter: (instance: Pick<ZetkinJourneyInstance, 'tags'>) =>
+        instance.tags.filter(
+          (tag) => tag.group?.id == colData.group.id && !tag.value_type
+        ),
     };
   } else if (colData.type == JourneyTagColumnType.UNSORTED) {
     return {
       ...colData,
-      tagsGetter: (instance: ZetkinJourneyInstance) =>
-        instance.tags.filter((tag) => !tag.group),
+      tagsGetter: (instance: Pick<ZetkinJourneyInstance, 'tags'>) =>
+        instance.tags.filter((tag) => !tag.group && !tag.value_type),
     };
   } else {
     // Must be VALUE_TAG
     return {
       ...colData,
-      valueGetter: (instance: ZetkinJourneyInstance) =>
+      valueGetter: (instance: Pick<ZetkinJourneyInstance, 'tags'>) =>
         instance.tags.find((tag) => tag.id == colData.tag.id)?.value ?? null,
     };
   }
 }
 
 export function getTagColumns(
-  instances: ZetkinJourneyInstance[]
+  instances: Pick<ZetkinJourneyInstance, 'tags'>[]
 ): JourneyTagColumn[] {
   const tagIds = new Set<number>();
   const groupIds = new Set<number>();


### PR DESCRIPTION
## Description
This PR changes the journey column algorithm to exclude value tags (which have their own columns) from other columns, so that value tags aren't rendered twice in the table.

## Screenshots
### Before the fix
Note how the "Amount won" column gets it's own column, and also shows up in the "Case outcome" columns.

<img width="801" alt="image" src="https://user-images.githubusercontent.com/550212/171989202-c1f48501-eecb-42f8-817c-8e13c77072cd.png">

### After the fix
Note how the value tag does no longer show up in any other columns than it's dedicated value column.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/550212/171989179-96a4f032-75ce-47bf-a44a-e7819ab6b0d4.png">

## Changes
* Modifies the algorithm to exclude value tags from other columns
* Changes the types in `getTagColumns()` so that the inputs can be simpler than full `ZetkinJourneyInstance` objects
* Adds some basic tests to verify functionality

## Notes to reviewer
None

## Related issues
Undocumented
