### PR TITLE
Animated call assignment stats

### DIFF
--- a/src/features/callAssignments/components/StatusCardHeader.tsx
+++ b/src/features/callAssignments/components/StatusCardHeader.tsx
@@ -1,6 +1,8 @@
 import { makeStyles } from '@material-ui/styles';
 import { Box, Divider, Theme, Typography } from '@material-ui/core';
 
+import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
+
 interface StatusCardHeaderProps {
   chipColor: keyof Theme['palette']['targetingStatusBar'];
   subtitle: string;
@@ -45,7 +47,13 @@ const StatusCardHeader = ({
           <Typography variant="h4">{title}</Typography>
           <Typography color="secondary">{subtitle}</Typography>
         </Box>
-        {value != undefined && <Box className={classes.chip}>{value}</Box>}
+        {value != undefined && (
+          <ZUIAnimatedNumber value={value || 0}>
+            {(animatedValue) => (
+              <Box className={classes.chip}>{animatedValue}</Box>
+            )}
+          </ZUIAnimatedNumber>
+        )}
       </Box>
       <Divider />
     </Box>

--- a/src/features/callAssignments/components/StatusCardItem.tsx
+++ b/src/features/callAssignments/components/StatusCardItem.tsx
@@ -1,5 +1,7 @@
 import { Box, ListItem, Typography } from '@material-ui/core';
 
+import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
+
 interface StatusCardItemProps {
   title: string;
   value: number | undefined;
@@ -13,9 +15,12 @@ const StatusCardItem = ({ title, value }: StatusCardItemProps) => {
           <Typography color="secondary" variant="h5">
             {title}
           </Typography>
-          <Typography variant="h3">
-            {value != undefined ? value : '-'}
-          </Typography>
+          <ZUIAnimatedNumber value={value || 0}>
+            {(animatedValue) => {
+              const output = value != undefined ? animatedValue : '-';
+              return <Typography variant="h3">{output}</Typography>;
+            }}
+          </ZUIAnimatedNumber>
         </Box>
       </Box>
     </ListItem>

--- a/src/zui/ZUIAnimatedNumber/index.stories.tsx
+++ b/src/zui/ZUIAnimatedNumber/index.stories.tsx
@@ -1,0 +1,22 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUIAnimatedNumber from '.';
+
+export default {
+  component: ZUIAnimatedNumber,
+  title: 'Atoms/ZUIAnimatedNumber',
+} as ComponentMeta<typeof ZUIAnimatedNumber>;
+
+const Template: ComponentStory<typeof ZUIAnimatedNumber> = (args) => {
+  const value = args.value || 0;
+  return (
+    <div style={{ width: 400 }}>
+      <ZUIAnimatedNumber {...args} value={value}>
+        {(animatedValue) => <h1>{animatedValue}</h1>}
+      </ZUIAnimatedNumber>
+    </div>
+  );
+};
+
+export const basic = Template.bind({});
+basic.args = {};

--- a/src/zui/ZUIAnimatedNumber/index.tsx
+++ b/src/zui/ZUIAnimatedNumber/index.tsx
@@ -1,0 +1,68 @@
+import { FC, ReactElement, useEffect, useRef, useState } from 'react';
+
+type ZUIAnimatedNumberRenderFunc = (value: string) => ReactElement;
+
+interface ZUIAnimatedNumberProps {
+  children: ZUIAnimatedNumberRenderFunc;
+  decimals?: number;
+  durationSeconds?: number;
+  startValue?: number;
+  value: number;
+}
+
+interface ZUIAnimatedNumberAnimState {
+  fromValue: number | null;
+  requestId: number | null;
+  startTime: number | null;
+}
+
+const ZUIAnimatedNumber: FC<ZUIAnimatedNumberProps> = ({
+  children,
+  decimals = 0,
+  durationSeconds = 0.5,
+  startValue,
+  value,
+}) => {
+  const [animatedValue, setAnimatedValue] = useState(value);
+
+  const animRef = useRef<ZUIAnimatedNumberAnimState>({
+    fromValue: null,
+    requestId: null,
+    startTime: null,
+  });
+
+  const animate = (time: number) => {
+    const animState = animRef.current;
+    if (animState.startTime === null || animState.fromValue === null) {
+      // Animation just (re)started, set it up
+      animState.startTime = time;
+      animState.fromValue =
+        startValue === undefined ? animatedValue : startValue;
+    }
+
+    const fullDiff = value - animState.fromValue;
+    const t = Math.min(
+      1.0,
+      (time - animState.startTime) / (durationSeconds * 1000)
+    );
+
+    if (t < 1.0) {
+      setAnimatedValue(animState.fromValue + t * fullDiff);
+      animState.requestId = requestAnimationFrame(animate);
+    } else {
+      // Set to real value at end of animation, to avoid any bugs in the
+      // calculation causing the final value to be anything but the real.
+      setAnimatedValue(value);
+    }
+  };
+
+  useEffect(() => {
+    // Restart animation
+    animRef.current.startTime = null;
+    animRef.current.requestId = requestAnimationFrame(animate);
+  }, [value]);
+
+  return children(animatedValue.toFixed(decimals));
+};
+
+export default ZUIAnimatedNumber;


### PR DESCRIPTION
## Description
This PR adds a counting animation to the stats numbers in a call assignment, to draw attention to their changes and create association between the animated bar and the numbers it represents.

## Screenshots
https://user-images.githubusercontent.com/550212/202840373-79220933-bbd1-4da9-8913-a07aab0233ff.mov

## Changes
* Adds new `ZUIAnimatedNumber` component
  * When it's `value` property changes, it will animate towards that property and re-render at each animation frame
  * The `durationSeconds` property defines the duration of the animation
  * The `startValue` can be used to set another start value than the current one, e.g. a third of the total of all call assignment targets if we want to use the animation to strictly reflect the initial animation of the bar
* Adds storybook entry for `ZUIAnimatedNumber`
* Changes `StatusCardHeader` to use animated number
* Changes `StatusCardItem` to use animated number

## Notes to reviewer
Try the component in storybook by modifying the arguments.

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/550212/202840525-71a82477-73f9-4061-82a9-cf5d233612c6.png">

## Related issues
Undocumented