### PR TITLE
Issue 795/collapse expand summary

### DIFF
--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -2,45 +2,25 @@ import { FormattedMessage } from 'react-intl';
 import Link from 'next/link';
 import {
   Box,
-  Button,
   Chip,
   CircularProgress,
-  Collapse,
   Grid,
   makeStyles,
   Theme,
   Typography,
 } from '@material-ui/core';
-import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { LetterparserNode, parse } from 'letterparser';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import CleanHtml from 'components/CleanHtml';
+import ZetkinCollapsible from 'components/ZetkinCollapsible';
 
 interface PrettyEmailProps {
   emailStr: string;
 }
 
-const COLLAPSED_SIZE = 100;
-
 const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
   const [emailData, setEmailData] = useState<LetterparserNode | null>(null);
-  const [needsCollapse, setNeedsCollapse] = useState(false);
-  const [didMeasure, setDidMeasure] = useState(false);
-  const [collapsed, setCollapsed] = useState(true);
-
-  const divCallback = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (node) {
-        const height = node.clientHeight;
-        if (height > COLLAPSED_SIZE && !needsCollapse) {
-          setNeedsCollapse(true);
-        }
-        setDidMeasure(true);
-      }
-    },
-    [setNeedsCollapse]
-  );
 
   useEffect(() => {
     async function parseEmailStr() {
@@ -60,26 +40,9 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
         >
           {emailData.headers.Subject}
         </Typography>
-        <Collapse
-          collapsedSize={COLLAPSED_SIZE}
-          in={(didMeasure && !needsCollapse) || !collapsed}
-        >
-          <div ref={divCallback}>
-            <EmailBody body={emailData.body} />
-          </div>
-        </Collapse>
-        {needsCollapse && (
-          <Button
-            color="primary"
-            onClick={() => setCollapsed(!collapsed)}
-            startIcon={collapsed ? <ExpandMore /> : <ExpandLess />}
-            style={{ textTransform: 'uppercase' }}
-          >
-            <FormattedMessage
-              id={collapsed ? 'misc.email.expand' : 'misc.email.collapse'}
-            />
-          </Button>
-        )}
+        <ZetkinCollapsible collapsedHeight={100}>
+          <EmailBody body={emailData.body} />
+        </ZetkinCollapsible>
       </Box>
     );
   } else {

--- a/src/components/Timeline/updates/elements/PrettyEmail.tsx
+++ b/src/components/Timeline/updates/elements/PrettyEmail.tsx
@@ -13,7 +13,7 @@ import { LetterparserNode, parse } from 'letterparser';
 import { useEffect, useState } from 'react';
 
 import CleanHtml from 'components/CleanHtml';
-import ZetkinCollapsible from 'components/ZetkinCollapsible';
+import ZetkinCollapse from 'components/ZetkinCollapse';
 
 interface PrettyEmailProps {
   emailStr: string;
@@ -40,9 +40,9 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
         >
           {emailData.headers.Subject}
         </Typography>
-        <ZetkinCollapsible collapsedHeight={100}>
+        <ZetkinCollapse collapsedSize={100}>
           <EmailBody body={emailData.body} />
-        </ZetkinCollapsible>
+        </ZetkinCollapse>
       </Box>
     );
   } else {

--- a/src/components/ZetkinCollapse.stories.tsx
+++ b/src/components/ZetkinCollapse.stories.tsx
@@ -1,0 +1,68 @@
+import ZetkinCollapse from './ZetkinCollapse';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  component: ZetkinCollapse,
+  title: 'Atoms/ZetkinCollapse',
+} as ComponentMeta<typeof ZetkinCollapse>;
+
+const Template: ComponentStory<typeof ZetkinCollapse> = (args) => (
+  <ZetkinCollapse collapsedSize={args.collapsedSize}>
+    {args.children}
+  </ZetkinCollapse>
+);
+
+export const basic = Template.bind({});
+basic.args = {
+  children: (
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed
+      venenatis urna. Maecenas non nibh eu diam bibendum egestas id bibendum
+      mauris. Duis lacinia neque eu ligula rhoncus vehicula. Duis aliquet libero
+      ac condimentum laoreet.
+      <br />
+      <br />
+      In porttitor egestas arcu, facilisis elementum odio pharetra in. Phasellus
+      consequat tristique mauris, sit amet luctus augue aliquet sit amet.
+      Curabitur id interdum lorem. Suspendisse at tellus tincidunt, rhoncus sem
+      non, dictum libero. Nam non tortor sit amet nibh ornare cursus nec in ex.
+      Nam scelerisque, odio nec ornare consequat, augue elit malesuada libero,
+      malesuada elementum urna erat tincidunt urna.
+      <br />
+      <br />
+      Nullam dignissim ex nulla, in sagittis nunc porta nec. Aenean in elit
+      iaculis, ornare arcu non, fermentum mauris. Nulla suscipit tincidunt nisl.
+      Curabitur et malesuada elit. Aliquam et augue lacus. Quisque aliquam
+      lectus a tristique porta. Donec id arcu mauris. Mauris eget mi faucibus,
+      congue metus eu, rutrum lorem. Proin neque tortor, facilisis quis rutrum
+      et, semper vitae orci. Aliquam id pulvinar nibh. Duis in cursus purus.
+      <br />
+      <br />
+      Nunc tempus sem non diam suscipit, at finibus lectus consectetur. Fusce
+      maximus ut libero sit amet venenatis. Praesent iaculis commodo tellus, a
+      pharetra sem venenatis fermentum. Nullam at fermentum arcu, ac malesuada
+      turpis. In condimentum nunc id varius sagittis. Vestibulum ante ipsum
+      primis in faucibus orci luctus et ultrices posuere cubilia curae; Integer
+      eu leo a ipsum tempor congue id tempor felis. Phasellus vitae mi ipsum.
+      <br />
+      <br />
+      Nunc urna ipsum, pharetra sit amet ipsum eget, venenatis pulvinar lorem.
+      Sed molestie sapien lacus, eu laoreet lorem tempor sed. Mauris iaculis
+      eget nisl placerat gravida.
+    </p>
+  ),
+  collapsedSize: 100,
+};
+
+export const shortText = Template.bind({});
+shortText.args = {
+  children: (
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed
+      venenatis urna. Maecenas non nibh eu diam bibendum egestas id bibendum
+      mauris. Duis lacinia neque eu ligula rhoncus vehicula. Duis aliquet libero
+      ac condimentum laoreet.
+    </p>
+  ),
+  collapsedSize: 100,
+};

--- a/src/components/ZetkinCollapse.tsx
+++ b/src/components/ZetkinCollapse.tsx
@@ -3,13 +3,13 @@ import { Button, Collapse } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { useCallback, useState } from 'react';
 
-interface ZetkinCollapsibleProps {
-  collapsedHeight: number;
+interface ZetkinCollapse {
+  collapsedSize: number;
 }
 
-const ZetkinCollapsible: React.FC<ZetkinCollapsibleProps> = ({
+const ZetkinCollapse: React.FC<ZetkinCollapse> = ({
   children,
-  collapsedHeight,
+  collapsedSize,
 }) => {
   const [needsCollapse, setNeedsCollapse] = useState(false);
   const [didMeasure, setDidMeasure] = useState(false);
@@ -19,7 +19,7 @@ const ZetkinCollapsible: React.FC<ZetkinCollapsibleProps> = ({
     (node: HTMLDivElement | null) => {
       if (node) {
         const height = node.clientHeight;
-        if (height > collapsedHeight && !needsCollapse) {
+        if (height > collapsedSize && !needsCollapse) {
           setNeedsCollapse(true);
         }
         setDidMeasure(true);
@@ -31,7 +31,7 @@ const ZetkinCollapsible: React.FC<ZetkinCollapsibleProps> = ({
   return (
     <>
       <Collapse
-        collapsedSize={collapsedHeight}
+        collapsedSize={collapsedSize}
         in={(didMeasure && !needsCollapse) || !collapsed}
       >
         <div ref={divCallback}>{children}</div>
@@ -52,4 +52,4 @@ const ZetkinCollapsible: React.FC<ZetkinCollapsibleProps> = ({
   );
 };
 
-export default ZetkinCollapsible;
+export default ZetkinCollapse;

--- a/src/components/ZetkinCollapse.tsx
+++ b/src/components/ZetkinCollapse.tsx
@@ -3,11 +3,11 @@ import { Button, Collapse } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import { useCallback, useState } from 'react';
 
-interface ZetkinCollapse {
+interface ZetkinCollapseProps {
   collapsedSize: number;
 }
 
-const ZetkinCollapse: React.FC<ZetkinCollapse> = ({
+const ZetkinCollapse: React.FC<ZetkinCollapseProps> = ({
   children,
   collapsedSize,
 }) => {

--- a/src/components/ZetkinCollapsible.tsx
+++ b/src/components/ZetkinCollapsible.tsx
@@ -1,0 +1,55 @@
+import { FormattedMessage } from 'react-intl';
+import { Button, Collapse } from '@material-ui/core';
+import { ExpandLess, ExpandMore } from '@material-ui/icons';
+import { useCallback, useState } from 'react';
+
+interface ZetkinCollapsibleProps {
+  collapsedHeight: number;
+}
+
+const ZetkinCollapsible: React.FC<ZetkinCollapsibleProps> = ({
+  children,
+  collapsedHeight,
+}) => {
+  const [needsCollapse, setNeedsCollapse] = useState(false);
+  const [didMeasure, setDidMeasure] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
+
+  const divCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) {
+        const height = node.clientHeight;
+        if (height > collapsedHeight && !needsCollapse) {
+          setNeedsCollapse(true);
+        }
+        setDidMeasure(true);
+      }
+    },
+    [setNeedsCollapse]
+  );
+
+  return (
+    <>
+      <Collapse
+        collapsedSize={collapsedHeight}
+        in={(didMeasure && !needsCollapse) || !collapsed}
+      >
+        <div ref={divCallback}>{children}</div>
+      </Collapse>
+      {needsCollapse && (
+        <Button
+          color="primary"
+          onClick={() => setCollapsed(!collapsed)}
+          startIcon={collapsed ? <ExpandMore /> : <ExpandLess />}
+          style={{ textTransform: 'uppercase' }}
+        >
+          <FormattedMessage
+            id={collapsed ? 'misc.buttons.expand' : 'misc.buttons.collapse'}
+          />
+        </Button>
+      )}
+    </>
+  );
+};
+
+export default ZetkinCollapsible;

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -9,7 +9,7 @@ import Markdown from 'components/Markdown';
 import SnackbarContext from 'hooks/SnackbarContext';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
-import ZetkinCollapsible from 'components/ZetkinCollapsible';
+import ZetkinCollapse from 'components/ZetkinCollapse';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 import ZetkinSection from 'components/ZetkinSection';
 
@@ -105,9 +105,9 @@ const JourneyInstanceSummary = ({
         // Not editing
         <>
           {journeyInstance.summary.length > 0 ? (
-            <ZetkinCollapsible collapsedHeight={100}>
+            <ZetkinCollapse collapsedSize={100}>
               <Markdown markdown={journeyInstance.summary} />
-            </ZetkinCollapsible>
+            </ZetkinCollapse>
           ) : (
             <Typography
               color="secondary"

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -105,8 +105,13 @@ const JourneyInstanceSummary = ({
         // Not editing
         <>
           {journeyInstance.summary.length > 0 ? (
-            <ZetkinCollapse collapsedSize={100}>
-              <Markdown markdown={journeyInstance.summary} />
+            <ZetkinCollapse collapsedSize={90}>
+              <Markdown
+                BoxProps={{
+                  fontSize: '1rem',
+                }}
+                markdown={journeyInstance.summary}
+              />
             </ZetkinCollapse>
           ) : (
             <Typography

--- a/src/components/organize/journeys/JourneyInstanceSummary.tsx
+++ b/src/components/organize/journeys/JourneyInstanceSummary.tsx
@@ -1,7 +1,6 @@
 import { Edit } from '@material-ui/icons';
 import { useRouter } from 'next/router';
-import { Button, makeStyles, Typography } from '@material-ui/core';
-import { ExpandLess, ExpandMore } from '@material-ui/icons';
+import { Button, Typography } from '@material-ui/core';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useEffect, useRef, useState } from 'react';
 
@@ -10,29 +9,20 @@ import Markdown from 'components/Markdown';
 import SnackbarContext from 'hooks/SnackbarContext';
 import SubmitCancelButtons from 'components/forms/common/SubmitCancelButtons';
 import ZetkinAutoTextArea from 'components/ZetkinAutoTextArea';
+import ZetkinCollapsible from 'components/ZetkinCollapsible';
 import { ZetkinJourneyInstance } from 'types/zetkin';
 import ZetkinSection from 'components/ZetkinSection';
-
-const useStyles = makeStyles(() => ({
-  collapsed: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-}));
 
 const JourneyInstanceSummary = ({
   journeyInstance,
 }: {
   journeyInstance: ZetkinJourneyInstance;
 }): JSX.Element => {
-  const classes = useStyles();
   const { orgId } = useRouter().query;
   const intl = useIntl();
   const { showSnackbar } = useContext(SnackbarContext);
 
   const editingRef = useRef<HTMLTextAreaElement>(null);
-
-  const [summaryCollapsed, setSummaryCollapsed] = useState<boolean>(true);
 
   const [editingSummary, setEditingSummary] = useState<boolean>(false);
   const [summary, setSummary] = useState<string>(journeyInstance.summary);
@@ -115,20 +105,11 @@ const JourneyInstanceSummary = ({
         // Not editing
         <>
           {journeyInstance.summary.length > 0 ? (
-            <Markdown
-              BoxProps={{
-                className: summaryCollapsed ? classes.collapsed : '',
-                onClick: () => setSummaryCollapsed(true),
-                style: {
-                  overflowWrap: 'break-word',
-                  padding: '0.75rem 0',
-                },
-              }}
-              markdown={journeyInstance.summary}
-            />
+            <ZetkinCollapsible collapsedHeight={100}>
+              <Markdown markdown={journeyInstance.summary} />
+            </ZetkinCollapsible>
           ) : (
             <Typography
-              className={summaryCollapsed ? classes.collapsed : ''}
               color="secondary"
               onClick={() => setEditingSummary(true)}
               style={{
@@ -139,22 +120,6 @@ const JourneyInstanceSummary = ({
             >
               {summaryPlaceholder}
             </Typography>
-          )}
-          {journeyInstance.summary.length > 100 && (
-            <Button
-              color="primary"
-              onClick={() => setSummaryCollapsed((prev) => !prev)}
-              startIcon={summaryCollapsed ? <ExpandMore /> : <ExpandLess />}
-              style={{ textTransform: 'uppercase' }}
-            >
-              <Msg
-                id={
-                  summaryCollapsed
-                    ? 'pages.organizeJourneyInstance.expandButton'
-                    : 'pages.organizeJourneyInstance.collapseButton'
-                }
-              />
-            </Button>
           )}
         </>
       )}

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -6,6 +6,8 @@ ConfirmDialog:
   defaultTitle: Confirm
   defaultWarningText: Are you sure you want to do this action? It can not be undone.
 buttons:
+  collapse: Show less
+  expand: Show more
   readMore: Read more
 components:
   editTextInPlace:
@@ -29,8 +31,6 @@ dataTable:
     hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
     title: Sort
 email:
-  collapse: Show less
-  expand: Show more
   headers:
     cc: CC
     from: From


### PR DESCRIPTION
## Description
This PR adds a ZetkinCollapse component, that conditionally renders its children with a "show more/show less"-button, if the content of the children is higher than the height sent in to the component.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/187471396-2a7f6974-f29d-476a-9e55-dec12fb192d2.png)
![bild](https://user-images.githubusercontent.com/58265097/187471466-e20bc137-e688-4d6c-97fa-c0b18ecde6ae.png)

## Changes
* Adds a ZetkinCollapse component
* Adds a storybook story for this component
* Changes JourneyInstanceSummary and PrettyEmail components to use ZetkinCollapse
* Adjusts font size in the summary

## Related issues
Resolves #795 
