### PR TITLE
Issue 758/filter timeline

### DIFF
--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -1,13 +1,16 @@
+import { Alert } from '@material-ui/lab';
 import { FormattedMessage } from 'react-intl';
 import React from 'react';
 import {
   Button,
+  CardActionArea,
   Collapse,
   Divider,
   Fade,
   Grid,
   MenuItem,
   Select,
+  Typography,
 } from '@material-ui/core';
 
 import TimelineAddNote from './TimelineAddNote';
@@ -42,15 +45,29 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
   return (
     <Fade appear in timeout={1000}>
       <Grid container direction="column" spacing={5}>
-        <Grid item xs={6}>
+        <Grid item sm={6} xl={4} xs={12}>
+          {/* Filter timeline select */}
           <Select
             fullWidth
-            label="Type"
             onChange={(event) =>
               setUpdateTypeFilter(
                 event.target.value as UPDATE_TYPE_FILTER_OPTIONS
               )
             }
+            renderValue={(value) => (
+              <Typography color="secondary">
+                <FormattedMessage
+                  id="misc.timeline.filter.filterSelectLabel"
+                  values={{
+                    filter: (
+                      <FormattedMessage
+                        id={`misc.timeline.filter.byType.${value}`}
+                      />
+                    ),
+                  }}
+                />
+              </Typography>
+            )}
             value={updateTypeFilter}
             variant="outlined"
           >
@@ -68,6 +85,21 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
         <Grid item>
           <TimelineAddNote disabled={disabled} onSubmit={onAddNote} />
         </Grid>
+        {updateTypeFilter !== 'all' && (
+          <Grid item>
+            <CardActionArea>
+              <Alert
+                onClick={() =>
+                  setUpdateTypeFilter(UPDATE_TYPE_FILTER_OPTIONS.All)
+                }
+                severity="warning"
+                style={{ cursor: 'pointer' }}
+              >
+                <FormattedMessage id="misc.timeline.filter.warning" />
+              </Alert>
+            </CardActionArea>
+          </Grid>
+        )}
         {renderUpdateList()}
         {expandable && renderExpandButton()}
       </Grid>

--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -14,7 +14,9 @@ import TimelineAddNote from './TimelineAddNote';
 import TimelineUpdate from './TimelineUpdate';
 import { ZetkinNoteBody } from 'types/zetkin';
 import { ZetkinUpdate } from 'types/updates';
-import useFilterUpdates, { UpdateFilterOptions } from './useFilterUpdates';
+import useFilterUpdates, {
+  UPDATE_TYPE_FILTER_OPTIONS,
+} from './useFilterUpdates';
 
 export interface TimelineProps {
   disabled?: boolean;
@@ -45,16 +47,22 @@ const Timeline: React.FunctionComponent<TimelineProps> = ({
             fullWidth
             label="Type"
             onChange={(event) =>
-              setUpdateTypeFilter(event.target.value as UpdateFilterOptions)
+              setUpdateTypeFilter(
+                event.target.value as UPDATE_TYPE_FILTER_OPTIONS
+              )
             }
             value={updateTypeFilter}
             variant="outlined"
           >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="notes">Notes</MenuItem>
-            <MenuItem value="files">Files</MenuItem>
-            <MenuItem value="milestones">Milestones</MenuItem>
-            <MenuItem value="tags">Tags</MenuItem>
+            {Object.values(UPDATE_TYPE_FILTER_OPTIONS).map((option) => {
+              return (
+                <MenuItem key={option} value={option}>
+                  <FormattedMessage
+                    id={`misc.timeline.filter.byType.${option}`}
+                  />
+                </MenuItem>
+              );
+            })}
           </Select>
         </Grid>
         <Grid item>

--- a/src/components/Timeline/useFilterUpdates.tsx
+++ b/src/components/Timeline/useFilterUpdates.tsx
@@ -3,16 +3,19 @@ import { useMemo, useState } from 'react';
 
 import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
 
-export type UpdateFilterOptions =
-  | 'all'
-  | 'notes'
-  | 'files'
-  | 'milestones'
-  | 'tags';
+export enum UPDATE_TYPE_FILTER_OPTIONS {
+  All = 'all',
+  NOTES = 'notes',
+  FILES = 'files',
+  PEOPLE = 'people',
+  MILESTONES = 'milestones',
+  TAGS = 'tags',
+}
 
 const useFilterUpdates = (updates: ZetkinUpdate[]) => {
-  const [updateTypeFilter, setUpdateTypeFilter] =
-    useState<UpdateFilterOptions>('all');
+  const [updateTypeFilter, setUpdateTypeFilter] = useState(
+    UPDATE_TYPE_FILTER_OPTIONS.All
+  );
 
   const sortedUpdates = useMemo(
     () =>
@@ -33,6 +36,13 @@ const useFilterUpdates = (updates: ZetkinUpdate[]) => {
         update.type === UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE &&
         update.details.note.files.length > 0
       );
+    } else if (updateTypeFilter === 'people') {
+      return [
+        UPDATE_TYPES.JOURNEYINSTANCE_ADDASSIGNEE,
+        UPDATE_TYPES.JOURNEYINSTANCE_REMOVEASSIGNEE,
+        UPDATE_TYPES.JOURNEYINSTANCE_ADDSUBJECT,
+        UPDATE_TYPES.JOURNEYINSTANCE_REMOVESUBJECT,
+      ].includes(update.type);
     } else if (updateTypeFilter === 'milestones') {
       return update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATEMILESTONE;
     } else if (updateTypeFilter === 'tags') {

--- a/src/components/Timeline/useFilterUpdates.tsx
+++ b/src/components/Timeline/useFilterUpdates.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { useMemo, useState } from 'react';
+
+import { UPDATE_TYPES, ZetkinUpdate } from 'types/updates';
+
+export type UpdateFilterOptions =
+  | 'all'
+  | 'notes'
+  | 'files'
+  | 'milestones'
+  | 'tags';
+
+const useFilterUpdates = (updates: ZetkinUpdate[]) => {
+  const [updateTypeFilter, setUpdateTypeFilter] =
+    useState<UpdateFilterOptions>('all');
+
+  const sortedUpdates = useMemo(
+    () =>
+      updates.sort(
+        (u0, u1) =>
+          new Date(u1.timestamp).getTime() - new Date(u0.timestamp).getTime()
+      ),
+    [updates]
+  );
+
+  const filteredUpdates = sortedUpdates.filter((update) => {
+    if (updateTypeFilter === 'all') {
+      return true;
+    } else if (updateTypeFilter === 'notes') {
+      return update.type === UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE;
+    } else if (updateTypeFilter === 'files') {
+      return (
+        update.type === UPDATE_TYPES.JOURNEYINSTANCE_ADDNOTE &&
+        update.details.note.files.length > 0
+      );
+    } else if (updateTypeFilter === 'milestones') {
+      return update.type === UPDATE_TYPES.JOURNEYINSTANCE_UPDATEMILESTONE;
+    } else if (updateTypeFilter === 'tags') {
+      const tagSelectors = [
+        UPDATE_TYPES.ANY_ADDTAGS,
+        UPDATE_TYPES.ANY_REMOVETAGS,
+      ].map((type) => type.slice(2));
+      return tagSelectors.some((selector) => update.type.includes(selector));
+    }
+  });
+
+  return {
+    filteredUpdates,
+    setUpdateTypeFilter,
+    updateTypeFilter,
+  };
+};
+
+export default useFilterUpdates;

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -53,3 +53,11 @@ snackbar:
 timeline:
   add_note_placeholder: Enter text to leave a note
   expand: show full timeline
+  filter:
+    byType:
+      all: All
+      files: Files
+      milestones: Milestones
+      notes: Notes
+      people: People
+      tags: Tags


### PR DESCRIPTION
## Description
This PR allows the user to filter the timeline by the type of update.


## Screenshots
[Add screenshots here]


## Changes

* Adds
  * Hook for filtering and sorting
  * Select to choose the type of update to filter by
  * Alert that is shown when filtering, clicking the alert clears the filter 

## Notes to reviewer
* Create timeline updates of different types
* Filter the timeline and check everything works as expected

## Related issues
Resolves #758
