### PR TITLE
Call assignment stats in header

### DIFF
--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -1,14 +1,16 @@
-import { useIntl } from 'react-intl';
-import { Box, Button } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import CallAssignmentStatusChip from '../components/CallAssignmentStatusChip';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
 import ZUIDateRangePicker from 'zui/ZUIDateRangePicker/ZUIDateRangePicker';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
+import ZUIFuture from 'zui/ZUIFuture';
 import CallAssignmentModel, {
   CallAssignmentState,
 } from '../models/CallAssignmentModel';
+import { Headset, People } from '@material-ui/icons';
 
 interface CallAssignmentLayoutProps {
   children: React.ReactNode;
@@ -29,9 +31,11 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
       new CallAssignmentModel(env, parseInt(orgId), parseInt(assignmentId))
   );
 
-  const future = model.getData();
+  const dataFuture = model.getData();
+  const statsFuture = model.getStats();
+  const callersFuture = model.getFilteredCallers();
 
-  if (!future.data) {
+  if (!dataFuture.data) {
     return null;
   }
 
@@ -60,12 +64,50 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
           <CallAssignmentStatusChip state={model.state} />
           <Box marginX={2}>
             <ZUIDateRangePicker
-              endDate={future.data.end_date || null}
+              endDate={dataFuture.data.end_date || null}
               onChange={(startDate, endDate) => {
                 model.setDates(startDate, endDate);
               }}
-              startDate={future.data.start_date || null}
+              startDate={dataFuture.data.start_date || null}
             />
+          </Box>
+          <Box display="flex" marginX={1}>
+            <ZUIFuture
+              future={statsFuture}
+              ignoreDataWhileLoading
+              skeletonWidth={100}
+            >
+              {(data) => (
+                <>
+                  <People />
+                  <Typography marginLeft={1}>
+                    <Msg
+                      id="layout.organize.callAssignment.stats.targets"
+                      values={{ numTargets: data?.allTargets }}
+                    />
+                  </Typography>
+                </>
+              )}
+            </ZUIFuture>
+          </Box>
+          <Box display="flex" marginX={1}>
+            <ZUIFuture
+              future={callersFuture}
+              ignoreDataWhileLoading
+              skeletonWidth={100}
+            >
+              {(data) => (
+                <>
+                  <Headset />
+                  <Typography marginLeft={1}>
+                    <Msg
+                      id="layout.organize.callAssignment.stats.callers"
+                      values={{ numCallers: data.length }}
+                    />
+                  </Typography>
+                </>
+              )}
+            </ZUIFuture>
           </Box>
         </Box>
       }
@@ -86,7 +128,7 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
       title={
         <ZUIEditTextinPlace
           onChange={(newTitle) => model.setTitle(newTitle)}
-          value={future.data.title}
+          value={dataFuture.data.title}
         />
       }
     >

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -59,8 +59,12 @@ export default class CallAssignmentModel {
     return this._repo.getCallAssignment(this._orgId, this._id);
   }
 
-  getFilteredCallers(searchString: string): IFuture<CallAssignmentCaller[]> {
+  getFilteredCallers(searchString = ''): IFuture<CallAssignmentCaller[]> {
     const callers = this._repo.getCallAssignmentCallers(this._orgId, this._id);
+
+    if (callers.isLoading) {
+      return callers;
+    }
 
     if (callers.data && searchString) {
       const fuse = new Fuse(callers.data, {

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -78,6 +78,7 @@ const callAssignmentsSlice = createSlice({
     },
     callersLoad: (state, action: PayloadAction<number>) => {
       state.callersById[action.payload] = remoteList<CallAssignmentCaller>();
+      state.callersById[action.payload].isLoading = true;
     },
     callersLoaded: (
       state,

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -2,6 +2,9 @@ callAssignment:
   actions:
     end: End assignment
     start: Start assignment
+  stats:
+    callers: '{numCallers, plural, =0 {No callers} one {1 caller} other {# callers}}'
+    targets: '{numTargets, plural, =0 {No targets} one {1 targets} other {# targets}}'
   tabs:
     callers: Callers
     insights: Insights

--- a/src/zui/ZUIFuture/index.tsx
+++ b/src/zui/ZUIFuture/index.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+import { Skeleton } from '@mui/material';
+
+import { IFuture } from 'core/caching/futures';
+
+type ZUIFutureBuilderFunc<DataType> = (
+  data: DataType,
+  isLoading: boolean
+) => JSX.Element;
+
+interface ZUIFutureProps<DataType> {
+  children: JSX.Element | null | ZUIFutureBuilderFunc<DataType>;
+  future: IFuture<DataType>;
+  ignoreDataWhileLoading?: boolean;
+  skeleton?: JSX.Element;
+  skeletonHeight?: number;
+  skeletonWidth?: number;
+}
+
+function ZUIFuture<DataType>({
+  children,
+  future,
+  ignoreDataWhileLoading = false,
+  skeleton,
+  skeletonHeight = 50,
+  skeletonWidth = 50,
+}: ZUIFutureProps<DataType>): ReturnType<FC> {
+  if (!skeleton) {
+    skeleton = <Skeleton height={skeletonHeight} width={skeletonWidth} />;
+  }
+
+  if (future.data) {
+    if (future.isLoading && ignoreDataWhileLoading) {
+      return skeleton;
+    }
+
+    if (typeof children == 'function') {
+      return children(future.data, future.isLoading);
+    } else {
+      return children;
+    }
+  } else if (future.isLoading) {
+    return skeleton;
+  } else {
+    // TODO: Handle errors somehow?
+    return null;
+  }
+}
+
+export default ZUIFuture;


### PR DESCRIPTION
## Description
This PR adds basic stats to the call assignment header.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/207569120-cae67242-294d-4174-ac2c-43d2b3fe5796.png)


## Changes
* Adds new `ZUIFuture` component to conditionally render future (async loading) content
* Fixes issues with how callers were not reported as loading while loading (due to filtering logic)
* Displays target count and caller count in header

## Notes to reviewer
Please only review this after #855 has been merged.


## Related issues
Resolves #837 