### PR TITLE
Issue 839/cleanup

### DIFF
--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -72,7 +72,7 @@ const CallerInstructions = ({
                           setKey((current) => current + 1);
                         },
                         warningText: intl.formatMessage({
-                          id: 'pages.organizeCallAssignment.conversation.instructions.unsavedMessage',
+                          id: 'pages.organizeCallAssignment.conversation.instructions.confirm',
                         }),
                       });
                     }}

--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -1,5 +1,12 @@
 import { Link } from '@material-ui/core';
-import { Box, Button, Paper, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Paper,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import { useContext, useState } from 'react';
 
@@ -20,6 +27,9 @@ const CallerInstructions = ({
   const intl = useIntl();
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   const model = useModel(
     (store) => new CallerInstructionsModel(store, orgId, assignmentId)
   );
@@ -30,8 +40,23 @@ const CallerInstructions = ({
 
   const [key, setKey] = useState(1);
   return (
-    <Paper>
-      <Box padding={2}>
+    <Paper
+      //These styles are added to enable the editor to grow with the window.
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: isMobile ? '90vh' : 'calc(100vh - 300px)',
+        minHeight: 0,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+          padding: 2,
+        }}
+      >
         <Typography variant="h4">
           <Msg id="pages.organizeCallAssignment.conversation.instructions.title" />
         </Typography>
@@ -40,8 +65,17 @@ const CallerInstructions = ({
             evt.preventDefault();
             model.save();
           }}
+          style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
         >
-          <Box marginBottom={2} marginTop={4}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              marginBottom: 2,
+              marginTop: 4,
+              minHeight: 0,
+            }}
+          >
             <ZUITextEditor
               key={key}
               initialValue={model.getInstructions()}

--- a/src/features/callAssignments/components/ConversationSettings.tsx
+++ b/src/features/callAssignments/components/ConversationSettings.tsx
@@ -33,6 +33,8 @@ const ConversationSettings = ({
             <Msg id="pages.organizeCallAssignment.conversation.settings.notes.title" />
           </Typography>
           <Switch
+            //this looks backwards bc in interface we use the positive "allow"
+            checked={!model.getData().data?.disable_caller_notes}
             onChange={(evt) => model.setCallerNotesEnabled(evt.target.checked)}
           />
         </Box>
@@ -49,6 +51,7 @@ const ConversationSettings = ({
             <Msg id="pages.organizeCallAssignment.conversation.settings.targetData.title" />
           </Typography>
           <Switch
+            checked={model.getData().data?.expose_target_details}
             onChange={(evt) =>
               model.setTargetDetailsExposed(evt.target.checked)
             }

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -113,6 +113,11 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
       <Box
         className={classes.container}
         onClick={() => ReactEditor.focus(editor)}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        }}
       >
         {/* Only render when slate has been generated */}
         {initialValueSlate && (
@@ -129,8 +134,9 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
               renderElement={renderElement}
               renderLeaf={renderLeaf}
               spellCheck
+              style={{ overflowY: 'scroll' }}
             />
-            <Collapse in={active}>
+            <Collapse in={active} sx={{ flexShrink: 0 }}>
               <Toolbar onClickAttach={onClickAttach} />
             </Collapse>
           </Slate>


### PR DESCRIPTION
## Description
This PR cleans up some things that were missed in the #867 and #883 PR:s.

## Changes
* Makes caller instructions editor grow and scroll
* Correctly displays the state of the conversation settings. 
* Gives correct message in the confirm dialog when reverting to saved instructions.

## Related issues
Resolves #839 
