### PR TITLE
Display external id on person profile page.

### DIFF
--- a/src/components/organize/people/PersonDetailsCard.tsx
+++ b/src/components/organize/people/PersonDetailsCard.tsx
@@ -28,6 +28,7 @@ const nativeFieldsToDisplay = [
   'zip_code',
   'country',
   'gender',
+  'ext_id',
 ];
 
 const PersonDetailsCard: React.FunctionComponent<{

--- a/src/layout/organize/SinglePersonLayout.tsx
+++ b/src/layout/organize/SinglePersonLayout.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 
 import { personResource } from 'api/people';
 import TabbedLayout from './TabbedLayout';
+import { Box, Typography } from '@material-ui/core';
 
 interface SinglePersonLayoutProps {
   fixedHeight?: boolean;
@@ -40,7 +41,22 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
           messageId: 'layout.organize.person.tabs.manage',
         },
       ]}
-      title={`${person?.first_name} ${person?.last_name}`}
+      title={
+        <Box
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+          }}
+        >
+          {`${person?.first_name} ${person?.last_name}`}
+          {person?.ext_id && (
+            <Typography
+              color="secondary"
+              variant="h3"
+            >{`\u00A0#${person?.ext_id}`}</Typography>
+          )}
+        </Box>
+      }
     >
       {children}
     </TabbedLayout>


### PR DESCRIPTION
## Description
This PR adds the external id to the title in a person's profile page, if there is one.


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/173384651-1613a500-c386-40ee-9ef5-60fb2e79b57c.png)

## Changes
* Conditionally adds external id to title in Single Person Layout.

## Related issues
Resolves #742 
