### PR TITLE
Issue 986/survey text block

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
@@ -26,7 +26,12 @@ const BlockWrapper: FC<BlockWrapperProps> = ({
           <IconButton onClick={() => onToggleHidden(!hidden)}>
             <RemoveRedEye />
           </IconButton>
-          <IconButton onClick={() => onDelete()}>
+          <IconButton
+            onClick={(evt) => {
+              evt.stopPropagation();
+              onDelete();
+            }}
+          >
             <Delete />
           </IconButton>
         </Box>

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,6 +1,6 @@
-import { useIntl } from 'react-intl';
 import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
 import { FC, useState } from 'react';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import theme from 'theme';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
@@ -23,36 +23,25 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
         setPreview(true);
         onSave({
           content,
-          header: header
-            ? header
-            : intl.formatMessage({ id: 'misc.surveys.blocks.text.header' }),
+          header,
         });
       }}
     >
       {preview ? (
         <Box onClick={() => setPreview(false)}>
-          <Typography
-            color={
-              element.text_block.header ===
-              intl.formatMessage({ id: 'misc.surveys.blocks.text.header' })
-                ? 'secondary'
-                : 'black'
-            }
-            variant="h4"
-          >
-            {element.text_block.header}
-          </Typography>
-          <Typography
-            color={
-              element.text_block.content ===
-              intl.formatMessage({ id: 'misc.surveys.blocks.text.content' })
-                ? 'secondary'
-                : 'black'
-            }
-            sx={{ paddingTop: 1 }}
-          >
-            {element.text_block.content}
-          </Typography>
+          {!header && !content && (
+            <Typography color="secondary" variant="h4">
+              <Msg id="misc.surveys.blocks.text.empty" />
+            </Typography>
+          )}
+          {header && (
+            <Typography variant="h4">{element.text_block.header}</Typography>
+          )}
+          {content && (
+            <Typography sx={{ paddingTop: 1 }}>
+              {element.text_block.content}
+            </Typography>
+          )}
         </Box>
       ) : (
         <Box display="flex" flexDirection="column">

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -8,7 +8,7 @@ import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 interface TextBlockProps {
   element: ZetkinSurveyTextElement;
   isMostRecent: boolean;
-  onSave: (textBlock: { content: string; header: string }) => void;
+  onSave: (textBlock: ZetkinSurveyTextElement['text_block']) => void;
 }
 
 const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,5 +1,5 @@
 import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import theme from 'theme';
@@ -13,32 +13,58 @@ interface TextBlockProps {
 
 const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
   const intl = useIntl();
-  const [header, setHeader] = useState('');
-  const [content, setContent] = useState('');
+  const [header, setHeader] = useState(element.text_block.header);
+  const [content, setContent] = useState(element.text_block.content);
   const [preview, setPreview] = useState(!isMostRecent);
+
+  const [focusHeader, setFocusHeader] = useState(true);
+  const [focusContent, setFocusContent] = useState(false);
+
+  const headerRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (focusHeader) {
+      headerRef.current?.focus();
+    }
+  }, [focusHeader]);
+
+  useEffect(() => {
+    if (focusContent) {
+      contentRef.current?.focus();
+    }
+  }, [focusContent]);
 
   return (
     <ClickAwayListener
       onClickAway={() => {
-        setPreview(true);
         onSave({
           content,
           header,
         });
+        setPreview(true);
+        setFocusHeader(false);
+        setFocusContent(false);
       }}
     >
       {preview ? (
         <Box onClick={() => setPreview(false)}>
-          {!header && !content && (
-            <Typography color="secondary" variant="h4">
+          <Typography
+            color={header ? 'inherit' : 'secondary'}
+            onClick={() => setFocusHeader(true)}
+            variant="h4"
+          >
+            {header ? (
+              element.text_block.header
+            ) : (
               <Msg id="misc.surveys.blocks.text.empty" />
-            </Typography>
-          )}
-          {header && (
-            <Typography variant="h4">{element.text_block.header}</Typography>
-          )}
+            )}
+          </Typography>
           {content && (
-            <Typography sx={{ paddingTop: 1 }}>
+            <Typography
+              onClick={() => setFocusContent(true)}
+              sx={{ paddingTop: 1 }}
+            >
               {element.text_block.content}
             </Typography>
           )}
@@ -46,7 +72,10 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
       ) : (
         <Box display="flex" flexDirection="column">
           <TextField
-            InputProps={{ sx: { fontSize: theme.typography.h4.fontSize } }}
+            InputProps={{
+              inputRef: headerRef,
+              sx: { fontSize: theme.typography.h4.fontSize },
+            }}
             label={intl.formatMessage({
               id: 'misc.surveys.blocks.text.header',
             })}
@@ -55,6 +84,7 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
             value={header}
           />
           <TextField
+            InputProps={{ inputRef: contentRef }}
             label={intl.formatMessage({
               id: 'misc.surveys.blocks.text.content',
             })}

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,13 +1,80 @@
-import { Box } from '@mui/material';
-import { FC } from 'react';
+import { useIntl } from 'react-intl';
+import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
+import { FC, useState } from 'react';
+
+import theme from 'theme';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 
 interface TextBlockProps {
   element: ZetkinSurveyTextElement;
+  onSave: (textBlock: { content: string; header: string }) => void; //Pick<ZetkinSurveyTextElement, 'text_block'>
 }
 
-const TextBlock: FC<TextBlockProps> = ({ element }) => {
-  return <Box>{JSON.stringify(element)}</Box>;
+const TextBlock: FC<TextBlockProps> = ({ element, onSave }) => {
+  const intl = useIntl();
+  const [header, setHeader] = useState('');
+  const [content, setContent] = useState('');
+  const [preview, setPreview] = useState(false);
+
+  return (
+    <ClickAwayListener
+      onClickAway={() => {
+        setPreview(true);
+        onSave({
+          content,
+          header: header
+            ? header
+            : intl.formatMessage({ id: 'misc.surveys.blocks.text.header' }),
+        });
+      }}
+    >
+      {preview ? (
+        <Box onClick={() => setPreview(false)}>
+          <Typography
+            color={
+              element.text_block.header ===
+              intl.formatMessage({ id: 'misc.surveys.blocks.text.header' })
+                ? 'secondary'
+                : 'black'
+            }
+            variant="h4"
+          >
+            {element.text_block.header}
+          </Typography>
+          <Typography
+            color={
+              element.text_block.content ===
+              intl.formatMessage({ id: 'misc.surveys.blocks.text.content' })
+                ? 'secondary'
+                : 'black'
+            }
+            sx={{ paddingTop: 1 }}
+          >
+            {element.text_block.content}
+          </Typography>
+        </Box>
+      ) : (
+        <Box display="flex" flexDirection="column">
+          <TextField
+            InputProps={{ sx: { fontSize: theme.typography.h4.fontSize } }}
+            label={intl.formatMessage({
+              id: 'misc.surveys.blocks.text.header',
+            })}
+            onChange={(evt) => setHeader(evt.target.value)}
+            sx={{ paddingBottom: 2 }}
+            value={header}
+          />
+          <TextField
+            label={intl.formatMessage({
+              id: 'misc.surveys.blocks.text.content',
+            })}
+            onChange={(evt) => setContent(evt.target.value)}
+            value={content}
+          />
+        </Box>
+      )}
+    </ClickAwayListener>
+  );
 };
 
 export default TextBlock;

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -6,16 +6,21 @@ import theme from 'theme';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 
 interface TextBlockProps {
+  inEditMode: boolean;
   element: ZetkinSurveyTextElement;
-  isMostRecent: boolean;
-  onSave: (textBlock: ZetkinSurveyTextElement['text_block']) => void;
+  onEditModeEnter: () => void;
+  onEditModeExit: (textBlock: ZetkinSurveyTextElement['text_block']) => void;
 }
 
-const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
+const TextBlock: FC<TextBlockProps> = ({
+  inEditMode,
+  element,
+  onEditModeEnter,
+  onEditModeExit,
+}) => {
   const intl = useIntl();
   const [header, setHeader] = useState(element.text_block.header);
   const [content, setContent] = useState(element.text_block.content);
-  const [preview, setPreview] = useState(!isMostRecent);
 
   const [focusHeader, setFocusHeader] = useState(true);
   const [focusContent, setFocusContent] = useState(false);
@@ -36,14 +41,11 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
   }, [focusContent]);
 
   const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
-    if (evt.key === 'Escape') {
-      setPreview(true);
-    } else if (evt.key === 'Enter') {
-      onSave({
+    if (evt.key === 'Enter') {
+      onEditModeExit({
         content,
         header,
       });
-      setPreview(true);
       setFocusHeader(false);
       setFocusContent(false);
     }
@@ -52,38 +54,15 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
   return (
     <ClickAwayListener
       onClickAway={() => {
-        onSave({
+        onEditModeExit({
           content,
           header,
         });
-        setPreview(true);
         setFocusHeader(false);
         setFocusContent(false);
       }}
     >
-      {preview ? (
-        <Box onClick={() => setPreview(false)}>
-          <Typography
-            color={header ? 'inherit' : 'secondary'}
-            onClick={() => setFocusHeader(true)}
-            variant="h4"
-          >
-            {header ? (
-              element.text_block.header
-            ) : (
-              <Msg id="misc.surveys.blocks.text.empty" />
-            )}
-          </Typography>
-          {content && (
-            <Typography
-              onClick={() => setFocusContent(true)}
-              sx={{ paddingTop: 1 }}
-            >
-              {element.text_block.content}
-            </Typography>
-          )}
-        </Box>
-      ) : (
+      {inEditMode ? (
         <Box display="flex" flexDirection="column">
           <TextField
             InputProps={{
@@ -107,6 +86,28 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
             onKeyDown={(evt) => handleKeyDown(evt)}
             value={content}
           />
+        </Box>
+      ) : (
+        <Box onClick={() => onEditModeEnter()}>
+          <Typography
+            color={header ? 'inherit' : 'secondary'}
+            onClick={() => setFocusHeader(true)}
+            variant="h4"
+          >
+            {header ? (
+              element.text_block.header
+            ) : (
+              <Msg id="misc.surveys.blocks.text.empty" />
+            )}
+          </Typography>
+          {content && (
+            <Typography
+              onClick={() => setFocusContent(true)}
+              sx={{ paddingTop: 1 }}
+            >
+              {element.text_block.content}
+            </Typography>
+          )}
         </Box>
       )}
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -7,14 +7,15 @@ import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 
 interface TextBlockProps {
   element: ZetkinSurveyTextElement;
+  isMostRecent: boolean;
   onSave: (textBlock: { content: string; header: string }) => void; //Pick<ZetkinSurveyTextElement, 'text_block'>
 }
 
-const TextBlock: FC<TextBlockProps> = ({ element, onSave }) => {
+const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
   const intl = useIntl();
   const [header, setHeader] = useState('');
   const [content, setContent] = useState('');
-  const [preview, setPreview] = useState(false);
+  const [preview, setPreview] = useState(!isMostRecent);
 
   return (
     <ClickAwayListener

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,5 +1,12 @@
 import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
-import { FC, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import {
+  FC,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import theme from 'theme';
@@ -19,20 +26,21 @@ const TextBlock: FC<TextBlockProps> = ({
   onEditModeExit,
 }) => {
   const intl = useIntl();
+
   const [header, setHeader] = useState(element.text_block.header);
   const [content, setContent] = useState(element.text_block.content);
+  const [focus, setFocus] = useState<'content' | null>(null);
 
-  const [focus, setFocus] = useState<'content' | 'header' | null>(null);
-
-  const headerRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLInputElement>(null);
+
+  const headerRef = useCallback((node: HTMLInputElement) => {
+    node?.focus();
+  }, []);
 
   useEffect(() => {
     if (focus === 'content') {
-      contentRef.current?.focus();
-    }
-    if (focus === 'header') {
-      headerRef.current?.focus();
+      const input = contentRef.current;
+      input?.focus();
     }
   }, [focus]);
 
@@ -84,11 +92,7 @@ const TextBlock: FC<TextBlockProps> = ({
         </Box>
       ) : (
         <Box onClick={() => onEditModeEnter()}>
-          <Typography
-            color={header ? 'inherit' : 'secondary'}
-            onClick={() => setFocus('header')}
-            variant="h4"
-          >
+          <Typography color={header ? 'inherit' : 'secondary'} variant="h4">
             {header ? (
               element.text_block.header
             ) : (

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,5 +1,5 @@
 import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import theme from 'theme';
@@ -8,7 +8,7 @@ import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 interface TextBlockProps {
   element: ZetkinSurveyTextElement;
   isMostRecent: boolean;
-  onSave: (textBlock: { content: string; header: string }) => void; //Pick<ZetkinSurveyTextElement, 'text_block'>
+  onSave: (textBlock: { content: string; header: string }) => void;
 }
 
 const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
@@ -34,6 +34,20 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
       contentRef.current?.focus();
     }
   }, [focusContent]);
+
+  const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
+    if (evt.key === 'Escape') {
+      setPreview(true);
+    } else if (evt.key === 'Enter') {
+      onSave({
+        content,
+        header,
+      });
+      setPreview(true);
+      setFocusHeader(false);
+      setFocusContent(false);
+    }
+  };
 
   return (
     <ClickAwayListener
@@ -80,6 +94,7 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
               id: 'misc.surveys.blocks.text.header',
             })}
             onChange={(evt) => setHeader(evt.target.value)}
+            onKeyDown={(evt) => handleKeyDown(evt)}
             sx={{ paddingBottom: 2 }}
             value={header}
           />
@@ -89,6 +104,7 @@ const TextBlock: FC<TextBlockProps> = ({ element, isMostRecent, onSave }) => {
               id: 'misc.surveys.blocks.text.content',
             })}
             onChange={(evt) => setContent(evt.target.value)}
+            onKeyDown={(evt) => handleKeyDown(evt)}
             value={content}
           />
         </Box>

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -22,23 +22,19 @@ const TextBlock: FC<TextBlockProps> = ({
   const [header, setHeader] = useState(element.text_block.header);
   const [content, setContent] = useState(element.text_block.content);
 
-  const [focusHeader, setFocusHeader] = useState(true);
-  const [focusContent, setFocusContent] = useState(false);
+  const [focus, setFocus] = useState<'content' | 'header' | null>(null);
 
   const headerRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (focusHeader) {
-      headerRef.current?.focus();
-    }
-  }, [focusHeader]);
-
-  useEffect(() => {
-    if (focusContent) {
+    if (focus === 'content') {
       contentRef.current?.focus();
     }
-  }, [focusContent]);
+    if (focus === 'header') {
+      headerRef.current?.focus();
+    }
+  }, [focus]);
 
   const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
     if (evt.key === 'Enter') {
@@ -46,8 +42,7 @@ const TextBlock: FC<TextBlockProps> = ({
         content,
         header,
       });
-      setFocusHeader(false);
-      setFocusContent(false);
+      setFocus(null);
     }
   };
 
@@ -58,8 +53,8 @@ const TextBlock: FC<TextBlockProps> = ({
           content,
           header,
         });
-        setFocusHeader(false);
-        setFocusContent(false);
+
+        setFocus(null);
       }}
     >
       {inEditMode ? (
@@ -91,7 +86,7 @@ const TextBlock: FC<TextBlockProps> = ({
         <Box onClick={() => onEditModeEnter()}>
           <Typography
             color={header ? 'inherit' : 'secondary'}
-            onClick={() => setFocusHeader(true)}
+            onClick={() => setFocus('header')}
             variant="h4"
           >
             {header ? (
@@ -102,7 +97,7 @@ const TextBlock: FC<TextBlockProps> = ({
           </Typography>
           {content && (
             <Typography
-              onClick={() => setFocusContent(true)}
+              onClick={() => setFocus('content')}
               sx={{ paddingTop: 1 }}
             >
               {element.text_block.content}

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -29,9 +29,16 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     const data = model.getData().data;
     if (data) {
       const elements = data.elements;
+
+      //If a block was just added, set its id to be in edit mode.
       if (lengthRef.current < elements.length && lengthRef.current !== 0) {
         setIdOfBlockInEditMode(elements[elements.length - 1].id);
+      } else if (lengthRef.current === 0) {
+        if (elements.length === 1) {
+          setIdOfBlockInEditMode(elements[0].id);
+        }
       }
+
       lengthRef.current = elements.length;
     }
   }, [model.getData().data?.elements.length]);

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -44,6 +44,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                   if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
                     return (
                       <BlockWrapper
+                        key={elem.id}
                         hidden={elem.hidden}
                         onDelete={() => handleDelete(elem.id)}
                         onToggleHidden={(hidden) =>
@@ -58,6 +59,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                   ) {
                     return (
                       <BlockWrapper
+                        key={elem.id}
                         hidden={elem.hidden}
                         onDelete={() => handleDelete(elem.id)}
                         onToggleHidden={(hidden) =>
@@ -71,6 +73,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                 } else if (elem.type == ELEMENT_TYPE.TEXT) {
                   return (
                     <BlockWrapper
+                      key={elem.id}
                       hidden={elem.hidden}
                       onDelete={() => handleDelete(elem.id)}
                       onToggleHidden={(hidden) =>

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -8,7 +8,11 @@ import OpenQuestionBlock from './blocks/OpenQuestionBlock';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import TextBlock from './blocks/TextBlock';
 import ZUIFuture from 'zui/ZUIFuture';
-import { ELEMENT_TYPE, RESPONSE_TYPE } from 'utils/types/zetkin';
+import {
+  ELEMENT_TYPE,
+  RESPONSE_TYPE,
+  ZetkinSurveyTextElement,
+} from 'utils/types/zetkin';
 
 interface SurveyEditorProps {
   model: SurveyDataModel;
@@ -25,7 +29,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
 
   function handleTextBlockUpdate(
     elemId: number,
-    textBlock: { content: string; header: string }
+    textBlock: ZetkinSurveyTextElement['text_block']
   ) {
     model.updateTextBlock(elemId, textBlock);
   }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -34,6 +34,9 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     <>
       <ZUIFuture future={model.getData()}>
         {(data) => {
+          const mostRecentlyAddedElement = data.elements
+            .concat()
+            .sort((elem1, elem2) => elem2.id - elem1.id)[0];
           return (
             <Box paddingBottom={data.elements.length ? 4 : 0}>
               {data.elements.map((elem) => {
@@ -76,6 +79,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                     >
                       <TextBlock
                         element={elem}
+                        isMostRecent={elem.id === mostRecentlyAddedElement.id}
                         onSave={(textBlock) =>
                           handleTextBlockUpdate(elem.id, textBlock)
                         }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -25,7 +25,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
 
   function handleTextBlockUpdate(
     elemId: number,
-    textBlock: { content: string; header: string } //Pick<ZetkinSurveyTextElement, 'text_block'>
+    textBlock: { content: string; header: string }
   ) {
     model.updateTextBlock(elemId, textBlock);
   }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -23,6 +23,13 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     model.toggleElementHidden(elemId, hidden);
   }
 
+  function handleTextBlockUpdate(
+    elemId: number,
+    textBlock: { content: string; header: string } //Pick<ZetkinSurveyTextElement, 'text_block'>
+  ) {
+    model.updateTextBlock(elemId, textBlock);
+  }
+
   return (
     <>
       <ZUIFuture future={model.getData()}>
@@ -67,7 +74,12 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                         handleToggleHidden(elem.id, hidden)
                       }
                     >
-                      <TextBlock element={elem} />
+                      <TextBlock
+                        element={elem}
+                        onSave={(textBlock) =>
+                          handleTextBlockUpdate(elem.id, textBlock)
+                        }
+                      />
                     </BlockWrapper>
                   );
                 }

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -20,11 +20,6 @@ export default class SurveyDataModel extends ModelBase {
   private _surveyId: number;
 
   addElement(element: ZetkinSurveyElementPostBody) {
-    const { data } = this.getData();
-    if (!data) {
-      return;
-    }
-
     this._repo.addElement(this._orgId, this._surveyId, element);
   }
 

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -3,8 +3,11 @@ import dayjs from 'dayjs';
 import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
-import { ZetkinSurveyExtended } from 'utils/types/zetkin';
 import SurveysRepo, { ZetkinSurveyElementPostBody } from '../repos/SurveysRepo';
+import {
+  ZetkinSurveyExtended,
+  ZetkinSurveyTextElement,
+} from 'utils/types/zetkin';
 
 export enum SurveyState {
   UNPUBLISHED = 'unpublished',
@@ -158,7 +161,7 @@ export default class SurveyDataModel extends ModelBase {
 
   updateTextBlock(
     elemId: number,
-    textBlock: { content: string; header: string }
+    textBlock: ZetkinSurveyTextElement['text_block']
   ) {
     this._repo.updateElement(this._orgId, this._surveyId, elemId, {
       text_block: textBlock,

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -160,4 +160,13 @@ export default class SurveyDataModel extends ModelBase {
       expires: today,
     });
   }
+
+  updateTextBlock(
+    elemId: number,
+    textBlock: { content: string; header: string }
+  ) {
+    this._repo.updateElement(this._orgId, this._surveyId, elemId, {
+      text_block: textBlock,
+    });
+  }
 }

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -118,12 +118,12 @@ export default class SurveysRepo {
     orgId: number,
     surveyId: number,
     elemId: number,
-    data: Pick<ZetkinSurveyElement, 'hidden'>
+    data: ZetkinSurveyElementPostBody
   ) {
-    const element = await this._apiClient.patch<ZetkinSurveyElement>(
-      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}`,
-      data
-    );
+    const element = await this._apiClient.patch<
+      ZetkinSurveyElement,
+      ZetkinSurveyElementPostBody
+    >(`/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}`, data);
     this._store.dispatch(elementUpdated([surveyId, elemId, element]));
   }
 

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -30,18 +30,29 @@ export type ZetkinSurveyElementPostBody =
   | ZetkinSurveyTextQuestionElementPostBody
   | ZetkinSurveyOptionsQuestionElementPostBody;
 
-type ZetkinTextQuestionPostBody = Omit<ZetkinTextQuestion, 'required'>;
 type ZetkinSurveyTextQuestionElementPostBody = {
   hidden: boolean;
-  question: ZetkinTextQuestionPostBody;
+  question: Omit<ZetkinTextQuestion, 'required'>;
   type: ELEMENT_TYPE.QUESTION;
 };
 
-type ZetkinOptionsQuestionPostBody = Omit<ZetkinOptionsQuestion, 'required'>;
 type ZetkinSurveyOptionsQuestionElementPostBody = {
   hidden: boolean;
-  question: ZetkinOptionsQuestionPostBody;
+  question: Omit<ZetkinOptionsQuestion, 'required'>;
   type: ELEMENT_TYPE.QUESTION;
+};
+
+type ZetkinSurveyElementPatchBody =
+  | ZetkinSurveyTextElementPatchBody
+  | Partial<Omit<ZetkinSurveyOptionsQuestionElementPostBody, 'type'>>
+  | Partial<Omit<ZetkinSurveyTextQuestionElementPostBody, 'type'>>;
+
+type ZetkinSurveyTextElementPatchBody = {
+  hidden?: boolean;
+  text_block?: {
+    content?: string;
+    header?: string;
+  };
 };
 
 export default class SurveysRepo {
@@ -118,11 +129,11 @@ export default class SurveysRepo {
     orgId: number,
     surveyId: number,
     elemId: number,
-    data: ZetkinSurveyElementPostBody
+    data: ZetkinSurveyElementPatchBody
   ) {
     const element = await this._apiClient.patch<
       ZetkinSurveyElement,
-      ZetkinSurveyElementPostBody
+      ZetkinSurveyElementPatchBody
     >(`/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}`, data);
     this._store.dispatch(elementUpdated([surveyId, elemId, element]));
   }

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -6,4 +6,5 @@ addBlocks:
 blocks:
   text:
     content: Description
+    empty: Untitled block
     header: Title

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -3,3 +3,7 @@ addBlocks:
   openQuestionButton: Open question
   textButton: Text
   title: Choose a block type to add more content to your survey
+blocks:
+  text:
+    content: Description
+    header: Title


### PR DESCRIPTION
## Description
This PR adds a component for survey text blocks, logic to handle which block is in edit mode and methods to save to api.


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/220147781-6ea88142-27de-493f-9f0b-8e31b5032ecc.png)
![bild](https://user-images.githubusercontent.com/58265097/220147868-65bdb9a5-2c7b-4382-a507-8f01cef0284b.png)

## Changes
* Changes TextBlock component to display and edit text blocks.
* Adds logic in SurveyEditor to put a recently added block in edit mode (ideas by @richardolsson )

## Notes to reviewer
I'm a bit unsure about the look of the preview state vs the edit state, how it feels to toggle between the two. Would love feedback and ideas about it. 


## Related issues
Resolves #986