### PR TITLE
Issue 996/add blocks to survey

### DIFF
--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -62,7 +62,24 @@ const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
         >
           <Msg id="misc.surveys.addBlocks.openQuestionButton" />
         </Button>
-        <Button startIcon={<FormatListBulleted />} variant="outlined">
+        <Button
+          onClick={() =>
+            model.addElement({
+              hidden: false,
+              question: {
+                description: '',
+                question: '',
+                response_config: {
+                  widget_type: 'checkbox',
+                },
+                response_type: RESPONSE_TYPE.OPTIONS,
+              },
+              type: ELEMENT_TYPE.QUESTION,
+            })
+          }
+          startIcon={<FormatListBulleted />}
+          variant="outlined"
+        >
           <Msg id="misc.surveys.addBlocks.choiceQuestionButton" />
         </Button>
       </Box>

--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -16,7 +16,6 @@ const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
       sx={{
         backgroundColor: theme.palette.grey[200],
         border: 'none',
-        marginTop: 4,
         padding: 2,
       }}
     >

--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -1,15 +1,16 @@
 import { FormattedMessage as Msg } from 'react-intl';
 import { Box, Button, Card, Typography } from '@mui/material';
-
 import {
   FormatAlignLeft,
   FormatListBulleted,
   TextFields,
 } from '@mui/icons-material';
 
+import { ELEMENT_TYPE } from 'utils/types/zetkin';
+import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import theme from 'theme';
 
