### PR TITLE
Journey export bugs

### DIFF
--- a/src/locale/server/en.yml
+++ b/src/locale/server/en.yml
@@ -11,4 +11,5 @@ export:
       subjects: Subjects
       summary: Summary
       title: Title
+      unsortedTags: Ungrouped Tags
       updated: Updated

--- a/src/pages/api/journeyInstances/download.ts
+++ b/src/pages/api/journeyInstances/download.ts
@@ -143,8 +143,9 @@ export default async function handler(
       ];
 
       return {
-        // Set the width to 3 + the max number of characters on any row
-        width: 3 + Math.max.apply(null, allLengths),
+        // Set the width to 3 + the max number of characters on any row,
+        // but cap to 50 characters to not get super wide columns
+        width: 3 + Math.min(50, Math.max.apply(null, allLengths)),
       };
     });
 


### PR DESCRIPTION
## Description
This PR fixes an internal server error bug caused by a missing localization (did not exist for any language, so no fallback was found).

While at it, I also added a cap to the column width in Excel files, so that the columns aren't rendered super wide just because there's a lot of text in them.

## Screenshots
None

## Changes
* Adds a missing localization for unsorted tag columns
* Changes column width calculation so that it never exceeds 50 characters wide.

## Notes to reviewer
This only happened in live data, but having investigated it, it should be possible to reproduce #745 (on `main`) just by having an unsorted tag be applied to a journey instance before downloading.

## Related issues
Resolves #745 
