### PR TITLE
Align text to center.

### DIFF
--- a/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
@@ -71,8 +71,12 @@ const ColumnEditor: FunctionComponent<ColumnEditorProps> = ({
             />
           </Box>
         </Box>
-
-        <Box alignSelf="center" display="flex" flexDirection="column">
+        <Box
+          alignItems="center"
+          alignSelf="center"
+          display="flex"
+          flexDirection="column"
+        >
           <Box height={100} paddingBottom={1} width={100}>
             {choice.renderCardVisual(color)}
           </Box>


### PR DESCRIPTION
## Description
This PR aligns the titles in the column editor to center (they were accidentally left aligned before).


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/214610588-e0274158-38fa-4bfa-b7cd-0c1e3dd31162.png)

## Changes
* Aligns icon and title to center.

## Related issues
Resolves #946 
