### PR TITLE
Issue 876/view column search

### DIFF
--- a/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
@@ -1,5 +1,5 @@
-import { ChevronLeft } from '@mui/icons-material';
 import { Box, Button, Link, Typography } from '@mui/material';
+import { ChevronLeft, Close } from '@mui/icons-material';
 import { FunctionComponent, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
@@ -11,6 +11,7 @@ interface ColumnEditorProps {
   existingColumns: ZetkinViewColumn[];
   color: string;
   onCancel: () => void;
+  onClose: () => void;
   onSave: (columns: SelectedViewColumn[]) => Promise<void>;
 }
 
@@ -19,6 +20,7 @@ const ColumnEditor: FunctionComponent<ColumnEditorProps> = ({
   color,
   existingColumns,
   onCancel,
+  onClose,
   onSave,
 }) => {
   const intl = useIntl();
@@ -31,23 +33,43 @@ const ColumnEditor: FunctionComponent<ColumnEditorProps> = ({
   return (
     <Box display="flex" flexDirection="column" height="100%">
       <Box bgcolor={color} display="flex" flexDirection="column" padding={2}>
-        <Box alignSelf="flex-start" display="flex" sx={{ cursor: 'pointer' }}>
-          <Link
-            component="div"
-            onClick={() => onCancel()}
-            sx={{
-              color: 'white',
-              cursor: 'pointer',
-              display: 'flex',
-              fontFamily: 'inherit',
-              justifyContent: 'center',
-            }}
-            underline="none"
-            variant="h5"
+        <Box display="flex">
+          <Box
+            alignSelf="flex-start"
+            display="flex"
+            sx={{ cursor: 'pointer' }}
+            width="100%"
           >
-            <ChevronLeft sx={{ color: 'white' }} />
-            <Msg id="misc.views.columnDialog.editor.buttonLabels.change" />
-          </Link>
+            <Link
+              component="div"
+              onClick={() => onCancel()}
+              sx={{
+                color: 'white',
+                cursor: 'pointer',
+                display: 'flex',
+                fontFamily: 'inherit',
+                justifyContent: 'center',
+              }}
+              underline="none"
+              variant="h5"
+            >
+              <ChevronLeft sx={{ color: 'white' }} />
+              <Msg id="misc.views.columnDialog.editor.buttonLabels.change" />
+            </Link>
+          </Box>
+          <Box alignSelf="flex-end" display="flex" sx={{ cursor: 'pointer' }}>
+            <Close
+              fontSize="medium"
+              onClick={() => onClose()}
+              sx={{
+                color: 'white',
+                cursor: 'pointer',
+                display: 'flex',
+                fontFamily: 'inherit',
+                justifyContent: 'center',
+              }}
+            />
+          </Box>
         </Box>
 
         <Box alignSelf="center" display="flex" flexDirection="column">

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -1,5 +1,14 @@
-import { Box, Grid, List, ListItem, Typography } from '@mui/material';
-import { FunctionComponent, useRef } from 'react';
+import Fuse from 'fuse.js';
+import {
+  Box,
+  Grid,
+  List,
+  ListItem,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Close, Search } from '@mui/icons-material';
+import { FunctionComponent, useRef, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import categories from './categories';
@@ -25,91 +34,152 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
     theme.breakpoints.down('sm')
   );
 
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchString, setSearchString] = useState('');
+  const [searchResults, setSearchResults] = useState<ColumnChoice[]>([]);
+
+  const search = () => {
+    const fuse = new Fuse(choices, {
+      keys: ['keywords'],
+      threshold: 0.4,
+    });
+
+    const results = fuse
+      .search(searchString)
+      .map((fuseResult) => fuseResult.item);
+    setSearchResults(results);
+  };
+
   const choiceContainerRef = useRef<HTMLDivElement>();
 
   return (
-    <Box display="flex" height="100%">
-      <Box
-        alignItems="center"
-        display={isMobile ? 'none' : 'flex'}
-        flexDirection="column"
-        justifyContent="space-between"
-        sx={{
-          overflowY: 'scroll',
-        }}
-        width="20%"
-      >
-        <List>
+    <Box display="flex" flexDirection="column" height="100%">
+      <Box display="flex" justifyContent="space-between" padding={2}>
+        <Typography variant="h4">Columns</Typography>
+        <Box alignItems="center" display="flex">
+          <TextField
+            InputProps={{ endAdornment: <Search color="secondary" /> }}
+            onChange={(evt) => {
+              setSearchString(evt.target.value);
+              if (evt.target.value === '') {
+                setIsSearching(false);
+                return;
+              }
+              setIsSearching(true);
+              search();
+            }}
+            placeholder="Find a column"
+            sx={{ paddingRight: 2 }}
+            value={searchString}
+            variant="outlined"
+          />
+          <Close color="secondary" fontSize="medium" />
+        </Box>
+      </Box>
+      <Box display="flex" height="100%">
+        <Box
+          alignItems="center"
+          display={isMobile ? 'none' : 'flex'}
+          flexDirection="column"
+          justifyContent="space-between"
+          sx={{
+            overflowY: 'scroll',
+          }}
+          width="20%"
+        >
+          <List>
+            {categories.map((category, index) => (
+              <ListItem
+                key={index}
+                onClick={() => {
+                  setSearchString('');
+                  setIsSearching(false);
+                  if (choiceContainerRef.current) {
+                    const element = choiceContainerRef.current.querySelector(
+                      `#category-${index}`
+                    );
+                    element?.scrollIntoView({ behavior: 'smooth' });
+                  }
+                }}
+                sx={{ cursor: 'pointer', paddingY: 2 }}
+              >
+                <Typography>
+                  <Msg
+                    id={`misc.views.columnDialog.categories.${category.key}.title`}
+                  />
+                </Typography>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+        <Box ref={choiceContainerRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
+          {isSearching && (
+            <Box padding={2}>
+              <Typography variant="h4">{`Results for "${searchString}"`}</Typography>
+              <Box>
+                {searchResults.length > 0 ? (
+                  searchResults.map((searchResult) => (
+                    <Typography key={searchResult.key}>
+                      <Msg
+                        id={`misc.views.columnDialog.choices.${searchResult.key}.title`}
+                      />
+                    </Typography>
+                  ))
+                ) : (
+                  <Typography>{`There are no column choices that match "${searchString}"`}</Typography>
+                )}
+              </Box>
+            </Box>
+          )}
           {categories.map((category, index) => (
-            <ListItem
-              key={index}
-              onClick={() => {
-                if (choiceContainerRef.current) {
-                  const element = choiceContainerRef.current.querySelector(
-                    `#category-${index}`
-                  );
-                  element?.scrollIntoView({ behavior: 'smooth' });
-                }
-              }}
-              sx={{ cursor: 'pointer', paddingY: 2 }}
-            >
-              <Typography>
+            <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
+              <Typography variant="h4">
                 <Msg
                   id={`misc.views.columnDialog.categories.${category.key}.title`}
                 />
               </Typography>
-            </ListItem>
+              <Typography variant="h5">
+                <Msg
+                  id={`misc.views.columnDialog.categories.${category.key}.description`}
+                />
+              </Typography>
+              <Grid container paddingTop={2} spacing={3}>
+                {category.choices.map((choiceName) => {
+                  const choice = choices.find(
+                    (choice) => choice.key === choiceName
+                  );
+                  if (!choice) {
+                    return;
+                  }
+                  const alreadyInView =
+                    choice.alreadyInView &&
+                    choice.alreadyInView(existingColumns);
+                  return (
+                    <Grid key={choice.key} item lg={4} sm={6} xs={12}>
+                      <ColumnChoiceCard
+                        alreadyInView={alreadyInView}
+                        cardVisual={choice.renderCardVisual(
+                          alreadyInView ? 'gray' : '#234890'
+                        )}
+                        color={alreadyInView ? 'gray' : '#234890'}
+                        description={intl.formatMessage({
+                          id: `misc.views.columnDialog.choices.${choice.key}.description`,
+                        })}
+                        onAdd={() => onAdd(choice)}
+                        onConfigure={() => onConfigure(choice)}
+                        showAddButton={!!choice.defaultColumns}
+                        showConfigureButton={!!choice.renderConfigForm}
+                        title={intl.formatMessage({
+                          id: `misc.views.columnDialog.choices.${choice.key}.title`,
+                        })}
+                      />
+                    </Grid>
+                  );
+                })}
+              </Grid>
+            </Box>
           ))}
-        </List>
-      </Box>
-      <Box ref={choiceContainerRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
-        {categories.map((category, index) => (
-          <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
-            <Typography variant="h4">
-              <Msg
-                id={`misc.views.columnDialog.categories.${category.key}.title`}
-              />
-            </Typography>
-            <Typography variant="h5">
-              <Msg
-                id={`misc.views.columnDialog.categories.${category.key}.description`}
-              />
-            </Typography>
-            <Grid container paddingTop={2} spacing={3}>
-              {category.choices.map((choiceName) => {
-                const choice = choices.find(
-                  (choice) => choice.key === choiceName
-                );
-                if (!choice) {
-                  return;
-                }
-                const alreadyInView =
-                  choice.alreadyInView && choice.alreadyInView(existingColumns);
-                return (
-                  <Grid key={choice.key} item lg={4} sm={6} xs={12}>
-                    <ColumnChoiceCard
-                      alreadyInView={alreadyInView}
-                      cardVisual={choice.renderCardVisual(
-                        alreadyInView ? 'gray' : '#234890'
-                      )}
-                      color={alreadyInView ? 'gray' : '#234890'}
-                      description={intl.formatMessage({
-                        id: `misc.views.columnDialog.choices.${choice.key}.description`,
-                      })}
-                      onAdd={() => onAdd(choice)}
-                      onConfigure={() => onConfigure(choice)}
-                      showAddButton={!!choice.defaultColumns}
-                      showConfigureButton={!!choice.renderConfigForm}
-                      title={intl.formatMessage({
-                        id: `misc.views.columnDialog.choices.${choice.key}.title`,
-                      })}
-                    />
-                  </Grid>
-                );
-              })}
-            </Grid>
-          </Box>
-        ))}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -21,12 +21,14 @@ import choices, { ColumnChoice } from './choices';
 interface ColumnGalleryProps {
   existingColumns: ZetkinViewColumn[];
   onAdd: (choice: ColumnChoice) => void;
+  onCancel: () => void;
   onConfigure: (choice: ColumnChoice) => void;
 }
 
 const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
   existingColumns,
   onAdd,
+  onCancel,
   onConfigure,
 }) => {
   const intl = useIntl();
@@ -58,7 +60,9 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
         <Typography variant="h4">Columns</Typography>
         <Box alignItems="center" display="flex">
           <TextField
-            InputProps={{ endAdornment: <Search color="secondary" /> }}
+            InputProps={{
+              endAdornment: <Search color="secondary" />,
+            }}
             onChange={(evt) => {
               setSearchString(evt.target.value);
               if (evt.target.value === '') {
@@ -73,7 +77,12 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
             value={searchString}
             variant="outlined"
           />
-          <Close color="secondary" fontSize="medium" />
+          <Close
+            color="secondary"
+            fontSize="medium"
+            onClick={() => onCancel()}
+            sx={{ cursor: 'pointer' }}
+          />
         </Box>
       </Box>
       <Box display="flex" height="100%">

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -57,7 +57,9 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
   return (
     <Box display="flex" flexDirection="column" height="100%">
       <Box display="flex" justifyContent="space-between" padding={2}>
-        <Typography variant="h4">Columns</Typography>
+        <Typography variant="h4">
+          <Msg id="misc.views.columnDialog.gallery.columns" />
+        </Typography>
         <Box alignItems="center" display="flex">
           <TextField
             InputProps={{
@@ -72,7 +74,9 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
               setIsSearching(true);
               search();
             }}
-            placeholder="Find a column"
+            placeholder={intl.formatMessage({
+              id: 'misc.views.columnDialog.gallery.searchPlaceholder',
+            })}
             sx={{ paddingRight: 2 }}
             value={searchString}
             variant="outlined"
@@ -124,7 +128,12 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
         <Box ref={choiceContainerRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
           {isSearching ? (
             <Box padding={2}>
-              <Typography variant="h4">{`Results for "${searchString}"`}</Typography>
+              <Typography variant="h4">
+                <Msg
+                  id="misc.views.columnDialog.gallery.searchResults"
+                  values={{ searchString: searchString }}
+                />
+              </Typography>
               <Box>
                 {searchResults.length > 0 ? (
                   <Grid container paddingTop={2} spacing={3}>
@@ -158,7 +167,12 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
                     })}
                   </Grid>
                 ) : (
-                  <Typography>{`There are no column choices that match "${searchString}"`}</Typography>
+                  <Typography>
+                    <Msg
+                      id="misc.views.columnDialog.gallery.noSearchResults"
+                      values={{ searchString: searchString }}
+                    />
+                  </Typography>
                 )}
               </Box>
             </Box>

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Close, Search } from '@mui/icons-material';
-import { FunctionComponent, useRef, useState } from 'react';
+import { FunctionComponent, useMemo, useRef, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import categories from './categories';
@@ -38,9 +38,6 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
 
   const [isSearching, setIsSearching] = useState(false);
   const [searchString, setSearchString] = useState('');
-  const [searchResults, setSearchResults] = useState<
-    (ColumnChoice | undefined)[]
-  >([]);
 
   //list of objects with localized strings to use in the fuse-search
   const searchObjects = choices.map((choice) => ({
@@ -67,13 +64,11 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
       .search(searchString)
       .map((fuseResult) => fuseResult.item.key);
 
-    //get the choice objects with matching keys
-    const results = keys.map((key) =>
-      choices.find((choice) => choice.key === key)
-    );
-
-    setSearchResults(results);
+    //return the choice objects with matching keys
+    return keys.map((key) => choices.find((choice) => choice.key === key));
   };
+
+  const searchResults = useMemo(() => search(), [searchString]);
 
   const choiceContainerRef = useRef<HTMLDivElement>();
 
@@ -95,7 +90,6 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
                 return;
               }
               setIsSearching(true);
-              search();
             }}
             placeholder={intl.formatMessage({
               id: 'misc.views.columnDialog.gallery.searchPlaceholder',

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -21,14 +21,14 @@ import choices, { ColumnChoice } from './choices';
 interface ColumnGalleryProps {
   existingColumns: ZetkinViewColumn[];
   onAdd: (choice: ColumnChoice) => void;
-  onCancel: () => void;
+  onClose: () => void;
   onConfigure: (choice: ColumnChoice) => void;
 }
 
 const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
   existingColumns,
   onAdd,
-  onCancel,
+  onClose,
   onConfigure,
 }) => {
   const intl = useIntl();
@@ -80,7 +80,7 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
           <Close
             color="secondary"
             fontSize="medium"
-            onClick={() => onCancel()}
+            onClick={() => onClose()}
             sx={{ cursor: 'pointer' }}
           />
         </Box>

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery.tsx
@@ -113,72 +113,100 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
           </List>
         </Box>
         <Box ref={choiceContainerRef} flexGrow={1} sx={{ overflowY: 'scroll' }}>
-          {isSearching && (
+          {isSearching ? (
             <Box padding={2}>
               <Typography variant="h4">{`Results for "${searchString}"`}</Typography>
               <Box>
                 {searchResults.length > 0 ? (
-                  searchResults.map((searchResult) => (
-                    <Typography key={searchResult.key}>
-                      <Msg
-                        id={`misc.views.columnDialog.choices.${searchResult.key}.title`}
-                      />
-                    </Typography>
-                  ))
+                  <Grid container paddingTop={2} spacing={3}>
+                    {searchResults.map((searchResult) => {
+                      const alreadyInView =
+                        searchResult.alreadyInView &&
+                        searchResult.alreadyInView(existingColumns);
+                      return (
+                        <Grid key={searchResult.key} item lg={4} sm={6} xs={12}>
+                          <ColumnChoiceCard
+                            alreadyInView={alreadyInView}
+                            cardVisual={searchResult.renderCardVisual(
+                              alreadyInView ? 'gray' : '#234890'
+                            )}
+                            color={alreadyInView ? 'gray' : '#234890'}
+                            description={intl.formatMessage({
+                              id: `misc.views.columnDialog.choices.${searchResult.key}.description`,
+                            })}
+                            onAdd={() => onAdd(searchResult)}
+                            onConfigure={() => onConfigure(searchResult)}
+                            showAddButton={!!searchResult.defaultColumns}
+                            showConfigureButton={
+                              !!searchResult.renderConfigForm
+                            }
+                            title={intl.formatMessage({
+                              id: `misc.views.columnDialog.choices.${searchResult.key}.title`,
+                            })}
+                          />
+                        </Grid>
+                      );
+                    })}
+                  </Grid>
                 ) : (
                   <Typography>{`There are no column choices that match "${searchString}"`}</Typography>
                 )}
               </Box>
             </Box>
+          ) : (
+            categories.map((category, index) => (
+              <Box
+                key={`category-${index}`}
+                id={`category-${index}`}
+                padding={2}
+              >
+                <Typography variant="h4">
+                  <Msg
+                    id={`misc.views.columnDialog.categories.${category.key}.title`}
+                  />
+                </Typography>
+                <Typography variant="h5">
+                  <Msg
+                    id={`misc.views.columnDialog.categories.${category.key}.description`}
+                  />
+                </Typography>
+                <Grid container paddingTop={2} spacing={3}>
+                  {category.choices.map((choiceName) => {
+                    const choice = choices.find(
+                      (choice) => choice.key === choiceName
+                    );
+                    if (!choice) {
+                      return;
+                    }
+                    const alreadyInView =
+                      choice.alreadyInView &&
+                      choice.alreadyInView(existingColumns);
+                    return (
+                      <Grid key={choice.key} item lg={4} sm={6} xs={12}>
+                        <ColumnChoiceCard
+                          alreadyInView={alreadyInView}
+                          cardVisual={choice.renderCardVisual(
+                            alreadyInView ? 'gray' : '#234890'
+                          )}
+                          color={alreadyInView ? 'gray' : '#234890'}
+                          description={intl.formatMessage({
+                            id: `misc.views.columnDialog.choices.${choice.key}.description`,
+                          })}
+                          onAdd={() => onAdd(choice)}
+                          onConfigure={() => onConfigure(choice)}
+                          showAddButton={!!choice.defaultColumns}
+                          showConfigureButton={!!choice.renderConfigForm}
+                          title={intl.formatMessage({
+                            id: `misc.views.columnDialog.choices.${choice.key}.title`,
+                          })}
+                        />
+                      </Grid>
+                    );
+                  })}
+                </Grid>
+              </Box>
+            ))
           )}
-          {categories.map((category, index) => (
-            <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
-              <Typography variant="h4">
-                <Msg
-                  id={`misc.views.columnDialog.categories.${category.key}.title`}
-                />
-              </Typography>
-              <Typography variant="h5">
-                <Msg
-                  id={`misc.views.columnDialog.categories.${category.key}.description`}
-                />
-              </Typography>
-              <Grid container paddingTop={2} spacing={3}>
-                {category.choices.map((choiceName) => {
-                  const choice = choices.find(
-                    (choice) => choice.key === choiceName
-                  );
-                  if (!choice) {
-                    return;
-                  }
-                  const alreadyInView =
-                    choice.alreadyInView &&
-                    choice.alreadyInView(existingColumns);
-                  return (
-                    <Grid key={choice.key} item lg={4} sm={6} xs={12}>
-                      <ColumnChoiceCard
-                        alreadyInView={alreadyInView}
-                        cardVisual={choice.renderCardVisual(
-                          alreadyInView ? 'gray' : '#234890'
-                        )}
-                        color={alreadyInView ? 'gray' : '#234890'}
-                        description={intl.formatMessage({
-                          id: `misc.views.columnDialog.choices.${choice.key}.description`,
-                        })}
-                        onAdd={() => onAdd(choice)}
-                        onConfigure={() => onConfigure(choice)}
-                        showAddButton={!!choice.defaultColumns}
-                        showConfigureButton={!!choice.renderConfigForm}
-                        title={intl.formatMessage({
-                          id: `misc.views.columnDialog.choices.${choice.key}.title`,
-                        })}
-                      />
-                    </Grid>
-                  );
-                })}
-              </Grid>
-            </Box>
-          ))}
         </Box>
       </Box>
     </Box>

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
@@ -1,0 +1,75 @@
+import { Box, Grid, Typography } from '@mui/material';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
+
+import categories from '../categories';
+import choices from '../choices';
+import { ColumnChoice } from '../choices';
+import ColumnChoiceCard from '../ColumnChoiceCard';
+import { ZetkinViewColumn } from '../../types';
+
+interface CategoriesProps {
+  existingColumns: ZetkinViewColumn[];
+  onAdd: (choice: ColumnChoice) => void;
+  onConfigure: (choice: ColumnChoice) => void;
+}
+
+const ChoiceCategories = ({
+  existingColumns,
+  onAdd,
+  onConfigure,
+}: CategoriesProps) => {
+  const intl = useIntl();
+  return (
+    <Box>
+      {categories.map((category, index) => (
+        <Box key={`category-${index}`} id={`category-${index}`} padding={2}>
+          <Typography variant="h4">
+            <Msg
+              id={`misc.views.columnDialog.categories.${category.key}.title`}
+            />
+          </Typography>
+          <Typography variant="h5">
+            <Msg
+              id={`misc.views.columnDialog.categories.${category.key}.description`}
+            />
+          </Typography>
+          <Grid container paddingTop={2} spacing={3}>
+            {category.choices.map((choiceName) => {
+              const choice = choices.find(
+                (choice) => choice.key === choiceName
+              );
+              if (!choice) {
+                return;
+              }
+              const alreadyInView =
+                choice.alreadyInView && choice.alreadyInView(existingColumns);
+              return (
+                <Grid key={choice.key} item lg={4} sm={6} xs={12}>
+                  <ColumnChoiceCard
+                    alreadyInView={alreadyInView}
+                    cardVisual={choice.renderCardVisual(
+                      alreadyInView ? 'gray' : '#234890'
+                    )}
+                    color={alreadyInView ? 'gray' : '#234890'}
+                    description={intl.formatMessage({
+                      id: `misc.views.columnDialog.choices.${choice.key}.description`,
+                    })}
+                    onAdd={() => onAdd(choice)}
+                    onConfigure={() => onConfigure(choice)}
+                    showAddButton={!!choice.defaultColumns}
+                    showConfigureButton={!!choice.renderConfigForm}
+                    title={intl.formatMessage({
+                      id: `misc.views.columnDialog.choices.${choice.key}.title`,
+                    })}
+                  />
+                </Grid>
+              );
+            })}
+          </Grid>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default ChoiceCategories;

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
@@ -1,0 +1,57 @@
+import { Grid } from '@mui/material';
+import { useIntl } from 'react-intl';
+
+import { ColumnChoice } from '../choices';
+import ColumnChoiceCard from '../ColumnChoiceCard';
+import { ZetkinViewColumn } from '../../types';
+
+interface SearchResultsProps {
+  existingColumns: ZetkinViewColumn[];
+  onAdd: (choice: ColumnChoice) => void;
+  onConfigure: (choice: ColumnChoice) => void;
+  searchResults: (ColumnChoice | undefined)[];
+}
+
+const SearchResults = ({
+  existingColumns,
+  onAdd,
+  onConfigure,
+  searchResults,
+}: SearchResultsProps) => {
+  const intl = useIntl();
+  return (
+    <Grid container paddingTop={2} spacing={3}>
+      {searchResults.map((searchResult) => {
+        if (!searchResult) {
+          return;
+        }
+        const alreadyInView =
+          searchResult.alreadyInView &&
+          searchResult.alreadyInView(existingColumns);
+        return (
+          <Grid key={searchResult.key} item lg={4} sm={6} xs={12}>
+            <ColumnChoiceCard
+              alreadyInView={alreadyInView}
+              cardVisual={searchResult.renderCardVisual(
+                alreadyInView ? 'gray' : '#234890'
+              )}
+              color={alreadyInView ? 'gray' : '#234890'}
+              description={intl.formatMessage({
+                id: `misc.views.columnDialog.choices.${searchResult.key}.description`,
+              })}
+              onAdd={() => onAdd(searchResult)}
+              onConfigure={() => onConfigure(searchResult)}
+              showAddButton={!!searchResult.defaultColumns}
+              showConfigureButton={!!searchResult.renderConfigForm}
+              title={intl.formatMessage({
+                id: `misc.views.columnDialog.choices.${searchResult.key}.title`,
+              })}
+            />
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};
+
+export default SearchResults;

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
@@ -1,22 +1,15 @@
 import Fuse from 'fuse.js';
-import {
-  Box,
-  Grid,
-  List,
-  ListItem,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Box, List, ListItem, TextField, Typography } from '@mui/material';
 import { Close, Search } from '@mui/icons-material';
 import { FunctionComponent, useMemo, useRef, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
-
-import categories from './categories';
-import ColumnChoiceCard from './ColumnChoiceCard';
 import { Theme, useMediaQuery } from '@mui/material';
 
+import categories from '../categories';
+import ChoiceCategories from './ChoiceCategories';
+import SearchResults from './SearchResults';
 import { ZetkinViewColumn } from 'features/views/components/types';
-import choices, { ColumnChoice } from './choices';
+import choices, { ColumnChoice } from '../choices';
 
 interface ColumnGalleryProps {
   existingColumns: ZetkinViewColumn[];
@@ -153,39 +146,12 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
               </Typography>
               <Box>
                 {searchResults.length > 0 ? (
-                  <Grid container paddingTop={2} spacing={3}>
-                    {searchResults.map((searchResult) => {
-                      if (!searchResult) {
-                        return;
-                      }
-                      const alreadyInView =
-                        searchResult.alreadyInView &&
-                        searchResult.alreadyInView(existingColumns);
-                      return (
-                        <Grid key={searchResult.key} item lg={4} sm={6} xs={12}>
-                          <ColumnChoiceCard
-                            alreadyInView={alreadyInView}
-                            cardVisual={searchResult.renderCardVisual(
-                              alreadyInView ? 'gray' : '#234890'
-                            )}
-                            color={alreadyInView ? 'gray' : '#234890'}
-                            description={intl.formatMessage({
-                              id: `misc.views.columnDialog.choices.${searchResult.key}.description`,
-                            })}
-                            onAdd={() => onAdd(searchResult)}
-                            onConfigure={() => onConfigure(searchResult)}
-                            showAddButton={!!searchResult.defaultColumns}
-                            showConfigureButton={
-                              !!searchResult.renderConfigForm
-                            }
-                            title={intl.formatMessage({
-                              id: `misc.views.columnDialog.choices.${searchResult.key}.title`,
-                            })}
-                          />
-                        </Grid>
-                      );
-                    })}
-                  </Grid>
+                  <SearchResults
+                    existingColumns={existingColumns}
+                    onAdd={onAdd}
+                    onConfigure={onConfigure}
+                    searchResults={searchResults}
+                  />
                 ) : (
                   <Typography>
                     <Msg
@@ -197,58 +163,11 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
               </Box>
             </Box>
           ) : (
-            categories.map((category, index) => (
-              <Box
-                key={`category-${index}`}
-                id={`category-${index}`}
-                padding={2}
-              >
-                <Typography variant="h4">
-                  <Msg
-                    id={`misc.views.columnDialog.categories.${category.key}.title`}
-                  />
-                </Typography>
-                <Typography variant="h5">
-                  <Msg
-                    id={`misc.views.columnDialog.categories.${category.key}.description`}
-                  />
-                </Typography>
-                <Grid container paddingTop={2} spacing={3}>
-                  {category.choices.map((choiceName) => {
-                    const choice = choices.find(
-                      (choice) => choice.key === choiceName
-                    );
-                    if (!choice) {
-                      return;
-                    }
-                    const alreadyInView =
-                      choice.alreadyInView &&
-                      choice.alreadyInView(existingColumns);
-                    return (
-                      <Grid key={choice.key} item lg={4} sm={6} xs={12}>
-                        <ColumnChoiceCard
-                          alreadyInView={alreadyInView}
-                          cardVisual={choice.renderCardVisual(
-                            alreadyInView ? 'gray' : '#234890'
-                          )}
-                          color={alreadyInView ? 'gray' : '#234890'}
-                          description={intl.formatMessage({
-                            id: `misc.views.columnDialog.choices.${choice.key}.description`,
-                          })}
-                          onAdd={() => onAdd(choice)}
-                          onConfigure={() => onConfigure(choice)}
-                          showAddButton={!!choice.defaultColumns}
-                          showConfigureButton={!!choice.renderConfigForm}
-                          title={intl.formatMessage({
-                            id: `misc.views.columnDialog.choices.${choice.key}.title`,
-                          })}
-                        />
-                      </Grid>
-                    );
-                  })}
-                </Grid>
-              </Box>
-            ))
+            <ChoiceCategories
+              existingColumns={existingColumns}
+              onAdd={onAdd}
+              onConfigure={onConfigure}
+            />
           )}
         </Box>
       </Box>

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -21,6 +21,7 @@ export type ColumnChoice = {
   alreadyInView?: (columns: ZetkinViewColumn[]) => boolean;
   defaultColumns?: (intl: IntlShape) => PendingZetkinViewColumn[];
   key: string;
+  keywords: string[];
   renderCardVisual: (color: string) => JSX.Element;
   renderConfigForm?: (props: {
     existingColumns: ZetkinViewColumn[];
@@ -64,6 +65,14 @@ const choices: ColumnChoice[] = [
       },
     ],
     key: CHOICES.FIRST_AND_LAST_NAME,
+    keywords: [
+      'firstname',
+      'name',
+      'first name',
+      'lastname',
+      'last name',
+      'first and last name',
+    ],
     renderCardVisual: (color: string) => {
       return <DoubleIconCardVisual color={color} icons={[Person, Person]} />;
     },
@@ -79,6 +88,7 @@ const choices: ColumnChoice[] = [
       );
     },
     key: CHOICES.PERSON_FIELDS,
+    keywords: ['fields', 'person fields', 'personfields', 'field'],
     renderCardVisual: (color: string) => (
       <SingleIconCardVisual color={color} icon={Person} />
     ),

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -21,7 +21,6 @@ export type ColumnChoice = {
   alreadyInView?: (columns: ZetkinViewColumn[]) => boolean;
   defaultColumns?: (intl: IntlShape) => PendingZetkinViewColumn[];
   key: string;
-  keywords: string[];
   renderCardVisual: (color: string) => JSX.Element;
   renderConfigForm?: (props: {
     existingColumns: ZetkinViewColumn[];
@@ -65,14 +64,6 @@ const choices: ColumnChoice[] = [
       },
     ],
     key: CHOICES.FIRST_AND_LAST_NAME,
-    keywords: [
-      'firstname',
-      'name',
-      'first name',
-      'lastname',
-      'last name',
-      'first and last name',
-    ],
     renderCardVisual: (color: string) => {
       return <DoubleIconCardVisual color={color} icons={[Person, Person]} />;
     },
@@ -88,7 +79,6 @@ const choices: ColumnChoice[] = [
       );
     },
     key: CHOICES.PERSON_FIELDS,
-    keywords: ['fields', 'person fields', 'personfields', 'field'],
     renderCardVisual: (color: string) => (
       <SingleIconCardVisual color={color} icon={Person} />
     ),

--- a/src/features/views/components/ViewColumnDialog/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/index.tsx
@@ -12,13 +12,13 @@ import {
 
 interface ViewColumnDialogProps {
   columns: ZetkinViewColumn[];
-  onCancel: () => void;
+  onClose: () => void;
   onSave: (columns: SelectedViewColumn[]) => Promise<void>;
 }
 
 const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
   columns: existingColumns,
-  onCancel,
+  onClose,
   onSave,
 }) => {
   const intl = useIntl();
@@ -37,7 +37,7 @@ const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
       fullScreen={fullScreen}
       fullWidth
       maxWidth="lg"
-      onClose={() => onCancel()}
+      onClose={() => onClose()}
       open
     >
       <Box height="90vh">
@@ -64,7 +64,7 @@ const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
               const columns = choice.defaultColumns(intl);
               await onSave(columns);
             }}
-            onCancel={onCancel}
+            onClose={onClose}
             onConfigure={onConfigure}
           />
         )}

--- a/src/features/views/components/ViewColumnDialog/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/index.tsx
@@ -47,6 +47,7 @@ const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
             color="#234890"
             existingColumns={existingColumns}
             onCancel={() => setColumnChoice(null)}
+            onClose={onClose}
             onSave={async (columns) => {
               await onSave(columns);
               setColumnChoice(null);

--- a/src/features/views/components/ViewColumnDialog/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/index.tsx
@@ -64,6 +64,7 @@ const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
               const columns = choice.defaultColumns(intl);
               await onSave(columns);
             }}
+            onCancel={onCancel}
             onConfigure={onConfigure}
           />
         )}

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -409,7 +409,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       {columnToConfigure && (
         <ViewColumnDialog
           columns={columns}
-          onCancel={onColumnCancel}
+          onClose={onColumnCancel}
           onSave={async (columns) => {
             // TODO: Handle these async calls better
             // (maybe custom API endpoint to bulk create/edit columns?)

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -7,9 +7,11 @@ columnDialog:
   choices:
     firstAndLastName:
       description: First and last name of person
+      keywords: name combo
       title: First and Last Name
     personFields:
       description: Add your choice of fields like email, phone number, etc.
+      keywords: field multiple
       title: Person fields
   commonHeaders:
     firstName: First Name

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -31,8 +31,12 @@ columnDialog:
   gallery:
     add: Add
     alreadyInView: Already in view
+    columns: Columns
     configure: Configure
     header: Add column to view
+    noSearchResults: There are no column choices that match "{searchString}"
+    searchPlaceholder: Find a column
+    searchResults: Results for "{searchString}"
 columnMenu:
   configure: Configure column
   confirmDelete: >-


### PR DESCRIPTION
## Description
This PR adds the ability to search for choices in the view column dialog.


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/213388160-4651817a-1d6a-4115-9346-3e84d809bac7.png)

![bild](https://user-images.githubusercontent.com/58265097/213388099-7b2c777d-1f2b-47d5-a7f2-e54d9751fac5.png)

## Changes
* Adds a search field to `ColumnGallery`
* Adds `keywords` to each choice, in the yml file
* Adds logic to use Fuse to search in localised `keywords`, `title` and `description`

## Notes to reviewer
The keywords I put for each choice are improvised and needs revision - thinking it could happen together with clustering and making the categories and going over the titles and description formulations.


## Related issues
Resolves #876 
