### PR TITLE
Callassignment header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -2,7 +2,9 @@ import { ZetkinQuery } from 'utils/types/zetkin';
 
 export interface CallAssignmentData {
   cooldown: number;
+  end_date?: string;
   id: number;
+  start_date?: string;
   target: ZetkinQuery;
   title: string;
 }

--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -18,6 +18,7 @@ export interface CallAssignmentStats {
   calledTooRecently: number;
   done: number;
   missingPhoneNumber: number;
+  mostRecentCallTime: string | null;
   organizerActionNeeded: number;
   queue: number;
   ready: number;

--- a/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
-import { useIntl } from 'react-intl';
-import { Chip, makeStyles } from '@material-ui/core';
+import { FormattedMessage } from 'react-intl';
+import { Box, CircularProgress, makeStyles } from '@material-ui/core';
 
 import { CallAssignmentState } from '../models/CallAssignmentModel';
 
@@ -9,32 +9,35 @@ interface CallAssignmentStatusChipProps {
 }
 
 const useStyles = makeStyles((theme) => ({
+  chip: {
+    alignItems: 'center',
+    borderRadius: '2em',
+    color: 'white',
+    display: 'inline-flex',
+    fontSize: 14,
+    fontWeight: 'bold',
+    padding: '0.5em 0.7em',
+  },
   closed: {
     backgroundColor: theme.palette.error.main,
-    color: 'white',
-    fontWeight: 'bold',
   },
   draft: {
     backgroundColor: theme.palette.grey[500],
-    color: 'white',
-    fontWeight: 'bold',
   },
   open: {
     backgroundColor: theme.palette.success.main,
-    color: 'white',
-    fontWeight: 'bold',
   },
   scheduled: {
     backgroundColor: theme.palette.targetingStatusBar.blue,
-    color: 'white',
-    fontWeight: 'bold',
+  },
+  spinner: {
+    marginLeft: '0.5em',
   },
 }));
 
 const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
   state,
 }) => {
-  const intl = useIntl();
   const classes = useStyles();
 
   if (state == CallAssignmentState.UNKNOWN) {
@@ -42,6 +45,7 @@ const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
   }
 
   const classMap: Record<CallAssignmentState, string> = {
+    [CallAssignmentState.ACTIVE]: classes.open,
     [CallAssignmentState.CLOSED]: classes.closed,
     [CallAssignmentState.DRAFT]: classes.draft,
     [CallAssignmentState.OPEN]: classes.open,
@@ -49,15 +53,19 @@ const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
     [CallAssignmentState.UNKNOWN]: classes.draft,
   };
 
-  const className = classMap[state];
+  const colorClassName = classMap[state];
 
   return (
-    <Chip
-      className={className}
-      label={intl.formatMessage({
-        id: `pages.organizeCallAssignment.state.${state}`,
-      })}
-    />
+    <Box className={`${colorClassName} ${classes.chip}`}>
+      <FormattedMessage id={`pages.organizeCallAssignment.state.${state}`} />
+      {state == CallAssignmentState.ACTIVE && (
+        <CircularProgress
+          className={classes.spinner}
+          size={14}
+          style={{ color: 'white' }}
+        />
+      )}
+    </Box>
   );
 };
 

