### PR TITLE
Call assignment callers

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "validator": "^13.6.0",
     "xlsx-js-style": "^1.2.0",
     "yaml": "^1.10.0",
-    "zetkin": "~1.3.1"
+    "zetkin": "~1.3.1",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",

--- a/src/core/api/client/BrowserApiClient.ts
+++ b/src/core/api/client/BrowserApiClient.ts
@@ -21,4 +21,25 @@ export default class BrowserApiClient implements IApiClient {
     const body = await res.json();
     return body.data;
   }
+
+  async put<DataType = void>(
+    path: string,
+    data?: Partial<DataType> | undefined
+  ): Promise<DataType> {
+    const options: RequestInit = {
+      method: 'PUT',
+    };
+
+    if (data) {
+      options.body = JSON.stringify(data);
+      options.headers = {
+        'Content-Type': 'application/json',
+      };
+    }
+
+    const res = await fetch(path, options);
+
+    const body = await res.json();
+    return body.data;
+  }
 }

--- a/src/core/api/client/BrowserApiClient.ts
+++ b/src/core/api/client/BrowserApiClient.ts
@@ -22,6 +22,21 @@ export default class BrowserApiClient implements IApiClient {
     return body.data;
   }
 
+  async post<DataType, InputType = DataType>(
+    path: string,
+    data: Partial<InputType>
+  ): Promise<DataType> {
+    const res = await fetch(path, {
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+    const body = await res.json();
+    return body.data;
+  }
+
   async put<DataType = void>(
     path: string,
     data?: Partial<DataType> | undefined

--- a/src/core/api/client/BrowserApiClient.ts
+++ b/src/core/api/client/BrowserApiClient.ts
@@ -1,6 +1,12 @@
 import IApiClient from './IApiClient';
 
 export default class BrowserApiClient implements IApiClient {
+  async delete(path: string): Promise<void> {
+    await fetch(path, {
+      method: 'DELETE',
+    });
+  }
+
   async get<DataType>(path: string): Promise<DataType> {
     const res = await fetch(path);
     const body = await res.json();

--- a/src/core/api/client/IApiClient.ts
+++ b/src/core/api/client/IApiClient.ts
@@ -5,4 +5,8 @@ export default interface IApiClient {
   ): Promise<DataType>;
   get<DataType>(path: string): Promise<DataType>;
   patch<DataType>(path: string, data: Partial<DataType>): Promise<DataType>;
+  post<DataType, InputType = DataType>(
+    path: string,
+    data: Partial<InputType>
+  ): Promise<DataType>;
 }

--- a/src/core/api/client/IApiClient.ts
+++ b/src/core/api/client/IApiClient.ts
@@ -1,4 +1,8 @@
 export default interface IApiClient {
+  put<DataType = void>(
+    path: string,
+    data?: Partial<DataType>
+  ): Promise<DataType>;
   get<DataType>(path: string): Promise<DataType>;
   patch<DataType>(path: string, data: Partial<DataType>): Promise<DataType>;
 }

--- a/src/core/api/client/IApiClient.ts
+++ b/src/core/api/client/IApiClient.ts
@@ -1,4 +1,5 @@
 export default interface IApiClient {
+  delete(path: string): Promise<void>;
   put<DataType = void>(
     path: string,
     data?: Partial<DataType>

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -7,7 +7,9 @@ import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { CallAssignmentCaller } from '../apiTypes';
 import TagChip from 'features/tags/components/TagManager/components/TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIResponsiveContainer from 'zui/ZUIResponsiveContainer';
+import { Edit } from '@mui/icons-material';
 
 const useStyles = makeStyles((theme) => ({
   chip: {
@@ -118,6 +120,17 @@ const CallAssignmentCallersList = ({
             <Button onClick={() => onCustomize(props.row)} variant="outlined">
               <Msg id="pages.organizeCallAssignment.callers.customizeButton" />
             </Button>
+            <ZUIEllipsisMenu
+              items={[
+                {
+                  label: intl.formatMessage({
+                    id: 'pages.organizeCallAssignment.callers.actions.customize',
+                  }),
+                  onSelect: () => onCustomize(props.row),
+                  startIcon: <Edit />,
+                },
+              ]}
+            />
           </Box>
         );
       },

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -121,6 +121,7 @@ const CallAssignmentCallersList = ({
       disableColumnMenu
       disableColumnReorder
       disableColumnResize
+      hideFooter
       rows={rows}
       style={{
         border: 'none',

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -9,7 +9,7 @@ import TagChip from 'features/tags/components/TagManager/components/TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIResponsiveContainer from 'zui/ZUIResponsiveContainer';
-import { Edit } from '@mui/icons-material';
+import { Delete, Edit } from '@mui/icons-material';
 
 const useStyles = makeStyles((theme) => ({
   chip: {
@@ -61,9 +61,11 @@ const TagsCell = ({ tags }: { tags: ZetkinTag[] }) => {
 const CallAssignmentCallersList = ({
   callers,
   onCustomize,
+  onRemove,
 }: {
   callers: CallAssignmentCaller[];
   onCustomize: (caller: CallAssignmentCaller) => void;
+  onRemove: (caller: CallAssignmentCaller) => void;
 }) => {
   const intl = useIntl();
   const { orgId } = useRouter().query;
@@ -128,6 +130,13 @@ const CallAssignmentCallersList = ({
                   }),
                   onSelect: () => onCustomize(props.row),
                   startIcon: <Edit />,
+                },
+                {
+                  label: intl.formatMessage({
+                    id: 'pages.organizeCallAssignment.callers.actions.remove',
+                  }),
+                  onSelect: () => onRemove(props.row),
+                  startIcon: <Delete />,
                 },
               ]}
             />

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -2,7 +2,7 @@ import { makeStyles } from '@mui/styles';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
 import { Avatar, Box, Tooltip } from '@mui/material';
-import { DataGridPro, GridColDef, GridRowData } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 
 import { CallAssignmentCaller } from '../apiTypes';
 import TagChip from 'features/tags/components/TagManager/components/TagChip';
@@ -64,7 +64,7 @@ const CallAssignmentCallersList = ({
   const intl = useIntl();
   const { orgId } = useRouter().query;
 
-  const columns: GridColDef[] = [
+  const columns: GridColDef<CallAssignmentCaller>[] = [
     {
       disableColumnMenu: true,
       field: 'id',
@@ -80,38 +80,32 @@ const CallAssignmentCallersList = ({
       headerName: intl.formatMessage({
         id: 'pages.organizeCallAssignment.callers.nameColumn',
       }),
+      valueGetter: (params) =>
+        `${params.row.first_name} ${params.row.last_name}`,
     },
     {
-      field: 'prioritizedTags',
+      field: 'prioritized_tags',
       flex: 1,
       headerName: intl.formatMessage({
         id: 'pages.organizeCallAssignment.callers.prioritizedTagsColumn',
       }),
       renderCell: (props) => {
-        return <TagsCell tags={props.row.prioritizedTags} />;
+        return <TagsCell tags={props.row.prioritized_tags} />;
       },
       sortable: false,
     },
     {
-      field: 'excludedTags',
+      field: 'excluded_tags',
       flex: 1,
       headerName: intl.formatMessage({
         id: 'pages.organizeCallAssignment.callers.excludedTagsColumn',
       }),
       renderCell: (props) => {
-        return <TagsCell tags={props.row.excludedTags} />;
+        return <TagsCell tags={props.row.excluded_tags} />;
       },
       sortable: false,
     },
   ];
-
-  const rows: GridRowData[] =
-    callers.map((caller) => ({
-      excludedTags: caller.excluded_tags,
-      id: caller.id,
-      name: `${caller.first_name} ${caller.last_name}`,
-      prioritizedTags: caller.prioritized_tags,
-    })) ?? [];
 
   return (
     <DataGridPro
@@ -122,7 +116,7 @@ const CallAssignmentCallersList = ({
       disableColumnReorder
       disableColumnResize
       hideFooter
-      rows={rows}
+      rows={callers}
       style={{
         border: 'none',
       }}

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -1,8 +1,8 @@
 import { makeStyles } from '@mui/styles';
-import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
-import { Avatar, Box, Tooltip } from '@mui/material';
+import { Avatar, Box, Button, Tooltip } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import { CallAssignmentCaller } from '../apiTypes';
 import TagChip from 'features/tags/components/TagManager/components/TagChip';
@@ -58,8 +58,10 @@ const TagsCell = ({ tags }: { tags: ZetkinTag[] }) => {
 
 const CallAssignmentCallersList = ({
   callers,
+  onCustomize,
 }: {
   callers: CallAssignmentCaller[];
+  onCustomize: (caller: CallAssignmentCaller) => void;
 }) => {
   const intl = useIntl();
   const { orgId } = useRouter().query;
@@ -105,6 +107,22 @@ const CallAssignmentCallersList = ({
       },
       sortable: false,
     },
+    {
+      align: 'right',
+      field: 'actions',
+      flex: 1,
+      headerName: '',
+      renderCell: (props) => {
+        return (
+          <Box>
+            <Button onClick={() => onCustomize(props.row)} variant="outlined">
+              <Msg id="pages.organizeCallAssignment.callers.customizeButton" />
+            </Button>
+          </Box>
+        );
+      },
+      sortable: false,
+    },
   ];
 
   return (
@@ -115,6 +133,7 @@ const CallAssignmentCallersList = ({
       disableColumnMenu
       disableColumnReorder
       disableColumnResize
+      disableSelectionOnClick
       hideFooter
       rows={callers}
       style={{

--- a/src/features/callAssignments/components/CallerConfigDialog.tsx
+++ b/src/features/callAssignments/components/CallerConfigDialog.tsx
@@ -1,0 +1,121 @@
+import { makeStyles } from '@mui/styles';
+import { Typography } from '@mui/material';
+import { useIntl } from 'react-intl';
+import { FC, useEffect, useState } from 'react';
+
+import { CallAssignmentCaller } from '../apiTypes';
+import TagManager from 'features/tags/components/TagManager';
+import { ZetkinTag } from 'utils/types/zetkin';
+import ZUIDialog from 'zui/ZUIDialog';
+import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
+
+interface CallerConfigDialogProps {
+  caller: CallAssignmentCaller | null;
+  onClose: () => void;
+  onSubmit: (prioTags: ZetkinTag[], excludedTags: ZetkinTag[]) => void;
+  open: boolean;
+}
+
+const CallerConfigDialog: FC<CallerConfigDialogProps> = ({
+  caller,
+  onClose,
+  onSubmit,
+  open,
+}) => {
+  const intl = useIntl();
+  const [prioTags, setPrioTags] = useState<ZetkinTag[]>([]);
+  const [excludedTags, setExcludedTags] = useState<ZetkinTag[]>([]);
+
+  useEffect(() => {
+    if (caller) {
+      setPrioTags(caller.prioritized_tags);
+      setExcludedTags(caller.excluded_tags);
+    }
+  }, [caller]);
+
+  return (
+    <ZUIDialog
+      onClose={onClose}
+      open={open}
+      title={
+        caller
+          ? intl.formatMessage(
+              { id: 'pages.organizeCallAssignment.callers.customize.title' },
+              { name: `${caller.first_name} ${caller.last_name}` }
+            )
+          : ''
+      }
+    >
+      {caller && (
+        <form
+          onSubmit={(ev) => {
+            ev.preventDefault();
+            onSubmit(prioTags, excludedTags);
+          }}
+        >
+          <CallerTagSection
+            onChange={setPrioTags}
+            subtitle={intl.formatMessage({
+              id: 'pages.organizeCallAssignment.callers.customize.prioritize.intro',
+            })}
+            tags={prioTags}
+            title={intl.formatMessage({
+              id: 'pages.organizeCallAssignment.callers.customize.prioritize.h',
+            })}
+          />
+          <CallerTagSection
+            onChange={setExcludedTags}
+            subtitle={intl.formatMessage({
+              id: 'pages.organizeCallAssignment.callers.customize.exclude.intro',
+            })}
+            tags={excludedTags}
+            title={intl.formatMessage({
+              id: 'pages.organizeCallAssignment.callers.customize.exclude.h',
+            })}
+          />
+          <ZUISubmitCancelButtons onCancel={onClose} />
+        </form>
+      )}
+    </ZUIDialog>
+  );
+};
+
+const useStyles = makeStyles(() => ({
+  subtitle: {
+    marginBottom: '0.5em',
+  },
+  title: {
+    fontSize: '1em',
+    fontWeight: 'bold',
+    marginTop: '1em',
+  },
+}));
+
+const CallerTagSection: FC<{
+  onChange: (tags: ZetkinTag[]) => void;
+  subtitle: string;
+  tags: ZetkinTag[];
+  title: string;
+}> = ({ onChange, subtitle, tags, title }) => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Typography className={classes.title} variant="h3">
+        {title}
+      </Typography>
+      <Typography className={classes.subtitle} variant="body1">
+        {subtitle}
+      </Typography>
+      <TagManager
+        assignedTags={tags}
+        groupTags={false}
+        ignoreValues={true}
+        onAssignTag={(tag) => onChange(tags.concat([tag]))}
+        onUnassignTag={(tag) => onChange(tags.filter((t) => t.id != tag.id))}
+      />
+    </>
+  );
+};
+
+export default CallerConfigDialog;

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -15,7 +15,7 @@ import {
   PlaceholderFuture,
   ResolvedFuture,
 } from 'core/caching/futures';
-import { ZetkinPerson, ZetkinQuery } from 'utils/types/zetkin';
+import { ZetkinPerson, ZetkinQuery, ZetkinTag } from 'utils/types/zetkin';
 
 export enum CallAssignmentState {
   ACTIVE = 'active',
@@ -124,6 +124,20 @@ export default class CallAssignmentModel {
   get isTargeted() {
     const { data } = this.getData();
     return data && data.target?.filter_spec?.length != 0;
+  }
+
+  setCallerTags(
+    callerId: number,
+    prioTags: ZetkinTag[],
+    excludedTags: ZetkinTag[]
+  ): void {
+    this._repo.setCallerTags(
+      this._orgId,
+      this._id,
+      callerId,
+      prioTags,
+      excludedTags
+    );
   }
 
   setCooldown(cooldown: number): void {

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -4,7 +4,6 @@ import Fuse from 'fuse.js';
 import CallAssignmentsRepo from '../repos/CallAssignmentsRepo';
 import Environment from 'core/env/Environment';
 import { Store } from 'core/store';
-import { ZetkinQuery } from 'utils/types/zetkin';
 import {
   CallAssignmentCaller,
   CallAssignmentData,
@@ -16,6 +15,7 @@ import {
   PlaceholderFuture,
   ResolvedFuture,
 } from 'core/caching/futures';
+import { ZetkinPerson, ZetkinQuery } from 'utils/types/zetkin';
 
 export enum CallAssignmentState {
   ACTIVE = 'active',
@@ -32,6 +32,10 @@ export default class CallAssignmentModel {
   private _orgId: number;
   private _repo: CallAssignmentsRepo;
   private _store: Store;
+
+  addCaller(person: ZetkinPerson): void {
+    this._repo.addCaller(this._orgId, this._id, person.id);
+  }
 
   constructor(env: Environment, orgId: number, id: number) {
     this._env = env;

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -126,6 +126,10 @@ export default class CallAssignmentModel {
     return data && data.target?.filter_spec?.length != 0;
   }
 
+  removeCaller(callerId: number) {
+    this._repo.removeCaller(this._orgId, this._id, callerId);
+  }
+
   setCallerTags(
     callerId: number,
     prioTags: ZetkinTag[],

--- a/src/features/callAssignments/repos/CallAssignmentsRepo.ts
+++ b/src/features/callAssignments/repos/CallAssignmentsRepo.ts
@@ -17,6 +17,8 @@ import {
   callerAdded,
   callerConfigure,
   callerConfigured,
+  callerRemove,
+  callerRemoved,
   callersLoad,
   callersLoaded,
   statsLoad,
@@ -117,6 +119,15 @@ export default class CallAssignmentsRepo {
     } else {
       return new RemoteItemFuture(statsItem);
     }
+  }
+
+  removeCaller(orgId: number, id: number, callerId: number) {
+    this._store.dispatch(callerRemove([id, callerId]));
+    this._apiClient
+      .delete(`/api/orgs/${orgId}/call_assignments/${id}/callers/${callerId}`)
+      .then(() => {
+        this._store.dispatch(callerRemoved([id, callerId]));
+      });
   }
 
   setCallerTags(

--- a/src/features/callAssignments/repos/CallAssignmentsRepo.ts
+++ b/src/features/callAssignments/repos/CallAssignmentsRepo.ts
@@ -1,7 +1,9 @@
+import { BodySchema } from 'pages/api/callAssignments/setCallerTags';
 import Environment from 'core/env/Environment';
 import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
+import { ZetkinTag } from '../../../utils/types/zetkin';
 import {
   CallAssignmentCaller,
   CallAssignmentData,
@@ -13,6 +15,8 @@ import {
   callAssignmentUpdated,
   callerAdd,
   callerAdded,
+  callerConfigure,
+  callerConfigured,
   callersLoad,
   callersLoaded,
   statsLoad,
@@ -113,6 +117,30 @@ export default class CallAssignmentsRepo {
     } else {
       return new RemoteItemFuture(statsItem);
     }
+  }
+
+  setCallerTags(
+    orgId: number,
+    assignmentId: number,
+    callerId: number,
+    prioTags: ZetkinTag[],
+    excludedTags: ZetkinTag[]
+  ) {
+    this._store.dispatch(callerConfigure([assignmentId, callerId]));
+    this._apiClient
+      .post<CallAssignmentCaller, BodySchema>(
+        `/api/callAssignments/setCallerTags`,
+        {
+          assignmentId,
+          callerId,
+          excludedTags: excludedTags.map((tag) => tag.id),
+          orgId,
+          prioTags: prioTags.map((tag) => tag.id),
+        }
+      )
+      .then((data: CallAssignmentCaller) => {
+        this._store.dispatch(callerConfigured([assignmentId, data]));
+      });
   }
 
   updateCallAssignment(

--- a/src/features/callAssignments/repos/CallAssignmentsRepo.ts
+++ b/src/features/callAssignments/repos/CallAssignmentsRepo.ts
@@ -11,6 +11,8 @@ import {
   callAssignmentLoad,
   callAssignmentLoaded,
   callAssignmentUpdated,
+  callerAdd,
+  callerAdded,
   callersLoad,
   callersLoaded,
   statsLoad,
@@ -26,6 +28,20 @@ import {
 export default class CallAssignmentsRepo {
   private _apiClient: IApiClient;
   private _store: Store;
+
+  addCaller(orgId: number, id: number, callerId: number) {
+    this._store.dispatch(callerAdd([id, callerId]));
+    const promise = this._apiClient
+      .put<CallAssignmentCaller>(
+        `/api/orgs/${orgId}/call_assignments/${id}/callers/${callerId}`
+      )
+      .then((data) => {
+        this._store.dispatch(callerAdded([id, data]));
+        return data;
+      });
+
+    return new PromiseFuture(promise);
+  }
 
   constructor(env: Environment) {
     this._apiClient = env.apiClient;

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -76,6 +76,21 @@ const callAssignmentsSlice = createSlice({
         .filter((ca) => ca.id != action.payload.id)
         .concat([remoteItem(action.payload.id, { data: action.payload })]);
     },
+    callerAdd: (state, action: PayloadAction<[number, number]>) => {
+      const [assignmentId, callerId] = action.payload;
+      state.callersById[assignmentId].items.push(
+        remoteItem(callerId, { isLoading: true })
+      );
+    },
+    callerAdded: (
+      state,
+      action: PayloadAction<[number, CallAssignmentCaller]>
+    ) => {
+      const [caId, caller] = action.payload;
+      state.callersById[caId].items = state.callersById[caId].items
+        .filter((c) => c.id != caller.id)
+        .concat([remoteItem(caller.id, { data: caller })]);
+    },
     callersLoad: (state, action: PayloadAction<number>) => {
       state.callersById[action.payload] = remoteList<CallAssignmentCaller>();
       state.callersById[action.payload].isLoading = true;
@@ -127,6 +142,8 @@ export const {
   callAssignmentLoad,
   callAssignmentLoaded,
   callAssignmentUpdated,
+  callerAdd,
+  callerAdded,
   callersLoad,
   callersLoaded,
   statsLoad,

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -113,6 +113,21 @@ const callAssignmentsSlice = createSlice({
         item.data = caller;
       }
     },
+    callerRemove: (state, action: PayloadAction<[number, number]>) => {
+      const [caId, callerId] = action.payload;
+      const item = state.callersById[caId].items.find(
+        (item) => item.id == callerId
+      );
+      if (item) {
+        item.isLoading = true;
+      }
+    },
+    callerRemoved: (state, action: PayloadAction<[number, number]>) => {
+      const [caId, callerId] = action.payload;
+      state.callersById[caId].items = state.callersById[caId].items.filter(
+        (item) => item.id != callerId
+      );
+    },
     callersLoad: (state, action: PayloadAction<number>) => {
       state.callersById[action.payload] = remoteList<CallAssignmentCaller>();
       state.callersById[action.payload].isLoading = true;
@@ -168,6 +183,8 @@ export const {
   callerAdded,
   callerConfigure,
   callerConfigured,
+  callerRemove,
+  callerRemoved,
   callersLoad,
   callersLoaded,
   statsLoad,

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -91,6 +91,28 @@ const callAssignmentsSlice = createSlice({
         .filter((c) => c.id != caller.id)
         .concat([remoteItem(caller.id, { data: caller })]);
     },
+    callerConfigure: (state, action: PayloadAction<[number, number]>) => {
+      const [caId, callerId] = action.payload;
+      const item = state.callersById[caId].items.find(
+        (item) => item.id == callerId
+      );
+      if (item) {
+        item.isLoading = true;
+      }
+    },
+    callerConfigured: (
+      state,
+      action: PayloadAction<[number, CallAssignmentCaller]>
+    ) => {
+      const [caId, caller] = action.payload;
+      const item = state.callersById[caId].items.find(
+        (item) => item.id == caller.id
+      );
+      if (item) {
+        item.isLoading = false;
+        item.data = caller;
+      }
+    },
     callersLoad: (state, action: PayloadAction<number>) => {
       state.callersById[action.payload] = remoteList<CallAssignmentCaller>();
       state.callersById[action.payload].isLoading = true;
@@ -144,6 +166,8 @@ export const {
   callAssignmentUpdated,
   callerAdd,
   callerAdded,
+  callerConfigure,
+  callerConfigured,
   callersLoad,
   callersLoaded,
   statsLoad,

--- a/src/features/tags/components/TagManager/TagManagerController.tsx
+++ b/src/features/tags/components/TagManager/TagManagerController.tsx
@@ -15,6 +15,7 @@ export interface TagManagerControllerProps {
   disableEditTags?: boolean;
   disabledTags?: ZetkinTag[];
   groupTags?: boolean;
+  ignoreValues?: boolean;
   onAssignTag: (tag: ZetkinTag) => void;
   onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
   onEditTag: (tag: EditTag) => void;
@@ -30,6 +31,7 @@ export const TagManagerController: React.FunctionComponent<
   disableEditTags,
   disabledTags,
   groupTags = true,
+  ignoreValues = false,
   onAssignTag,
   onCreateTag,
   onEditTag,
@@ -62,6 +64,7 @@ export const TagManagerController: React.FunctionComponent<
             disabledTags={disabledTags || assignedTags}
             disableEditTags={disableEditTags}
             groups={availableGroups}
+            ignoreValues={ignoreValues}
             onClose={() => setAddTagButton(null)}
             onCreateTag={async (tag) => {
               const newTag = await onCreateTag(tag);

--- a/src/features/tags/components/TagManager/components/TagSelect/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/index.tsx
@@ -14,6 +14,7 @@ const TagSelect: React.FunctionComponent<{
   disableEditTags?: boolean;
   disabledTags: ZetkinTag[];
   groups: ZetkinTagGroup[];
+  ignoreValues?: boolean;
   onClose: () => void;
   onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
   onEditTag: (tag: EditTag) => void;
@@ -23,6 +24,7 @@ const TagSelect: React.FunctionComponent<{
   disableEditTags,
   disabledTags,
   groups,
+  ignoreValues = false,
   onClose,
   onCreateTag,
   onEditTag,
@@ -125,7 +127,7 @@ const TagSelect: React.FunctionComponent<{
             listProps={getListboxProps()}
             onEdit={(tag) => setTagToEdit(tag)}
             onSelect={(tag) => {
-              if (tag.value_type) {
+              if (tag.value_type && !ignoreValues) {
                 setSelectedValueTag(tag);
                 setInputValue('');
               } else {

--- a/src/features/tags/components/TagManager/components/TagsList.tsx
+++ b/src/features/tags/components/TagManager/components/TagsList.tsx
@@ -45,13 +45,15 @@ const TagsList: React.FunctionComponent<{
   }
 
   //   Flat list of tags
+  const sortedTags = tags
+    .concat()
+    .sort((tag0, tag1) => tag0.title.localeCompare(tag1.title));
+
   return (
     <Box display="flex" flexWrap="wrap" style={{ gap: 4 }}>
-      {tags
-        .sort((tag0, tag1) => tag0.title.localeCompare(tag1.title))
-        .map((tag) => {
-          return <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />;
-        })}
+      {sortedTags.map((tag) => {
+        return <TagChip key={tag.id} onDelete={onUnassignTag} tag={tag} />;
+      })}
     </Box>
   );
 };

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -9,6 +9,8 @@ blocked:
   subtitle: Targets not ready to be called
   title: Blocked
 callers:
+  actions:
+    customize: Customize queue
   add:
     alreadyAdded: Already added
     placeholder: Add caller

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -11,6 +11,7 @@ blocked:
 callers:
   actions:
     customize: Customize queue
+    remove: Remove from assignment
   add:
     alreadyAdded: Already added
     placeholder: Add caller

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -12,6 +12,15 @@ callers:
   add:
     alreadyAdded: Already added
     placeholder: Add caller
+  customize:
+    exclude:
+      h: Excluded tags
+      intro: Never call targets with these tags.
+    prioritize:
+      h: Prioritized tags
+      intro: First call targets with these tags.
+    title: Customize Queue for {name}
+  customizeButton: Customize
   excludedTagsColumn: Excluded tags
   nameColumn: Name
   prioritizedTagsColumn: Prioritized tags

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -9,6 +9,9 @@ blocked:
   subtitle: Targets not ready to be called
   title: Blocked
 callers:
+  add:
+    alreadyAdded: Already added
+    placeholder: Add caller
   excludedTagsColumn: Excluded tags
   nameColumn: Name
   prioritizedTagsColumn: Prioritized tags

--- a/src/pages/api/callAssignments/setCallerTags.ts
+++ b/src/pages/api/callAssignments/setCallerTags.ts
@@ -1,0 +1,99 @@
+import { z } from 'zod';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import { CallAssignmentCaller } from 'features/callAssignments/apiTypes';
+import { ZetkinTag } from 'utils/types/zetkin';
+import { ApiFetch, createApiFetch } from 'utils/apiFetch';
+
+const bodySchema = z.object({
+  assignmentId: z.number(),
+  callerId: z.number(),
+  excludedTags: z.array(z.number()),
+  orgId: z.number(),
+  prioTags: z.array(z.number()),
+});
+
+export type BodySchema = z.infer<typeof bodySchema>;
+
+export default async function setCallerTags(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const parsed = bodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json(parsed.error);
+    return;
+  }
+
+  const { orgId, assignmentId, callerId, prioTags, excludedTags } = parsed.data;
+
+  const apiFetch = createApiFetch(req.headers);
+  const callerRes = await apiFetch(
+    `/orgs/${orgId}/call_assignments/${assignmentId}/callers/${callerId}`
+  );
+  const callerData = (await callerRes.json()).data as CallAssignmentCaller;
+
+  const basePath = `/orgs/${orgId}/call_assignments/${assignmentId}/callers/${callerId}`;
+  const updatedPrioTags = await updateTags(
+    apiFetch,
+    basePath + '/prioritized_tags',
+    callerData.prioritized_tags,
+    prioTags
+  );
+  const updatedExcludedTags = await updateTags(
+    apiFetch,
+    basePath + '/excluded_tags',
+    callerData.excluded_tags,
+    excludedTags
+  );
+
+  res.status(200).json({
+    data: {
+      ...callerData,
+      excluded_tags: updatedExcludedTags,
+      prioritized_tags: updatedPrioTags,
+    },
+  });
+}
+
+async function updateTags(
+  apiFetch: ApiFetch,
+  basePath: string,
+  existing: ZetkinTag[],
+  requestedIds: number[]
+): Promise<ZetkinTag[]> {
+  // Find and add tags that should be assigned, but weren't
+  const newTags: ZetkinTag[] = [];
+  const newTagIds = requestedIds.filter(
+    (tagId) => !existing.find((tag) => tag.id == tagId)
+  );
+  for (const tagId of newTagIds) {
+    try {
+      const addRes = await apiFetch(`${basePath}/${tagId}`, { method: 'PUT' });
+      const addData = await addRes.json();
+      newTags.push(addData.data as ZetkinTag);
+    } catch (err) {
+      // Supress errors
+    }
+  }
+
+  // Find and remove tags that were assigned, but shouldn't be
+  const removedTagIds: number[] = [];
+  const removeTagIds = existing
+    .filter((tag) => !requestedIds.includes(tag.id))
+    .map((tag) => tag.id);
+
+  for (const tagId of removeTagIds) {
+    try {
+      await apiFetch(`${basePath}/${tagId}`, { method: 'DELETE' });
+      removedTagIds.push(tagId);
+    } catch (err) {
+      // Supress errors
+    }
+  }
+
+  // Return tags after changes
+  return existing
+    .concat(newTags)
+    .filter((tag) => !removedTagIds.includes(tag.id));
+}

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/callers.tsx
@@ -11,9 +11,11 @@ import {
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useEffect, useRef, useState } from 'react';
 
+import { CallAssignmentCaller } from 'features/callAssignments/apiTypes';
 import CallAssignmentCallersList from 'features/callAssignments/components/CallAssignmentCallersList';
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
 import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
+import CallerConfigDialog from 'features/callAssignments/components/CallerConfigDialog';
 import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
@@ -61,6 +63,8 @@ const CallersPage: PageWithLayout<CallersPageProps> = ({
   );
   const intl = useIntl();
   const selectInputRef = useRef<HTMLInputElement>();
+  const [selectedCaller, setSelectedCaller] =
+    useState<CallAssignmentCaller | null>(null);
 
   useEffect(() => {
     setOnServer(false);
@@ -103,7 +107,10 @@ const CallersPage: PageWithLayout<CallersPageProps> = ({
               variant="outlined"
             />
           </Box>
-          <CallAssignmentCallersList callers={future.data || []} />
+          <CallAssignmentCallersList
+            callers={future.data || []}
+            onCustomize={(caller) => setSelectedCaller(caller)}
+          />
         </Box>
       </Paper>
       <Box marginTop={2}>
@@ -131,6 +138,17 @@ const CallersPage: PageWithLayout<CallersPageProps> = ({
           selectedPerson={null}
         />
       </Box>
+      <CallerConfigDialog
+        caller={selectedCaller}
+        onClose={() => setSelectedCaller(null)}
+        onSubmit={(prioTags, excludedTags) => {
+          if (selectedCaller) {
+            model.setCallerTags(selectedCaller.id, prioTags, excludedTags);
+          }
+          setSelectedCaller(null);
+        }}
+        open={!!selectedCaller}
+      />
     </Box>
   );
 };

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/callers.tsx
@@ -110,6 +110,7 @@ const CallersPage: PageWithLayout<CallersPageProps> = ({
           <CallAssignmentCallersList
             callers={future.data || []}
             onCustomize={(caller) => setSelectedCaller(caller)}
+            onRemove={(caller) => model.removeCaller(caller.id)}
           />
         </Box>
       </Paper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16292,6 +16292,11 @@ zetkin@~1.3.1:
     btoa "^1.2.1"
     client-oauth2 "^4.1.0"
 
+zod@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
+  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==
+
 zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"


### PR DESCRIPTION
## Description
This PR adds the insofar missing pieces to the callers list: adding callers, removing callers and configuring caller queues.

## Screenshots
<img width="1584" alt="image" src="https://user-images.githubusercontent.com/550212/208297806-a3f57b7a-42ca-4e12-ad15-eab5444d80b4.png">

<img width="1584" alt="image" src="https://user-images.githubusercontent.com/550212/208297821-5733a851-9f96-406f-80e4-f2d1f04405ce.png">

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds `DELETE`, `POST` and `PUT` methods to API clients
* Adds UI (and logic) to add callers to an assignment
* Adds UI (and logic) to remove callers from an assignment
* Adds modal (and logic) for customizing callers in an assignment
  * Adds API route to handle submission of lists of tags, and making the relevant API add/remove requests to the Zetkin API
  * Introduces the `zod` validation library, which is great for making sure runtime validation and Typescript types are in sync
* Fixes a bug in `TagsManager`, when rendering tags non-grouped
* Changes `TagsManager` to allow it to be used in a way where value tags are just selected, with no value specified, using new property called `ignoreValues`
* Simplifies logic in `CallAssignmentCallersList´, to use the `callers` array directly instead of mapping to a new object

## Notes to reviewer
There were some requirements in the issues that I couldn't solve now, so I have created separate issues for #863 and #864.

## Related issues
Resolves #829 
Resolves #830 
Resolves #831 
