### PR TITLE
Cell UI for `local_bool` view columns

### DIFF
--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -50,7 +50,7 @@ test.describe('View detail page', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
 
     await page.locator('[role=cell] >> input[type=checkbox]').nth(0).click();
-    await page.locator('[role=cell] >> input[type=checkbox]').nth(1).click();
+    await page.locator('[role=cell] >> input[type=checkbox]').nth(2).click();
 
     await Promise.all([
       page.waitForNavigation(),

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -39,6 +39,7 @@ test.describe('View detail page', () => {
     await expect(page.locator(removeButton)).toBeHidden();
     await page
       .locator('[role=row]:has-text("Clara") input[type=checkbox]')
+      .first()
       .click();
     await page.locator(removeButton).waitFor();
     await expect(page.locator(removeButton)).toBeVisible();

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -1,0 +1,54 @@
+import { FC } from 'react';
+import { Box, Checkbox, useTheme } from '@mui/material';
+import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
+
+import { IColumnType } from '.';
+import useViewDataModel from 'features/views/hooks/useViewDataModel';
+import { LocalBoolViewColumn, ZetkinViewRow } from '../../types';
+
+export default class LocalBoolColumnType implements IColumnType {
+  cellToString(cell: boolean): string {
+    return String(cell);
+  }
+
+  getColDef(column: LocalBoolViewColumn): Omit<GridColDef, 'field'> {
+    return {
+      headerAlign: 'center',
+      renderCell: (params: GridRenderCellParams<boolean, ZetkinViewRow>) => {
+        return (
+          <Cell cell={params.value} column={column} personId={params.row.id} />
+        );
+      },
+    };
+  }
+}
+
+const Cell: FC<{
+  cell?: boolean;
+  column: LocalBoolViewColumn;
+  personId: number;
+}> = ({ cell, column, personId }) => {
+  const theme = useTheme();
+  const model = useViewDataModel();
+
+  const checked = !!cell;
+
+  return (
+    <Box
+      alignItems="center"
+      bgcolor={checked ? theme.palette.success.light : 'none'}
+      display="flex"
+      height="100%"
+      justifyContent="center"
+      width="100%"
+    >
+      <Checkbox
+        checked={checked}
+        color="success"
+        onChange={(ev) => {
+          model.setCellValue(personId, column.id, !!ev.target.checked);
+        }}
+      />
+    </Box>
+  );
+};

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -1,5 +1,6 @@
 import { GridColDef } from '@mui/x-data-grid-pro';
 
+import LocalBoolColumnType from './LocalBoolColumnType';
 import LocalPersonColumnType from './LocalPersonColumnType';
 import LocalQueryColumnType from './LocalQueryColumnType';
 import PersonTagColumnType from './PersonTagColumnType';
@@ -45,7 +46,7 @@ class DummyColumnType implements IColumnType {
  */
 const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
   [COLUMN_TYPE.JOURNEY_ASSIGNEE]: new DummyColumnType(),
-  [COLUMN_TYPE.LOCAL_BOOL]: new SimpleColumnType(),
+  [COLUMN_TYPE.LOCAL_BOOL]: new LocalBoolColumnType(),
   [COLUMN_TYPE.LOCAL_PERSON]: new LocalPersonColumnType(),
   [COLUMN_TYPE.LOCAL_QUERY]: new LocalQueryColumnType(),
   [COLUMN_TYPE.PERSON_FIELD]: new SimpleColumnType(),

--- a/src/features/views/models/ViewDataModel.ts
+++ b/src/features/views/models/ViewDataModel.ts
@@ -34,7 +34,7 @@ export default class ViewDataModel extends ModelBase {
   }
 
   setCellValue<CellType>(personId: number, colId: number, data: CellType) {
-    if (data) {
+    if (data !== null) {
       this._repo.setCellData(this._orgId, this._viewId, personId, colId, data);
     } else {
       this._repo.clearCellData(this._orgId, this._viewId, personId, colId);


### PR DESCRIPTION
## Description
This PR implements cell UI for the `local_bool` view column type.

## Screenshots
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/550212/216629284-76a68844-d533-491b-8ec7-20e9fd7ccc4a.png">

## Changes
* Adds UI for the `local_bool` type
* Fixes a bug in `ViewDataModel.setCellValue()` so that it understands `false` as an actual value

## Notes to reviewer
The design called for a different checkbox behaviour in terms of hover states, but I think it makes sense to use the standard MUI `Checkbox` and it's built-in hover states, so that's what I did.

Please review and merge #962 first.

## Related issues
Resolves #909 