### PR TITLE
Moving views and folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "nprogress": "^0.2.0",
     "random-seed": "^0.3.0",
     "react": "^18.2.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.1",
     "react-final-form": "^6.5.9",

--- a/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
@@ -1,0 +1,68 @@
+import { FC } from 'react';
+import { makeStyles } from '@mui/styles';
+import { Box, Paper } from '@mui/material';
+import { useDragLayer, XYCoord } from 'react-dnd';
+
+import BrowserItemIcon from './BrowserItemIcon';
+import { ViewBrowserItem } from 'features/views/models/ViewBrowserModel';
+
+const useStyles = makeStyles({
+  dragLayer: {
+    left: 0,
+    pointerEvens: 'none',
+    position: 'fixed',
+    top: 0,
+    zIndex: 9999,
+  },
+  dragPreview: {
+    backgroundColor: 'white',
+    padding: 10,
+    pointerEvents: 'none',
+    position: 'absolute',
+    whiteSpace: 'nowrap',
+  },
+});
+
+interface CollectedProps {
+  currentOffset: XYCoord | null;
+  isDragging: boolean;
+  item: ViewBrowserItem;
+}
+
+const BrowserDragLayer: FC = () => {
+  const styles = useStyles();
+
+  const dragProps = useDragLayer<CollectedProps, ViewBrowserItem>(
+    (monitor) => ({
+      currentOffset: monitor.getSourceClientOffset(),
+      isDragging: monitor.isDragging(),
+      item: monitor.getItem(),
+    })
+  );
+
+  const { isDragging, item, currentOffset } = dragProps;
+
+  if (isDragging && currentOffset) {
+    return (
+      <Box className={styles.dragLayer}>
+        <Paper
+          className={styles.dragPreview}
+          elevation={5}
+          style={{
+            left: currentOffset.x,
+            top: currentOffset.y,
+          }}
+        >
+          <Box display="flex" gap={2}>
+            <BrowserItemIcon item={item} />
+            {item.title}
+          </Box>
+        </Paper>
+      </Box>
+    );
+  }
+
+  return null;
+};
+
+export default BrowserDragLayer;

--- a/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
@@ -1,12 +1,20 @@
 import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
