### PR TITLE
Remove pagination prop to display all items in grid as default.

### DIFF
--- a/src/components/journeys/JourneyInstancesDataTable/index.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.tsx
@@ -61,7 +61,6 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
           }
         }}
         pageSize={50}
-        pagination
         rows={rows}
         sortModel={sortModel}
         storageKey={storageKey}


### PR DESCRIPTION
## Description
This PR fixes bug and now all instances are visible in the data grid as default.


## Changes
*Removes pagination prop.

## Related issues
Resolves #741 
