### PR TITLE
Edit button for Call Assignment done query

### DIFF
--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -11,6 +11,7 @@ export interface CallAssignmentCaller {
 export interface CallAssignmentData {
   cooldown: number;
   end_date: string | null;
+  goal: ZetkinQuery;
   id: number;
   start_date: string | null;
   target: ZetkinQuery;

--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -1,6 +1,9 @@
+import { Edit } from '@mui/icons-material';
 import SettingsIcon from '@material-ui/icons/Settings';
+import { useState } from 'react';
 import {
   Box,
+  Button,
   Card,
   ClickAwayListener,
   Grid,
@@ -13,9 +16,9 @@ import {
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import CallAssignmentModel from '../models/CallAssignmentModel';
+import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog';
 import StatusCardHeader from './StatusCardHeader';
 import StatusCardItem from './StatusCardItem';
-import { useState } from 'react';
 
 interface CallAssignmentStatusCardProps {
   model: CallAssignmentModel;
@@ -29,11 +32,13 @@ const CallAssignmentStatusCards = ({
   const { data } = model.getData();
   const cooldown = data?.cooldown ?? null;
   const hasTargets = model.hasTargets;
+  const goalQuery = data?.goal;
 
   const [anchorEl, setAnchorEl] = useState<
     null | (EventTarget & SVGSVGElement)
   >(null);
   const [newCooldown, setNewCooldown] = useState<number | null>(cooldown);
+  const [queryDialogOpen, setQueryDialogOpen] = useState(false);
 
   return (
     <Grid container spacing={2}>
@@ -185,6 +190,25 @@ const CallAssignmentStatusCards = ({
             })}
             value={stats?.done}
           />
+          <Box p={2}>
+            <Button
+              onClick={() => setQueryDialogOpen(true)}
+              startIcon={<Edit />}
+              variant="outlined"
+            >
+              <Msg id="pages.organizeCallAssignment.done.defineButton" />
+            </Button>
+            {queryDialogOpen && (
+              <SmartSearchDialog
+                onDialogClose={() => setQueryDialogOpen(false)}
+                onSave={(query) => {
+                  model.setGoal(query);
+                  setQueryDialogOpen(false);
+                }}
+                query={goalQuery}
+              />
+            )}
+          </Box>
         </Card>
       </Grid>
     </Grid>

--- a/src/features/callAssignments/components/CallAssignmentTargets.tsx
+++ b/src/features/callAssignments/components/CallAssignmentTargets.tsx
@@ -9,10 +9,6 @@ import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 
 const useStyles = makeStyles((theme) => ({
-  button: {
-    borderColor: theme.palette.targetingStatusBar.blue,
-    color: theme.palette.targetingStatusBar.blue,
-  },
   chip: {
     backgroundColor: theme.palette.targetingStatusBar.gray,
     borderRadius: '1em',
@@ -55,7 +51,6 @@ const CallAssignmentTargets = ({ model }: { model: CallAssignmentModel }) => {
             <Divider />
             <Box p={2}>
               <Button
-                className={classes.button}
                 onClick={() => setQueryDialogOpen(true)}
                 startIcon={<Edit />}
                 variant="outlined"
@@ -72,7 +67,6 @@ const CallAssignmentTargets = ({ model }: { model: CallAssignmentModel }) => {
               </Typography>
               <Box pt={1}>
                 <Button
-                  className={classes.button}
                   onClick={() => setQueryDialogOpen(true)}
                   startIcon={<Add />}
                   variant="outlined"

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -46,6 +46,10 @@ describe('CallAssignmentModel', () => {
             {
               cooldown: 3,
               end_date: null,
+              goal: {
+                filter_spec: [],
+                id: 102,
+              },
               id: 2,
               start_date: null,
               target: {
@@ -74,6 +78,10 @@ describe('CallAssignmentModel', () => {
             {
               cooldown: 3,
               end_date: null,
+              goal: {
+                filter_spec: [],
+                id: 102,
+              },
               id: 2,
               start_date: null,
               target: {
@@ -112,6 +120,10 @@ describe('CallAssignmentModel', () => {
           {
             cooldown: 3,
             end_date: endDate,
+            goal: {
+              filter_spec: [],
+              id: 102,
+            },
             id: 2,
             start_date: startDate,
             target: {
@@ -252,6 +264,10 @@ describe('CallAssignmentModel', () => {
             {
               cooldown: 3,
               end_date: null,
+              goal: {
+                filter_spec: [],
+                id: 102,
+              },
               id: 2,
               start_date: null,
               target: {
@@ -285,6 +301,10 @@ describe('CallAssignmentModel', () => {
             {
               cooldown: 3,
               end_date: null,
+              goal: {
+                filter_spec: [],
+                id: 102,
+              },
               id: 2,
               start_date: null,
               target: {
@@ -351,6 +371,10 @@ describe('CallAssignmentModel', () => {
             {
               cooldown: 3,
               end_date: null,
+              goal: {
+                filter_spec: [],
+                id: 102,
+              },
               id: 2,
               start_date: null,
               target: {
@@ -561,6 +585,10 @@ describe('CallAssignmentModel', () => {
           {
             cooldown: 3,
             end_date: endDate,
+            goal: {
+              filter_spec: [],
+              id: 102,
+            },
             id: 2,
             start_date: startDate,
             target: {
@@ -622,6 +650,10 @@ describe('CallAssignmentModel', () => {
           {
             cooldown: 3,
             end_date: endDate,
+            goal: {
+              filter_spec: [],
+              id: 102,
+            },
             id: 2,
             start_date: startDate,
             target: {

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -144,6 +144,35 @@ export default class CallAssignmentModel {
     });
   }
 
+  setGoal(query: Partial<ZetkinQuery>) {
+    // TODO: Refactor once SmartSearch is supported in redux framework
+    const state = this._store.getState();
+    const caItem = state.callAssignments.assignmentList.items.find(
+      (item) => item.id == this._id
+    );
+    const callAssignment = caItem?.data;
+
+    if (callAssignment) {
+      this._store.dispatch(callAssignmentLoad(this._id));
+      fetch(
+        `/api/orgs/${this._orgId}/people/queries/${callAssignment.goal.id}`,
+        {
+          body: JSON.stringify(query),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          method: 'PATCH',
+        }
+      )
+        .then((res) => res.json())
+        .then((data: { data: ZetkinQuery }) =>
+          this._store.dispatch(
+            callAssignmentUpdated({ ...callAssignment, goal: data.data })
+          )
+        );
+    }
+  }
+
   setTargets(query: Partial<ZetkinQuery>): void {
     // TODO: Refactor once SmartSearch is supported in redux framework
     const state = this._store.getState();

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -67,7 +67,9 @@ const callAssignmentsSlice = createSlice({
         statsItem &&
         (callAssignment?.cooldown != action.payload.cooldown ||
           JSON.stringify(action.payload.target.filter_spec) !=
-            JSON.stringify(callAssignment?.target.filter_spec))
+            JSON.stringify(callAssignment?.target.filter_spec) ||
+          JSON.stringify(action.payload.goal.filter_spec) !=
+            JSON.stringify(callAssignment?.goal.filter_spec))
       ) {
         statsItem.isStale = true;
       }

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -15,6 +15,7 @@ callers:
   searchBox: Search
   title: Callers
 done:
+  defineButton: Edit done criteria
   subtitle: Targets that meet the done criteria
   title: Done
 ready:


### PR DESCRIPTION
## Description
This PR adds the missing button to edit call assignment `goal` queries, communicated to users as "done criteria".

## Screenshots
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/550212/208236051-6e479344-0bec-481f-a53e-43758d3f0e0e.png">


## Changes
* Adds UI to edit call assignment goal queries
* Changes the button for editing targeting queries to use default colors


## Notes to reviewer
Locate and click the new button in the "Done" section. Try editing query and see the numbers update.

## Related issues
Resolves #857 
