### PR TITLE
View sharing dialog ("Share" tab)

### DIFF
--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -1,3 +1,12 @@
 export interface ApiResponse<DataType> {
   data: DataType;
 }
+
+export interface ZetkinObjectAccess {
+  level: 'configure' | 'edit' | 'readonly';
+  person: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
+}

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -9,4 +9,10 @@ export interface ZetkinObjectAccess {
     id: number;
     last_name: string;
   };
+  updated: string;
+  updated_by: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
 }

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@mui/material';
-import { FC, useRef } from 'react';
+import { Box, FormControlLabel, Switch } from '@mui/material';
+import { FC, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
@@ -17,6 +17,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
 }) => {
   const intl = useIntl();
   const selectInputRef = useRef<HTMLInputElement>();
+  const [showOfficials, setShowOfficials] = useState(true);
 
   const accessFuture = model.getAccessList();
   const officialsFuture = model.getOfficials();
@@ -28,7 +29,11 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
       >
         {({ data: { accessList, officials } }) => (
           <>
-            <Box display="flex" justifyContent="space-between">
+            <Box
+              alignItems="center"
+              display="flex"
+              justifyContent="space-between"
+            >
               <Box>
                 <FormattedMessage
                   id="pages.people.views.shareDialog.share.statusLabel"
@@ -38,10 +43,22 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
                   }}
                 />
               </Box>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={showOfficials}
+                    onChange={(ev) => setShowOfficials(ev.target.checked)}
+                  />
+                }
+                label={
+                  <FormattedMessage id="pages.people.views.shareDialog.share.showOfficials" />
+                }
+                labelPlacement="start"
+              />
             </Box>
             <ZUIAccessList
               accessList={accessList}
-              officials={officials}
+              officials={showOfficials ? officials : []}
               onChangeLevel={(personId, level) =>
                 model.grantAccess(personId, level)
               }

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material';
-import { useIntl } from 'react-intl';
 import { FC, useRef } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 import ViewSharingModel from 'features/views/models/ViewSharingModel';
