### PR TITLE
Better timestamps

### DIFF
--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -30,14 +30,18 @@ export const getStaticColumns = (): GridColDef[] => [
   {
     field: 'created',
     renderCell: (params) => (
-      <ZetkinDateTime datetime={params.value as string} />
+      <ZetkinDateTime convertToLocal datetime={params.value as string} />
     ),
     type: 'date',
   },
   {
     field: 'updated',
     renderCell: (params) => (
-      <ZetkinRelativeTime datetime={params.value as string} />
+      <ZetkinRelativeTime
+        convertToLocal
+        datetime={params.value as string}
+        forcePast
+      />
     ),
     type: 'date',
   },

--- a/src/components/organize/journeys/JourneyMilestoneCard.tsx
+++ b/src/components/organize/journeys/JourneyMilestoneCard.tsx
@@ -92,7 +92,11 @@ const JourneyMilestoneCard = ({
                 id="pages.organizeJourneyInstance.markedCompleteLabel"
                 values={{
                   relativeTime: (
-                    <ZetkinRelativeTime datetime={milestone.completed} />
+                    <ZetkinRelativeTime
+                      convertToLocal
+                      datetime={milestone.completed}
+                      forcePast
+                    />
                   ),
                 }}
               />

--- a/src/layout/organize/JourneyInstanceLayout.tsx
+++ b/src/layout/organize/JourneyInstanceLayout.tsx
@@ -146,8 +146,33 @@ const JourneyInstanceLayout: React.FunctionComponent = ({ children }) => {
             <JourneyStatusChip instance={journeyInstance} />
           </Box>
           <Typography style={{ marginRight: '1rem' }}>
-            <Msg id="layout.organize.journeys.lastActivity" />{' '}
-            <ZetkinRelativeTime datetime={journeyInstance.updated} />
+            {journeyInstance.updated ? (
+              <Msg
+                id="layout.organize.journeyInstance.updated"
+                values={{
+                  relative: (
+                    <ZetkinRelativeTime
+                      convertToLocal
+                      datetime={journeyInstance.updated}
+                      forcePast
+                    />
+                  ),
+                }}
+              />
+            ) : (
+              <Msg
+                id="layout.organize.journeyInstance.created"
+                values={{
+                  relative: (
+                    <ZetkinRelativeTime
+                      convertToLocal
+                      datetime={journeyInstance.created}
+                      forcePast
+                    />
+                  ),
+                }}
+              />
+            )}
           </Typography>
           {journeyInstance.next_milestone && (
             <>

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -8,6 +8,9 @@ header:
   collapseButton:
     collapse: Collapse
     expand: Expand
+journeyInstance:
+  created: Created {relative}
+  updated: Last activity {relative}
 journeyInstances:
   menu:
     downloadCsv: Download {pluralLabel} as CSV

--- a/src/types/zetkin.ts
+++ b/src/types/zetkin.ts
@@ -304,7 +304,7 @@ export interface ZetkinJourneyInstance {
   summary: string;
   tags: ZetkinTag[];
   title?: string;
-  updated: string;
+  updated: string | null;
 }
 
 export interface ZetkinJourneyMilestone {

--- a/src/utils/testing/mocks/mockJourneyInstance.ts
+++ b/src/utils/testing/mocks/mockJourneyInstance.ts
@@ -7,7 +7,7 @@ import { ZetkinJourneyInstance } from 'types/zetkin';
 const journeyInstance: ZetkinJourneyInstance = {
   assignees: [person],
   closed: null,
-  created: '2022-04-01T03:29:12+02:00',
+  created: '2022-04-01T03:29:12.000',
   id: 333,
   journey: {
     id: 1,
@@ -24,7 +24,7 @@ const journeyInstance: ZetkinJourneyInstance = {
   summary: 'Haohrez uhca evo fup fonruh do vafeesa lida penco rillesven.',
   tags: [],
   title: 'Training ID 1',
-  updated: '2022-04-03T23:59:12+02:00',
+  updated: '2022-04-03T23:59:12.000',
 };
 
 const mockJourneyInstance = (


### PR DESCRIPTION
## Description
This PR improves the rendering of several timestamps.

## Screenshots
None

## Changes
* Adds `convertToLocal` and `forcePast` to a couple of instances of dates
* Refactors the localized timestamp in the header of journey instance pages
  * Correctly handles when `updated` is `null`
  * Includes the timestamp in the localized string

## Notes to reviewer
None

## Related issues
Undocumented