### PR TITLE
Editable survey title

### DIFF
--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,4 +1,7 @@
+import SurveyDataModel from '../models/SurveyDataModel';
 import TabbedLayout from 'utils/layout/TabbedLayout';
+import useModel from 'core/useModel';
+import ZUIFuture from 'zui/ZUIFuture';
 
 interface SurveyLayoutProps {
   children: React.ReactNode;
@@ -12,6 +15,10 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
   campaignId,
   surveyId,
 }) => {
+  const model = useModel(
+    (env) => new SurveyDataModel(env, parseInt(orgId), parseInt(surveyId))
+  );
+
   return (
     <TabbedLayout
       baseHref={`/organize/${orgId}/campaigns/${campaignId}/surveys/${surveyId}`}
@@ -27,6 +34,13 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
           messageId: 'layout.organize.surveys.tabs.submissions',
         },
       ]}
+      title={
+        <ZUIFuture future={model.getData()}>
+          {(data) => {
+            return <>{data.title}</>;
+          }}
+        </ZUIFuture>
+      }
     />
   );
 };

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,6 +1,7 @@
 import SurveyDataModel from '../models/SurveyDataModel';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
+import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 
 interface SurveyLayoutProps {
@@ -37,7 +38,14 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
       title={
         <ZUIFuture future={model.getData()}>
           {(data) => {
-            return <>{data.title}</>;
+            return (
+              <ZUIEditTextinPlace
+                onChange={(val) => {
+                  model.setTitle(val);
+                }}
+                value={data.title}
+              />
+            );
           }}
         </ZUIFuture>
       }

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -19,4 +19,8 @@ export default class SurveyDataModel extends ModelBase {
   getData(): IFuture<ZetkinSurvey> {
     return this._repo.getSurvey(this._orgId, this._surveyId);
   }
+
+  setTitle(title: string) {
+    this._repo.updateSurvey(this._orgId, this._surveyId, { title });
+  }
 }

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -1,0 +1,22 @@
+import Environment from 'core/env/Environment';
+import { IFuture } from 'core/caching/futures';
+import { ModelBase } from 'core/models';
+import SurveysRepo from '../repos/SurveysRepo';
+import { ZetkinSurvey } from 'utils/types/zetkin';
+
+export default class SurveyDataModel extends ModelBase {
+  private _orgId: number;
+  private _repo: SurveysRepo;
+  private _surveyId: number;
+
+  constructor(env: Environment, orgId: number, surveyId: number) {
+    super();
+    this._orgId = orgId;
+    this._surveyId = surveyId;
+    this._repo = new SurveysRepo(env);
+  }
+
+  getData(): IFuture<ZetkinSurvey> {
+    return this._repo.getSurvey(this._orgId, this._surveyId);
+  }
+}

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -8,8 +8,11 @@ import {
   submissionLoaded,
   surveyLoad,
   surveyLoaded,
+  surveyUpdate,
+  surveyUpdated,
 } from '../store';
 import {
+  ZetkinSurvey,
   ZetkinSurveyExtended,
   ZetkinSurveySubmission,
 } from 'utils/types/zetkin';
@@ -60,5 +63,21 @@ export default class SurveysRepo {
     } else {
       return new RemoteItemFuture(item);
     }
+  }
+
+  updateSurvey(
+    orgId: number,
+    surveyId: number,
+    data: Partial<Omit<ZetkinSurvey, 'id'>>
+  ) {
+    this._store.dispatch(surveyUpdate([surveyId, Object.keys(data)]));
+    this._apiClient
+      .patch<ZetkinSurveyExtended>(
+        `/api/orgs/${orgId}/surveys/${surveyId}`,
+        data
+      )
+      .then((survey) => {
+        this._store.dispatch(surveyUpdated(survey));
+      });
   }
 }

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 import {
+  ZetkinSurvey,
   ZetkinSurveyExtended,
   ZetkinSurveySubmission,
 } from 'utils/types/zetkin';
@@ -60,9 +61,30 @@ const surveysSlice = createSlice({
       item.isLoading = false;
       item.loaded = new Date().toISOString();
     },
+    surveyUpdate: (state, action: PayloadAction<[number, string[]]>) => {
+      const [surveyId, mutating] = action.payload;
+      const item = state.surveyList.items.find((item) => item.id == surveyId);
+      if (item) {
+        item.mutating = mutating;
+      }
+    },
+    surveyUpdated: (state, action: PayloadAction<ZetkinSurvey>) => {
+      const survey = action.payload;
+      const item = state.surveyList.items.find((item) => item.id == survey.id);
+      if (item) {
+        item.data = { ...item.data, ...survey } as ZetkinSurveyExtended;
+        item.mutating = [];
+      }
+    },
   },
 });
 
 export default surveysSlice;
-export const { submissionLoad, submissionLoaded, surveyLoad, surveyLoaded } =
-  surveysSlice.actions;
+export const {
+  submissionLoad,
+  submissionLoaded,
+  surveyLoad,
+  surveyLoaded,
+  surveyUpdate,
+  surveyUpdated,
+} = surveysSlice.actions;


### PR DESCRIPTION
## Description
This PR adds the survey title to the header of survey pages introduced in #1006, and makes the title editable using `ZUIEditTextInPlace`.

## Screenshots
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/550212/218126169-f0309acc-3e0b-4c5b-8304-498c7f1ed13d.png">

## Changes
* Adds model, repo and store logic for updating survey titles
* Adds the title to the header of survey pages

## Notes to reviewer
None

## Related issues
Resolves #983 