-import { Box, Paper } from '@mui/material';
-import { useDragLayer, XYCoord } from 'react-dnd';
+import { Box, Paper, Theme } from '@mui/material';
+import { useDragDropManager, useDragLayer, XYCoord } from 'react-dnd';
 
 import BrowserItemIcon from './BrowserItemIcon';
 import { ViewBrowserItem } from 'features/views/models/ViewBrowserModel';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles<Theme, CollectedProps>((theme) => ({
+  '@keyframes dragPreview-in': {
+    '0%': {
+      transform: 'scale(0.3) rotate(0)',
+    },
+    '100%': {
+      transform: 'scale(1.1) rotate(5deg)',
+    },
+  },
   dragLayer: {
     left: 0,
     pointerEvens: 'none',
@@ -15,30 +23,49 @@ const useStyles = makeStyles({
     zIndex: 9999,
   },
   dragPreview: {
+    animation: `$dragPreview-in 400ms ${theme.transitions.easing.easeInOut}`,
     backgroundColor: 'white',
+    boxShadow: (props) =>
+      props.canDrop
+        ? '0 6px 6px rgba(0,0,0,0.2)'
+        : '0 14px 14px rgba(0,0,0,0.2)',
     padding: 10,
     pointerEvents: 'none',
     position: 'absolute',
+    transform: (props) =>
+      props.canDrop ? 'scale(1) rotate(0)' : 'scale(1.1) rotate(5deg)',
+    transition: 'transform 200ms, box-shadow 200ms',
     whiteSpace: 'nowrap',
   },
-});
+}));
 
 interface CollectedProps {
+  canDrop: boolean;
   currentOffset: XYCoord | null;
   isDragging: boolean;
   item: ViewBrowserItem;
 }
 
 const BrowserDragLayer: FC = () => {
-  const styles = useStyles();
+  const mgr = useDragDropManager();
+  const dragProps = useDragLayer<CollectedProps, ViewBrowserItem>((monitor) => {
+    // This is a bit of a hack, because react-dnd does not have a canDrop()
+    // method on the monitor passed to useDragLayer(). Instead, we go into
+    // the internals of react-dnd and check that there are target IDs under
+    // the cursor, and that we can drop onto any of them.
+    const mgrMonitor = mgr.getMonitor();
+    const targetIds = mgrMonitor.getTargetIds();
+    const canDrop = targetIds.some((id) => mgrMonitor.canDropOnTarget(id));
 
-  const dragProps = useDragLayer<CollectedProps, ViewBrowserItem>(
-    (monitor) => ({
+    return {
+      canDrop: canDrop,
       currentOffset: monitor.getSourceClientOffset(),
       isDragging: monitor.isDragging(),
       item: monitor.getItem(),
-    })
-  );
+    };
+  });
+
+  const styles = useStyles(dragProps);
 
   const { isDragging, item, currentOffset } = dragProps;
 
@@ -47,7 +74,6 @@ const BrowserDragLayer: FC = () => {
       <Box className={styles.dragLayer}>
         <Paper
           className={styles.dragPreview}
-          elevation={5}
           style={{
             left: currentOffset.x,
             top: currentOffset.y,

--- a/src/features/views/components/ViewBrowser/BrowserDragableItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserDragableItem.tsx
@@ -1,0 +1,31 @@
+import { Box } from '@mui/material';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import { useDrag } from 'react-dnd';
+import { FC, ReactNode, useEffect } from 'react';
+
+import { ViewBrowserItem } from 'features/views/models/ViewBrowserModel';
+
+interface BrowserDragItemProps {
+  children: ReactNode;
+  item: ViewBrowserItem;
+}
+
+const BrowserDraggableItem: FC<BrowserDragItemProps> = ({ children, item }) => {
+  const [, dragRef, preview] = useDrag({
+    item: item,
+    type: 'ITEM',
+  });
+
+  useEffect(() => {
+    // Use an empty image as drag/drop preview, to hide while dragging.
+    // A nicer preview is rendered by the BrowserDragLayer component.
+    preview(getEmptyImage(), { captureDraggingState: true });
+  }, []);
+  return (
+    <Box ref={dragRef} display="flex" gap={1}>
+      {children}
+    </Box>
+  );
+};
+
+export default BrowserDraggableItem;

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
+import { useDrag } from 'react-dnd';
 import { Box, CircularProgress, Link } from '@mui/material';
 
 import ViewBrowserModel, {
@@ -27,6 +28,11 @@ const useStyles = makeStyles(() => ({
 const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
   const styles = useStyles();
 
+  const [, dragRef] = useDrag({
+    item: item,
+    type: 'ITEM',
+  });
+
   if (item.type == 'back') {
     const subPath = item.folderId ? 'folders/' + item.folderId : '';
 
@@ -46,7 +52,7 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
     );
   } else {
     return (
-      <Box display="flex" gap={1}>
+      <Box ref={dragRef} display="flex" gap={1}>
         <NextLink href={`${basePath}/${item.id}`} passHref>
           <Link className={styles.itemLink}>{item.title}</Link>
         </NextLink>

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { makeStyles } from '@mui/styles';
+import NextLink from 'next/link';
+import { Box, CircularProgress, Link } from '@mui/material';
+
+import ViewBrowserModel, {
+  ViewBrowserItem,
+} from 'features/views/models/ViewBrowserModel';
+
+interface BrowserItemProps {
+  basePath: string;
+  item: ViewBrowserItem;
+  model: ViewBrowserModel;
+}
+
+const useStyles = makeStyles(() => ({
+  itemLink: {
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+    color: 'inherit',
+    textDecoration: 'none',
+  },
+}));
+
+const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
+  const styles = useStyles();
+
+  if (item.type == 'back') {
+    const subPath = item.folderId ? 'folders/' + item.folderId : '';
+
+    return (
+      <NextLink href={`${basePath}/${subPath}`} passHref>
+        <Link className={styles.itemLink}>
+          {item.title ? (
+            <FormattedMessage
+              id="pages.people.views.browser.backToFolder"
+              values={{ folder: <em>{item.title}</em> }}
+            />
+          ) : (
+            <FormattedMessage id="pages.people.views.browser.backToRoot" />
+          )}
+        </Link>
+      </NextLink>
+    );
+  } else {
+    return (
+      <Box display="flex" gap={1}>
+        <NextLink href={`${basePath}/${item.id}`} passHref>
+          <Link className={styles.itemLink}>{item.title}</Link>
+        </NextLink>
+        {model.itemIsRenaming(item.type, item.data.id) && (
+          <CircularProgress size={20} />
+        )}
+      </Box>
+    );
+  }
+};
+
+export default BrowserItem;

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,9 +1,10 @@
 import { FormattedMessage } from 'react-intl';
+import { getEmptyImage } from 'react-dnd-html5-backend';
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { useDrag } from 'react-dnd';
 import { Box, CircularProgress, Link, Theme } from '@mui/material';
-import { FC, useContext } from 'react';
+import { FC, useContext, useEffect } from 'react';
 
 import { BrowserRowContext, BrowserRowDropProps } from './BrowserRow';
 import ViewBrowserModel, {
@@ -31,10 +32,16 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
   const dropProps = useContext(BrowserRowContext);
   const styles = useStyles(dropProps);
 
-  const [, dragRef] = useDrag({
+  const [, dragRef, preview] = useDrag({
     item: item,
     type: 'ITEM',
   });
+
+  useEffect(() => {
+    // Use an empty image as drag/drop preview, to hide while dragging.
+    // A nicer preview is rendered by the BrowserDragLayer component.
+    preview(getEmptyImage(), { captureDraggingState: true });
+  }, []);
 
   if (item.type == 'back') {
     const subPath = item.folderId ? 'folders/' + item.folderId : '';

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,10 +1,11 @@
-import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { useDrag } from 'react-dnd';
-import { Box, CircularProgress, Link } from '@mui/material';
+import { Box, CircularProgress, Link, Theme } from '@mui/material';
+import { FC, useContext } from 'react';
 
+import { BrowserRowContext, BrowserRowDropProps } from './BrowserRow';
 import ViewBrowserModel, {
   ViewBrowserItem,
 } from 'features/views/models/ViewBrowserModel';
@@ -15,18 +16,20 @@ interface BrowserItemProps {
   model: ViewBrowserModel;
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles<Theme, BrowserRowDropProps>({
   itemLink: {
     '&:hover': {
       textDecoration: 'underline',
     },
     color: 'inherit',
+    fontWeight: (props) => (props.active ? 'bold' : 'normal'),
     textDecoration: 'none',
   },
-}));
+});
 
 const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
-  const styles = useStyles();
+  const dropProps = useContext(BrowserRowContext);
+  const styles = useStyles(dropProps);
 
   const [, dragRef] = useDrag({
     item: item,
@@ -35,17 +38,20 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
 
   if (item.type == 'back') {
     const subPath = item.folderId ? 'folders/' + item.folderId : '';
+    const msgPrefix = dropProps.active ? 'moveTo' : 'backTo';
 
     return (
       <NextLink href={`${basePath}/${subPath}`} passHref>
         <Link className={styles.itemLink}>
           {item.title ? (
             <FormattedMessage
-              id="pages.people.views.browser.backToFolder"
+              id={`pages.people.views.browser.${msgPrefix}Folder`}
               values={{ folder: <em>{item.title}</em> }}
             />
           ) : (
-            <FormattedMessage id="pages.people.views.browser.backToRoot" />
+            <FormattedMessage
+              id={`pages.people.views.browser.${msgPrefix}Root`}
+            />
           )}
         </Link>
       </NextLink>

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,11 +1,10 @@
 import { FormattedMessage } from 'react-intl';
-import { getEmptyImage } from 'react-dnd-html5-backend';
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
-import { useDrag } from 'react-dnd';
-import { Box, CircularProgress, Link, Theme } from '@mui/material';
-import { FC, useContext, useEffect } from 'react';
+import { CircularProgress, Link, Theme } from '@mui/material';
+import { FC, useContext } from 'react';
 
+import BrowserDraggableItem from './BrowserDragableItem';
 import { BrowserRowContext, BrowserRowDropProps } from './BrowserRow';
 import ViewBrowserModel, {
   ViewBrowserItem,
@@ -32,17 +31,6 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
   const dropProps = useContext(BrowserRowContext);
   const styles = useStyles(dropProps);
 
-  const [, dragRef, preview] = useDrag({
-    item: item,
-    type: 'ITEM',
-  });
-
-  useEffect(() => {
-    // Use an empty image as drag/drop preview, to hide while dragging.
-    // A nicer preview is rendered by the BrowserDragLayer component.
-    preview(getEmptyImage(), { captureDraggingState: true });
-  }, []);
-
   if (item.type == 'back') {
     const subPath = item.folderId ? 'folders/' + item.folderId : '';
     const msgPrefix = dropProps.active ? 'moveTo' : 'backTo';
@@ -65,14 +53,14 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, model }) => {
     );
   } else {
     return (
-      <Box ref={dragRef} display="flex" gap={1}>
+      <BrowserDraggableItem item={item}>
         <NextLink href={`${basePath}/${item.id}`} passHref>
           <Link className={styles.itemLink}>{item.title}</Link>
         </NextLink>
         {model.itemIsRenaming(item.type, item.data.id) && (
           <CircularProgress size={20} />
         )}
-      </Box>
+      </BrowserDraggableItem>
     );
   }
 };

--- a/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
@@ -1,10 +1,12 @@
-import { FC } from 'react';
 import {
   ArrowBack,
   Folder,
+  FolderOpen,
   InsertDriveFileOutlined,
 } from '@mui/icons-material';
+import { FC, useContext } from 'react';
 
+import { BrowserRowContext } from './BrowserRow';
 import { ViewBrowserItem } from 'features/views/models/ViewBrowserModel';
 
 interface BrowserItemIconProps {
@@ -12,8 +14,9 @@ interface BrowserItemIconProps {
 }
 
 const BrowserItemIcon: FC<BrowserItemIconProps> = ({ item }) => {
+  const dropProps = useContext(BrowserRowContext);
   if (item.type == 'folder') {
-    return <Folder />;
+    return dropProps.active ? <FolderOpen /> : <Folder />;
   } else if (item.type == 'back') {
     return <ArrowBack />;
   } else if (item.type == 'view') {

--- a/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import {
+  ArrowBack,
+  Folder,
+  InsertDriveFileOutlined,
+} from '@mui/icons-material';
+
+import { ViewBrowserItem } from 'features/views/models/ViewBrowserModel';
+
+interface BrowserItemIconProps {
+  item: ViewBrowserItem;
+}
+
+const BrowserItemIcon: FC<BrowserItemIconProps> = ({ item }) => {
+  if (item.type == 'folder') {
+    return <Folder />;
+  } else if (item.type == 'back') {
+    return <ArrowBack />;
+  } else if (item.type == 'view') {
+    return <InsertDriveFileOutlined />;
+  } else {
+    // Will never happen
+    return null;
+  }
+};
+
+export default BrowserItemIcon;

--- a/src/features/views/components/ViewBrowser/BrowserRow.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserRow.tsx
@@ -1,0 +1,55 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import { useDrop } from 'react-dnd';
+import { GridRow, GridRowProps } from '@mui/x-data-grid-pro';
+
+import ViewBrowserModel, {
+  ViewBrowserItem,
+} from 'features/views/models/ViewBrowserModel';
+
+interface BrowserRowProps {
+  item: ViewBrowserItem;
+  model: ViewBrowserModel;
+  rowProps: GridRowProps;
+}
+
+interface CollectedProps {
+  active: boolean;
+}
+
+/**
+ * Row component for MUI X DataGrid, to be used in the ViewBrowser.
+ * Adds support for dropping views/folders onto the row, highlighting
+ * the row when dragging over, etc.
+ */
+const BrowserRow: FC<BrowserRowProps> = ({ item, model, rowProps }) => {
+  const [, dropRef] = useDrop<ViewBrowserItem, unknown, CollectedProps>({
+    accept: 'ITEM',
+    canDrop: (draggedItem) =>
+      draggedItem.type == 'view' || draggedItem.id != item.id,
+    collect: (monitor) => {
+      return {
+        active: monitor.isOver() && monitor.canDrop(),
+      };
+    },
+    drop: (draggedItem) => {
+      if (draggedItem.type == 'folder' || draggedItem.type == 'view') {
+        const parentId = item.type == 'back' ? item.folderId : item.data.id;
+        model.moveItem(draggedItem.type, draggedItem.data.id, parentId);
+      }
+    },
+  });
+
+  if (item.type == 'view') {
+    // No drop target for views
+    return <GridRow {...rowProps} />;
+  }
+
+  return (
+    <Box ref={dropRef}>
+      <GridRow {...rowProps} />
+    </Box>
+  );
+};
+
+export default BrowserRow;

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -9,6 +9,7 @@ import {
 import { FC, useEffect, useState } from 'react';
 import { Theme, useMediaQuery } from '@mui/material';
 
+import BrowserDraggableItem from './BrowserDragableItem';
 import BrowserDragLayer from './BrowserDragLayer';
 import BrowserItem from './BrowserItem';
 import BrowserItemIcon from './BrowserItemIcon';
@@ -65,7 +66,15 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
       filterable: false,
       headerName: '',
       renderCell: (params) => {
-        return <BrowserItemIcon item={params.row} />;
+        if (params.row.type == 'back') {
+          return <BrowserItemIcon item={params.row} />;
+        } else {
+          return (
+            <BrowserDraggableItem item={params.row}>
+              <BrowserItemIcon item={params.row} />
+            </BrowserDraggableItem>
+          );
+        }
       },
       sortable: false,
       width: 40,

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -2,6 +2,7 @@ import { useIntl } from 'react-intl';
 import {
   DataGridPro,
   GridColDef,
+  GridRowProps,
   GridSortModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
@@ -10,6 +11,7 @@ import { Theme, useMediaQuery } from '@mui/material';
 
 import BrowserItem from './BrowserItem';
 import BrowserItemIcon from './BrowserItemIcon';
+import BrowserRow from './BrowserRow';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIPerson from 'zui/ZUIPerson';
@@ -173,6 +175,14 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
             apiRef={gridApiRef}
             autoHeight
             columns={colDefs}
+            components={{
+              Row: (props: GridRowProps) => {
+                const item = props.row as ViewBrowserItem;
+                return (
+                  <BrowserRow item={item} model={model} rowProps={props} />
+                );
+              },
+            }}
             disableSelectionOnClick
             experimentalFeatures={{ newEditingApi: true }}
             hideFooter

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -79,9 +79,13 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
           );
         } else {
           return (
-            <BrowserDraggableItem item={params.row}>
-              <BrowserItemIcon item={params.row} />
-            </BrowserDraggableItem>
+            <NextLink href={`${basePath}/${item.id}`} passHref>
+              <Link color="inherit">
+                <BrowserDraggableItem item={params.row}>
+                  <BrowserItemIcon item={params.row} />
+                </BrowserDraggableItem>
+              </Link>
+            </NextLink>
           );
         }
       },

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -1,17 +1,4 @@
-import { makeStyles } from '@mui/styles';
-import NextLink from 'next/link';
-import {
-  ArrowBack,
-  Folder,
-  InsertDriveFileOutlined,
-} from '@mui/icons-material';
-import {
-  Box,
-  CircularProgress,
-  Link,
-  Theme,
-  useMediaQuery,
-} from '@mui/material';
+import { useIntl } from 'react-intl';
 import {
   DataGridPro,
   GridColDef,
@@ -19,13 +6,17 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FC, useEffect, useState } from 'react';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { Theme, useMediaQuery } from '@mui/material';
 
+import BrowserItem from './BrowserItem';
+import BrowserItemIcon from './BrowserItemIcon';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIPerson from 'zui/ZUIPerson';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
-import ViewBrowserModel, { ViewBrowserItem } from '../models/ViewBrowserModel';
+import ViewBrowserModel, {
+  ViewBrowserItem,
+} from '../../models/ViewBrowserModel';
 
 interface ViewBrowserProps {
   basePath: string;
@@ -41,16 +32,6 @@ function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
   return index0 - index1;
 }
 
-const useStyles = makeStyles(() => ({
-  itemLink: {
-    '&:hover': {
-      textDecoration: 'underline',
-    },
-    color: 'inherit',
-    textDecoration: 'none',
-  },
-}));
-
 const ViewBrowser: FC<ViewBrowserProps> = ({
   basePath,
   folderId = null,
@@ -58,7 +39,6 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
 }) => {
   const intl = useIntl();
   const [sortModel, setSortModel] = useState<GridSortModel>([]);
-  const styles = useStyles();
   const isMobile = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
@@ -82,13 +62,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
       filterable: false,
       headerName: '',
       renderCell: (params) => {
-        if (params.row.type == 'folder') {
-          return <Folder />;
-        } else if (params.row.type == 'back') {
-          return <ArrowBack />;
-        } else if (params.row.type == 'view') {
-          return <InsertDriveFileOutlined />;
-        }
+        return <BrowserItemIcon item={params.row} />;
       },
       sortable: false,
       width: 40,
@@ -102,37 +76,9 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
         id: 'pages.people.views.viewsList.columns.title',
       }),
       renderCell: (params) => {
-        if (params.row.type == 'back') {
-          const subPath = params.row.folderId
-            ? 'folders/' + params.row.folderId
-            : '';
-
-          return (
-            <NextLink href={`${basePath}/${subPath}`} passHref>
-              <Link className={styles.itemLink}>
-                {params.row.title ? (
-                  <FormattedMessage
-                    id="pages.people.views.browser.backToFolder"
-                    values={{ folder: <em>{params.row.title}</em> }}
-                  />
-                ) : (
-                  <FormattedMessage id="pages.people.views.browser.backToRoot" />
-                )}
-              </Link>
-            </NextLink>
-          );
-        } else {
-          return (
-            <Box display="flex" gap={1}>
-              <NextLink href={`${basePath}/${params.row.id}`} passHref>
-                <Link className={styles.itemLink}>{params.row.title}</Link>
-              </NextLink>
-              {model.itemIsRenaming(params.row.type, params.row.data.id) && (
-                <CircularProgress size={20} />
-              )}
-            </Box>
-          );
-        }
+        return (
+          <BrowserItem basePath={basePath} item={params.row} model={model} />
+        );
       },
     },
   ];

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -9,6 +9,7 @@ import {
 import { FC, useEffect, useState } from 'react';
 import { Theme, useMediaQuery } from '@mui/material';
 
+import BrowserDragLayer from './BrowserDragLayer';
 import BrowserItem from './BrowserItem';
 import BrowserItemIcon from './BrowserItemIcon';
 import BrowserRow from './BrowserRow';
@@ -171,33 +172,36 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
         });
 
         return (
-          <DataGridPro
-            apiRef={gridApiRef}
-            autoHeight
-            columns={colDefs}
-            components={{
-              Row: (props: GridRowProps) => {
-                const item = props.row as ViewBrowserItem;
-                return (
-                  <BrowserRow item={item} model={model} rowProps={props} />
-                );
-              },
-            }}
-            disableSelectionOnClick
-            experimentalFeatures={{ newEditingApi: true }}
-            hideFooter
-            isCellEditable={(params) => params.row.type != 'back'}
-            onSortModelChange={(model) => setSortModel(model)}
-            processRowUpdate={(item) => {
-              if (item.type != 'back') {
-                model.renameItem(item.type, item.data.id, item.title);
-              }
-              return item;
-            }}
-            rows={rows}
-            sortingMode="server"
-            sx={{ borderWidth: 0 }}
-          />
+          <>
+            <BrowserDragLayer />
+            <DataGridPro
+              apiRef={gridApiRef}
+              autoHeight
+              columns={colDefs}
+              components={{
+                Row: (props: GridRowProps) => {
+                  const item = props.row as ViewBrowserItem;
+                  return (
+                    <BrowserRow item={item} model={model} rowProps={props} />
+                  );
+                },
+              }}
+              disableSelectionOnClick
+              experimentalFeatures={{ newEditingApi: true }}
+              hideFooter
+              isCellEditable={(params) => params.row.type != 'back'}
+              onSortModelChange={(model) => setSortModel(model)}
+              processRowUpdate={(item) => {
+                if (item.type != 'back') {
+                  model.renameItem(item.type, item.data.id, item.title);
+                }
+                return item;
+              }}
+              rows={rows}
+              sortingMode="server"
+              sx={{ borderWidth: 0 }}
+            />
+          </>
         );
       }}
     </ZUIFuture>

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import { useIntl } from 'react-intl';
 import {
   DataGridPro,
@@ -7,7 +8,7 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FC, useEffect, useState } from 'react';
-import { Theme, useMediaQuery } from '@mui/material';
+import { Link, Theme, useMediaQuery } from '@mui/material';
 
 import BrowserDraggableItem from './BrowserDragableItem';
 import BrowserDragLayer from './BrowserDragLayer';
@@ -66,8 +67,16 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
       filterable: false,
       headerName: '',
       renderCell: (params) => {
-        if (params.row.type == 'back') {
-          return <BrowserItemIcon item={params.row} />;
+        const item = params.row;
+        const subPath = item.folderId ? 'folders/' + item.folderId : '';
+        if (item.type == 'back') {
+          return (
+            <NextLink href={`${basePath}/${subPath}`} passHref>
+              <Link color="inherit">
+                <BrowserItemIcon item={params.row} />
+              </Link>
+            </NextLink>
+          );
         } else {
           return (
             <BrowserDraggableItem item={params.row}>

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -166,6 +166,14 @@ export default class ViewBrowserModel extends ModelBase {
     }
   }
 
+  moveItem(type: 'folder' | 'view', id: number, newParentId: number | null) {
+    if (type == 'folder') {
+      this._repo.updateFolder(this._orgId, id, { parent_id: newParentId });
+    } else if (type == 'view') {
+      this._repo.updateView(this._orgId, id, { folder_id: newParentId });
+    }
+  }
+
   get recentlyCreatedFolder(): ZetkinViewFolder | null {
     const state = this._env.store.getState();
     return state.views.recentlyCreatedFolder;

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -144,7 +144,7 @@ export default class ViewBrowserModel extends ModelBase {
           data: view,
           folderId: folderId,
           id: 'views/' + view.id,
-          owner: '',
+          owner: view.owner.name,
           title: view.title,
           type: 'view',
         });

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -23,6 +23,16 @@ type ZetkinViewFolderPostBody = {
   title: string;
 };
 
+type ZetkinViewUpdateBody = Partial<Omit<ZetkinView, 'id' | 'folder'>> & {
+  folder_id?: number | null;
+};
+
+type ZetkinViewFolderUpdateBody = Partial<
+  Omit<ZetkinViewFolder, 'id' | 'parent'>
+> & {
+  parent_id?: number | null;
+};
+
 export default class ViewsRepo {
   private _apiClient: IApiClient;
   private _store: Store;
@@ -85,7 +95,7 @@ export default class ViewsRepo {
   updateFolder(
     orgId: number,
     folderId: number,
-    data: Partial<Omit<ZetkinViewFolder, 'id'>>
+    data: ZetkinViewFolderUpdateBody
   ): IFuture<ZetkinViewFolder> {
     const mutating = Object.keys(data);
     this._store.dispatch(folderUpdate([folderId, mutating]));
@@ -105,7 +115,7 @@ export default class ViewsRepo {
   updateView(
     orgId: number,
     viewId: number,
-    data: Partial<Omit<ZetkinView, 'id'>>
+    data: ZetkinViewUpdateBody
   ): IFuture<ZetkinView> {
     const mutating = Object.keys(data);
     this._store.dispatch(viewUpdate([viewId, mutating]));

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -64,7 +64,7 @@ const viewsSlice = createSlice({
           (attr) => !mutating.includes(attr)
         );
         if (item.data) {
-          item.data.title = folder.title;
+          item.data = folder;
         }
       }
     },
@@ -95,7 +95,7 @@ const viewsSlice = createSlice({
           (attr) => !mutating.includes(attr)
         );
         if (item.data) {
-          item.data.title = view.title;
+          item.data = view;
         }
       }
     },

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -6,6 +6,8 @@ browser:
   backToRoot: Back to all views
   menu:
     rename: Rename
+  moveToFolder: 'Move to {folder}'
+  moveToRoot: Move to all views
 layout:
   deleteDialog:
     error: There was an error deleting the view

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,8 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { AppProps } from 'next/app';
 import createStore from 'core/store';
 import CssBaseline from '@mui/material/CssBaseline';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Hydrate } from 'react-query/hydration';
 import { IntlProvider } from 'react-intl';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
@@ -105,10 +107,12 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                   <QueryClientProvider client={queryClient}>
                     <ZUISnackbarProvider>
                       <ZUIConfirmDialogProvider>
-                        <Hydrate state={dehydratedState}>
-                          <CssBaseline />
-                          {getLayout(<Component {...restProps} />, restProps)}
-                        </Hydrate>
+                        <DndProvider backend={HTML5Backend}>
+                          <Hydrate state={dehydratedState}>
+                            <CssBaseline />
+                            {getLayout(<Component {...restProps} />, restProps)}
+                          </Hydrate>
+                        </DndProvider>
                       </ZUIConfirmDialogProvider>
                     </ZUISnackbarProvider>
                     <ReactQueryDevtools initialIsOpen={false} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,6 +2761,21 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
 
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
+
 "@react-leaflet/core@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.1.1.tgz#827fd05bb542cf874116176d8ef48d5b12163f81"
@@ -7196,6 +7211,15 @@ direction@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/direction/-/direction-1.0.4.tgz#2b86fb686967e987088caf8b89059370d4837442"
   integrity sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==
+
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -13230,6 +13254,24 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-docgen-typescript@^2.1.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
@@ -13572,7 +13614,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.1.2:
+redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==


### PR DESCRIPTION
## Description
This PR implements drag-and-drop to move views and folders in the view browser. A small preview is shown while dragging, and the folders underneith react when dragging a view/folder over them.

## Screenshots

https://user-images.githubusercontent.com/550212/213091240-c37e0016-7219-4c95-8522-9de9fb6d539d.mov



## Changes
* Refactors `ViewBrowser` to be a component directory with a number of sub-components
* Adds model, repo and store logic for moving browser items into folders
* Implements `react-dnd` for dragging and dropping
* Tweaks the visuals
  * Folders react by switching icon and going **bold** when dragging something over it
  * Dragging something previews it as a little elevated card with icon and title

## Notes to reviewer
There is a bug in the dev version of the Platform API which means it's not possible to move a view or folder into the root, so if you move something into a folder, you can't move it back out again. A fix is coming.

## Related issues
Resolves #902 