### PR TITLE
Misc view edit improvements

### DIFF
--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -125,6 +125,7 @@ const TagChip: React.FunctionComponent<{
         onDelete(tag);
       }}
       size="large"
+      tabIndex={-1}
     >
       <Clear className={classes.deleteIcon} fontSize="inherit" />
     </IconButton>

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -1,10 +1,19 @@
-import { FC } from 'react';
 import { Box, Checkbox, useTheme } from '@mui/material';
-import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
+import { FC, KeyboardEvent } from 'react';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  MuiEvent,
+} from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
 import useViewDataModel from 'features/views/hooks/useViewDataModel';
-import { LocalBoolViewColumn, ZetkinViewRow } from '../../types';
+import ViewDataModel from 'features/views/models/ViewDataModel';
+import {
+  LocalBoolViewColumn,
+  ZetkinViewColumn,
+  ZetkinViewRow,
+} from '../../types';
 
 export default class LocalBoolColumnType implements IColumnType {
   cellToString(cell: boolean): string {
@@ -24,6 +33,20 @@ export default class LocalBoolColumnType implements IColumnType {
 
   getSearchableStrings(): string[] {
     return [];
+  }
+
+  handleKeyDown(
+    model: ViewDataModel,
+    column: ZetkinViewColumn,
+    personId: number,
+    data: boolean,
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+  ): void {
+    if (ev.key == 'Enter' || ev.key == ' ') {
+      model.setCellValue(personId, column.id, !data);
+      ev.defaultMuiPrevented = true;
+      ev.preventDefault();
+    }
   }
 }
 
@@ -52,6 +75,7 @@ const Cell: FC<{
         onChange={(ev) => {
           model.setCellValue(personId, column.id, !!ev.target.checked);
         }}
+        tabIndex={-1}
       />
     </Box>
   );

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -9,6 +9,7 @@ import {
 import { IColumnType } from '.';
 import useViewDataModel from 'features/views/hooks/useViewDataModel';
 import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinObjectAccess } from 'core/api/types';
 import {
   LocalBoolViewColumn,
   ZetkinViewColumn,
@@ -40,8 +41,13 @@ export default class LocalBoolColumnType implements IColumnType {
     column: ZetkinViewColumn,
     personId: number,
     data: boolean,
-    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>,
+    accessLevel: ZetkinObjectAccess['level'] | null
   ): void {
+    if (accessLevel == 'readonly') {
+      return;
+    }
+
     if (ev.key == 'Enter' || ev.key == ' ') {
       model.setCellValue(personId, column.id, !data);
       ev.defaultMuiPrevented = true;

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -74,6 +74,16 @@ const EditTextarea = (props: GridRenderEditCellParams<string>) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
   const apiRef = useGridApiContext();
 
+  const handleTextAreaRef = useCallback((el: HTMLTextAreaElement | null) => {
+    if (el) {
+      // When entering edit mode, focus the text area and put
+      // caret at the end of the text
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+      el.scrollTop = el.scrollHeight;
+    }
+  }, []);
+
   const handleRef = useCallback((el: HTMLElement | null) => {
     setAnchorEl(el);
   }, []);
@@ -121,6 +131,7 @@ const EditTextarea = (props: GridRenderEditCellParams<string>) => {
         <Popper anchorEl={anchorEl} open placement="bottom-start">
           <Paper elevation={1} sx={{ minWidth: colDef.computedWidth, p: 1 }}>
             <InputBase
+              inputRef={handleTextAreaRef}
               multiline
               onChange={handleChange}
               onKeyDown={handleKeyDown}

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -106,7 +106,8 @@ const EditTextarea = (props: GridRenderEditCellParams<string>) => {
         event.key === 'Escape' ||
         (event.key === 'Enter' &&
           !event.shiftKey &&
-          (event.ctrlKey || event.metaKey))
+          !event.ctrlKey &&
+          !event.metaKey)
       ) {
         const params = apiRef.current.getCellParams(id, field);
         apiRef.current.publishEvent('cellKeyDown', params, event);

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -8,7 +8,9 @@ import {
 } from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
+import { LocalTextViewColumn } from '../../types';
 import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinObjectAccess } from 'core/api/types';
 
 type LocalTextViewCell = string | null;
 
@@ -16,9 +18,12 @@ export default class LocalTextColumnType implements IColumnType {
   cellToString(cell: LocalTextViewCell): string {
     return cell ? cell : '';
   }
-  getColDef(): Omit<GridColDef, 'field'> {
+  getColDef(
+    column: LocalTextViewColumn,
+    accessLevel: ZetkinObjectAccess['level'] | null
+  ): Omit<GridColDef, 'field'> {
     return {
-      editable: true,
+      editable: accessLevel != 'readonly',
       renderCell: (params) => <Cell cell={params.value} />,
       renderEditCell: (params) => <EditTextarea {...params} />,
       width: 250,

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
@@ -14,6 +14,7 @@ import TagModel from 'features/tags/models/TagModel';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import useModel from 'core/useModel';
 import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinObjectAccess } from 'core/api/types';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUIFuture from 'zui/ZUIFuture';
 import { PersonTagViewColumn, ZetkinViewRow } from '../../types';
@@ -52,8 +53,14 @@ export default class PersonTagColumnType implements IColumnType {
     column: PersonTagViewColumn,
     personId: number,
     data: PersonTagViewCell,
-    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>,
+    accessLevel: ZetkinObjectAccess['level']
   ): void {
+    if (accessLevel) {
+      // Any non-null value means we're in restricted mode
+      return;
+    }
+
     if (ev.key == 'Enter' || ev.key == ' ') {
       model.toggleTag(personId, column.config.tag_id, !data);
       ev.defaultMuiPrevented = true;

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
@@ -1,16 +1,25 @@
 import { Box } from '@mui/material';
-import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
 import { useRouter } from 'next/router';
-import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
+import { FC, KeyboardEvent } from 'react';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  MuiEvent,
+} from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
 import TagChip from 'features/tags/components/TagManager/components/TagChip';
 import TagModel from 'features/tags/models/TagModel';
 import useModel from 'core/useModel';
+import ViewDataModel from 'features/views/models/ViewDataModel';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUIFuture from 'zui/ZUIFuture';
 import { PersonTagViewColumn, ZetkinViewRow } from '../../types';
+
+type PersonTagViewCell = null | {
+  value?: string;
+};
 
 export default class PersonTagColumnType implements IColumnType {
   cellToString(cell: ZetkinTag): string {
@@ -35,6 +44,19 @@ export default class PersonTagColumnType implements IColumnType {
 
   getSearchableStrings(): string[] {
     return [];
+  }
+
+  handleKeyDown(
+    model: ViewDataModel,
+    column: PersonTagViewColumn,
+    personId: number,
+    data: PersonTagViewCell,
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+  ): void {
+    if (ev.key == 'Enter' || ev.key == ' ') {
+      model.toggleTag(personId, column.config.tag_id, !data);
+      ev.defaultMuiPrevented = true;
+    }
   }
 }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -1,4 +1,5 @@
-import { GridColDef } from '@mui/x-data-grid-pro';
+import { KeyboardEvent } from 'react';
+import { GridColDef, MuiEvent } from '@mui/x-data-grid-pro';
 
 import LocalBoolColumnType from './LocalBoolColumnType';
 import LocalPersonColumnType from './LocalPersonColumnType';
@@ -18,6 +19,13 @@ export interface IColumnType<
   cellToString(cell: CellType, column: ColumnType): string;
   getColDef(column: ColumnType): Omit<GridColDef, 'field'>;
   getSearchableStrings(cell: CellType): string[];
+  handleKeyDown?(
+    model: ViewDataModel,
+    column: ColumnType,
+    personId: number,
+    data: CellType,
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+  ): void;
   processRowUpdate?(
     model: ViewDataModel,
     colId: number,

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -10,6 +10,7 @@ import SimpleColumnType from './SimpleColumnType';
 import SurveyResponseColumnType from './SurveyResponseColumnType';
 import SurveySubmittedColumnType from './SurveySubmittedColumnType';
 import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinObjectAccess } from 'core/api/types';
 import { COLUMN_TYPE, ZetkinViewColumn } from 'features/views/components/types';
 
 export interface IColumnType<
@@ -17,14 +18,18 @@ export interface IColumnType<
   CellType = unknown
 > {
   cellToString(cell: CellType, column: ColumnType): string;
-  getColDef(column: ColumnType): Omit<GridColDef, 'field'>;
+  getColDef(
+    column: ColumnType,
+    accessLevel: ZetkinObjectAccess['level'] | null
+  ): Omit<GridColDef, 'field'>;
   getSearchableStrings(cell: CellType): string[];
   handleKeyDown?(
     model: ViewDataModel,
     column: ColumnType,
     personId: number,
     data: CellType,
-    ev: MuiEvent<KeyboardEvent<HTMLElement>>
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>,
+    accessLevel: ZetkinObjectAccess['level'] | null
   ): void;
   processRowUpdate?(
     model: ViewDataModel,

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -4,7 +4,12 @@ import NextLink from 'next/link';
 import NProgress from 'nprogress';
 import { useIntl } from 'react-intl';
 import { useRouter } from 'next/router';
-import { DataGridPro, GridColDef, useGridApiRef } from '@mui/x-data-grid-pro';
+import {
+  DataGridPro,
+  GridCellEditStartReasons,
+  GridColDef,
+  useGridApiRef,
+} from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';
 
 import columnTypes from './columnTypes';
@@ -360,6 +365,16 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           noRowsLabel: intl.formatMessage({
             id: `misc.views.empty.notice.${contentSource}`,
           }),
+        }}
+        onCellEditStart={(params, event) => {
+          if (params.reason == GridCellEditStartReasons.printableKeyDown) {
+            // Don't enter edit mode when the user just presses a printable character.
+            // Doing so is the default DataGrid behaviour (as in spreadsheets) but it
+            // means the user will overwrite the original value, which is rarely what
+            // you want with the precious data that exists in views (when there is no
+            // undo feature).
+            event.defaultMuiPrevented = true;
+          }
         }}
         onSelectionModelChange={(model) => setSelection(model as number[])}
         processRowUpdate={(after, before) => {

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -15,6 +15,7 @@ import { FunctionComponent, useContext, useState } from 'react';
 
 import columnTypes from './columnTypes';
 import EmptyView from 'features/views/components/EmptyView';
+import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import useModel from 'core/useModel';
 import useModelsFromQueryString from 'zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString';
 import useViewDataModel from 'features/views/hooks/useViewDataModel';
@@ -83,6 +84,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const [waiting, setWaiting] = useState(false);
 
   const { gridProps: modelGridProps } = useModelsFromQueryString();
+  const [, accessLevel] = useAccessLevel();
 
   const [quickSearch, setQuickSearch] = useState('');
   const router = useRouter();
@@ -268,7 +270,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       resizable: true,
       sortable: true,
       width: 150,
-      ...columnTypes[col.type].getColDef(col),
+      ...columnTypes[col.type].getColDef(col, accessLevel),
     })),
   ];
 
@@ -383,7 +385,14 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
             if (col) {
               const handleKeyDown = columnTypes[col.type].handleKeyDown;
               if (handleKeyDown) {
-                handleKeyDown(model, col, params.row.id, params.value, ev);
+                handleKeyDown(
+                  model,
+                  col,
+                  params.row.id,
+                  params.value,
+                  ev,
+                  accessLevel
+                );
               }
             }
           }

--- a/src/features/views/components/ViewSurveySubmissionPreview/index.stories.tsx
+++ b/src/features/views/components/ViewSurveySubmissionPreview/index.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { AccessLevelProvider } from 'features/views/hooks/useAccessLevel';
 import ViewSurveySubmissionPreview from '.';
 
 export default {
@@ -11,15 +12,17 @@ export default {
 const Template: ComponentStory<typeof ViewSurveySubmissionPreview> = (args) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   return (
-    <>
-      <div>
-        <a ref={(elem) => setAnchorEl(elem)}>Cell content</a>
-      </div>
-      <ViewSurveySubmissionPreview
-        anchorEl={anchorEl}
-        submissions={args.submissions}
-      />
-    </>
+    <AccessLevelProvider>
+      <>
+        <div>
+          <a ref={(elem) => setAnchorEl(elem)}>Cell content</a>
+        </div>
+        <ViewSurveySubmissionPreview
+          anchorEl={anchorEl}
+          submissions={args.submissions}
+        />
+      </>
+    </AccessLevelProvider>
   );
 };
 

--- a/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
+++ b/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
@@ -11,6 +11,7 @@ import {
 import { FC, ReactNode, useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
+import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 
 interface PreviewableSubmissionData {
@@ -52,6 +53,7 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
       }),
     [submissions]
   );
+  const [isRestricted] = useAccessLevel();
 
   const [mostRecent, ...older] = sorted;
 
@@ -80,14 +82,16 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
                   <ZUIRelativeTime datetime={mostRecent.submitted} forcePast />
                 </Typography>
                 <Box marginBottom={1}>{mostRecent.matchingContent}</Box>
-                <Button
-                  onClick={() =>
-                    onOpenSubmission && onOpenSubmission(mostRecent.id)
-                  }
-                  startIcon={<AssignmentTurnedInOutlined />}
-                >
-                  <FormattedMessage id="misc.views.surveyPreview.mostRecent.openButton" />
-                </Button>
+                {!isRestricted && (
+                  <Button
+                    onClick={() =>
+                      onOpenSubmission && onOpenSubmission(mostRecent.id)
+                    }
+                    startIcon={<AssignmentTurnedInOutlined />}
+                  >
+                    <FormattedMessage id="misc.views.surveyPreview.mostRecent.openButton" />
+                  </Button>
+                )}
               </Box>
             )}
           </Box>
@@ -110,14 +114,16 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
                           forcePast
                         />
                       </Typography>
-                      <Button
-                        onClick={() =>
-                          onOpenSubmission && onOpenSubmission(submission.id)
-                        }
-                        startIcon={<AssignmentTurnedInOutlined />}
-                      >
-                        <FormattedMessage id="misc.views.surveyPreview.older.openButton" />
-                      </Button>
+                      {!isRestricted && (
+                        <Button
+                          onClick={() =>
+                            onOpenSubmission && onOpenSubmission(submission.id)
+                          }
+                          startIcon={<AssignmentTurnedInOutlined />}
+                        >
+                          <FormattedMessage id="misc.views.surveyPreview.older.openButton" />
+                        </Button>
+                      )}
                     </Box>
                     <Box>{submission.matchingContent}</Box>
                   </Box>

--- a/src/features/views/models/ViewDataModel.ts
+++ b/src/features/views/models/ViewDataModel.ts
@@ -1,6 +1,7 @@
 import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
+import TagsRepo from 'features/tags/repos/TagsRepo';
 import ViewDataRepo from '../repos/ViewDataRepo';
 import ViewsRepo from '../repos/ViewsRepo';
 import { ZetkinPerson, ZetkinQuery } from 'utils/types/zetkin';
@@ -13,6 +14,7 @@ import {
 export default class ViewDataModel extends ModelBase {
   private _orgId: number;
   private _repo: ViewDataRepo;
+  private _tagsRepo: TagsRepo;
   private _viewId: number;
   private _viewsRepo: ViewsRepo;
 
@@ -28,6 +30,7 @@ export default class ViewDataModel extends ModelBase {
     super();
 
     this._repo = new ViewDataRepo(env);
+    this._tagsRepo = new TagsRepo(env);
     this._viewsRepo = new ViewsRepo(env);
     this._orgId = orgId;
     this._viewId = viewId;
@@ -71,6 +74,14 @@ export default class ViewDataModel extends ModelBase {
 
   setTitle(newTitle: string) {
     this._repo.updateView(this._orgId, this._viewId, { title: newTitle });
+  }
+
+  toggleTag(personId: number, tagId: number, assigned: boolean) {
+    if (assigned) {
+      this._tagsRepo.assignTagToPerson(this._orgId, personId, tagId);
+    } else {
+      this._tagsRepo.removeTagFromPerson(this._orgId, personId, tagId);
+    }
   }
 
   updateColumn(columnId: number, data: Partial<Omit<ZetkinViewColumn, 'id'>>) {

--- a/src/pages/organize/[orgId]/people/views/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/views/[viewId]/index.tsx
@@ -77,10 +77,12 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
     return null;
   }
 
+  const columnsFuture = model.getColumns();
+
   return (
     <ZUIFutures
       futures={{
-        cols: model.getColumns(),
+        cols: columnsFuture,
         rows: model.getRows(),
         view: model.getView(),
       }}
@@ -93,7 +95,7 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
           <ViewDataModelProvider model={model}>
             <AccessLevelProvider>
               <>
-                {!model.getColumns().isLoading && (
+                {(!columnsFuture.isLoading || !!columnsFuture.data?.length) && (
                   <ViewDataTable columns={cols} rows={rows} view={view} />
                 )}
               </>

--- a/src/zui/ZUIDataTableSorting/index.spec..tsx
+++ b/src/zui/ZUIDataTableSorting/index.spec..tsx
@@ -19,7 +19,8 @@ describe('ZUIDataTableSorting.tsx', () => {
           id: idx,
           title: field,
           type: COLUMN_TYPE.PERSON_FIELD,
-        })
+        }),
+        null
       ),
     };
   });


### PR DESCRIPTION
## Description
This PR makes a number of minor improvements to views, focusing on editing view data (using the keyboard and in restricted mode).

## Screenshots
Nothing really visually new.
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/550212/216824972-af195b97-c8e1-4d90-9b5e-7ff1fa233826.png">

## Changes
* Adds a framework for keyboard input in view cells
* Adds a framework for handling access level when rendering view cells
* Implements keyboard toggling of `person_tag` cells (assigning a tag this way requires changes to the backend, which I have made and submitted for review)
* Implements keyboard toggling of `local_bool` cells
* Makes improvements (IMO) to editing of `local_text` cells
  * When going into edit mode, the text area focuses so that you can start typing
  * When going into edit mode, the input caret is positioned at the end of the text
  * Pressing enter leaves the edit mode whereas shift+enter adds newline (this mimics spreadsheets)
* Refactors `person_tag` cells to work in restricted mode (when tag cannot be loaded). This requires changes to the backend which I have made and submitted for review.
* Disables editing of `person_tag` and `local_person` cells in restricted mode
* Conditionally disables `local_bool` and `local_text` editing based on access level
* Disables the "Open" button in `ViewSurveySubmissionPreview` when in restricted mode

## Notes to reviewer
Make sure to review only after merging #968.

Two changes are required on the backend for this to function entirely, so some features may not work as expected when reviewing, especially toggling tags, and tag columns in general when in restricted mode.

## Related issues
Deals with multiple issues raised in #965 