### PR TITLE
Issue 877/view column categorization

### DIFF
--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -4,6 +4,8 @@ import { FunctionComponent, useRef } from 'react';
 
 import categories from './categories';
 import ColumnChoiceCard from './ColumnChoiceCard';
+import { Theme, useMediaQuery } from '@mui/material';
+
 import { ZetkinViewColumn } from 'features/views/components/types';
 import choices, { ColumnChoice } from './choices';
 
@@ -19,6 +21,9 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
   onConfigure,
 }) => {
   const intl = useIntl();
+  const isMobile = useMediaQuery((theme: Theme) =>
+    theme.breakpoints.down('sm')
+  );
 
   const categoriesRef = useRef<HTMLDivElement>();
 
@@ -26,7 +31,7 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
     <Box display="flex" height="100%">
       <Box
         alignItems="center"
-        display="flex"
+        display={isMobile ? 'none' : 'flex'}
         flexDirection="column"
         justifyContent="space-between"
         sx={{

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -1,7 +1,8 @@
-import { FunctionComponent } from 'react';
-import { Grid } from '@mui/material';
 import { useIntl } from 'react-intl';
+import { Box, Grid, List, ListItem, Typography } from '@mui/material';
+import { FunctionComponent, useRef } from 'react';
 
+import categories from './categories';
 import ColumnChoiceCard from './ColumnChoiceCard';
 import { ZetkinViewColumn } from 'features/views/components/types';
 import choices, { ColumnChoice } from './choices';
@@ -18,34 +19,82 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
   onConfigure,
 }) => {
   const intl = useIntl();
+
+  const categoriesRef = useRef<HTMLDivElement>();
+
   return (
-    <Grid container spacing={3}>
-      {choices.map((choice) => {
-        const alreadyInView =
-          choice.alreadyInView && choice.alreadyInView(existingColumns);
-        return (
-          <Grid key={choice.key} item md={4} sm={6}>
-            <ColumnChoiceCard
-              alreadyInView={alreadyInView}
-              cardVisual={choice.renderCardVisual(
-                alreadyInView ? 'gray' : '#234890'
-              )}
-              color={alreadyInView ? 'gray' : '#234890'}
-              description={intl.formatMessage({
-                id: `misc.views.columnDialog.choices.${choice.key}.description`,
+    <Box display="flex" height="100%">
+      <Box
+        alignItems="center"
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
+        sx={{
+          overflowY: 'scroll',
+        }}
+        width="20%"
+      >
+        <List>
+          {categories.map((category, index) => (
+            <ListItem
+              key={index}
+              onClick={() => {
+                if (categoriesRef.current) {
+                  const element = categoriesRef.current.querySelector(
+                    `#category-${index}`
+                  );
+                  element?.scrollIntoView({ behavior: 'smooth' });
+                }
+              }}
+              sx={{ cursor: 'pointer', paddingY: 2 }}
+            >
+              <Typography>{category.title}</Typography>
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+      <Box ref={categoriesRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
+        {categories.map((category, index) => (
+          <Box key={category.title} id={`category-${index}`} padding={2}>
+            <Typography variant="h4">{category.title}</Typography>
+            <Typography variant="h5">{category.description}</Typography>
+            <Grid container paddingTop={2} spacing={3}>
+              {category.choices.map((choiceName) => {
+                const choice = choices.find(
+                  (choice) => choice.key === choiceName
+                );
+                if (!choice) {
+                  return;
+                }
+                const alreadyInView =
+                  choice.alreadyInView && choice.alreadyInView(existingColumns);
+                return (
+                  <Grid key={choice.key} item lg={4} sm={6} xs={12}>
+                    <ColumnChoiceCard
+                      alreadyInView={alreadyInView}
+                      cardVisual={choice.renderCardVisual(
+                        alreadyInView ? 'gray' : '#234890'
+                      )}
+                      color={alreadyInView ? 'gray' : '#234890'}
+                      description={intl.formatMessage({
+                        id: `misc.views.columnDialog.choices.${choice.key}.description`,
+                      })}
+                      onAdd={() => onAdd(choice)}
+                      onConfigure={() => onConfigure(choice)}
+                      showAddButton={!!choice.defaultColumns}
+                      showConfigureButton={!!choice.renderConfigForm}
+                      title={intl.formatMessage({
+                        id: `misc.views.columnDialog.choices.${choice.key}.title`,
+                      })}
+                    />
+                  </Grid>
+                );
               })}
-              onAdd={() => onAdd(choice)}
-              onConfigure={() => onConfigure(choice)}
-              showAddButton={!!choice.defaultColumns}
-              showConfigureButton={!!choice.renderConfigForm}
-              title={intl.formatMessage({
-                id: `misc.views.columnDialog.choices.${choice.key}.title`,
-              })}
-            />
-          </Grid>
-        );
-      })}
-    </Grid>
+            </Grid>
+          </Box>
+        ))}
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -1,6 +1,6 @@
-import { useIntl } from 'react-intl';
 import { Box, Grid, List, ListItem, Typography } from '@mui/material';
 import { FunctionComponent, useRef } from 'react';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import categories from './categories';
 import ColumnChoiceCard from './ColumnChoiceCard';
@@ -53,16 +53,28 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
               }}
               sx={{ cursor: 'pointer', paddingY: 2 }}
             >
-              <Typography>{category.title}</Typography>
+              <Typography>
+                <Msg
+                  id={`misc.views.columnDialog.categories.${category.key}.title`}
+                />
+              </Typography>
             </ListItem>
           ))}
         </List>
       </Box>
       <Box ref={categoriesRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
         {categories.map((category, index) => (
-          <Box key={category.title} id={`category-${index}`} padding={2}>
-            <Typography variant="h4">{category.title}</Typography>
-            <Typography variant="h5">{category.description}</Typography>
+          <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
+            <Typography variant="h4">
+              <Msg
+                id={`misc.views.columnDialog.categories.${category.key}.title`}
+              />
+            </Typography>
+            <Typography variant="h5">
+              <Msg
+                id={`misc.views.columnDialog.categories.${category.key}.description`}
+              />
+            </Typography>
             <Grid container paddingTop={2} spacing={3}>
               {category.choices.map((choiceName) => {
                 const choice = choices.find(

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -25,7 +25,7 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
     theme.breakpoints.down('sm')
   );
 
-  const categoriesRef = useRef<HTMLDivElement>();
+  const choiceContainerRef = useRef<HTMLDivElement>();
 
   return (
     <Box display="flex" height="100%">
@@ -44,8 +44,8 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
             <ListItem
               key={index}
               onClick={() => {
-                if (categoriesRef.current) {
-                  const element = categoriesRef.current.querySelector(
+                if (choiceContainerRef.current) {
+                  const element = choiceContainerRef.current.querySelector(
                     `#category-${index}`
                   );
                   element?.scrollIntoView({ behavior: 'smooth' });
@@ -62,7 +62,7 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
           ))}
         </List>
       </Box>
-      <Box ref={categoriesRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
+      <Box ref={choiceContainerRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
         {categories.map((category, index) => (
           <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
             <Typography variant="h4">

--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -3,8 +3,7 @@ import { CHOICES } from './choices';
 const categories = [
   {
     choices: [CHOICES.FIRST_AND_LAST_NAME, CHOICES.PERSON_FIELDS],
-    description: 'Columns that are useful when organizing people and members.',
-    title: 'Basic Columns',
+    key: 'basic',
   },
 ];
 

--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -1,9 +1,13 @@
 import { CHOICES } from './choices';
 
+const enum CATEGORIES {
+  BASIC = 'basic',
+}
+
 const categories = [
   {
     choices: [CHOICES.FIRST_AND_LAST_NAME, CHOICES.PERSON_FIELDS],
-    key: 'basic',
+    key: CATEGORIES.BASIC,
   },
 ];
 

--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -1,0 +1,11 @@
+import { CHOICES } from './choices';
+
+const categories = [
+  {
+    choices: [CHOICES.FIRST_AND_LAST_NAME, CHOICES.PERSON_FIELDS],
+    description: 'Columns that are useful when organizing people and members.',
+    title: 'Basic Columns',
+  },
+];
+
+export default categories;

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -12,6 +12,11 @@ import {
   ZetkinViewColumn,
 } from '../types';
 
+export enum CHOICES {
+  FIRST_AND_LAST_NAME = 'firstAndLastName',
+  PERSON_FIELDS = 'personFields',
+}
+
 export type ColumnChoice = {
   alreadyInView?: (columns: ZetkinViewColumn[]) => boolean;
   defaultColumns?: (intl: IntlShape) => PendingZetkinViewColumn[];
@@ -26,7 +31,10 @@ export type ColumnChoice = {
 const choices: ColumnChoice[] = [
   {
     alreadyInView: (columns) => {
-      const fieldsToAdd = ['first_name', 'last_name'];
+      const fieldsToAdd = [
+        NATIVE_PERSON_FIELDS.FIRST_NAME,
+        NATIVE_PERSON_FIELDS.LAST_NAME,
+      ];
       return fieldsToAdd.every((fieldName) =>
         columns.some(
           (col) =>
@@ -38,7 +46,7 @@ const choices: ColumnChoice[] = [
     defaultColumns: (intl) => [
       {
         config: {
-          field: 'first_name',
+          field: NATIVE_PERSON_FIELDS.FIRST_NAME,
         },
         title: intl.formatMessage({
           id: 'misc.views.columnDialog.commonHeaders.firstName',
@@ -47,7 +55,7 @@ const choices: ColumnChoice[] = [
       },
       {
         config: {
-          field: 'last_name',
+          field: NATIVE_PERSON_FIELDS.LAST_NAME,
         },
         title: intl.formatMessage({
           id: 'misc.views.columnDialog.commonHeaders.lastName',
@@ -55,7 +63,7 @@ const choices: ColumnChoice[] = [
         type: COLUMN_TYPE.PERSON_FIELD,
       },
     ],
-    key: 'firstAndLastName',
+    key: CHOICES.FIRST_AND_LAST_NAME,
     renderCardVisual: (color: string) => {
       return <DoubleIconCardVisual color={color} icons={[Person, Person]} />;
     },
@@ -70,7 +78,7 @@ const choices: ColumnChoice[] = [
         )
       );
     },
-    key: 'personFields',
+    key: CHOICES.PERSON_FIELDS,
     renderCardVisual: (color: string) => (
       <SingleIconCardVisual color={color} icon={Person} />
     ),

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -1,5 +1,9 @@
 # eslint-disable yml/key-name-casing
 columnDialog:
+  categories:
+    basic:
+      description: Columns that are useful when organizing people and members.
+      title: Basic Columns
   choices:
     firstAndLastName:
       description: First and last name of person


### PR DESCRIPTION
## Description
This PR adds a framework for adding categories to the column choice modal. Each category is represented in a menu on the left hand side, and clicking scrolls the corresponding category into view. 

Note: exact categories and what choices they contain is still TBD

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/212934063-4f6122a4-3662-44dd-9322-a26835ecc25f.png)

## Changes
* Adds the `categories` file, where you can add categories and give them a list of choices.
* Adds a side menu to the `ColumnGallery` with names of all categories (invisible on mobile)

## Related issues
Resolves #877
