### PR TITLE
Raise the threshold for what gets included in search results.

### DIFF
--- a/src/features/journeys/components/JourneyInstancesDataTable/getRows.ts
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getRows.ts
@@ -20,6 +20,7 @@ const options = {
     'tags.title',
     'title',
   ],
+  threshold: 0.4,
 };
 
 export const getRows = ({


### PR DESCRIPTION
## Description
This PR attempts to make Journey instance search a bit more concise by raising the threshold for what is included in the search results. 


## Changes
* Sets the match threshold to 0.4 instead of the default 0.6 (0-1 where 1 is complete matching anarchy and 0 is extreme matching rigidity)

## Notes to reviewer
This is not an exact science, click around and see how it works for you. It can be adjusted back and forward until we find a good balance.

## Related issues
Resolves #816 
