### PR TITLE
Issue 740/improve journey instances filtering

### DIFF
--- a/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
@@ -31,7 +31,7 @@ test.describe('Journey instance list', () => {
     moxy.teardown();
   });
 
-  test('persists sort and filter state', async ({ appUri, page }) => {
+  test.only('persists sort and filter state', async ({ appUri, page }) => {
     await page.goto(appUri + '/organize/1/journeys/1');
 
     // Open filters dialog
@@ -42,7 +42,7 @@ test.describe('Journey instance list', () => {
       .locator('label:text("Columns") + * select')
       .selectOption({ label: 'Tags' });
     await page
-      .locator('select:has-text("contains")')
+      .locator('select:has-text("Has")')
       .selectOption({ label: 'is empty' });
 
     // Click title header twice to sort descending

--- a/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/journey-instance-list.spec.ts
@@ -31,7 +31,7 @@ test.describe('Journey instance list', () => {
     moxy.teardown();
   });
 
-  test.only('persists sort and filter state', async ({ appUri, page }) => {
+  test('persists sort and filter state', async ({ appUri, page }) => {
     await page.goto(appUri + '/organize/1/journeys/1');
 
     // Open filters dialog

--- a/src/components/journeys/JourneyInstancesDataTable/FilterValueSelect.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/FilterValueSelect.tsx
@@ -3,15 +3,16 @@ import { JSXElementConstructor } from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
 import { FormControl, InputLabel, Select } from '@material-ui/core';
 
-import { ZetkinPerson } from 'types/zetkin';
-
 const FilterValueSelect: JSXElementConstructor<
-  GridFilterInputValueProps & { subjects?: ZetkinPerson[] }
-> = ({ applyValue, item, subjects }) => {
+  GridFilterInputValueProps & {
+    labelMessageId?: string;
+    options?: { id: number; title: string }[];
+  }
+> = ({ applyValue, item, labelMessageId, options }) => {
   return (
     <FormControl>
       <InputLabel>
-        <Msg id="misc.journeys.journeyInstancesFilters.personLabel" />
+        <Msg id={labelMessageId} />
       </InputLabel>
       <Select
         native
@@ -19,9 +20,9 @@ const FilterValueSelect: JSXElementConstructor<
         value={item.value}
       >
         <option value=""></option>
-        {subjects?.map((subject) => (
-          <option key={subject.id} value={subject.id}>
-            {`${subject.first_name} ${subject.last_name}`}
+        {options?.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.title}
           </option>
         ))}
       </Select>

--- a/src/components/journeys/JourneyInstancesDataTable/FilterValueSelect.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/FilterValueSelect.tsx
@@ -1,0 +1,32 @@
+import { GridFilterInputValueProps } from '@mui/x-data-grid-pro';
+import { JSXElementConstructor } from 'react';
+import { FormattedMessage as Msg } from 'react-intl';
+import { FormControl, InputLabel, Select } from '@material-ui/core';
+
+import { ZetkinPerson } from 'types/zetkin';
+
+const FilterValueSelect: JSXElementConstructor<
+  GridFilterInputValueProps & { subjects?: ZetkinPerson[] }
+> = ({ applyValue, item, subjects }) => {
+  return (
+    <FormControl>
+      <InputLabel>
+        <Msg id="misc.journeys.journeyInstancesFilters.personLabel" />
+      </InputLabel>
+      <Select
+        native
+        onChange={(event) => applyValue({ ...item, value: event.target.value })}
+        value={item.value}
+      >
+        <option value=""></option>
+        {subjects?.map((subject) => (
+          <option key={subject.id} value={subject.id}>
+            {`${subject.first_name} ${subject.last_name}`}
+          </option>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default FilterValueSelect;

--- a/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
+++ b/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
@@ -1,11 +1,17 @@
 import { GridColDef } from '@mui/x-data-grid-pro';
+import { IntlShape } from 'react-intl';
 
 import { getStaticColumns } from './getStaticColumns';
 import getTagColumns from './getTagColumns';
 import { JourneyTagColumnData } from 'utils/journeyInstanceUtils';
+import { ZetkinJourneyInstance } from 'types/zetkin';
 
-const getColumns = (tagColumns: JourneyTagColumnData[]): GridColDef[] => {
-  const staticColumns = getStaticColumns();
+const getColumns = (
+  intl: IntlShape,
+  journeyInstances: ZetkinJourneyInstance[],
+  tagColumns: JourneyTagColumnData[]
+): GridColDef[] => {
+  const staticColumns = getStaticColumns(intl, journeyInstances);
   return (
     staticColumns
       .splice(0, 2)

--- a/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
+++ b/src/components/journeys/JourneyInstancesDataTable/getColumns.ts
@@ -15,7 +15,7 @@ const getColumns = (
   return (
     staticColumns
       .splice(0, 2)
-      .concat(getTagColumns(tagColumns))
+      .concat(getTagColumns(intl, journeyInstances, tagColumns))
       // Add/override common props
       .concat(staticColumns)
       .map((col) => ({

--- a/src/components/journeys/JourneyInstancesDataTable/getRows.ts
+++ b/src/components/journeys/JourneyInstancesDataTable/getRows.ts
@@ -10,11 +10,11 @@ interface GetRowsProps {
 const options = {
   includeScore: true,
   keys: [
-    'assigned_to.first_name',
-    'assigned_to.last_name',
+    'assignees.first_name',
+    'assignees.last_name',
     'next_milestone.title',
-    'people.first_name',
-    'people.last_name',
+    'subjects.first_name',
+    'subjects.last_name',
     'summary',
     'tags.value',
     'tags.title',

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -222,54 +222,28 @@ export const getStaticColumns = (
     {
       field: 'nextMilestoneTitle',
       filterOperators: [
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId:
-              'misc.journeys.journeyInstancesFilters.milestoneLabel',
-            options: uniqueMilestones,
-          },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              return (
-                (
-                  params.row as ZetkinJourneyInstance
-                ).next_milestone?.id.toString() === item.value
-              );
-            };
-          },
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.isOperator',
-          }),
-          value: 'is',
-        },
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId:
-              'misc.journeys.journeyInstancesFilters.milestoneLabel',
-            options: uniqueMilestones,
-          },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              return (
-                (
-                  params.row as ZetkinJourneyInstance
-                ).next_milestone?.id.toString() !== item.value
-              );
-            };
-          },
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.isNotOperator',
-          }),
-          value: 'isNot',
-        },
+        makeSelectFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.isOperator',
+          'is',
+          'misc.journeys.journeyInstancesFilters.milestoneLabel',
+          uniqueMilestones,
+          (item, params) =>
+            (
+              params.row as ZetkinJourneyInstance
+            ).next_milestone?.id.toString() === item.value
+        ),
+        makeSelectFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.isNotOperator',
+          'isNot',
+          'misc.journeys.journeyInstancesFilters.milestoneLabel',
+          uniqueMilestones,
+          (item, params) =>
+            (
+              params.row as ZetkinJourneyInstance
+            ).next_milestone?.id.toString() !== item.value
+        ),
       ],
       valueGetter: (params) =>
         (params.row as ZetkinJourneyInstance).next_milestone?.title,

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -1,4 +1,6 @@
-import { GridColDef } from '@mui/x-data-grid-pro';
+import { JSXElementConstructor } from 'react';
+import { TextField } from '@material-ui/core';
+import { GridColDef, GridFilterInputValueProps } from '@mui/x-data-grid-pro';
 
 import JourneyInstanceTitle from 'components/journeys/JourneyInstanceTitle';
 import PersonHoverCard from 'components/PersonHoverCard';
@@ -9,6 +11,20 @@ import {
   ZetkinJourneyInstance,
   ZetkinPerson as ZetkinPersonType,
 } from 'types/zetkin';
+
+const TestValueInput: JSXElementConstructor<GridFilterInputValueProps> = ({
+  applyValue,
+  item,
+}) => {
+  return (
+    <TextField
+      fullWidth
+      onChange={(event) => applyValue({ ...item, value: event.target.value })}
+      placeholder="Filter value"
+      value={item.value}
+    />
+  );
+};
 
 // Name concatenation
 const getPeopleString = (people: ZetkinPersonType[]) =>
@@ -32,7 +48,37 @@ export const getStaticColumns = (): GridColDef[] => [
   },
   {
     field: 'subjects',
-    valueGetter: (params) =>
+    filterOperators: [
+      {
+        InputComponent: TestValueInput,
+        getApplyFilterFn: (item) => {
+          return (params) => {
+            const people = params.value as ZetkinPersonType[];
+
+            return !!people.find((person) => {
+              return person.id.toString() === item.value;
+            });
+          };
+        },
+        label: 'Has ID',
+        value: 'has',
+      },
+      {
+        InputComponent: TestValueInput,
+        getApplyFilterFn: (item) => {
+          return (params) => {
+            const people = params.value as ZetkinPersonType[];
+
+            return !!people.find((person) => {
+              return person.id.toString() !== item.value;
+            });
+          };
+        },
+        label: 'Does not have ID',
+        value: 'does not have',
+      },
+    ],
+    valueFormatter: (params) =>
       getPeopleString(params.value as ZetkinPersonType[]),
   },
   {

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -87,12 +87,20 @@ function makeIncludesFilterOperator(
   );
 }
 
-const isEmpty = () => {
-  return (params: GridCellParams) => {
-    const people = params.value as ZetkinPersonType[];
-    return people.length === 0;
+function makeEmptyFilterOperator(intl: IntlShape): GridFilterOperator {
+  return {
+    getApplyFilterFn: () => {
+      return (params: GridCellParams) => {
+        const people = params.value as ZetkinPersonType[];
+        return people.length === 0;
+      };
+    },
+    label: intl.formatMessage({
+      id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
+    }),
+    value: 'isEmpty',
   };
-};
+}
 
 const sortByName = (value0: GridCellValue, value1: GridCellValue) => {
   const names0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
@@ -187,13 +195,7 @@ export const getStaticColumns = (
           'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
           uniqueSubjects
         ),
-        {
-          getApplyFilterFn: isEmpty,
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
-          }),
-          value: 'isEmpty',
-        },
+        makeEmptyFilterOperator(intl),
       ],
       sortComparator: (value0, value1) => sortByName(value0, value1),
       valueFormatter: (params) =>
@@ -300,13 +302,7 @@ export const getStaticColumns = (
           'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
           uniqueAssignees
         ),
-        {
-          getApplyFilterFn: isEmpty,
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
-          }),
-          value: 'isEmpty',
-        },
+        makeEmptyFilterOperator(intl),
       ],
       renderCell: (params) =>
         (params.row.assignees as ZetkinPersonType[]).map((person) => (

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -57,17 +57,17 @@ export const getStaticColumns = (
   journeyInstances
     .flatMap((instance) => instance.subjects)
     .forEach((person) => (peopleById[person.id.toString()] = person));
-  const uniqueSubjects = Object.values(peopleById).sort((p0, p1) =>
-    fullName(p0).localeCompare(fullName(p1))
-  );
+  const uniqueSubjects = Object.values(peopleById)
+    .sort((p0, p1) => fullName(p0).localeCompare(fullName(p1)))
+    .map((subject) => ({ id: subject.id, title: fullName(subject) }));
 
   const assigneesById: Record<string, ZetkinPersonType> = {};
   journeyInstances
     .flatMap((instance) => instance.assignees)
     .forEach((assignee) => (assigneesById[assignee.id.toString()] = assignee));
-  const uniqueAssignees = Object.values(assigneesById).sort((a0, a1) =>
-    fullName(a0).localeCompare(fullName(a1))
-  );
+  const uniqueAssignees = Object.values(assigneesById)
+    .sort((a0, a1) => fullName(a0).localeCompare(fullName(a1)))
+    .map((assignee) => ({ id: assignee.id, title: fullName(assignee) }));
 
   return [
     {
@@ -90,7 +90,10 @@ export const getStaticColumns = (
       filterOperators: [
         {
           InputComponent: FilterValueSelect,
-          InputComponentProps: { subjects: uniqueSubjects },
+          InputComponentProps: {
+            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
+            options: uniqueSubjects,
+          },
           getApplyFilterFn: (item) => includes(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.includesOperator',
@@ -99,10 +102,13 @@ export const getStaticColumns = (
         },
         {
           InputComponent: FilterValueSelect,
-          InputComponentProps: { subjects: uniqueSubjects },
+          InputComponentProps: {
+            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
+            options: uniqueSubjects,
+          },
           getApplyFilterFn: (item) => doesNotInclude(item),
           label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.excludesOperator',
+            id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
           }),
           value: 'doesNotInclude',
         },
@@ -153,7 +159,10 @@ export const getStaticColumns = (
       filterOperators: [
         {
           InputComponent: FilterValueSelect,
-          InputComponentProps: { subjects: uniqueAssignees },
+          InputComponentProps: {
+            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
+            options: uniqueAssignees,
+          },
           getApplyFilterFn: (item) => includes(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.includesOperator',
@@ -162,10 +171,13 @@ export const getStaticColumns = (
         },
         {
           InputComponent: FilterValueSelect,
-          InputComponentProps: { subjects: uniqueAssignees },
+          InputComponentProps: {
+            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
+            options: uniqueAssignees,
+          },
           getApplyFilterFn: (item) => doesNotInclude(item),
           label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.excludesOperator',
+            id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
           }),
           value: 'doesNotInclude',
         },

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -113,6 +113,27 @@ export const getStaticColumns = (
           value: 'doesNotInclude',
         },
       ],
+      sortComparator: (value0, value1) => {
+        const subjects0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
+          fullName(p0).localeCompare(fullName(p1))
+        );
+        const subjects1 = (value1 as ZetkinPersonType[]).sort((p0, p1) =>
+          fullName(p0).localeCompare(fullName(p1))
+        );
+
+        const name0 = subjects0[0] ? fullName(subjects0[0]) : '';
+        const name1 = subjects1[0] ? fullName(subjects1[0]) : '';
+
+        if (!name0 && !name1) {
+          return 0;
+        } else if (!name0) {
+          return 1;
+        } else if (!name1) {
+          return -1;
+        } else {
+          return name0.localeCompare(name1);
+        }
+      },
       valueFormatter: (params) =>
         getPeopleString(params.value as ZetkinPersonType[]),
     },
@@ -194,6 +215,27 @@ export const getStaticColumns = (
             />
           </PersonHoverCard>
         )),
+      sortComparator: (value0, value1) => {
+        const assignees0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
+          fullName(p0).localeCompare(fullName(p1))
+        );
+        const assignees1 = (value1 as ZetkinPersonType[]).sort((p0, p1) =>
+          fullName(p0).localeCompare(fullName(p1))
+        );
+
+        const name0 = assignees0[0] ? fullName(assignees0[0]) : '';
+        const name1 = assignees1[0] ? fullName(assignees1[0]) : '';
+
+        if (!name0 && !name1) {
+          return 0;
+        } else if (!name0) {
+          return 1;
+        } else if (!name1) {
+          return -1;
+        } else {
+          return name0.localeCompare(name1);
+        }
+      },
       valueFormatter: (params) =>
         getPeopleString(params.value as ZetkinPersonType[]),
     },

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -1,8 +1,11 @@
-import { JSXElementConstructor } from 'react';
-import { FormControl, InputLabel, Select } from '@material-ui/core';
-import { GridColDef, GridFilterInputValueProps } from '@mui/x-data-grid-pro';
-import { IntlShape, FormattedMessage as Msg } from 'react-intl';
+import { IntlShape } from 'react-intl';
+import {
+  GridCellParams,
+  GridColDef,
+  GridFilterItem,
+} from '@mui/x-data-grid-pro';
 
+import FilterValueSelect from './FilterValueSelect';
 import JourneyInstanceTitle from 'components/journeys/JourneyInstanceTitle';
 import PersonHoverCard from 'components/PersonHoverCard';
 import ZetkinDateTime from 'components/ZetkinDateTime';
@@ -13,28 +16,30 @@ import {
   ZetkinPerson as ZetkinPersonType,
 } from 'types/zetkin';
 
-const TestValueInput: JSXElementConstructor<
-  GridFilterInputValueProps & { subjects?: ZetkinPersonType[] }
-> = ({ applyValue, item, subjects }) => {
-  return (
-    <FormControl>
-      <InputLabel>
-        <Msg id="misc.journeys.journeyInstancesFilters.personLabel" />
-      </InputLabel>
-      <Select
-        native
-        onChange={(event) => applyValue({ ...item, value: event.target.value })}
-        value={item.value}
-      >
-        <option value=""></option>
-        {subjects?.map((subject) => (
-          <option key={subject.id} value={subject.id}>
-            {fullName(subject)}
-          </option>
-        ))}
-      </Select>
-    </FormControl>
-  );
+const includes = (item: GridFilterItem) => {
+  return (params: GridCellParams) => {
+    if (!item.value) {
+      return true;
+    }
+    const people = params.value as ZetkinPersonType[];
+
+    return !!people.find((person) => {
+      return person.id.toString() === item.value;
+    });
+  };
+};
+
+const doesNotInclude = (item: GridFilterItem) => {
+  return (params: GridCellParams) => {
+    if (!item.value) {
+      return true;
+    }
+    const assignees = params.value as ZetkinPersonType[];
+
+    return !!assignees.find((assignee) => {
+      return assignee.id.toString() !== item.value;
+    });
+  };
 };
 
 const fullName = (person: ZetkinPersonType) =>
@@ -84,40 +89,18 @@ export const getStaticColumns = (
       field: 'subjects',
       filterOperators: [
         {
-          InputComponent: TestValueInput,
+          InputComponent: FilterValueSelect,
           InputComponentProps: { subjects: uniqueSubjects },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              const people = params.value as ZetkinPersonType[];
-
-              return !!people.find((person) => {
-                return person.id.toString() === item.value;
-              });
-            };
-          },
+          getApplyFilterFn: (item) => includes(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.includesOperator',
           }),
           value: 'includes',
         },
         {
-          InputComponent: TestValueInput,
+          InputComponent: FilterValueSelect,
           InputComponentProps: { subjects: uniqueSubjects },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              const people = params.value as ZetkinPersonType[];
-
-              return !!people.find((person) => {
-                return person.id.toString() !== item.value;
-              });
-            };
-          },
+          getApplyFilterFn: (item) => doesNotInclude(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.excludesOperator',
           }),
@@ -169,40 +152,18 @@ export const getStaticColumns = (
       field: 'assignees',
       filterOperators: [
         {
-          InputComponent: TestValueInput,
+          InputComponent: FilterValueSelect,
           InputComponentProps: { subjects: uniqueAssignees },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              const assignees = params.value as ZetkinPersonType[];
-
-              return !!assignees.find((assignee) => {
-                return assignee.id.toString() === item.value;
-              });
-            };
-          },
+          getApplyFilterFn: (item) => includes(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.includesOperator',
           }),
           value: 'includes',
         },
         {
-          InputComponent: TestValueInput,
+          InputComponent: FilterValueSelect,
           InputComponentProps: { subjects: uniqueAssignees },
-          getApplyFilterFn: (item) => {
-            return (params) => {
-              if (!item.value) {
-                return true;
-              }
-              const assignees = params.value as ZetkinPersonType[];
-
-              return !!assignees.find((assignee) => {
-                return assignee.id.toString() !== item.value;
-              });
-            };
-          },
+          getApplyFilterFn: (item) => doesNotInclude(item),
           label: intl.formatMessage({
             id: 'misc.journeys.journeyInstancesFilters.excludesOperator',
           }),

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -3,7 +3,6 @@ import {
   GridCellParams,
   GridCellValue,
   GridColDef,
-  GridFilterItem,
   GridFilterOperator,
 } from '@mui/x-data-grid-pro';
 
@@ -19,18 +18,35 @@ import {
   ZetkinPerson as ZetkinPersonType,
 } from 'types/zetkin';
 
-const doesNotInclude = (item: GridFilterItem) => {
-  return (params: GridCellParams) => {
-    if (!item.value) {
-      return true;
-    }
-    const assignees = params.value as ZetkinPersonType[];
+function makeDoesNotIncludeFilterOperator(
+  intl: IntlShape,
+  labelMsgId: string,
+  options: { id: number; title: string }[]
+): GridFilterOperator {
+  return {
+    InputComponent: FilterValueSelect,
+    InputComponentProps: {
+      labelMessageId: labelMsgId,
+      options,
+    },
+    getApplyFilterFn: (item) => {
+      return (params: GridCellParams) => {
+        if (!item.value) {
+          return true;
+        }
+        const people = params.value as ZetkinPersonType[];
 
-    return !!assignees.find((assignee) => {
-      return assignee.id.toString() !== item.value;
-    });
+        return !people.find((person) => {
+          return person.id.toString() === item.value;
+        });
+      };
+    },
+    label: intl.formatMessage({
+      id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
+    }),
+    value: 'doesNotInclude',
   };
-};
+}
 
 function makeIncludesFilterOperator(
   intl: IntlShape,
@@ -157,18 +173,11 @@ export const getStaticColumns = (
           'misc.journeys.journeyInstancesFilters.personLabel',
           uniqueSubjects
         ),
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
-            options: uniqueSubjects,
-          },
-          getApplyFilterFn: (item) => doesNotInclude(item),
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
-          }),
-          value: 'doesNotInclude',
-        },
+        makeDoesNotIncludeFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
+          uniqueSubjects
+        ),
         {
           getApplyFilterFn: isEmpty,
           label: intl.formatMessage({
@@ -277,18 +286,11 @@ export const getStaticColumns = (
           'misc.journeys.journeyInstancesFilters.personLabel',
           uniqueAssignees
         ),
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
-            options: uniqueAssignees,
-          },
-          getApplyFilterFn: (item) => doesNotInclude(item),
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
-          }),
-          value: 'doesNotInclude',
-        },
+        makeDoesNotIncludeFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
+          uniqueAssignees
+        ),
         {
           getApplyFilterFn: isEmpty,
           label: intl.formatMessage({

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -43,6 +43,13 @@ const doesNotInclude = (item: GridFilterItem) => {
   };
 };
 
+const isEmpty = () => {
+  return (params: GridCellParams) => {
+    const people = params.value as ZetkinPersonType[];
+    return people.length === 0;
+  };
+};
+
 const sortByName = (value0: GridCellValue, value1: GridCellValue) => {
   const names0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
     fullName(p0).localeCompare(fullName(p1))
@@ -135,6 +142,13 @@ export const getStaticColumns = (
           }),
           value: 'doesNotInclude',
         },
+        {
+          getApplyFilterFn: isEmpty,
+          label: intl.formatMessage({
+            id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
+          }),
+          value: 'isEmpty',
+        },
       ],
       sortComparator: (value0, value1) => sortByName(value0, value1),
       valueFormatter: (params) =>
@@ -204,6 +218,13 @@ export const getStaticColumns = (
             id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
           }),
           value: 'doesNotInclude',
+        },
+        {
+          getApplyFilterFn: isEmpty,
+          label: intl.formatMessage({
+            id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
+          }),
+          value: 'isEmpty',
         },
       ],
       renderCell: (params) =>

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -4,6 +4,7 @@ import {
   GridCellValue,
   GridColDef,
   GridFilterItem,
+  GridFilterOperator,
 } from '@mui/x-data-grid-pro';
 
 import FilterValueSelect from './FilterValueSelect';
@@ -18,19 +19,6 @@ import {
   ZetkinPerson as ZetkinPersonType,
 } from 'types/zetkin';
 
-const includes = (item: GridFilterItem) => {
-  return (params: GridCellParams) => {
-    if (!item.value) {
-      return true;
-    }
-    const people = params.value as ZetkinPersonType[];
-
-    return !!people.find((person) => {
-      return person.id.toString() === item.value;
-    });
-  };
-};
-
 const doesNotInclude = (item: GridFilterItem) => {
   return (params: GridCellParams) => {
     if (!item.value) {
@@ -43,6 +31,36 @@ const doesNotInclude = (item: GridFilterItem) => {
     });
   };
 };
+
+function makeIncludesFilterOperator(
+  intl: IntlShape,
+  labelMsgId: string,
+  options: { id: number; title: string }[]
+): GridFilterOperator {
+  return {
+    InputComponent: FilterValueSelect,
+    InputComponentProps: {
+      labelMessageId: labelMsgId,
+      options,
+    },
+    getApplyFilterFn: (item) => {
+      return (params: GridCellParams) => {
+        if (!item.value) {
+          return true;
+        }
+        const people = params.value as ZetkinPersonType[];
+
+        return !!people.find((person) => {
+          return person.id.toString() === item.value;
+        });
+      };
+    },
+    label: intl.formatMessage({
+      id: 'misc.journeys.journeyInstancesFilters.includesOperator',
+    }),
+    value: 'includes',
+  };
+}
 
 const isEmpty = () => {
   return (params: GridCellParams) => {
@@ -134,18 +152,11 @@ export const getStaticColumns = (
     {
       field: 'subjects',
       filterOperators: [
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
-            options: uniqueSubjects,
-          },
-          getApplyFilterFn: (item) => includes(item),
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.includesOperator',
-          }),
-          value: 'includes',
-        },
+        makeIncludesFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.personLabel',
+          uniqueSubjects
+        ),
         {
           InputComponent: FilterValueSelect,
           InputComponentProps: {
@@ -261,18 +272,11 @@ export const getStaticColumns = (
     {
       field: 'assignees',
       filterOperators: [
-        {
-          InputComponent: FilterValueSelect,
-          InputComponentProps: {
-            labelMessageId: 'misc.journeys.journeyInstancesFilters.personLabel',
-            options: uniqueAssignees,
-          },
-          getApplyFilterFn: (item) => includes(item),
-          label: intl.formatMessage({
-            id: 'misc.journeys.journeyInstancesFilters.includesOperator',
-          }),
-          value: 'includes',
-        },
+        makeIncludesFilterOperator(
+          intl,
+          'misc.journeys.journeyInstancesFilters.personLabel',
+          uniqueAssignees
+        ),
         {
           InputComponent: FilterValueSelect,
           InputComponentProps: {

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -3,6 +3,7 @@ import {
   GridCellParams,
   GridCellValue,
   GridColDef,
+  GridFilterItem,
   GridFilterOperator,
 } from '@mui/x-data-grid-pro';
 
@@ -18,15 +19,18 @@ import {
   ZetkinPerson as ZetkinPersonType,
 } from 'types/zetkin';
 
-function makeDoesNotIncludeFilterOperator(
+function makeSelectFilterOperator(
   intl: IntlShape,
-  labelMsgId: string,
-  options: { id: number; title: string }[]
+  operatorLabelMsgId: string,
+  operatorValue: string,
+  selectMsgId: string,
+  options: { id: number; title: string }[],
+  optionMatches: (item: GridFilterItem, params: GridCellParams) => boolean
 ): GridFilterOperator {
   return {
     InputComponent: FilterValueSelect,
     InputComponentProps: {
-      labelMessageId: labelMsgId,
+      labelMessageId: selectMsgId,
       options,
     },
     getApplyFilterFn: (item) => {
@@ -34,18 +38,33 @@ function makeDoesNotIncludeFilterOperator(
         if (!item.value) {
           return true;
         }
-        const people = params.value as ZetkinPersonType[];
 
-        return !people.find((person) => {
-          return person.id.toString() === item.value;
-        });
+        return optionMatches(item, params);
       };
     },
-    label: intl.formatMessage({
-      id: 'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
-    }),
-    value: 'doesNotInclude',
+    label: intl.formatMessage({ id: operatorLabelMsgId }),
+    value: operatorValue,
   };
+}
+
+function makeDoesNotIncludeFilterOperator(
+  intl: IntlShape,
+  labelMsgId: string,
+  options: { id: number; title: string }[]
+): GridFilterOperator {
+  return makeSelectFilterOperator(
+    intl,
+    'misc.journeys.journeyInstancesFilters.doesNotIncludeOperator',
+    'doesNotInclude',
+    labelMsgId,
+    options,
+    (item, params) => {
+      const people = params.value as ZetkinPersonType[];
+      return !people.find((person) => {
+        return person.id.toString() === item.value;
+      });
+    }
+  );
 }
 
 function makeIncludesFilterOperator(
@@ -53,29 +72,19 @@ function makeIncludesFilterOperator(
   labelMsgId: string,
   options: { id: number; title: string }[]
 ): GridFilterOperator {
-  return {
-    InputComponent: FilterValueSelect,
-    InputComponentProps: {
-      labelMessageId: labelMsgId,
-      options,
-    },
-    getApplyFilterFn: (item) => {
-      return (params: GridCellParams) => {
-        if (!item.value) {
-          return true;
-        }
-        const people = params.value as ZetkinPersonType[];
-
-        return !!people.find((person) => {
-          return person.id.toString() === item.value;
-        });
-      };
-    },
-    label: intl.formatMessage({
-      id: 'misc.journeys.journeyInstancesFilters.includesOperator',
-    }),
-    value: 'includes',
-  };
+  return makeSelectFilterOperator(
+    intl,
+    'misc.journeys.journeyInstancesFilters.includesOperator',
+    'includes',
+    labelMsgId,
+    options,
+    (item, params) => {
+      const people = params.value as ZetkinPersonType[];
+      return !!people.find((person) => {
+        return person.id.toString() === item.value;
+      });
+    }
+  );
 }
 
 const isEmpty = () => {

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -1,6 +1,7 @@
 import { IntlShape } from 'react-intl';
 import {
   GridCellParams,
+  GridCellValue,
   GridColDef,
   GridFilterItem,
 } from '@mui/x-data-grid-pro';
@@ -40,6 +41,28 @@ const doesNotInclude = (item: GridFilterItem) => {
       return assignee.id.toString() !== item.value;
     });
   };
+};
+
+const sortByName = (value0: GridCellValue, value1: GridCellValue) => {
+  const names0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
+    fullName(p0).localeCompare(fullName(p1))
+  );
+  const names1 = (value1 as ZetkinPersonType[]).sort((p0, p1) =>
+    fullName(p0).localeCompare(fullName(p1))
+  );
+
+  const name0 = names0[0] ? fullName(names0[0]) : '';
+  const name1 = names1[0] ? fullName(names1[0]) : '';
+
+  if (!name0 && !name1) {
+    return 0;
+  } else if (!name0) {
+    return 1;
+  } else if (!name1) {
+    return -1;
+  } else {
+    return name0.localeCompare(name1);
+  }
 };
 
 const fullName = (person: ZetkinPersonType) =>
@@ -113,27 +136,7 @@ export const getStaticColumns = (
           value: 'doesNotInclude',
         },
       ],
-      sortComparator: (value0, value1) => {
-        const subjects0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
-          fullName(p0).localeCompare(fullName(p1))
-        );
-        const subjects1 = (value1 as ZetkinPersonType[]).sort((p0, p1) =>
-          fullName(p0).localeCompare(fullName(p1))
-        );
-
-        const name0 = subjects0[0] ? fullName(subjects0[0]) : '';
-        const name1 = subjects1[0] ? fullName(subjects1[0]) : '';
-
-        if (!name0 && !name1) {
-          return 0;
-        } else if (!name0) {
-          return 1;
-        } else if (!name1) {
-          return -1;
-        } else {
-          return name0.localeCompare(name1);
-        }
-      },
+      sortComparator: (value0, value1) => sortByName(value0, value1),
       valueFormatter: (params) =>
         getPeopleString(params.value as ZetkinPersonType[]),
     },
@@ -215,27 +218,7 @@ export const getStaticColumns = (
             />
           </PersonHoverCard>
         )),
-      sortComparator: (value0, value1) => {
-        const assignees0 = (value0 as ZetkinPersonType[]).sort((p0, p1) =>
-          fullName(p0).localeCompare(fullName(p1))
-        );
-        const assignees1 = (value1 as ZetkinPersonType[]).sort((p0, p1) =>
-          fullName(p0).localeCompare(fullName(p1))
-        );
-
-        const name0 = assignees0[0] ? fullName(assignees0[0]) : '';
-        const name1 = assignees1[0] ? fullName(assignees1[0]) : '';
-
-        if (!name0 && !name1) {
-          return 0;
-        } else if (!name0) {
-          return 1;
-        } else if (!name1) {
-          return -1;
-        } else {
-          return name0.localeCompare(name1);
-        }
-      },
+      sortComparator: (value0, value1) => sortByName(value0, value1),
       valueFormatter: (params) =>
         getPeopleString(params.value as ZetkinPersonType[]),
     },

--- a/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -247,9 +247,10 @@ export const getStaticColumns = (
     },
     {
       field: 'nextMilestoneDeadline',
-      renderCell: (params) => (
-        <ZetkinRelativeTime datetime={params.value as string} />
-      ),
+      renderCell: (params) =>
+        params.value ? (
+          <ZetkinRelativeTime datetime={params.value as string} />
+        ) : null,
       type: 'date',
       valueGetter: (params) =>
         (params.row as ZetkinJourneyInstance).next_milestone?.deadline,

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -51,6 +51,14 @@ const doesNotHave = (
   };
 };
 
+const isEmpty = (col: JourneyTagGroupColumn | JourneyUnsortedTagsColumn) => {
+  return (params: GridCellParams) => {
+    const tags = col.tagsGetter(params.row as ZetkinJourneyInstance);
+
+    return tags.length === 0;
+  };
+};
+
 const sortByTagName = (value0: GridCellValue, value1: GridCellValue) => {
   const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
     t0.title.localeCompare(t1.title)
@@ -121,15 +129,7 @@ const getTagColumns = (
             value: 'doesNotHave',
           },
           {
-            getApplyFilterFn: () => {
-              return (params) => {
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return tags.length === 0;
-              };
-            },
+            getApplyFilterFn: () => isEmpty(col),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
             }),
@@ -199,15 +199,7 @@ const getTagColumns = (
             value: 'doesNotHave',
           },
           {
-            getApplyFilterFn: () => {
-              return (params) => {
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return tags.length === 0;
-              };
-            },
+            getApplyFilterFn: () => isEmpty(col),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
             }),

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -1,14 +1,54 @@
-import { GridColDef } from '@mui/x-data-grid-pro';
 import { FormattedMessage, IntlShape } from 'react-intl';
+import {
+  GridCellParams,
+  GridColDef,
+  GridFilterItem,
+} from '@mui/x-data-grid-pro';
 
 import FilterValueSelect from './FilterValueSelect';
 import TagChip from 'components/organize/TagManager/components/TagChip';
 import {
   JourneyTagColumnData,
   JourneyTagColumnType,
+  JourneyTagGroupColumn,
+  JourneyUnsortedTagsColumn,
   makeJourneyTagColumn,
 } from 'utils/journeyInstanceUtils';
 import { ZetkinJourneyInstance, ZetkinTag } from 'types/zetkin';
+
+const has = (
+  col: JourneyTagGroupColumn | JourneyUnsortedTagsColumn,
+  item: GridFilterItem
+) => {
+  return (params: GridCellParams) => {
+    if (!item.value) {
+      return true;
+    }
+
+    const tags = col.tagsGetter(params.row as ZetkinJourneyInstance);
+
+    return !!tags.find((tag) => {
+      return tag.id.toString() === item.value;
+    });
+  };
+};
+
+const doesNotHave = (
+  col: JourneyTagGroupColumn | JourneyUnsortedTagsColumn,
+  item: GridFilterItem
+) => {
+  return (params: GridCellParams) => {
+    if (!item.value) {
+      return true;
+    }
+
+    const tags = col.tagsGetter(params.row as ZetkinJourneyInstance);
+
+    return !!tags.find((tag) => {
+      return tag.id.toString() !== item.value;
+    });
+  };
+};
 
 const getTagColumns = (
   intl: IntlShape,
@@ -39,21 +79,7 @@ const getTagColumns = (
               labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
               options: uniqueTags,
             },
-            getApplyFilterFn: (item) => {
-              return (params) => {
-                if (!item.value) {
-                  return true;
-                }
-
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return !!tags.find((tag) => {
-                  return tag.id.toString() === item.value;
-                });
-              };
-            },
+            getApplyFilterFn: (item) => has(col, item),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.hasOperator',
             }),
@@ -65,21 +91,7 @@ const getTagColumns = (
               labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
               options: uniqueTags,
             },
-            getApplyFilterFn: (item) => {
-              return (params) => {
-                if (!item.value) {
-                  return true;
-                }
-
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return !!tags.find((tag) => {
-                  return tag.id.toString() !== item.value;
-                });
-              };
-            },
+            getApplyFilterFn: (item) => doesNotHave(col, item),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.doesNotHaveOperator',
             }),
@@ -125,21 +137,7 @@ const getTagColumns = (
               labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
               options: uniqueTags,
             },
-            getApplyFilterFn: (item) => {
-              return (params) => {
-                if (!item.value) {
-                  return true;
-                }
-
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return !!tags.find((tag) => {
-                  return tag.id.toString() === item.value;
-                });
-              };
-            },
+            getApplyFilterFn: (item) => has(col, item),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.hasOperator',
             }),
@@ -151,21 +149,7 @@ const getTagColumns = (
               labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
               options: uniqueTags,
             },
-            getApplyFilterFn: (item) => {
-              return (params) => {
-                if (!item.value) {
-                  return true;
-                }
-
-                const tags = col.tagsGetter(
-                  params.row as ZetkinJourneyInstance
-                );
-
-                return !!tags.find((tag) => {
-                  return tag.id.toString() !== item.value;
-                });
-              };
-            },
+            getApplyFilterFn: (item) => doesNotHave(col, item),
             label: intl.formatMessage({
               id: 'misc.journeys.journeyInstancesFilters.doesNotHaveOperator',
             }),

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -106,11 +106,36 @@ const getTagColumns = (
               <TagChip key={tag.id} size="small" tag={tag as ZetkinTag} />
             ));
         },
