### PR TITLE
Issue 890/follow up combo modal choice

### DIFF
--- a/src/features/tasks/components/types.ts
+++ b/src/features/tasks/components/types.ts
@@ -70,9 +70,8 @@ export interface ZetkinTask<TaskTypeConfig = AnyTaskTypeConfig> {
 }
 
 // POST and PUT requests use this data shape
-export interface ZetkinTaskRequestBody<
-  Config = AnyTaskTypeConfig
-> extends Partial<
+export interface ZetkinTaskRequestBody<Config = AnyTaskTypeConfig>
+  extends Partial<
     Omit<
       // Remove these fields
       ZetkinTask<Config>,

--- a/src/features/tasks/components/types.ts
+++ b/src/features/tasks/components/types.ts
@@ -70,8 +70,9 @@ export interface ZetkinTask<TaskTypeConfig = AnyTaskTypeConfig> {
 }
 
 // POST and PUT requests use this data shape
-export interface ZetkinTaskRequestBody<Config = AnyTaskTypeConfig>
-  extends Partial<
+export interface ZetkinTaskRequestBody<
+  Config = AnyTaskTypeConfig
+> extends Partial<
     Omit<
       // Remove these fields
       ZetkinTask<Config>,

--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -11,7 +11,7 @@ const categories = [
       CHOICES.PERSON_FIELDS,
       CHOICES.TAG,
       CHOICES.BOOLEAN,
-      CHOICES.FOLLOW_UP
+      CHOICES.FOLLOW_UP,
     ],
     key: CATEGORIES.BASIC,
   },

--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -11,6 +11,7 @@ const categories = [
       CHOICES.PERSON_FIELDS,
       CHOICES.TAG,
       CHOICES.BOOLEAN,
+      CHOICES.FOLLOW_UP
     ],
     key: CATEGORIES.BASIC,
   },

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -1,5 +1,5 @@
 import { IntlShape } from 'react-intl';
-import { CheckBox, LocalOffer, Person } from '@mui/icons-material';
+import { CheckBox, Description, LocalOffer, Person } from '@mui/icons-material';
 
 import DoubleIconCardVisual from './DoubleIconCardVisual';
 import getUniqueColumnName from '../../utils/getUniqueColumnName';
@@ -16,6 +16,7 @@ import {
 
 export enum CHOICES {
   FIRST_AND_LAST_NAME = 'firstAndLastName',
+  FOLLOW_UP = 'followUp',
   PERSON_FIELDS = 'personFields',
   TAG = 'tag',
   BOOLEAN = 'toggle',
@@ -112,9 +113,6 @@ const choices: ColumnChoice[] = [
   {
     defaultColumns: (intl, columns) => [
       {
-        config: {
-          field: 'local_bool',
-        },
         title: getUniqueColumnName(
           intl.formatMessage({
             id: 'misc.views.columnDialog.choices.toggle.columnTitle',
@@ -127,6 +125,32 @@ const choices: ColumnChoice[] = [
     key: CHOICES.BOOLEAN,
     renderCardVisual: (color: string) => (
       <SingleIconCardVisual color={color} icon={CheckBox} />
+    ),
+  },
+  {
+    defaultColumns: (intl, columns) => [
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.followUp.columnTitleCheckbox',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_BOOL,
+      },
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.followUp.columnTitleNotes',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_TEXT,
+      },
+    ],
+    key: CHOICES.FOLLOW_UP,
+    renderCardVisual: (color: string) => (
+      <DoubleIconCardVisual color={color} icons={[CheckBox, Description]} />
     ),
   },
 ];

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -153,6 +153,10 @@ const choices: ColumnChoice[] = [
     renderCardVisual: (color: string) => (
       <DoubleIconCardVisual color={color} icons={[CheckBox, Description]} />
     ),
+  },
+  {
+    defaultColumns: (intl, columns) => [
+      {
         config: {
           field: COLUMN_TYPE.LOCAL_PERSON,
         },

--- a/src/features/views/components/types.ts
+++ b/src/features/views/components/types.ts
@@ -44,6 +44,7 @@ export enum COLUMN_TYPE {
   JOURNEY_ASSIGNEE = 'journey_assignee',
   LOCAL_BOOL = 'local_bool',
   LOCAL_PERSON = 'local_person',
+  LOCAL_TEXT = 'local_text',
   PERSON_FIELD = 'person_field',
   PERSON_NOTES = 'person_notes',
   PERSON_QUERY = 'person_query',
@@ -66,6 +67,11 @@ export interface LocalBoolViewColumn extends ZetkinViewColumnBase {
 
 export interface LocalPersonViewColumn extends ZetkinViewColumnBase {
   type: COLUMN_TYPE.LOCAL_PERSON;
+  config?: Record<string, never>;
+}
+
+export interface LocalTextViewColumn extends ZetkinViewColumnBase {
+  type: COLUMN_TYPE.LOCAL_TEXT;
   config?: Record<string, never>;
 }
 
@@ -113,6 +119,7 @@ export type ZetkinViewColumn =
   | JourneyAssigneeViewColumn
   | LocalBoolViewColumn
   | LocalPersonViewColumn
+  | LocalTextViewColumn
   | PersonNotesViewColumn
   | PersonFieldViewColumn
   | PersonQueryViewColumn

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -9,6 +9,11 @@ columnDialog:
       description: First and last name of person
       keywords: name combo
       title: First and Last Name
+    followUp:
+      columnTitleCheckbox: Checkbox
+      columnTitleNotes: Notes
+      description: Adds a checkbox column and a notes column
+      title: Follow-up
     personFields:
       description: Add your choice of fields like email, phone number, etc.
       keywords: field multiple

--- a/src/pages/api/views/download.ts
+++ b/src/pages/api/views/download.ts
@@ -57,6 +57,7 @@ const valueFormatters: Record<ZetkinViewColumn['type'], ValueFunc> = {
     const person = cell as ZetkinPerson | null;
     return person ? `${person.first_name} ${person.last_name}` : '';
   }) as ValueFunc,
+  [COLUMN_TYPE.LOCAL_TEXT]: directFormatter,
   [COLUMN_TYPE.PERSON_FIELD]: directFormatter,
   [COLUMN_TYPE.PERSON_NOTES]: ((cell) => {
     const notes = cell as ZetkinNote[];


### PR DESCRIPTION
## Description
This PR adds the follow-up combo modal choice that allows the user to add in views a `local_bool `(toggle) column and a `local_text `(notes) column. It also adds the `local_text `type of column in views.


## Screenshots
![1](https://user-images.githubusercontent.com/36491300/214005982-1cf34bb2-2ae6-471c-827a-9e626e83c003.PNG)
![2](https://user-images.githubusercontent.com/36491300/214006023-536dfe58-e933-419e-8104-a20dd6e5b044.PNG)

## Changes
* Adds a `follow-up combo` object to choices
* Adds `follow-up combo` to BASIC category (to be revised later)
* Adds `local_text `as column type
* Localization for `follow-up combo`


## Notes to reviewer
Unnecessary noise of CI lint failed runs. I had a mismatch version of prettier (locally I was using a newer version than in the project) so jobs were failing only in Github. Thanks @ziggabyte to help me to find and fix the problem 💯 .


## Related issues
Resolves #890
