### PR TITLE
Sort and filter querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@storybook/react": "^6.5.5",
     "@storybook/testing-library": "^0.0.11",
     "@testing-library/react": "^12.1.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^13.5.0",
     "@types/chance": "^1.1.3",
     "@types/is-url": "^1.2.30",

--- a/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from '@playwright/test';
+
+import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
+import KPD from '../../../../mockData/orgs/KPD';
+import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';
+import test from '../../../../fixtures/next';
+
+test.describe('Journey instance list', () => {
+  test.beforeEach(({ login, moxy }) => {
+    moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+    moxy.setZetkinApiMock('/orgs/1/journeys/1', 'get', MemberOnboarding);
+    moxy.setZetkinApiMock('/orgs/1/journeys/1/instances', 'get', [
+      ClarasOnboarding,
+      {
+        ...ClarasOnboarding,
+        id: ClarasOnboarding.id + 1,
+        tags: [],
+        title: 'Another onboarding',
+      },
+      {
+        ...ClarasOnboarding,
+        id: ClarasOnboarding.id + 2,
+        tags: [],
+        title: 'Better onboarding',
+      },
+    ]);
+    login();
+  });
+
+  test.afterEach(({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test('persists sort and filter state', async ({ appUri, page }) => {
+    await page.goto(appUri + '/organize/1/journeys/1');
+
+    // Open filters dialog
+    await page.locator('text=FILTERS').click();
+
+    // Configure filters to only show instances with no tags
+    await page
+      .locator('label:text("Columns") + * select')
+      .selectOption({ label: 'Tags' });
+    await page
+      .locator('select:has-text("contains")')
+      .selectOption({ label: 'is empty' });
+
+    // Click title header twice to sort descending
+    await page.locator('[role=columnheader]:has-text("title")').click();
+    await page.locator('[role=columnheader]:has-text("title")').click();
+
+    // Check that there are three rows (including header) and
+    // that they are sorted reverse alphabetically
+    const rows = await page.locator('[role=row]');
+    expect(await rows.count()).toBe(3);
+    expect(rows.nth(1)).toContainText('Better');
+    expect(rows.nth(2)).toContainText('Another');
+
+    // Reload the page
+    await page.reload();
+
+    // Check that grid state persisted
+    const rowsAfterRefresh = await page.locator('[role=row]');
+    expect(await rowsAfterRefresh.count()).toBe(3);
+    expect(rowsAfterRefresh.nth(1)).toContainText('Better');
+    expect(rowsAfterRefresh.nth(2)).toContainText('Another');
+
+    await page.waitForTimeout(5000);
+  });
+});

--- a/src/components/BreadcrumbTrail.tsx
+++ b/src/components/BreadcrumbTrail.tsx
@@ -2,9 +2,7 @@ import getBreadcrumbs from '../fetching/getBreadcrumbs';
 import { FormattedMessage as Msg } from 'react-intl';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import NextLink from 'next/link';
-import { ParsedUrlQuery } from 'node:querystring';
 import { useQuery } from 'react-query';
-import { useRouter } from 'next/router';
 import {
   Breadcrumbs,
   Link,
@@ -12,9 +10,13 @@ import {
   useMediaQuery,
 } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { NextRouter, useRouter } from 'next/router';
 
-const getQueryString = function (query: ParsedUrlQuery): string {
-  return Object.entries(query)
+const getQueryString = function (router: NextRouter): string {
+  // Only use parameters that are part of the path (e.g. [personId])
+  // and not ones that are part of the actual querystring (e.g. ?filter_*)
+  return Object.entries(router.query)
+    .filter(([key]) => router.pathname.includes(`[${key}]`))
     .map(([key, val]) => `${key}=${val}`)
     .join('&');
 };
@@ -51,7 +53,7 @@ const BreadcrumbTrail = ({
   const classes = useStyles({ highlight });
   const router = useRouter();
   const path = router.pathname;
-  const query = getQueryString(router.query);
+  const query = getQueryString(router);
   const breadcrumbsQuery = useQuery(
     ['breadcrumbs', path, query],
     getBreadcrumbs(path, query)

--- a/src/components/UserConfigurableDataGrid/index.tsx
+++ b/src/components/UserConfigurableDataGrid/index.tsx
@@ -1,6 +1,7 @@
 import { DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
 
 import useConfigurableDataGridColumns from './useConfigurableDataGridColumns';
+import { useModelsFromQueryString } from './useModelsFromQueryString';
 
 type UserConfigurableDataGridProps = DataGridProProps & {
   storageKey: string;
@@ -13,10 +14,13 @@ const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
   const { columns, setColumnOrder, setColumnWidth } =
     useConfigurableDataGridColumns(storageKey, gridProps.columns);
 
+  const { filterModel, setFilterModel } = useModelsFromQueryString();
+
   return (
     <DataGridPro
       {...gridProps}
       columns={columns}
+      filterModel={filterModel}
       onColumnOrderChange={(params, event, details) => {
         // Subtract one for selection column, if it's visible
         const targetIndex = gridProps.checkboxSelection
@@ -35,6 +39,9 @@ const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
         if (gridProps.onColumnResize) {
           gridProps.onColumnResize(params, event, details);
         }
+      }}
+      onFilterModelChange={(model) => {
+        setFilterModel(model);
       }}
     />
   );

--- a/src/components/UserConfigurableDataGrid/index.tsx
+++ b/src/components/UserConfigurableDataGrid/index.tsx
@@ -14,13 +14,13 @@ const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
   const { columns, setColumnOrder, setColumnWidth } =
     useConfigurableDataGridColumns(storageKey, gridProps.columns);
 
-  const { filterModel, setFilterModel } = useModelsFromQueryString();
+  const { gridProps: modelGridProps } = useModelsFromQueryString();
 
   return (
     <DataGridPro
       {...gridProps}
+      {...modelGridProps}
       columns={columns}
-      filterModel={filterModel}
       onColumnOrderChange={(params, event, details) => {
         // Subtract one for selection column, if it's visible
         const targetIndex = gridProps.checkboxSelection
@@ -39,9 +39,6 @@ const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
         if (gridProps.onColumnResize) {
           gridProps.onColumnResize(params, event, details);
         }
-      }}
-      onFilterModelChange={(model) => {
-        setFilterModel(model);
       }}
     />
   );

--- a/src/components/UserConfigurableDataGrid/useModelsFromQueryString.spec.ts
+++ b/src/components/UserConfigurableDataGrid/useModelsFromQueryString.spec.ts
@@ -1,0 +1,49 @@
+import mockRouter from 'next-router-mock';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useModelsFromQueryString } from './useModelsFromQueryString';
+
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+
+describe('useModelsFromQueryString()', () => {
+  describe('parser', () => {
+    it('handles single filter', () => {
+      mockRouter.setCurrentUrl('/irrelevant?filter_first_name_contains=Clara');
+
+      const { result } = renderHook(() => useModelsFromQueryString());
+
+      expect(result.current.filterModel).toMatchObject({
+        items: [
+          {
+            columnField: 'first_name',
+            operatorValue: 'contains',
+            value: 'Clara',
+          },
+        ],
+      });
+    });
+
+    it('handles duplicate filters', () => {
+      mockRouter.setCurrentUrl(
+        '/irrelevant?filter_name_contains=Clara&filter_name_contains=Zetkin'
+      );
+
+      const { result } = renderHook(() => useModelsFromQueryString());
+
+      expect(result.current.filterModel).toMatchObject({
+        items: [
+          {
+            columnField: 'name',
+            operatorValue: 'contains',
+            value: 'Clara',
+          },
+          {
+            columnField: 'name',
+            operatorValue: 'contains',
+            value: 'Zetkin',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
+++ b/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
@@ -1,0 +1,101 @@
+import { ParsedUrlQuery } from 'querystring';
+import { useRouter } from 'next/router';
+import { GridFilterModel, GridLinkOperator } from '@mui/x-data-grid-pro';
+import { useEffect, useState } from 'react';
+
+interface UseModelsFromQueryString {
+  filterModel: GridFilterModel;
+  setFilterModel: (model: GridFilterModel) => void;
+}
+
+export function useModelsFromQueryString(): UseModelsFromQueryString {
+  const router = useRouter();
+
+  const [filterModel, setFilterModel] = useState<GridFilterModel>(
+    parseFilterModelFromQuery(router.query)
+  );
+
+  // Update router URL when model changes
+  useEffect(() => {
+    const pathWithoutQuery = router.asPath.includes('?')
+      ? router.asPath.slice(0, router.asPath.indexOf('?'))
+      : router.asPath;
+
+    const qs = serializeFilterQueryString(filterModel);
+
+    const filterPath = [pathWithoutQuery, qs]
+      .filter((elem) => elem.length)
+      .join('?');
+    if (filterPath != router.asPath) {
+      router.push(filterPath, filterPath, {
+        shallow: true,
+      });
+    }
+  }, [filterModel]);
+
+  // Update model when router URL changes
+  useEffect(() => {
+    const modelQueryString = serializeFilterQueryString(filterModel);
+    const routerQueryString = router.asPath.slice(
+      router.asPath.indexOf('?') + 1
+    );
+
+    if (modelQueryString != routerQueryString) {
+      setFilterModel(parseFilterModelFromQuery(router.query));
+    }
+  }, [router.asPath, router.query]);
+
+  return {
+    filterModel,
+    setFilterModel,
+  };
+}
+
+function parseFilterModelFromQuery(query: ParsedUrlQuery): GridFilterModel {
+  const items = Object.entries(query)
+    .filter(([param]) => param.startsWith('filter_'))
+    .map(([param, val], idx) => {
+      // Split the query param, ignoring the first field ('filter')
+      const paramFields = param.split('_').slice(1);
+
+      // The last will be the operator
+      const op = paramFields.pop();
+
+      // The remaining ones are the name of the field, possibly containing underscores
+      const field = paramFields.join('_');
+
+      return {
+        columnField: field,
+        id: idx,
+        operatorValue: op,
+        value: val || undefined,
+      };
+    });
+
+  return {
+    items,
+    ...(!!items.length && {
+      linkOperator:
+        query.filterOperator == 'or'
+          ? GridLinkOperator.Or
+          : GridLinkOperator.And,
+    }),
+  };
+}
+
+function serializeFilterQueryString(filterModel: GridFilterModel): string {
+  const qs = filterModel.items
+    .map(
+      (filter) =>
+        `filter_${filter.columnField}_${filter.operatorValue}` +
+        (filter.value ? `=${encodeURIComponent(filter.value)}` : '')
+    )
+    .join('&');
+
+  // Include the operator if more than one filter
+  if (filterModel.items.length > 1) {
+    return qs + `&filterOperator=${filterModel.linkOperator || 'and'}`;
+  } else {
+    return qs;
+  }
+}

--- a/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
+++ b/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
@@ -94,22 +94,26 @@ export function useModelsFromQueryString(): UseModelsFromQueryString {
 function parseFilterModelFromQuery(query: ParsedUrlQuery): GridFilterModel {
   const items = Object.entries(query)
     .filter(([param]) => param.startsWith('filter_'))
-    .map(([param, val], idx) => {
-      // Split the query param, ignoring the first field ('filter')
-      const paramFields = param.split('_').slice(1);
+    .flatMap(([param, val], idx) => {
+      const values = Array.isArray(val) ? val : [val];
 
-      // The last will be the operator
-      const op = paramFields.pop();
+      return values.map((val, valIdx) => {
+        // Split the query param, ignoring the first field ('filter')
+        const paramFields = param.split('_').slice(1);
 
-      // The remaining ones are the name of the field, possibly containing underscores
-      const field = paramFields.join('_');
+        // The last will be the operator
+        const op = paramFields.pop();
 
-      return {
-        columnField: field,
-        id: idx,
-        operatorValue: op,
-        value: val || undefined,
-      };
+        // The remaining ones are the name of the field, possibly containing underscores
+        const field = paramFields.join('_');
+
+        return {
+          columnField: field,
+          id: idx * 10000 + valIdx,
+          operatorValue: op,
+          value: val || undefined,
+        };
+      });
     });
 
   return {

--- a/src/components/journeys/JourneyInstancesDataTable/index.spec.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.spec.tsx
@@ -5,6 +5,8 @@ import { ZetkinJourneyInstance } from 'types/zetkin';
 
 const journeyInstances = [mockJourneyInstance({ assignees: [], subjects: [] })];
 
+jest.mock('next/dist/client/router', () => require('next-router-mock'));
+
 describe('JourneyInstancesDataTable.tsx', () => {
   it('Renders with no data', async () => {
     const { getByText } = render(

--- a/src/components/journeys/JourneyInstancesDataTable/index.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.tsx
@@ -33,9 +33,11 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
   // Add localised header titles
   const intl = useIntl();
   const columnsWithHeaderTitles = columns.map((column) => ({
-    headerName: intl.formatMessage({
-      id: `pages.organizeJourneyInstances.columns.${column.field}`,
-    }),
+    headerName:
+      column.headerName ||
+      intl.formatMessage({
+        id: `pages.organizeJourneyInstances.columns.${column.field}`,
+      }),
     ...column,
   }));
 

--- a/src/layout/organize/TabbedLayout.tsx
+++ b/src/layout/organize/TabbedLayout.tsx
@@ -57,7 +57,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
   const router = useRouter();
 
   const currentTab =
-    router.asPath === baseHref
+    router.asPath.split('?')[0] === baseHref
       ? defaultTab
       : `/${router.pathname.split('/').pop()}`;
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -33,9 +33,18 @@ if (process.env.NEXT_PUBLIC_MUIX_LICENSE_KEY) {
 
 // Progress bar
 NProgress.configure({ showSpinner: false });
-Router.events.on('routeChangeStart', () => NProgress.start());
-Router.events.on('routeChangeComplete', () => NProgress.done());
-Router.events.on('routeChangeError', () => NProgress.done());
+Router.events.on(
+  'routeChangeStart',
+  (url, { shallow }) => !shallow && NProgress.start()
+);
+Router.events.on(
+  'routeChangeComplete',
+  (url, { shallow }) => !shallow && NProgress.done()
+);
+Router.events.on(
+  'routeChangeError',
+  (url, { shallow }) => !shallow && NProgress.done()
+);
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,6 +3592,14 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.1.2":
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
@@ -12640,6 +12648,13 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.0.1:
   version "3.2.0"


### PR DESCRIPTION
## Description
This PR adds logic to reflect the sort and filter state of a `UserConfigurableDataGrid` in the querystring of the page.


## Screenshots
Note the URL in the screenshow below, which reflects the filter on "Member type" and sorting on "Title".
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/550212/174486995-c2ec9279-b6b4-4268-9548-03f037e8fd12.png">

## Changes
* Adds a new `useModelFromQueryString()` hook
  * Serializes any changes to `sortModel` and `filterModel` and updates the query string
  * Parses the deserialized `router.query` when it changes, and updates the state of the `sortModel` and `filterModel`
* Uses the new hook in `UserConfigurableDataGrid`
* Fixes some issues with using querystrings in our URLs:
  * Fixes an issue in `TabbedLayout` which was not considering the querystring when comparing the current path and `basePath` to figure out whether the current tab was the "home" tab
  * Disables the `NProgress` progress bar when the router is navigated using `shallow: true`, i.e. when there is no loading happening before navigation
  * Changes how breadcrumbs are cached, so that only the query parameters that come from the path (not the query string) are used

## Notes to reviewer
This should work both for Views and Journey instances.

## Related issues
Resolves #736
