### PR TITLE
Make journey instance summary render as markdown.

### DIFF
--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useEffect, useRef, useState } from 'react';
 
 import { journeyInstanceResource } from 'api/journeys';
+import Markdown from 'components/Markdown';
 import SnackbarContext from 'hooks/SnackbarContext';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
@@ -115,16 +116,16 @@ const JourneyInstanceSummary = ({
         // Not editing
         <>
           {journeyInstance.summary.length > 0 ? (
-            <Typography
-              className={summaryCollapsed ? classes.collapsed : ''}
-              onClick={() => setEditingSummary(true)}
-              style={{
-                padding: '0.75rem 0',
+            <Markdown
+              BoxProps={{
+                className: summaryCollapsed ? classes.collapsed : '',
+                onClick: () => setSummaryCollapsed(true),
+                style: {
+                  padding: '0.75rem 0',
+                },
               }}
-              variant="body1"
-            >
-              {journeyInstance.summary}
-            </Typography>
+              markdown={journeyInstance.summary}
+            />
           ) : (
             <Typography
               className={summaryCollapsed ? classes.collapsed : ''}


### PR DESCRIPTION
## Description
This PR makes journey instance summaries render as markdown.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/174644596-007d9cf1-81c2-4a22-8802-04199481a57e.png)

## Changes
* Adds the Markdown component to render the summary as markdown.

## Related issues
Resolves #764 
