### PR TITLE
Break very long strings in summaries and updates.

### DIFF
--- a/playwright/tests/organize/journeys/journey-instance/milestones.spec.ts
+++ b/playwright/tests/organize/journeys/journey-instance/milestones.spec.ts
@@ -81,7 +81,7 @@ test.describe('Journey instance Milestones tab', () => {
         ClarasOnboarding
       );
 
-      const newDeadline = '2022-06-23';
+      const newDeadline = '2022-06-24';
       const { log: patchReqLog } = moxy.setZetkinApiMock(
         `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/milestones/${AttendMeeting.id}`,
         'patch',
@@ -97,8 +97,8 @@ test.describe('Journey instance Milestones tab', () => {
         )
         .first()
         .click();
-      //Click June 23
-      await page.locator('p:has-text("23")').click();
+      //Click June 24
+      await page.locator('p:has-text("24")').click();
 
       await Promise.all([
         page.waitForResponse(

--- a/src/features/journeys/components/JourneyInstanceSummary.tsx
+++ b/src/features/journeys/components/JourneyInstanceSummary.tsx
@@ -109,6 +109,9 @@ const JourneyInstanceSummary = ({
               <ZUIMarkdown
                 BoxProps={{
                   fontSize: '1rem',
+                  style: {
+                    overflowWrap: 'anywhere',
+                  },
                 }}
                 markdown={journeyInstance.summary}
               />

--- a/src/zui/ZUITimeline/updates/elements/UpdateContainer.tsx
+++ b/src/zui/ZUITimeline/updates/elements/UpdateContainer.tsx
@@ -27,7 +27,9 @@ const UpdateContainer: React.FC<UpdateContainerProps> = ({
       <UpdateHeader timestamp={update.timestamp}>{headerContent}</UpdateHeader>
       {children && (
         <>
-          <div style={{ gridColumn: '2 / end' }}>{children}</div>
+          <div style={{ gridColumn: '2 / end', overflowWrap: 'anywhere' }}>
+            {children}
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Description
This PR addresses that summaries could overflow their containers if they contained very very long strings (like, fx, a really long url)

## Changes
* Makes containers for summaries break lines if too long

## Related issues
Resolves #801
