### PR TITLE
Issue 824/targeting targets section

### DIFF
--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -8,6 +8,7 @@ export interface CallAssignmentData {
 }
 
 export interface CallAssignmentStats {
+  allTargets: number;
   allocated: number;
   blocked: number;
   callBackLater: number;

--- a/src/features/callAssignments/components/CallAssignmentTargets.tsx
+++ b/src/features/callAssignments/components/CallAssignmentTargets.tsx
@@ -1,0 +1,106 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { useState } from 'react';
+import { Add, Edit } from '@material-ui/icons';
+import {
+  Box,
+  Button,
+  Card,
+  Divider,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
+
+import CallAssignmentModel from '../models/CallAssignmentModel';
+import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog';
+import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
+
+const useStyles = makeStyles((theme) => ({
+  button: {
+    borderColor: theme.palette.targetingStatusBar.blue,
+    color: theme.palette.targetingStatusBar.blue,
+  },
+  chip: {
+    backgroundColor: theme.palette.targetingStatusBar.gray,
+    borderRadius: '1em',
+    color: 'secondary',
+    display: 'flex',
+    fontSize: '1.8em',
+    lineHeight: 'normal',
+    marginRight: '0.1em',
+    overflow: 'hidden',
+    padding: '0.2em 0.7em',
+  },
+}));
+
+const CallAssignmentTargets = ({ model }: { model: CallAssignmentModel }) => {
+  const classes = useStyles();
+
+  const [queryDialogOpen, setQueryDialogOpen] = useState(false);
+
+  const stats = model.getStats();
+  const { target } = model.getData();
+
+  return (
+    <>
+      <Card>
+        <Box display="flex" justifyContent="space-between" p={2}>
+          <Typography variant="h4">
+            <Msg id="pages.organizeCallAssignment.targets.title" />
+          </Typography>
+          {model.isTargeted && (
+            <ZUIAnimatedNumber value={stats?.allTargets || 0}>
+              {(animatedValue) => (
+                <Box className={classes.chip}>{animatedValue}</Box>
+              )}
+            </ZUIAnimatedNumber>
+          )}
+        </Box>
+        {model.isTargeted ? (
+          <>
+            <Divider />
+            <Box p={2}>
+              <Button
+                className={classes.button}
+                onClick={() => setQueryDialogOpen(true)}
+                startIcon={<Edit />}
+                variant="outlined"
+              >
+                <Msg id="pages.organizeCallAssignment.targets.editButton" />
+              </Button>
+            </Box>
+          </>
+        ) : (
+          <Box pb={2} px={2}>
+            <Box bgcolor="background.secondary" p={2}>
+              <Typography>
+                <Msg id="pages.organizeCallAssignment.targets.subtitle" />
+              </Typography>
+              <Box pt={1}>
+                <Button
+                  className={classes.button}
+                  onClick={() => setQueryDialogOpen(true)}
+                  startIcon={<Add />}
+                  variant="outlined"
+                >
+                  <Msg id="pages.organizeCallAssignment.targets.defineButton" />
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Card>
+      {queryDialogOpen && (
+        <SmartSearchDialog
+          onDialogClose={() => setQueryDialogOpen(false)}
+          onSave={(query) => {
+            model.setTargets(query);
+            setQueryDialogOpen(false);
+          }}
+          query={target}
+        />
+      )}
+    </>
+  );
+};
+
+export default CallAssignmentTargets;

--- a/src/features/callAssignments/components/CallAssignmentTargets.tsx
+++ b/src/features/callAssignments/components/CallAssignmentTargets.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
   chip: {
     backgroundColor: theme.palette.targetingStatusBar.gray,
     borderRadius: '1em',
-    color: 'secondary',
+    color: theme.palette.text.secondary,
     display: 'flex',
     fontSize: '1.8em',
     lineHeight: 'normal',

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -46,7 +46,7 @@ export default class CallAssignmentModel {
     const state = this._store.getState();
     const stats = state.callAssignments.statsById[this._id];
 
-    if (this.isTargeted) {
+    if (!this.isTargeted) {
       return null;
     }
 
@@ -92,7 +92,7 @@ export default class CallAssignmentModel {
 
   get isTargeted() {
     const data = this.getData();
-    return data.target.filter_spec?.length === 0;
+    return data.target.filter_spec?.length != 0;
   }
 
   setCooldown(cooldown: number) {

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -63,6 +63,7 @@ export default class CallAssignmentModel {
         });
 
       return {
+        allTargets: 0,
         allocated: 0,
         blocked: 0,
         callBackLater: 0,

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -1,4 +1,5 @@
 import { Store } from 'core/store';
+import { ZetkinQuery } from 'utils/types/zetkin';
 import { CallAssignmentData, CallAssignmentStats } from '../apiTypes';
 import {
   callAssignmentLoad,
@@ -122,6 +123,32 @@ export default class CallAssignmentModel {
         .then((data: { data: CallAssignmentData }) => {
           this._store.dispatch(callAssignmentUpdated(data.data));
         });
+    }
+  }
+
+  setTargets(query: Partial<ZetkinQuery>) {
+    const state = this._store.getState();
+    const callAssignment = state.callAssignments.callAssignments.find(
+      (ca) => ca.id == this._id
+    );
+    if (callAssignment) {
+      this._store.dispatch(callAssignmentLoad());
+      fetch(
+        `/api/orgs/${this._orgId}/people/queries/${callAssignment.target.id}`,
+        {
+          body: JSON.stringify(query),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'PATCH',
+        }
+      )
+        .then((res) => res.json())
+        .then((data: { data: ZetkinQuery }) =>
+          this._store.dispatch(
+            callAssignmentUpdated({ ...callAssignment, target: data.data })
+          )
+        );
     }
   }
 

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -49,6 +49,21 @@ const callAssignmentsSlice = createSlice({
         state.callAssignments = state.callAssignments
           .filter((ca) => ca.id != action.payload.id)
           .concat([action.payload]);
+      } else {
+        state.statsById[action.payload.id] = {
+          allTargets: 0,
+          allocated: 0,
+          blocked: 0,
+          callBackLater: 0,
+          calledTooRecently: 0,
+          done: 0,
+          isLoading: false,
+          isStale: true,
+          missingPhoneNumber: 0,
+          organizerActionNeeded: 0,
+          queue: 0,
+          ready: 0,
+        };
       }
     },
     statsLoad: (state, action: PayloadAction<number>) => {

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -38,7 +38,13 @@ const callAssignmentsSlice = createSlice({
       const callAssignment = state.callAssignments.find(
         (ca) => ca.id === action.payload.id
       );
-      if (stats && callAssignment?.cooldown != action.payload.cooldown) {
+      if (
+        //TODO: clean up this hot mess w better caching logic
+        (stats && callAssignment?.cooldown != action.payload.cooldown) ||
+        (stats &&
+          JSON.stringify(action.payload.target.filter_spec) !=
+            JSON.stringify(callAssignment?.target.filter_spec))
+      ) {
         stats.isStale = true;
         state.callAssignments = state.callAssignments
           .filter((ca) => ca.id != action.payload.id)

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -40,30 +40,16 @@ const callAssignmentsSlice = createSlice({
       );
       if (
         //TODO: clean up this hot mess w better caching logic
-        (stats && callAssignment?.cooldown != action.payload.cooldown) ||
-        (stats &&
-          JSON.stringify(action.payload.target.filter_spec) !=
-            JSON.stringify(callAssignment?.target.filter_spec))
+        callAssignment?.cooldown != action.payload.cooldown ||
+        JSON.stringify(action.payload.target.filter_spec) !=
+          JSON.stringify(callAssignment?.target.filter_spec)
       ) {
-        stats.isStale = true;
+        if (stats) {
+          stats.isStale = true;
+        }
         state.callAssignments = state.callAssignments
           .filter((ca) => ca.id != action.payload.id)
           .concat([action.payload]);
-      } else {
-        state.statsById[action.payload.id] = {
-          allTargets: 0,
-          allocated: 0,
-          blocked: 0,
-          callBackLater: 0,
-          calledTooRecently: 0,
-          done: 0,
-          isLoading: false,
-          isStale: true,
-          missingPhoneNumber: 0,
-          organizerActionNeeded: 0,
-          queue: 0,
-          ready: 0,
-        };
       }
     },
     statsLoad: (state, action: PayloadAction<number>) => {

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -47,6 +47,7 @@ const callAssignmentsSlice = createSlice({
     },
     statsLoad: (state, action: PayloadAction<number>) => {
       state.statsById[action.payload] = {
+        allTargets: 0,
         allocated: 0,
         blocked: 0,
         callBackLater: 0,
@@ -67,6 +68,7 @@ const callAssignmentsSlice = createSlice({
     ) => {
       state.isLoading = false;
       state.statsById[action.payload.id] = {
+        allTargets: action.payload.allTargets,
         allocated: action.payload.allocated,
         blocked: action.payload.blocked,
         callBackLater: action.payload.callBackLater,

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -17,3 +17,8 @@ ready:
   subtitle: Targets to be called
   title: Ready
 statusSectionTitle: Status
+targets:
+  defineButton: Define target group
+  editButton: Edit target group
+  subtitle: Use smart search to define target group for this assignment.
+  title: Targets

--- a/src/pages/api/callAssignments/targets.ts
+++ b/src/pages/api/callAssignments/targets.ts
@@ -74,7 +74,10 @@ export default async function handler(
 
   const queue: number = ready - allocated;
 
+  const allTargets: number = blocked + ready + done;
+
   res.status(200).json({
+    allTargets,
     allocated,
     blocked,
     callBackLater,

--- a/src/pages/api/callAssignments/targets.ts
+++ b/src/pages/api/callAssignments/targets.ts
@@ -5,6 +5,7 @@ export interface ZetkinTarget {
   status: {
     block_reasons: string[];
     blocked: boolean;
+    goal_fulfilled: boolean;
   };
 }
 
@@ -43,10 +44,15 @@ export default async function handler(
   let allocated = 0,
     callBackLater = 0,
     calledTooRecently = 0,
+    doneButBlocked = 0,
     missingPhoneNumber = 0,
     organizerActionNeeded = 0;
 
   blockedTargets.forEach((target: ZetkinTarget) => {
+    if (target.status.goal_fulfilled) {
+      doneButBlocked++;
+    }
+
     const reasons = target.status.block_reasons;
     if (reasons.includes('organizer_action_needed')) {
       organizerActionNeeded++;
@@ -68,7 +74,9 @@ export default async function handler(
     organizerActionNeeded;
 
   const done: number =
-    statsData.data.num_target_matches - statsData.data.num_remaining_targets;
+    statsData.data.num_target_matches -
+    statsData.data.num_remaining_targets -
+    doneButBlocked;
 
   const ready: number = statsData.data.num_target_matches + allocated - done;
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -22,6 +22,10 @@ import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
 
 const useStyles = makeStyles((theme) => ({
+  button: {
+    borderColor: theme.palette.targetingStatusBar.blue,
+    color: theme.palette.targetingStatusBar.blue,
+  },
   chip: {
     backgroundColor: theme.palette.targetingStatusBar.gray,
     borderRadius: '1em',
@@ -122,6 +126,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
               <Divider />
               <Box p={2}>
                 <Button
+                  className={classes.button}
                   onClick={() => setQueryDialogOpen(true)}
                   startIcon={<Edit />}
                   variant="outlined"
@@ -132,12 +137,13 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
             </>
           ) : (
             <Box pb={2} px={2}>
-              <Box bgcolor="gray" p={2}>
+              <Box bgcolor="background.secondary" p={2}>
                 <Typography>
                   <Msg id="pages.organizeCallAssignment.targets.subtitle" />
                 </Typography>
                 <Box pt={1}>
                   <Button
+                    className={classes.button}
                     onClick={() => setQueryDialogOpen(true)}
                     startIcon={<Add />}
                     variant="outlined"

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -106,7 +106,9 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
       <Box mb={2}>
         <Card>
           <Box display="flex" justifyContent="space-between" p={2}>
-            <Typography variant="h4">Targets</Typography>
+            <Typography variant="h4">
+              <Msg id="pages.organizeCallAssignment.targets.title" />
+            </Typography>
             {model.isTargeted && (
               <ZUIAnimatedNumber value={stats?.allTargets || 0}>
                 {(animatedValue) => (
@@ -124,7 +126,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
                   startIcon={<Edit />}
                   variant="outlined"
                 >
-                  Edit target group
+                  <Msg id="pages.organizeCallAssignment.targets.editButton" />
                 </Button>
               </Box>
             </>
@@ -132,7 +134,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
             <Box pb={2} px={2}>
               <Box bgcolor="gray" p={2}>
                 <Typography>
-                  Use smart search to define target group for this assignment.
+                  <Msg id="pages.organizeCallAssignment.targets.subtitle" />
                 </Typography>
                 <Box pt={1}>
                   <Button
@@ -140,7 +142,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
                     startIcon={<Add />}
                     variant="outlined"
                   >
-                    Define target group
+                    <Msg id="pages.organizeCallAssignment.targets.defineButton" />
                   </Button>
                 </Box>
               </Box>

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -1,6 +1,14 @@
 import { GetServerSideProps } from 'next';
 import { FormattedMessage as Msg } from 'react-intl';
-import { Box, Typography } from '@material-ui/core';
+import { Add, Edit } from '@material-ui/icons';
+import {
+  Box,
+  Button,
+  Card,
+  Divider,
+  makeStyles,
+  Typography,
+} from '@material-ui/core';
 import { useEffect, useState } from 'react';
 
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
@@ -10,6 +18,20 @@ import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useModel from 'core/useModel';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
+
+const useStyles = makeStyles((theme) => ({
+  chip: {
+    backgroundColor: theme.palette.targetingStatusBar.gray,
+    borderRadius: '1em',
+    color: 'secondary',
+    display: 'flex',
+    fontSize: '1.8em',
+    lineHeight: 'normal',
+    marginRight: '0.1em',
+    overflow: 'hidden',
+    padding: '0.2em 0.7em',
+  },
+}));
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -42,6 +64,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
   orgId,
   assignmentId,
 }) => {
+  const classes = useStyles();
   const [onServer, setOnServer] = useState(true);
   const model = useModel(
     (store) =>
@@ -75,6 +98,38 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
 
   return (
     <Box>
+      <Box mb={2}>
+        <Card>
+          <Box display="flex" justifyContent="space-between" p={2}>
+            <Typography variant="h4">Targets</Typography>
+            {model.isTargeted && <Box className={classes.chip}>100</Box>}
+          </Box>
+          {model.isTargeted ? (
+            <>
+              <Divider />
+              <Box p={2}>
+                <Button startIcon={<Edit />} variant="outlined">
+                  Edit target group
+                </Button>
+              </Box>
+            </>
+          ) : (
+            <Box pb={2} px={2}>
+              <Box bgcolor="gray" p={2}>
+                <Typography>
+                  Use smart search to define target group for this assignment.
+                </Typography>
+                <Box pt={1}>
+                  <Button startIcon={<Add />} variant="outlined">
+                    Define target group
+                  </Button>
+                </Box>
+              </Box>
+            </Box>
+          )}
+        </Card>
+      </Box>
+
       <Box mb={2}>
         <Typography variant="h3">
           <Msg id="pages.organizeCallAssignment.statusSectionTitle" />

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -16,6 +16,7 @@ import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentM
 import CallAssignmentStatusCards from 'features/callAssignments/components/CallAssignmentStatusCards';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
+import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog';
 import useModel from 'core/useModel';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
@@ -67,6 +68,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
 }) => {
   const classes = useStyles();
   const [onServer, setOnServer] = useState(true);
+  const [queryDialogOpen, setQueryDialogOpen] = useState(false);
   const model = useModel(
     (store) =>
       new CallAssignmentModel(store, parseInt(orgId), parseInt(assignmentId))
@@ -97,6 +99,8 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
       ? [stats.blocked, stats.ready, stats.done]
       : [1, 1, 1];
 
+  const { target } = model.getData();
+
   return (
     <Box>
       <Box mb={2}>
@@ -115,7 +119,11 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
             <>
               <Divider />
               <Box p={2}>
-                <Button startIcon={<Edit />} variant="outlined">
+                <Button
+                  onClick={() => setQueryDialogOpen(true)}
+                  startIcon={<Edit />}
+                  variant="outlined"
+                >
                   Edit target group
                 </Button>
               </Box>
@@ -127,7 +135,11 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
                   Use smart search to define target group for this assignment.
                 </Typography>
                 <Box pt={1}>
-                  <Button startIcon={<Add />} variant="outlined">
+                  <Button
+                    onClick={() => setQueryDialogOpen(true)}
+                    startIcon={<Add />}
+                    variant="outlined"
+                  >
                     Define target group
                   </Button>
                 </Box>
@@ -135,6 +147,16 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
             </Box>
           )}
         </Card>
+        {queryDialogOpen && (
+          <SmartSearchDialog
+            onDialogClose={() => setQueryDialogOpen(false)}
+            onSave={(query) => {
+              model.setTargets(query);
+              setQueryDialogOpen(false);
+            }}
+            query={target}
+          />
+        )}
       </Box>
 
       <Box mb={2}>

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -1,43 +1,16 @@
 import { GetServerSideProps } from 'next';
 import { FormattedMessage as Msg } from 'react-intl';
-import { Add, Edit } from '@material-ui/icons';
-import {
-  Box,
-  Button,
-  Card,
-  Divider,
-  makeStyles,
-  Typography,
-} from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { useEffect, useState } from 'react';
 
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
 import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
 import CallAssignmentStatusCards from 'features/callAssignments/components/CallAssignmentStatusCards';
+import CallAssignmentTargets from 'features/callAssignments/components/CallAssignmentTargets';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
-import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog';
 import useModel from 'core/useModel';
-import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
-
-const useStyles = makeStyles((theme) => ({
-  button: {
-    borderColor: theme.palette.targetingStatusBar.blue,
-    color: theme.palette.targetingStatusBar.blue,
-  },
-  chip: {
-    backgroundColor: theme.palette.targetingStatusBar.gray,
-    borderRadius: '1em',
-    color: 'secondary',
-    display: 'flex',
-    fontSize: '1.8em',
-    lineHeight: 'normal',
-    marginRight: '0.1em',
-    overflow: 'hidden',
-    padding: '0.2em 0.7em',
-  },
-}));
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -70,9 +43,7 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
   orgId,
   assignmentId,
 }) => {
-  const classes = useStyles();
   const [onServer, setOnServer] = useState(true);
-  const [queryDialogOpen, setQueryDialogOpen] = useState(false);
   const model = useModel(
     (store) =>
       new CallAssignmentModel(store, parseInt(orgId), parseInt(assignmentId))
@@ -103,70 +74,11 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
       ? [stats.blocked, stats.ready, stats.done]
       : [1, 1, 1];
 
-  const { target } = model.getData();
-
   return (
     <Box>
       <Box mb={2}>
-        <Card>
-          <Box display="flex" justifyContent="space-between" p={2}>
-            <Typography variant="h4">
-              <Msg id="pages.organizeCallAssignment.targets.title" />
-            </Typography>
-            {model.isTargeted && (
-              <ZUIAnimatedNumber value={stats?.allTargets || 0}>
-                {(animatedValue) => (
-                  <Box className={classes.chip}>{animatedValue}</Box>
-                )}
-              </ZUIAnimatedNumber>
-            )}
-          </Box>
-          {model.isTargeted ? (
-            <>
-              <Divider />
-              <Box p={2}>
-                <Button
-                  className={classes.button}
-                  onClick={() => setQueryDialogOpen(true)}
-                  startIcon={<Edit />}
-                  variant="outlined"
-                >
-                  <Msg id="pages.organizeCallAssignment.targets.editButton" />
-                </Button>
-              </Box>
-            </>
-          ) : (
-            <Box pb={2} px={2}>
-              <Box bgcolor="background.secondary" p={2}>
-                <Typography>
-                  <Msg id="pages.organizeCallAssignment.targets.subtitle" />
-                </Typography>
-                <Box pt={1}>
-                  <Button
-                    className={classes.button}
-                    onClick={() => setQueryDialogOpen(true)}
-                    startIcon={<Add />}
-                    variant="outlined"
-                  >
-                    <Msg id="pages.organizeCallAssignment.targets.defineButton" />
-                  </Button>
-                </Box>
-              </Box>
-            </Box>
-          )}
-        </Card>
-        {queryDialogOpen && (
-          <SmartSearchDialog
-            onDialogClose={() => setQueryDialogOpen(false)}
-            onSave={(query) => {
-              model.setTargets(query);
-              setQueryDialogOpen(false);
-            }}
-            query={target}
-          />
-        )}
+        <CallAssignmentTargets model={model} />
       </Box>
-
       <Box mb={2}>
         <Typography variant="h3">
           <Msg id="pages.organizeCallAssignment.statusSectionTitle" />

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/index.tsx
@@ -17,6 +17,7 @@ import CallAssignmentStatusCards from 'features/callAssignments/components/CallA
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useModel from 'core/useModel';
+import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
 
 const useStyles = makeStyles((theme) => ({
@@ -102,7 +103,13 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
         <Card>
           <Box display="flex" justifyContent="space-between" p={2}>
             <Typography variant="h4">Targets</Typography>
-            {model.isTargeted && <Box className={classes.chip}>100</Box>}
+            {model.isTargeted && (
+              <ZUIAnimatedNumber value={stats?.allTargets || 0}>
+                {(animatedValue) => (
+                  <Box className={classes.chip}>{animatedValue}</Box>
+                )}
+              </ZUIAnimatedNumber>
+            )}
           </Box>
           {model.isTargeted ? (
             <>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,6 +28,7 @@ declare module '@material-ui/core/styles/createPalette' {
 const themePalette = {
   background: {
     default: '#F9F9F9',
+    secondary: 'rgba(0,0,0,0.04)',
   },
   error: {
     main: '#EE323E',


### PR DESCRIPTION
## Description
This PR adds a targets section to the call assignments targeting screen.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/204316552-bbbb8a2b-90f8-41c5-ab6f-d579e06318d8.png)

## Changes
* Adds CallAssignmentTargets component, that lets users open a smart search dialog to create or edit their targeting query.
* Adds a setTargets method on the Call assignment model
* Adds a few colors from the designs to the Theme

## Notes to reviewer
This MVP version does not include the pictogram, that will later be in this section.

## Related issues
Resolves #824 
