### PR TITLE
Fix wrapping in summary text.

### DIFF
--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -17,7 +17,6 @@ const useStyles = makeStyles(() => ({
   collapsed: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
   },
 }));
 
@@ -121,6 +120,7 @@ const JourneyInstanceSummary = ({
                 className: summaryCollapsed ? classes.collapsed : '',
                 onClick: () => setSummaryCollapsed(true),
                 style: {
+                  overflowWrap: 'break-word',
                   padding: '0.75rem 0',
                 },
               }}


### PR DESCRIPTION
## Description
This PR makes journey instance summaries wrap properly when text is long.

## Changes
- removes white-space: no-wrap, and adds overflow-wrap: break-word

## Related issues
Resolves #783
