### PR TITLE
Rename views and folders

### DIFF
--- a/src/core/api/client/BackendApiClient.ts
+++ b/src/core/api/client/BackendApiClient.ts
@@ -1,0 +1,11 @@
+import { IncomingHttpHeaders } from 'http';
+
+import { createApiFetch } from 'utils/apiFetch';
+import FetchApiClient from './FetchApiClient';
+
+export default class BackendApiClient extends FetchApiClient {
+  constructor(headers: IncomingHttpHeaders) {
+    const fetch = createApiFetch(headers, '');
+    super(fetch);
+  }
+}

--- a/src/core/api/client/BrowserApiClient.ts
+++ b/src/core/api/client/BrowserApiClient.ts
@@ -1,66 +1,13 @@
-import IApiClient from './IApiClient';
+import FetchApiClient from './FetchApiClient';
 
-export default class BrowserApiClient implements IApiClient {
-  async delete(path: string): Promise<void> {
-    await fetch(path, {
-      method: 'DELETE',
-    });
-  }
+// Fetch must be wrapped, because it can't be invoked
+// as a method on the class otherwise
+function wrappedFetch(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(path, init);
+}
 
-  async get<DataType>(path: string): Promise<DataType> {
-    const res = await fetch(path);
-    const body = await res.json();
-    return body.data;
-  }
-
-  async patch<DataType>(
-    path: string,
-    data: Partial<DataType>
-  ): Promise<DataType> {
-    const res = await fetch(path, {
-      body: JSON.stringify(data),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'PATCH',
-    });
-    const body = await res.json();
-    return body.data;
-  }
-
-  async post<DataType, InputType = DataType>(
-    path: string,
-    data: Partial<InputType>
-  ): Promise<DataType> {
-    const res = await fetch(path, {
-      body: JSON.stringify(data),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      method: 'POST',
-    });
-    const body = await res.json();
-    return body.data;
-  }
-
-  async put<DataType = void>(
-    path: string,
-    data?: Partial<DataType> | undefined
-  ): Promise<DataType> {
-    const options: RequestInit = {
-      method: 'PUT',
-    };
-
-    if (data) {
-      options.body = JSON.stringify(data);
-      options.headers = {
-        'Content-Type': 'application/json',
-      };
-    }
-
-    const res = await fetch(path, options);
-
-    const body = await res.json();
-    return body.data;
+export default class BrowserApiClient extends FetchApiClient {
+  constructor() {
+    super(wrappedFetch);
   }
 }

--- a/src/core/api/client/FetchApiClient.ts
+++ b/src/core/api/client/FetchApiClient.ts
@@ -1,0 +1,73 @@
+import { ApiFetch } from 'utils/apiFetch';
+import IApiClient from './IApiClient';
+
+export default class FetchApiClient implements IApiClient {
+  private _fetch: ApiFetch;
+
+  constructor(fetch: ApiFetch) {
+    this._fetch = fetch;
+  }
+
+  async delete(path: string): Promise<void> {
+    await this._fetch(path, {
+      method: 'DELETE',
+    });
+  }
+
+  async get<DataType>(path: string): Promise<DataType> {
+    const res = await this._fetch(path);
+    const body = await res.json();
+    return body.data;
+  }
+
+  async patch<DataType>(
+    path: string,
+    data: Partial<DataType>
+  ): Promise<DataType> {
+    const res = await this._fetch(path, {
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PATCH',
+    });
+    const body = await res.json();
+    return body.data;
+  }
+
+  async post<DataType, InputType = DataType>(
+    path: string,
+    data: Partial<InputType>
+  ): Promise<DataType> {
+    const res = await this._fetch(path, {
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+    const body = await res.json();
+    return body.data;
+  }
+
+  async put<DataType = void>(
+    path: string,
+    data?: Partial<DataType> | undefined
+  ): Promise<DataType> {
+    const options: RequestInit = {
+      method: 'PUT',
+    };
+
+    if (data) {
+      options.body = JSON.stringify(data);
+      options.headers = {
+        'Content-Type': 'application/json',
+      };
+    }
+
+    const res = await this._fetch(path, options);
+
+    const body = await res.json();
+    return body.data;
+  }
+}

--- a/src/features/views/components/ViewBrowser.tsx
+++ b/src/features/views/components/ViewBrowser.tsx
@@ -5,11 +5,17 @@ import {
   Folder,
   InsertDriveFileOutlined,
 } from '@mui/icons-material';
-import { DataGridPro, GridColDef, GridSortModel } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro,
+  GridColDef,
+  GridSortModel,
+  useGridApiRef,
+} from '@mui/x-data-grid-pro';
 import { FC, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link, Theme, useMediaQuery } from '@mui/material';
 
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIPerson from 'zui/ZUIPerson';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
@@ -50,6 +56,8 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
   const isMobile = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
+
+  const gridApiRef = useGridApiRef();
 
   const colDefs: GridColDef<ViewBrowserItem>[] = [
     {
@@ -129,6 +137,33 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
         }
       },
     });
+
+    colDefs.push({
+      field: 'menu',
+      headerName: '',
+      renderCell: (params) => {
+        return (
+          <ZUIEllipsisMenu
+            items={[
+              {
+                label: intl.formatMessage({
+                  id: 'pages.people.views.browser.menu.rename',
+                }),
+                onSelect: (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  gridApiRef.current.startCellEditMode({
+                    field: 'title',
+                    id: params.row.id,
+                  });
+                },
+              },
+            ]}
+          />
+        );
+      },
+      width: 40,
+    });
   }
 
   return (
@@ -165,6 +200,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
 
         return (
           <DataGridPro
+            apiRef={gridApiRef}
             autoHeight
             columns={colDefs}
             disableSelectionOnClick

--- a/src/features/views/components/ViewBrowser.tsx
+++ b/src/features/views/components/ViewBrowser.tsx
@@ -71,6 +71,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
     },
     {
       disableColumnMenu: true,
+      editable: true,
       field: 'title',
       flex: 2,
       headerName: intl.formatMessage({
@@ -167,8 +168,15 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
             autoHeight
             columns={colDefs}
             disableSelectionOnClick
+            experimentalFeatures={{ newEditingApi: true }}
             hideFooter
             onSortModelChange={(model) => setSortModel(model)}
+            processRowUpdate={(item) => {
+              if (item.type != 'back') {
+                model.renameItem(item.type, item.data.id, item.title);
+              }
+              return item;
+            }}
             rows={rows}
             sortingMode="server"
             sx={{ borderWidth: 0 }}

--- a/src/features/views/components/ViewBrowser.tsx
+++ b/src/features/views/components/ViewBrowser.tsx
@@ -6,6 +6,13 @@ import {
   InsertDriveFileOutlined,
 } from '@mui/icons-material';
 import {
+  Box,
+  CircularProgress,
+  Link,
+  Theme,
+  useMediaQuery,
+} from '@mui/material';
+import {
   DataGridPro,
   GridColDef,
   GridSortModel,
@@ -13,7 +20,6 @@ import {
 } from '@mui/x-data-grid-pro';
 import { FC, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link, Theme, useMediaQuery } from '@mui/material';
 
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -107,9 +113,14 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
           );
         } else {
           return (
-            <NextLink href={`${basePath}/${params.row.id}`} passHref>
-              <Link className={styles.itemLink}>{params.row.title}</Link>
-            </NextLink>
+            <Box display="flex" gap={1}>
+              <NextLink href={`${basePath}/${params.row.id}`} passHref>
+                <Link className={styles.itemLink}>{params.row.title}</Link>
+              </NextLink>
+              {model.itemIsRenaming(params.row.type, params.row.data.id) && (
+                <CircularProgress size={20} />
+              )}
+            </Box>
           );
         }
       },

--- a/src/features/views/components/ViewBrowser.tsx
+++ b/src/features/views/components/ViewBrowser.tsx
@@ -153,6 +153,9 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
       field: 'menu',
       headerName: '',
       renderCell: (params) => {
+        if (params.row.type == 'back') {
+          return null;
+        }
         return (
           <ZUIEllipsisMenu
             items={[
@@ -217,6 +220,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
             disableSelectionOnClick
             experimentalFeatures={{ newEditingApi: true }}
             hideFooter
+            isCellEditable={(params) => params.row.type != 'back'}
             onSortModelChange={(model) => setSortModel(model)}
             processRowUpdate={(item) => {
               if (item.type != 'back') {

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -80,4 +80,10 @@ export default class ViewBrowserModel extends ModelBase {
       items.concat(itemsFuture.data.filter((item) => item.folderId == folderId))
     );
   }
+
+  renameItem(type: 'folder' | 'view', id: number, title: string) {
+    if (type == 'folder') {
+      this._repo.updateFolder(this._orgId, id, { title });
+    }
+  }
 }

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -1,9 +1,26 @@
 import Environment from 'core/env/Environment';
 import { ModelBase } from 'core/models';
 import ViewsRepo from '../repos/ViewsRepo';
-import { ViewTreeItem } from 'pages/api/views/tree';
-import { ZetkinViewFolder } from '../components/types';
 import { FutureBase, IFuture, ResolvedFuture } from 'core/caching/futures';
+import { ZetkinView, ZetkinViewFolder } from '../components/types';
+
+export interface ViewBrowserFolderItem {
+  id: number | string;
+  type: 'folder';
+  title: string;
+  owner: string;
+  data: ZetkinViewFolder;
+  folderId: number | null;
+}
+
+export interface ViewBrowserViewItem {
+  id: number | string;
+  type: 'view';
+  title: string;
+  owner: string;
+  data: ZetkinView;
+  folderId: number | null;
+}
 
 type ViewBrowserBackItem = {
   folderId: number | null;
@@ -12,7 +29,10 @@ type ViewBrowserBackItem = {
   type: 'back';
 };
 
-export type ViewBrowserItem = ViewTreeItem | ViewBrowserBackItem;
+export type ViewBrowserItem =
+  | ViewBrowserFolderItem
+  | ViewBrowserViewItem
+  | ViewBrowserBackItem;
 
 export default class ViewBrowserModel extends ModelBase {
   private _env: Environment;
@@ -32,10 +52,9 @@ export default class ViewBrowserModel extends ModelBase {
       return new FutureBase(null, itemsFuture.error, itemsFuture.isLoading);
     }
 
-    const item = itemsFuture.data.find(
-      (item) => item.type == 'folder' && item.data.id == folderId
+    return new ResolvedFuture(
+      itemsFuture.data.folders.find((folder) => folder.id == folderId) || null
     );
-    return new ResolvedFuture(item?.type == 'folder' ? item.data : null);
   }
 
   getItemSummary(
@@ -47,11 +66,11 @@ export default class ViewBrowserModel extends ModelBase {
     }
 
     return new ResolvedFuture({
-      folders: itemsFuture.data.filter(
-        (item) => item.type == 'folder' && item.folderId == folderId
+      folders: itemsFuture.data.folders.filter(
+        (folder) => folder.parent?.id == folderId
       ).length,
-      views: itemsFuture.data.filter(
-        (item) => item.type == 'view' && item.folderId == folderId
+      views: itemsFuture.data.views.filter(
+        (view) => view.folder?.id == folderId
       ).length,
     });
   }
@@ -59,36 +78,65 @@ export default class ViewBrowserModel extends ModelBase {
   getItems(folderId: number | null = null): IFuture<ViewBrowserItem[]> {
     const itemsFuture = this._repo.getViewTree(this._orgId);
     if (!itemsFuture.data) {
-      return itemsFuture;
+      return new FutureBase(null, itemsFuture.error, itemsFuture.isLoading);
     }
 
     const items: ViewBrowserItem[] = [];
 
     if (folderId) {
-      const folderItem = itemsFuture.data.find(
-        (item) => item.type == 'folder' && item.data.id == folderId
+      const folder = itemsFuture.data.folders.find(
+        (folder) => folder.id == folderId
       );
-      if (folderItem) {
+      if (folder) {
         items.push({
-          folderId: folderItem.folderId,
+          folderId: folder.parent?.id ?? null,
           id: 'back',
-          title: (folderItem.data as ZetkinViewFolder).parent?.title ?? null,
+          title: folder.parent?.title ?? null,
           type: 'back',
         });
       }
     }
 
-    return new ResolvedFuture(
-      items.concat(itemsFuture.data.filter((item) => item.folderId == folderId))
-    );
+    itemsFuture.data.folders
+      .filter((folder) => folder.parent?.id == folderId)
+      .forEach((folder) => {
+        items.push({
+          data: folder,
+          folderId: folderId,
+          id: 'folders/' + folder.id,
+          owner: '',
+          title: folder.title,
+          type: 'folder',
+        });
+      });
+
+    itemsFuture.data.views
+      .filter((view) => view.folder?.id == folderId)
+      .forEach((view) => {
+        items.push({
+          data: view,
+          folderId: folderId,
+          id: 'views/' + view.id,
+          owner: '',
+          title: view.title,
+          type: 'view',
+        });
+      });
+
+    return new ResolvedFuture(items);
   }
 
   itemIsRenaming(type: 'folder' | 'view', id: number): boolean {
     const state = this._env.store.getState();
-    const item = state.views.treeList.items.find(
-      (item) => item.data?.type == type && item.data?.data.id == id
-    );
-    return item?.mutating.includes('title') ?? false;
+    if (type == 'folder') {
+      const item = state.views.folderList.items.find((item) => item.id == id);
+      return item?.mutating.includes('title') ?? false;
+    } else if (type == 'view') {
+      const item = state.views.viewList.items.find((item) => item.id == id);
+      return item?.mutating.includes('title') ?? false;
+    } else {
+      return false;
+    }
   }
 
   renameItem(type: 'folder' | 'view', id: number, title: string) {

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -15,11 +15,13 @@ type ViewBrowserBackItem = {
 export type ViewBrowserItem = ViewTreeItem | ViewBrowserBackItem;
 
 export default class ViewBrowserModel extends ModelBase {
+  private _env: Environment;
   private _orgId: number;
   private _repo: ViewsRepo;
 
   constructor(env: Environment, orgId: number) {
     super();
+    this._env = env;
     this._orgId = orgId;
     this._repo = new ViewsRepo(env);
   }
@@ -79,6 +81,14 @@ export default class ViewBrowserModel extends ModelBase {
     return new ResolvedFuture(
       items.concat(itemsFuture.data.filter((item) => item.folderId == folderId))
     );
+  }
+
+  itemIsRenaming(type: 'folder' | 'view', id: number): boolean {
+    const state = this._env.store.getState();
+    const item = state.views.treeList.items.find(
+      (item) => item.data?.type == type && item.data?.data.id == id
+    );
+    return item?.mutating.includes('title') ?? false;
   }
 
   renameItem(type: 'folder' | 'view', id: number, title: string) {

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -84,6 +84,8 @@ export default class ViewBrowserModel extends ModelBase {
   renameItem(type: 'folder' | 'view', id: number, title: string) {
     if (type == 'folder') {
       this._repo.updateFolder(this._orgId, id, { title });
+    } else if (type == 'view') {
+      this._repo.updateView(this._orgId, id, { title });
     }
   }
 }

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -3,9 +3,16 @@ import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import { ViewTreeItem } from 'pages/api/views/tree';
-import { ZetkinViewFolder } from '../components/types';
-import { folderUpdate, folderUpdated, treeLoad, treeLoadded } from '../store';
+import {
+  folderUpdate,
+  folderUpdated,
+  treeLoad,
+  treeLoadded,
+  viewUpdate,
+  viewUpdated,
+} from '../store';
 import { IFuture, PromiseFuture, RemoteListFuture } from 'core/caching/futures';
+import { ZetkinView, ZetkinViewFolder } from '../components/types';
 
 export default class ViewsRepo {
   private _apiClient: IApiClient;
@@ -47,6 +54,23 @@ export default class ViewsRepo {
       .then((folder) => {
         this._store.dispatch(folderUpdated([folder, mutating]));
         return folder;
+      });
+
+    return new PromiseFuture(promise);
+  }
+
+  updateView(
+    orgId: number,
+    viewId: number,
+    data: Partial<Omit<ZetkinView, 'id'>>
+  ): IFuture<ZetkinView> {
+    const mutating = Object.keys(data);
+    this._store.dispatch(viewUpdate([viewId, mutating]));
+    const promise = this._apiClient
+      .patch<ZetkinView>(`/api/orgs/${orgId}/people/views/${viewId}`, data)
+      .then((view) => {
+        this._store.dispatch(viewUpdated([view, mutating]));
+        return view;
       });
 
     return new PromiseFuture(promise);

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -3,8 +3,9 @@ import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import { ViewTreeItem } from 'pages/api/views/tree';
+import { ZetkinViewFolder } from '../components/types';
+import { folderUpdate, folderUpdated, treeLoad, treeLoadded } from '../store';
 import { IFuture, PromiseFuture, RemoteListFuture } from 'core/caching/futures';
-import { treeLoad, treeLoadded } from '../store';
 
 export default class ViewsRepo {
   private _apiClient: IApiClient;
@@ -29,5 +30,25 @@ export default class ViewsRepo {
     } else {
       return new RemoteListFuture(state.views.treeList);
     }
+  }
+
+  updateFolder(
+    orgId: number,
+    folderId: number,
+    data: Partial<Omit<ZetkinViewFolder, 'id'>>
+  ): IFuture<ZetkinViewFolder> {
+    const mutating = Object.keys(data);
+    this._store.dispatch(folderUpdate([folderId, mutating]));
+    const promise = this._apiClient
+      .patch<ZetkinViewFolder>(
+        `/api/orgs/${orgId}/people/view_folders/${folderId}`,
+        data
+      )
+      .then((folder) => {
+        this._store.dispatch(folderUpdated([folder, mutating]));
+        return folder;
+      });
+
+    return new PromiseFuture(promise);
   }
 }

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -51,9 +51,38 @@ const viewsSlice = createSlice({
       state.treeList = remoteList(action.payload);
       state.treeList.loaded = new Date().toISOString();
     },
+    viewUpdate: (state, action: PayloadAction<[number, string[]]>) => {
+      const [id, mutating] = action.payload;
+      const item = state.treeList.items.find(
+        (item) => item.data?.type == 'view' && item.data?.data.id == id
+      );
+      if (item) {
+        item.mutating = mutating;
+      }
+    },
+    viewUpdated: (state, action: PayloadAction<[ZetkinView, string[]]>) => {
+      const [folder, mutating] = action.payload;
+      const item = state.treeList.items.find(
+        (item) => item.data?.type == 'view' && item.data?.data.id == folder.id
+      );
+      if (item) {
+        item.mutating = item.mutating.filter(
+          (attr) => !mutating.includes(attr)
+        );
+        if (item.data) {
+          item.data.title = folder.title;
+        }
+      }
+    },
   },
 });
 
 export default viewsSlice;
-export const { folderUpdate, folderUpdated, treeLoad, treeLoadded } =
-  viewsSlice.actions;
+export const {
+  folderUpdate,
+  folderUpdated,
+  viewUpdate,
+  viewUpdated,
+  treeLoad,
+  treeLoadded,
+} = viewsSlice.actions;

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -1,8 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { ViewTreeItem } from 'pages/api/views/tree';
-import { ZetkinView } from './components/types';
 import { remoteList, RemoteList } from 'utils/storeUtils';
+import { ZetkinView, ZetkinViewFolder } from './components/types';
 
 export interface ViewsStoreSlice {
   treeList: RemoteList<ViewTreeItem>;
@@ -18,6 +18,32 @@ const viewsSlice = createSlice({
   initialState,
   name: 'views',
   reducers: {
+    folderUpdate: (state, action: PayloadAction<[number, string[]]>) => {
+      const [id, mutating] = action.payload;
+      const item = state.treeList.items.find(
+        (item) => item.data?.type == 'folder' && item.data?.data.id == id
+      );
+      if (item) {
+        item.mutating = mutating;
+      }
+    },
+    folderUpdated: (
+      state,
+      action: PayloadAction<[ZetkinViewFolder, string[]]>
+    ) => {
+      const [folder, mutating] = action.payload;
+      const item = state.treeList.items.find(
+        (item) => item.data?.type == 'folder' && item.data?.data.id == folder.id
+      );
+      if (item) {
+        item.mutating = item.mutating.filter(
+          (attr) => !mutating.includes(attr)
+        );
+        if (item.data) {
+          item.data.title = folder.title;
+        }
+      }
+    },
     treeLoad: (state) => {
       state.treeList.isLoading = true;
     },
@@ -29,4 +55,5 @@ const viewsSlice = createSlice({
 });
 
 export default viewsSlice;
-export const { treeLoad, treeLoadded } = viewsSlice.actions;
+export const { folderUpdate, folderUpdated, treeLoad, treeLoadded } =
+  viewsSlice.actions;

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -1,6 +1,8 @@
 browser:
   backToFolder: 'Back to {folder}'
   backToRoot: Back to all views
+  menu:
+    rename: Rename
 createViewButton:
   errorDialog:
     content: Sorry, we're having trouble creating that view.

--- a/src/pages/api/views/tree.ts
+++ b/src/pages/api/views/tree.ts
@@ -1,5 +1,6 @@
-import { createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinView, ZetkinViewFolder } from 'features/views/components/types';
 
 export type ViewTreeData = {
@@ -11,17 +12,17 @@ export default async function handle(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
-  const apiFetch = createApiFetch(req.headers);
   const { orgId } = req.query;
 
-  try {
-    const viewsRes = await apiFetch(`/orgs/${orgId}/people/views`);
-    const viewsData = await viewsRes.json();
-    const views = viewsData.data as ZetkinView[];
+  const client = new BackendApiClient(req.headers);
 
-    const foldersRes = await apiFetch(`/orgs/${orgId}/people/view_folders`);
-    const foldersData = await foldersRes.json();
-    const folders = foldersData.data as ZetkinViewFolder[];
+  try {
+    const views = await client.get<ZetkinView[]>(
+      `/api/orgs/${orgId}/people/views`
+    );
+    const folders = await client.get<ZetkinViewFolder[]>(
+      `/api/orgs/${orgId}/people/view_folders`
+    );
 
     const output: ViewTreeData = {
       folders,

--- a/src/pages/api/views/tree.ts
+++ b/src/pages/api/views/tree.ts
@@ -2,25 +2,10 @@ import { createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { ZetkinView, ZetkinViewFolder } from 'features/views/components/types';
 
-export interface ViewTreeFolder {
-  id: number | string;
-  type: 'folder';
-  title: string;
-  owner: string;
-  data: ZetkinViewFolder;
-  folderId: number | null;
-}
-
-export interface ViewTreeView {
-  id: number | string;
-  type: 'view';
-  title: string;
-  owner: string;
-  data: ZetkinView;
-  folderId: number | null;
-}
-
-export type ViewTreeItem = ViewTreeFolder | ViewTreeView;
+export type ViewTreeData = {
+  folders: ZetkinViewFolder[];
+  views: ZetkinView[];
+};
 
 export default async function handle(
   req: NextApiRequest,
@@ -38,29 +23,12 @@ export default async function handle(
     const foldersData = await foldersRes.json();
     const folders = foldersData.data as ZetkinViewFolder[];
 
-    const outputFolders = folders.map<ViewTreeFolder>((folder) => ({
-      data: folder,
-      folderId: folder.parent ? folder.parent.id : null,
-      id: 'folders/' + folder.id,
-      owner: '',
-      title: folder.title,
-      type: 'folder',
-    }));
+    const output: ViewTreeData = {
+      folders,
+      views,
+    };
 
-    const outputViews = views.map<ViewTreeView>((view) => ({
-      data: view,
-      folderId: view.folder ? view.folder.id : null,
-      id: 'views/' + view.id,
-      owner: view.owner.name,
-      title: view.title,
-      type: 'view',
-    }));
-
-    const output: ViewTreeItem[] = [...outputFolders, ...outputViews];
-
-    res.status(200).json({
-      data: output,
-    });
+    res.status(200).json({ data: output });
   } catch (err) {
     res.status(500).end();
   }

--- a/src/utils/apiFetch.ts
+++ b/src/utils/apiFetch.ts
@@ -3,12 +3,15 @@ import { stringToBool } from './stringUtils';
 
 export type ApiFetch = (path: string, init?: RequestInit) => Promise<Response>;
 
-export const createApiFetch = (headers: IncomingHttpHeaders): ApiFetch => {
+export const createApiFetch = (
+  headers: IncomingHttpHeaders,
+  prefix = 'api'
+): ApiFetch => {
   return (path, init) => {
     const protocol = stringToBool(process.env.ZETKIN_USE_TLS)
       ? 'https'
       : 'http';
-    const apiUrl = `${protocol}://${process.env.ZETKIN_APP_HOST}/api${path}`;
+    const apiUrl = `${protocol}://${process.env.ZETKIN_APP_HOST}/${prefix}${path}`;
     return fetch(apiUrl, {
       ...init,
       headers: {


### PR DESCRIPTION
## Description
This PR adds ability to rename a folder or view.

## Screenshots
### Ellipsis menu
![image](https://user-images.githubusercontent.com/550212/212391211-bd1e215b-c94e-4ebf-be0e-39a933e2e085.png)

### Editing
![image](https://user-images.githubusercontent.com/550212/212391266-9764940e-0e45-4a8c-817f-18695f1ba785.png)

### Saving
![image](https://user-images.githubusercontent.com/550212/212391324-42cc70ac-a0d9-4a6e-996c-056a7a08d049.png)

## Changes
* Adds repo, store and model logic for updating views and folders
* Adds a new `BackendApiClient` classes and rewrites recent custom API endpoints to use it
* Configures DataGrid to allow editing of title cells (except for "back" row)
* Adds ellipsis menu to trigger edit mode in title cell
* Adds loading indicator to title while renaming

## Notes to reviewer
Requires the most up to date API, which is not yet deployed on the dev server.

## Related issues
Resolves #900 