+        sortComparator: (value0, value1) => {
+          const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
+            t0.title.localeCompare(t1.title)
+          );
+          const tags1 = (value1 as ZetkinTag[]).sort((t0, t1) =>
+            t0.title.localeCompare(t1.title)
+          );
+
+          const tagName0 = tags0[0]?.title ?? '';
+          const tagName1 = tags1[0]?.title ?? '';
+
+          if (!tagName0 && !tagName1) {
+            return 0;
+          } else if (!tagName0) {
+            return 1;
+          } else if (!tagName1) {
+            return -1;
+          } else {
+            return tagName0.localeCompare(tagName1);
+          }
+        },
         valueFormatter: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)
             .map((tag) => tag.title)
             .join(', '),
+        valueGetter: (params) => {
+          const instance = params.row as ZetkinJourneyInstance;
+          return col.tagsGetter(instance);
+        },
       });
     } else if (col.type == JourneyTagColumnType.VALUE_TAG) {
       colDefs.push({
@@ -169,11 +194,36 @@ const getTagColumns = (
             />
           </div>
         ),
-        valueGetter: (params) =>
+        sortComparator: (value0, value1) => {
+          const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
+            t0.title.localeCompare(t1.title)
+          );
+          const tags1 = (value1 as ZetkinTag[]).sort((t0, t1) =>
+            t0.title.localeCompare(t1.title)
+          );
+
+          const tagName0 = tags0[0]?.title ?? '';
+          const tagName1 = tags1[0]?.title ?? '';
+
+          if (!tagName0 && !tagName1) {
+            return 0;
+          } else if (!tagName0) {
+            return 1;
+          } else if (!tagName1) {
+            return -1;
+          } else {
+            return tagName0.localeCompare(tagName1);
+          }
+        },
+        valueFormatter: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)
             .map((tag) => tag.title)
             .join(', '),
+        valueGetter: (params) => {
+          const instance = params.row as ZetkinJourneyInstance;
+          return col.tagsGetter(instance);
+        },
       });
     }
   });

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -1,6 +1,7 @@
-import { FormattedMessage } from 'react-intl';
 import { GridColDef } from '@mui/x-data-grid-pro';
