### PR TITLE
Issue 1050/sub query in notin

### DIFF
--- a/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
@@ -55,6 +55,11 @@ const DisplaySubQuery = ({ filter }: DisplaySubQueryProps): JSX.Element => {
         addRemoveSelect: (
           <Msg id={`misc.smartSearch.sub_query.addRemoveSelect.${op}`} />
         ),
+        matchSelect: (
+          <Msg
+            id={`misc.smartSearch.sub_query.matchSelect.${filter.config.operator}`}
+          />
+        ),
         query: (
           <Msg
             id={`misc.smartSearch.query.preview.${query?.type || 'none'}`}

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -10,6 +10,7 @@ import getStandaloneQueries from 'utils/fetching/getStandaloneQueries';
 import StyledSelect from '../../inputs/StyledSelect';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
+  IN_OPERATOR,
   NewSmartSearchFilter,
   OPERATION,
   QUERY_TYPE,
@@ -68,6 +69,7 @@ const SubQuery = ({
     useSmartSearchFilter<SubQueryFilterConfig>(initialFilter);
 
   const [selectedQuery, setSelectedQuery] = useState<ZetkinQuery>();
+  const [operator, setOperator] = useState<IN_OPERATOR>(IN_OPERATOR.IN);
 
   useEffect(() => {
     if (queries.length) {
@@ -87,6 +89,7 @@ const SubQuery = ({
       onSubmit({
         ...filter,
         config: {
+          operator: operator,
           query_id: selectedQuery.id,
         },
       });
@@ -107,6 +110,10 @@ const SubQuery = ({
   const handleOptionChange = (option: number) => {
     const newQuery = queries.find((q) => q.id === option);
     setSelectedQuery(newQuery);
+  };
+
+  const handleMatchOperatorChange = (operator: IN_OPERATOR) => {
+    setOperator(operator);
   };
 
   return (
@@ -137,6 +144,21 @@ const SubQuery = ({
                     />
                   </MenuItem>
                 ))}
+              </StyledSelect>
+            ),
+            matchSelect: (
+              <StyledSelect
+                onChange={(e) =>
+                  handleMatchOperatorChange(e.target.value as IN_OPERATOR)
+                }
+                value={operator || IN_OPERATOR.IN}
+              >
+                <MenuItem key={IN_OPERATOR.IN} value={IN_OPERATOR.IN}>
+                  <Msg id="misc.smartSearch.sub_query.matchSelect.in" />
+                </MenuItem>
+                <MenuItem key={IN_OPERATOR.NOTIN} value={IN_OPERATOR.NOTIN}>
+                  <Msg id="misc.smartSearch.sub_query.matchSelect.notin" />
+                </MenuItem>
               </StyledSelect>
             ),
             query: !selectedQuery ? (

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -187,6 +187,7 @@ export interface CampaignParticipationConfig {
 
 export interface SubQueryFilterConfig {
   query_id: number;
+  operator?: IN_OPERATOR;
 }
 
 interface TaskTimeFrameBefore {

--- a/src/locale/misc/smartSearch/en.yml
+++ b/src/locale/misc/smartSearch/en.yml
@@ -211,7 +211,10 @@ sub_query:
   examples:
     one: Remove people who match Smart Search Query 'People who live in Stockholm'.
     two: Add people who match the target group of call Assignment 'Assignment one'.
-  inputString: '{addRemoveSelect} people that match {query}.'
+  inputString: '{addRemoveSelect} people that {matchSelect} {query}.'
+  matchSelect:
+    in: match
+    notin: do not match
 survey_option:
   addRemoveSelect:
     add: Add

--- a/src/locale/misc/smartSearch/en.yml
+++ b/src/locale/misc/smartSearch/en.yml
@@ -210,8 +210,8 @@ sub_query:
     sub: Sub
   examples:
     one: Remove people who match Smart Search Query 'People who live in Stockholm'.
-    two: Add people who match the target group of call Assignment 'Assignment one'.
-  inputString: '{addRemoveSelect} people that {matchSelect} {query}.'
+    two: Add people who do not match the target group of call assignment 'Assignment one'.
+  inputString: '{addRemoveSelect} people who {matchSelect} {query}.'
   matchSelect:
     in: match
     notin: do not match


### PR DESCRIPTION
## Description
This PR implements the in/notin flag on the sub_query filter.

## Screenshots
![bild](https://user-images.githubusercontent.com/14962107/221210276-c5d916f1-e73e-487a-9e83-7f90bcea9fdb.png)

## Changes

* Adds in/notin flag to sub_query filter


## Notes to reviewer
Do not review this until #1046 is merged. This branch is based on that one because the IN_OPERATOR type is reused.

## Related issues
Resolves #1050 
