### PR TITLE
Issue 880/local text modal card

### DIFF
--- a/src/features/views/components/ViewColumnDialog/categories.ts
+++ b/src/features/views/components/ViewColumnDialog/categories.ts
@@ -14,6 +14,7 @@ const categories = [
       CHOICES.FOLLOW_UP,
       CHOICES.LOCAL_PERSON,
       CHOICES.DELEGATE,
+      CHOICES.LOCAL_TEXT,
     ],
     key: CATEGORIES.BASIC,
   },

--- a/src/features/views/components/ViewColumnDialog/choices.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices.tsx
@@ -1,5 +1,11 @@
 import { IntlShape } from 'react-intl';
-import { CheckBox, Description, LocalOffer, Person } from '@mui/icons-material';
+import {
+  CheckBox,
+  Description,
+  EventNote,
+  LocalOffer,
+  Person,
+} from '@mui/icons-material';
 
 import DoubleIconCardVisual from './DoubleIconCardVisual';
 import getUniqueColumnName from '../../utils/getUniqueColumnName';
@@ -23,6 +29,7 @@ export enum CHOICES {
   TAG = 'tag',
   BOOLEAN = 'toggle',
   LOCAL_PERSON = 'localPerson',
+  LOCAL_TEXT = 'localText',
 }
 
 export type ColumnChoice = {
@@ -218,6 +225,26 @@ const choices: ColumnChoice[] = [
     key: CHOICES.DELEGATE,
     renderCardVisual: (color: string) => {
       return <MultiIconCardVisual color={color} icon={Person} />;
+    },
+  },
+  {
+    defaultColumns: (intl, columns) => [
+      {
+        config: {
+          field: COLUMN_TYPE.LOCAL_TEXT,
+        },
+        title: getUniqueColumnName(
+          intl.formatMessage({
+            id: 'misc.views.columnDialog.choices.localText.columnTitle',
+          }),
+          columns
+        ),
+        type: COLUMN_TYPE.LOCAL_TEXT,
+      },
+    ],
+    key: CHOICES.LOCAL_TEXT,
+    renderCardVisual: (color: string) => {
+      return <SingleIconCardVisual color={color} icon={EventNote} />;
     },
   },
 ];

--- a/src/locale/misc/views/en.yml
+++ b/src/locale/misc/views/en.yml
@@ -25,6 +25,10 @@ columnDialog:
       columnTitle: Assignee
       description: Let's you pick an assignee on every row
       title: Assigned Person
+    localText:
+      columnTitle: Notes
+      description: Add a column to write notes about a person.
+      title: Notes
     personFields:
       description: Add your choice of fields like email, phone number, etc.
       keywords: field multiple


### PR DESCRIPTION
## Description
This PR contains the local_text modal card (Notes) that allows users to write notes about a person in a view.


## Screenshots
![3-1](https://user-images.githubusercontent.com/36491300/214080192-8af5a754-1559-4328-b8af-3e3625d1e296.PNG)
![3-2](https://user-images.githubusercontent.com/36491300/214080208-69e22bbd-9202-4e19-898c-28610dafc5b6.PNG)

## Changes
* Adds local_text modal card to categories dialog
* Adds local_text object configuration and visual settings to choices array
* Adds localization strings for local_text modal card and column


## Notes to reviewer


## Related issues
Resolves #880 
