### PR TITLE
Implement rendering of journeyinstance.convert updates

### DIFF
--- a/src/components/Timeline/TimelineUpdate.tsx
+++ b/src/components/Timeline/TimelineUpdate.tsx
@@ -1,6 +1,7 @@
 import TimelineAssigned from './updates/TimelineAssigned';
 import TimelineGeneric from './updates/TimelineGeneric';
 import TimelineJourneyClose from './updates/TimelineJourneyClose';
+import TimelineJourneyConvert from './updates/TimelineJourneyConvert';
 import TimelineJourneyInstance from './updates/TimelineJourneyInstance';
 import TimelineJourneyMilestone from './updates/TimelineJourneyMilestone';
 import TimelineJourneyStart from './updates/TimelineJourneyStart';
@@ -49,6 +50,8 @@ const TimelineUpdate: React.FunctionComponent<Props> = ({ update }) => {
     return <TimelineNoteAdded update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_CLOSE) {
     return <TimelineJourneyClose update={update} />;
+  } else if (update.type == UPDATE_TYPES.JOURNEYINSTANCE_CONVERT) {
+    return <TimelineJourneyConvert update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATE) {
     return <TimelineJourneyInstance update={update} />;
   } else if (update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATEMILESTONE) {

--- a/src/components/Timeline/updates/TimelineJourneyConvert.tsx
+++ b/src/components/Timeline/updates/TimelineJourneyConvert.tsx
@@ -1,0 +1,31 @@
+import { FormattedMessage } from 'react-intl';
+
+import UpdateContainer from './elements/UpdateContainer';
+import ZetkinPersonLink from 'components/ZetkinPersonLink';
+import { ZetkinUpdateJourneyInstanceConvert } from 'types/updates';
+
+interface TimelineJourneyConvertProps {
+  update: ZetkinUpdateJourneyInstanceConvert;
+}
+
+const TimelineJourneyConvert: React.FC<TimelineJourneyConvertProps> = ({
+  update,
+}) => {
+  return (
+    <UpdateContainer
+      headerContent={
+        <FormattedMessage
+          id="misc.updates.journeyinstance.convert"
+          values={{
+            actor: <ZetkinPersonLink person={update.actor} />,
+            newLabel: update.details.new_journey.singular_label,
+            oldLabel: update.details.old_journey.singular_label,
+          }}
+        />
+      }
+      update={update}
+    ></UpdateContainer>
+  );
+};
+
+export default TimelineJourneyConvert;

--- a/src/locale/misc/updates/en.yml
+++ b/src/locale/misc/updates/en.yml
@@ -8,6 +8,7 @@ journeyinstance:
   addsubject: '{actor} added {subject}'
   close:
     header: '{actor} closed the journey'
+  convert: '{actor} converted from {oldLabel} to {newLabel}'
   create:
     header: '{actor} started a new journey'
   open: '{actor} opened the journey again'

--- a/src/types/updates.ts
+++ b/src/types/updates.ts
@@ -1,4 +1,5 @@
 import {
+  ZetkinJourney,
   ZetkinJourneyInstance,
   ZetkinJourneyMilestone,
   ZetkinJourneyMilestoneStatus,
@@ -14,6 +15,7 @@ export enum UPDATE_TYPES {
   JOURNEYINSTANCE_ADDSUBJECT = 'journeyinstance.addsubject',
   JOURNEYINSTANCE_ADDNOTE = 'journeyinstance.addnote',
   JOURNEYINSTANCE_CLOSE = 'journeyinstance.close',
+  JOURNEYINSTANCE_CONVERT = 'journeyinstance.convert',
   JOURNEYINSTANCE_CREATE = 'journeyinstance.create',
   JOURNEYINSTANCE_OPEN = 'journeyinstance.open',
   JOURNEYINSTANCE_REMOVEASSIGNEE = 'journeyinstance.removeassignee',
@@ -96,6 +98,15 @@ export type ZetkinUpdateJourneyInstanceClose = ZetkinUpdateBase<
   }
 >;
 
+export type ZetkinUpdateJourneyInstanceConvert = ZetkinUpdateBase<
+  UPDATE_TYPES.JOURNEYINSTANCE_CONVERT,
+  ZetkinJourneyInstance,
+  {
+    new_journey: ZetkinJourney;
+    old_journey: ZetkinJourney;
+  }
+>;
+
 export type ZetkinUpdateJourneyInstanceOpen = ZetkinUpdateBase<
   UPDATE_TYPES.JOURNEYINSTANCE_OPEN,
   ZetkinJourneyInstance,
@@ -124,6 +135,7 @@ export type ZetkinUpdate =
   | ZetkinUpdateJourneyInstanceAddNote
   | ZetkinUpdateJourneyInstanceAssignee
   | ZetkinUpdateJourneyInstanceClose
+  | ZetkinUpdateJourneyInstanceConvert
   | ZetkinUpdateJourneyInstanceMilestone
   | ZetkinUpdateJourneyInstanceOpen
   | ZetkinUpdateJourneyInstanceStart

--- a/src/utils/testing/mocks/mockUpdate.ts
+++ b/src/utils/testing/mocks/mockUpdate.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { pick } from 'lodash';
 
+import mockJourney from './mockJourney';
 import mockJourneyInstance from './mockJourneyInstance';
 import mockNote from './mockNote';
 import { mockObject } from 'utils/testing/mocks';
@@ -61,6 +62,14 @@ const mockUpdate = (
       details: { outcome: '' },
       target: pick(mockJourneyInstance(), ['id', 'title']),
       type: 'journeyinstance.close',
+    },
+    [UPDATE_TYPES.JOURNEYINSTANCE_CONVERT]: {
+      details: {
+        newJourney: mockJourney(),
+        oldJourney: mockJourney(),
+      },
+      target: pick(mockJourneyInstance(), ['id', 'title']),
+      type: 'journeyinstance.convert',
     },
     [UPDATE_TYPES.JOURNEYINSTANCE_CREATE]: {
       details: { data: mockJourneyInstance() },


### PR DESCRIPTION
## Description
This PR adds rendering capabilities for the new `journeyinstance.convert` timeline update.

## Screenshots
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/550212/172170454-050948b4-5415-4511-bbd6-3b01eb031317.png">

## Changes
* Adds renderer component for the new timeline update

## Notes to reviewer
This requires changes to the API which are currently in review.

## Related issues
Undocumented