### PR TITLE
issue-759/localise view ellipsis menu

### DIFF
--- a/src/pages/organize/[orgId]/people/views/[viewId].tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId].tsx
@@ -14,7 +14,7 @@ import ZetkinQuery from 'components/ZetkinQuery';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize'],
+  localeScope: ['layout.organize', 'pages.people.views'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {


### PR DESCRIPTION
## Description
This PR fixes a bug where the ellipsis menu on a view for changing the view type, query, or deleting the view wasn't loading the locale strings, so the id string was shown.


## Screenshots
![Screenshot from 2022-06-27 17-38-29](https://user-images.githubusercontent.com/41007222/175991799-f7a04d67-4bd8-4ea9-a772-87606ed02580.png)


## Changes
* Adds
  * `pages.people.views` to the locale scope in the scafford for the page `.../views/[viewId].tsx`.


## Notes to reviewer
Go check out the ellipsis menu on a view page.


## Related issues
Resolves #759 
