### PR TITLE
Allow values to be included when tagging journey instances

### DIFF
--- a/src/api/journeys.ts
+++ b/src/api/journeys.ts
@@ -5,6 +5,7 @@ import {
   createUseMutation,
   createUseMutationDelete,
   createUseMutationPut,
+  createUseMutationPutWithBody,
   createUseQuery,
 } from './utils/resourceHookFactories';
 import {
@@ -63,7 +64,9 @@ export const journeyInstanceResource = (orgId: string, instanceId: string) => {
     prefetch: createPrefetch<ZetkinJourneyInstance>(key, url),
     useAddAssignee: createUseMutationPut({ key, url: `${url}/assignees` }),
     useAddSubject: createUseMutationPut({ key, url: `${url}/subjects` }),
-    useAssignTag: createUseMutationPut({ key, url: `${url}/tags` }),
+    useAssignTag: createUseMutationPutWithBody<Pick<ZetkinTag, 'id' | 'value'>>(
+      { key, url: `${url}/tags` }
+    ),
     useClose: createUseMutation<
       { closed: string; outcome?: string; tags?: ZetkinTag[] },
       ZetkinJourneyInstance

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -159,7 +159,10 @@ const JourneyDetailsPage: PageWithLayout<JourneyDetailsPageProps> = ({
             onAddAssignee={onAddAssignee}
             onAddSubject={onAddSubject}
             onAssignTag={(tag) => {
-              assignTagMutation.mutate(tag.id);
+              assignTagMutation.mutate({
+                id: tag.id,
+                value: tag.value,
+              });
             }}
             onRemoveAssignee={onRemoveAssignee}
             onRemoveSubject={onRemoveSubject}


### PR DESCRIPTION
## Description
This PR makes it possible to use value tags on journey instances.

## Screenshots
<img width="1327" alt="image" src="https://user-images.githubusercontent.com/550212/172171630-8a76b4ed-e5e4-403b-a72d-e13f1b9d60c0.png">

## Changes
* Changes the API resource hook for journey instances to allow data when assigning a tag

## Notes to reviewer
Using this requires changes on the server-side, which are currently in review.

## Related issues
Undocumented