### PR TITLE
Fix broken tag select in Smart Search dialog

### DIFF
--- a/src/features/smartSearch/components/inputs/StyledItemSelect.tsx
+++ b/src/features/smartSearch/components/inputs/StyledItemSelect.tsx
@@ -1,6 +1,6 @@
 import makeStyles from '@mui/styles/makeStyles';
 import { FormattedMessage as Msg } from 'react-intl';
-import { Autocomplete, AutocompleteProps } from '@mui/material';
+import { Autocomplete, AutocompleteProps, Box } from '@mui/material';
 import { Chip, TextField } from '@mui/material';
 import { Theme, Tooltip } from '@mui/material';
 
@@ -51,20 +51,28 @@ const StyledItemSelect = (props: StyledItemSelectProps): JSX.Element => {
           variant="standard"
         />
       )}
-      renderOption={(item) => {
+      renderOption={(optionProps, item) => {
         const title = item.title || '';
         const shortenedLabel = getEllipsedString(title, 15);
-        return shortenedLabel.length === title.length ? (
-          <Chip
-            key={item.id}
-            color="primary"
-            label={item.title}
-            variant="outlined"
-          />
-        ) : (
-          <Tooltip key={item.id} title={item.title}>
-            <Chip color="primary" label={shortenedLabel} variant="outlined" />
-          </Tooltip>
+        return (
+          <Box component="li" {...optionProps}>
+            {shortenedLabel.length === title.length ? (
+              <Chip
+                key={item.id}
+                color="primary"
+                label={item.title}
+                variant="outlined"
+              />
+            ) : (
+              <Tooltip key={item.id} title={item.title}>
+                <Chip
+                  color="primary"
+                  label={shortenedLabel}
+                  variant="outlined"
+                />
+              </Tooltip>
+            )}
+          </Box>
         );
       }}
       renderTags={() => null}


### PR DESCRIPTION
## Description
This PR fixes a bug that was discovered after the MUI migration.


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/550212/207556264-850e179a-78c8-4d0e-bd6c-76ffb3272927.png)

### After
![image](https://user-images.githubusercontent.com/550212/207556014-149614f2-4fef-475a-b5ec-dd8aa34c851a.png)


## Changes
* Adapts to the new workings of MUIv5 `Autocomplete`
* Uses boxes to render chips


## Notes to reviewer
Please do not review until #855 has been merged.

To reproduce the issue on main:

1. Navigate to any Smart Search dialog
2. Go to configure a selection by tag
3. Note how tags are rendered empty and can't be clicked


## Related issues
Related to, but does not fully resolve #856 