### PR TITLE
Issue884/person tag modal choice

### DIFF
--- a/src/features/views/components/ViewColumnDialog/PersonTagConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/PersonTagConfig.tsx
@@ -1,0 +1,45 @@
+import { FormControl } from '@mui/material';
+import TagManager from 'features/tags/components/TagManager';
+import { useState } from 'react';
+import { ZetkinTag } from 'utils/types/zetkin';
+
+import { COLUMN_TYPE, SelectedViewColumn } from '../types';
+
+interface PersonTagConfigProps {
+  onOutputConfigured: (columns: SelectedViewColumn[]) => void;
+}
+
+const PersonTagConfig = ({ onOutputConfigured }: PersonTagConfigProps) => {
+  const [selectedTags, setSelectedTags] = useState<ZetkinTag[]>([]);
+
+  const makeColumns = (tags: ZetkinTag[]) => {
+    return tags.map((tag) => ({
+      config: { tag_id: tag.id },
+      title: tag.title,
+      type: COLUMN_TYPE.PERSON_TAG,
+    }));
+  };
+
+  return (
+    <FormControl sx={{ width: 300 }}>
+      <TagManager
+        assignedTags={selectedTags}
+        groupTags={false}
+        onAssignTag={(tag) => {
+          const newAssignedTags = selectedTags.concat([tag] as ZetkinTag[]);
+          setSelectedTags(newAssignedTags);
+          const columns = makeColumns(newAssignedTags);
+          onOutputConfigured(columns);
+        }}
+        onUnassignTag={(tag) => {
+          const unassignedTags = selectedTags.filter((t) => t.id != tag.id);
+          setSelectedTags(unassignedTags);
+          const columns = makeColumns(unassignedTags);
+          onOutputConfigured(columns);
+        }}
+      />
+    </FormControl>
+  );
+};
+
+export default PersonTagConfig;

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -1,8 +1,9 @@
 import { IntlShape } from 'react-intl';
-import { Person } from '@mui/icons-material';
+import { LocalOffer, Person } from '@mui/icons-material';
 
 import DoubleIconCardVisual from './DoubleIconCardVisual';
 import PersonFieldConfig from './PersonFieldConfig';
+import PersonTagConfig from './PersonTagConfig';
 import SingleIconCardVisual from './SingleIconCardVisual';
 import {
   COLUMN_TYPE,
@@ -83,6 +84,16 @@ const choices: ColumnChoice[] = [
         onOutputConfigured={props.onOutputConfigured}
       />
     ),
+  },
+  {
+    key: 'tag',
+    renderCardVisual: (color: string) => (
+      <SingleIconCardVisual color={color} icon={LocalOffer} />
+    ),
+    renderConfigForm: (props: {
+      existingColumns: ZetkinViewColumn[];
+      onOutputConfigured: (columns: SelectedViewColumn[]) => void;
+    }) => <PersonTagConfig onOutputConfigured={props.onOutputConfigured} />,
   },
 ];
 

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -7,6 +7,9 @@ columnDialog:
     personFields:
       description: Add your choice of fields like email, phone number, etc.
       title: Person fields
+    tag:
+      description: Show a checkmark if the person has this tag
+      title: Tag
   commonHeaders:
     firstName: First Name
     lastName: Last Name


### PR DESCRIPTION
## Description
This PR contains the Tag card choice inside the View Column Modal and handles the addition of tag columns to a view via Tag Manager widget. 

## Screenshots
<img width="1275" alt="1" src="https://user-images.githubusercontent.com/36491300/212991074-833dfb06-3206-4bdb-8a56-f7637087f025.png">

<img width="1234" alt="2" src="https://user-images.githubusercontent.com/36491300/212991098-c5c43e62-7c8f-4a5c-a462-9c9c1d915001.png">

<img width="1224" alt="3" src="https://user-images.githubusercontent.com/36491300/212991124-ca893c1c-2220-4e83-bce8-2cac74d77e47.png">

<img width="1239" alt="4" src="https://user-images.githubusercontent.com/36491300/212991149-7e9a3e04-f33c-4e61-880c-2e2e0030022d.png">

## Changes
* Adds a new `PersonTag` card
* Adds a new `PersonTagConfig` component that handles via `TagManager` the selection of tags to add to the view.

## Notes to reviewer
Next time I'll organise the code in more commits 🙏 
Special thanks to @ziggabyte to guide me with my first issue 🌹 


## Related issues
Resolves #884
