### PR TITLE
Add outcome column to journey instances list

### DIFF
--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -63,6 +63,9 @@ export const getStaticColumns = (): GridColDef[] => [
     field: 'summary',
   },
   {
+    field: 'outcome',
+  },
+  {
     field: 'assignees',
     renderCell: (params) =>
       (params.row.assignees as ZetkinPersonType[]).map((person) => (

--- a/src/locale/pages/organizeJourneyInstances/en.yml
+++ b/src/locale/pages/organizeJourneyInstances/en.yml
@@ -3,6 +3,7 @@ columns:
   created: Created
   nextMilestoneDeadline: Next milestone deadline
   nextMilestoneTitle: Next milestone
+  outcome: Outcome notes
   subjects: People
   summary: Summary
   tagsFree: Tags


### PR DESCRIPTION
## Description
This PR adds the "outcome" column to the journey instances list, after I realized it wasn't displayed anywhere except on the timeline.

## Screenshots
<img width="736" alt="image" src="https://user-images.githubusercontent.com/550212/172625984-d6c759ba-051c-4d4b-a53a-4399be043605.png">

## Changes
* Adds `outcome` to the list of static columns for the `JourneyInstancesDataTable`

## Notes to reviewer
None

## Related issues
Undocumented