### PR TITLE
issue-775/hover-card-load-on-hover

### DIFF
--- a/src/components/PersonHoverCard.tsx
+++ b/src/components/PersonHoverCard.tsx
@@ -46,32 +46,32 @@ const PersonHoverCard: React.FunctionComponent<{
   const { data: person } = personResource(
     orgId as string,
     personId.toString()
-  ).useQuery();
+  ).useQuery({ enabled: Boolean(anchorEl) });
   const { data: tags } = personTagsResource(
     orgId as string,
     personId.toString()
-  ).useQuery();
+  ).useQuery({ enabled: Boolean(anchorEl) });
 
-  if (person) {
-    return (
-      <Box
-        onMouseEnter={openPopover}
-        onMouseLeave={closePopover}
-        style={{ display: 'flex' }}
-        {...BoxProps}
+  return (
+    <Box
+      onMouseEnter={openPopover}
+      onMouseLeave={closePopover}
+      style={{ display: 'flex' }}
+      {...BoxProps}
+    >
+      {children}
+      <Popper
+        anchorEl={anchorEl}
+        id="person-hover-card"
+        modifiers={{
+          preventOverflow: {
+            boundariesElement: 'scrollParent',
+            enabled: true,
+          },
+        }}
+        open={open}
       >
-        {children}
-        <Popper
-          anchorEl={anchorEl}
-          id="person-hover-card"
-          modifiers={{
-            preventOverflow: {
-              boundariesElement: 'scrollParent',
-              enabled: true,
-            },
-          }}
-          open={open}
-        >
+        {person && (
           <Fade in={open} timeout={200}>
             <Card elevation={5} style={{ padding: 24 }} variant="elevation">
               <Grid
@@ -118,12 +118,10 @@ const PersonHoverCard: React.FunctionComponent<{
               </Grid>
             </Card>
           </Fade>
-        </Popper>
-      </Box>
-    );
-  } else {
-    return null;
-  }
+        )}
+      </Popper>
+    </Box>
+  );
 };
 
 export default PersonHoverCard;


### PR DESCRIPTION
## Description
This PR only loads the queries in a person hover card once the anchor element is being hovered.

## Changes
* Changes
  * Only enables `personResource`, `personTagsResource` queries when the card is being hovered.
  * The hover card only appears once the query has resolved
    * This means if the connection is slow, then nothing happens for a bit until it loads. This could be fixed by using a ZetkinQuery and showing a loading state, but this could be a bit ugly because then the size of the card will change. I think the current implementation is a good middle ground of performance vs user experience.
    * It also loads on EVERY hover, but because of browser caching, this shouldn't be an issue for performance.  


## Notes to reviewer
* Navigate to a journey and a view.
* Hover over people and avatars
* Check the network panel that requests are made to the person and their tags endpoints when hovering

## Related issues
Resolves #775 
