### PR TITLE
View search

### DIFF
--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -13,6 +13,7 @@ test.describe('Search', async () => {
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/actions', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/tasks', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/tasks', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/search/view', 'post', []);
     login();
   });
 

--- a/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
@@ -1,4 +1,5 @@
 import { Event } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
@@ -23,7 +24,10 @@ const CampaignListItem: React.FunctionComponent<{
             <Event />
           </Avatar>
         </ListItemAvatar>
-        <ResultsListItemText primary={campaign.title} secondary="Campaign" />
+        <ResultsListItemText
+          primary={campaign.title}
+          secondary={<FormattedMessage id="misc.search.results.campaign" />}
+        />
       </ListItem>
     </Link>
   );

--- a/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
@@ -1,3 +1,4 @@
+import { FormattedMessage } from 'react-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
@@ -22,7 +23,7 @@ const PersonListItem: React.FunctionComponent<{ person: ZetkinPerson }> = ({
         </ListItemAvatar>
         <ResultsListItemText
           primary={person.first_name + ' ' + person.last_name}
-          secondary={'Person'}
+          secondary={<FormattedMessage id="misc.search.results.person" />}
         />
       </ListItem>
     </Link>

--- a/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { MobileFriendly } from '@mui/icons-material';
+import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
 import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
@@ -9,8 +10,16 @@ import { ZetkinTask } from 'utils/types/zetkin';
 const TaskListItem: React.FunctionComponent<{ task: ZetkinTask }> = ({
   task,
 }) => {
+  const intl = useIntl();
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
+
+  const elements = [
+    intl.formatMessage({ id: 'misc.search.results.task.campaign' }),
+    task.campaign.title,
+    intl.formatMessage({ id: 'misc.search.results.task.task' }),
+  ];
+
   return (
     <Link
       key={task.id}
@@ -25,7 +34,7 @@ const TaskListItem: React.FunctionComponent<{ task: ZetkinTask }> = ({
         </ListItemAvatar>
         <ResultsListItemText
           primary={task.title}
-          secondary={'Campaign / ' + task.campaign.title + ' / Task'}
+          secondary={elements.join(' / ')}
         />
       </ListItem>
     </Link>

--- a/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
@@ -1,0 +1,42 @@
+import { InsertDriveFileOutlined } from '@mui/icons-material';
+import Link from 'next/link';
+import { useIntl } from 'react-intl';
+import { useRouter } from 'next/router';
+import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
+
+import ResultsListItemText from './ResultsListItemText';
+import { ZetkinView } from 'utils/types/zetkin';
+
+const ViewListItem: React.FunctionComponent<{ view: ZetkinView }> = ({
+  view,
+}) => {
+  const intl = useIntl();
+  const router = useRouter();
+  const { orgId } = router.query as { orgId: string };
+
+  const elements = [
+    intl.formatMessage({ id: 'misc.search.results.view.people' }),
+  ];
+  if (view.folder) {
+    elements.push(view.folder.title);
+  }
+  elements.push(intl.formatMessage({ id: 'misc.search.results.view.view' }));
+
+  return (
+    <Link href={`/organize/${orgId}/people/views/${view.id}`} passHref>
+      <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
+        <ListItemAvatar>
+          <Avatar>
+            <InsertDriveFileOutlined />
+          </Avatar>
+        </ListItemAvatar>
+        <ResultsListItemText
+          primary={view.title}
+          secondary={elements.join(' / ')}
+        />
+      </ListItem>
+    </Link>
+  );
+};
+
+export default ViewListItem;

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -7,6 +7,7 @@ import { List, ListItem, ListItemText } from '@mui/material';
 import CampaignListItem from './CampaignListItem';
 import PersonListItem from './PersonListItem';
 import TaskListItem from './TaskListItem';
+import ViewListItem from './ViewListItem';
 import {
   SEARCH_DATA_TYPE,
   SearchResult,
@@ -41,6 +42,9 @@ const ResultsList: FunctionComponent<ResultsListProps> = ({
             }
             if (result.type === SEARCH_DATA_TYPE.TASK) {
               return <TaskListItem task={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.VIEW) {
+              return <ViewListItem view={result.match} />;
             }
           })}
         </>

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/display-name */
 import { FunctionComponent } from 'react';
 import { FormattedMessage as Msg } from 'react-intl';
 

--- a/src/features/search/components/types.ts
+++ b/src/features/search/components/types.ts
@@ -1,9 +1,15 @@
-import { ZetkinCampaign, ZetkinPerson, ZetkinTask } from 'utils/types/zetkin';
+import {
+  ZetkinCampaign,
+  ZetkinPerson,
+  ZetkinTask,
+  ZetkinView,
+} from 'utils/types/zetkin';
 
 export enum SEARCH_DATA_TYPE {
   PERSON = 'person',
   CAMPAIGN = 'campaign',
   TASK = 'task',
+  VIEW = 'view',
 }
 
 export interface PersonSearchResult {
@@ -18,8 +24,13 @@ export interface TaskSearchResult {
   type: SEARCH_DATA_TYPE.TASK;
   match: ZetkinTask;
 }
+export interface ViewSearchResult {
+  type: SEARCH_DATA_TYPE.VIEW;
+  match: ZetkinView;
+}
 
 export type SearchResult =
   | PersonSearchResult
   | CampaignSearchResult
-  | TaskSearchResult;
+  | TaskSearchResult
+  | ViewSearchResult;

--- a/src/locale/misc/search/en.yml
+++ b/src/locale/misc/search/en.yml
@@ -1,4 +1,9 @@
 results:
+  campaign: Campaign
+  person: Person
+  task:
+    campaign: Campaign
+    task: Task
   view:
     people: People
     view: View

--- a/src/locale/misc/search/en.yml
+++ b/src/locale/misc/search/en.yml
@@ -1,0 +1,4 @@
+results:
+  view:
+    people: People
+    view: View

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -51,6 +51,7 @@ const search = async (
       makeSearchRequest(SEARCH_DATA_TYPE.PERSON, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.CAMPAIGN, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.TASK, query, apiFetch),
+      makeSearchRequest(SEARCH_DATA_TYPE.VIEW, query, apiFetch),
     ]);
 
     const searchResults = results.flat();

--- a/src/utils/api/makeSearchRequest.ts
+++ b/src/utils/api/makeSearchRequest.ts
@@ -5,8 +5,17 @@ import {
   PersonSearchResult,
   SEARCH_DATA_TYPE,
   TaskSearchResult,
+  ViewSearchResult,
 } from 'features/search/components/types';
 
+async function makeSearchRequest(
+  dataType: SEARCH_DATA_TYPE.VIEW,
+  query: {
+    orgId: number | string;
+    q: string;
+  },
+  apiFetch: ApiFetch
+): Promise<ViewSearchResult[]>;
 async function makeSearchRequest(
   dataType: SEARCH_DATA_TYPE.TASK,
   query: {


### PR DESCRIPTION
## Description
This PR adds support for searching for views. The listing displays the name of the view, and the name of the folder where it lives.

## Screenshots
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/550212/213009463-b303a9a5-422a-4232-aef1-b2bd24f144f3.png">


## Changes
* Adds logic to search for views alongside other content types
* Removes an eslint exception comment that didn't seem to be necessary
* Internationalizes a bunch of strings that were previously left hard-coded in the search dialog

## Notes to reviewer
I found a bug in the platform API causing views not to be indexed when creating or renaming them, so if you try to search for a view, you may not find anything. Will fix that bug elsewhere.

## Related issues
Resolves #904 