### PR TITLE
Improvements to column type definitions

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -29,6 +29,7 @@ export default class LocalBoolColumnType implements IColumnType {
           <Cell cell={params.value} column={column} personId={params.row.id} />
         );
       },
+      type: 'boolean',
     };
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -41,6 +41,7 @@ export default class LocalPersonColumnType
   ): Omit<GridColDef<ZetkinViewRow>, 'field'> {
     return {
       align: 'center',
+      filterable: false,
       headerAlign: 'center',
       renderCell: (params) => {
         return <Cell cell={params.value} column={col} row={params.row} />;

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -30,7 +30,9 @@ import { ZetkinPerson, ZetkinViewRow } from 'utils/types/zetkin';
 
 type LocalPersonViewCell = null | ZetkinPerson;
 
-export default class LocalPersonColumnType implements IColumnType {
+export default class LocalPersonColumnType
+  implements IColumnType<LocalPersonViewColumn, LocalPersonViewCell>
+{
   cellToString(cell: ZetkinPerson | null): string {
     return cell ? `${cell.first_name} ${cell.last_name}` : '';
   }
@@ -42,6 +44,24 @@ export default class LocalPersonColumnType implements IColumnType {
       headerAlign: 'center',
       renderCell: (params) => {
         return <Cell cell={params.value} column={col} row={params.row} />;
+      },
+      sortComparator: (
+        val0: LocalPersonViewCell,
+        val1: LocalPersonViewCell
+      ) => {
+        if (!val0 && !val1) {
+          return 0;
+        }
+        if (!val0) {
+          return 1;
+        }
+        if (!val1) {
+          return -1;
+        }
+
+        const name0 = val0.first_name + val1.last_name;
+        const name1 = val1.first_name + val1.last_name;
+        return name0.localeCompare(name1);
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -32,6 +32,7 @@ export default class SurveyOptionColumnType
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },
+      type: 'boolean',
     };
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -29,6 +29,23 @@ export default class SurveyOptionsColumnType
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },
+      sortComparator: (
+        val0: SurveyOptionsViewCell | undefined,
+        val1: SurveyOptionsViewCell | undefined
+      ) => {
+        if (!val0 && !val1) {
+          return 0;
+        } else if (!val0) {
+          return -1;
+        } else if (!val1) {
+          return 1;
+        }
+
+        // Sort total number of options selected
+        const count0 = val0.reduce((sum, sub) => sum + sub.selected.length, 0);
+        const count1 = val1.reduce((sum, sub) => sum + sub.selected.length, 0);
+        return count0 - count1;
+      },
     };
   }
   getSearchableStrings(cell: SurveyOptionsViewCell): string[] {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -26,6 +26,7 @@ export default class SurveyOptionsColumnType
 
   getColDef(): Omit<GridColDef, 'field'> {
     return {
+      filterable: false,
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -26,6 +26,7 @@ export default class SurveyResponseColumnType
 
   getColDef(): Omit<GridColDef<SurveyResponseViewCell>, 'field'> {
     return {
+      filterable: false,
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -41,14 +41,17 @@ export interface IColumnType<
   ): void;
 }
 
-// TODO: Remove this once all real types have been implemented
-class DummyColumnType implements IColumnType {
+/**
+ * This column type is used for any column that is using a type that this
+ * frontend does not yet support, and will just render empty cells.
+ */
+class UnsupportedColumnType implements IColumnType {
   cellToString(): string {
     return '';
   }
 
   getColDef(): Omit<GridColDef, 'field'> {
-    return {};
+    return { valueGetter: () => '' };
   }
 
   getSearchableStrings(): string[] {
@@ -84,6 +87,7 @@ const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
   [COLUMN_TYPE.SURVEY_RESPONSE]: new SurveyResponseColumnType(),
   [COLUMN_TYPE.SURVEY_SUBMITTED]: new SurveySubmittedColumnType(),
   [COLUMN_TYPE.LOCAL_TEXT]: new LocalTextColumnType(),
+  [COLUMN_TYPE.UNSUPPORTED]: new UnsupportedColumnType(),
 };
 
 export default columnTypes;

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -73,12 +73,10 @@ class DummyColumnType implements IColumnType {
  * the value correctly.
  */
 const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
-  [COLUMN_TYPE.JOURNEY_ASSIGNEE]: new DummyColumnType(),
   [COLUMN_TYPE.LOCAL_BOOL]: new LocalBoolColumnType(),
   [COLUMN_TYPE.LOCAL_PERSON]: new LocalPersonColumnType(),
   [COLUMN_TYPE.LOCAL_QUERY]: new LocalQueryColumnType(),
   [COLUMN_TYPE.PERSON_FIELD]: new SimpleColumnType(),
-  [COLUMN_TYPE.PERSON_NOTES]: new DummyColumnType(),
   [COLUMN_TYPE.PERSON_QUERY]: new LocalQueryColumnType(),
   [COLUMN_TYPE.PERSON_TAG]: new PersonTagColumnType(),
   [COLUMN_TYPE.SURVEY_OPTION]: new SurveyOptionColumnType(),

--- a/src/features/views/components/types.ts
+++ b/src/features/views/components/types.ts
@@ -45,26 +45,17 @@ export interface ZetkinViewColumnBase {
 }
 
 export enum COLUMN_TYPE {
-  JOURNEY_ASSIGNEE = 'journey_assignee',
   LOCAL_BOOL = 'local_bool',
   LOCAL_PERSON = 'local_person',
   LOCAL_QUERY = 'local_query',
   LOCAL_TEXT = 'local_text',
   PERSON_FIELD = 'person_field',
-  PERSON_NOTES = 'person_notes',
   PERSON_QUERY = 'person_query',
   PERSON_TAG = 'person_tag',
   SURVEY_OPTION = 'survey_option',
   SURVEY_OPTIONS = 'survey_options',
   SURVEY_RESPONSE = 'survey_response',
   SURVEY_SUBMITTED = 'survey_submitted',
-}
-
-export interface JourneyAssigneeViewColumn extends ZetkinViewColumnBase {
-  type: COLUMN_TYPE.JOURNEY_ASSIGNEE;
-  config: {
-    journey_id?: number;
-  };
 }
 
 export interface LocalBoolViewColumn extends ZetkinViewColumnBase {
@@ -86,11 +77,6 @@ export interface LocalQueryViewColumn extends ZetkinViewColumnBase {
 
 export interface LocalTextViewColumn extends ZetkinViewColumnBase {
   type: COLUMN_TYPE.LOCAL_TEXT;
-  config?: Record<string, never>;
-}
-
-export interface PersonNotesViewColumn extends ZetkinViewColumnBase {
-  type: COLUMN_TYPE.PERSON_NOTES;
   config?: Record<string, never>;
 }
 
@@ -145,12 +131,10 @@ export interface SurveySubmittedViewColumn extends ZetkinViewColumnBase {
 }
 
 export type ZetkinViewColumn =
-  | JourneyAssigneeViewColumn
   | LocalBoolViewColumn
   | LocalPersonViewColumn
   | LocalQueryViewColumn
   | LocalTextViewColumn
-  | PersonNotesViewColumn
   | PersonFieldViewColumn
   | PersonQueryViewColumn
   | PersonTagViewColumn

--- a/src/features/views/components/types.ts
+++ b/src/features/views/components/types.ts
@@ -56,6 +56,7 @@ export enum COLUMN_TYPE {
   SURVEY_OPTIONS = 'survey_options',
   SURVEY_RESPONSE = 'survey_response',
   SURVEY_SUBMITTED = 'survey_submitted',
+  UNSUPPORTED = 'unsupported',
 }
 
 export interface LocalBoolViewColumn extends ZetkinViewColumnBase {
@@ -130,6 +131,11 @@ export interface SurveySubmittedViewColumn extends ZetkinViewColumnBase {
   };
 }
 
+export interface UnsupportedViewColumn extends ZetkinViewColumnBase {
+  type: COLUMN_TYPE.UNSUPPORTED;
+  config: undefined;
+}
+
 export type ZetkinViewColumn =
   | LocalBoolViewColumn
   | LocalPersonViewColumn
@@ -141,7 +147,8 @@ export type ZetkinViewColumn =
   | SurveyOptionViewColumn
   | SurveyOptionsViewColumn
   | SurveyResponseViewColumn
-  | SurveySubmittedViewColumn;
+  | SurveySubmittedViewColumn
+  | UnsupportedViewColumn;
 
 export type NewZetkinViewColumn = Record<string, never>;
 

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -1,3 +1,4 @@
+import columnTypes from './components/ViewDataTable/columnTypes';
 import { DeleteFolderReport } from 'pages/api/views/deleteFolder';
 import { ViewTreeData } from 'pages/api/views/tree';
 import { ZetkinObjectAccess } from 'core/api/types';
@@ -209,7 +210,16 @@ const viewsSlice = createSlice({
       action: PayloadAction<[number, ZetkinViewColumn[]]>
     ) => {
       const [viewId, columns] = action.payload;
-      state.columnsByViewId[viewId] = remoteList(columns);
+      const supportedColumns = columns.map((column) => {
+        const copy: ZetkinViewColumn = { ...column };
+        if (!Object.keys(columnTypes).includes(copy.type)) {
+          copy.type = COLUMN_TYPE.UNSUPPORTED;
+        }
+
+        return copy;
+      });
+
+      state.columnsByViewId[viewId] = remoteList(supportedColumns);
       state.columnsByViewId[viewId].loaded = new Date().toISOString();
     },
     folderCreate: (state) => {


### PR DESCRIPTION
## Description
This PR makes some improvements to the view column type definitions.

## Screenshots
Very little visual change.

## Changes
* Removes unsupported column types (`journey_assignee` and `person_notes`)
* Adds a special column type called `unsupported`, which renders nothing and is used for any unsupported type
* Implements sorting and filtering for boolean columns
* Implements sorting for `local_person` and `survey_options` columns
* Disable filtering on complex column types which would be too time-consuming to build proper filtering support for now

## Notes to reviewer
None

## Related issues
Solves another few items in the #965 polishing issue.