### PR TITLE
Issue 755/task details style

### DIFF
--- a/src/components/organize/tasks/TaskDetailsSection.tsx
+++ b/src/components/organize/tasks/TaskDetailsSection.tsx
@@ -17,108 +17,103 @@ const TaskDetailsCard: React.FunctionComponent<TaskDetailsCardProps> = ({
 }) => {
   const intl = useIntl();
   return (
-    <>
-      <ZetkinSection title="Details">
-        <Card>
-          <List disablePadding>
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.instructionsLabel',
-              })}
-              value={task.instructions}
-            />
+    <ZetkinSection
+      title={intl.formatMessage({
+        id: 'misc.tasks.taskDetails.title',
+      })}
+    >
+      <Card>
+        <List disablePadding>
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.instructionsLabel',
+            })}
+            value={task.instructions}
+          />
 
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.timeEstimateLabel',
-              })}
-              value={
-                task.time_estimate
-                  ? intl.formatMessage(
-                      {
-                        id: 'misc.tasks.forms.createTask.fields.time_estimate_options.hoursAndMinutes',
-                      },
-                      {
-                        hours: Math.floor(task.time_estimate / 60),
-                        minutes: task.time_estimate % 60,
-                      }
-                    )
-                  : intl.formatMessage({
-                      id: 'misc.tasks.forms.createTask.fields.time_estimate_options.noEstimate',
-                    })
-              }
-            />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.timeEstimateLabel',
+            })}
+            value={
+              task.time_estimate
+                ? intl.formatMessage(
+                    {
+                      id: 'misc.tasks.forms.createTask.fields.time_estimate_options.hoursAndMinutes',
+                    },
+                    {
+                      hours: Math.floor(task.time_estimate / 60),
+                      minutes: task.time_estimate % 60,
+                    }
+                  )
+                : intl.formatMessage({
+                    id: 'misc.tasks.forms.createTask.fields.time_estimate_options.noEstimate',
+                  })
+            }
+          />
 
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.typeLabel',
-              })}
-              value={intl.formatMessage({
-                id: `misc.tasks.types.${task.type}`,
-              })}
-            />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.typeLabel',
+            })}
+            value={intl.formatMessage({
+              id: `misc.tasks.types.${task.type}`,
+            })}
+          />
 
-            <TaskTypeDetailsSection task={task} />
-          </List>
-        </Card>
-      </ZetkinSection>
-      <ZetkinSection title="Time">
-        <Card>
-          <List disablePadding>
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.publishedTime',
-              })}
-              value={
-                task.published && <ZetkinDateTime datetime={task.published} />
-              }
-            />
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.deadlineTime',
-              })}
-              value={
-                task.deadline && <ZetkinDateTime datetime={task.deadline} />
-              }
-            />
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.expiresTime',
-              })}
-              value={task.expires && <ZetkinDateTime datetime={task.expires} />}
-            />
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.reassignInterval.label',
-              })}
-              value={
-                task.reassign_interval &&
-                intl.formatMessage(
-                  { id: 'misc.tasks.taskDetails.reassignInterval.value' },
-                  { value: task.reassign_interval }
-                )
-              }
-            />
-            <TaskProperty
-              title={intl.formatMessage({
-                id: 'misc.tasks.taskDetails.reassignLimit.label',
-              })}
-              value={
-                task.reassign_limit &&
-                intl.formatMessage(
-                  {
-                    id: 'misc.tasks.taskDetails.reassignLimit.value',
-                  },
-                  {
-                    value: task.reassign_limit,
-                  }
-                )
-              }
-            />
-          </List>
-        </Card>
-      </ZetkinSection>
-    </>
+          <TaskTypeDetailsSection task={task} />
+
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.publishedTime',
+            })}
+            value={
+              task.published && <ZetkinDateTime datetime={task.published} />
+            }
+          />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.deadlineTime',
+            })}
+            value={task.deadline && <ZetkinDateTime datetime={task.deadline} />}
+          />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.expiresTime',
+            })}
+            value={task.expires && <ZetkinDateTime datetime={task.expires} />}
+          />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.reassignInterval.label',
+            })}
+            value={
+              task.reassign_interval &&
+              intl.formatMessage(
+                { id: 'misc.tasks.taskDetails.reassignInterval.value' },
+                { value: task.reassign_interval }
+              )
+            }
+          />
+          <TaskProperty
+            title={intl.formatMessage({
+              id: 'misc.tasks.taskDetails.reassignLimit.label',
+            })}
+            value={
+              task.reassign_limit &&
+              intl.formatMessage(
+                {
+                  id: 'misc.tasks.taskDetails.reassignLimit.value',
+                },
+                {
+                  value: task.reassign_limit,
+                }
+              )
+            }
+          />
+        </List>
+      </Card>
+    </ZetkinSection>
   );
 };
 

