### PR TITLE
Issue 974/error when adding columns

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -57,7 +57,7 @@ export default class LocalBoolColumnType implements IColumnType {
 }
 
 const Cell: FC<{
-  cell?: boolean;
+  cell?: boolean | undefined;
   column: LocalBoolViewColumn;
   personId: number;
 }> = ({ cell, column, personId }) => {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -69,7 +69,7 @@ const useStyles = makeStyles<Theme, { isRestrictedMode: boolean }>({
 });
 
 const Cell: FC<{
-  cell: LocalPersonViewCell;
+  cell: LocalPersonViewCell | undefined;
   column: LocalPersonViewColumn;
   row: ZetkinViewRow;
 }> = ({ cell, column, row }) => {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
@@ -31,7 +31,11 @@ export default class LocalQueryColumnType
   }
 }
 
-const Cell: FC<{ cell: LocalQueryViewCell | undefined }> = () => {
+const Cell: FC<{ cell: LocalQueryViewCell | undefined }> = ({ cell }) => {
+  if (!cell) {
+    return null;
+  }
+
   return (
     <Box
       alignItems="center"

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
@@ -31,11 +31,7 @@ export default class LocalQueryColumnType
   }
 }
 
-const Cell: FC<{ cell: LocalQueryViewCell }> = ({ cell }) => {
-  if (!cell) {
-    return null;
-  }
-
+const Cell: FC<{ cell: LocalQueryViewCell | undefined }> = () => {
   return (
     <Box
       alignItems="center"

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles({
   },
 });
 
-const Cell: FC<{ cell: LocalTextViewCell }> = ({ cell }) => {
+const Cell: FC<{ cell: LocalTextViewCell | undefined }> = ({ cell }) => {
   const styles = useStyles();
 
   if (!cell) {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -89,7 +89,7 @@ const Cell: FC<{
     return null;
   }
 
-  const sorted = cell.sort((sub0, sub1) => {
+  const sorted = cell.concat().sort((sub0, sub1) => {
     const d0 = new Date(sub0.submitted);
     const d1 = new Date(sub1.submitted);
     return d1.getTime() - d0.getTime();

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -75,18 +75,21 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Cell: FC<{
-  cell: SurveyOptionsViewCell;
+  cell: SurveyOptionsViewCell | undefined;
 }> = ({ cell }) => {
   const { orgId } = useRouter().query;
   const styles = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
 
+  if (!cell) {
+    return null;
+  }
   if (cell.length == 0) {
     return null;
   }
 
-  const sorted = cell?.sort((sub0, sub1) => {
+  const sorted = cell.sort((sub0, sub1) => {
     const d0 = new Date(sub0.submitted);
     const d1 = new Date(sub1.submitted);
     return d1.getTime() - d0.getTime();

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -82,10 +82,7 @@ const Cell: FC<{
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
 
-  if (!cell) {
-    return null;
-  }
-  if (cell.length == 0) {
+  if (!cell || cell?.length == 0) {
     return null;
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -55,11 +55,15 @@ const useStyles = makeStyles({
   },
 });
 
-const Cell: FC<{ cell: SurveyResponseViewCell }> = ({ cell }) => {
+const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
   const { orgId } = useRouter().query;
   const styles = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
+
+  if (!cell) {
+    return null;
+  }
 
   if (cell.length == 0) {
     return null;

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -61,11 +61,7 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
 
-  if (!cell) {
-    return null;
-  }
-
-  if (cell.length == 0) {
+  if (!cell || cell?.length == 0) {
     return null;
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -38,11 +38,7 @@ const Cell: FC<{ cell: SurveySubmittedViewCell | undefined }> = ({ cell }) => {
   const { orgId } = useRouter().query;
   const { openPane } = usePanes();
 
-  if (!cell) {
-    return null;
-  }
-
-  if (cell.length === 0) {
+  if (!cell || cell?.length == 0) {
     return null;
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -34,9 +34,13 @@ export default class SurveySubmittedColumnType
   }
 }
 
-const Cell: FC<{ cell: SurveySubmittedViewCell }> = ({ cell }) => {
+const Cell: FC<{ cell: SurveySubmittedViewCell | undefined }> = ({ cell }) => {
   const { orgId } = useRouter().query;
   const { openPane } = usePanes();
+
+  if (!cell) {
+    return null;
+  }
 
   if (cell.length === 0) {
     return null;


### PR DESCRIPTION
## Description
This PR fixes the bug when adding the new column types in Views, handling the exception when the cell is undefined. It also fixes another bug in `SurveyOptionsColumnType` allowing the array `cell `to be concatenated before it´s sorted.


## Screenshots
https://user-images.githubusercontent.com/36491300/217559963-ff1bf3a4-7d68-4c97-9f31-38a5a47b81a7.mp4



## Changes
* Adds type `undefined ` in cell in the IColumnType implementations
* Adds function to checked of if cell is undefined and handles the exception (in the Column types that are necessary)
* Adds concat() function in the cell array in  `SurveyOptionsColumnType` before it´s sorted.


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #974
