### PR TITLE
Issue 891/delegate combo modal choice

### DIFF
--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -13,6 +13,7 @@ const categories = [
       CHOICES.BOOLEAN,
       CHOICES.FOLLOW_UP,
       CHOICES.LOCAL_PERSON,
+      CHOICES.DELEGATE,
     ],
     key: CATEGORIES.BASIC,
   },

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -3,6 +3,7 @@ import { CheckBox, Description, LocalOffer, Person } from '@mui/icons-material';
 
 import DoubleIconCardVisual from './DoubleIconCardVisual';
 import getUniqueColumnName from '../../utils/getUniqueColumnName';
+import MultiIconCardVisual from './MultiIconCardVisual';
 import PersonFieldConfig from './PersonFieldConfig';
 import PersonTagConfig from './PersonTagConfig';
 import SingleIconCardVisual from './SingleIconCardVisual';
@@ -15,6 +16,7 @@ import {
 } from '../types';
 
 export enum CHOICES {
+  DELEGATE = 'delegate',
   FIRST_AND_LAST_NAME = 'firstAndLastName',
   FOLLOW_UP = 'followUp',
   PERSON_FIELDS = 'personFields',
@@ -172,6 +174,50 @@ const choices: ColumnChoice[] = [
     key: CHOICES.LOCAL_PERSON,
     renderCardVisual: (color: string) => {
       return <SingleIconCardVisual color={color} icon={Person} />;
+    },
+  },
+  {
+    defaultColumns: (intl, columns) => [
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.delegate.columnTitleAssignee',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_PERSON,
+      },
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.delegate.columnTitleContacted',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_BOOL,
+      },
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.delegate.columnTitleResponded',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_BOOL,
+      },
+      {
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.delegate.columnTitleNotes',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_TEXT,
+      },
+    ],
+    key: CHOICES.DELEGATE,
+    renderCardVisual: (color: string) => {
+      return <MultiIconCardVisual color={color} icon={Person} />;
     },
   },
 ];

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -5,6 +5,13 @@ columnDialog:
       description: Columns that are useful when organizing people and members.
       title: Basic Columns
   choices:
+    delegate:
+      columnTitleAssignee: Assignee
+      columnTitleContacted: Contacted
+      columnTitleNotes: Notes
+      columnTitleResponded: Responded
+      description: Adds a set of columns commonly used to delegate outreach work to some assignee.
+      title: Delegate
     firstAndLastName:
       description: First and last name of person
       keywords: name combo


### PR DESCRIPTION
## Description
This PR adds a Delegate modal card choice that allows the user to add in views 4 columns: 
- a local_person column ("Assignee")
- 2 local_bool ("Contacted" & "Responded") columns
-  a local_text ("Notes") column. 


## Screenshots
![1-2](https://user-images.githubusercontent.com/36491300/214061883-c7ab70c0-16ec-4dd2-b00d-c5c100b8ca59.PNG)
![1-1](https://user-images.githubusercontent.com/36491300/214061905-8d6518a5-8a9d-455d-9b49-c31d2f192d1e.PNG)


## Changes
* Adds `Delegate `choice in the categories array to allow the render of the card
* Adds the default configuration to create the `Delegate `columns in the view
* Adds localization for delegate modal card


## Notes to reviewer

## Related issues
Resolves #891 
