### PR TITLE
Issue 988/survey scheduling

### DIFF
--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -3,6 +3,7 @@ import SurveyStatusChip from '../components/SurveyStatusChip';
 import SurveySubmissionsModel from '../models/SurveySubmissionsModel';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
+import ZUIDateRangePicker from 'zui/ZUIDateRangePicker/ZUIDateRangePicker';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIFutures from 'zui/ZUIFutures';
@@ -35,6 +36,7 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
   );
 
   const hasQuestions = !!model.getData().data?.elements.length;
+  const dataFuture = model.getData();
 
   return (
     <TabbedLayout
@@ -58,6 +60,15 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
       subtitle={
         <Box alignItems="center" display="flex">
           <SurveyStatusChip state={model.state} />
+          <Box marginX={2}>
+            <ZUIDateRangePicker
+              endDate={dataFuture.data?.expires || null}
+              onChange={(startDate, endDate) => {
+                model.setDates(startDate, endDate);
+              }}
+              startDate={dataFuture.data?.published || null}
+            />
+          </Box>
           <Box display="flex" marginX={1}>
             <ZUIFutures
               futures={{

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -93,9 +93,9 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
                     icon: <ChatBubbleOutline />,
                     label: (
                       <Msg
-                        id="layout.organize.surveys.stats.questions"
+                        id="layout.organize.surveys.stats.submissions"
                         values={{
-                          numQuestions: submissionsLength,
+                          numSubmissions: submissionsLength,
                         }}
                       />
                     ),

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -101,6 +101,13 @@ export default class SurveyDataModel extends ModelBase {
     }
   }
 
+  setDates(published: string | null, expires: string | null): void {
+    this._repo.updateSurvey(this._orgId, this._surveyId, {
+      expires: expires,
+      published: published,
+    });
+  }
+
   setTitle(title: string) {
     this._repo.updateSurvey(this._orgId, this._surveyId, { title });
   }


### PR DESCRIPTION
## Description
This PR renders a calendar to change published and expires date through ZUIDateRangePicker
+ Fix error that shows 'questions' instead of 'submissions' to submissions stats


## Screenshots
when publish and expires dates are in the past
![image](https://user-images.githubusercontent.com/77925373/220363776-674dcc63-395b-4eb6-abba-6f59da12fac2.png)

when published date is in past but expiry date is in future
![image](https://user-images.githubusercontent.com/77925373/220363926-31472991-a759-4050-9bdc-6ab37cca02a4.png)

when both dates are in future
![image](https://user-images.githubusercontent.com/77925373/220364018-14345c5c-6ba1-41d0-97c9-60c95ae5f3b4.png)

when there are no dates
![image](https://user-images.githubusercontent.com/77925373/220364078-547a1526-b1d7-4878-9bfb-5cb1d9cc8e0a.png)


## Changes

* Adds ZUIDateRangePicker in SurveyLayout.
* Adds setDates in SurveyDataModel
* Changes path to yml file regarding submission stats error

## Related issues
Resolves #988 
