### PR TITLE
Add collaborator count to view-page subtitle

### DIFF
--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -230,30 +230,43 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
               ),
             }}
           >
-            {({ queries: { colsQuery, rowsQuery } }) => (
-              <ZUIIconLabelRow
-                iconLabels={[
-                  {
-                    icon: <Group />,
-                    label: (
-                      <FormattedMessage
-                        id="pages.people.views.layout.subtitle.people"
-                        values={{ count: rowsQuery.data.length }}
-                      />
-                    ),
-                  },
-                  {
-                    icon: <ViewColumnOutlined />,
-                    label: (
-                      <FormattedMessage
-                        id="pages.people.views.layout.subtitle.columns"
-                        values={{ count: colsQuery.data.length }}
-                      />
-                    ),
-                  },
-                ]}
-              />
-            )}
+            {({ queries: { colsQuery, rowsQuery } }) => {
+              const labels = [
+                {
+                  icon: <Group />,
+                  label: (
+                    <FormattedMessage
+                      id="pages.people.views.layout.subtitle.people"
+                      values={{ count: rowsQuery.data.length }}
+                    />
+                  ),
+                },
+                {
+                  icon: <ViewColumnOutlined />,
+                  label: (
+                    <FormattedMessage
+                      id="pages.people.views.layout.subtitle.columns"
+                      values={{ count: colsQuery.data.length }}
+                    />
+                  ),
+                },
+              ];
+
+              const accessListFuture = shareModel.getAccessList();
+              if (accessListFuture.data?.length) {
+                labels.push({
+                  icon: <Share />,
+                  label: (
+                    <FormattedMessage
+                      id="pages.people.views.layout.subtitle.collaborators"
+                      values={{ count: accessListFuture.data.length }}
+                    />
+                  ),
+                });
+              }
+
+              return <ZUIIconLabelRow iconLabels={labels} />;
+            }}
           </ZUIQuery>
         }
         tabs={[{ href: `/`, messageId: 'layout.organize.view.tabs.view' }]}

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -28,6 +28,7 @@ layout:
   jumpMenu:
     placeholder: Start typing to find view
   subtitle:
+    collaborators: '{count, plural, =1 {1 outside collaborator} other {# outside collaborators}}'
     columns: '{count, plural, =0 {No columns} =1 {1 column} other {# columns}}'
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:


### PR DESCRIPTION
## Description
This PR adds information in the View page subtitle about how many collaborators are on the access list.


## Screenshots
### One collaborator
![image](https://user-images.githubusercontent.com/550212/213698583-c68fb924-c52a-4d02-9313-84d77737814a.png)

### Multiple collaborators
![image](https://user-images.githubusercontent.com/550212/213698665-5e517656-e04f-48d7-a4e4-6a59f27208b3.png)

### No collaborators
![image](https://user-images.githubusercontent.com/550212/213698715-f04b1e95-f3e6-43fb-ba4e-0674c3c3bde9.png)

## Changes
* Adds another icon label to the subtitle when there are collaborators in the access list

## Notes to reviewer
API not deployed to server yet, but reach out for a demo.

## Related issues
Resolves #871 