+import { FormattedMessage, IntlShape } from 'react-intl';
 
+import FilterValueSelect from './FilterValueSelect';
 import TagChip from 'components/organize/TagManager/components/TagChip';
 import {
   JourneyTagColumnData,
@@ -9,15 +10,82 @@ import {
 } from 'utils/journeyInstanceUtils';
 import { ZetkinJourneyInstance, ZetkinTag } from 'types/zetkin';
 
-const getTagColumns = (tagColumns: JourneyTagColumnData[]): GridColDef[] => {
+const getTagColumns = (
+  intl: IntlShape,
+  journeyInstances: ZetkinJourneyInstance[],
+  tagColumns: JourneyTagColumnData[]
+): GridColDef[] => {
   const colDefs: GridColDef[] = [];
 
   tagColumns.forEach((colData) => {
+    fetch;
     const col = makeJourneyTagColumn(colData);
 
     if (col.type == JourneyTagColumnType.TAG_GROUP) {
+      const tagsById: Record<string, ZetkinTag> = {};
+      journeyInstances
+        .flatMap((instance) => col.tagsGetter(instance))
+        .forEach((tag) => (tagsById[tag.id.toString()] = tag));
+      const uniqueTags = Object.values(tagsById).sort((t0, t1) =>
+        t0.title.localeCompare(t1.title)
+      );
+
       colDefs.push({
         field: `tagGroup${col.group.id}`,
+        filterOperators: [
+          {
+            InputComponent: FilterValueSelect,
+            InputComponentProps: {
+              labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
+              options: uniqueTags,
+            },
+            getApplyFilterFn: (item) => {
+              return (params) => {
+                if (!item.value) {
+                  return true;
+                }
+
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return !!tags.find((tag) => {
+                  return tag.id.toString() === item.value;
+                });
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.hasOperator',
+            }),
+            value: 'has',
+          },
+          {
+            InputComponent: FilterValueSelect,
+            InputComponentProps: {
+              labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
+              options: uniqueTags,
+            },
+            getApplyFilterFn: (item) => {
+              return (params) => {
+                if (!item.value) {
+                  return true;
+                }
+
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return !!tags.find((tag) => {
+                  return tag.id.toString() !== item.value;
+                });
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.doesNotHaveOperator',
+            }),
+            value: 'doesNotHave',
+          },
+        ],
         headerName: col.group.title,
         renderCell: (params) => {
           return col
@@ -26,7 +94,7 @@ const getTagColumns = (tagColumns: JourneyTagColumnData[]): GridColDef[] => {
               <TagChip key={tag.id} size="small" tag={tag as ZetkinTag} />
             ));
         },
-        valueGetter: (params) =>
+        valueFormatter: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)
             .map((tag) => tag.title)
@@ -40,8 +108,70 @@ const getTagColumns = (tagColumns: JourneyTagColumnData[]): GridColDef[] => {
           col.valueGetter(params.row as ZetkinJourneyInstance),
       });
     } else if (col.type == JourneyTagColumnType.UNSORTED) {
+      const tagsById: Record<string, ZetkinTag> = {};
+      journeyInstances
+        .flatMap((instance) => col.tagsGetter(instance))
+        .forEach((tag) => (tagsById[tag.id.toString()] = tag));
+      const uniqueTags = Object.values(tagsById).sort((t0, t1) =>
+        t0.title.localeCompare(t1.title)
+      );
+
       colDefs.push({
         field: 'tagsFree',
+        filterOperators: [
+          {
+            InputComponent: FilterValueSelect,
+            InputComponentProps: {
+              labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
+              options: uniqueTags,
+            },
+            getApplyFilterFn: (item) => {
+              return (params) => {
+                if (!item.value) {
+                  return true;
+                }
+
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return !!tags.find((tag) => {
+                  return tag.id.toString() === item.value;
+                });
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.hasOperator',
+            }),
+            value: 'has',
+          },
+          {
+            InputComponent: FilterValueSelect,
+            InputComponentProps: {
+              labelMessageId: 'misc.journeys.journeyInstancesFilters.tagLabel',
+              options: uniqueTags,
+            },
+            getApplyFilterFn: (item) => {
+              return (params) => {
+                if (!item.value) {
+                  return true;
+                }
+
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return !!tags.find((tag) => {
+                  return tag.id.toString() !== item.value;
+                });
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.doesNotHaveOperator',
+            }),
+            value: 'doesNotHave',
+          },
+        ],
         renderCell: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -1,6 +1,7 @@
 import { FormattedMessage, IntlShape } from 'react-intl';
 import {
   GridCellParams,
+  GridCellValue,
   GridColDef,
   GridFilterItem,
 } from '@mui/x-data-grid-pro';
@@ -48,6 +49,28 @@ const doesNotHave = (
       return tag.id.toString() !== item.value;
     });
   };
+};
+
+const sortByTagName = (value0: GridCellValue, value1: GridCellValue) => {
+  const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
+    t0.title.localeCompare(t1.title)
+  );
+  const tags1 = (value1 as ZetkinTag[]).sort((t0, t1) =>
+    t0.title.localeCompare(t1.title)
+  );
+
+  const tagName0 = tags0[0]?.title ?? '';
+  const tagName1 = tags1[0]?.title ?? '';
+
+  if (!tagName0 && !tagName1) {
+    return 0;
+  } else if (!tagName0) {
+    return 1;
+  } else if (!tagName1) {
+    return -1;
+  } else {
+    return tagName0.localeCompare(tagName1);
+  }
 };
 
 const getTagColumns = (
@@ -106,27 +129,7 @@ const getTagColumns = (
               <TagChip key={tag.id} size="small" tag={tag as ZetkinTag} />
             ));
         },
-        sortComparator: (value0, value1) => {
-          const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
-            t0.title.localeCompare(t1.title)
-          );
-          const tags1 = (value1 as ZetkinTag[]).sort((t0, t1) =>
-            t0.title.localeCompare(t1.title)
-          );
-
-          const tagName0 = tags0[0]?.title ?? '';
-          const tagName1 = tags1[0]?.title ?? '';
-
-          if (!tagName0 && !tagName1) {
-            return 0;
-          } else if (!tagName0) {
-            return 1;
-          } else if (!tagName1) {
-            return -1;
-          } else {
-            return tagName0.localeCompare(tagName1);
-          }
-        },
+        sortComparator: (value0, value1) => sortByTagName(value0, value1),
         valueFormatter: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)
