### PR TITLE
View download

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "slate": "^0.78.0",
     "slate-history": "^0.66.0",
     "slate-react": "^0.77.4",
+    "slugify": "^1.6.5",
     "unified": "^10.1.2",
     "validator": "^13.6.0",
     "xlsx-js-style": "^1.2.0",

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
@@ -1,0 +1,66 @@
+import { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { makeStyles } from '@mui/styles';
+import { Box, Button, Link, Typography } from '@mui/material';
+
+interface ShareViewDialogDownloadTabProps {
+  onAbort?: () => void;
+}
+
+const useStyles = makeStyles({
+  container: {
+    alignItems: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    justifyContent: 'center',
+  },
+  link: {
+    cursor: 'pointer',
+  },
+  warning: {
+    maxWidth: 400,
+    textAlign: 'center',
+  },
+});
+
+const ShareViewDialogDownloadTab: FC<ShareViewDialogDownloadTabProps> = ({
+  onAbort,
+}) => {
+  const styles = useStyles();
+
+  return (
+    <Box className={styles.container}>
+      <Box className={styles.warning}>
+        <Typography marginBottom={1} variant="body1">
+          <FormattedMessage id="pages.people.views.shareDialog.download.warning1" />
+        </Typography>
+        <Typography marginBottom={1} variant="body1">
+          <FormattedMessage
+            id="pages.people.views.shareDialog.download.warning2"
+            values={{
+              shareLink: (
+                <Link
+                  className={styles.link}
+                  onClick={() => {
+                    if (onAbort) {
+                      onAbort();
+                    }
+                  }}
+                >
+                  <FormattedMessage id="pages.people.views.shareDialog.download.shareLink" />
+                </Link>
+              ),
+            }}
+          />
+        </Typography>
+        <Box display="flex" gap={1} justifyContent="center" marginTop={3}>
+          <Button variant="outlined">Download CSV file</Button>
+          <Button variant="outlined">Download Excel file</Button>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ShareViewDialogDownloadTab;

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { makeStyles } from '@mui/styles';
+import { useRouter } from 'next/router';
 import { Box, Button, Link, Typography } from '@mui/material';
 
 interface ShareViewDialogDownloadTabProps {
@@ -28,6 +29,7 @@ const ShareViewDialogDownloadTab: FC<ShareViewDialogDownloadTabProps> = ({
   onAbort,
 }) => {
   const styles = useStyles();
+  const { orgId, viewId } = useRouter().query;
 
   return (
     <Box className={styles.container}>
@@ -55,8 +57,20 @@ const ShareViewDialogDownloadTab: FC<ShareViewDialogDownloadTabProps> = ({
           />
         </Typography>
         <Box display="flex" gap={1} justifyContent="center" marginTop={3}>
-          <Button variant="outlined">Download CSV file</Button>
-          <Button variant="outlined">Download Excel file</Button>
+          <Button
+            component="a"
+            href={`/api/views/download?orgId=${orgId}&viewId=${viewId}&format=csv`}
+            variant="outlined"
+          >
+            <FormattedMessage id="pages.people.views.shareDialog.download.buttons.csv" />
+          </Button>
+          <Button
+            component="a"
+            href={`/api/views/download?orgId=${orgId}&viewId=${viewId}&format=xlsx`}
+            variant="outlined"
+          >
+            <FormattedMessage id="pages.people.views.shareDialog.download.buttons.xlsx" />
+          </Button>
         </Box>
       </Box>
     </Box>

--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 import { FC, useState } from 'react';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 
+import ShareViewDialogDownloadTab from './ShareViewDialogDownloadTab';
 import ShareViewDialogShareTab from './ShareViewDialogShareTab';
 import ViewSharingModel from 'features/views/models/ViewSharingModel';
 import { ZetkinView } from '../types';
@@ -52,7 +53,9 @@ const ShareViewDialog: FC<ShareViewDialogProps> = ({
         <TabPanel className={styles.tabPanel} value="share">
           <ShareViewDialogShareTab model={model} />
         </TabPanel>
-        <TabPanel className={styles.tabPanel} value="download"></TabPanel>
+        <TabPanel className={styles.tabPanel} value="download">
+          <ShareViewDialogDownloadTab onAbort={() => setTab('share')} />
+        </TabPanel>
       </TabContext>
     </ZUIDialog>
   );

--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -18,8 +18,8 @@ interface ShareViewDialogProps {
 
 const useStyles = makeStyles({
   tabPanel: {
-    height: '100vh',
-    maxHeight: '600px',
+    height: 'calc(100vh - 240px)',
+    maxHeight: 600,
     paddingBottom: 0,
     paddingLeft: 0,
     paddingRight: 0,

--- a/src/features/views/components/ViewDataTable/cells/SurveyResponseViewCell.tsx
+++ b/src/features/views/components/ViewDataTable/cells/SurveyResponseViewCell.tsx
@@ -6,7 +6,7 @@ import { FunctionComponent, useState } from 'react';
 import noPropagate from 'utils/noPropagate';
 import { ViewGridCellParams } from '.';
 
-interface SurveyResponse {
+export interface SurveyResponse {
   submission_id: number;
   text: string;
 }

--- a/src/features/views/components/ViewDataTable/cells/SurveySubmittedViewCell.tsx
+++ b/src/features/views/components/ViewDataTable/cells/SurveySubmittedViewCell.tsx
@@ -3,15 +3,17 @@ import { GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { ViewGridCellParams } from '.';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 
-interface Submission {
+export interface SurveySubmission {
   submission_id: number;
   submitted: string;
 }
 
-export type SurveySubmittedParams = ViewGridCellParams<Submission[] | null>;
+export type SurveySubmittedParams = ViewGridCellParams<
+  SurveySubmission[] | null
+>;
 
 export const getNewestSubmission = (
-  submissions: Submission[]
+  submissions: SurveySubmission[]
 ): string | null => {
   if (!submissions.length) {
     return null;

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -32,6 +32,10 @@ layout:
     columns: '{count, plural, =0 {No columns} =1 {1 column} other {# columns}}'
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
+  download:
+    shareLink: share data securely
+    warning1: Avoid exporting data from Zetkin when you can, to ensure that all data is kept in order.
+    warning2: You can {shareLink} within Zetkin. Exporting makes sense when you want to copy data to another system.
   share:
     addPlaceholder: Add collaborator
     collabInstructions: After adding collaborators, copy and send them the {viewLink}

--- a/src/locale/pages/people/views/en.yml
+++ b/src/locale/pages/people/views/en.yml
@@ -33,6 +33,9 @@ layout:
     people: '{count, plural, =0 {Empty} =1 {1 person} other {# people}}'
 shareDialog:
   download:
+    buttons:
+      csv: Download CSV file
+      xlsx: Download Excel file
     shareLink: share data securely
     warning1: Avoid exporting data from Zetkin when you can, to ensure that all data is kept in order.
     warning2: You can {shareLink} within Zetkin. Exporting makes sense when you want to copy data to another system.

--- a/src/pages/api/views/download.ts
+++ b/src/pages/api/views/download.ts
@@ -1,3 +1,4 @@
+import slugify from 'slugify';
 import XLSX from 'xlsx-js-style';
 import { NextApiRequest, NextApiResponse } from 'next';
 
@@ -56,8 +57,7 @@ export default async function handler(
     )
   );
 
-  // TODO: Slugify this
-  const filePrefix = view.title;
+  const filePrefix = slugify(view.title).toLowerCase();
   const fileName = `${filePrefix}-${new Date().toISOString()}.${format}`;
 
   let fileData: string | Buffer;

--- a/src/pages/api/views/download.ts
+++ b/src/pages/api/views/download.ts
@@ -1,0 +1,117 @@
+import XLSX from 'xlsx-js-style';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import {
+  ZetkinView,
+  ZetkinViewColumn,
+  ZetkinViewRow,
+} from 'utils/types/zetkin';
+
+const FORMAT_TYPES = {
+  csv: 'text/csv',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const { format = 'csv', orgId, viewId } = req.query;
+
+  if (
+    !orgId ||
+    Array.isArray(orgId) ||
+    Array.isArray(viewId) ||
+    Array.isArray(format)
+  ) {
+    return res.status(400).end();
+  }
+
+  if (format != 'csv' && format != 'xlsx') {
+    return res.status(400).end();
+  }
+  const formatType = FORMAT_TYPES[format];
+
+  const apiClient = new BackendApiClient(req.headers);
+
+  const view = await apiClient.get<ZetkinView>(
+    `/api/orgs/${orgId}/people/views/${viewId}`
+  );
+  const columns = await apiClient.get<ZetkinViewColumn[]>(
+    `/api/orgs/${orgId}/people/views/${viewId}/columns`
+  );
+  const rows = await apiClient.get<ZetkinViewRow[]>(
+    `/api/orgs/${orgId}/people/views/${viewId}/rows`
+  );
+
+  const headerRow: string[] = ['ID'].concat(columns.map((col) => col.title));
+
+  const dataRows: (string | number | Date)[][] = rows.map((row) =>
+    [row.id.toString()].concat(
+      row.content.map((cell) => {
+        // TODO: Handle different types of columns separately
+        return cell as string;
+      })
+    )
+  );
+
+  // TODO: Slugify this
+  const filePrefix = view.title;
+  const fileName = `${filePrefix}-${new Date().toISOString()}.${format}`;
+
+  let fileData: string | Buffer;
+
+  const wb = XLSX.utils.book_new();
+  const sheet = XLSX.utils.aoa_to_sheet([headerRow, ...dataRows], {
+    dateNF: 'YYYY-MM-DD HH:mm:ss',
+  });
+  XLSX.utils.book_append_sheet(wb, sheet);
+
+  if (format == 'csv') {
+    // Make header uppercase
+    headerRow.forEach((_, idx) => {
+      const addr = XLSX.utils.encode_cell({ c: idx, r: 0 });
+      sheet[addr].v = sheet[addr].v.toString().toUpperCase();
+    });
+
+    fileData = XLSX.write(wb, { bookType: 'csv', type: 'buffer' });
+  } else if (format == 'xlsx') {
+    sheet['!cols'] = headerRow.map((col, idx) => {
+      const allLengths = [
+        col.length,
+        ...dataRows.map((row) =>
+          row[idx] instanceof Date ? 16 : row[idx]?.toString().length ?? 0
+        ),
+      ];
+
+      return {
+        // Set the width to 3 + the max number of characters on any row,
+        // but cap to 50 characters to not get super wide columns
+        width: 3 + Math.min(50, Math.max.apply(null, allLengths)),
+      };
+    });
+
+    // Style header as bold
+    headerRow.forEach((_, idx) => {
+      sheet[XLSX.utils.encode_cell({ c: idx, r: 0 })].s = {
+        font: { bold: true },
+      };
+    });
+
+    fileData = XLSX.write(wb, {
+      type: 'buffer',
+    });
+  } else {
+    // This should never happen, because format is already checked
+    // at the beginning of this function. We do this anyway to make
+    // Typescript aware that fileData will always have a value.
+    return res.status(400).end();
+  }
+
+  res
+    .status(200)
+    .setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
+    .setHeader('Content-Type', formatType)
+    .send(fileData);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14342,6 +14342,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.5.tgz#c8f5c072bf2135b80703589b39a3d41451fbe8c8"
+  integrity sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
## Description
This PR adds an API endpoint and GUI for downloading view contents as CSV/XLSX.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/213727929-20be9506-c73f-4586-8e63-e6fec05f6c0e.png)

## Changes
* Adds a new API endpoint for downloading view contents as CSV or XLSX, modeled after the journey data download endpoint
  * "Formatter" functions are used to convert the cell value retrieved from the API into a value that can be included in the file
  * Logic is added to make sure that it's impossible to forget to add a formatter for column types, using some typescript hacking that has some drawbacks, but at least achieves the goal of reporting an error if a developer adds a new column type and forgets to add a formatter here.
* Adds UI in the share dialog to navigate to the download endpoints
* Adds `slugify` library to easily generate a slug for the download file name

## Notes to reviewer
None

## Related issues
Resolves #872 