-const AddBlocks = () => {
+const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
   return (
     <Card
       sx={{
@@ -24,6 +25,16 @@ const AddBlocks = () => {
       </Typography>
       <Box display="flex" paddingTop={2}>
         <Button
+          onClick={() =>
+            model.addElement({
+              hidden: false,
+              text_block: {
+                content: '',
+                header: '',
+              },
+              type: ELEMENT_TYPE.TEXT,
+            })
+          }
           startIcon={<TextFields />}
           sx={{ marginRight: 1 }}
           variant="outlined"

--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -6,9 +6,9 @@ import {
   TextFields,
 } from '@mui/icons-material';
 
-import { ELEMENT_TYPE } from 'utils/types/zetkin';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import theme from 'theme';
+import { ELEMENT_TYPE, RESPONSE_TYPE } from 'utils/types/zetkin';
 
 const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
   return (
@@ -42,6 +42,20 @@ const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
           <Msg id="misc.surveys.addBlocks.textButton" />
         </Button>
         <Button
+          onClick={() =>
+            model.addElement({
+              hidden: false,
+              question: {
+                description: '',
+                question: '',
+                response_config: {
+                  multiline: false,
+                },
+                response_type: RESPONSE_TYPE.TEXT,
+              },
+              type: ELEMENT_TYPE.QUESTION,
+            })
+          }
           startIcon={<FormatAlignLeft />}
           sx={{ marginRight: 1 }}
           variant="outlined"

--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -1,0 +1,48 @@
+import { FormattedMessage as Msg } from 'react-intl';
+import { Box, Button, Card, Typography } from '@mui/material';
+
+import {
+  FormatAlignLeft,
+  FormatListBulleted,
+  TextFields,
+} from '@mui/icons-material';
+
+import theme from 'theme';
+
+const AddBlocks = () => {
+  return (
+    <Card
+      sx={{
+        backgroundColor: theme.palette.grey[200],
+        border: 'none',
+        marginTop: 4,
+        padding: 2,
+      }}
+    >
+      <Typography color="secondary">
+        <Msg id="misc.surveys.addBlocks.title" />
+      </Typography>
+      <Box display="flex" paddingTop={2}>
+        <Button
+          startIcon={<TextFields />}
+          sx={{ marginRight: 1 }}
+          variant="outlined"
+        >
+          <Msg id="misc.surveys.addBlocks.textButton" />
+        </Button>
+        <Button
+          startIcon={<FormatAlignLeft />}
+          sx={{ marginRight: 1 }}
+          variant="outlined"
+        >
+          <Msg id="misc.surveys.addBlocks.openQuestionButton" />
+        </Button>
+        <Button startIcon={<FormatListBulleted />} variant="outlined">
+          <Msg id="misc.surveys.addBlocks.choiceQuestionButton" />
+        </Button>
+      </Box>
+    </Card>
+  );
+};
+
+export default AddBlocks;

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -76,7 +76,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
           );
         }}
       </ZUIFuture>
-      <AddBlocks />
+      <AddBlocks model={model} />
     </>
   );
 };

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { FC } from 'react';
 
+import AddBlocks from './AddBlocks';
 import BlockWrapper from './blocks/BlockWrapper';
 import ChoiceQuestionBlock from './blocks/ChoiceQuestionBlock';
 import OpenQuestionBlock from './blocks/OpenQuestionBlock';
@@ -23,13 +24,41 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
   }
 
   return (
-    <ZUIFuture future={model.getData()}>
-      {(data) => {
-        return (
-          <Box>
-            {data.elements.map((elem) => {
-              if (elem.type == ELEMENT_TYPE.QUESTION) {
-                if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
+    <>
+      <ZUIFuture future={model.getData()}>
+        {(data) => {
+          return (
+            <Box>
+              {data.elements.map((elem) => {
+                if (elem.type == ELEMENT_TYPE.QUESTION) {
+                  if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
+                    return (
+                      <BlockWrapper
+                        hidden={elem.hidden}
+                        onDelete={() => handleDelete(elem.id)}
+                        onToggleHidden={(hidden) =>
+                          handleToggleHidden(elem.id, hidden)
+                        }
+                      >
+                        <OpenQuestionBlock question={elem.question} />
+                      </BlockWrapper>
+                    );
+                  } else if (
+                    elem.question.response_type == RESPONSE_TYPE.OPTIONS
+                  ) {
+                    return (
+                      <BlockWrapper
+                        hidden={elem.hidden}
+                        onDelete={() => handleDelete(elem.id)}
+                        onToggleHidden={(hidden) =>
+                          handleToggleHidden(elem.id, hidden)
+                        }
+                      >
+                        <ChoiceQuestionBlock question={elem.question} />
+                      </BlockWrapper>
+                    );
+                  }
+                } else if (elem.type == ELEMENT_TYPE.TEXT) {
                   return (
                     <BlockWrapper
                       hidden={elem.hidden}
@@ -38,42 +67,17 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                         handleToggleHidden(elem.id, hidden)
                       }
                     >
-                      <OpenQuestionBlock question={elem.question} />
-                    </BlockWrapper>
-                  );
-                } else if (
-                  elem.question.response_type == RESPONSE_TYPE.OPTIONS
-                ) {
-                  return (
-                    <BlockWrapper
-                      hidden={elem.hidden}
-                      onDelete={() => handleDelete(elem.id)}
-                      onToggleHidden={(hidden) =>
-                        handleToggleHidden(elem.id, hidden)
-                      }
-                    >
-                      <ChoiceQuestionBlock question={elem.question} />
+                      <TextBlock element={elem} />
                     </BlockWrapper>
                   );
                 }
-              } else if (elem.type == ELEMENT_TYPE.TEXT) {
-                return (
-                  <BlockWrapper
-                    hidden={elem.hidden}
-                    onDelete={() => handleDelete(elem.id)}
-                    onToggleHidden={(hidden) =>
-                      handleToggleHidden(elem.id, hidden)
-                    }
-                  >
-                    <TextBlock element={elem} />
-                  </BlockWrapper>
-                );
-              }
-            })}
-          </Box>
-        );
-      }}
-    </ZUIFuture>
+              })}
+            </Box>
+          );
+        }}
+      </ZUIFuture>
+      <AddBlocks />
+    </>
   );
 };
 

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -28,7 +28,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
       <ZUIFuture future={model.getData()}>
         {(data) => {
           return (
-            <Box>
+            <Box paddingBottom={data.elements.length ? 4 : 0}>
               {data.elements.map((elem) => {
                 if (elem.type == ELEMENT_TYPE.QUESTION) {
                   if (elem.question.response_type == RESPONSE_TYPE.TEXT) {

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -3,8 +3,8 @@ import dayjs from 'dayjs';
 import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
-import SurveysRepo from '../repos/SurveysRepo';
 import { ZetkinSurveyExtended } from 'utils/types/zetkin';
+import SurveysRepo, { ZetkinSurveyElementPostBody } from '../repos/SurveysRepo';
 
 export enum SurveyState {
   UNPUBLISHED = 'unpublished',
@@ -18,6 +18,15 @@ export default class SurveyDataModel extends ModelBase {
   private _orgId: number;
   private _repo: SurveysRepo;
   private _surveyId: number;
+
+  addElement(element: ZetkinSurveyElementPostBody) {
+    const { data } = this.getData();
+    if (!data) {
+      return;
+    }
+
+    this._repo.addElement(this._orgId, this._surveyId, element);
+  }
 
   constructor(env: Environment, orgId: number, surveyId: number) {
     super();

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -30,17 +30,15 @@ export type ZetkinSurveyElementPostBody =
   | ZetkinSurveyTextQuestionElementPostBody
   | ZetkinSurveyOptionsQuestionElementPostBody;
 
-type ZetkinTextQuestionPostBody = Omit<ZetkinTextQuestion, 'required'>;
 type ZetkinSurveyTextQuestionElementPostBody = {
   hidden: boolean;
-  question: ZetkinTextQuestionPostBody;
+  question: Omit<ZetkinTextQuestion, 'required'>;
   type: ELEMENT_TYPE.QUESTION;
 };
 
-type ZetkinOptionsQuestionPostBody = Omit<ZetkinOptionsQuestion, 'required'>;
 type ZetkinSurveyOptionsQuestionElementPostBody = {
   hidden: boolean;
-  question: ZetkinOptionsQuestionPostBody;
+  question: Omit<ZetkinOptionsQuestion, 'required'>;
   type: ELEMENT_TYPE.QUESTION;
 };
 

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -3,6 +3,7 @@ import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import {
+  elementAdded,
   elementDeleted,
   elementUpdated,
   submissionLoad,
@@ -17,12 +18,35 @@ import {
   ZetkinSurvey,
   ZetkinSurveyElement,
   ZetkinSurveyExtended,
+  ZetkinSurveyOptionsQuestionElement,
   ZetkinSurveySubmission,
+  ZetkinSurveyTextElement,
+  ZetkinSurveyTextQuestionElement,
 } from 'utils/types/zetkin';
+
+export type ZetkinSurveyElementPostBody =
+  | Partial<Omit<ZetkinSurveyTextElement, 'id'>>
+  | Partial<Omit<ZetkinSurveyTextQuestionElement, 'id'>>
+  | Partial<Omit<ZetkinSurveyOptionsQuestionElement, 'id'>>;
 
 export default class SurveysRepo {
   private _apiClient: IApiClient;
   private _store: Store;
+
+  async addElement(
+    orgId: number,
+    surveyId: number,
+    data: ZetkinSurveyElementPostBody
+  ) {
+    await this._apiClient
+      .post<ZetkinSurveyElement, ZetkinSurveyElementPostBody>(
+        `/api/orgs/${orgId}/surveys/${surveyId}/elements`,
+        data
+      )
+      .then((newElement) => {
+        this._store.dispatch(elementAdded([surveyId, newElement]));
+      });
+  }
 
   constructor(env: Environment) {
     this._store = env.store;

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -3,6 +3,16 @@ import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import {
+  ELEMENT_TYPE,
+  ZetkinSurvey,
+  ZetkinSurveyElement,
+  ZetkinSurveyExtended,
+  ZetkinSurveyOptionsQuestionElement,
+  ZetkinSurveySubmission,
+  ZetkinSurveyTextElement,
+  ZetkinTextQuestion,
+} from 'utils/types/zetkin';
+import {
   elementAdded,
   elementDeleted,
   elementUpdated,
@@ -14,20 +24,18 @@ import {
   surveyUpdated,
 } from '../store';
 import { IFuture, PromiseFuture, RemoteItemFuture } from 'core/caching/futures';
-import {
-  ZetkinSurvey,
-  ZetkinSurveyElement,
-  ZetkinSurveyExtended,
-  ZetkinSurveyOptionsQuestionElement,
-  ZetkinSurveySubmission,
-  ZetkinSurveyTextElement,
-  ZetkinSurveyTextQuestionElement,
-} from 'utils/types/zetkin';
 
 export type ZetkinSurveyElementPostBody =
   | Partial<Omit<ZetkinSurveyTextElement, 'id'>>
-  | Partial<Omit<ZetkinSurveyTextQuestionElement, 'id'>>
+  | ZetkinSurveyTextQuestionElementPostBody
   | Partial<Omit<ZetkinSurveyOptionsQuestionElement, 'id'>>;
+
+type ZetkinTextQuestionPostBody = Omit<ZetkinTextQuestion, 'required'>;
+type ZetkinSurveyTextQuestionElementPostBody = {
+  hidden: boolean;
+  question: ZetkinTextQuestionPostBody;
+  type: ELEMENT_TYPE.QUESTION;
+};
 
 export default class SurveysRepo {
   private _apiClient: IApiClient;

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -4,10 +4,10 @@ import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import {
   ELEMENT_TYPE,
+  ZetkinOptionsQuestion,
   ZetkinSurvey,
   ZetkinSurveyElement,
   ZetkinSurveyExtended,
-  ZetkinSurveyOptionsQuestionElement,
   ZetkinSurveySubmission,
   ZetkinSurveyTextElement,
   ZetkinTextQuestion,
@@ -28,12 +28,19 @@ import { IFuture, PromiseFuture, RemoteItemFuture } from 'core/caching/futures';
 export type ZetkinSurveyElementPostBody =
   | Partial<Omit<ZetkinSurveyTextElement, 'id'>>
   | ZetkinSurveyTextQuestionElementPostBody
-  | Partial<Omit<ZetkinSurveyOptionsQuestionElement, 'id'>>;
+  | ZetkinSurveyOptionsQuestionElementPostBody;
 
 type ZetkinTextQuestionPostBody = Omit<ZetkinTextQuestion, 'required'>;
 type ZetkinSurveyTextQuestionElementPostBody = {
   hidden: boolean;
   question: ZetkinTextQuestionPostBody;
+  type: ELEMENT_TYPE.QUESTION;
+};
+
+type ZetkinOptionsQuestionPostBody = Omit<ZetkinOptionsQuestion, 'required'>;
+type ZetkinSurveyOptionsQuestionElementPostBody = {
+  hidden: boolean;
+  question: ZetkinOptionsQuestionPostBody;
   type: ELEMENT_TYPE.QUESTION;
 };
 

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -21,6 +21,18 @@ const surveysSlice = createSlice({
   initialState,
   name: 'surveys',
   reducers: {
+    elementAdded: (
+      state,
+      action: PayloadAction<[number, ZetkinSurveyElement]>
+    ) => {
+      const [surveyId, newElement] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      if (surveyItem && surveyItem.data) {
+        surveyItem.data.elements.push(newElement);
+      }
+    },
     elementDeleted: (state, action: PayloadAction<[number, number]>) => {
       const [surveyId, elemId] = action.payload;
       const surveyItem = state.surveyList.items.find(
@@ -107,6 +119,7 @@ const surveysSlice = createSlice({
 
 export default surveysSlice;
 export const {
+  elementAdded,
   elementDeleted,
   elementUpdated,
   submissionLoad,

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -1,0 +1,5 @@
+addBlocks:
+  choiceQuestionButton: Choice question
+  openQuestionButton: Open question
+  textButton: Text
+  title: Choose a block type to add more content to your survey

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -174,7 +174,6 @@ export interface ZetkinSurvey {
   callers_only: boolean;
   published: string | null;
   expires: string | null;
-  elements: ZetkinSurveyElement[];
 }
 
 export interface ZetkinSurveyExtended extends ZetkinSurvey {


### PR DESCRIPTION
## Description
This PR adds a card with buttons to add text blocks and questions to the survey.

## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/218998242-ee4d44bc-6218-4f50-b4ab-78b979b4e1ba.png)

## Changes
* Adds the `AddBlocks` component that has three buttons to add text blocks, text questions and choice questions respectively.
* Adds an `addElement` method to the model, repo and store to deal with the adding of an element to the survey.

## Notes to reviewer
I did nothing to control the width of the component, assuming this will be decided by its parent at a later stage in the process? But not sure of this. 
I'm also not sure about how to make the post body-types that i made in the repo look nicer - maybe some typescript magic can be done here?

## Related issues
Resolves #996 