@@ -194,27 +197,7 @@ const getTagColumns = (
             />
           </div>
         ),
-        sortComparator: (value0, value1) => {
-          const tags0 = (value0 as ZetkinTag[]).sort((t0, t1) =>
-            t0.title.localeCompare(t1.title)
-          );
-          const tags1 = (value1 as ZetkinTag[]).sort((t0, t1) =>
-            t0.title.localeCompare(t1.title)
-          );
-
-          const tagName0 = tags0[0]?.title ?? '';
-          const tagName1 = tags1[0]?.title ?? '';
-
-          if (!tagName0 && !tagName1) {
-            return 0;
-          } else if (!tagName0) {
-            return 1;
-          } else if (!tagName1) {
-            return -1;
-          } else {
-            return tagName0.localeCompare(tagName1);
-          }
-        },
+        sortComparator: (value0, value1) => sortByTagName(value0, value1),
         valueFormatter: (params) =>
           col
             .tagsGetter(params.row as ZetkinJourneyInstance)

--- a/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/getTagColumns.tsx
@@ -120,6 +120,21 @@ const getTagColumns = (
             }),
             value: 'doesNotHave',
           },
+          {
+            getApplyFilterFn: () => {
+              return (params) => {
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return tags.length === 0;
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
+            }),
+            value: 'isEmpty',
+          },
         ],
         headerName: col.group.title,
         renderCell: (params) => {
@@ -182,6 +197,21 @@ const getTagColumns = (
               id: 'misc.journeys.journeyInstancesFilters.doesNotHaveOperator',
             }),
             value: 'doesNotHave',
