### PR TITLE
Issue 878/local bool modal choice

### DIFF
--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -6,7 +6,12 @@ const enum CATEGORIES {
 
 const categories = [
   {
-    choices: [CHOICES.FIRST_AND_LAST_NAME, CHOICES.PERSON_FIELDS],
+    choices: [
+      CHOICES.FIRST_AND_LAST_NAME,
+      CHOICES.PERSON_FIELDS,
+      CHOICES.TAG,
+      CHOICES.BOOLEAN,
+    ],
     key: CATEGORIES.BASIC,
   },
 ];

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -1,7 +1,8 @@
 import { IntlShape } from 'react-intl';
-import { LocalOffer, Person } from '@mui/icons-material';
+import { CheckBox, LocalOffer, Person } from '@mui/icons-material';
 
 import DoubleIconCardVisual from './DoubleIconCardVisual';
+import getUniqueColumnName from '../../utils/getUniqueColumnName';
 import PersonFieldConfig from './PersonFieldConfig';
 import PersonTagConfig from './PersonTagConfig';
 import SingleIconCardVisual from './SingleIconCardVisual';
@@ -16,11 +17,16 @@ import {
 export enum CHOICES {
   FIRST_AND_LAST_NAME = 'firstAndLastName',
   PERSON_FIELDS = 'personFields',
+  TAG = 'tag',
+  BOOLEAN = 'toggle',
 }
 
 export type ColumnChoice = {
   alreadyInView?: (columns: ZetkinViewColumn[]) => boolean;
-  defaultColumns?: (intl: IntlShape) => PendingZetkinViewColumn[];
+  defaultColumns?: (
+    intl: IntlShape,
+    columns: ZetkinViewColumn[]
+  ) => PendingZetkinViewColumn[];
   key: string;
   renderCardVisual: (color: string) => JSX.Element;
   renderConfigForm?: (props: {
@@ -70,6 +76,16 @@ const choices: ColumnChoice[] = [
     },
   },
   {
+    key: CHOICES.TAG,
+    renderCardVisual: (color: string) => (
+      <SingleIconCardVisual color={color} icon={LocalOffer} />
+    ),
+    renderConfigForm: (props: {
+      existingColumns: ZetkinViewColumn[];
+      onOutputConfigured: (columns: SelectedViewColumn[]) => void;
+    }) => <PersonTagConfig onOutputConfigured={props.onOutputConfigured} />,
+  },
+  {
     alreadyInView: (columns) => {
       return Object.values(NATIVE_PERSON_FIELDS).every((fieldName) =>
         columns.some(
@@ -94,15 +110,27 @@ const choices: ColumnChoice[] = [
     ),
   },
   {
-    key: 'tag',
+    defaultColumns: (intl, columns) => [
+      {
+        config: {
+          field: 'local_bool',
+        },
+        title: getUniqueColumnName('pepa', columns),
+        type: COLUMN_TYPE.LOCAL_BOOL,
+      },
+    ],
+    key: CHOICES.BOOLEAN,
     renderCardVisual: (color: string) => (
-      <SingleIconCardVisual color={color} icon={LocalOffer} />
+      <SingleIconCardVisual color={color} icon={CheckBox} />
     ),
-    renderConfigForm: (props: {
-      existingColumns: ZetkinViewColumn[];
-      onOutputConfigured: (columns: SelectedViewColumn[]) => void;
-    }) => <PersonTagConfig onOutputConfigured={props.onOutputConfigured} />,
   },
 ];
 
+/* title: getUniqueColumnName(
+  intl.formatMessage({
+    id: 'misc.views.columnDialog.choices.toggle.columnTitle',
+  }),
+  columns
+),
+ */
 export default choices;

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -115,7 +115,12 @@ const choices: ColumnChoice[] = [
         config: {
           field: 'local_bool',
         },
-        title: getUniqueColumnName('pepa', columns),
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.toggle.columnTitle',
+          }),
+          columns
+        ),
         type: COLUMN_TYPE.LOCAL_BOOL,
       },
     ],
@@ -126,11 +131,4 @@ const choices: ColumnChoice[] = [
   },
 ];
 
-/* title: getUniqueColumnName(
-  intl.formatMessage({
-    id: 'misc.views.columnDialog.choices.toggle.columnTitle',
-  }),
-  columns
-),
- */
 export default choices;

--- a/src/features/views/components/ViewColumnDialog/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/index.tsx
@@ -61,7 +61,7 @@ const ViewColumnDialog: FunctionComponent<ViewColumnDialogProps> = ({
                 return null;
               }
 
-              const columns = choice.defaultColumns(intl);
+              const columns = choice.defaultColumns(intl, existingColumns);
               await onSave(columns);
             }}
             onConfigure={onConfigure}