@@ -28,6 +28,17 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
       >
         {({ data: { accessList, officials } }) => (
           <>
+            <Box display="flex" justifyContent="space-between">
+              <Box>
+                <FormattedMessage
+                  id="pages.people.views.shareDialog.share.statusLabel"
+                  values={{
+                    collaborators: accessList.length,
+                    officials: officials.length,
+                  }}
+                />
+              </Box>
+            </Box>
             <ZUIAccessList
               accessList={accessList}
               officials={officials}

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -6,7 +6,7 @@ import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 import ViewSharingModel from 'features/views/models/ViewSharingModel';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAccessList from 'zui/ZUIAccessList';
-import ZUIFuture from 'zui/ZUIFuture';
+import ZUIFutures from 'zui/ZUIFutures';
 
 interface ShareViewDialogShareTabProps {
   model: ViewSharingModel;
@@ -19,14 +19,18 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
   const selectInputRef = useRef<HTMLInputElement>();
 
   const accessFuture = model.getAccessList();
+  const officialsFuture = model.getOfficials();
 
   return (
     <Box>
-      <ZUIFuture future={accessFuture}>
-        {(accessList) => (
+      <ZUIFutures
+        futures={{ accessList: accessFuture, officials: officialsFuture }}
+      >
+        {({ data: { accessList, officials } }) => (
           <>
             <ZUIAccessList
-              list={accessList}
+              accessList={accessList}
+              officials={officials}
               onChangeLevel={(personId, level) =>
                 model.grantAccess(personId, level)
               }
@@ -61,7 +65,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
             />
           </>
         )}
-      </ZUIFuture>
+      </ZUIFutures>
     </Box>
   );
 };

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -10,6 +10,7 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAccessList from 'zui/ZUIAccessList';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIInlineCopyToClipboard from 'zui/ZUIInlineCopyToClipBoard';
+import ZUIScrollingContainer from 'zui/ZUIScrollingContainer';
 
 interface ShareViewDialogShareTabProps {
   model: ViewSharingModel;
@@ -29,7 +30,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
   const officialsFuture = model.getOfficials();
 
   return (
-    <Box>
+    <Box display="flex" flexDirection="column" gap={1} height="100%">
       <ZUIFutures
         futures={{ accessList: accessFuture, officials: officialsFuture }}
       >
@@ -62,41 +63,48 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
                 labelPlacement="start"
               />
             </Box>
-            <ZUIAccessList
-              accessList={accessList}
-              officials={showOfficials ? officials : []}
-              onChangeLevel={(personId, level) =>
-                model.grantAccess(personId, level)
-              }
-              onRevoke={(personId) => model.revokeAccess(personId)}
-              orgId={model.orgId}
-            />
-            <MUIOnlyPersonSelect
-              getOptionDisabled={(person) =>
-                accessList.some((item) => item.person.id == person.id)
-              }
-              getOptionExtraLabel={(person) => {
-                const accessItem = accessList.find(
-                  (item) => item.person.id == person.id
-                );
-                if (accessItem) {
-                  return intl.formatMessage({
-                    id: `zui.accessList.levels.${accessItem.level}`,
-                  });
+            <ZUIScrollingContainer disableHorizontal flexGrow={1}>
+              <ZUIAccessList
+                accessList={accessList}
+                officials={showOfficials ? officials : []}
+                onChangeLevel={(personId, level) =>
+                  model.grantAccess(personId, level)
                 }
-                return '';
-              }}
-              inputRef={selectInputRef}
-              onChange={function (person: ZetkinPerson): void {
-                model.grantAccess(person.id, 'readonly');
+                onRevoke={(personId) => model.revokeAccess(personId)}
+                orgId={model.orgId}
+              />
+            </ZUIScrollingContainer>
+            <Box marginTop={1}>
+              <MUIOnlyPersonSelect
+                getOptionDisabled={(person) =>
+                  accessList.some((item) => item.person.id == person.id)
+                }
+                getOptionExtraLabel={(person) => {
+                  const accessItem = accessList.find(
+                    (item) => item.person.id == person.id
+                  );
+                  if (accessItem) {
+                    return intl.formatMessage({
+                      id: `zui.accessList.levels.${accessItem.level}`,
+                    });
+                  }
+                  return '';
+                }}
+                inputRef={selectInputRef}
+                onChange={function (person: ZetkinPerson): void {
+                  model.grantAccess(person.id, 'readonly');
 
-                // Blur and re-focus input to reset, so that user can type again to
-                // add another person, without taking their hands off the keyboard.
-                selectInputRef?.current?.blur();
-                selectInputRef?.current?.focus();
-              }}
-              selectedPerson={null}
-            />
+                  // Blur and re-focus input to reset, so that user can type again to
+                  // add another person, without taking their hands off the keyboard.
+                  selectInputRef?.current?.blur();
+                  selectInputRef?.current?.focus();
+                }}
+                placeholder={intl.formatMessage({
+                  id: 'pages.people.views.shareDialog.share.addPlaceholder',
+                })}
+                selectedPerson={null}
+              />
+            </Box>
             <Box textAlign="right">
               <FormattedMessage
                 id="pages.people.views.shareDialog.share.collabInstructions"

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -77,7 +77,8 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
             <Box marginTop={1}>
               <MUIOnlyPersonSelect
                 getOptionDisabled={(person) =>
-                  accessList.some((item) => item.person.id == person.id)
+                  accessList.some((item) => item.person.id == person.id) ||
+                  officials.some((item) => item.id == person.id)
                 }
                 getOptionExtraLabel={(person) => {
                   const accessItem = accessList.find(
@@ -88,6 +89,16 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
                       id: `zui.accessList.levels.${accessItem.level}`,
                     });
                   }
+
+                  const official = officials.find(
+                    (item) => item.id == person.id
+                  );
+                  if (official) {
+                    return intl.formatMessage({
+                      id: `zui.accessList.roles.${official.role}`,
+                    });
+                  }
+
                   return '';
                 }}
                 inputRef={selectInputRef}

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -4,10 +4,12 @@ import { FC, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
+import useAbsoluteUrl from 'utils/hooks/useAbsoluteUrl';
 import ViewSharingModel from 'features/views/models/ViewSharingModel';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAccessList from 'zui/ZUIAccessList';
 import ZUIFutures from 'zui/ZUIFutures';
+import ZUIInlineCopyToClipboard from 'zui/ZUIInlineCopyToClipBoard';
 
 interface ShareViewDialogShareTabProps {
   model: ViewSharingModel;
@@ -19,6 +21,9 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
   const intl = useIntl();
   const selectInputRef = useRef<HTMLInputElement>();
   const [showOfficials, setShowOfficials] = useState(true);
+  const shareLinkUrl = useAbsoluteUrl(
+    `/organize/${model.orgId}/people/views/${model.viewId}/shared`
+  );
 
   const accessFuture = model.getAccessList();
   const officialsFuture = model.getOfficials();
@@ -97,14 +102,19 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
                 id="pages.people.views.shareDialog.share.collabInstructions"
                 values={{
                   viewLink: (
-                    <NextLink
-                      href={`/organize/${model.orgId}/people/views/${model.viewId}/shared`}
-                      passHref
+                    <ZUIInlineCopyToClipboard
+                      alwaysShowIcon
+                      copyText={shareLinkUrl}
                     >
-                      <Link>
-                        <FormattedMessage id="pages.people.views.shareDialog.share.viewLink" />
-                      </Link>
-                    </NextLink>
+                      <NextLink
+                        href={`/organize/${model.orgId}/people/views/${model.viewId}/shared`}
+                        passHref
+                      >
+                        <Link>
+                          <FormattedMessage id="pages.people.views.shareDialog.share.viewLink" />
+                        </Link>
+                      </NextLink>
+                    </ZUIInlineCopyToClipboard>
                   ),
                 }}
               />

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -1,0 +1,25 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+
+import ViewSharingModel from 'features/views/models/ViewSharingModel';
+import ZUIAccessList from 'zui/ZUIAccessList';
+import ZUIFuture from 'zui/ZUIFuture';
+
+interface ShareViewDialogShareTabProps {
+  model: ViewSharingModel;
+}
+
+const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
+  model,
+}) => {
+  const accessFuture = model.getAccessList();
+  return (
+    <Box>
+      <ZUIFuture future={accessFuture}>
+        {(data) => <ZUIAccessList list={data} orgId={model.orgId} />}
+      </ZUIFuture>
+    </Box>
+  );
+};
+
+export default ShareViewDialogShareTab;

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -30,6 +30,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
               onChangeLevel={(personId, level) =>
                 model.grantAccess(personId, level)
               }
+              onRevoke={(personId) => model.revokeAccess(personId)}
               orgId={model.orgId}
             />
             <MUIOnlyPersonSelect

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -25,7 +25,13 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
       <ZUIFuture future={accessFuture}>
         {(accessList) => (
           <>
-            <ZUIAccessList list={accessList} orgId={model.orgId} />
+            <ZUIAccessList
+              list={accessList}
+              onChangeLevel={(personId, level) =>
+                model.grantAccess(personId, level)
+              }
+              orgId={model.orgId}
+            />
             <MUIOnlyPersonSelect
               getOptionDisabled={(person) =>
                 accessList.some((item) => item.person.id == person.id)

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -1,4 +1,5 @@
-import { Box, FormControlLabel, Switch } from '@mui/material';
+import NextLink from 'next/link';
+import { Box, FormControlLabel, Link, Switch } from '@mui/material';
 import { FC, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -91,6 +92,23 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
               }}
               selectedPerson={null}
             />
+            <Box textAlign="right">
+              <FormattedMessage
+                id="pages.people.views.shareDialog.share.collabInstructions"
+                values={{
+                  viewLink: (
+                    <NextLink
+                      href={`/organize/${model.orgId}/people/views/${model.viewId}/shared`}
+                      passHref
+                    >
+                      <Link>
+                        <FormattedMessage id="pages.people.views.shareDialog.share.viewLink" />
+                      </Link>
+                    </NextLink>
+                  ),
+                }}
+              />
+            </Box>
           </>
         )}
       </ZUIFutures>

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -1,7 +1,10 @@
 import { Box } from '@mui/material';
-import { FC } from 'react';
+import { useIntl } from 'react-intl';
+import { FC, useRef } from 'react';
 
+import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 import ViewSharingModel from 'features/views/models/ViewSharingModel';
+import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAccessList from 'zui/ZUIAccessList';
 import ZUIFuture from 'zui/ZUIFuture';
 
@@ -12,11 +15,45 @@ interface ShareViewDialogShareTabProps {
 const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
   model,
 }) => {
+  const intl = useIntl();
+  const selectInputRef = useRef<HTMLInputElement>();
+
   const accessFuture = model.getAccessList();
+
   return (
     <Box>
       <ZUIFuture future={accessFuture}>
-        {(data) => <ZUIAccessList list={data} orgId={model.orgId} />}
+        {(accessList) => (
+          <>
+            <ZUIAccessList list={accessList} orgId={model.orgId} />
+            <MUIOnlyPersonSelect
+              getOptionDisabled={(person) =>
+                accessList.some((item) => item.person.id == person.id)
+              }
+              getOptionExtraLabel={(person) => {
+                const accessItem = accessList.find(
+                  (item) => item.person.id == person.id
+                );
+                if (accessItem) {
+                  return intl.formatMessage({
+                    id: `zui.accessList.levels.${accessItem.level}`,
+                  });
+                }
+                return '';
+              }}
+              inputRef={selectInputRef}
+              onChange={function (person: ZetkinPerson): void {
+                model.grantAccess(person.id, 'readonly');
+
+                // Blur and re-focus input to reset, so that user can type again to
+                // add another person, without taking their hands off the keyboard.
+                selectInputRef?.current?.blur();
+                selectInputRef?.current?.focus();
+              }}
+              selectedPerson={null}
+            />
+          </>
+        )}
       </ZUIFuture>
     </Box>
   );

--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from '@mui/styles';
 import { Tab } from '@mui/material';
 import { useIntl } from 'react-intl';
 import { FC, useState } from 'react';
@@ -14,12 +15,23 @@ interface ShareViewDialogProps {
   view: ZetkinView;
 }
 
+const useStyles = makeStyles({
+  tabPanel: {
+    height: '100vh',
+    maxHeight: '600px',
+    paddingBottom: 0,
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
+});
+
 const ShareViewDialog: FC<ShareViewDialogProps> = ({
   model,
   onClose,
   view,
 }) => {
   const intl = useIntl();
+  const styles = useStyles();
   const [tab, setTab] = useState<'share' | 'download'>('share');
 
   return (
@@ -37,10 +49,10 @@ const ShareViewDialog: FC<ShareViewDialogProps> = ({
           <Tab label="Share" value="share" />
           <Tab label="Download" value="download" />
         </TabList>
-        <TabPanel value="share">
+        <TabPanel className={styles.tabPanel} value="share">
           <ShareViewDialogShareTab model={model} />
         </TabPanel>
-        <TabPanel value="download"></TabPanel>
+        <TabPanel className={styles.tabPanel} value="download"></TabPanel>
       </TabContext>
     </ZUIDialog>
   );

--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -1,0 +1,49 @@
+import { Tab } from '@mui/material';
+import { useIntl } from 'react-intl';
+import { FC, useState } from 'react';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+
+import ShareViewDialogShareTab from './ShareViewDialogShareTab';
+import ViewSharingModel from 'features/views/models/ViewSharingModel';
+import { ZetkinView } from '../types';
+import ZUIDialog from 'zui/ZUIDialog';
+
+interface ShareViewDialogProps {
+  model: ViewSharingModel;
+  onClose: () => void;
+  view: ZetkinView;
+}
+
+const ShareViewDialog: FC<ShareViewDialogProps> = ({
+  model,
+  onClose,
+  view,
+}) => {
+  const intl = useIntl();
+  const [tab, setTab] = useState<'share' | 'download'>('share');
+
+  return (
+    <ZUIDialog
+      maxWidth="md"
+      onClose={onClose}
+      open={true}
+      title={intl.formatMessage(
+        { id: 'pages.people.views.shareDialog.title' },
+        { title: view.title }
+      )}
+    >
+      <TabContext value={tab}>
+        <TabList onChange={(ev, newValue) => setTab(newValue)} value={tab}>
+          <Tab label="Share" value="share" />
+          <Tab label="Download" value="download" />
+        </TabList>
+        <TabPanel value="share">
+          <ShareViewDialogShareTab model={model} />
+        </TabPanel>
+        <TabPanel value="download"></TabPanel>
+      </TabContext>
+    </ZUIDialog>
+  );
+};
+
+export default ShareViewDialog;

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -1,6 +1,6 @@
 import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
-import { Box, Theme } from '@mui/material';
+import { Box, Button, Theme } from '@mui/material';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { FunctionComponent, useContext, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
@@ -11,8 +11,11 @@ import getViewColumns from '../fetching/getViewColumns';
 import getViewRows from '../fetching/getViewRows';
 import NProgress from 'nprogress';
 import patchView from 'features/views/fetching/patchView';
+import ShareViewDialog from '../components/ShareViewDialog';
 import TabbedLayout from 'utils/layout/TabbedLayout';
+import useModel from 'core/useModel';
 import ViewJumpMenu from 'features/views/components/ViewJumpMenu';
+import ViewSharingModel from '../models/ViewSharingModel';
 import ViewSmartSearchDialog from 'features/views/components/ViewSmartSearchDialog';
 import { viewsResource } from 'features/views/api/views';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
@@ -21,7 +24,7 @@ import { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUIQuery from 'zui/ZUIQuery';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
-import { Group, ViewColumnOutlined } from '@mui/icons-material';
+import { Group, Share, ViewColumnOutlined } from '@mui/icons-material';
 
 const useStyles = makeStyles<Theme, { deactivated: boolean }>(() => ({
   deactivateWrapper: {
@@ -42,11 +45,21 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   const router = useRouter();
   const { orgId, viewId } = router.query;
 
+  const shareModel = useModel(
+    (env) =>
+      new ViewSharingModel(
+        env,
+        parseInt(orgId as string),
+        parseInt(viewId as string)
+      )
+  );
+
   const [deactivated, setDeactivated] = useState(false);
   const classes = useStyles({ deactivated });
   const intl = useIntl();
   const queryClient = useQueryClient();
   const [queryDialogOpen, setQueryDialogOpen] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const viewQuery = useQuery(
     ['view', viewId],
     getView(orgId as string, viewId as string)
@@ -190,6 +203,15 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   return (
     <Box className={classes.deactivateWrapper}>
       <TabbedLayout
+        actionButtons={
+          <Button
+            endIcon={<Share />}
+            onClick={() => setShareDialogOpen(true)}
+            variant="contained"
+          >
+            <FormattedMessage id="pages.people.views.layout.actions.share" />
+          </Button>
+        }
         baseHref={`/organize/${orgId}/people/views/${viewId}`}
         defaultTab="/"
         ellipsisMenuItems={ellipsisMenu}
@@ -244,6 +266,13 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
           onDialogClose={() => setQueryDialogOpen(false)}
           orgId={orgId as string}
           view={view}
+        />
+      )}
+      {view && shareDialogOpen && (
+        <ShareViewDialog
+          model={shareModel}
+          onClose={() => setShareDialogOpen(false)}
+          view={viewQuery.data}
         />
       )}
     </Box>

--- a/src/features/views/models/ViewSharingModel.ts
+++ b/src/features/views/models/ViewSharingModel.ts
@@ -28,4 +28,8 @@ export default class ViewSharingModel extends ModelBase {
   get orgId(): number {
     return this._orgId;
   }
+
+  revokeAccess(personId: number): void {
+    this._repo.revokeAccess(this._orgId, this._viewId, personId);
+  }
 }

--- a/src/features/views/models/ViewSharingModel.ts
+++ b/src/features/views/models/ViewSharingModel.ts
@@ -21,6 +21,10 @@ export default class ViewSharingModel extends ModelBase {
     return this._repo.getViewAccessList(this._orgId, this._viewId);
   }
 
+  grantAccess(personId: number, level: ZetkinObjectAccess['level']) {
+    this._repo.grantAccess(this._orgId, this._viewId, personId, level);
+  }
+
   get orgId(): number {
     return this._orgId;
   }

--- a/src/features/views/models/ViewSharingModel.ts
+++ b/src/features/views/models/ViewSharingModel.ts
@@ -3,6 +3,7 @@ import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
 import ViewsRepo from '../repos/ViewsRepo';
 import { ZetkinObjectAccess } from 'core/api/types';
+import { ZetkinOfficial } from 'utils/types/zetkin';
 
 export default class ViewSharingModel extends ModelBase {
   private _orgId: number;
@@ -19,6 +20,10 @@ export default class ViewSharingModel extends ModelBase {
 
   getAccessList(): IFuture<ZetkinObjectAccess[]> {
     return this._repo.getViewAccessList(this._orgId, this._viewId);
+  }
+
+  getOfficials(): IFuture<ZetkinOfficial[]> {
+    return this._repo.getOfficials(this._orgId);
   }
 
   grantAccess(personId: number, level: ZetkinObjectAccess['level']) {

--- a/src/features/views/models/ViewSharingModel.ts
+++ b/src/features/views/models/ViewSharingModel.ts
@@ -1,0 +1,27 @@
+import Environment from 'core/env/Environment';
+import { IFuture } from 'core/caching/futures';
+import { ModelBase } from 'core/models';
+import ViewsRepo from '../repos/ViewsRepo';
+import { ZetkinObjectAccess } from 'core/api/types';
+
+export default class ViewSharingModel extends ModelBase {
+  private _orgId: number;
+  private _repo: ViewsRepo;
+  private _viewId: number;
+
+  constructor(env: Environment, orgId: number, viewId: number) {
+    super();
+
+    this._repo = new ViewsRepo(env);
+    this._orgId = orgId;
+    this._viewId = viewId;
+  }
+
+  getAccessList(): IFuture<ZetkinObjectAccess[]> {
+    return this._repo.getViewAccessList(this._orgId, this._viewId);
+  }
+
+  get orgId(): number {
+    return this._orgId;
+  }
+}

--- a/src/features/views/models/ViewSharingModel.ts
+++ b/src/features/views/models/ViewSharingModel.ts
@@ -37,4 +37,8 @@ export default class ViewSharingModel extends ModelBase {
   revokeAccess(personId: number): void {
     this._repo.revokeAccess(this._orgId, this._viewId, personId);
   }
+
+  get viewId(): number {
+    return this._viewId;
+  }
 }

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -9,6 +9,7 @@ import {
   accessAdded,
   accessLoad,
   accessLoaded,
+  accessRevoked,
   allItemsLoad,
   allItemsLoaded,
   folderCreate,
@@ -155,6 +156,14 @@ export default class ViewsRepo {
       )
       .then((accessObj) => {
         this._store.dispatch(accessAdded([viewId, accessObj]));
+      });
+  }
+
+  revokeAccess(orgId: number, viewId: number, personId: number) {
+    this._apiClient
+      .delete(`/api/orgs/${orgId}/people/views/${viewId}/access/${personId}`)
+      .then(() => {
+        this._store.dispatch(accessRevoked([viewId, personId]));
       });
   }
 

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -6,6 +6,7 @@ import { Store } from 'core/store';
 import { ViewTreeData } from 'pages/api/views/tree';
 import { ZetkinObjectAccess } from 'core/api/types';
 import {
+  accessAdded,
   accessLoad,
   accessLoaded,
   allItemsLoad,
@@ -137,6 +138,24 @@ export default class ViewsRepo {
         views: state.views.viewList.items.map((item) => item.data!),
       });
     }
+  }
+
+  grantAccess(
+    orgId: number,
+    viewId: number,
+    personId: number,
+    level: ZetkinObjectAccess['level']
+  ) {
+    this._apiClient
+      .put<ZetkinObjectAccess>(
+        `/api/orgs/${orgId}/people/views/${viewId}/access/${personId}`,
+        {
+          level,
+        }
+      )
+      .then((accessObj) => {
+        this._store.dispatch(accessAdded([viewId, accessObj]));
+      });
   }
 
   updateFolder(

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -34,14 +34,26 @@ const viewsSlice = createSlice({
       const [viewId, accessObj] = action.payload;
       const list = state.accessByViewId[viewId];
       if (list) {
-        list.items.push(
-          remoteItem(accessObj.person.id, {
-            data: {
-              id: accessObj.person.id,
-              ...accessObj,
-            },
-          })
-        );
+        let updated = false;
+        const newItem = remoteItem(accessObj.person.id, {
+          data: {
+            id: accessObj.person.id,
+            ...accessObj,
+          },
+        });
+
+        list.items = list.items.map((item) => {
+          if (item.id == accessObj.person.id) {
+            updated = true;
+            return newItem;
+          } else {
+            return item;
+          }
+        });
+
+        if (!updated) {
+          list.items.push(newItem);
+        }
       }
     },
     accessLoad: (state, action: PayloadAction<number>) => {

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -78,6 +78,13 @@ const viewsSlice = createSlice({
       );
       state.accessByViewId[viewId].loaded = new Date().toISOString();
     },
+    accessRevoked: (state, action: PayloadAction<[number, number]>) => {
+      const [viewId, personId] = action.payload;
+      const list = state.accessByViewId[viewId];
+      if (list) {
+        list.items = list.items.filter((item) => item.id != personId);
+      }
+    },
     allItemsLoad: (state) => {
       state.folderList.isLoading = true;
       state.viewList.isLoading = true;
@@ -180,6 +187,7 @@ export const {
   accessAdded,
   accessLoad,
   accessLoaded,
+  accessRevoked,
   allItemsLoad,
   allItemsLoaded,
   folderCreate,

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -27,6 +27,23 @@ const viewsSlice = createSlice({
   initialState,
   name: 'views',
   reducers: {
+    accessAdded: (
+      state,
+      action: PayloadAction<[number, ZetkinObjectAccess]>
+    ) => {
+      const [viewId, accessObj] = action.payload;
+      const list = state.accessByViewId[viewId];
+      if (list) {
+        list.items.push(
+          remoteItem(accessObj.person.id, {
+            data: {
+              id: accessObj.person.id,
+              ...accessObj,
+            },
+          })
+        );
+      }
+    },
     accessLoad: (state, action: PayloadAction<number>) => {
       if (!state.accessByViewId[action.payload]) {
         state.accessByViewId[action.payload] =
@@ -148,6 +165,7 @@ const viewsSlice = createSlice({
 
 export default viewsSlice;
 export const {
+  accessAdded,
   accessLoad,
   accessLoaded,
   allItemsLoad,

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -1,6 +1,7 @@
 import { DeleteFolderReport } from 'pages/api/views/deleteFolder';
 import { ViewTreeData } from 'pages/api/views/tree';
 import { ZetkinObjectAccess } from 'core/api/types';
+import { ZetkinOfficial } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 import { ZetkinView, ZetkinViewFolder } from './components/types';
@@ -12,6 +13,7 @@ type ZetkinObjectAccessWithId = ZetkinObjectAccess & {
 export interface ViewsStoreSlice {
   accessByViewId: Record<number | string, RemoteList<ZetkinObjectAccessWithId>>;
   folderList: RemoteList<ZetkinViewFolder>;
+  officialList: RemoteList<ZetkinOfficial>;
   recentlyCreatedFolder: ZetkinViewFolder | null;
   viewList: RemoteList<ZetkinView>;
 }
@@ -19,6 +21,7 @@ export interface ViewsStoreSlice {
 const initialState: ViewsStoreSlice = {
   accessByViewId: {},
   folderList: remoteList(),
+  officialList: remoteList(),
   recentlyCreatedFolder: null,
   viewList: remoteList(),
 };
@@ -142,6 +145,13 @@ const viewsSlice = createSlice({
         }
       }
     },
+    officialsLoad: (state) => {
+      state.officialList.isLoading = true;
+    },
+    officialsLoaded: (state, action: PayloadAction<ZetkinOfficial[]>) => {
+      state.officialList = remoteList(action.payload);
+      state.officialList.loaded = new Date().toISOString();
+    },
     viewCreate: (state) => {
       state.viewList.isLoading = true;
     },
@@ -195,6 +205,8 @@ export const {
   folderDeleted,
   folderUpdate,
   folderUpdated,
+  officialsLoad,
+  officialsLoaded,
   viewCreate,
   viewCreated,
   viewDeleted,

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -32,8 +32,10 @@ layout:
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
   share:
+    collabInstructions: Outside collaborators are able to access {viewLink}
     showOfficials: Show officials
     statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.
+    viewLink: the restricted view
   title: 'Share "{title}"'
 viewsList:
   columns:

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -16,6 +16,8 @@ browser:
   moveToFolder: 'Move to {folder}'
   moveToRoot: Move to all views
 layout:
+  actions:
+    share: Share
   deleteDialog:
     error: There was an error deleting the view
   ellipsisMenu:
@@ -28,6 +30,8 @@ layout:
   subtitle:
     columns: '{count, plural, =0 {No columns} =1 {1 column} other {# columns}}'
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
+shareDialog:
+  title: 'Share "{title}"'
 viewsList:
   columns:
     created: Date created

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -32,6 +32,7 @@ layout:
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
   share:
+    showOfficials: Show officials
     statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.
   title: 'Share "{title}"'
 viewsList:

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -32,6 +32,7 @@ layout:
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
   share:
+    addPlaceholder: Share with…
     collabInstructions: Outside collaborators are able to access {viewLink}
     showOfficials: Show officials
     statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -31,6 +31,8 @@ layout:
     columns: '{count, plural, =0 {No columns} =1 {1 column} other {# columns}}'
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
+  share:
+    statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.
   title: 'Share "{title}"'
 viewsList:
   columns:

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -32,11 +32,11 @@ layout:
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
   share:
-    addPlaceholder: Share with…
-    collabInstructions: Outside collaborators are able to access {viewLink}
+    addPlaceholder: Add collaborator
+    collabInstructions: After adding collaborators, copy and send them the {viewLink}
     showOfficials: Show officials
     statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.
-    viewLink: the restricted view
+    viewLink: restricted link
   title: 'Share "{title}"'
 viewsList:
   columns:

--- a/src/locale/zui/accessList/en.yml
+++ b/src/locale/zui/accessList/en.yml
@@ -1,3 +1,4 @@
+added: Added by {sharer} {updated}
 levels:
   configure: Edit & Configure
   edit: Editing

--- a/src/locale/zui/accessList/en.yml
+++ b/src/locale/zui/accessList/en.yml
@@ -1,0 +1,5 @@
+levels:
+  configure: Edit & Configure
+  edit: Editing
+  readonly: Read-only
+removeAccess: Remove access

--- a/src/locale/zui/accessList/en.yml
+++ b/src/locale/zui/accessList/en.yml
@@ -3,3 +3,6 @@ levels:
   edit: Editing
   readonly: Read-only
 removeAccess: Remove access
+roles:
+  admin: Admin
+  organizer: Organizer

--- a/src/locale/zui/copyToClipboard/en.yml
+++ b/src/locale/zui/copyToClipboard/en.yml
@@ -1,0 +1,1 @@
+copiedValue: 'Copied "{value}"'

--- a/src/utils/hooks/useAbsoluteUrl.ts
+++ b/src/utils/hooks/useAbsoluteUrl.ts
@@ -1,0 +1,30 @@
+import { stringToBool } from 'utils/stringUtils';
+
+type URLDraft = {
+  host: string;
+  pathname: string;
+  protocol: string;
+};
+
+export default function useAbsoluteUrl(path = '') {
+  const draft: URLDraft = {
+    host: '',
+    pathname: '',
+    protocol: '',
+  };
+
+  if (typeof location == 'undefined') {
+    // On server
+    draft.protocol = stringToBool(process.env.ZETKIN_USE_TLS)
+      ? 'https:'
+      : 'http:';
+    draft.host = process.env.ZETKIN_APP_HOST || 'app.zetkin.org';
+  } else {
+    // In browser
+    draft.protocol = location.protocol;
+    draft.host = location.host;
+  }
+  draft.pathname = path;
+
+  return `${draft.protocol}//${draft.host}${path}`;
+}

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -186,7 +186,7 @@ export const scaffold =
     // Figure out browser's preferred language
     const lang = getBrowserLanguage(contextFromNext.req);
 
-    const localeScope = (options?.localeScope ?? []).concat(['misc']);
+    const localeScope = (options?.localeScope ?? []).concat(['misc', 'zui']);
     const messages = await getMessages(lang, localeScope);
 
     if (hasProps(result)) {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -37,6 +37,13 @@ export interface ZetkinMembership {
   role: string | null;
 }
 
+export interface ZetkinOfficial {
+  id: number;
+  role: 'organizer' | 'admin';
+  first_name: string;
+  last_name: string;
+}
+
 export interface ZetkinEventResponse {
   action_id: number;
   id: number;

--- a/src/zui/ZUIAccessList/AccessListItem.tsx
+++ b/src/zui/ZUIAccessList/AccessListItem.tsx
@@ -1,0 +1,33 @@
+import { Box, ListItem, Typography } from '@mui/material';
+import { FC, ReactNode } from 'react';
+
+import ZUIAvatar from 'zui/ZUIAvatar';
+
+interface AccessListItemProps {
+  action?: ReactNode;
+  orgId: number;
+  personId: number;
+  title: string;
+}
+const AccessListItem: FC<AccessListItemProps> = ({
+  action,
+  orgId,
+  personId,
+  title,
+}) => {
+  return (
+    <ListItem>
+      <Box alignItems="center" display="flex" gap={2} p={1} width="100%">
+        <Box>
+          <ZUIAvatar orgId={orgId} personId={personId} />
+        </Box>
+        <Box flexGrow={1}>
+          <Typography>{title}</Typography>
+        </Box>
+        <Box>{action}</Box>
+      </Box>
+    </ListItem>
+  );
+};
+
+export default AccessListItem;

--- a/src/zui/ZUIAccessList/AccessListItem.tsx
+++ b/src/zui/ZUIAccessList/AccessListItem.tsx
@@ -17,9 +17,9 @@ const AccessListItem: FC<AccessListItemProps> = ({
 }) => {
   return (
     <ListItem>
-      <Box alignItems="center" display="flex" gap={2} p={1} width="100%">
+      <Box alignItems="center" display="flex" gap={2} width="100%">
         <Box>
-          <ZUIAvatar orgId={orgId} personId={personId} />
+          <ZUIAvatar orgId={orgId} personId={personId} size="sm" />
         </Box>
         <Box flexGrow={1}>
           <Typography>{title}</Typography>

--- a/src/zui/ZUIAccessList/AccessListItem.tsx
+++ b/src/zui/ZUIAccessList/AccessListItem.tsx
@@ -7,12 +7,14 @@ interface AccessListItemProps {
   action?: ReactNode;
   orgId: number;
   personId: number;
-  title: string;
+  subtitle?: ReactNode;
+  title: ReactNode;
 }
 const AccessListItem: FC<AccessListItemProps> = ({
   action,
   orgId,
   personId,
+  subtitle,
   title,
 }) => {
   return (
@@ -22,7 +24,10 @@ const AccessListItem: FC<AccessListItemProps> = ({
           <ZUIAvatar orgId={orgId} personId={personId} size="sm" />
         </Box>
         <Box flexGrow={1}>
-          <Typography>{title}</Typography>
+          <Typography component="div">{title}</Typography>
+          <Typography color="gray" component="div" variant="caption">
+            {subtitle}
+          </Typography>
         </Box>
         <Box>{action}</Box>
       </Box>

--- a/src/zui/ZUIAccessList/index.stories.tsx
+++ b/src/zui/ZUIAccessList/index.stories.tsx
@@ -10,14 +10,18 @@ export default {
 const Template: ComponentStory<typeof ZUIAccessList> = (args) => {
   return (
     <div style={{ width: 700 }}>
-      <ZUIAccessList list={args.list} orgId={args.orgId} />
+      <ZUIAccessList
+        accessList={args.accessList}
+        officials={args.officials}
+        orgId={args.orgId}
+      />
     </div>
   );
 };
 
 export const basic = Template.bind({});
 basic.args = {
-  list: [
+  accessList: [
     {
       level: 'configure',
       person: {
@@ -73,6 +77,20 @@ basic.args = {
         id: 1,
         last_name: 'Zetkin',
       },
+    },
+  ],
+  officials: [
+    {
+      first_name: 'Angela',
+      id: 2,
+      last_name: 'Davis',
+      role: 'admin',
+    },
+    {
+      first_name: 'Angela',
+      id: 2,
+      last_name: 'Davis',
+      role: 'organizer',
     },
   ],
   orgId: 1,

--- a/src/zui/ZUIAccessList/index.stories.tsx
+++ b/src/zui/ZUIAccessList/index.stories.tsx
@@ -1,0 +1,79 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUIAccessList from '.';
+
+export default {
+  component: ZUIAccessList,
+  title: 'Molecules/ZUIAccessList',
+} as ComponentMeta<typeof ZUIAccessList>;
+
+const Template: ComponentStory<typeof ZUIAccessList> = (args) => {
+  return (
+    <div style={{ width: 700 }}>
+      <ZUIAccessList list={args.list} orgId={args.orgId} />
+    </div>
+  );
+};
+
+export const basic = Template.bind({});
+basic.args = {
+  list: [
+    {
+      level: 'configure',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'edit',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+    },
+  ],
+  orgId: 1,
+};

--- a/src/zui/ZUIAccessList/index.stories.tsx
+++ b/src/zui/ZUIAccessList/index.stories.tsx
@@ -29,6 +29,12 @@ basic.args = {
         id: 1,
         last_name: 'Zetkin',
       },
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
+      },
     },
     {
       level: 'edit',
@@ -37,13 +43,11 @@ basic.args = {
         id: 1,
         last_name: 'Zetkin',
       },
-    },
-    {
-      level: 'readonly',
-      person: {
-        first_name: 'Clara',
-        id: 1,
-        last_name: 'Zetkin',
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
       },
     },
     {
@@ -53,13 +57,11 @@ basic.args = {
         id: 1,
         last_name: 'Zetkin',
       },
-    },
-    {
-      level: 'readonly',
-      person: {
-        first_name: 'Clara',
-        id: 1,
-        last_name: 'Zetkin',
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
       },
     },
     {
@@ -69,6 +71,12 @@ basic.args = {
         id: 1,
         last_name: 'Zetkin',
       },
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
+      },
     },
     {
       level: 'readonly',
@@ -76,6 +84,40 @@ basic.args = {
         first_name: 'Clara',
         id: 1,
         last_name: 'Zetkin',
+      },
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
+      },
+    },
+    {
+      level: 'readonly',
+      person: {
+        first_name: 'Clara',
+        id: 1,
+        last_name: 'Zetkin',
+      },
+      updated: '1857-07-05T13:37:00.000Z',
+      updated_by: {
+        first_name: 'Angela',
+        id: 2,
+        last_name: 'Davis',
       },
     },
   ],

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -1,0 +1,74 @@
+import { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+import {
+  Box,
+  Divider,
+  FormControl,
+  List,
+  ListItem,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+
+import { ZetkinObjectAccess } from 'core/api/types';
+import ZUIAvatar from 'zui/ZUIAvatar';
+
+interface ZUIAccessListProps {
+  orgId: number;
+  list: ZetkinObjectAccess[];
+}
+
+const ZUIAccessList: FC<ZUIAccessListProps> = ({ list, orgId }) => {
+  return (
+    <List>
+      {list.map((item) => {
+        const { person, level } = item;
+        return (
+          <>
+            <ListItem>
+              <Box
+                alignItems="center"
+                display="flex"
+                gap={2}
+                p={1}
+                width="100%"
+              >
+                <Box>
+                  <ZUIAvatar orgId={orgId} personId={item.person.id} />
+                </Box>
+                <Box flexGrow={1}>
+                  <Typography>
+                    {`${person.first_name} ${person.last_name}`}
+                  </Typography>
+                </Box>
+                <Box>
+                  <FormControl fullWidth size="small">
+                    <Select value={level}>
+                      <MenuItem value="readonly">
+                        <FormattedMessage id="zui.accessList.levels.readonly" />
+                      </MenuItem>
+                      <MenuItem value="edit">
+                        <FormattedMessage id="zui.accessList.levels.edit" />
+                      </MenuItem>
+                      <MenuItem value="configure">
+                        <FormattedMessage id="zui.accessList.levels.configure" />
+                      </MenuItem>
+                      <Divider />
+                      <MenuItem value="delete">
+                        <FormattedMessage id="zui.accessList.removeAccess" />
+                      </MenuItem>
+                    </Select>
+                  </FormControl>
+                </Box>
+              </Box>
+            </ListItem>
+            <Divider />
+          </>
+        );
+      })}
+    </List>
+  );
+};
+
+export default ZUIAccessList;

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -1,19 +1,10 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
-import {
-  Box,
-  Divider,
-  FormControl,
-  List,
-  ListItem,
-  MenuItem,
-  Select,
-  Typography,
-} from '@mui/material';
+import { Divider, FormControl, List, MenuItem, Select } from '@mui/material';
 
+import AccessListItem from './AccessListItem';
 import { ZetkinObjectAccess } from 'core/api/types';
 import { ZetkinOfficial } from 'utils/types/zetkin';
-import ZUIAvatar from 'zui/ZUIAvatar';
 
 interface ZUIAccessListProps {
   accessList: ZetkinObjectAccess[];
@@ -38,25 +29,14 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
       {officials.map((item) => {
         return (
           <>
-            <ListItem>
-              <Box
-                alignItems="center"
-                display="flex"
-                gap={2}
-                p={1}
-                width="100%"
-              >
-                <Box>
-                  <ZUIAvatar orgId={orgId} personId={item.id} />
-                </Box>
-                <Box flexGrow={1}>
-                  <Typography>{`${item.first_name} ${item.last_name}`}</Typography>
-                </Box>
-                <Box>
-                  <FormattedMessage id={`zui.accessList.roles.${item.role}`} />
-                </Box>
-              </Box>
-            </ListItem>
+            <AccessListItem
+              action={
+                <FormattedMessage id={`zui.accessList.roles.${item.role}`} />
+              }
+              orgId={orgId}
+              personId={item.id}
+              title={`${item.first_name} ${item.last_name}`}
+            />
             <Divider />
           </>
         );
@@ -65,59 +45,46 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
         const { person, level } = item;
         return (
           <>
-            <ListItem>
-              <Box
-                alignItems="center"
-                display="flex"
-                gap={2}
-                p={1}
-                width="100%"
-              >
-                <Box>
-                  <ZUIAvatar orgId={orgId} personId={item.person.id} />
-                </Box>
-                <Box flexGrow={1}>
-                  <Typography>
-                    {`${person.first_name} ${person.last_name}`}
-                  </Typography>
-                </Box>
-                <Box>
-                  <FormControl fullWidth size="small">
-                    <Select
-                      onChange={(ev) => {
-                        const level = ev.target.value;
-                        if (
-                          level == 'configure' ||
-                          level == 'edit' ||
-                          level == 'readonly'
-                        ) {
-                          if (onChangeLevel) {
-                            onChangeLevel(person.id, level);
-                          }
-                        } else if (level == 'delete' && onRevoke) {
-                          onRevoke(person.id);
+            <AccessListItem
+              action={
+                <FormControl fullWidth size="small">
+                  <Select
+                    onChange={(ev) => {
+                      const level = ev.target.value;
+                      if (
+                        level == 'configure' ||
+                        level == 'edit' ||
+                        level == 'readonly'
+                      ) {
+                        if (onChangeLevel) {
+                          onChangeLevel(person.id, level);
                         }
-                      }}
-                      value={level}
-                    >
-                      <MenuItem value="readonly">
-                        <FormattedMessage id="zui.accessList.levels.readonly" />
-                      </MenuItem>
-                      <MenuItem value="edit">
-                        <FormattedMessage id="zui.accessList.levels.edit" />
-                      </MenuItem>
-                      <MenuItem value="configure">
-                        <FormattedMessage id="zui.accessList.levels.configure" />
-                      </MenuItem>
-                      <Divider />
-                      <MenuItem value="delete">
-                        <FormattedMessage id="zui.accessList.removeAccess" />
-                      </MenuItem>
-                    </Select>
-                  </FormControl>
-                </Box>
-              </Box>
-            </ListItem>
+                      } else if (level == 'delete' && onRevoke) {
+                        onRevoke(person.id);
+                      }
+                    }}
+                    value={level}
+                  >
+                    <MenuItem value="readonly">
+                      <FormattedMessage id="zui.accessList.levels.readonly" />
+                    </MenuItem>
+                    <MenuItem value="edit">
+                      <FormattedMessage id="zui.accessList.levels.edit" />
+                    </MenuItem>
+                    <MenuItem value="configure">
+                      <FormattedMessage id="zui.accessList.levels.configure" />
+                    </MenuItem>
+                    <Divider />
+                    <MenuItem value="delete">
+                      <FormattedMessage id="zui.accessList.removeAccess" />
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              }
+              orgId={orgId}
+              personId={person.id}
+              title={`${person.first_name} ${person.last_name}`}
+            />
             <Divider />
           </>
         );

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -24,11 +24,15 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
   onRevoke,
   orgId,
 }) => {
+  let first = true;
   return (
     <List>
       {officials.map((item) => {
+        const showDivider = !first;
+        first = false;
         return (
           <>
+            {showDivider && <Divider />}
             <AccessListItem
               action={
                 <FormattedMessage id={`zui.accessList.roles.${item.role}`} />
@@ -37,14 +41,16 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
               personId={item.id}
               title={`${item.first_name} ${item.last_name}`}
             />
-            <Divider />
           </>
         );
       })}
       {accessList.map((item) => {
         const { person, level } = item;
+        const showDivider = !first;
+        first = false;
         return (
           <>
+            {showDivider && <Divider />}
             <AccessListItem
               action={
                 <FormControl fullWidth size="small">
@@ -85,7 +91,6 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
               personId={person.id}
               title={`${person.first_name} ${person.last_name}`}
             />
-            <Divider />
           </>
         );
       })}

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { Divider, FormControl, List, MenuItem, Select } from '@mui/material';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import AccessListItem from './AccessListItem';
 import { ZetkinObjectAccess } from 'core/api/types';
 import { ZetkinOfficial } from 'utils/types/zetkin';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 
 interface ZUIAccessListProps {
   accessList: ZetkinObjectAccess[];
@@ -24,6 +25,7 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
   onRevoke,
   orgId,
 }) => {
+  const intl = useIntl();
   let first = true;
   return (
     <List>
@@ -39,13 +41,14 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
               }
               orgId={orgId}
               personId={item.id}
+              subtitle="-"
               title={`${item.first_name} ${item.last_name}`}
             />
           </>
         );
       })}
       {accessList.map((item) => {
-        const { person, level } = item;
+        const { person, level, updated, updated_by: sharer } = item;
         const showDivider = !first;
         first = false;
         return (
@@ -89,6 +92,19 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
               }
               orgId={orgId}
               personId={person.id}
+              subtitle={intl.formatMessage(
+                { id: 'zui.accessList.added' },
+                {
+                  sharer: `${sharer.first_name} ${sharer.last_name}`,
+                  updated: (
+                    <ZUIRelativeTime
+                      convertToLocal
+                      datetime={updated}
+                      forcePast
+                    />
+                  ),
+                }
+              )}
               title={`${person.first_name} ${person.last_name}`}
             />
           </>

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -15,11 +15,19 @@ import { ZetkinObjectAccess } from 'core/api/types';
 import ZUIAvatar from 'zui/ZUIAvatar';
 
 interface ZUIAccessListProps {
-  orgId: number;
   list: ZetkinObjectAccess[];
+  onChangeLevel?: (
+    personId: number,
+    level: ZetkinObjectAccess['level']
+  ) => void;
+  orgId: number;
 }
 
-const ZUIAccessList: FC<ZUIAccessListProps> = ({ list, orgId }) => {
+const ZUIAccessList: FC<ZUIAccessListProps> = ({
+  list,
+  onChangeLevel,
+  orgId,
+}) => {
   return (
     <List>
       {list.map((item) => {
@@ -44,7 +52,21 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({ list, orgId }) => {
                 </Box>
                 <Box>
                   <FormControl fullWidth size="small">
-                    <Select value={level}>
+                    <Select
+                      onChange={(ev) => {
+                        const level = ev.target.value;
+                        if (
+                          level == 'configure' ||
+                          level == 'edit' ||
+                          level == 'readonly'
+                        ) {
+                          if (onChangeLevel) {
+                            onChangeLevel(person.id, level);
+                          }
+                        }
+                      }}
+                      value={level}
+                    >
                       <MenuItem value="readonly">
                         <FormattedMessage id="zui.accessList.levels.readonly" />
                       </MenuItem>

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -12,10 +12,12 @@ import {
 } from '@mui/material';
 
 import { ZetkinObjectAccess } from 'core/api/types';
+import { ZetkinOfficial } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
 
 interface ZUIAccessListProps {
-  list: ZetkinObjectAccess[];
+  accessList: ZetkinObjectAccess[];
+  officials: ZetkinOfficial[];
   onChangeLevel?: (
     personId: number,
     level: ZetkinObjectAccess['level']
@@ -25,14 +27,41 @@ interface ZUIAccessListProps {
 }
 
 const ZUIAccessList: FC<ZUIAccessListProps> = ({
-  list,
+  accessList,
+  officials,
   onChangeLevel,
   onRevoke,
   orgId,
 }) => {
   return (
     <List>
-      {list.map((item) => {
+      {officials.map((item) => {
+        return (
+          <>
+            <ListItem>
+              <Box
+                alignItems="center"
+                display="flex"
+                gap={2}
+                p={1}
+                width="100%"
+              >
+                <Box>
+                  <ZUIAvatar orgId={orgId} personId={item.id} />
+                </Box>
+                <Box flexGrow={1}>
+                  <Typography>{`${item.first_name} ${item.last_name}`}</Typography>
+                </Box>
+                <Box>
+                  <FormattedMessage id={`zui.accessList.roles.${item.role}`} />
+                </Box>
+              </Box>
+            </ListItem>
+            <Divider />
+          </>
+        );
+      })}
+      {accessList.map((item) => {
         const { person, level } = item;
         return (
           <>

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -20,12 +20,14 @@ interface ZUIAccessListProps {
     personId: number,
     level: ZetkinObjectAccess['level']
   ) => void;
+  onRevoke?: (personId: number) => void;
   orgId: number;
 }
 
 const ZUIAccessList: FC<ZUIAccessListProps> = ({
   list,
   onChangeLevel,
+  onRevoke,
   orgId,
 }) => {
   return (
@@ -63,6 +65,8 @@ const ZUIAccessList: FC<ZUIAccessListProps> = ({
                           if (onChangeLevel) {
                             onChangeLevel(person.id, level);
                           }
+                        } else if (level == 'delete' && onRevoke) {
+                          onRevoke(person.id);
                         }
                       }}
                       value={level}

--- a/src/zui/ZUIAvatar/index.stories.tsx
+++ b/src/zui/ZUIAvatar/index.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUIAvatar from '.';
+
+export default {
+  component: ZUIAvatar,
+  title: 'Atoms/ZUIAvatar',
+} as ComponentMeta<typeof ZUIAvatar>;
+
+const Template: ComponentStory<typeof ZUIAvatar> = (args) => {
+  return <ZUIAvatar orgId={args.orgId} personId={args.personId} />;
+};
+
+export const basic = Template.bind({});
+basic.args = {
+  orgId: 1,
+  personId: 1,
+};

--- a/src/zui/ZUIAvatar/index.tsx
+++ b/src/zui/ZUIAvatar/index.tsx
@@ -4,10 +4,20 @@ import { FC } from 'react';
 interface ZUIAvatarProps {
   orgId: number;
   personId: number;
+  size?: 'sm' | 'md';
 }
+const SIZES = {
+  md: 40,
+  sm: 30,
+};
 
-const ZUIAvatar: FC<ZUIAvatarProps> = ({ orgId, personId }) => {
-  return <Avatar src={`/api/orgs/${orgId}/people/${personId}/avatar`} />;
+const ZUIAvatar: FC<ZUIAvatarProps> = ({ orgId, personId, size = 'md' }) => {
+  return (
+    <Avatar
+      src={`/api/orgs/${orgId}/people/${personId}/avatar`}
+      style={{ height: SIZES[size], width: SIZES[size] }}
+    />
+  );
 };
 
 export default ZUIAvatar;

--- a/src/zui/ZUIAvatar/index.tsx
+++ b/src/zui/ZUIAvatar/index.tsx
@@ -1,0 +1,13 @@
+import { Avatar } from '@mui/material';
+import { FC } from 'react';
+
+interface ZUIAvatarProps {
+  orgId: number;
+  personId: number;
+}
+
+const ZUIAvatar: FC<ZUIAvatarProps> = ({ orgId, personId }) => {
+  return <Avatar src={`/api/orgs/${orgId}/people/${personId}/avatar`} />;
+};
+
+export default ZUIAvatar;

--- a/src/zui/ZUICopyToClipboard.tsx
+++ b/src/zui/ZUICopyToClipboard.tsx
@@ -2,35 +2,8 @@ import copy from 'copy-to-clipboard';
 import { FormattedMessage } from 'react-intl';
 import { ButtonBase, Collapse, Fade, Grid, Typography } from '@mui/material';
 import React, { useState } from 'react';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
-interface IconProps {
-  size?: number;
-  svgProps?: SvgIconProps;
-  color?: 'inherit' | 'disabled' | 'action' | 'secondary' | 'primary' | 'error';
-  htmlColor?: string;
-}
-
-const CopyIcon = ({
-  size,
-  color,
-  htmlColor,
-  svgProps,
-}: IconProps): JSX.Element => {
-  return (
-    <SvgIcon
-      color={color}
-      htmlColor={htmlColor}
-      style={{ fontSize: size }}
-      {...svgProps}
-      viewBox="0 0 24 24"
-    >
-      <g>
-        <path d="M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z" />
-      </g>
-    </SvgIcon>
-  );
-};
+import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 
 const ZUICopyToClipboard: React.FunctionComponent<{
   children: React.ReactNode;

--- a/src/zui/ZUIFutures/index.tsx
+++ b/src/zui/ZUIFutures/index.tsx
@@ -60,12 +60,6 @@ function ZUIFutures<G extends Record<string, unknown>>({
     dataObjects[key] = future.data;
   });
 
-  /*
-  const dataObjects = futures as {
-    [I in keyof G]: G[I];
-  };
-  */
-
   // Render children if query resolves successfully
   return typeof children === 'function' ? (
     children({ data: dataObjects as { [I in keyof G]: G[I] } }) // Expose the successfully resolved query if children is a function

--- a/src/zui/ZUIFutures/index.tsx
+++ b/src/zui/ZUIFutures/index.tsx
@@ -1,0 +1,77 @@
+import { ErrorOutlined } from '@mui/icons-material';
+import { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Box, CircularProgress, Typography } from '@mui/material';
+
+import { IFuture } from 'core/caching/futures';
+
+interface ZUIFuturesProps<G extends Record<string, unknown>> {
+  children?:
+    | React.ReactNode
+    | (({
+        data,
+      }: {
+        data: { [I in keyof G]: G[I] };
+      }) => React.ReactElement | null);
+  errorIndicator?: React.ReactElement;
+  futures: { [I in keyof G]: IFuture<G[I]> };
+  loadingIndicator?: React.ReactElement;
+}
+
+function ZUIFutures<G extends Record<string, unknown>>({
+  children,
+  errorIndicator,
+  futures,
+  loadingIndicator,
+}: ZUIFuturesProps<G>): ReturnType<FC> {
+  if (Object.values(futures).some((future) => future.error)) {
+    return (
+      errorIndicator || (
+        <Box
+          alignItems="center"
+          data-testid="error-indicator"
+          display="flex"
+          flexDirection="column"
+          justifyItems="center"
+          padding={3}
+          width="100%"
+        >
+          <ErrorOutlined color="error" fontSize="large" />
+          <Typography variant="body1">
+            <FormattedMessage id="misc.errorLoading" />
+          </Typography>
+        </Box>
+      )
+    );
+  }
+
+  if (Object.values(futures).some((future) => future.isLoading)) {
+    return (
+      loadingIndicator || (
+        <Box display="flex" justifyContent="center" padding={3} width="100%">
+          <CircularProgress data-testid="loading-indicator" disableShrink />
+        </Box>
+      )
+    );
+  }
+
+  const dataObjects: Record<string, unknown> = {};
+  Object.entries(futures).forEach(([key, future]) => {
+    dataObjects[key] = future.data;
+  });
+
+  /*
+  const dataObjects = futures as {
+    [I in keyof G]: G[I];
+  };
+  */
+
+  // Render children if query resolves successfully
+  return typeof children === 'function' ? (
+    children({ data: dataObjects as { [I in keyof G]: G[I] } }) // Expose the successfully resolved query if children is a function
+  ) : (
+    <>{children || null}</>
+  ); // Otherwise render children
+}
+
+export default ZUIFutures;

--- a/src/zui/ZUIInlineCopyToClipBoard.tsx
+++ b/src/zui/ZUIInlineCopyToClipBoard.tsx
@@ -1,8 +1,10 @@
 import copy from 'copy-to-clipboard';
-import { FormattedMessage } from 'react-intl';
-import { Box, Collapse, Fade, IconButton, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import { useIntl } from 'react-intl';
+import { Box, Fade, IconButton } from '@mui/material';
+import React, { useContext, useState } from 'react';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+import ZUISnackbarContext from './ZUISnackbarContext';
 
 interface IconProps {
   size?: number;
@@ -37,13 +39,23 @@ const ZUIInlineCopyToClipboard: React.FunctionComponent<{
   children: React.ReactNode;
   copyText: string | number | boolean;
 }> = ({ alwaysShowIcon = false, children, copyText }) => {
+  const intl = useIntl();
   const [hover, setHover] = useState<boolean>(false);
-  const [copied, setCopied] = useState<boolean>(false);
+
+  const { showSnackbar } = useContext(ZUISnackbarContext);
 
   const handleClick = () => {
-    copy(copyText.toString());
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2500);
+    const str = copyText.toString();
+    copy(str);
+    showSnackbar(
+      'success',
+      intl.formatMessage(
+        { id: 'zui.copyToClipboard.copiedValue' },
+        {
+          value: str.length > 30 ? str.slice(0, 30) + '…' : str,
+        }
+      )
+    );
   };
 
   return (
@@ -65,23 +77,6 @@ const ZUIInlineCopyToClipboard: React.FunctionComponent<{
           <IconButton onClick={() => handleClick()}>
             <CopyIcon />
           </IconButton>
-          <Box
-            style={{
-              left: '36px',
-              position: 'absolute',
-              top: '6px',
-            }}
-          >
-            <Collapse in={copied}>
-              <Typography
-                color="secondary"
-                style={{ fontSize: 11, fontWeight: 'bold' }}
-                variant="button"
-              >
-                <FormattedMessage id="misc.copyToClipboard.copied" />
-              </Typography>
-            </Collapse>
-          </Box>
         </Box>
       </Fade>
     </Box>

--- a/src/zui/ZUIInlineCopyToClipBoard.tsx
+++ b/src/zui/ZUIInlineCopyToClipBoard.tsx
@@ -1,0 +1,91 @@
+import copy from 'copy-to-clipboard';
+import { FormattedMessage } from 'react-intl';
+import { Box, Collapse, Fade, IconButton, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+
+interface IconProps {
+  size?: number;
+  svgProps?: SvgIconProps;
+  color?: 'inherit' | 'disabled' | 'action' | 'secondary' | 'primary' | 'error';
+  htmlColor?: string;
+}
+
+export const CopyIcon = ({
+  size,
+  color,
+  htmlColor,
+  svgProps,
+}: IconProps): JSX.Element => {
+  return (
+    <SvgIcon
+      color={color}
+      htmlColor={htmlColor}
+      style={{ fontSize: size }}
+      {...svgProps}
+      viewBox="0 0 24 24"
+    >
+      <g>
+        <path d="M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z" />
+      </g>
+    </SvgIcon>
+  );
+};
+
+const ZUIInlineCopyToClipboard: React.FunctionComponent<{
+  alwaysShowIcon?: boolean;
+  children: React.ReactNode;
+  copyText: string | number | boolean;
+}> = ({ alwaysShowIcon = false, children, copyText }) => {
+  const [hover, setHover] = useState<boolean>(false);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const handleClick = () => {
+    copy(copyText.toString());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  };
+
+  return (
+    <Box
+      alignItems="center"
+      display="inline-flex"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <Box>{children}</Box>
+      <Fade in={hover || alwaysShowIcon}>
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="column"
+          height={40}
+          position="relative"
+        >
+          <IconButton onClick={() => handleClick()}>
+            <CopyIcon />
+          </IconButton>
+          <Box
+            style={{
+              left: '36px',
+              position: 'absolute',
+              top: '6px',
+            }}
+          >
+            <Collapse in={copied}>
+              <Typography
+                color="secondary"
+                style={{ fontSize: 11, fontWeight: 'bold' }}
+                variant="button"
+              >
+                <FormattedMessage id="misc.copyToClipboard.copied" />
+              </Typography>
+            </Collapse>
+          </Box>
+        </Box>
+      </Fade>
+    </Box>
+  );
+};
+
+export default ZUIInlineCopyToClipboard;

--- a/src/zui/ZUIScrollingContainer/index.tsx
+++ b/src/zui/ZUIScrollingContainer/index.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { makeStyles } from '@mui/styles';
+import { Box, BoxProps, Theme } from '@mui/material';
+
+type ZUIScrollingContainerProps = Omit<BoxProps, 'className' | 'overflow'> & {
+  disableHorizontal?: boolean;
+};
+
+const useStyles = makeStyles<Theme, ZUIScrollingContainerProps>({
+  container: {
+    overflowX: (props) => (props.disableHorizontal ? 'auto' : 'scroll'),
+    overflowY: 'scroll',
+  },
+});
+
+const ZUIScrollingContainer: FC<ZUIScrollingContainerProps> = ({
+  children,
+  ...props
+}) => {
+  const styles = useStyles(props);
+
+  return (
+    <Box {...props} className={styles.container}>
+      {children}
+    </Box>
+  );
+};
+
+export default ZUIScrollingContainer;


### PR DESCRIPTION
## Description
This PR implements the "Share view" dialog and the first of it's two tabs, in which an official can share a view with outside collaborators and configure their level of access.

## Screenshots
### Shared with 6 people
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/550212/213626514-5666b09b-4cb3-4624-8fd6-5c77c3a85438.png">

### Adding someone
Officials and people that have already been given access are disabled.
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/550212/213626986-076949e2-d8a9-481d-8567-485773d7cb5c.png">

### Copied link
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/550212/213626668-cb758070-bbb8-4ada-9ad9-0ae70a5eb1c3.png">

### Empty (officials hidden)
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/550212/213626467-c99a22cd-b5cd-4591-bdcf-0282efc44327.png">

## Changes
* Adds reusable ZUI component for avatars (`ZUIAvatar`)
* Adds reusable ZUI component for access list (`ZUIAccessList`) which may be used in other places later
* Adds reusable ZUI component for scrolling containers (`ZUIScrollingContainer`)
* Adds reusable `useAbsoluteUrl()` hook, to construct an absolute URL for the current environment
* Adds plural equivalent of `ZUIFuture` (`ZUIFutures`, roughly modeled after `ZUIQuery`)
* Adds inline equivalent of `ZUICopyToClipboard` (`ZUIInlineCopyToClipboard`)
* Adds new `ShareViewDialog` with two tabs, the second of which is empty in this PR
* Adds a "Share" button to the view page that opens the dialog
* Adds a new model to handle view sharing, `ViewSharingModel`

## Notes to reviewer
* The API is not yet running on the dev server, so it's only possible to run this with the platform running locally. Let me know if you want me to demo it!
* The current revision of the API is missing information about who shared to whom, but that will be added once it's been implemented in the API.
* I've added the capability to load officials to the `views` store and repo for now. They really don't belong there, but we can move them once we implement the greater "officials" feature (adding/removing official privileges).

## Related issues
Resolves #870