### PR TITLE
Add three tabs and its layout for it

### DIFF
--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,0 +1,33 @@
+import TabbedLayout from 'utils/layout/TabbedLayout';
+
+interface SurveyLayoutProps {
+  children: React.ReactNode;
+  orgId: string;
+  campaignId: string;
+  surveyId: string;
+}
+
+const SurveyLayout: React.FC<SurveyLayoutProps> = ({
+  orgId,
+  campaignId,
+  surveyId,
+}) => {
+  return (
+    <TabbedLayout
+      baseHref={`/organize/${orgId}/campaigns/${campaignId}/surveys/${surveyId}`}
+      defaultTab="/"
+      tabs={[
+        { href: '/', messageId: 'layout.organize.surveys.tabs.overview' },
+        {
+          href: '/questions',
+          messageId: 'layout.organize.surveys.tabs.questions',
+        },
+        {
+          href: '/submissions',
+          messageId: 'layout.organize.surveys.tabs.submissions',
+        },
+      ]}
+    />
+  );
+};
+export default SurveyLayout;

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -30,4 +30,5 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
     />
   );
 };
+
 export default SurveyLayout;

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -68,6 +68,11 @@ search:
   label: Search
   noResults: No results for this search
   placeholder: Type to search
+surveys:
+  tabs:
+    overview: Overview
+    questions: Questions
+    submissions: Submissions
 tasks:
   tabs:
     assignees: Assignees

--- a/src/locale/misc/breadcrumbs/en.yml
+++ b/src/locale/misc/breadcrumbs/en.yml
@@ -17,6 +17,8 @@ new: New
 organize: Organize
 people: People
 projects: Projects
+questions: Questions
+submissions: Submissions
 surveys: Surveys
 tasks: Tasks
 views: Views

--- a/src/locale/misc/breadcrumbs/en.yml
+++ b/src/locale/misc/breadcrumbs/en.yml
@@ -17,5 +17,6 @@ new: New
 organize: Organize
 people: People
 projects: Projects
+surveys: Surveys
 tasks: Tasks
 views: Views

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -170,6 +170,12 @@ async function fetchLabel(
     ).then((res) => res.json());
     return assignment.data.title;
   }
+  if (fieldName == 'surveyId') {
+    const survey = await apiFetch(`/orgs/${orgId}/surveys/${fieldValue}`).then(
+      (res) => res.json()
+    );
+    return survey.data.title;
+  }
   return fieldValue;
 }
 

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -1,0 +1,44 @@
+import { GetServerSideProps } from 'next';
+import { PageWithLayout } from 'utils/types';
+import { scaffold } from 'utils/next';
+import SurveyLayout from 'features/surveys/layout/SurveyLayout';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId, campId, surveyId } = ctx.params!;
+
+    return {
+      props: {
+        campId,
+        orgId,
+        surveyId,
+      },
+    };
+  },
+  {
+    authLevelRequired: 2,
+    localeScope: ['layout.organize.surveys'],
+  }
+);
+
+interface SurveyPageProps {
+  campId: string;
+  orgId: string;
+  surveyId: string;
+}
+const SurveyPage: PageWithLayout<SurveyPageProps> = () => {
+  return <></>;
+};
+SurveyPage.getLayout = function getLayout(page, props) {
+  return (
+    <SurveyLayout
+      campaignId={props.campId}
+      orgId={props.orgId}
+      surveyId={props.surveyId}
+    >
+      {page}
+    </SurveyLayout>
+  );
+};
+
+export default SurveyPage;

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
@@ -21,16 +21,16 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-interface SurveyPageProps {
+interface QuestionPageProps {
   campId: string;
   orgId: string;
   surveyId: string;
 }
 
-const SurveyPage: PageWithLayout<SurveyPageProps> = () => {
+const QuestionPage: PageWithLayout<QuestionPageProps> = () => {
   return <></>;
 };
-SurveyPage.getLayout = function getLayout(page, props) {
+QuestionPage.getLayout = function getLayout(page, props) {
   return (
     <SurveyLayout
       campaignId={props.campId}
@@ -42,4 +42,4 @@ SurveyPage.getLayout = function getLayout(page, props) {
   );
 };
 
-export default SurveyPage;
+export default QuestionPage;

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
@@ -21,16 +21,16 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-interface QuestionPageProps {
+interface QuestionsPageProps {
   campId: string;
   orgId: string;
   surveyId: string;
 }
 
-const QuestionPage: PageWithLayout<QuestionPageProps> = () => {
+const QuestionsPage: PageWithLayout<QuestionsPageProps> = () => {
   return <></>;
 };
-QuestionPage.getLayout = function getLayout(page, props) {
+QuestionsPage.getLayout = function getLayout(page, props) {
   return (
     <SurveyLayout
       campaignId={props.campId}
@@ -42,4 +42,4 @@ QuestionPage.getLayout = function getLayout(page, props) {
   );
 };
 
-export default QuestionPage;
+export default QuestionsPage;

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
@@ -21,16 +21,16 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-interface SubmissionPageProps {
+interface SubmissionsPageProps {
   campId: string;
   orgId: string;
   surveyId: string;
 }
 
-const SubmissionPage: PageWithLayout<SubmissionPageProps> = () => {
+const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = () => {
   return <></>;
 };
-SubmissionPage.getLayout = function getLayout(page, props) {
+SubmissionsPage.getLayout = function getLayout(page, props) {
   return (
     <SurveyLayout
       campaignId={props.campId}
@@ -42,4 +42,4 @@ SubmissionPage.getLayout = function getLayout(page, props) {
   );
 };
 
-export default SubmissionPage;
+export default SubmissionsPage;

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
@@ -21,16 +21,16 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-interface SurveyPageProps {
+interface SubmissionPageProps {
   campId: string;
   orgId: string;
   surveyId: string;
 }
 
-const SurveyPage: PageWithLayout<SurveyPageProps> = () => {
+const SubmissionPage: PageWithLayout<SubmissionPageProps> = () => {
   return <></>;
 };
-SurveyPage.getLayout = function getLayout(page, props) {
+SubmissionPage.getLayout = function getLayout(page, props) {
   return (
     <SurveyLayout
       campaignId={props.campId}
@@ -42,4 +42,4 @@ SurveyPage.getLayout = function getLayout(page, props) {
   );
 };
 
-export default SurveyPage;
+export default SubmissionPage;


### PR DESCRIPTION
## Description
User can see three tabs when they are on surveys. 


## Screenshots
![image](https://user-images.githubusercontent.com/77925373/218078040-74bf60ad-2cd5-4055-afb5-b19df5d622b1.png)

![image](https://user-images.githubusercontent.com/77925373/218102052-733c08fe-2c01-4735-ade6-e8011c3fcf84.png)

![image](https://user-images.githubusercontent.com/77925373/218102119-b420a689-e4e1-4cd3-8b28-a3ecb072f702.png)





## Changes

* Adds SurveyLayout in /features/surveys/layout
* Adds survey page and [surveyId] to /campaigns/[campId] in page
* Adds surveys key(?) in en.yml in /locale/layout/organize 
* Adds surveys key in en.yml in /locale/misc/breadcrums
* Adds questions, submissions page


## Notes to reviewer


## Related issues
Resolves #982
