### PR TITLE
Make the sorting sort again

### DIFF
--- a/src/components/UserConfigurableDataGrid/index.tsx
+++ b/src/components/UserConfigurableDataGrid/index.tsx
@@ -14,7 +14,7 @@ const UserConfigurableDataGrid: React.FC<UserConfigurableDataGridProps> = ({
   const { columns, setColumnOrder, setColumnWidth } =
     useConfigurableDataGridColumns(storageKey, gridProps.columns);
 
-  const { gridProps: modelGridProps } = useModelsFromQueryString();
+  const { gridProps: modelGridProps } = useModelsFromQueryString(gridProps);
 
   return (
     <DataGridPro

--- a/src/components/UserConfigurableDataGrid/useModelsFromQueryString.spec.ts
+++ b/src/components/UserConfigurableDataGrid/useModelsFromQueryString.spec.ts
@@ -10,7 +10,9 @@ describe('useModelsFromQueryString()', () => {
     it('handles single filter', () => {
       mockRouter.setCurrentUrl('/irrelevant?filter_first_name_contains=Clara');
 
-      const { result } = renderHook(() => useModelsFromQueryString());
+      const { result } = renderHook(() =>
+        useModelsFromQueryString({ columns: [], rows: [] })
+      );
 
       expect(result.current.filterModel).toMatchObject({
         items: [
@@ -28,7 +30,9 @@ describe('useModelsFromQueryString()', () => {
         '/irrelevant?filter_name_contains=Clara&filter_name_contains=Zetkin'
       );
 
-      const { result } = renderHook(() => useModelsFromQueryString());
+      const { result } = renderHook(() =>
+        useModelsFromQueryString({ columns: [], rows: [] })
+      );
 
       expect(result.current.filterModel).toMatchObject({
         items: [

--- a/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
+++ b/src/components/UserConfigurableDataGrid/useModelsFromQueryString.ts
@@ -20,7 +20,9 @@ interface UseModelsFromQueryString {
   sortModel: GridSortModel;
 }
 
-export function useModelsFromQueryString(): UseModelsFromQueryString {
+export function useModelsFromQueryString(
+  gridProps: DataGridProProps
+): UseModelsFromQueryString {
   const router = useRouter();
 
   const [filterModel, setFilterModel] = useState<GridFilterModel>(
@@ -28,8 +30,15 @@ export function useModelsFromQueryString(): UseModelsFromQueryString {
   );
 
   const [sortModel, setSortModel] = useState<GridSortModel>(
-    parseSortModelFromQuery(router.query)
+    gridProps.sortModel || parseSortModelFromQuery(router.query)
   );
+
+  // Update sortModel state to match parent sortModel state
+  useEffect(() => {
+    if (gridProps.sortModel) {
+      setSortModel(gridProps.sortModel);
+    }
+  }, [gridProps.sortModel]);
 
   // Update router URL when model changes
   useEffect(() => {
@@ -66,6 +75,10 @@ export function useModelsFromQueryString(): UseModelsFromQueryString {
 
     if (!isEqual(routerSortModel, sortModel)) {
       setSortModel(routerSortModel);
+
+      if (gridProps.onSortModelChange) {
+        gridProps.onSortModelChange(routerSortModel);
+      }
     }
   }, [router.query]);
 


### PR DESCRIPTION
## Description
This PR fixes the issue of UserConfigurableDataGrid not sorting properly, by making two states update each other. 

## Changes
- the useModelsFromQueryString hook now takes in gridProps
- if gridProps has a sortModel, use that to initiate state in hook
- if gridProps has a sortModel, update state in hook whenever that sortModel updates
- update test accordingly

## Related issues
Resolves #774 
