### PR TITLE
Add a column type for survey response date.

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -53,7 +53,9 @@ const Cell: FC<{ cell: SurveySubmittedViewCell }> = ({ cell }) => {
       sx={{ cursor: 'default' }}
       width="100%"
     >
-      <ZUIRelativeTime datetime={sorted[0].submitted} />
+      <Box sx={{ overflowX: 'hidden' }}>
+        <ZUIRelativeTime datetime={sorted[0].submitted} />
+      </Box>
       <AssignmentTurnedInOutlined
         color="secondary"
         onClick={() =>

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -1,12 +1,17 @@
+import { AssignmentTurnedInOutlined } from '@mui/icons-material';
 import { Box } from '@mui/material';
 import { FC } from 'react';
 import { GridColDef } from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
+import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import { SurveySubmittedViewColumn } from '../../types';
+import { usePanes } from 'utils/panes';
+import { useRouter } from 'next/router';
 import ZUIRelativeTime from '../../../../../zui/ZUIRelativeTime';
 
 type SurveySubmittedViewCell = {
+  submission_id: number;
   submitted: string;
 }[];
 
@@ -27,6 +32,9 @@ export default class SurveySubmittedColumnType
 }
 
 const Cell: FC<{ cell: SurveySubmittedViewCell }> = ({ cell }) => {
+  const { orgId } = useRouter().query;
+  const { openPane } = usePanes();
+
   if (cell.length === 0) {
     return null;
   }
@@ -38,8 +46,31 @@ const Cell: FC<{ cell: SurveySubmittedViewCell }> = ({ cell }) => {
   });
 
   return (
-    <Box sx={{ cursor: 'default' }}>
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="space-between"
+      sx={{ cursor: 'default' }}
+      width="100%"
+    >
       <ZUIRelativeTime datetime={sorted[0].submitted} />
+      <AssignmentTurnedInOutlined
+        color="secondary"
+        onClick={() =>
+          openPane({
+            render() {
+              return (
+                <SurveySubmissionPane
+                  id={sorted[0].submission_id}
+                  orgId={parseInt(orgId as string)}
+                />
+              );
+            },
+            width: 400,
+          })
+        }
+        sx={{ cursor: 'pointer' }}
+      />
     </Box>
   );
 };

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -1,0 +1,45 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import { GridColDef } from '@mui/x-data-grid-pro';
+
+import { IColumnType } from '.';
+import { SurveySubmittedViewColumn } from '../../types';
+import ZUIRelativeTime from '../../../../../zui/ZUIRelativeTime';
+
+type SurveySubmittedViewCell = {
+  submitted: string;
+}[];
+
+export default class SurveySubmittedColumnType
+  implements IColumnType<SurveySubmittedViewColumn, SurveySubmittedViewCell>
+{
+  cellToString(cell: SurveySubmittedViewCell): string {
+    return cell.length ? new Date(cell[0].submitted).toLocaleDateString() : '';
+  }
+  getColDef(): Omit<GridColDef<SurveySubmittedViewCell>, 'field'> {
+    return {
+      renderCell: (params) => {
+        return <Cell cell={params.value} />;
+      },
+      width: 250,
+    };
+  }
+}
+
+const Cell: FC<{ cell: SurveySubmittedViewCell }> = ({ cell }) => {
+  if (cell.length === 0) {
+    return null;
+  }
+
+  const sorted = cell.sort((sub0, sub1) => {
+    const d0 = new Date(sub0.submitted);
+    const d1 = new Date(sub1.submitted);
+    return d1.getTime() - d0.getTime();
+  });
+
+  return (
+    <Box sx={{ cursor: 'default' }}>
+      <ZUIRelativeTime datetime={sorted[0].submitted} />
+    </Box>
+  );
+};

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -2,6 +2,7 @@ import { GridColDef } from '@mui/x-data-grid-pro';
 
 import SimpleColumnType from './SimpleColumnType';
 import SurveyResponseColumnType from './SurveyResponseColumnType';
+import SurveySubmittedColumnType from './SurveySubmittedColumnType';
 import { COLUMN_TYPE, ZetkinViewColumn } from 'features/views/components/types';
 
 export interface IColumnType<
@@ -49,7 +50,7 @@ const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
   [COLUMN_TYPE.PERSON_TAG]: new DummyColumnType(),
   [COLUMN_TYPE.SURVEY_OPTIONS]: new DummyColumnType(),
   [COLUMN_TYPE.SURVEY_RESPONSE]: new SurveyResponseColumnType(),
-  [COLUMN_TYPE.SURVEY_SUBMITTED]: new DummyColumnType(),
+  [COLUMN_TYPE.SURVEY_SUBMITTED]: new SurveySubmittedColumnType(),
   [COLUMN_TYPE.LOCAL_TEXT]: new SimpleColumnType(),
 };
 


### PR DESCRIPTION
## Description
This PR adds a column type and cell for survey response date. 


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/216124742-66000f49-7042-4c76-9ce5-7df2e038feac.png)

## Changes
* Adds column type and cell for survey response date.

## Related issues
Resolves #908 
