### PR TITLE
Fix call assignment stats

### DIFF
--- a/src/zui/ZUIFuture/index.tsx
+++ b/src/zui/ZUIFuture/index.tsx
@@ -22,7 +22,7 @@ function ZUIFuture<DataType>({
   future,
   ignoreDataWhileLoading = false,
   skeleton,
-  skeletonHeight = 50,
+  skeletonHeight,
   skeletonWidth = 50,
 }: ZUIFutureProps<DataType>): ReturnType<FC> {
   if (!skeleton) {


### PR DESCRIPTION
## Description
This PR fixes the call assignment stats bug described in #852, by getting the numbers from the platform instead of loading the queue and calculating the numbers.

It also makes a minor change to how `ZUIFuture` renders skeletons by default.

## Screenshots
No visual change

## Changes
* Replaces backend logic to retrieve call assignment stats from the recently upgraded stats endpoint
* Changes `ZUIFuture` to default to no specified height (as suggested by @ziggabyte elsewhere)

## Notes to reviewer
Follow instructions in issue.

## Related issues
Resolves #852 