### PR TITLE
GUI for starting, ending and scheduling call assignments

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,8 @@
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import dayjs from 'dayjs';
 import { IntlProvider } from 'react-intl';
 import isoWeek from 'dayjs/plugin/isoWeek';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { muiTheme } from 'storybook-addon-material-ui';
 import { RouterContext } from 'next/dist/shared/lib/router-context'; // next 11.1
 import withMock from 'storybook-addon-mock';
@@ -25,7 +27,9 @@ const AsyncIntlProvider = (props) => {
 
   return (
     <IntlProvider defaultLocale="en" locale="en" messages={messages}>
-      {props.children}
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        {props.children}
+      </LocalizationProvider>
     </IntlProvider>
   );
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@mui/styles": "^5.10.6",
     "@mui/system": "^5.10.7",
     "@mui/x-data-grid-pro": "^5.17.8",
-    "@mui/x-date-pickers": "^5.0.3",
+    "@mui/x-date-pickers-pro": "^5.0.10",
     "@nivo/bar": "^0.79.1",
     "@nivo/core": "^0.79.0",
     "@nivo/pie": "^0.79.1",

--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -10,9 +10,9 @@ export interface CallAssignmentCaller {
 
 export interface CallAssignmentData {
   cooldown: number;
-  end_date?: string;
+  end_date: string | null;
   id: number;
-  start_date?: string;
+  start_date: string | null;
   target: ZetkinQuery;
   title: string;
 }

--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -1,7 +1,10 @@
+import { Box } from '@mui/material';
+
 import CallAssignmentModel from '../models/CallAssignmentModel';
 import CallAssignmentStatusChip from '../components/CallAssignmentStatusChip';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
+import ZUIDateRangePicker from 'zui/ZUIDateRangePicker/ZUIDateRangePicker';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 
 interface CallAssignmentLayoutProps {
@@ -32,7 +35,20 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
     <TabbedLayout
       baseHref={`/organize/${orgId}/campaigns/${campaignId}/callassignments/${assignmentId}`}
       defaultTab="/"
-      subtitle={<CallAssignmentStatusChip state={model.state} />}
+      subtitle={
+        <Box alignItems="center" display="flex">
+          <CallAssignmentStatusChip state={model.state} />
+          <Box marginX={2}>
+            <ZUIDateRangePicker
+              endDate={future.data.end_date || null}
+              onChange={(startDate, endDate) => {
+                model.setDates(startDate, endDate);
+              }}
+              startDate={future.data.start_date || null}
+            />
+          </Box>
+        </Box>
+      }
       tabs={[
         {
           href: '/',

--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -1,11 +1,14 @@
-import { Box } from '@mui/material';
+import { useIntl } from 'react-intl';
+import { Box, Button } from '@mui/material';
 
-import CallAssignmentModel from '../models/CallAssignmentModel';
 import CallAssignmentStatusChip from '../components/CallAssignmentStatusChip';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
 import ZUIDateRangePicker from 'zui/ZUIDateRangePicker/ZUIDateRangePicker';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
+import CallAssignmentModel, {
+  CallAssignmentState,
+} from '../models/CallAssignmentModel';
 
 interface CallAssignmentLayoutProps {
   children: React.ReactNode;
@@ -20,6 +23,7 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
   campaignId,
   assignmentId,
 }) => {
+  const intl = useIntl();
   const model = useModel(
     (env) =>
       new CallAssignmentModel(env, parseInt(orgId), parseInt(assignmentId))
@@ -33,6 +37,22 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
 
   return (
     <TabbedLayout
+      actionButtons={
+        model.state == CallAssignmentState.OPEN ||
+        model.state == CallAssignmentState.ACTIVE ? (
+          <Button onClick={() => model.end()} variant="contained">
+            {intl.formatMessage({
+              id: 'layout.organize.callAssignment.actions.end',
+            })}
+          </Button>
+        ) : (
+          <Button onClick={() => model.start()} variant="contained">
+            {intl.formatMessage({
+              id: 'layout.organize.callAssignment.actions.start',
+            })}
+          </Button>
+        )
+      }
       baseHref={`/organize/${orgId}/campaigns/${campaignId}/callassignments/${assignmentId}`}
       defaultTab="/"
       subtitle={

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -43,7 +43,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              end_date: null,
               id: 2,
+              start_date: null,
               target: {
                 filter_spec: [],
                 id: 101,
@@ -69,7 +71,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              end_date: null,
               id: 2,
+              start_date: null,
               target: {
                 filter_spec: [
                   {
@@ -97,8 +101,8 @@ describe('CallAssignmentModel', () => {
 
   describe('state', () => {
     const mockStoreData = (
-      startDate?: string,
-      endDate?: string,
+      startDate: string | null = null,
+      endDate: string | null = null,
       mostRecentCallTime: string | null = null
     ) => ({
       callAssignments: {
@@ -245,7 +249,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              end_date: null,
               id: 2,
+              start_date: null,
               target: {
                 filter_spec: [],
                 id: 101,
@@ -276,7 +282,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              end_date: null,
               id: 2,
+              start_date: null,
               target: {
                 filter_spec: [
                   {
@@ -340,7 +348,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              end_date: null,
               id: 2,
+              start_date: null,
               target: {
                 filter_spec: [
                   {

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -588,6 +588,7 @@ describe('CallAssignmentModel', () => {
     it.each([
       [pastDate(3), pastDate(1), { end_date: null }],
       [pastDate(3), today, { end_date: null }],
+      [today, today, { end_date: null }],
       [futureDate(1), futureDate(3), { start_date: today }],
       [futureDate(1), null, { start_date: today }],
       [null, pastDate(1), { end_date: null, start_date: today }],

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -118,6 +118,13 @@ export default class CallAssignmentModel {
     this._repo.updateCallAssignment(this._orgId, this._id, { cooldown });
   }
 
+  setDates(startDate: string | null, endDate: string | null) {
+    return this._repo.updateCallAssignment(this._orgId, this._id, {
+      end_date: endDate,
+      start_date: startDate,
+    });
+  }
+
   setTargets(query: Partial<ZetkinQuery>): void {
     // TODO: Refactor once SmartSearch is supported in redux framework
     const state = this._store.getState();

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -118,8 +118,8 @@ export default class CallAssignmentModel {
     this._repo.updateCallAssignment(this._orgId, this._id, { cooldown });
   }
 
-  setDates(startDate: string | null, endDate: string | null) {
-    return this._repo.updateCallAssignment(this._orgId, this._id, {
+  setDates(startDate: string | null, endDate: string | null): void {
+    this._repo.updateCallAssignment(this._orgId, this._id, {
       end_date: endDate,
       start_date: startDate,
     });

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -216,7 +216,7 @@ export default class CallAssignmentModel {
       const endDate = dayjs(endStr);
 
       if (
-        startDate.isBefore(today) &&
+        (startDate.isBefore(today) || startDate.isSame(today)) &&
         (endDate.isBefore(today) || endDate.isSame(today))
       ) {
         // Start is past, end is past

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import Fuse from 'fuse.js';
 
 import CallAssignmentsRepo from '../repos/CallAssignmentsRepo';
@@ -38,6 +39,20 @@ export default class CallAssignmentModel {
     this._orgId = orgId;
     this._id = id;
     this._repo = new CallAssignmentsRepo(env);
+  }
+
+  end(): void {
+    const { data } = this.getData();
+    if (!data) {
+      return;
+    }
+
+    const now = dayjs();
+    const today = now.format('YYYY-MM-DD');
+
+    this._repo.updateCallAssignment(this._orgId, this._id, {
+      end_date: today,
+    });
   }
 
   getData(): IFuture<CallAssignmentData> {
@@ -156,6 +171,65 @@ export default class CallAssignmentModel {
 
   setTitle(title: string): void {
     this._repo.updateCallAssignment(this._orgId, this._id, { title });
+  }
+
+  start(): void {
+    const { data } = this.getData();
+    if (!data) {
+      return;
+    }
+
+    const now = dayjs();
+    const today = now.format('YYYY-MM-DD');
+
+    const { start_date: startStr, end_date: endStr } = data;
+
+    if (!startStr && !endStr) {
+      this._repo.updateCallAssignment(this._orgId, this._id, {
+        start_date: today,
+      });
+    } else if (!startStr) {
+      // End date is non-null
+      const endDate = dayjs(endStr);
+      if (endDate.isBefore(today)) {
+        this._repo.updateCallAssignment(this._orgId, this._id, {
+          end_date: null,
+          start_date: today,
+        });
+      } else if (endDate.isAfter(today)) {
+        this._repo.updateCallAssignment(this._orgId, this._id, {
+          start_date: today,
+        });
+      }
+    } else if (!endStr) {
+      // Start date is non-null
+      const startDate = dayjs(startStr);
+      if (startDate.isAfter(today)) {
+        // End date is null, start date is future
+        this._repo.updateCallAssignment(this._orgId, this._id, {
+          start_date: today,
+        });
+      }
+    } else {
+      // Start and end date are non-null
+      const startDate = dayjs(startStr);
+      const endDate = dayjs(endStr);
+
+      if (
+        startDate.isBefore(today) &&
+        (endDate.isBefore(today) || endDate.isSame(today))
+      ) {
+        // Start is past, end is past
+        this._repo.updateCallAssignment(this._orgId, this._id, {
+          end_date: null,
+        });
+      } else if (startDate.isAfter(today) && endDate.isAfter(today)) {
+        // Start is future, end is future
+        this._repo.updateCallAssignment(this._orgId, this._id, {
+          start_date: today,
+        });
+      }
+    }
   }
 
   get state(): CallAssignmentState {

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -1,4 +1,7 @@
 callAssignment:
+  actions:
+    end: End assignment
+    start: Start assignment
   tabs:
     callers: Callers
     insights: Insights

--- a/src/locale/misc/en.yml
+++ b/src/locale/misc/en.yml
@@ -30,6 +30,10 @@ dataTable:
     button: Sort
     hint: 'Hint: hold down {shiftKeyIcon} while clicking multiple columns'
     title: Sort
+dateRange:
+  draft: No start date
+  finite: From {start, date, medium} to {end, date, medium}
+  indefinite: From {start, date, medium} onwards
 email:
   headers:
     cc: CC

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.stories.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.stories.tsx
@@ -8,10 +8,8 @@ export default {
 } as ComponentMeta<typeof ZUIDateRangePicker>;
 
 const Template: ComponentStory<typeof ZUIDateRangePicker> = () => (
-  <ZUIDateRangePicker />
+  <ZUIDateRangePicker endDate={null} startDate={null} />
 );
 
 export const basic = Template.bind({});
-basic.args = {
-  datetime: new Date().toISOString(),
-};
+basic.args = {};

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.stories.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUIDateRangePicker from '.';
+
+export default {
+  component: ZUIDateRangePicker,
+  title: 'Molecules/ZUIDateRangePicker',
+} as ComponentMeta<typeof ZUIDateRangePicker>;
+
+const Template: ComponentStory<typeof ZUIDateRangePicker> = () => (
+  <ZUIDateRangePicker />
+);
+
+export const basic = Template.bind({});
+basic.args = {
+  datetime: new Date().toISOString(),
+};

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -32,13 +32,30 @@ const rangeStr = (intl: IntlShape, values: DateRange<Dayjs>): string => {
   }
 };
 
-const ZUIDateRangePicker: FC = () => {
+interface ZUIDateRangePickerProps {
+  endDate: string | null;
+  onChange?: (startDate: string | null, endDate: string | null) => void;
+  startDate: string | null;
+}
+
+const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
+  endDate,
+  onChange,
+  startDate,
+}) => {
   const intl = useIntl();
   const [anchorEl, setAnchorEl] = useState<HTMLSpanElement | null>(null);
   const [value, setValue] = useState<DateRange<Dayjs>>([
     dayjs('1857-07-05'),
     dayjs('1933-06-20'),
   ]);
+
+  useEffect(() => {
+    setValue([
+      startDate ? dayjs(startDate) : null,
+      endDate ? dayjs(endDate) : null,
+    ]);
+  }, [endDate, startDate]);
 
   // Calculate duration to use when shifting the entire range,
   // which happens when setting a start date that precedes the
@@ -60,6 +77,12 @@ const ZUIDateRangePicker: FC = () => {
       <ClickAwayListener
         onClickAway={() => {
           setAnchorEl(null);
+          if (onChange) {
+            onChange(
+              start?.format('YYYY-MM-DD') ?? null,
+              end?.format('YYYY-MM-DD') ?? null
+            );
+          }
         }}
       >
         <Popper anchorEl={anchorEl} open={!!anchorEl}>
@@ -74,11 +97,11 @@ const ZUIDateRangePicker: FC = () => {
                 <DateTextField
                   label="Start"
                   onChange={(date) => {
-                    let endDate = value[1];
-                    if (date && endDate?.isBefore(date)) {
-                      endDate = date.add(duration, 'day');
+                    let newEndDate = value[1];
+                    if (date && newEndDate?.isBefore(date)) {
+                      newEndDate = date.add(duration, 'day');
                     }
-                    setValue([date, endDate]);
+                    setValue([date, newEndDate]);
                   }}
                   value={value[0]}
                 />
@@ -87,11 +110,11 @@ const ZUIDateRangePicker: FC = () => {
                 <DateTextField
                   label="End"
                   onChange={(date) => {
-                    let startDate = value[0];
-                    if (date && startDate?.isAfter(date)) {
-                      startDate = date?.subtract(duration, 'day');
+                    let newStartDate = value[0];
+                    if (date && newStartDate?.isAfter(date)) {
+                      newStartDate = date?.subtract(duration, 'day');
                     }
-                    setValue([startDate, date]);
+                    setValue([newStartDate, date]);
                   }}
                   value={value[1]}
                 />

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -1,4 +1,3 @@
-import { Clear } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import {
   Box,
@@ -11,6 +10,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { CalendarToday, Clear } from '@mui/icons-material';
 import { DateRange, StaticDateRangePicker } from '@mui/x-date-pickers-pro';
 import dayjs, { Dayjs } from 'dayjs';
 import { IntlShape, useIntl } from 'react-intl';
@@ -80,16 +80,20 @@ const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
 
   return (
     <>
-      <Typography
-        className={classes.label}
-        component="span"
-        onClick={(ev: MouseEvent<HTMLSpanElement>) => {
-          ev.stopPropagation();
-          setAnchorEl(ev.currentTarget);
-        }}
-      >
-        {rangeStr(intl, value)}
-      </Typography>
+      <Box alignItems="center" className={classes.label} display="flex">
+        <CalendarToday />
+
+        <Typography
+          component="span"
+          marginLeft={1}
+          onClick={(ev: MouseEvent<HTMLSpanElement>) => {
+            ev.stopPropagation();
+            setAnchorEl(ev.currentTarget);
+          }}
+        >
+          {rangeStr(intl, value)}
+        </Typography>
+      </Box>
       <ClickAwayListener
         onClickAway={() => {
           setAnchorEl(null);

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -1,4 +1,12 @@
-import { Box, Paper, Popper, TextField } from '@mui/material';
+import { Clear } from '@mui/icons-material';
+import {
+  Box,
+  IconButton,
+  InputAdornment,
+  Paper,
+  Popper,
+  TextField,
+} from '@mui/material';
 import { DateRange, StaticDateRangePicker } from '@mui/x-date-pickers-pro';
 import dayjs, { Dayjs } from 'dayjs';
 import React, { FC, useCallback, useEffect, useState } from 'react';
@@ -79,8 +87,29 @@ const DateTextField: FC<DateTextFieldProps> = ({ label, onChange, value }) => {
   return (
     <TextField
       fullWidth
+      InputProps={{
+        endAdornment: value ? (
+          <InputAdornment position="end">
+            <IconButton
+              onClick={() => {
+                onChange(null);
+              }}
+            >
+              <Clear />
+            </IconButton>
+          </InputAdornment>
+        ) : null,
+      }}
       label={label}
       onBlur={(ev) => {
+        // If user leaves the field empty, clear
+        if (ev.target.value == '') {
+          onChange(null);
+          return;
+        }
+
+        // If user entered a valid date, change
+        // to that date, or revert to previous
         const parsed = dayjs(ev.target.value);
         if (parsed.isValid()) {
           onChange(parsed);

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -22,6 +22,12 @@ const ZUIDateRangePicker: FC = () => {
     setAnchorEl(elem);
   }, []);
 
+  // Calculate duration to use when shifting the entire range,
+  // which happens when setting a start date that precedes the
+  // end date, and vice versa.
+  const [start, end] = value;
+  const duration = start && end ? end.diff(start, 'day') : 1;
+
   return (
     <>
       <span ref={callback}>Label</span>
@@ -37,7 +43,11 @@ const ZUIDateRangePicker: FC = () => {
               <DateTextField
                 label="Start"
                 onChange={(date) => {
-                  setValue([date, value[1]]);
+                  let endDate = value[1];
+                  if (date && endDate?.isBefore(date)) {
+                    endDate = date.add(duration, 'day');
+                  }
+                  setValue([date, endDate]);
                 }}
                 value={value[0]}
               />
@@ -46,7 +56,11 @@ const ZUIDateRangePicker: FC = () => {
               <DateTextField
                 label="End"
                 onChange={(date) => {
-                  setValue([value[0], date]);
+                  let startDate = value[0];
+                  if (date && startDate?.isAfter(date)) {
+                    startDate = date?.subtract(duration, 'day');
+                  }
+                  setValue([startDate, date]);
                 }}
                 value={value[1]}
               />

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -1,9 +1,11 @@
 import { Clear } from '@mui/icons-material';
+import { makeStyles } from '@mui/styles';
 import {
   Box,
   ClickAwayListener,
   IconButton,
   InputAdornment,
+  lighten,
   Paper,
   Popper,
   TextField,
@@ -38,6 +40,17 @@ interface ZUIDateRangePickerProps {
   startDate: string | null;
 }
 
+const useStyles = makeStyles((theme) => ({
+  label: {
+    '&:hover': {
+      borderBottomColor: lighten(theme.palette.primary.main, 0.65),
+      borderBottomStyle: 'dotted',
+      borderBottomWidth: 2,
+    },
+    cursor: 'pointer',
+  },
+}));
+
 const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
   endDate,
   onChange,
@@ -49,6 +62,8 @@ const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
     dayjs('1857-07-05'),
     dayjs('1933-06-20'),
   ]);
+
+  const classes = useStyles();
 
   useEffect(() => {
     setValue([
@@ -66,6 +81,7 @@ const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
   return (
     <>
       <Typography
+        className={classes.label}
         component="span"
         onClick={(ev: MouseEvent<HTMLSpanElement>) => {
           ev.stopPropagation();

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -1,26 +1,44 @@
 import { Clear } from '@mui/icons-material';
 import {
   Box,
+  ClickAwayListener,
   IconButton,
   InputAdornment,
   Paper,
   Popper,
   TextField,
+  Typography,
 } from '@mui/material';
 import { DateRange, StaticDateRangePicker } from '@mui/x-date-pickers-pro';
 import dayjs, { Dayjs } from 'dayjs';
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import { IntlShape, useIntl } from 'react-intl';
+import React, { FC, MouseEvent, useEffect, useState } from 'react';
+
+const rangeStr = (intl: IntlShape, values: DateRange<Dayjs>): string => {
+  const [start, end] = values;
+
+  if (start && end) {
+    return intl.formatMessage(
+      { id: 'misc.dateRange.finite' },
+      { end: end.toDate(), start: start.toDate() }
+    );
+  } else if (start) {
+    return intl.formatMessage(
+      { id: 'misc.dateRange.indefinite' },
+      { start: start.toDate() }
+    );
+  } else {
+    return intl.formatMessage({ id: 'misc.dateRange.draft' });
+  }
+};
 
 const ZUIDateRangePicker: FC = () => {
-  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const intl = useIntl();
+  const [anchorEl, setAnchorEl] = useState<HTMLSpanElement | null>(null);
   const [value, setValue] = useState<DateRange<Dayjs>>([
     dayjs('1857-07-05'),
     dayjs('1933-06-20'),
   ]);
-
-  const callback = useCallback((elem: HTMLDivElement) => {
-    setAnchorEl(elem);
-  }, []);
 
   // Calculate duration to use when shifting the entire range,
   // which happens when setting a start date that precedes the
@@ -30,53 +48,67 @@ const ZUIDateRangePicker: FC = () => {
 
   return (
     <>
-      <span ref={callback}>Label</span>
-      <Popper anchorEl={anchorEl} open={true}>
-        <Paper elevation={2}>
-          <Box
-            alignItems="stretch"
-            display="flex"
-            flexDirection="column"
-            paddingTop={2}
-          >
-            <Box marginX={2} marginY={1}>
-              <DateTextField
-                label="Start"
-                onChange={(date) => {
-                  let endDate = value[1];
-                  if (date && endDate?.isBefore(date)) {
-                    endDate = date.add(duration, 'day');
-                  }
-                  setValue([date, endDate]);
-                }}
-                value={value[0]}
+      <Typography
+        component="span"
+        onClick={(ev: MouseEvent<HTMLSpanElement>) => {
+          ev.stopPropagation();
+          setAnchorEl(ev.currentTarget);
+        }}
+      >
+        {rangeStr(intl, value)}
+      </Typography>
+      <ClickAwayListener
+        onClickAway={() => {
+          setAnchorEl(null);
+        }}
+      >
+        <Popper anchorEl={anchorEl} open={!!anchorEl}>
+          <Paper elevation={2}>
+            <Box
+              alignItems="stretch"
+              display="flex"
+              flexDirection="column"
+              paddingTop={2}
+            >
+              <Box marginX={2} marginY={1}>
+                <DateTextField
+                  label="Start"
+                  onChange={(date) => {
+                    let endDate = value[1];
+                    if (date && endDate?.isBefore(date)) {
+                      endDate = date.add(duration, 'day');
+                    }
+                    setValue([date, endDate]);
+                  }}
+                  value={value[0]}
+                />
+              </Box>
+              <Box marginX={2} marginY={1}>
+                <DateTextField
+                  label="End"
+                  onChange={(date) => {
+                    let startDate = value[0];
+                    if (date && startDate?.isAfter(date)) {
+                      startDate = date?.subtract(duration, 'day');
+                    }
+                    setValue([startDate, date]);
+                  }}
+                  value={value[1]}
+                />
+              </Box>
+              <StaticDateRangePicker
+                calendars={1}
+                displayStaticWrapperAs="desktop"
+                label="date range"
+                minDate={dayjs('1800-01-01')}
+                onChange={(newValue: DateRange<Dayjs>) => setValue(newValue)}
+                renderInput={() => <></>}
+                value={value}
               />
             </Box>
-            <Box marginX={2} marginY={1}>
-              <DateTextField
-                label="End"
-                onChange={(date) => {
-                  let startDate = value[0];
-                  if (date && startDate?.isAfter(date)) {
-                    startDate = date?.subtract(duration, 'day');
-                  }
-                  setValue([startDate, date]);
-                }}
-                value={value[1]}
-              />
-            </Box>
-            <StaticDateRangePicker
-              calendars={1}
-              displayStaticWrapperAs="desktop"
-              label="date range"
-              minDate={dayjs('1800-01-01')}
-              onChange={(newValue: DateRange<Dayjs>) => setValue(newValue)}
-              renderInput={() => <></>}
-              value={value}
-            />
-          </Box>
-        </Paper>
-      </Popper>
+          </Paper>
+        </Popper>
+      </ClickAwayListener>
     </>
   );
 };

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -1,0 +1,100 @@
+import { Box, Paper, Popper, TextField } from '@mui/material';
+import { DateRange, StaticDateRangePicker } from '@mui/x-date-pickers-pro';
+import dayjs, { Dayjs } from 'dayjs';
+import React, { FC, useCallback, useEffect, useState } from 'react';
+
+const ZUIDateRangePicker: FC = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const [value, setValue] = useState<DateRange<Dayjs>>([
+    dayjs('1857-07-05'),
+    dayjs('1933-06-20'),
+  ]);
+
+  const callback = useCallback((elem: HTMLDivElement) => {
+    setAnchorEl(elem);
+  }, []);
+
+  return (
+    <>
+      <span ref={callback}>Label</span>
+      <Popper anchorEl={anchorEl} open={true}>
+        <Paper elevation={2}>
+          <Box
+            alignItems="stretch"
+            display="flex"
+            flexDirection="column"
+            paddingTop={2}
+          >
+            <Box marginX={2} marginY={1}>
+              <DateTextField
+                label="Start"
+                onChange={(date) => {
+                  setValue([date, value[1]]);
+                }}
+                value={value[0]}
+              />
+            </Box>
+            <Box marginX={2} marginY={1}>
+              <DateTextField
+                label="End"
+                onChange={(date) => {
+                  setValue([value[0], date]);
+                }}
+                value={value[1]}
+              />
+            </Box>
+            <StaticDateRangePicker
+              calendars={1}
+              displayStaticWrapperAs="desktop"
+              label="date range"
+              minDate={dayjs('1800-01-01')}
+              onChange={(newValue: DateRange<Dayjs>) => setValue(newValue)}
+              renderInput={() => <></>}
+              value={value}
+            />
+          </Box>
+        </Paper>
+      </Popper>
+    </>
+  );
+};
+
+interface DateTextFieldProps {
+  label: string;
+  onChange: (day: Dayjs | null) => void;
+  value: Dayjs | null;
+}
+
+const DateTextField: FC<DateTextFieldProps> = ({ label, onChange, value }) => {
+  const [rawValue, setRawValue] = useState('');
+
+  const resetValue = () => {
+    setRawValue(value?.format('l') ?? '');
+  };
+
+  useEffect(() => {
+    resetValue();
+  }, [value]);
+
+  return (
+    <TextField
+      fullWidth
+      label={label}
+      onBlur={(ev) => {
+        const parsed = dayjs(ev.target.value);
+        if (parsed.isValid()) {
+          onChange(parsed);
+        } else {
+          resetValue();
+        }
+      }}
+      onChange={(ev) => {
+        setRawValue(ev.target.value);
+      }}
+      value={rawValue}
+      variant="outlined"
+    />
+  );
+};
+
+export default ZUIDateRangePicker;

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -58,10 +58,7 @@ const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
 }) => {
   const intl = useIntl();
   const [anchorEl, setAnchorEl] = useState<HTMLSpanElement | null>(null);
-  const [value, setValue] = useState<DateRange<Dayjs>>([
-    dayjs('1857-07-05'),
-    dayjs('1933-06-20'),
-  ]);
+  const [value, setValue] = useState<DateRange<Dayjs>>([null, null]);
 
   const classes = useStyles();
 
@@ -164,9 +161,18 @@ interface DateTextFieldProps {
 
 const DateTextField: FC<DateTextFieldProps> = ({ label, onChange, value }) => {
   const [rawValue, setRawValue] = useState('');
+  const intl = useIntl();
 
   const resetValue = () => {
-    setRawValue(value?.format('l') ?? '');
+    setRawValue(
+      value
+        ? intl.formatDate(value.toDate(), {
+            day: 'numeric',
+            month: 'numeric',
+            year: 'numeric',
+          })
+        : ''
+    );
   };
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,16 +1474,16 @@
     "@date-io/core" "^2.16.0"
 
 "@date-io/luxon@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.16.0.tgz#97773d56532706c1a68113a1de07eecd0d41bebb"
-  integrity sha512-L8UXHa/9VbfRqP4KB7JUZwFgOVxo22rONVod1o7GMN2Oku4PzJ0k1kXc+nLP9lRlF1UAA28oQsQqn85Y/PdBZw==
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@date-io/luxon/-/luxon-2.16.1.tgz#b08786614cb58831c729a15807753011e4acb966"
+  integrity sha512-aeYp5K9PSHV28946pC+9UKUi/xMMYoaGelrpDibZSgHu2VWHXrr7zWLEr+pMPThSs5vt8Ei365PO+84pCm37WQ==
   dependencies:
     "@date-io/core" "^2.16.0"
 
 "@date-io/moment@^2.15.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.16.0.tgz#a6658c05e14e7fcc57adeda675462e0b6750542d"
-  integrity sha512-wvu/40k128kF6P0jPbiyZcPR14VjJAgYEs+mYtsXz/AyWpC2DEJKly7ub+dpevUywbTzzpZysyCxCdzLzxD/uw==
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-2.16.1.tgz#ec6e0daa486871e0e6412036c6f806842a0eeed4"
+  integrity sha512-JkxldQxUqZBfZtsaCcCMkm/dmytdyq5pS1RxshCQ4fHhsvP5A7gSqPD22QbVXMcJydi3d3v1Y8BQdUKEuGACZQ==
   dependencies:
     "@date-io/core" "^2.16.0"
 
@@ -2447,10 +2447,28 @@
     prop-types "^15.8.1"
     reselect "^4.1.6"
 
-"@mui/x-date-pickers@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.3.tgz#970362d93f7cc99bc2210370d1f254f7f8f61ef5"
-  integrity sha512-njoQvsh7WzgiHu0wGSSPnQ4emT3SDzxCpaKK9DM0jRaxyxfC2wQX431RWmouG8JjnugTltwLnPwkKjLclHQhhA==
+"@mui/x-date-pickers-pro@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers-pro/-/x-date-pickers-pro-5.0.10.tgz#0e664e237c3ad6255313fa22f6a459cd36940b59"
+  integrity sha512-104x0+P8RrtI7/cL+3Z6V7uo4KouuzlLKM2e24fxiOf1/BFxQ0QgA6hkBlQnSeOZhZdHKzHXjbjrmYoMAyIkxw==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@date-io/date-fns" "^2.15.0"
+    "@date-io/dayjs" "^2.15.0"
+    "@date-io/luxon" "^2.15.0"
+    "@date-io/moment" "^2.15.0"
+    "@mui/utils" "^5.10.3"
+    "@mui/x-date-pickers" "5.0.10"
+    "@mui/x-license-pro" "5.17.12"
+    clsx "^1.2.1"
+    prop-types "^15.7.2"
+    react-transition-group "^4.4.5"
+    rifm "^0.12.1"
+
+"@mui/x-date-pickers@5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-5.0.10.tgz#b701bf697c63ca1c588720be6f95a1512c840a39"
+  integrity sha512-k+SKBqlpYsY49JVs7PORDvnfoXw9nJELfImR/3jTgHqP8hQQ6loFjB9ZFvc5NjV4Jf2NIJFmdcp6g8cO31Wmbg==
   dependencies:
     "@babel/runtime" "^7.18.9"
     "@date-io/core" "^2.15.0"
@@ -2472,6 +2490,14 @@
   dependencies:
     "@babel/runtime" "^7.18.9"
     "@mui/utils" "^5.9.3"
+
+"@mui/x-license-pro@5.17.12":
+  version "5.17.12"
+  resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-5.17.12.tgz#d069416b7191f9f5b77b2bf7375d2c51aead497c"
+  integrity sha512-UzFaE+9A30kfguCuME0D5zqsItqbHZ3xZwmyrJr8MvZOEoqiJWF4NT4Pvlg2nqaPYt/h81j7sjVFa3KiwT0vbg==
+  dependencies:
+    "@babel/runtime" "^7.18.9"
+    "@mui/utils" "^5.10.3"
 
 "@next/env@12.2.5":
   version "12.2.5"


### PR DESCRIPTION
## Description
This PR adds GUI to update call assignment dates.


## Screenshots
<img width="1348" alt="image" src="https://user-images.githubusercontent.com/550212/206806770-1d641de7-98c6-4c50-be03-f26f9c587f4c.png">


## Changes
* Adds new `ZUIDateRangePicker` (as outlined in #833)
* Uses the new picker in the call assignment header to display and update dates
* Adds `start()` and `end()` methods on `CallAssignmentModel`, including tests
* Adds start/end buttons to call assignment pages, using logic from `CallAssignmentModel.start()` and `CallAssignmentModel.end()`


## Notes to reviewer
Please review only after #854 has been merged.

## Related issues
Resolves #833
Resolves #836 