### PR TITLE
Issue 841/conversation settings

### DIFF
--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -10,7 +10,9 @@ export interface CallAssignmentCaller {
 
 export interface CallAssignmentData {
   cooldown: number;
+  disable_caller_notes: boolean;
   end_date: string | null;
+  expose_target_details: boolean;
   goal: ZetkinQuery;
   id: number;
   instructions: string;

--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -1,0 +1,105 @@
+import { Link } from '@material-ui/core';
+import { Box, Button, Paper, Typography } from '@mui/material';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
+import { useContext, useState } from 'react';
+
+import CallerInstructionsModel from '../models/CallerInstructionsModel';
+import useModel from 'core/useModel';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
+import ZUITextEditor from 'zui/ZUITextEditor';
+
+interface CallerInstructionsProps {
+  assignmentId: number;
+  orgId: number;
+}
+
+const CallerInstructions = ({
+  assignmentId,
+  orgId,
+}: CallerInstructionsProps) => {
+  const intl = useIntl();
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+
+  const model = useModel(
+    (store) => new CallerInstructionsModel(store, orgId, assignmentId)
+  );
+
+  const onChange = (markdown: string) => {
+    model.setInstructions(markdown);
+  };
+
+  const [key, setKey] = useState(1);
+  return (
+    <Paper>
+      <Box padding={2}>
+        <Typography variant="h4">
+          <Msg id="pages.organizeCallAssignment.conversation.instructions.title" />
+        </Typography>
+        <form
+          onSubmit={(evt) => {
+            evt.preventDefault();
+            model.save();
+          }}
+        >
+          <Box marginBottom={2} marginTop={4}>
+            <ZUITextEditor
+              key={key}
+              initialValue={model.getInstructions()}
+              onChange={onChange}
+              placeholder={intl.formatMessage({
+                id: 'pages.organizeCallAssignment.conversation.instructions.editorPlaceholder',
+              })}
+            />
+          </Box>
+          <Box alignItems="center" display="flex" justifyContent="flex-end">
+            <Box marginRight={2}>
+              {!model.isSaving && !model.hasUnsavedChanges && (
+                <Typography>
+                  <Msg id="pages.organizeCallAssignment.conversation.instructions.savedMessage" />
+                </Typography>
+              )}
+              {!model.isSaving && model.hasUnsavedChanges && (
+                <Typography component="span">
+                  <Msg id="pages.organizeCallAssignment.conversation.instructions.unsavedMessage" />{' '}
+                  <Link
+                    color="textPrimary"
+                    component="span"
+                    onClick={() => {
+                      showConfirmDialog({
+                        onSubmit: () => {
+                          model.revert();
+                          //Force Slate to re-mount
+                          setKey((current) => current + 1);
+                        },
+                        warningText: intl.formatMessage({
+                          id: 'pages.organizeCallAssignment.conversation.instructions.unsavedMessage',
+                        }),
+                      });
+                    }}
+                    style={{ cursor: 'pointer', fontFamily: 'inherit' }}
+                  >
+                    <Msg id="pages.organizeCallAssignment.conversation.instructions.revertLink" />
+                  </Link>
+                </Typography>
+              )}
+            </Box>
+            <Button
+              color="primary"
+              disabled={!model.hasUnsavedChanges}
+              type="submit"
+              variant="contained"
+            >
+              {model.isSaving ? (
+                <Msg id="pages.organizeCallAssignment.conversation.instructions.savingButton" />
+              ) : (
+                <Msg id="pages.organizeCallAssignment.conversation.instructions.saveButton" />
+              )}
+            </Button>
+          </Box>
+        </form>
+      </Box>
+    </Paper>
+  );
+};
+
+export default CallerInstructions;

--- a/src/features/callAssignments/components/ConversationSettings.tsx
+++ b/src/features/callAssignments/components/ConversationSettings.tsx
@@ -1,0 +1,64 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { Box, Paper, Switch, Typography } from '@mui/material';
+
+import CallAssignmentModel from '../models/CallAssignmentModel';
+import useModel from 'core/useModel';
+
+interface ConversationSettingsProps {
+  assignmentId: number;
+  orgId: number;
+}
+
+const ConversationSettings = ({
+  assignmentId,
+  orgId,
+}: ConversationSettingsProps) => {
+  const model = useModel(
+    (store) => new CallAssignmentModel(store, orgId, assignmentId)
+  );
+
+  return (
+    <Paper>
+      <Box padding={2}>
+        <Typography variant="h4">
+          <Msg id="pages.organizeCallAssignment.conversation.settings.title" />
+        </Typography>
+        <Box
+          alignItems="center"
+          display="flex"
+          justifyContent="space-between"
+          marginTop={2}
+        >
+          <Typography variant="h6">
+            <Msg id="pages.organizeCallAssignment.conversation.settings.notes.title" />
+          </Typography>
+          <Switch
+            onChange={(evt) => model.setCallerNotes(evt.target.checked)}
+          />
+        </Box>
+        <Typography>
+          <Msg id="pages.organizeCallAssignment.conversation.settings.notes.message" />
+        </Typography>
+        <Box
+          alignItems="center"
+          display="flex"
+          justifyContent="space-between"
+          marginTop={1}
+        >
+          <Typography variant="h6">
+            <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
+            a
+          </Typography>
+          <Switch
+            onChange={(evt) => model.setCallerAccess(evt.target.checked)}
+          />
+        </Box>
+        <Typography>
+          <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.message" />
+        </Typography>
+      </Box>
+    </Paper>
+  );
+};
+
+export default ConversationSettings;

--- a/src/features/callAssignments/components/ConversationSettings.tsx
+++ b/src/features/callAssignments/components/ConversationSettings.tsx
@@ -47,7 +47,6 @@ const ConversationSettings = ({
         >
           <Typography variant="h6">
             <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
-            a
           </Typography>
           <Switch
             onChange={(evt) => model.setCallerAccess(evt.target.checked)}

--- a/src/features/callAssignments/components/ConversationSettings.tsx
+++ b/src/features/callAssignments/components/ConversationSettings.tsx
@@ -33,7 +33,7 @@ const ConversationSettings = ({
             <Msg id="pages.organizeCallAssignment.conversation.settings.notes.title" />
           </Typography>
           <Switch
-            onChange={(evt) => model.setCallerNotes(evt.target.checked)}
+            onChange={(evt) => model.setCallerNotesEnabled(evt.target.checked)}
           />
         </Box>
         <Typography>
@@ -49,7 +49,9 @@ const ConversationSettings = ({
             <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
           </Typography>
           <Switch
-            onChange={(evt) => model.setCallerAccess(evt.target.checked)}
+            onChange={(evt) =>
+              model.setTargetDetailsExposed(evt.target.checked)
+            }
           />
         </Box>
         <Typography>

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -45,7 +45,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              disable_caller_notes: false,
               end_date: null,
+              expose_target_details: false,
               goal: {
                 filter_spec: [],
                 id: 102,
@@ -78,7 +80,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              disable_caller_notes: false,
               end_date: null,
+              expose_target_details: false,
               goal: {
                 filter_spec: [],
                 id: 102,
@@ -121,7 +125,9 @@ describe('CallAssignmentModel', () => {
         assignmentList: mockList<CallAssignmentData>([
           {
             cooldown: 3,
+            disable_caller_notes: false,
             end_date: endDate,
+            expose_target_details: false,
             goal: {
               filter_spec: [],
               id: 102,
@@ -266,7 +272,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              disable_caller_notes: false,
               end_date: null,
+              expose_target_details: false,
               goal: {
                 filter_spec: [],
                 id: 102,
@@ -304,7 +312,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              disable_caller_notes: false,
               end_date: null,
+              expose_target_details: false,
               goal: {
                 filter_spec: [],
                 id: 102,
@@ -375,7 +385,9 @@ describe('CallAssignmentModel', () => {
           assignmentList: mockList<CallAssignmentData>([
             {
               cooldown: 3,
+              disable_caller_notes: false,
               end_date: null,
+              expose_target_details: false,
               goal: {
                 filter_spec: [],
                 id: 102,
@@ -590,7 +602,9 @@ describe('CallAssignmentModel', () => {
         assignmentList: mockList<CallAssignmentData>([
           {
             cooldown: 3,
+            disable_caller_notes: false,
             end_date: endDate,
+            expose_target_details: false,
             goal: {
               filter_spec: [],
               id: 102,
@@ -656,7 +670,9 @@ describe('CallAssignmentModel', () => {
         assignmentList: mockList<CallAssignmentData>([
           {
             cooldown: 3,
+            disable_caller_notes: false,
             end_date: endDate,
+            expose_target_details: false,
             goal: {
               filter_spec: [],
               id: 102,

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -132,15 +132,9 @@ export default class CallAssignmentModel extends ModelBase {
     this._repo.removeCaller(this._orgId, this._id, callerId);
   }
 
-  setCallerAccess(expose_target_details: boolean) {
+  setCallerNotesEnabled(enabled: boolean) {
     this._repo.updateCallAssignment(this._orgId, this._id, {
-      expose_target_details,
-    });
-  }
-
-  setCallerNotes(disable_caller_notes: boolean) {
-    this._repo.updateCallAssignment(this._orgId, this._id, {
-      disable_caller_notes,
+      disable_caller_notes: !enabled,
     });
   }
 
@@ -210,6 +204,12 @@ export default class CallAssignmentModel extends ModelBase {
           )
         );
     }
+  }
+
+  setTargetDetailsExposed(exposeTargetDetails: boolean) {
+    this._repo.updateCallAssignment(this._orgId, this._id, {
+      expose_target_details: exposeTargetDetails,
+    });
   }
 
   setTargets(query: Partial<ZetkinQuery>): void {

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -132,6 +132,18 @@ export default class CallAssignmentModel extends ModelBase {
     this._repo.removeCaller(this._orgId, this._id, callerId);
   }
 
+  setCallerAccess(expose_target_details: boolean) {
+    this._repo.updateCallAssignment(this._orgId, this._id, {
+      expose_target_details,
+    });
+  }
+
+  setCallerNotes(disable_caller_notes: boolean) {
+    this._repo.updateCallAssignment(this._orgId, this._id, {
+      disable_caller_notes,
+    });
+  }
+
   setCallerTags(
     callerId: number,
     prioTags: ZetkinTag[],

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -30,14 +30,17 @@ callers:
   searchBox: Search
   title: Callers
 conversation:
-  confirm: Do you want to delete all unsaved changes and go back to saved instructions?
-  editorPlaceholder: Add instructions for your callers
-  revertLink: Revert to saved version?
-  saveButton: Save
-  savedMessage: Everything is up to date!
-  savingButton: Saving...
-  title: Caller instructions
-  unsavedMessage: You have unsaved changes.
+  instructions:
+    confirm: Do you want to delete all unsaved changes and go back to saved instructions?
+    editorPlaceholder: Add instructions for your callers
+    revertLink: Revert to saved version?
+    saveButton: Save
+    savedMessage: Everything is up to date!
+    savingButton: Saving...
+    title: Caller instructions
+    unsavedMessage: You have unsaved changes.
+  settings:
+    title: Conversation settings
 done:
   defineButton: Edit done criteria
   subtitle: Targets that meet the done criteria

--- a/src/locale/pages/organizeCallAssignment/en.yml
+++ b/src/locale/pages/organizeCallAssignment/en.yml
@@ -40,6 +40,12 @@ conversation:
     title: Caller instructions
     unsavedMessage: You have unsaved changes.
   settings:
+    notes:
+      message: Disabling caller notes may increase the call rate but could lead to important information being lost.
+      title: Allow caller to make notes
+    targetData:
+      message: Target name and phone number are always visible to callers. Enabling additional target data will share all person fields with callers.
+      title: Show additional target data
     title: Conversation settings
 done:
   defineButton: Edit done criteria

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
@@ -1,17 +1,11 @@
 import { GetServerSideProps } from 'next';
-import { Link } from '@material-ui/core';
-import { Box, Button, Grid, Paper, Switch, Typography } from '@mui/material';
-import { FormattedMessage as Msg, useIntl } from 'react-intl';
-import { useContext, useState } from 'react';
+import { Grid } from '@mui/material';
 
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
-import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
-import CallerInstructionsModel from 'features/callAssignments/models/CallerInstructionsModel';
+import CallerInstructions from 'features/callAssignments/components/CallerInstructions';
+import ConversationSettings from 'features/callAssignments/components/ConversationSettings';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
-import useModel from 'core/useModel';
-import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
-import ZUITextEditor from 'zui/ZUITextEditor';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -45,147 +39,19 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
   assignmentId,
   orgId,
 }) => {
-  const intl = useIntl();
-  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
-
-  const model = useModel(
-    (store) =>
-      new CallerInstructionsModel(
-        store,
-        parseInt(orgId),
-        parseInt(assignmentId)
-      )
-  );
-
-  const callAssignmentModel = useModel(
-    (store) =>
-      new CallAssignmentModel(store, parseInt(orgId), parseInt(assignmentId))
-  );
-
-  const onChange = (markdown: string) => {
-    model.setInstructions(markdown);
-  };
-
-  const [key, setKey] = useState(1);
-
   return (
     <Grid container spacing={2}>
       <Grid item lg={8} md={6} sm={12}>
-        <Paper>
-          <Box padding={2}>
-            <Typography variant="h4">
-              <Msg id="pages.organizeCallAssignment.conversation.instructions.title" />
-            </Typography>
-            <form
-              onSubmit={(evt) => {
-                evt.preventDefault();
-                model.save();
-              }}
-            >
-              <Box marginBottom={2} marginTop={4}>
-                <ZUITextEditor
-                  key={key}
-                  initialValue={model.getInstructions()}
-                  onChange={onChange}
-                  placeholder={intl.formatMessage({
-                    id: 'pages.organizeCallAssignment.conversation.instructions.editorPlaceholder',
-                  })}
-                />
-              </Box>
-              <Box alignItems="center" display="flex" justifyContent="flex-end">
-                <Box marginRight={2}>
-                  {!model.isSaving && !model.hasUnsavedChanges && (
-                    <Typography>
-                      <Msg id="pages.organizeCallAssignment.conversation.instructions.savedMessage" />
-                    </Typography>
-                  )}
-                  {!model.isSaving && model.hasUnsavedChanges && (
-                    <Typography component="span">
-                      <Msg id="pages.organizeCallAssignment.conversation.instructions.unsavedMessage" />{' '}
-                      <Link
-                        color="textPrimary"
-                        component="span"
-                        onClick={() => {
-                          showConfirmDialog({
-                            onSubmit: () => {
-                              model.revert();
-                              //Force Slate to re-mount
-                              setKey((current) => current + 1);
-                            },
-                            warningText: intl.formatMessage({
-                              id: 'pages.organizeCallAssignment.conversation.instructions.unsavedMessage',
-                            }),
-                          });
-                        }}
-                        style={{ cursor: 'pointer', fontFamily: 'inherit' }}
-                      >
-                        <Msg id="pages.organizeCallAssignment.conversation.instructions.revertLink" />
-                      </Link>
-                    </Typography>
-                  )}
-                </Box>
-                <Button
-                  color="primary"
-                  disabled={!model.hasUnsavedChanges}
-                  type="submit"
-                  variant="contained"
-                >
-                  {model.isSaving ? (
-                    <Msg id="pages.organizeCallAssignment.conversation.instructions.savingButton" />
-                  ) : (
-                    <Msg id="pages.organizeCallAssignment.conversation.instructions.saveButton" />
-                  )}
-                </Button>
-              </Box>
-            </form>
-          </Box>
-        </Paper>
+        <CallerInstructions
+          assignmentId={parseInt(assignmentId)}
+          orgId={parseInt(orgId)}
+        />
       </Grid>
       <Grid item lg={4} md={6} sm={12}>
-        <Paper>
-          <Box padding={2}>
-            <Typography variant="h4">
-              <Msg id="pages.organizeCallAssignment.conversation.settings.title" />
-            </Typography>
-            <Box
-              alignItems="center"
-              display="flex"
-              justifyContent="space-between"
-              marginTop={2}
-            >
-              <Typography variant="h6">
-                <Msg id="pages.organizeCallAssignment.conversation.settings.notes.title" />
-              </Typography>
-              <Switch
-                onChange={(evt) =>
-                  callAssignmentModel.setCallerNotes(evt.target.checked)
-                }
-              />
-            </Box>
-            <Typography>
-              <Msg id="pages.organizeCallAssignment.conversation.settings.notes.message" />
-            </Typography>
-            <Box
-              alignItems="center"
-              display="flex"
-              justifyContent="space-between"
-              marginTop={1}
-            >
-              <Typography variant="h6">
-                <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
-                a
-              </Typography>
-              <Switch
-                onChange={(evt) =>
-                  callAssignmentModel.setCallerAccess(evt.target.checked)
-                }
-              />
-            </Box>
-            <Typography>
-              <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.message" />
-            </Typography>
-          </Box>
-        </Paper>
+        <ConversationSettings
+          assignmentId={parseInt(assignmentId)}
+          orgId={parseInt(orgId)}
+        />
       </Grid>
     </Grid>
   );

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { Link } from '@material-ui/core';
-import { Box, Button, Paper, Typography } from '@mui/material';
+import { Box, Button, Grid, Paper, Switch, Typography } from '@mui/material';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useState } from 'react';
 
@@ -63,80 +63,114 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
   const [key, setKey] = useState(1);
 
   return (
-    <Paper>
-      <Box padding={2}>
-        <Typography variant="h4">
-          <Msg id="pages.organizeCallAssignment.conversation.title" />
-        </Typography>
-        <form
-          onSubmit={(evt) => {
-            evt.preventDefault();
-            model.save();
-          }}
-        >
-          <Box marginBottom={2} marginTop={4}>
-            <ZUITextEditor
-              key={key}
-              initialValue={model.getInstructions()}
-              onChange={onChange}
-              placeholder={intl.formatMessage({
-                id: 'pages.organizeCallAssignment.conversation.editorPlaceholder',
-              })}
-            />
-          </Box>
-          <Box alignItems="center" display="flex" justifyContent="flex-end">
-            <Box marginRight={2}>
-              {!model.isSaving && !model.hasUnsavedChanges && (
-                <Typography>
-                  <Msg id="pages.organizeCallAssignment.conversation.savedMessage" />
-                </Typography>
-              )}
-              {!model.isSaving && model.hasUnsavedChanges && (
-                <Box display="flex">
-                  <Typography>
-                    <Msg id="pages.organizeCallAssignment.conversation.unsavedMessage" />
-                  </Typography>
-                  <Link
-                    color="textPrimary"
-                    component={Typography}
-                    onClick={() => {
-                      showConfirmDialog({
-                        onSubmit: () => {
-                          model.revert();
-                          //Force Slate to re-mount
-                          setKey((current) => current + 1);
-                        },
-                        warningText: intl.formatMessage({
-                          id: 'pages.organizeCallAssignment.conversation.confirm',
-                        }),
-                      });
-                    }}
-                    sx={{
-                      cursor: 'pointer',
-                      paddingLeft: 0.5,
-                    }}
-                  >
-                    <Msg id="pages.organizeCallAssignment.conversation.revertLink" />
-                  </Link>
-                </Box>
-              )}
-            </Box>
-            <Button
-              color="primary"
-              disabled={!model.hasUnsavedChanges}
-              type="submit"
-              variant="contained"
+    <Grid container spacing={2}>
+      <Grid item lg={8} md={6} sm={12}>
+        <Paper>
+          <Box padding={2}>
+            <Typography variant="h4">
+              <Msg id="pages.organizeCallAssignment.conversation.instructions.title" />
+            </Typography>
+            <form
+              onSubmit={(evt) => {
+                evt.preventDefault();
+                model.save();
+              }}
             >
-              {model.isSaving ? (
-                <Msg id="pages.organizeCallAssignment.conversation.savingButton" />
-              ) : (
-                <Msg id="pages.organizeCallAssignment.conversation.saveButton" />
-              )}
-            </Button>
+              <Box marginBottom={2} marginTop={4}>
+                <ZUITextEditor
+                  key={key}
+                  initialValue={model.getInstructions()}
+                  onChange={onChange}
+                  placeholder={intl.formatMessage({
+                    id: 'pages.organizeCallAssignment.conversation.instructions.editorPlaceholder',
+                  })}
+                />
+              </Box>
+              <Box alignItems="center" display="flex" justifyContent="flex-end">
+                <Box marginRight={2}>
+                  {!model.isSaving && !model.hasUnsavedChanges && (
+                    <Typography>
+                      <Msg id="pages.organizeCallAssignment.conversation.instructions.savedMessage" />
+                    </Typography>
+                  )}
+                  {!model.isSaving && model.hasUnsavedChanges && (
+                    <Typography component="span">
+                      <Msg id="pages.organizeCallAssignment.conversation.instructions.unsavedMessage" />{' '}
+                      <Link
+                        color="textPrimary"
+                        component="span"
+                        onClick={() => {
+                          showConfirmDialog({
+                            onSubmit: () => {
+                              model.revert();
+                              //Force Slate to re-mount
+                              setKey((current) => current + 1);
+                            },
+                            warningText: intl.formatMessage({
+                              id: 'pages.organizeCallAssignment.conversation.instructions.unsavedMessage',
+                            }),
+                          });
+                        }}
+                        style={{ cursor: 'pointer', fontFamily: 'inherit' }}
+                      >
+                        <Msg id="pages.organizeCallAssignment.conversation.instructions.revertLink" />
+                      </Link>
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  color="primary"
+                  disabled={!model.hasUnsavedChanges}
+                  type="submit"
+                  variant="contained"
+                >
+                  {model.isSaving ? (
+                    <Msg id="pages.organizeCallAssignment.conversation.instructions.savingButton" />
+                  ) : (
+                    <Msg id="pages.organizeCallAssignment.conversation.instructions.saveButton" />
+                  )}
+                </Button>
+              </Box>
+            </form>
           </Box>
-        </form>
-      </Box>
-    </Paper>
+        </Paper>
+      </Grid>
+      <Grid item lg={4} md={6} sm={12}>
+        <Paper>
+          <Box padding={2}>
+            <Typography variant="h4">
+              <Msg id="pages.organizeCallAssignment.conversation.settings.title" />
+            </Typography>
+            <Box
+              alignItems="center"
+              display="flex"
+              justifyContent="space-between"
+              marginTop={2}
+            >
+              <Typography variant="h6">Allow caller to make notes</Typography>
+              <Switch />
+            </Box>
+            <Typography>
+              Disabling caller notes may increase the call rate but may lead to
+              important information being lost.
+            </Typography>
+            <Box
+              alignItems="center"
+              display="flex"
+              justifyContent="space-between"
+              marginTop={1}
+            >
+              <Typography variant="h6">Show additional target data</Typography>
+              <Switch />
+            </Box>
+            <Typography>
+              Target name and phone number are always visible to callers.
+              Enabling this will share all person fields with callers.
+            </Typography>
+          </Box>
+        </Paper>
+      </Grid>
+    </Grid>
   );
 };
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
@@ -153,7 +153,9 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               justifyContent="space-between"
               marginTop={2}
             >
-              <Typography variant="h6">Allow caller to make notes</Typography>
+              <Typography variant="h6">
+                <Msg id="pages.organizeCallAssignment.conversation.settings.notes.title" />
+              </Typography>
               <Switch
                 onChange={(evt) =>
                   callAssignmentModel.setCallerNotes(evt.target.checked)
@@ -161,8 +163,7 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               />
             </Box>
             <Typography>
-              Disabling caller notes may increase the call rate but may lead to
-              important information being lost.
+              <Msg id="pages.organizeCallAssignment.conversation.settings.notes.message" />
             </Typography>
             <Box
               alignItems="center"
@@ -170,7 +171,10 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               justifyContent="space-between"
               marginTop={1}
             >
-              <Typography variant="h6">Show additional target data</Typography>
+              <Typography variant="h6">
+                <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
+                a
+              </Typography>
               <Switch
                 onChange={(evt) =>
                   callAssignmentModel.setCallerAccess(evt.target.checked)
@@ -178,8 +182,7 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               />
             </Box>
             <Typography>
-              Target name and phone number are always visible to callers.
-              Enabling this will share all person fields with callers.
+              <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.message" />
             </Typography>
           </Box>
         </Paper>

--- a/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/callassignments/[callAssId]/conversation.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useState } from 'react';
 
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
+import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
 import CallerInstructionsModel from 'features/callAssignments/models/CallerInstructionsModel';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
@@ -54,6 +55,11 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
         parseInt(orgId),
         parseInt(assignmentId)
       )
+  );
+
+  const callAssignmentModel = useModel(
+    (store) =>
+      new CallAssignmentModel(store, parseInt(orgId), parseInt(assignmentId))
   );
 
   const onChange = (markdown: string) => {
@@ -148,7 +154,11 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               marginTop={2}
             >
               <Typography variant="h6">Allow caller to make notes</Typography>
-              <Switch />
+              <Switch
+                onChange={(evt) =>
+                  callAssignmentModel.setCallerNotes(evt.target.checked)
+                }
+              />
             </Box>
             <Typography>
               Disabling caller notes may increase the call rate but may lead to
@@ -161,7 +171,11 @@ const ConversationPage: PageWithLayout<ConversationPageProps> = ({
               marginTop={1}
             >
               <Typography variant="h6">Show additional target data</Typography>
-              <Switch />
+              <Switch
+                onChange={(evt) =>
+                  callAssignmentModel.setCallerAccess(evt.target.checked)
+                }
+              />
             </Box>
             <Typography>
               Target name and phone number are always visible to callers.


### PR DESCRIPTION
## Description
This PR adds a section for conversation settings under the Conversation tab in a call assignment.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/210528651-c34ab694-58d9-451d-adcb-31a6d1236c45.png)

## Changes
- Adds a ConversationSettings component that lets user set if callers have access to additional target data and if they are able to make notes or not. 
- Adds methods on CallAssignmentModel to set these two
- Refactors to make CallerInstructions into its own component.

## Related issues
Resolves #841 
