### PR TITLE
Publish/unpublish button for survey

### DIFF
--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,8 +1,10 @@
-import SurveyDataModel from '../models/SurveyDataModel';
+import { Button } from '@mui/material';
+import { FormattedMessage as Msg } from 'react-intl';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
+import SurveyDataModel, { SurveyState } from '../models/SurveyDataModel';
 
 interface SurveyLayoutProps {
   children: React.ReactNode;
@@ -20,8 +22,21 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
     (env) => new SurveyDataModel(env, parseInt(orgId), parseInt(surveyId))
   );
 
+  const hasQuestions = !!model.getData().data?.elements.length;
+
   return (
     <TabbedLayout
+      actionButtons={
+        model.state == SurveyState.PUBLISHED ? (
+          <Button variant="outlined">
+            <Msg id="layout.organize.surveys.actions.unpublish" />
+          </Button>
+        ) : (
+          <Button disabled={!hasQuestions} variant="contained">
+            <Msg id="layout.organize.surveys.actions.publish" />
+          </Button>
+        )
+      }
       baseHref={`/organize/${orgId}/campaigns/${campaignId}/surveys/${surveyId}`}
       defaultTab="/"
       tabs={[

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -32,7 +32,11 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
             <Msg id="layout.organize.surveys.actions.unpublish" />
           </Button>
         ) : (
-          <Button disabled={!hasQuestions} variant="contained">
+          <Button
+            disabled={!hasQuestions}
+            onClick={() => model.publish()}
+            variant="contained"
+          >
             <Msg id="layout.organize.surveys.actions.publish" />
           </Button>
         )

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -28,7 +28,7 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
     <TabbedLayout
       actionButtons={
         model.state == SurveyState.PUBLISHED ? (
-          <Button variant="outlined">
+          <Button onClick={() => model.unpublish()} variant="outlined">
             <Msg id="layout.organize.surveys.actions.unpublish" />
           </Button>
         ) : (

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
@@ -26,6 +28,64 @@ export default class SurveyDataModel extends ModelBase {
 
   getData(): IFuture<ZetkinSurvey> {
     return this._repo.getSurvey(this._orgId, this._surveyId);
+  }
+
+  publish(): void {
+    const { data } = this.getData();
+    if (!data) {
+      return;
+    }
+
+    const now = dayjs();
+    const today = now.format('YYYY-MM-DD');
+
+    const { published, expires } = data;
+
+    if (!published && !expires) {
+      this._repo.updateSurvey(this._orgId, this._surveyId, {
+        published: today,
+      });
+    } else if (!published) {
+      const endDate = dayjs(expires);
+      if (endDate.isBefore(today)) {
+        this._repo.updateSurvey(this._orgId, this._surveyId, {
+          expires: null,
+          published: today,
+        });
+      } else if (endDate.isAfter(today)) {
+        this._repo.updateSurvey(this._orgId, this._surveyId, {
+          published: today,
+        });
+      }
+    } else if (!expires) {
+      // Start date is non-null
+      const startDate = dayjs(published);
+      if (startDate.isAfter(today)) {
+        // End date is null, start date is future
+        this._repo.updateSurvey(this._orgId, this._surveyId, {
+          published: today,
+        });
+      }
+    } else {
+      // Start and end date are non-null
+      const startDate = dayjs(published);
+      const endDate = dayjs(expires);
+
+      if (
+        (startDate.isBefore(today) || startDate.isSame(today)) &&
+        (endDate.isBefore(today) || endDate.isSame(today))
+      ) {
+        // Start is past, end is past
+        this._repo.updateSurvey(this._orgId, this._surveyId, {
+          expires: null,
+        });
+      } else if (startDate.isAfter(today) && endDate.isAfter(today)) {
+        // Start is future, end is future
+        this._repo.updateSurvey(this._orgId, this._surveyId, {
+          published: today,
+        });
+      }
+    }
   }
 
   setTitle(title: string) {

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -4,6 +4,14 @@ import { ModelBase } from 'core/models';
 import SurveysRepo from '../repos/SurveysRepo';
 import { ZetkinSurvey } from 'utils/types/zetkin';
 
+export enum SurveyState {
+  UNPUBLISHED = 'unpublished',
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  SCHEDULED = 'scheduled',
+  UNKNOWN = 'unknown',
+}
+
 export default class SurveyDataModel extends ModelBase {
   private _orgId: number;
   private _repo: SurveysRepo;
@@ -22,5 +30,33 @@ export default class SurveyDataModel extends ModelBase {
 
   setTitle(title: string) {
     this._repo.updateSurvey(this._orgId, this._surveyId, { title });
+  }
+
+  get state(): SurveyState {
+    const { data } = this.getData();
+    if (!data) {
+      return SurveyState.UNKNOWN;
+    }
+
+    if (data.published) {
+      const publishDate = new Date(data.published);
+      const now = new Date();
+
+      if (publishDate > now) {
+        return SurveyState.SCHEDULED;
+      } else {
+        if (data.expires) {
+          const expiryDate = new Date(data.expires);
+
+          if (expiryDate < now) {
+            return SurveyState.UNPUBLISHED;
+          }
+        }
+
+        return SurveyState.PUBLISHED;
+      }
+    } else {
+      return SurveyState.DRAFT;
+    }
   }
 }

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -119,4 +119,18 @@ export default class SurveyDataModel extends ModelBase {
       return SurveyState.DRAFT;
     }
   }
+
+  unpublish(): void {
+    const { data } = this.getData();
+    if (!data) {
+      return;
+    }
+
+    const now = dayjs();
+    const today = now.format('YYYY-MM-DD');
+
+    this._repo.updateSurvey(this._orgId, this._surveyId, {
+      expires: today,
+    });
+  }
 }

--- a/src/locale/layout/organize/en.yml
+++ b/src/locale/layout/organize/en.yml
@@ -69,6 +69,9 @@ search:
   noResults: No results for this search
   placeholder: Type to search
 surveys:
+  actions:
+    publish: Publish survey
+    unpublish: Unpublish survey
   tabs:
     overview: Overview
     questions: Questions

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -172,6 +172,9 @@ export interface ZetkinSurvey {
   allow_anonymous: boolean;
   access: string;
   callers_only: boolean;
+  published: string | null;
+  expires: string | null;
+  elements: ZetkinSurveyElement[];
 }
 
 export interface ZetkinSurveyExtended extends ZetkinSurvey {


### PR DESCRIPTION
## Description
This PR adds an actionbutton to the survey layout where users can publish or unpublish a survey. 

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/218455340-a1fb6d71-ca28-4f9a-9685-94f063a250ea.png)
![bild](https://user-images.githubusercontent.com/58265097/218455386-1e8bd323-89be-47ab-91e9-5d92ff496a25.png)

## Changes
* Adds `SurveyState` enum of states of the survey
* Adds actionbutton to `SurveyLayout`
* Adds `publish()` and `unpublish()` methods to `SurveyDataModel`

## Related issues
Resolves #984 
