### PR TITLE
Issue 911/local text cell

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -1,4 +1,12 @@
-import { GridColDef } from '@mui/x-data-grid-pro';
+import { makeStyles } from '@mui/styles';
+import { Box, InputBase, InputBaseProps, Paper, Popper } from '@mui/material';
+import { FC, useCallback, useState } from 'react';
+import {
+  GridColDef,
+  GridRenderEditCellParams,
+  useGridApiContext,
+} from '@mui/x-data-grid-pro';
+
 import { IColumnType } from '.';
 import ViewDataModel from 'features/views/models/ViewDataModel';
 
@@ -11,6 +19,8 @@ export default class LocalTextColumnType implements IColumnType {
   getColDef(): Omit<GridColDef, 'field'> {
     return {
       editable: true,
+      renderCell: (params) => <Cell cell={params.value} />,
+      renderEditCell: (params) => <EditTextarea {...params} />,
       width: 250,
     };
   }
@@ -23,3 +33,101 @@ export default class LocalTextColumnType implements IColumnType {
     model.setCellValue(personId, colId, data);
   }
 }
+
+const useStyles = makeStyles({
+  cell: {
+    alignItems: 'center',
+    display: 'flex',
+    height: '100%',
+  },
+  content: {
+    '-webkit-box-orient': 'vertical',
+    '-webkit-line-clamp': 2,
+    display: '-webkit-box',
+    maxHeight: '100%',
+    overflow: 'hidden',
+    whiteSpace: 'normal',
+    width: '100%',
+  },
+});
+
+const Cell: FC<{ cell: LocalTextViewCell }> = ({ cell }) => {
+  const styles = useStyles();
+
+  if (!cell) {
+    return null;
+  }
+
+  return (
+    <Box className={styles.cell}>
+      <Box className={styles.content}>{cell}</Box>
+    </Box>
+  );
+};
+
+const EditTextarea = (props: GridRenderEditCellParams<string>) => {
+  const { id, field, value, colDef } = props;
+  const [valueState, setValueState] = useState(value);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
+  const apiRef = useGridApiContext();
+
+  const handleRef = useCallback((el: HTMLElement | null) => {
+    setAnchorEl(el);
+  }, []);
+
+  const handleChange = useCallback<NonNullable<InputBaseProps['onChange']>>(
+    (event) => {
+      const newValue = event.target.value;
+      setValueState(newValue);
+      apiRef.current.setEditCellValue(
+        { debounceMs: 200, field, id, value: newValue },
+        event
+      );
+    },
+    [apiRef, field, id]
+  );
+
+  const handleKeyDown = useCallback<NonNullable<InputBaseProps['onKeyDown']>>(
+    (event) => {
+      if (
+        event.key === 'Escape' ||
+        (event.key === 'Enter' &&
+          !event.shiftKey &&
+          (event.ctrlKey || event.metaKey))
+      ) {
+        const params = apiRef.current.getCellParams(id, field);
+        apiRef.current.publishEvent('cellKeyDown', params, event);
+      }
+    },
+    [apiRef, id, field]
+  );
+
+  return (
+    <div style={{ alignSelf: 'flex-start', position: 'relative' }}>
+      <div
+        ref={handleRef}
+        style={{
+          display: 'block',
+          height: 1,
+          position: 'absolute',
+          top: 0,
+          width: colDef.computedWidth,
+        }}
+      />
+      {anchorEl && (
+        <Popper anchorEl={anchorEl} open placement="bottom-start">
+          <Paper elevation={1} sx={{ minWidth: colDef.computedWidth, p: 1 }}>
+            <InputBase
+              multiline
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              rows={4}
+              sx={{ textarea: { resize: 'both' }, width: '100%' }}
+              value={valueState}
+            />
+          </Paper>
+        </Popper>
+      )}
+    </div>
+  );
+};

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -1,0 +1,25 @@
+import { GridColDef } from '@mui/x-data-grid-pro';
+import { IColumnType } from '.';
+import ViewDataModel from 'features/views/models/ViewDataModel';
+
+type LocalTextViewCell = string;
+
+export default class LocalTextColumnType implements IColumnType {
+  cellToString(cell: LocalTextViewCell): string {
+    return cell ? cell : '';
+  }
+  getColDef(): Omit<GridColDef, 'field'> {
+    return {
+      editable: true,
+      width: 250,
+    };
+  }
+  processRowUpdate(
+    model: ViewDataModel,
+    colId: number,
+    personId: number,
+    data: LocalTextViewCell
+  ): void {
+    model.setCellValue(personId, colId, data);
+  }
+}

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -2,9 +2,11 @@ import { GridColDef } from '@mui/x-data-grid-pro';
 
 import LocalPersonColumnType from './LocalPersonColumnType';
 import LocalQueryColumnType from './LocalQueryColumnType';
+import LocalTextColumnType from './LocalTextColumnType';
 import SimpleColumnType from './SimpleColumnType';
 import SurveyResponseColumnType from './SurveyResponseColumnType';
 import SurveySubmittedColumnType from './SurveySubmittedColumnType';
+import ViewDataModel from 'features/views/models/ViewDataModel';
 import { COLUMN_TYPE, ZetkinViewColumn } from 'features/views/components/types';
 
 export interface IColumnType<
@@ -13,6 +15,12 @@ export interface IColumnType<
 > {
   cellToString(cell: CellType, column: ColumnType): string;
   getColDef(column: ColumnType): Omit<GridColDef, 'field'>;
+  processRowUpdate?(
+    model: ViewDataModel,
+    colId: number,
+    personId: number,
+    data: CellType
+  ): void;
 }
 
 // TODO: Remove this once all real types have been implemented
@@ -54,7 +62,7 @@ const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
   [COLUMN_TYPE.SURVEY_OPTIONS]: new DummyColumnType(),
   [COLUMN_TYPE.SURVEY_RESPONSE]: new SurveyResponseColumnType(),
   [COLUMN_TYPE.SURVEY_SUBMITTED]: new SurveySubmittedColumnType(),
-  [COLUMN_TYPE.LOCAL_TEXT]: new SimpleColumnType(),
+  [COLUMN_TYPE.LOCAL_TEXT]: new LocalTextColumnType(),
 };
 
 export default columnTypes;


### PR DESCRIPTION
## Description
This PR adds a column type for `local_text` with the ability to edit multiline text. Made togeher with @richardolsson .
The multiline editor component is graciosly borrowed from MUI's examples: https://mui.com/x/react-data-grid/recipes-editing/#multiline-editing

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/216645948-0894d966-0ae8-4845-b20d-a1594dc5c00e.png)
![bild](https://user-images.githubusercontent.com/58265097/216646033-1d85ff32-7885-4e58-ac50-6c6bd1c7812f.png)

## Changes
- Adds a column type for local text
- Adds the `processRowUpdate` method to the interface to make it possible to update cell content to the api.

## Related issues
Resolves #911 