--- a/src/components/organize/tasks/TaskDetailsSection.tsx
+++ b/src/components/organize/tasks/TaskDetailsSection.tsx
@@ -1,11 +1,12 @@
 import { useIntl } from 'react-intl';
 
-import getTaskStatus from 'utils/getTaskStatus';
 import ZetkinDateTime from 'components/ZetkinDateTime';
 import { ZetkinTask } from 'types/zetkin';
 
 import TaskProperty from './TaskProperty';
 import TaskTypeDetailsSection from './TaskTypeDetailsSection';
+import ZetkinSection from 'components/ZetkinSection';
+import { Card, List } from '@material-ui/core';
 
 interface TaskDetailsCardProps {
   task: ZetkinTask;
@@ -15,101 +16,108 @@ const TaskDetailsCard: React.FunctionComponent<TaskDetailsCardProps> = ({
   task,
 }) => {
   const intl = useIntl();
-  const status = getTaskStatus(task);
   return (
     <>
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.statusLabel',
-        })}
-        value={intl.formatMessage({
-          id: `misc.tasks.statuses.${status}`,
-        })}
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.typeLabel',
-        })}
-        value={intl.formatMessage({
-          id: `misc.tasks.types.${task.type}`,
-        })}
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.instructionsLabel',
-        })}
-        value={task.instructions}
-      />
+      <ZetkinSection title="Details">
+        <Card>
+          <List disablePadding>
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.instructionsLabel',
+              })}
+              value={task.instructions}
+            />
 
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.timeEstimateLabel',
-        })}
-        value={
-          task.time_estimate
-            ? intl.formatMessage(
-                {
-                  id: 'misc.tasks.forms.createTask.fields.time_estimate_options.hoursAndMinutes',
-                },
-                {
-                  hours: Math.floor(task.time_estimate / 60),
-                  minutes: task.time_estimate % 60,
-                }
-              )
-            : intl.formatMessage({
-                id: 'misc.tasks.forms.createTask.fields.time_estimate_options.noEstimate',
-              })
-        }
-      />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.timeEstimateLabel',
+              })}
+              value={
+                task.time_estimate
+                  ? intl.formatMessage(
+                      {
+                        id: 'misc.tasks.forms.createTask.fields.time_estimate_options.hoursAndMinutes',
+                      },
+                      {
+                        hours: Math.floor(task.time_estimate / 60),
+                        minutes: task.time_estimate % 60,
+                      }
+                    )
+                  : intl.formatMessage({
+                      id: 'misc.tasks.forms.createTask.fields.time_estimate_options.noEstimate',
+                    })
+              }
+            />
 
-      <TaskTypeDetailsSection task={task} />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.typeLabel',
+              })}
+              value={intl.formatMessage({
+                id: `misc.tasks.types.${task.type}`,
+              })}
+            />
 
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.publishedTime',
-        })}
-        value={task.published && <ZetkinDateTime datetime={task.published} />}
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.deadlineTime',
-        })}
-        value={task.deadline && <ZetkinDateTime datetime={task.deadline} />}
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.expiresTime',
-        })}
-        value={task.expires && <ZetkinDateTime datetime={task.expires} />}
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.reassignInterval.label',
-        })}
-        value={
-          task.reassign_interval &&
-          intl.formatMessage(
-            { id: 'misc.tasks.taskDetails.reassignInterval.value' },
-            { value: task.reassign_interval }
-          )
-        }
-      />
-      <TaskProperty
-        title={intl.formatMessage({
-          id: 'misc.tasks.taskDetails.reassignLimit.label',
-        })}
-        value={
-          task.reassign_limit &&
-          intl.formatMessage(
-            {
-              id: 'misc.tasks.taskDetails.reassignLimit.value',
-            },
-            {
-              value: task.reassign_limit,
-            }
-          )
-        }
-      />
+            <TaskTypeDetailsSection task={task} />
+          </List>
+        </Card>
+      </ZetkinSection>
+      <ZetkinSection title="Time">
+        <Card>
+          <List disablePadding>
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.publishedTime',
+              })}
+              value={
+                task.published && <ZetkinDateTime datetime={task.published} />
+              }
+            />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.deadlineTime',
+              })}
+              value={
+                task.deadline && <ZetkinDateTime datetime={task.deadline} />
+              }
+            />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.expiresTime',
+              })}
+              value={task.expires && <ZetkinDateTime datetime={task.expires} />}
+            />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.reassignInterval.label',
+              })}
+              value={
+                task.reassign_interval &&
+                intl.formatMessage(
+                  { id: 'misc.tasks.taskDetails.reassignInterval.value' },
+                  { value: task.reassign_interval }
+                )
+              }
+            />
+            <TaskProperty
+              title={intl.formatMessage({
+                id: 'misc.tasks.taskDetails.reassignLimit.label',
+              })}
+              value={
+                task.reassign_limit &&
+                intl.formatMessage(
+                  {
+                    id: 'misc.tasks.taskDetails.reassignLimit.value',
+                  },
+                  {
+                    value: task.reassign_limit,
+                  }
+                )
+              }
+            />
+          </List>
+        </Card>
+      </ZetkinSection>
     </>
   );
 };