--- a/src/features/views/utils/getUniqueColumnName.spec.ts
+++ b/src/features/views/utils/getUniqueColumnName.spec.ts
@@ -1,0 +1,52 @@
+import getUniqueColumnName from './getUniqueColumnName';
+import { ZetkinViewColumn } from '../components/types';
+
+describe('getUniqueColumnName()', () => {
+  it('does nothing when there are no other columns', () => {
+    const result = getUniqueColumnName('title', []);
+    expect(result).toEqual('title');
+  });
+
+  it('does nothing when name is not used by any other column', () => {
+    const result = getUniqueColumnName('title', [
+      { title: 'First name' } as ZetkinViewColumn,
+      { title: 'Last name' } as ZetkinViewColumn,
+    ]);
+
+    expect(result).toEqual('title');
+  });
+
+  it('suffixes he number 2 when name is taken', () => {
+    const result = getUniqueColumnName('title', [
+      { title: 'First name' } as ZetkinViewColumn,
+      { title: 'Last name' } as ZetkinViewColumn,
+      { title: 'title' } as ZetkinViewColumn,
+    ]);
+
+    expect(result).toEqual('title 2');
+  });
+
+  it('increments number when suffixed name is taken', () => {
+    const result = getUniqueColumnName('title', [
+      { title: 'First name' } as ZetkinViewColumn,
+      { title: 'Last name' } as ZetkinViewColumn,
+      { title: 'title' } as ZetkinViewColumn,
+      { title: 'title 2' } as ZetkinViewColumn,
+    ]);
+
+    expect(result).toEqual('title 3');
+  });
+
+  it('increments number > 10 when suffixed name is taken', () => {
+    const columns = [{ title: 'title' } as ZetkinViewColumn];
+
+    // Fill up to 99
+    for (let i = 2; i < 100; i++) {
+      columns.push({ title: `title ${i}` } as ZetkinViewColumn);
+    }
+
+    const result = getUniqueColumnName('title', columns);
+
+    expect(result).toEqual('title 100');
+  });
+});

