### PR TITLE
Add info about creation in subtitle of journey instance layout.

### DIFF
--- a/src/layout/organize/JourneyInstanceLayout.tsx
+++ b/src/layout/organize/JourneyInstanceLayout.tsx
@@ -145,21 +145,14 @@ const JourneyInstanceLayout: React.FunctionComponent = ({ children }) => {
           <Box mr={1}>
             <JourneyStatusChip instance={journeyInstance} />
           </Box>
-          <Typography style={{ marginRight: '1rem' }}>
-            {journeyInstance.updated ? (
-              <Msg
-                id="layout.organize.journeyInstance.updated"
-                values={{
-                  relative: (
-                    <ZetkinRelativeTime
-                      convertToLocal
-                      datetime={journeyInstance.updated}
-                      forcePast
-                    />
-                  ),
-                }}
-              />
-            ) : (
+          <Box
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              marginRight: '1rem',
+            }}
+          >
+            <Typography>
               <Msg
                 id="layout.organize.journeyInstance.created"
                 values={{
@@ -172,8 +165,26 @@ const JourneyInstanceLayout: React.FunctionComponent = ({ children }) => {
                   ),
                 }}
               />
+            </Typography>
+            {journeyInstance.updated && (
+              <Typography>
+                {'\u00A0('}
+                <Msg
+                  id="layout.organize.journeyInstance.updated"
+                  values={{
+                    relative: (
+                      <ZetkinRelativeTime
+                        convertToLocal
+                        datetime={journeyInstance.updated}
+                        forcePast
+                      />
+                    ),
+                  }}
+                />
+                {')'}
+              </Typography>
             )}
-          </Typography>
+          </Box>
           {journeyInstance.next_milestone && (
             <>
               <ScheduleIcon

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -10,7 +10,7 @@ header:
     expand: Expand
 journeyInstance:
   created: Created {relative}
-  updated: Last activity {relative}
+  updated: last activity {relative}
 journeyInstances:
   menu:
     downloadCsv: Download {pluralLabel} as CSV


### PR DESCRIPTION
## Description
This PR adds the date of creation to the subtitle of a Journey instance page. The last update renders conditionally if there has been an update to the Journey instance.


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/185907046-4085e9a8-bfa4-43d6-a7c2-06aeebe0eb7f.png)


## Changes

* Adds a message with the relative time of when it was created.


## Related issues
Resolves #777
