### PR TITLE
Make fancy emails fit the parent.

### DIFF
--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -125,7 +125,14 @@ const EmailBody: React.FC<{
 
     return (
       <CleanHtml
-        BoxProps={{ className: classes.body, component: 'div' }}
+        BoxProps={{
+          className: classes.body,
+          component: 'div',
+          style: {
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          },
+        }}
         dirtyHtml={content}
       />
     );


### PR DESCRIPTION
## Description
This PR makes wide/fancy emails fit the width of the Timeline.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/174051753-483043b2-f2f0-435c-84f9-f1e156153f2f.png)

## Changes
* Adds white-space and word-break properties to the Box that renders the email html.

## Related issues
Resolves #749 