--- a/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
@@ -1,0 +1,64 @@
+import { FC } from 'react';
+import { useIntl } from 'react-intl';
+import { Chip, makeStyles } from '@material-ui/core';
+
+import { CallAssignmentState } from '../models/CallAssignmentModel';
+
+interface CallAssignmentStatusChipProps {
+  state: CallAssignmentState;
+}
+
+const useStyles = makeStyles((theme) => ({
+  closed: {
+    backgroundColor: theme.palette.error.main,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  draft: {
+    backgroundColor: theme.palette.grey[500],
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  open: {
+    backgroundColor: theme.palette.success.main,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  scheduled: {
+    backgroundColor: theme.palette.targetingStatusBar.blue,
+    color: 'white',
+    fontWeight: 'bold',
+  },
+}));
+
+const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
+  state,
+}) => {
+  const intl = useIntl();
+  const classes = useStyles();
+
+  if (state == CallAssignmentState.UNKNOWN) {
+    return null;
+  }
+
+  const classMap: Record<CallAssignmentState, string> = {
+    [CallAssignmentState.CLOSED]: classes.closed,
+    [CallAssignmentState.DRAFT]: classes.draft,
+    [CallAssignmentState.OPEN]: classes.open,
+    [CallAssignmentState.SCHEDULED]: classes.scheduled,
+    [CallAssignmentState.UNKNOWN]: classes.draft,
+  };
+
+  const className = classMap[state];
+
+  return (
+    <Chip
+      className={className}
+      label={intl.formatMessage({
+        id: `pages.organizeCallAssignment.state.${state}`,
+      })}
+    />
+  );
+};
+
+export default CallAssignmentStatusChip;

--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -1,4 +1,5 @@
 import CallAssignmentModel from '../models/CallAssignmentModel';
+import CallAssignmentStatusChip from '../components/CallAssignmentStatusChip';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
@@ -31,6 +32,7 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
     <TabbedLayout
       baseHref={`/organize/${orgId}/campaigns/${campaignId}/callassignments/${assignmentId}`}
       defaultTab="/"
+      subtitle={<CallAssignmentStatusChip state={model.state} />}
       tabs={[
         {
           href: '/',

--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -1,5 +1,7 @@
-import { callAssignmentQuery } from 'features/callAssignments/api/callAssignments';
+import CallAssignmentModel from '../models/CallAssignmentModel';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
+import useModel from 'core/useModel';
+import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 
 interface CallAssignmentLayoutProps {
   children: React.ReactNode;
@@ -14,7 +16,16 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
   campaignId,
   assignmentId,
 }) => {
-  const assQuery = callAssignmentQuery(orgId, assignmentId).useQuery();
+  const model = useModel(
+    (env) =>
+      new CallAssignmentModel(env, parseInt(orgId), parseInt(assignmentId))
+  );
+
+  const future = model.getData();
+
+  if (!future.data) {
+    return null;
+  }
 
   return (
     <TabbedLayout
@@ -30,7 +41,12 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
           messageId: 'layout.organize.callAssignment.tabs.insights',
         },
       ]}
-      title={assQuery.data?.title}
+      title={
+        <ZUIEditTextinPlace
+          onChange={(newTitle) => model.setTitle(newTitle)}
+          value={future.data.title}
+        />
+      }
     >
       {children}
     </TabbedLayout>

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -193,7 +193,7 @@ describe('CallAssignmentModel', () => {
     });
 
     it('is OPEN when dates are correct, and most recent call was too long ago', () => {
-      jest.useFakeTimers().setSystemTime(new Date('1857-08-04T14:37:00'));
+      jest.useFakeTimers().setSystemTime(new Date('1857-08-04T14:37:00Z'));
 
       const store = createStore(
         mockStoreData('1857-07-05', '1933-06-20', '1857-08-04T13:37:00Z')
@@ -202,7 +202,7 @@ describe('CallAssignmentModel', () => {
       const apiClient = instance(mockClient);
       const env = new Environment(store, apiClient);
       const model = new CallAssignmentModel(env, 1, 2);
-      expect(model.state).toBe(CallAssignmentState.ACTIVE);
+      expect(model.state).toBe(CallAssignmentState.OPEN);
     });
 
     it('is ACTIVE when open with very recent call', () => {

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -90,15 +90,43 @@ describe('CallAssignmentModel', () => {
   });
 
   describe('state', () => {
-    const mockAssignment = {
-      cooldown: 3,
-      id: 2,
-      target: {
-        filter_spec: [],
-        id: 101,
+    const mockStoreData = (
+      startDate?: string,
+      endDate?: string,
+      mostRecentCallTime: string | null = null
+    ) => ({
+      callAssignments: {
+        assignmentList: mockList<CallAssignmentData>([
+          {
+            cooldown: 3,
+            end_date: endDate,
+            id: 2,
+            start_date: startDate,
+            target: {
+              filter_spec: [{ config: {}, type: FILTER_TYPE.ALL }],
+              id: 101,
+            },
+            title: 'My assignment',
+          },
+        ]),
+        statsById: {
+          2: mockItem({
+            allTargets: 100,
+            allocated: 0,
+            blocked: 0,
+            callBackLater: 0,
+            calledTooRecently: 0,
+            done: 50,
+            id: 2,
+            missingPhoneNumber: 0,
+            mostRecentCallTime: mostRecentCallTime,
+            organizerActionNeeded: 0,
+            queue: 0,
+            ready: 50,
+          }),
+        },
       },
-      title: 'My assignment',
-    };
+    });
 
     afterEach(() => {
       jest.useRealTimers();
@@ -107,13 +135,14 @@ describe('CallAssignmentModel', () => {
     it('is UNKNOWN when not loaded', () => {
       const store = createStore({
         callAssignments: {
-          assignmentList: mockList<CallAssignmentData>(),
+          assignmentList: mockList(),
           statsById: {},
         },
       });
 
+      const mockData = mockStoreData();
       when(mockClient.get<CallAssignmentData>(anything())).thenResolve(
-        mockAssignment
+        mockData.callAssignments.assignmentList.items[0].data!
       );
 
       const apiClient = instance(mockClient);
@@ -123,16 +152,7 @@ describe('CallAssignmentModel', () => {
     });
 
     it('is DRAFT when there is no start date', () => {
-      const store = createStore({
-        callAssignments: {
-          assignmentList: mockList<CallAssignmentData>([
-            {
-              ...mockAssignment,
-            },
-          ]),
-          statsById: {},
-        },
-      });
+      const store = createStore(mockStoreData());
 
       jest.useFakeTimers().setSystemTime(new Date('1857-07-04'));
 
@@ -143,19 +163,7 @@ describe('CallAssignmentModel', () => {
     });
 
     it('is SCHEDULED when start date is in the future', () => {
-      const store = createStore({
-        callAssignments: {
-          assignmentList: mockList<CallAssignmentData>([
-            {
-              ...mockAssignment,
-              end_date: '1933-06-20',
-              start_date: '1857-07-05',
-            },
-          ]),
-          statsById: {},
-        },
-      });
-
+      const store = createStore(mockStoreData('1857-07-05', '1933-06-20'));
       jest.useFakeTimers().setSystemTime(new Date('1857-07-04'));
 
       const apiClient = instance(mockClient);
@@ -165,19 +173,7 @@ describe('CallAssignmentModel', () => {
     });
 
     it('is OPEN when start_date is in the past and end_date in the future', () => {
-      const store = createStore({
-        callAssignments: {
-          assignmentList: mockList<CallAssignmentData>([
-            {
-              ...mockAssignment,
-              end_date: '1933-06-20',
-              start_date: '1857-07-05',
-            },
-          ]),
-          statsById: {},
-        },
-      });
-
+      const store = createStore(mockStoreData('1857-07-05', '1933-06-20'));
       jest.useFakeTimers().setSystemTime(new Date('1857-07-08'));
 
       const apiClient = instance(mockClient);
@@ -187,18 +183,7 @@ describe('CallAssignmentModel', () => {
     });
 
     it('is OPEN when start_date is in the past and there is no end_date', () => {
-      const store = createStore({
-        callAssignments: {
-          assignmentList: mockList<CallAssignmentData>([
-            {
-              ...mockAssignment,
-              start_date: '1857-07-05',
-            },
-          ]),
-          statsById: {},
-        },
-      });
-
+      const store = createStore(mockStoreData('1857-07-05'));
       jest.useFakeTimers().setSystemTime(new Date('1857-08-04'));
 
       const apiClient = instance(mockClient);
@@ -207,19 +192,34 @@ describe('CallAssignmentModel', () => {
       expect(model.state).toBe(CallAssignmentState.OPEN);
     });
 
+    it('is OPEN when dates are correct, and most recent call was too long ago', () => {
+      jest.useFakeTimers().setSystemTime(new Date('1857-08-04T14:37:00'));
+
+      const store = createStore(
+        mockStoreData('1857-07-05', '1933-06-20', '1857-08-04T13:37:00Z')
+      );
+
+      const apiClient = instance(mockClient);
+      const env = new Environment(store, apiClient);
+      const model = new CallAssignmentModel(env, 1, 2);
+      expect(model.state).toBe(CallAssignmentState.ACTIVE);
+    });
+
+    it('is ACTIVE when open with very recent call', () => {
+      jest.useFakeTimers().setSystemTime(new Date('1857-08-04T13:38:00'));
+
+      const store = createStore(
+        mockStoreData('1857-07-05', '1933-06-20', '1857-08-04T13:37:00Z')
+      );
+
+      const apiClient = instance(mockClient);
+      const env = new Environment(store, apiClient);
+      const model = new CallAssignmentModel(env, 1, 2);
+      expect(model.state).toBe(CallAssignmentState.ACTIVE);
+    });
+
     it('is CLOSED when end date is in the past', () => {
-      const store = createStore({
-        callAssignments: {
-          assignmentList: mockList<CallAssignmentData>([
-            {
-              ...mockAssignment,
-              end_date: '1933-06-20',
-              start_date: '1857-07-05',
-            },
-          ]),
-          statsById: {},
-        },
-      });
+      const store = createStore(mockStoreData('1857-07-05', '1933-06-20'));
 
       jest.useFakeTimers().setSystemTime(new Date('1933-06-21'));
 
@@ -293,6 +293,7 @@ describe('CallAssignmentModel', () => {
         done: 50,
         id: 2,
         missingPhoneNumber: 0,
+        mostRecentCallTime: null,
         organizerActionNeeded: 0,
         queue: 0,
         ready: 50,
@@ -314,6 +315,7 @@ describe('CallAssignmentModel', () => {
         done: 0,
         id: 2,
         missingPhoneNumber: 0,
+        mostRecentCallTime: null,
         organizerActionNeeded: 0,
         queue: 0,
         ready: 0,
@@ -351,6 +353,7 @@ describe('CallAssignmentModel', () => {
               done: 50,
               id: 2,
               missingPhoneNumber: 0,
+              mostRecentCallTime: null,
               organizerActionNeeded: 0,
               queue: 0,
               ready: 50,
@@ -375,6 +378,7 @@ describe('CallAssignmentModel', () => {
         done: 50,
         id: 2,
         missingPhoneNumber: 0,
+        mostRecentCallTime: null,
         organizerActionNeeded: 0,
         queue: 0,
         ready: 50,

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -110,4 +110,8 @@ export default class CallAssignmentModel {
         );
     }
   }
+
+  setTitle(title: string): void {
+    this._repo.updateCallAssignment(this._orgId, this._id, { title });
+  }
 }

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -81,6 +81,7 @@ const callAssignmentsSlice = createSlice({
           calledTooRecently: 0,
           done: 0,
           missingPhoneNumber: 0,
+          mostRecentCallTime: null,
           organizerActionNeeded: 0,
           queue: 0,
           ready: 0,

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -17,6 +17,7 @@ ready:
   subtitle: Targets to be called
   title: Ready
 state:
+  active: Active
   closed: Closed
   draft: Draft
   open: Open

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -16,6 +16,11 @@ ready:
   queue: Targets in queue
   subtitle: Targets to be called
   title: Ready
+state:
+  closed: Closed
+  draft: Draft
+  open: Open
+  scheduled: Scheduled
 statusSectionTitle: Status
 targets:
   defineButton: Define target group

--- a/src/pages/api/callAssignments/targets.ts
+++ b/src/pages/api/callAssignments/targets.ts
@@ -32,6 +32,15 @@ export default async function handler(
     data: ZetkinCallAssignmentStats;
   };
 
+  let mostRecentCallTime: string | null = null;
+  const callsRes = await apiFetch(
+    `/orgs/${org}/call_assignments/${assignment}/calls?pp=1&p=0`
+  );
+  const callsData = await callsRes.json();
+  if (callsData.data.length) {
+    mostRecentCallTime = callsData.data[0].allocation_time;
+  }
+
   const targetsRes = await apiFetch(
     `/orgs/${org}/call_assignments/${assignment}/targets`
   );
@@ -93,6 +102,7 @@ export default async function handler(
       calledTooRecently,
       done,
       missingPhoneNumber,
+      mostRecentCallTime,
       organizerActionNeeded,
       queue,
       ready,

--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
 export interface ZUIEditTextinPlaceProps {
   allowEmpty?: boolean;
   disabled?: boolean;
-  onChange: (newValue: string) => Promise<void>;
+  onChange: (newValue: string) => void;
   placeholder?: string;
   value: string;
 }


### PR DESCRIPTION
## Description
This PR implements an editable title and a status chip for the call assignment header.

## Screenshots
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/550212/205456255-fa5fbdc2-4424-46d0-9b60-8852aca89d59.png">

## Changes
* Makes call assignment title editable
  * Uses `EditTextInPlace` for the call assignment title
  * Adds `setTitle()` method to `CallAssignmentModel`
* Adds the status of the call assignment to the subtitle
  * Adds a `state` property to `CallAssignmentModel`
  * Includes timestamp of most recent call in the stats API
  * Adds tests for the new property
  * Adds a `CallAssignmentStatusChip` to render the various states of the chip

## Notes to reviewer
Review #850 first, as this PR builds on the refactors done in that PR.

When reviewing this: 
* Try changing the title.
* Change the dates via Gen2 or using the API, refresh the page to see the status chip update
* Try making a call to see the "active" state

## Related issues
Resolves #834
Resolves #835 