### PR TITLE
Fix ZUIEditTextInPlace measuring issue in title

### DIFF
--- a/src/utils/layout/Header.tsx
+++ b/src/utils/layout/Header.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   },
   title: {
     marginBottom: '8px',
-    transition: 'all 0.3s ease',
+    transition: 'margin 0.3s ease',
   },
   titleGrid: {
     alignItems: 'center',


### PR DESCRIPTION
## Description
This PR fixes the bug related to edit-in-place title mentioned in #965.

## Screenshots
None

## Changes
* Removes font-size animation when entering a page with a title, which fixes the bug

## Notes to reviewer
1. On `main`, navigate to a survey page
2. Note how the title scales up and the `ZUIEditTextInPlace` measurement does not update correctly
3. Switch to this branch and refresh the page
4. Note how the title size is static, and the measurement is correct

## Related issues
Originally documented in #965