### PR TITLE
Tag manager shows tags grouped as default.

### DIFF
--- a/src/components/organize/TagManager/TagManagerController.tsx
+++ b/src/components/organize/TagManager/TagManagerController.tsx
@@ -29,7 +29,7 @@ export const TagManagerController: React.FunctionComponent<
   availableTags,
   disableEditTags,
   disabledTags,
-  groupTags = false,
+  groupTags = true,
   onAssignTag,
   onCreateTag,
   onEditTag,

--- a/src/components/organize/TagManager/index.tsx
+++ b/src/components/organize/TagManager/index.tsx
@@ -46,7 +46,7 @@ export const TagManagerSection: React.FunctionComponent<
 > = (props) => {
   const intl = useIntl();
 
-  const [isGrouped, setIsGrouped] = useState(false);
+  const [isGrouped, setIsGrouped] = useState(true);
 
   return (
     <ZetkinSection


### PR DESCRIPTION
## Description
This PR makes tag manager show tags grouped by default. 


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/173619361-7e8007b2-f0af-4f84-922f-07455ea2846f.png)

## Changes
* Sets tag manager to display tags grouped.

## Related issues
Resolves #737