+          },
+          {
+            getApplyFilterFn: () => {
+              return (params) => {
+                const tags = col.tagsGetter(
+                  params.row as ZetkinJourneyInstance
+                );
+
+                return tags.length === 0;
+              };
+            },
+            label: intl.formatMessage({
+              id: 'misc.journeys.journeyInstancesFilters.isEmptyOperator',
+            }),
+            value: 'isEmpty',
           },
         ],
         renderCell: (params) =>

--- a/src/components/journeys/JourneyInstancesDataTable/index.tsx
+++ b/src/components/journeys/JourneyInstancesDataTable/index.tsx
@@ -24,14 +24,14 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
   journeyInstances,
   storageKey = 'journeyInstances',
 }) => {
-  const columns = getColumns(tagColumnsData);
+  const intl = useIntl();
+  const columns = getColumns(intl, journeyInstances, tagColumnsData);
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
   const [quickSearch, setQuickSearch] = useState('');
 
   const rows = getRows({ journeyInstances, quickSearch });
 
   // Add localised header titles
-  const intl = useIntl();
   const columnsWithHeaderTitles = columns.map((column) => ({
     headerName:
       column.headerName ||

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -13,10 +13,10 @@ journeyInstanceCloseButton:
   error: There was an error closing the {singularLabel}
   label: Close {singularLabel}
 journeyInstancesFilters:
-  doesNotHaveOperator: Does not have
-  doesNotIncludeOperator: Does not include
-  hasOperator: Has
-  includesOperator: Includes
+  doesNotHaveOperator: does not have
+  doesNotIncludeOperator: does not include
+  hasOperator: has
+  includesOperator: includes
   isEmptyOperator: is empty
   personLabel: Person
   tagLabel: Tag

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -12,6 +12,10 @@ journeyInstanceCloseButton:
     outcomeTagsLabel: Outcome tags
   error: There was an error closing the {singularLabel}
   label: Close {singularLabel}
+journeyInstancesFilters:
+  excludesOperator: Does not include
+  includesOperator: Includes
+  personLabel: Person
 journeyInstanceReopenButton:
   error: There was an error reopening the {singularLabel}
   label: Reopen {singularLabel}

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -18,6 +18,9 @@ journeyInstancesFilters:
   hasOperator: has
   includesOperator: includes
   isEmptyOperator: is empty
+  isNotOperator: is not
+  isOperator: is
+  milestoneLabel: Milestone
   personLabel: Person
   tagLabel: Tag
 journeyInstanceReopenButton:

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -17,6 +17,7 @@ journeyInstancesFilters:
   doesNotIncludeOperator: Does not include
   hasOperator: Has
   includesOperator: Includes
+  isEmptyOperator: is empty
   personLabel: Person
   tagLabel: Tag
 journeyInstanceReopenButton:

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -12,6 +12,9 @@ journeyInstanceCloseButton:
     outcomeTagsLabel: Outcome tags
   error: There was an error closing the {singularLabel}
   label: Close {singularLabel}
+journeyInstanceReopenButton:
+  error: There was an error reopening the {singularLabel}
+  label: Reopen {singularLabel}
 journeyInstancesFilters:
   doesNotHaveOperator: does not have
   doesNotIncludeOperator: does not include
@@ -23,8 +26,5 @@ journeyInstancesFilters:
   milestoneLabel: Milestone
   personLabel: Person
   tagLabel: Tag
-journeyInstanceReopenButton:
-  error: There was an error reopening the {singularLabel}
-  label: Reopen {singularLabel}
 overview:
   overviewTitle: All journeys

--- a/src/locale/misc/journeys/en.yml
+++ b/src/locale/misc/journeys/en.yml
@@ -13,9 +13,12 @@ journeyInstanceCloseButton:
   error: There was an error closing the {singularLabel}
   label: Close {singularLabel}
 journeyInstancesFilters:
-  excludesOperator: Does not include
+  doesNotHaveOperator: Does not have
+  doesNotIncludeOperator: Does not include
+  hasOperator: Has
   includesOperator: Includes
   personLabel: Person
+  tagLabel: Tag
 journeyInstanceReopenButton:
   error: There was an error reopening the {singularLabel}
   label: Reopen {singularLabel}


### PR DESCRIPTION
## Description
This PR makes it possible to filter subjects, assignees, milestones and tags by custom operators and a dropdown with values.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/176649363-9e11212a-8cf5-43f9-ab36-741970ec207a.png)

## Changes
- adds custom filtering for columns of tags, subjects, assignees and next milestone
- adds custom sorting of tags, subjects and assignee columns
- fixes a little search bug that was apparently unrelated to the former changes

## Related issues
Resolves #740 
