### PR TITLE
Set state after column re-order

### DIFF
--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
@@ -228,18 +228,6 @@ describe('useConfigurableDataGridColumns', () => {
       expect(columns[2]).toEqual(inputColumns[0]);
     });
 
-    test('does not trigger re-render using state', () => {
-      const inputColumns = mockColumns(3);
-      const { setColumnOrder } = useConfigurableDataGridColumns(
-        'key',
-        inputColumns,
-        mockStorage
-      );
-
-      setColumnOrder('field0', 0);
-      expect(mockSetState).toHaveBeenCalledTimes(0);
-    });
-
     test('correctly updates storage when several times in a row', () => {
       const inputColumns = mockColumns(4);
       const { setColumnOrder } = useConfigurableDataGridColumns(

--- a/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
+++ b/src/components/UserConfigurableDataGrid/useConfigurableDataGridColumns.ts
@@ -60,11 +60,6 @@ export default function useConfigurableDataGridColumns(
       }
     }),
     setColumnOrder: (field, newIndex) => {
-      // Use the stored config and not the config from state when reordering.
-      // Changing the order does not require a re-render (because the grid
-      // already re-renders internally), so we don't update state when the
-      // order changes, instead just updating the storage, which is why that's
-      // where we have to go to find the most recent order config.
       const storedConfig = loadConfig(storage, key);
       const sortedFields = orderColumns(
         inputColumns,
@@ -83,6 +78,8 @@ export default function useConfigurableDataGridColumns(
       };
 
       storage.setItem(key, JSON.stringify(newConfig));
+
+      setConfig(newConfig);
     },
     setColumnWidth: (field, width) => {
       const storedConfig = loadConfig(storage, key);


### PR DESCRIPTION
## Description
This PR fixes a bug that made columns go back to their original order, if you re-ordered them and then re-ordered the rows by sorting.

## Changes
* Adds a state update when re-ordering columns.
* Removes test and comment.

## Related issues
Resolves #712 