--- a/src/components/organize/tasks/TaskProperty.tsx
+++ b/src/components/organize/tasks/TaskProperty.tsx
@@ -1,5 +1,7 @@
-import { useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { ListItem, ListItemText } from '@material-ui/core';
+
+import theme from 'theme';
 
 interface TaskPropertyProps {
   title: string;
@@ -10,16 +12,15 @@ const TaskProperty: React.FunctionComponent<TaskPropertyProps> = ({
   title,
   value,
 }) => {
-  const intl = useIntl();
-
   return (
     <ListItem divider>
       <ListItemText
         primary={
-          value ||
-          intl.formatMessage({
-            id: 'misc.tasks.forms.common.notSet',
-          })
+          value || (
+            <span style={{ color: theme.palette.error.main }}>
+              <FormattedMessage id="misc.tasks.forms.common.notSet" />
+            </span>
+          )
         }
         secondary={title}
       />

--- a/src/components/organize/tasks/TaskProperty.tsx
+++ b/src/components/organize/tasks/TaskProperty.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from 'react-intl';
-import { Box, Typography } from '@material-ui/core';
+import { ListItem, ListItemText } from '@material-ui/core';
 
 interface TaskPropertyProps {
   title: string;
@@ -13,15 +13,17 @@ const TaskProperty: React.FunctionComponent<TaskPropertyProps> = ({
   const intl = useIntl();
 
   return (
-    <Box mt={2}>
-      <Typography variant="subtitle2">{title}</Typography>
-      <Typography color={value ? 'inherit' : 'error'} variant="body1">
-        {value ||
+    <ListItem divider>
+      <ListItemText
+        primary={
+          value ||
           intl.formatMessage({
             id: 'misc.tasks.forms.common.notSet',
-          })}
-      </Typography>
-    </Box>
+          })
+        }
+        secondary={title}
+      />
+    </ListItem>
   );
 };
 

--- a/src/components/organize/tasks/TaskProperty.tsx
+++ b/src/components/organize/tasks/TaskProperty.tsx
@@ -1,29 +1,30 @@
 import { FormattedMessage } from 'react-intl';
-import { ListItem, ListItemText } from '@material-ui/core';
-
-import theme from 'theme';
+import NextLink from 'next/link';
+import { Link, ListItem, ListItemText } from '@material-ui/core';
 
 interface TaskPropertyProps {
   title: string;
   value?: string | React.ReactNode;
+  url?: boolean;
 }
 
 const TaskProperty: React.FunctionComponent<TaskPropertyProps> = ({
   title,
   value,
+  url,
 }) => {
+  const displayValue = !value ? (
+    <FormattedMessage id="misc.tasks.forms.common.notSet" />
+  ) : url ? (
+    <NextLink href={value as string} passHref>
+      <Link>{value}</Link>
+    </NextLink>
+  ) : (
+    value
+  );
   return (
     <ListItem divider>
-      <ListItemText
-        primary={
-          value || (
-            <span style={{ color: theme.palette.error.main }}>
-              <FormattedMessage id="misc.tasks.forms.common.notSet" />
-            </span>
-          )
-        }
-        secondary={title}
-      />
+      <ListItemText primary={displayValue} secondary={title} />
     </ListItem>
   );
 };

--- a/src/components/organize/tasks/TaskStatusChip.tsx
+++ b/src/components/organize/tasks/TaskStatusChip.tsx
@@ -4,11 +4,11 @@ import { useIntl } from 'react-intl';
 import { TASK_STATUS } from 'utils/getTaskStatus';
 
 enum ChipColors {
-  active = '#6CC551',
+  active = '#57a83d',
   closed = '#FF4242',
-  draft = '',
-  expired = 'grey',
-  scheduled = '#4A8FE7',
+  draft = 'grey',
+  expired = 'black',
+  scheduled = '#317ad6',
 }
 
 interface TaskStatusChipProps {

--- a/src/components/organize/tasks/TaskStatusChip.tsx
+++ b/src/components/organize/tasks/TaskStatusChip.tsx
@@ -23,8 +23,11 @@ const TaskStatusChip: React.FunctionComponent<TaskStatusChipProps> = ({
     <Chip
       label={intl.formatMessage({ id: `misc.tasks.statuses.${status}` })}
       size="small"
-      style={{ backgroundColor: ChipColors[status] }}
-      variant="outlined"
+      style={{
+        backgroundColor: ChipColors[status],
+        color: 'white',
+        fontWeight: 'bold',
+      }}
     />
   );
 };

--- a/src/components/organize/tasks/TaskTypeDetailsSection/ShareLinkDetails.tsx
+++ b/src/components/organize/tasks/TaskTypeDetailsSection/ShareLinkDetails.tsx
@@ -17,6 +17,7 @@ const ShareLinkDetails: React.FunctionComponent<ShareLinkDetailsProps> = ({
         title={intl.formatMessage({
           id: 'misc.tasks.forms.shareLinkConfig.fields.url',
         })}
+        url
         value={taskConfig.url}
       />
       <TaskProperty

--- a/src/components/organize/tasks/TaskTypeDetailsSection/VisitLinkDetails.tsx
+++ b/src/components/organize/tasks/TaskTypeDetailsSection/VisitLinkDetails.tsx
@@ -16,6 +16,7 @@ const VisitLinkDetails: React.FunctionComponent<VisitLinkDetailsProps> = ({
       title={intl.formatMessage({
         id: 'misc.tasks.forms.visitLinkConfig.fields.url',
       })}
+      url
       value={taskConfig.url}
     />
   );

--- a/src/components/organize/tasks/TaskTypeDetailsSection/WatchVideoDetails.tsx
+++ b/src/components/organize/tasks/TaskTypeDetailsSection/WatchVideoDetails.tsx
@@ -16,6 +16,7 @@ const WatchVideoDetails: React.FunctionComponent<WatchVideoDetailsProps> = ({
       title={intl.formatMessage({
         id: 'misc.tasks.forms.watchVideoConfig.fields.url',
       })}
+      url
       value={taskConfig.url}
     />
   );

--- a/src/layout/organize/SingleTaskLayout.tsx
+++ b/src/layout/organize/SingleTaskLayout.tsx
@@ -1,10 +1,13 @@
+import { Box } from '@material-ui/core';
 import { FunctionComponent } from 'react';
 import { useRouter } from 'next/router';
 
 import TabbedLayout from './TabbedLayout';
 
+import getTaskStatus from 'utils/getTaskStatus';
 import TaskActionButtons from 'components/organize/tasks/TaskActionButtons';
 import { taskResource } from 'api/tasks';
+import TaskStatusChip from 'components/organize/tasks/TaskStatusChip';
 import TaskStatusText from 'components/organize/tasks/TaskStatusText';
 
 const SingleTaskLayout: FunctionComponent = ({ children }) => {
@@ -23,7 +26,16 @@ const SingleTaskLayout: FunctionComponent = ({ children }) => {
       actionButtons={<TaskActionButtons task={task} />}
       baseHref={`/organize/${orgId}/campaigns/${campId}/calendar/tasks/${taskId}`}
       defaultTab="/"
-      subtitle={<TaskStatusText task={task} />}
+      subtitle={
+        <Box alignItems="center" display="flex">
+          <Box mr={1}>
+            <TaskStatusChip status={getTaskStatus(task)} />
+          </Box>
+          <Box>
+            <TaskStatusText task={task} />
+          </Box>
+        </Box>
+      }
       tabs={[
         { href: `/`, messageId: 'layout.organize.tasks.tabs.summary' },
         {

--- a/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/calendar/tasks/[taskId]/index.tsx
@@ -56,8 +56,8 @@ const TaskDetailPage: PageWithLayout<TaskDetailPageProps> = ({
       <Head>
         <title>{task?.title}</title>
       </Head>
-      <Grid container>
-        <Grid item lg={8} md={6} sm={12}>
+      <Grid container justifyContent="space-between" spacing={4}>
+        <Grid item lg={6} md={6} sm={12}>
           <TaskDetailsSection task={task} />
         </Grid>
         <Grid item lg={4} md={6} sm={12}>


### PR DESCRIPTION
## Description
This PR changes the style of the Task Details section to match the Person Details section.

## Screenshots
![Screenshot from 2022-06-22 12-59-40](https://user-images.githubusercontent.com/41007222/175024030-5f70ada2-15ae-436d-9d1e-629d304e6608.png)

## Changes

* Changes
  * Page layout breakpoints on the task detail page are changed to make the card less wide, similar to the Journey instance page. 
  * Task details list now uses a List within a card to be visually consistent with the Person Details section 
  * URL properties are links
  * <TaskStatusChip />
    * Changes colours so that it looks ok with a white background
    * Replaces the status shown in the details with a tag in the header (see screenshot)  

## Related issues
Resolves #755 

