### PR TITLE
Tweak issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,14 +9,14 @@ assignees: ''
 
 **Please be as thorough as possible, but if you can't answer everything, please just submit what you have! Thank you!**
 
-### Description
+## Description
+
+## Steps to reproduce
+1. Go to '...'
+2. Click on '....'
 
 ### Expected Behaviour
 
 ### Actual Behaviour
 
-### Steps to reproduce
-1. Go to '...'
-2. Click on '....'
-
-### Screenshots (if you have any)
+## Screenshots (if you have any)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,19 +7,19 @@ assignees: ''
 
 ---
 
-### Description
+## Description
 A user should be able to...
 
-### Relevant Job Stories
+## Relevant Job Stories
 
-### Prerequisites
+## Prerequisites
 
-### Requirements
+## Requirements
 - [ ] Requirement 1
 
-### Possible implementations
+## Possible implementations
 
-### Design specifications
+## Design specifications
 (Put any links to wireframes, figma, or other designs here etc here.)
 
-### Open questions
+## Open questions


### PR DESCRIPTION
## Description
This PR proposes some slight changes to the bug and task templates.

The only semantic change is that "expected behaviour" and "actual behaviour" come after the steps to reproduce, but are made part of that same section. This is purely my preference, probably because this is how Adobe did it back in the day when I was part of their beta program and reported a lot of bugs.

This proposal is mainly for my own personal comfort, so if anyone else cares about keeping it I don't mind. But I thought I'd try. 😊 

## Screenshots
None

## Changes
* Changes the highest header level to 2 instead of 3
* Changes the disposition of the bug report template so that:
  * Steps to reproduce comes before "Expected behaviour" and "Actual behaviour"
  * "Expected behaviour" and "Actual behaviour" are sub-headers of the steps to reproduce

## Notes to reviewer
None

## Related issues
Undocumented