### PR TITLE
Commit tokens to session in scaffold()

### DIFF
--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -92,6 +92,11 @@ export default async function handle(
   try {
     const method = HTTP_VERBS_TO_ZETKIN_METHODS[req.method!];
     const result = await method(resource, req);
+
+    // Update session in case tokens were refreshed
+    req.session.tokenData = z.getTokenData();
+    await req.session.commit();
+
     res.status(result.httpStatus).json(result.data);
   } catch (err) {
     if (err && typeof err === 'object' && 'httpStatus' in err) {

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -75,6 +75,7 @@ export default async function handle(
     host: process.env.ZETKIN_API_HOST,
     port: process.env.ZETKIN_API_PORT,
     ssl: stringToBool(process.env.ZETKIN_USE_TLS),
+    zetkinDomain: process.env.ZETKIN_API_DOMAIN,
   });
 
   const resource = z.resource(pathStr + (queryParams ? '?' + queryParams : ''));

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -179,6 +179,8 @@ export const scaffold =
     // Update token data in session, in case it was refreshed
     reqWithSession.session.tokenData = ctx.z.getTokenData();
 
+    await reqWithSession.session.commit();
+
     const result = (await wrapped(ctx)) || {};
 
     // Figure out browser's preferred language


### PR DESCRIPTION
## Description
This PR makes it so that `scaffold()` waits until refreshed tokens have been committed to the session before proceeding to the individual page's `getServerSideProps()` logic. That way, we know that the session will contain updated tokens before proceeding to make API requests.

Similarly, it makes sure that the API proxy (`[...path].ts`) correctly commits refreshed tokens to the session, which wasn't happening before. In fact, the API proxy was misconfigured so that refreshes could never happen.

## Screenshots
None

## Changes
* Adds `session.commit()` after updating the session tokens in both `scaffold()` and the API proxy `[...path].ts`.
* Adds missing configuration to the API proxy, to fix an undocumented bug which was preventing token refreshes from ever working. This is likely what would sometimes cause the user to be thrown out to login.

## Notes to reviewer
This is difficult to test without waiting for 60 minutes. I have developed it in an environment where I set the token expiry to 30 seconds.

## Related issues
Resolves #747 