--- a/src/features/views/utils/getUniqueColumnName.ts
+++ b/src/features/views/utils/getUniqueColumnName.ts
@@ -6,6 +6,7 @@ export default function getUniqueColumnName(
 ) {
   let title = defaultTitle;
   let count = 2;
+  // eslint-disable-next-line no-constant-condition
   while (true) {
     const titleIsAlreadyIn = columns.some((column) => column.title === title);
     if (titleIsAlreadyIn) {

--- a/src/features/views/utils/getUniqueColumnName.ts
+++ b/src/features/views/utils/getUniqueColumnName.ts
@@ -1,0 +1,36 @@
+import { ZetkinViewColumn } from '../components/types';
+
+export default function getUniqueColumnName(
+  defaultTitle: string,
+  columns: ZetkinViewColumn[]
+) {
+  let title = defaultTitle;
+
+  let foundNewTitle = false;
+  while (!foundNewTitle) {
+    let count = 2;
+    const titleIsAlreadyIn = columns.some((column) => column.title === title);
+    //const firstColumnTitle = isNaN(+title.slice(title.length - 1));
+    // make title and 1 variables
+    // make if statements variables
+    //write test
+    //create utils folder > create modul getUniqueColumnName +
+    if (titleIsAlreadyIn) {
+      /*        if (firstColumnTitle) {
+        title += ' ' + 2;
+        console.log('if');
+      } else {
+        const oldNumericSuffix = title.split(defaultTitle);
+        title = defaultTitle + (+oldNumericSuffix[0] + 1).toString();
+        console.log('else');
+      } */
+      const oldNumericSuffix = title.split(defaultTitle);
+      title = defaultTitle + ' ' + (+oldNumericSuffix[0] + count).toString();
+    } else {
+      foundNewTitle = true;
+    }
+
+    count++;
+  }
+  return title;
+}

--- a/src/features/views/utils/getUniqueColumnName.ts
+++ b/src/features/views/utils/getUniqueColumnName.ts
@@ -5,31 +5,15 @@ export default function getUniqueColumnName(
   columns: ZetkinViewColumn[]
 ) {
   let title = defaultTitle;
-
+  let count = 2;
   let foundNewTitle = false;
   while (!foundNewTitle) {
-    let count = 2;
     const titleIsAlreadyIn = columns.some((column) => column.title === title);
-    //const firstColumnTitle = isNaN(+title.slice(title.length - 1));
-    // make title and 1 variables
-    // make if statements variables
-    //write test
-    //create utils folder > create modul getUniqueColumnName +
     if (titleIsAlreadyIn) {
-      /*        if (firstColumnTitle) {
-        title += ' ' + 2;
-        console.log('if');
-      } else {
-        const oldNumericSuffix = title.split(defaultTitle);
-        title = defaultTitle + (+oldNumericSuffix[0] + 1).toString();
-        console.log('else');
-      } */
-      const oldNumericSuffix = title.split(defaultTitle);
-      title = defaultTitle + ' ' + (+oldNumericSuffix[0] + count).toString();
+      title = defaultTitle + ' ' + count.toString();
     } else {
       foundNewTitle = true;
     }
-
     count++;
   }
   return title;

--- a/src/features/views/utils/getUniqueColumnName.ts
+++ b/src/features/views/utils/getUniqueColumnName.ts
@@ -6,13 +6,12 @@ export default function getUniqueColumnName(
 ) {
   let title = defaultTitle;
   let count = 2;
-  let foundNewTitle = false;
-  while (!foundNewTitle) {
+  while (true) {
     const titleIsAlreadyIn = columns.some((column) => column.title === title);
     if (titleIsAlreadyIn) {
-      title = defaultTitle + ' ' + count.toString();
+      title = defaultTitle + ' ' + count;
     } else {
-      foundNewTitle = true;
+      break;
     }
     count++;
   }

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -14,6 +14,10 @@ columnDialog:
     tag:
       description: Show a checkmark if the person has this tag
       title: Tag
+    toggle:
+      columnTitle: Toggle
+      description: Checkbox column
+      title: Toggle
   commonHeaders:
     firstName: First Name
     lastName: Last Name


### PR DESCRIPTION
## Description
This PR contains the local boolean (toggle) card choice inside the View Column Modal and handles the addition of new local boolean columns with and incrementing title number("Toggle" + number).


## Screenshots
![1-1](https://user-images.githubusercontent.com/36491300/213568994-b76cd941-58cf-45f2-958a-4424cf1b5125.png)
![1-2](https://user-images.githubusercontent.com/36491300/213569019-fabd9c14-a927-498e-992c-5a80d4fb50a8.png)



## Changes
* Adds a new `Toggle` modal card.
* Adds new localisation strings for the `Toggle` modal card.
* Adds `PersonTag` and `Boolean` column to the new categories framework.
* Adds a new method `getUniqueColumnName` to increment the number in the title of the boolean columns.
* Adds a unit tests to check the new method `getUniqueColumnName`

## Notes to reviewer
Messy commit "work in progress" due to migration of computer.
Special thanks to @richardolsson help me with the tests ⛵ 


## Related issues
Resolves #878
