### PR TITLE
Empty state for survey overview tab

### DIFF
--- a/src/features/surveys/components/EmptyOverview.tsx
+++ b/src/features/surveys/components/EmptyOverview.tsx
@@ -1,0 +1,34 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { QuizOutlined } from '@mui/icons-material';
+import { Box, Button, Link, Typography } from '@mui/material';
+
+interface EmptyOverviewProps {
+  campId: string;
+  orgId: string;
+  surveyId: string;
+}
+
+const EmptyOverview = ({ campId, orgId, surveyId }: EmptyOverviewProps) => {
+  return (
+    <Box alignItems="center" display="flex" flexDirection="column">
+      <QuizOutlined
+        color="secondary"
+        sx={{ fontSize: '8em', paddingBottom: 2 }}
+      />
+      <Typography color="secondary">
+        <Msg id="pages.organizeSurvey.overview.noQuestions.title" />
+      </Typography>
+      <Link
+        href={`/organize/${orgId}/campaigns/${campId}/surveys/${surveyId}/questions`}
+        sx={{ marginTop: 4 }}
+        underline="none"
+      >
+        <Button variant="contained">
+          <Msg id="pages.organizeSurvey.overview.noQuestions.button" />
+        </Button>
+      </Link>
+    </Box>
+  );
+};
+
+export default EmptyOverview;

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -14,6 +14,7 @@ interface SurveyLayoutProps {
 }
 
 const SurveyLayout: React.FC<SurveyLayoutProps> = ({
+  children,
   orgId,
   campaignId,
   surveyId,
@@ -68,7 +69,9 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
           }}
         </ZUIFuture>
       }
-    />
+    >
+      {children}
+    </TabbedLayout>
   );
 };
 

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -120,6 +120,16 @@ export default class SurveyDataModel extends ModelBase {
     }
   }
 
+  get surveyIsEmpty(): boolean {
+    const { data } = this.getData();
+
+    if (!data) {
+      return true;
+    }
+
+    return data.elements.length ? false : true;
+  }
+
   unpublish(): void {
     const { data } = this.getData();
     if (!data) {

--- a/src/locale/pages/organizeSurvey/en.yml
+++ b/src/locale/pages/organizeSurvey/en.yml
@@ -1,0 +1,4 @@
+overview:
+  noQuestions:
+    button: Create questions
+    title: There are no questions in this survey yet

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -60,7 +60,7 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
       justifyContent="center"
       paddingTop={8}
     >
-      {!survey.elements.length && (
+      {model.surveyIsEmpty && (
         <EmptyOverview campId={campId} orgId={orgId} surveyId={surveyId} />
       )}
     </Box>

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -1,7 +1,14 @@
 import { GetServerSideProps } from 'next';
+import { FormattedMessage as Msg } from 'react-intl';
+import { QuizOutlined } from '@mui/icons-material';
+import { Box, Button, Link, Typography } from '@mui/material';
+
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
+import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import SurveyLayout from 'features/surveys/layout/SurveyLayout';
+import useModel from 'core/useModel';
+import useServerSide from 'core/useServerSide';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -17,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys'],
+    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
   }
 );
 
@@ -27,9 +34,59 @@ interface SurveyPageProps {
   surveyId: string;
 }
 
-const SurveyPage: PageWithLayout<SurveyPageProps> = () => {
-  return <></>;
+const SurveyPage: PageWithLayout<SurveyPageProps> = ({
+  campId,
+  orgId,
+  surveyId,
+}) => {
+  const model = useModel(
+    (env) => new SurveyDataModel(env, parseInt(orgId), parseInt(surveyId))
+  );
+  const onServer = useServerSide();
+
+  if (onServer) {
+    return null;
+  }
+
+  const { data: survey } = model.getData();
+
+  if (!survey) {
+    return null;
+  }
+
+  return (
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="center"
+      paddingTop={8}
+    >
+      {survey.elements.length ? (
+        <></>
+      ) : (
+        <Box alignItems="center" display="flex" flexDirection="column">
+          <QuizOutlined
+            color="secondary"
+            sx={{ fontSize: '8em', paddingBottom: 2 }}
+          />
+          <Typography color="secondary">
+            <Msg id="pages.organizeSurvey.overview.noQuestions.title" />
+          </Typography>
+          <Link
+            href={`/organize/${orgId}/campaigns/${campId}/surveys/${surveyId}/questions`}
+            sx={{ marginTop: 4 }}
+            underline="none"
+          >
+            <Button variant="contained">
+              <Msg id="pages.organizeSurvey.overview.noQuestions.button" />
+            </Button>
+          </Link>
+        </Box>
+      )}
+    </Box>
+  );
 };
+
 SurveyPage.getLayout = function getLayout(page, props) {
   return (
     <SurveyLayout

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -1,8 +1,7 @@
+import { Box } from '@mui/material';
 import { GetServerSideProps } from 'next';
-import { FormattedMessage as Msg } from 'react-intl';
-import { QuizOutlined } from '@mui/icons-material';
-import { Box, Button, Link, Typography } from '@mui/material';
 
+import EmptyOverview from 'features/surveys/components/EmptyOverview';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
@@ -61,27 +60,8 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
       justifyContent="center"
       paddingTop={8}
     >
-      {survey.elements.length ? (
-        <></>
-      ) : (
-        <Box alignItems="center" display="flex" flexDirection="column">
-          <QuizOutlined
-            color="secondary"
-            sx={{ fontSize: '8em', paddingBottom: 2 }}
-          />
-          <Typography color="secondary">
-            <Msg id="pages.organizeSurvey.overview.noQuestions.title" />
-          </Typography>
-          <Link
-            href={`/organize/${orgId}/campaigns/${campId}/surveys/${surveyId}/questions`}
-            sx={{ marginTop: 4 }}
-            underline="none"
-          >
-            <Button variant="contained">
-              <Msg id="pages.organizeSurvey.overview.noQuestions.button" />
-            </Button>
-          </Link>
-        </Box>
+      {!survey.elements.length && (
+        <EmptyOverview campId={campId} orgId={orgId} surveyId={surveyId} />
       )}
     </Box>
   );


### PR DESCRIPTION
## Description
This PR adds an empty state to the overview page, where the user is pointed to the questions tab to create some questions for their survey.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/218504709-1bacbd65-d007-4eb0-8fa6-516130cbd795.png)

## Changes
* Adds icon, text and button to the overview tab that displays if there are no questions in the survey.
* Adjusts the TabbedLayout to render its children.

## Notes to reviewer
Am not sure about how well I succeeded in placing the icon, text and button in the center of the page, as it is in the design. Am very open to changing things here.

## Related issues
Resolves #1009 
