### PR TITLE
Add subtitle with basic numbers to view page

### DIFF
--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -1,12 +1,14 @@
 import makeStyles from '@mui/styles/makeStyles';
-import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
 import { Box, Theme } from '@mui/material';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { FunctionComponent, useContext, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import defaultFetch from 'utils/fetching/defaultFetch';
 import getView from 'features/views/fetching/getView';
+import getViewColumns from '../fetching/getViewColumns';
+import getViewRows from '../fetching/getViewRows';
 import NProgress from 'nprogress';
 import patchView from 'features/views/fetching/patchView';
 import TabbedLayout from 'utils/layout/TabbedLayout';
@@ -16,8 +18,10 @@ import { viewsResource } from 'features/views/api/views';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
+import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUIQuery from 'zui/ZUIQuery';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+import { Group, ViewColumnOutlined } from '@mui/icons-material';
 
 const useStyles = makeStyles<Theme, { deactivated: boolean }>(() => ({
   deactivateWrapper: {
@@ -190,6 +194,46 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
         defaultTab="/"
         ellipsisMenuItems={ellipsisMenu}
         fixedHeight={true}
+        subtitle={
+          // TODO: Replace with model eventually
+          <ZUIQuery
+            queries={{
+              colsQuery: useQuery(
+                ['view', viewId, 'columns'],
+                getViewColumns(orgId as string, viewId as string)
+              ),
+              rowsQuery: useQuery(
+                ['view', viewId, 'rows'],
+                getViewRows(orgId as string, viewId as string)
+              ),
+            }}
+          >
+            {({ queries: { colsQuery, rowsQuery } }) => (
+              <ZUIIconLabelRow
+                iconLabels={[
+                  {
+                    icon: <Group />,
+                    label: (
+                      <FormattedMessage
+                        id="pages.people.views.layout.subtitle.people"
+                        values={{ count: rowsQuery.data.length }}
+                      />
+                    ),
+                  },
+                  {
+                    icon: <ViewColumnOutlined />,
+                    label: (
+                      <FormattedMessage
+                        id="pages.people.views.layout.subtitle.columns"
+                        values={{ count: colsQuery.data.length }}
+                      />
+                    ),
+                  },
+                ]}
+              />
+            )}
+          </ZUIQuery>
+        }
         tabs={[{ href: `/`, messageId: 'layout.organize.view.tabs.view' }]}
         title={title}
       >

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -18,6 +18,9 @@ layout:
     makeStatic: Convert to static view
   jumpMenu:
     placeholder: Start typing to find view
+  subtitle:
+    columns: '{count, plural, =0 {No columns} =1 {1 column} other {# columns}}'
+    people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 viewsList:
   columns:
     created: Date created

--- a/src/zui/ZUIIconLabel.tsx
+++ b/src/zui/ZUIIconLabel.tsx
@@ -3,7 +3,7 @@ import { Box, Typography } from '@mui/material';
 
 export interface ZUIIconLabelProps {
   icon: JSX.Element;
-  label: string;
+  label: string | JSX.Element;
 }
 
 const ZUIIconLabel: FC<ZUIIconLabelProps> = ({ icon, label }) => {


### PR DESCRIPTION
## Description
This PR adds a subtitle to view pages, which shows the number of rows and columns.

## Screenshots
<img width="1501" alt="image" src="https://user-images.githubusercontent.com/550212/213014542-8bced95d-ce2d-4ae0-92da-fefcafaaf5f6.png">

## Changes
* Adds a subtitle to view pages with row and column count

## Notes to reviewer
Note that the issue (#905) calls for a label to indicate number of hidden columns, but we do not support hiding columns at this point, so I have not implemented that requirement.

## Related issues
Resolves #905 