### PR TITLE
Show the "New column" button in shared view when access is "configure"

### DIFF
--- a/src/pages/organize/[orgId]/people/views/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId]/shared.tsx
@@ -2,14 +2,18 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useQuery } from 'react-query';
 
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import getOrg from 'utils/fetching/getOrg';
 import getView from 'features/views/fetching/getView';
 import getViewColumns from 'features/views/fetching/getViewColumns';
 import getViewRows from 'features/views/fetching/getViewRows';
+import IApiClient from 'core/api/client/IApiClient';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SharedViewLayout from 'features/views/layout/SharedViewLayout';
 import ViewDataTable from 'features/views/components/ViewDataTable';
+import { ZetkinMembership } from 'utils/types/zetkin';
+import { ZetkinObjectAccess } from 'core/api/types';
 import ZUIQuery from 'zui/ZUIQuery';
 
 const scaffoldOptions = {
@@ -18,8 +22,46 @@ const scaffoldOptions = {
   localeScope: ['layout.organize', 'pages.people.views'],
 };
 
+async function getAccessLevel(
+  apiClient: IApiClient,
+  orgId: number,
+  viewId: number
+): Promise<ZetkinObjectAccess['level'] | null> {
+  const memberships = await apiClient.get<ZetkinMembership[]>(
+    `/api/users/me/memberships`
+  );
+  const myMembership = memberships.find((mem) => mem.organization.id == orgId);
+
+  if (!myMembership) {
+    // NOTE: Might be superuser
+    return null;
+  }
+
+  const isOfficial = Boolean(myMembership.role);
+  if (isOfficial) {
+    return 'configure';
+  }
+
+  const accessList = await apiClient.get<ZetkinObjectAccess[]>(
+    `/api/orgs/${orgId}/people/views/${viewId}/access`
+  );
+  const accessObject = accessList.find(
+    (obj) => obj.person.id == myMembership.profile.id
+  );
+
+  return accessObject?.level ?? null;
+}
+
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, viewId } = ctx.params!;
+
+  // TODO: Handle this some other way with server-side models?
+  const apiClient = new BackendApiClient(ctx.req.headers);
+  const accessLevel = await getAccessLevel(
+    apiClient,
+    parseInt(orgId as string),
+    parseInt(viewId as string)
+  );
 
   await ctx.queryClient.prefetchQuery(
     ['org', orgId],
@@ -37,6 +79,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   if (orgState?.data && viewState?.data) {
     return {
       props: {
+        accessLevel,
         orgId,
         viewId,
       },
@@ -49,14 +92,18 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 }, scaffoldOptions);
 
 type SharedViewPageProps = {
+  accessLevel: ZetkinObjectAccess['level'];
   orgId: string;
   viewId: string;
 };
 
 const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
+  accessLevel,
   orgId,
   viewId,
 }) => {
+  const canConfigure = accessLevel == 'configure';
+
   return (
     <ZUIQuery
       queries={{
@@ -79,7 +126,7 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
           <ViewDataTable
             columns={colsQuery.data}
             disableBulkActions
-            disableConfigure
+            disableConfigure={!canConfigure}
             rows={rowsQuery.data}
             view={viewQuery.data}
           />


### PR DESCRIPTION
## Description
This PR adds logic to figure out whether a user of the `shared` view page should be allowed to add columns, which they should if they have the `configure` access level (or is an official).

## Screenshots
### When access is `readonly` or `edit`
<img width="1388" alt="image" src="https://user-images.githubusercontent.com/550212/214221118-56891283-0573-457a-91c4-ecaed1234fb7.png">

### When access is `configure`
Note the "New column" option in the toolbar
<img width="1388" alt="image" src="https://user-images.githubusercontent.com/550212/214221049-6f41e7a1-1d0a-4434-9828-9100d3456577.png">

## Changes
* Adds API requests to the server-side part of the `shared` page, to figure out the correct access level
* Adds simple logic to the rendering of the `shared` page to set `disableConfigure` correctly on the view table

## Notes to reviewer
Requires most recent development version of API which is not on the dev server right now.

## Related issues
Undocumented (couldn't do this as part of #934 because the API wasn't there at the time).