### PR TITLE
Issue 991/survey choice question block

### DIFF
--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -67,6 +67,7 @@ const AddBlocks = ({ model }: { model: SurveyDataModel }) => {
               hidden: false,
               question: {
                 description: '',
+                options: [],
                 question: '',
                 response_config: {
                   widget_type: 'checkbox',

--- a/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
@@ -1,20 +1,12 @@
-import { Box, Card, IconButton } from '@mui/material';
-import { Delete, RemoveRedEye } from '@mui/icons-material';
+import { Box, Card } from '@mui/material';
 import { FC, ReactNode } from 'react';
 
 interface BlockWrapperProps {
   children: ReactNode;
   hidden: boolean;
-  onDelete: () => void;
-  onToggleHidden: (hidden: boolean) => void;
 }
 
-const BlockWrapper: FC<BlockWrapperProps> = ({
-  children,
-  hidden,
-  onDelete,
-  onToggleHidden,
-}) => {
+const BlockWrapper: FC<BlockWrapperProps> = ({ children, hidden }) => {
   return (
     <Box
       marginBottom={1}
@@ -22,19 +14,6 @@ const BlockWrapper: FC<BlockWrapperProps> = ({
     >
       <Card>
         <Box m={2}>{children}</Box>
-        <Box display="flex" justifyContent="end" m={2}>
-          <IconButton onClick={() => onToggleHidden(!hidden)}>
-            <RemoveRedEye />
-          </IconButton>
-          <IconButton
-            onClick={(evt) => {
-              evt.stopPropagation();
-              onDelete();
-            }}
-          >
-            <Delete />
-          </IconButton>
-        </Box>
       </Card>
     </Box>
   );

--- a/src/features/surveys/components/SurveyEditor/blocks/Choice.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/Choice.tsx
@@ -1,0 +1,54 @@
+import { Close } from '@mui/icons-material';
+import { useIntl } from 'react-intl';
+import { useState } from 'react';
+import { Box, IconButton, TextField } from '@mui/material';
+
+import { WidgetType } from './ChoiceQuestionBlock';
+import { ZetkinSurveyOption } from 'utils/types/zetkin';
+
+interface ChoiceProps {
+  option: ZetkinSurveyOption;
+  onDeleteOption: (optionId: number) => void;
+  onUpdateOption: (optionId: number, text: string) => void;
+  widgetType: WidgetType;
+}
+
+const Choice = ({
+  option,
+  onDeleteOption,
+  onUpdateOption,
+
+  widgetType,
+}: ChoiceProps) => {
+  const intl = useIntl();
+  const [value, setValue] = useState(option.text);
+  return (
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="center"
+      paddingTop={2}
+      width="100%"
+    >
+      <Box paddingX={2}>{widgetType.previewIcon}</Box>
+      <TextField
+        fullWidth
+        label={intl.formatMessage({
+          id: 'misc.surveys.blocks.choiceQuestion.option',
+        })}
+        onBlur={() => onUpdateOption(option.id, value)}
+        onChange={(evt) => setValue(evt.target.value)}
+        sx={{ paddingLeft: 1 }}
+        value={value}
+      />
+      <IconButton
+        onClick={() => onDeleteOption(option.id)}
+        sx={{ paddingX: 2 }}
+      >
+        <Close />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default Choice;

--- a/src/features/surveys/components/SurveyEditor/blocks/Choice.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/Choice.tsx
@@ -1,7 +1,7 @@
 import { Close } from '@mui/icons-material';
 import { useIntl } from 'react-intl';
-import { useState } from 'react';
 import { Box, IconButton, TextField } from '@mui/material';
+import { Ref, useState } from 'react';
 
 import { WidgetType } from './ChoiceQuestionBlock';
 import { ZetkinSurveyOption } from 'utils/types/zetkin';
@@ -10,6 +10,7 @@ interface ChoiceProps {
   option: ZetkinSurveyOption;
   onDeleteOption: (optionId: number) => void;
   onUpdateOption: (optionId: number, text: string) => void;
+  inputRef: Ref<HTMLInputElement>;
   widgetType: WidgetType;
 }
 
@@ -17,7 +18,7 @@ const Choice = ({
   option,
   onDeleteOption,
   onUpdateOption,
-
+  inputRef,
   widgetType,
 }: ChoiceProps) => {
   const intl = useIntl();
@@ -33,6 +34,9 @@ const Choice = ({
       <Box paddingX={2}>{widgetType.previewIcon}</Box>
       <TextField
         fullWidth
+        InputProps={{
+          inputRef: inputRef,
+        }}
         label={intl.formatMessage({
           id: 'misc.surveys.blocks.choiceQuestion.option',
         })}

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -157,7 +157,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
     }
   };
 
-  const options = questionElement.options || [];
+  const options = questionElement.options;
 
   return (
     <ClickAwayListener

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -1,7 +1,6 @@
 import {
   Add,
   CheckBoxOutlined,
-  Close,
   RadioButtonChecked,
   RadioButtonUnchecked,
 } from '@mui/icons-material';
@@ -9,7 +8,6 @@ import {
   Box,
   Button,
   ClickAwayListener,
-  IconButton,
   ListItemIcon,
   MenuItem,
   TextField,
@@ -25,11 +23,12 @@ import {
 } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
+import Choice from './Choice';
 import DeleteHideButtons from './DeleteHideButtons';
 import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import theme from 'theme';
+import { ZetkinOptionsQuestion } from 'utils/types/zetkin';
 import ZUIDropdownIcon from 'zui/ZUIDropdownIcon';
-import { ZetkinOptionsQuestion, ZetkinSurveyOption } from 'utils/types/zetkin';
 
 const enum POLL_TYPE {
   CHECKBOX = 'checkbox',
@@ -37,7 +36,7 @@ const enum POLL_TYPE {
   SELECT = 'select',
 }
 
-type WidgetType = {
+export type WidgetType = {
   icon: JSX.Element;
   previewIcon: JSX.Element;
   value: POLL_TYPE;
@@ -59,50 +58,6 @@ const widgetTypes = {
     previewIcon: <ZUIDropdownIcon />,
     value: POLL_TYPE.SELECT,
   },
-};
-
-interface OptionProps {
-  option: ZetkinSurveyOption;
-  onDeleteOption: (optionId: number) => void;
-  onUpdateOption: (optionId: number, text: string) => void;
-  widgetType: WidgetType;
-}
-
-const Option = ({
-  option,
-  onDeleteOption,
-  onUpdateOption,
-  widgetType,
-}: OptionProps) => {
-  const intl = useIntl();
-  const [value, setValue] = useState(option.text);
-  return (
-    <Box
-      alignItems="center"
-      display="flex"
-      justifyContent="center"
-      paddingTop={2}
-      width="100%"
-    >
-      <Box paddingX={2}>{widgetType.previewIcon}</Box>
-      <TextField
-        fullWidth
-        label={intl.formatMessage({
-          id: 'misc.surveys.blocks.choiceQuestion.option',
-        })}
-        onBlur={() => onUpdateOption(option.id, value)}
-        onChange={(evt) => setValue(evt.target.value)}
-        sx={{ paddingLeft: 1 }}
-        value={value}
-      />
-      <IconButton
-        onClick={() => onDeleteOption(option.id)}
-        sx={{ paddingX: 2 }}
-      >
-        <Close />
-      </IconButton>
-    </Box>
-  );
 };
 
 interface ChoiceQuestionBlockProps {
@@ -237,7 +192,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
             </TextField>
             <Box alignItems="center" display="flex" flexDirection="column">
               {options.map((option) => (
-                <Option
+                <Choice
                   key={option.id}
                   onDeleteOption={(id) => onDeleteOption(id)}
                   onUpdateOption={(id, text) => onUpdateOption(id, text)}

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -96,6 +96,7 @@ const Option = ({
   onUpdateOption,
   widgetType,
 }: OptionProps) => {
+  const intl = useIntl();
   const [value, setValue] = useState(option.text);
   return (
     <Box
@@ -108,7 +109,9 @@ const Option = ({
       <Box paddingX={2}>{widgetType.previewIcon}</Box>
       <TextField
         fullWidth
-        label="Option"
+        label={intl.formatMessage({
+          id: 'misc.surveys.blocks.choiceQuestion.option',
+        })}
         onBlur={() => onUpdateOption(option.id, value)}
         onChange={(evt) => setValue(evt.target.value)}
         sx={{ paddingLeft: 1 }}
@@ -154,7 +157,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   const [widgetType, setWidgetType] = useState<WidgetType>(widgetTypes.radio);
   const [question, setQuestion] = useState(questionElement.question);
   const [description, setDescription] = useState(questionElement.description);
-  const [focus, setFocus] = useState<'description' | null>(null);
+  const [focus, setFocus] = useState<'description' | 'widgetType' | null>(null);
 
   const questionRef = useCallback((node: HTMLInputElement) => {
     node?.focus();
@@ -269,21 +272,44 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
         )}
         {!inEditMode && (
           <Box onClick={onEditModeEnter}>
-            <Typography color={question ? 'inherit' : 'secondary'} variant="h4">
-              {question ? (
-                questionElement.question
-              ) : (
-                <Msg id="misc.surveys.blocks.choiceQuestion.empty" />
-              )}
-            </Typography>
-            {description && (
+            <Box paddingBottom={1}>
               <Typography
-                onClick={() => setFocus('description')}
-                sx={{ paddingTop: 1 }}
+                color={question ? 'inherit' : 'secondary'}
+                variant="h4"
               >
-                {questionElement.description}
+                {question ? (
+                  questionElement.question
+                ) : (
+                  <Msg id="misc.surveys.blocks.choiceQuestion.empty" />
+                )}
               </Typography>
-            )}
+              {description && (
+                <Typography
+                  onClick={() => setFocus('description')}
+                  sx={{ paddingTop: 1 }}
+                >
+                  {questionElement.description}
+                </Typography>
+              )}
+            </Box>
+            {questionElement.options?.map((option) => (
+              <Box
+                key={option.id}
+                display="flex"
+                onClick={() => setFocus('widgetType')}
+                paddingTop={2}
+              >
+                <Box paddingX={2}>{widgetType.previewIcon}</Box>
+                <Typography
+                  color={option.text ? 'inherit' : 'secondary'}
+                  fontStyle={option.text ? 'inherit' : 'italic'}
+                >
+                  {option.text || (
+                    <Msg id="misc.surveys.blocks.choiceQuestion.emptyOption" />
+                  )}
+                </Typography>
+              </Box>
+            ))}
           </Box>
         )}
         <Box

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -84,10 +84,12 @@ const widgetTypes = {
 };
 
 interface OptionProps {
+  id: number;
+  onDeleteOption: (optionId: number) => void;
   widgetType: WidgetType;
 }
 
-const Option = ({ widgetType }: OptionProps) => {
+const Option = ({ id, onDeleteOption, widgetType }: OptionProps) => {
   return (
     <Box
       alignItems="center"
@@ -98,7 +100,7 @@ const Option = ({ widgetType }: OptionProps) => {
     >
       <Box paddingX={2}>{widgetType.previewIcon}</Box>
       <TextField fullWidth label="Option" sx={{ paddingLeft: 1 }} />
-      <IconButton sx={{ paddingX: 2 }}>
+      <IconButton onClick={() => onDeleteOption(id)} sx={{ paddingX: 2 }}>
         <Close />
       </IconButton>
     </Box>
@@ -110,6 +112,7 @@ interface ChoiceQuestionBlockProps {
   inEditMode: boolean;
   onAddOption: () => void;
   onDelete: () => void;
+  onDeleteOption: (optionId: number) => void;
   onEditModeEnter: () => void;
   onEditModeExit: (question: OptionsQuestionPatchBody) => void;
   onToggleHidden: (hidden: boolean) => void;
@@ -121,6 +124,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   inEditMode,
   onAddOption,
   onDelete,
+  onDeleteOption,
   onEditModeEnter,
   onEditModeExit,
   onToggleHidden,
@@ -233,7 +237,14 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
             </TextField>
             <Box alignItems="center" display="flex" flexDirection="column">
               {options.map((option) => (
-                <Option key={option.id} widgetType={widgetType} />
+                <Option
+                  key={option.id}
+                  id={option.id}
+                  onDeleteOption={(optionId: number) =>
+                    onDeleteOption(optionId)
+                  }
+                  widgetType={widgetType}
+                />
               ))}
             </Box>
           </Box>

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -148,7 +148,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
 
   const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
     if (evt.key === 'Enter') {
-      onEditModeExit({});
+      onEditModeExit({ question: {} });
       setFocus(null);
     }
   };
@@ -159,10 +159,12 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
     <ClickAwayListener
       onClickAway={() => {
         onEditModeExit({
-          description,
-          question,
-          response_config: {
-            widget_type: widgetType.value,
+          question: {
+            description,
+            question,
+            response_config: {
+              widget_type: widgetType.value,
+            },
           },
         });
         setFocus(null);

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -18,9 +18,9 @@ import {
 } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
+import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import theme from 'theme';
 import { ZetkinOptionsQuestion } from 'utils/types/zetkin';
-import { ZetkinSurveyOptionsQuestionElementPatchBody } from 'features/surveys/repos/SurveysRepo';
 
 const enum POLL_TYPE {
   CHECKBOX = 'checkbox',
@@ -57,9 +57,7 @@ const widgetTypes = [
 interface ChoiceQuestionBlockProps {
   inEditMode: boolean;
   onEditModeEnter: () => void;
-  onEditModeExit: (
-    question: ZetkinSurveyOptionsQuestionElementPatchBody
-  ) => void;
+  onEditModeExit: (question: OptionsQuestionPatchBody) => void;
   question: ZetkinOptionsQuestion;
 }
 
@@ -100,12 +98,10 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
     <ClickAwayListener
       onClickAway={() => {
         onEditModeExit({
-          question: {
-            description,
-            question,
-            response_config: {
-              widget_type: widgetType,
-            },
+          description,
+          question,
+          response_config: {
+            widget_type: widgetType,
           },
         });
         setFocus(null);

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -174,7 +174,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
               {question ? (
                 questionElement.question
               ) : (
-                <Msg id="misc.surveys.blocks.common.empty" />
+                <Msg id="misc.surveys.blocks.choiceQuestion.empty" />
               )}
             </Typography>
             {question && (

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -1,13 +1,19 @@
 import {
   Box,
   ClickAwayListener,
+  IconButton,
   ListItemIcon,
   MenuItem,
   SvgIcon,
   TextField,
   Typography,
 } from '@mui/material';
-import { CheckBoxOutlined, RadioButtonChecked } from '@mui/icons-material';
+import {
+  CheckBoxOutlined,
+  Delete,
+  RadioButtonChecked,
+  RemoveRedEye,
+} from '@mui/icons-material';
 import {
   FC,
   KeyboardEvent,
@@ -55,16 +61,22 @@ const widgetTypes = [
 ];
 
 interface ChoiceQuestionBlockProps {
+  hidden: boolean;
   inEditMode: boolean;
+  onDelete: () => void;
   onEditModeEnter: () => void;
   onEditModeExit: (question: OptionsQuestionPatchBody) => void;
+  onToggleHidden: (hidden: boolean) => void;
   question: ZetkinOptionsQuestion;
 }
 
 const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
+  hidden,
   inEditMode,
+  onDelete,
   onEditModeEnter,
   onEditModeExit,
+  onToggleHidden,
   question: questionElement,
 }) => {
   const intl = useIntl();
@@ -183,6 +195,19 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
             )}
           </Box>
         )}
+        <Box display="flex" justifyContent="end" m={2}>
+          <IconButton onClick={() => onToggleHidden(!hidden)}>
+            <RemoveRedEye />
+          </IconButton>
+          <IconButton
+            onClick={(evt) => {
+              evt.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Delete />
+          </IconButton>
+        </Box>
       </div>
     </ClickAwayListener>
   );

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -29,7 +29,7 @@ import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import DeleteHideButtons from './DeleteHideButtons';
 import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import theme from 'theme';
-import { ZetkinOptionsQuestion } from 'utils/types/zetkin';
+import { ZetkinOptionsQuestion, ZetkinSurveyOption } from 'utils/types/zetkin';
 
 const enum POLL_TYPE {
   CHECKBOX = 'checkbox',
@@ -84,12 +84,19 @@ const widgetTypes = {
 };
 
 interface OptionProps {
-  id: number;
+  option: ZetkinSurveyOption;
   onDeleteOption: (optionId: number) => void;
+  onUpdateOption: (optionId: number, text: string) => void;
   widgetType: WidgetType;
 }
 
-const Option = ({ id, onDeleteOption, widgetType }: OptionProps) => {
+const Option = ({
+  option,
+  onDeleteOption,
+  onUpdateOption,
+  widgetType,
+}: OptionProps) => {
+  const [value, setValue] = useState(option.text);
   return (
     <Box
       alignItems="center"
@@ -99,8 +106,18 @@ const Option = ({ id, onDeleteOption, widgetType }: OptionProps) => {
       width="100%"
     >
       <Box paddingX={2}>{widgetType.previewIcon}</Box>
-      <TextField fullWidth label="Option" sx={{ paddingLeft: 1 }} />
-      <IconButton onClick={() => onDeleteOption(id)} sx={{ paddingX: 2 }}>
+      <TextField
+        fullWidth
+        label="Option"
+        onBlur={() => onUpdateOption(option.id, value)}
+        onChange={(evt) => setValue(evt.target.value)}
+        sx={{ paddingLeft: 1 }}
+        value={value}
+      />
+      <IconButton
+        onClick={() => onDeleteOption(option.id)}
+        sx={{ paddingX: 2 }}
+      >
         <Close />
       </IconButton>
     </Box>
@@ -115,6 +132,7 @@ interface ChoiceQuestionBlockProps {
   onDeleteOption: (optionId: number) => void;
   onEditModeEnter: () => void;
   onEditModeExit: (question: OptionsQuestionPatchBody) => void;
+  onUpdateOption: (optionId: number, text: string) => void;
   onToggleHidden: (hidden: boolean) => void;
   question: ZetkinOptionsQuestion;
 }
@@ -128,6 +146,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   onEditModeEnter,
   onEditModeExit,
   onToggleHidden,
+  onUpdateOption,
   question: questionElement,
 }) => {
   const intl = useIntl();
@@ -239,10 +258,9 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
               {options.map((option) => (
                 <Option
                   key={option.id}
-                  id={option.id}
-                  onDeleteOption={(optionId: number) =>
-                    onDeleteOption(optionId)
-                  }
+                  onDeleteOption={(id) => onDeleteOption(id)}
+                  onUpdateOption={(id, text) => onUpdateOption(id, text)}
+                  option={option}
                   widgetType={widgetType}
                 />
               ))}

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -1,19 +1,13 @@
 import {
   Box,
   ClickAwayListener,
-  IconButton,
   ListItemIcon,
   MenuItem,
   SvgIcon,
   TextField,
   Typography,
 } from '@mui/material';
-import {
-  CheckBoxOutlined,
-  Delete,
-  RadioButtonChecked,
-  RemoveRedEye,
-} from '@mui/icons-material';
+import { CheckBoxOutlined, RadioButtonChecked } from '@mui/icons-material';
 import {
   FC,
   KeyboardEvent,
@@ -24,6 +18,7 @@ import {
 } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
+import DeleteHideButtons from './DeleteHideButtons';
 import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import theme from 'theme';
 import { ZetkinOptionsQuestion } from 'utils/types/zetkin';
@@ -196,17 +191,11 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
           </Box>
         )}
         <Box display="flex" justifyContent="end" m={2}>
-          <IconButton onClick={() => onToggleHidden(!hidden)}>
-            <RemoveRedEye />
-          </IconButton>
-          <IconButton
-            onClick={(evt) => {
-              evt.stopPropagation();
-              onDelete();
-            }}
-          >
-            <Delete />
-          </IconButton>
+          <DeleteHideButtons
+            hidden={hidden}
+            onDelete={onDelete}
+            onToggleHidden={onToggleHidden}
+          />
         </Box>
       </div>
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -12,7 +12,6 @@ import {
   IconButton,
   ListItemIcon,
   MenuItem,
-  SvgIcon,
   TextField,
   Typography,
 } from '@mui/material';
@@ -29,6 +28,7 @@ import { FormattedMessage as Msg, useIntl } from 'react-intl';
 import DeleteHideButtons from './DeleteHideButtons';
 import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import theme from 'theme';
+import ZUIDropdownIcon from 'zui/ZUIDropdownIcon';
 import { ZetkinOptionsQuestion, ZetkinSurveyOption } from 'utils/types/zetkin';
 
 const enum POLL_TYPE {
@@ -55,30 +55,8 @@ const widgetTypes = {
     value: POLL_TYPE.RADIO,
   },
   select: {
-    icon: (
-      <SvgIcon>
-        <svg fill="none" height="24" viewBox="0 0 24 24" width="24">
-          <path
-            d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3ZM19 19H5V5H19V19Z"
-            fill="black"
-            fillOpacity="0.54"
-          />
-          <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="black" fillOpacity="0.54" />
-        </svg>
-      </SvgIcon>
-    ),
-    previewIcon: (
-      <SvgIcon>
-        <svg fill="none" height="24" viewBox="0 0 24 24" width="24">
-          <path
-            d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3ZM19 19H5V5H19V19Z"
-            fill="black"
-            fillOpacity="0.54"
-          />
-          <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="black" fillOpacity="0.54" />
-        </svg>
-      </SvgIcon>
-    ),
+    icon: <ZUIDropdownIcon />,
+    previewIcon: <ZUIDropdownIcon />,
     value: POLL_TYPE.SELECT,
   },
 };

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -1,13 +1,111 @@
-import { Box } from '@mui/material';
-import { FC } from 'react';
+import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
+import {
+  FC,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { FormattedMessage as Msg, useIntl } from 'react-intl';
+
+import theme from 'theme';
 import { ZetkinOptionsQuestion } from 'utils/types/zetkin';
 
 interface ChoiceQuestionBlockProps {
+  inEditMode: boolean;
+  onEditModeEnter: () => void;
+  onEditModeExit: () => void;
   question: ZetkinOptionsQuestion;
 }
 
-const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({ question }) => {
-  return <Box>{JSON.stringify(question)}</Box>;
+const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
+  inEditMode,
+  onEditModeEnter,
+  onEditModeExit,
+  question: questionElement,
+}) => {
+  const intl = useIntl();
+
+  const [question, setQuestion] = useState(questionElement.question);
+  const [description, setDescription] = useState(questionElement.description);
+
+  const [focus, setFocus] = useState<'description' | null>(null);
+
+  const descriptionRef = useRef<HTMLInputElement>(null);
+
+  const questionRef = useCallback((node: HTMLInputElement) => {
+    node?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (focus === 'description') {
+      const input = descriptionRef.current;
+      input?.focus();
+    }
+  }, [focus]);
+
+  const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
+    if (evt.key === 'Enter') {
+      onEditModeExit();
+      setFocus(null);
+    }
+  };
+
+  return (
+    <ClickAwayListener
+      onClickAway={() => {
+        onEditModeExit();
+        setFocus(null);
+      }}
+    >
+      {inEditMode ? (
+        <Box display="flex" flexDirection="column">
+          <TextField
+            InputProps={{
+              inputRef: questionRef,
+              sx: { fontSize: theme.typography.h4.fontSize },
+            }}
+            label={intl.formatMessage({
+              id: 'misc.surveys.blocks.common.title',
+            })}
+            onChange={(evt) => setQuestion(evt.target.value)}
+            onKeyDown={(evt) => handleKeyDown(evt)}
+            sx={{ paddingBottom: 2 }}
+            value={question}
+          />
+          <TextField
+            InputProps={{ inputRef: descriptionRef }}
+            label={intl.formatMessage({
+              id: 'misc.surveys.blocks.common.description',
+            })}
+            onChange={(evt) => setDescription(evt.target.value)}
+            onKeyDown={(evt) => handleKeyDown(evt)}
+            sx={{ paddingBottom: 2 }}
+            value={description}
+          />
+        </Box>
+      ) : (
+        <Box onClick={onEditModeEnter}>
+          <Typography color={question ? 'inherit' : 'secondary'} variant="h4">
+            {question ? (
+              questionElement.question
+            ) : (
+              <Msg id="misc.surveys.blocks.common.empty" />
+            )}
+          </Typography>
+          {question && (
+            <Typography
+              onClick={() => setFocus('description')}
+              sx={{ paddingTop: 1 }}
+            >
+              {questionElement.description}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </ClickAwayListener>
+  );
 };
 
 export default ChoiceQuestionBlock;

--- a/src/features/surveys/components/SurveyEditor/blocks/DeleteHideButtons.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/DeleteHideButtons.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import { Box, IconButton } from '@mui/material';
+import { Delete, RemoveRedEye } from '@mui/icons-material';
+
+interface DeleteHideButtonsProps {
+  hidden: boolean;
+  onDelete: () => void;
+  onToggleHidden: (hidden: boolean) => void;
+}
+
+const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({
+  hidden,
+  onDelete,
+  onToggleHidden,
+}) => {
+  return (
+    <Box display="flex">
+      <IconButton onClick={() => onToggleHidden(!hidden)}>
+        <RemoveRedEye />
+      </IconButton>
+      <IconButton
+        onClick={(evt) => {
+          evt.stopPropagation();
+          onDelete();
+        }}
+      >
+        <Delete />
+      </IconButton>
+    </Box>
+  );
+};
+
+export default DeleteHideButtons;

--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -1,7 +1,7 @@
+import { Box } from '@mui/material';
 import { FC } from 'react';
-import { Box, IconButton } from '@mui/material';
-import { Delete, RemoveRedEye } from '@mui/icons-material';
 
+import DeleteHideButtons from './DeleteHideButtons';
 import { ZetkinTextQuestion } from 'utils/types/zetkin';
 
 interface OpenQuestionBlockProps {
@@ -21,17 +21,11 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
     <Box>
       {JSON.stringify(question)}
       <Box display="flex" justifyContent="end" m={2}>
-        <IconButton onClick={() => onToggleHidden(!hidden)}>
-          <RemoveRedEye />
-        </IconButton>
-        <IconButton
-          onClick={(evt) => {
-            evt.stopPropagation();
-            onDelete();
-          }}
-        >
-          <Delete />
-        </IconButton>
+        <DeleteHideButtons
+          hidden={hidden}
+          onDelete={onDelete}
+          onToggleHidden={onToggleHidden}
+        />
       </Box>
     </Box>
   );

--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -1,13 +1,40 @@
-import { Box } from '@mui/material';
 import { FC } from 'react';
+import { Box, IconButton } from '@mui/material';
+import { Delete, RemoveRedEye } from '@mui/icons-material';
+
 import { ZetkinTextQuestion } from 'utils/types/zetkin';
 
 interface OpenQuestionBlockProps {
+  hidden: boolean;
+  onDelete: () => void;
+  onToggleHidden: (hidden: boolean) => void;
   question: ZetkinTextQuestion;
 }
 
-const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({ question }) => {
-  return <Box>{JSON.stringify(question)}</Box>;
+const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
+  hidden,
+  onDelete,
+  onToggleHidden,
+  question,
+}) => {
+  return (
+    <Box>
+      {JSON.stringify(question)}
+      <Box display="flex" justifyContent="end" m={2}>
+        <IconButton onClick={() => onToggleHidden(!hidden)}>
+          <RemoveRedEye />
+        </IconButton>
+        <IconButton
+          onClick={(evt) => {
+            evt.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Delete />
+        </IconButton>
+      </Box>
+    </Box>
+  );
 };
 
 export default OpenQuestionBlock;

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,5 +1,12 @@
 import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
-import { FC, KeyboardEvent, useEffect, useRef, useState } from 'react';
+import {
+  FC,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
 import theme from 'theme';
@@ -22,23 +29,20 @@ const TextBlock: FC<TextBlockProps> = ({
   const [header, setHeader] = useState(element.text_block.header);
   const [content, setContent] = useState(element.text_block.content);
 
-  const [focusHeader, setFocusHeader] = useState(true);
-  const [focusContent, setFocusContent] = useState(false);
+  const [focus, setFocus] = useState<'content' | null>(null);
 
-  const headerRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (focusHeader) {
-      headerRef.current?.focus();
-    }
-  }, [focusHeader]);
+  const headerRef = useCallback((node: HTMLInputElement) => {
+    node?.focus();
+  }, []);
 
   useEffect(() => {
-    if (focusContent) {
-      contentRef.current?.focus();
+    if (focus === 'content') {
+      const input = contentRef.current;
+      input?.focus();
     }
-  }, [focusContent]);
+  }, [focus]);
 
   const handleKeyDown = (evt: KeyboardEvent<HTMLDivElement>) => {
     if (evt.key === 'Enter') {
@@ -46,8 +50,7 @@ const TextBlock: FC<TextBlockProps> = ({
         content,
         header,
       });
-      setFocusHeader(false);
-      setFocusContent(false);
+      setFocus(null);
     }
   };
 
@@ -58,8 +61,7 @@ const TextBlock: FC<TextBlockProps> = ({
           content,
           header,
         });
-        setFocusHeader(false);
-        setFocusContent(false);
+        setFocus(null);
       }}
     >
       {inEditMode ? (
@@ -89,11 +91,7 @@ const TextBlock: FC<TextBlockProps> = ({
         </Box>
       ) : (
         <Box onClick={() => onEditModeEnter()}>
-          <Typography
-            color={header ? 'inherit' : 'secondary'}
-            onClick={() => setFocusHeader(true)}
-            variant="h4"
-          >
+          <Typography color={header ? 'inherit' : 'secondary'} variant="h4">
             {header ? (
               element.text_block.header
             ) : (
@@ -102,7 +100,7 @@ const TextBlock: FC<TextBlockProps> = ({
           </Typography>
           {content && (
             <Typography
-              onClick={() => setFocusContent(true)}
+              onClick={() => setFocus('content')}
               sx={{ paddingTop: 1 }}
             >
               {element.text_block.content}

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,4 +1,11 @@
-import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
+import {
+  Box,
+  ClickAwayListener,
+  IconButton,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Delete, RemoveRedEye } from '@mui/icons-material';
 import {
   FC,
   KeyboardEvent,
@@ -13,17 +20,23 @@ import theme from 'theme';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 
 interface TextBlockProps {
+  hidden: boolean;
   inEditMode: boolean;
   element: ZetkinSurveyTextElement;
+  onDelete: () => void;
   onEditModeEnter: () => void;
   onEditModeExit: (textBlock: ZetkinSurveyTextElement['text_block']) => void;
+  onToggleHidden: (hidden: boolean) => void;
 }
 
 const TextBlock: FC<TextBlockProps> = ({
+  hidden,
   inEditMode,
+  onDelete,
   element,
   onEditModeEnter,
   onEditModeExit,
+  onToggleHidden,
 }) => {
   const intl = useIntl();
   const [header, setHeader] = useState(element.text_block.header);
@@ -64,50 +77,65 @@ const TextBlock: FC<TextBlockProps> = ({
         setFocus(null);
       }}
     >
-      {inEditMode ? (
-        <Box display="flex" flexDirection="column">
-          <TextField
-            InputProps={{
-              inputRef: headerRef,
-              sx: { fontSize: theme.typography.h4.fontSize },
-            }}
-            label={intl.formatMessage({
-              id: 'misc.surveys.blocks.text.header',
-            })}
-            onChange={(evt) => setHeader(evt.target.value)}
-            onKeyDown={(evt) => handleKeyDown(evt)}
-            sx={{ paddingBottom: 2 }}
-            value={header}
-          />
-          <TextField
-            InputProps={{ inputRef: contentRef }}
-            label={intl.formatMessage({
-              id: 'misc.surveys.blocks.text.content',
-            })}
-            onChange={(evt) => setContent(evt.target.value)}
-            onKeyDown={(evt) => handleKeyDown(evt)}
-            value={content}
-          />
-        </Box>
-      ) : (
-        <Box onClick={() => onEditModeEnter()}>
-          <Typography color={header ? 'inherit' : 'secondary'} variant="h4">
-            {header ? (
-              element.text_block.header
-            ) : (
-              <Msg id="misc.surveys.blocks.text.empty" />
-            )}
-          </Typography>
-          {content && (
-            <Typography
-              onClick={() => setFocus('content')}
-              sx={{ paddingTop: 1 }}
-            >
-              {element.text_block.content}
+      <div>
+        {inEditMode ? (
+          <Box display="flex" flexDirection="column">
+            <TextField
+              InputProps={{
+                inputRef: headerRef,
+                sx: { fontSize: theme.typography.h4.fontSize },
+              }}
+              label={intl.formatMessage({
+                id: 'misc.surveys.blocks.text.header',
+              })}
+              onChange={(evt) => setHeader(evt.target.value)}
+              onKeyDown={(evt) => handleKeyDown(evt)}
+              sx={{ paddingBottom: 2 }}
+              value={header}
+            />
+            <TextField
+              InputProps={{ inputRef: contentRef }}
+              label={intl.formatMessage({
+                id: 'misc.surveys.blocks.text.content',
+              })}
+              onChange={(evt) => setContent(evt.target.value)}
+              onKeyDown={(evt) => handleKeyDown(evt)}
+              value={content}
+            />
+          </Box>
+        ) : (
+          <Box onClick={() => onEditModeEnter()}>
+            <Typography color={header ? 'inherit' : 'secondary'} variant="h4">
+              {header ? (
+                element.text_block.header
+              ) : (
+                <Msg id="misc.surveys.blocks.text.empty" />
+              )}
             </Typography>
-          )}
+            {content && (
+              <Typography
+                onClick={() => setFocus('content')}
+                sx={{ paddingTop: 1 }}
+              >
+                {element.text_block.content}
+              </Typography>
+            )}
+          </Box>
+        )}
+        <Box display="flex" justifyContent="end" m={2}>
+          <IconButton onClick={() => onToggleHidden(!hidden)}>
+            <RemoveRedEye />
+          </IconButton>
+          <IconButton
+            onClick={(evt) => {
+              evt.stopPropagation();
+              onDelete();
+            }}
+          >
+            <Delete />
+          </IconButton>
         </Box>
-      )}
+      </div>
     </ClickAwayListener>
   );
 };

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  ClickAwayListener,
-  IconButton,
-  TextField,
-  Typography,
-} from '@mui/material';
-import { Delete, RemoveRedEye } from '@mui/icons-material';
+import { Box, ClickAwayListener, TextField, Typography } from '@mui/material';
 import {
   FC,
   KeyboardEvent,
@@ -16,6 +9,7 @@ import {
 } from 'react';
 import { FormattedMessage as Msg, useIntl } from 'react-intl';
 
+import DeleteHideButtons from './DeleteHideButtons';
 import theme from 'theme';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
 
@@ -123,17 +117,11 @@ const TextBlock: FC<TextBlockProps> = ({
           </Box>
         )}
         <Box display="flex" justifyContent="end" m={2}>
-          <IconButton onClick={() => onToggleHidden(!hidden)}>
-            <RemoveRedEye />
-          </IconButton>
-          <IconButton
-            onClick={(evt) => {
-              evt.stopPropagation();
-              onDelete();
-            }}
-          >
-            <Delete />
-          </IconButton>
+          <DeleteHideButtons
+            hidden={hidden}
+            onDelete={onDelete}
+            onToggleHidden={onToggleHidden}
+          />
         </Box>
       </div>
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -29,8 +29,13 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     const data = model.getData().data;
     if (data) {
       const elements = data.elements;
+      //If a block was just added, set its id to be in edit mode.
       if (lengthRef.current < elements.length && lengthRef.current !== 0) {
         setIdOfBlockInEditMode(elements[elements.length - 1].id);
+      } else if (lengthRef.current === 0) {
+        if (elements.length === 1) {
+          setIdOfBlockInEditMode(elements[0].id);
+        }
       }
       lengthRef.current = elements.length;
     }
@@ -77,7 +82,18 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                           handleToggleHidden(elem.id, hidden)
                         }
                       >
-                        <ChoiceQuestionBlock question={elem.question} />
+                        <ChoiceQuestionBlock
+                          inEditMode={elem.id === idOfBlockInEditMode}
+                          onEditModeEnter={() =>
+                            setIdOfBlockInEditMode(elem.id)
+                          }
+                          onEditModeExit={() => {
+                            if (elem.id === idOfBlockInEditMode) {
+                              setIdOfBlockInEditMode(undefined);
+                            }
+                          }}
+                          question={elem.question}
+                        />
                       </BlockWrapper>
                     );
                   }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -54,6 +54,10 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     model.deleteElement(elemId);
   }
 
+  function handleUpdateOption(elemId: number, optionId: number, text: string) {
+    model.updateElementOption(elemId, optionId, text);
+  }
+
   function handleToggleHidden(elemId: number, hidden: boolean) {
     model.toggleElementHidden(elemId, hidden);
   }
@@ -105,6 +109,9 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                           }}
                           onToggleHidden={(hidden) =>
                             handleToggleHidden(elem.id, hidden)
+                          }
+                          onUpdateOption={(optionId, text) =>
+                            handleUpdateOption(elem.id, optionId, text)
                           }
                           question={elem.question}
                         />

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -46,6 +46,10 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     model.addElementOption(elemId);
   }
 
+  function handleDeleteOption(elemId: number, optionId: number) {
+    model.deleteElementOption(elemId, optionId);
+  }
+
   function handleDelete(elemId: number) {
     model.deleteElement(elemId);
   }
@@ -85,6 +89,9 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                           inEditMode={elem.id === idOfBlockInEditMode}
                           onAddOption={() => handleAddOption(elem.id)}
                           onDelete={() => handleDelete(elem.id)}
+                          onDeleteOption={(optionId: number) =>
+                            handleDeleteOption(elem.id, optionId)
+                          }
                           onEditModeEnter={() =>
                             setIdOfBlockInEditMode(elem.id)
                           }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -94,7 +94,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                             if (elem.id === idOfBlockInEditMode) {
                               setIdOfBlockInEditMode(undefined);
                             }
-                            model.updateChoiceQuestion(elem.id, question);
+                            model.updateOptionsQuestion(elem.id, question);
                           }}
                           onToggleHidden={(hidden) =>
                             handleToggleHidden(elem.id, hidden)

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -5,6 +5,7 @@ import AddBlocks from './AddBlocks';
 import BlockWrapper from './blocks/BlockWrapper';
 import ChoiceQuestionBlock from './blocks/ChoiceQuestionBlock';
 import OpenQuestionBlock from './blocks/OpenQuestionBlock';
+import { OptionsQuestionPatchBody } from 'features/surveys/repos/SurveysRepo';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import TextBlock from './blocks/TextBlock';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -87,10 +88,13 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                           onEditModeEnter={() =>
                             setIdOfBlockInEditMode(elem.id)
                           }
-                          onEditModeExit={() => {
+                          onEditModeExit={(
+                            question: OptionsQuestionPatchBody
+                          ) => {
                             if (elem.id === idOfBlockInEditMode) {
                               setIdOfBlockInEditMode(undefined);
                             }
+                            model.updateChoiceQuestion(elem.id, question);
                           }}
                           question={elem.question}
                         />

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -42,6 +42,10 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
     }
   }, [model.getData().data?.elements.length]);
 
+  function handleAddOption(elemId: number) {
+    model.addElementOption(elemId);
+  }
+
   function handleDelete(elemId: number) {
     model.deleteElement(elemId);
   }
@@ -79,6 +83,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                         <ChoiceQuestionBlock
                           hidden={elem.hidden}
                           inEditMode={elem.id === idOfBlockInEditMode}
+                          onAddOption={() => handleAddOption(elem.id)}
                           onDelete={() => handleDelete(elem.id)}
                           onEditModeEnter={() =>
                             setIdOfBlockInEditMode(elem.id)

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -60,31 +60,26 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                 if (elem.type == ELEMENT_TYPE.QUESTION) {
                   if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
                     return (
-                      <BlockWrapper
-                        key={elem.id}
-                        hidden={elem.hidden}
-                        onDelete={() => handleDelete(elem.id)}
-                        onToggleHidden={(hidden) =>
-                          handleToggleHidden(elem.id, hidden)
-                        }
-                      >
-                        <OpenQuestionBlock question={elem.question} />
+                      <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                        <OpenQuestionBlock
+                          hidden={elem.hidden}
+                          onDelete={() => handleDelete(elem.id)}
+                          onToggleHidden={(hidden) =>
+                            handleToggleHidden(elem.id, hidden)
+                          }
+                          question={elem.question}
+                        />
                       </BlockWrapper>
                     );
                   } else if (
                     elem.question.response_type == RESPONSE_TYPE.OPTIONS
                   ) {
                     return (
-                      <BlockWrapper
-                        key={elem.id}
-                        hidden={elem.hidden}
-                        onDelete={() => handleDelete(elem.id)}
-                        onToggleHidden={(hidden) =>
-                          handleToggleHidden(elem.id, hidden)
-                        }
-                      >
+                      <BlockWrapper key={elem.id} hidden={elem.hidden}>
                         <ChoiceQuestionBlock
+                          hidden={elem.hidden}
                           inEditMode={elem.id === idOfBlockInEditMode}
+                          onDelete={() => handleDelete(elem.id)}
                           onEditModeEnter={() =>
                             setIdOfBlockInEditMode(elem.id)
                           }
@@ -96,6 +91,9 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                             }
                             model.updateChoiceQuestion(elem.id, question);
                           }}
+                          onToggleHidden={(hidden) =>
+                            handleToggleHidden(elem.id, hidden)
+                          }
                           question={elem.question}
                         />
                       </BlockWrapper>
@@ -103,17 +101,12 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                   }
                 } else if (elem.type == ELEMENT_TYPE.TEXT) {
                   return (
-                    <BlockWrapper
-                      key={elem.id}
-                      hidden={elem.hidden}
-                      onDelete={() => handleDelete(elem.id)}
-                      onToggleHidden={(hidden) =>
-                        handleToggleHidden(elem.id, hidden)
-                      }
-                    >
+                    <BlockWrapper key={elem.id} hidden={elem.hidden}>
                       <TextBlock
                         element={elem}
+                        hidden={elem.hidden}
                         inEditMode={elem.id === idOfBlockInEditMode}
+                        onDelete={() => handleDelete(elem.id)}
                         onEditModeEnter={() => setIdOfBlockInEditMode(elem.id)}
                         onEditModeExit={(
                           textBlock: ZetkinSurveyTextElement['text_block']
@@ -123,6 +116,9 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                           }
                           model.updateTextBlock(elem.id, textBlock);
                         }}
+                        onToggleHidden={(hidden) =>
+                          handleToggleHidden(elem.id, hidden)
+                        }
                       />
                     </BlockWrapper>
                   );

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -4,7 +4,10 @@ import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
 import { ZetkinSurveyExtended } from 'utils/types/zetkin';
-import SurveysRepo, { ZetkinSurveyElementPostBody } from '../repos/SurveysRepo';
+import SurveysRepo, {
+  OptionsQuestionPatchBody,
+  ZetkinSurveyElementPostBody,
+} from '../repos/SurveysRepo';
 
 export enum SurveyState {
   UNPUBLISHED = 'unpublished',
@@ -153,6 +156,15 @@ export default class SurveyDataModel extends ModelBase {
 
     this._repo.updateSurvey(this._orgId, this._surveyId, {
       expires: today,
+    });
+  }
+
+  updateChoiceQuestion(
+    elemId: number,
+    choiceQuestion: OptionsQuestionPatchBody
+  ) {
+    this._repo.updateElement(this._orgId, this._surveyId, elemId, {
+      ...choiceQuestion,
     });
   }
 

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -172,6 +172,16 @@ export default class SurveyDataModel extends ModelBase {
     });
   }
 
+  updateElementOption(elemId: number, optionId: number, text: string) {
+    this._repo.updateElementOption(
+      this._orgId,
+      this._surveyId,
+      elemId,
+      optionId,
+      text
+    );
+  }
+
   updateOptionsQuestion(
     elemId: number,
     optionsQuestion: OptionsQuestionPatchBody

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -163,13 +163,16 @@ export default class SurveyDataModel extends ModelBase {
     });
   }
 
-  updateChoiceQuestion(
+  updateOptionsQuestion(
     elemId: number,
-    choiceQuestion: OptionsQuestionPatchBody
+    optionsQuestion: OptionsQuestionPatchBody
   ) {
-    this._repo.updateElement(this._orgId, this._surveyId, elemId, {
-      ...choiceQuestion,
-    });
+    this._repo.updateElement(
+      this._orgId,
+      this._surveyId,
+      elemId,
+      optionsQuestion
+    );
   }
 
   updateTextBlock(

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -41,6 +41,15 @@ export default class SurveyDataModel extends ModelBase {
     this._repo.deleteSurveyElement(this._orgId, this._surveyId, elemId);
   }
 
+  deleteElementOption(elemId: number, optionId: number) {
+    this._repo.deleteElementOption(
+      this._orgId,
+      this._surveyId,
+      elemId,
+      optionId
+    );
+  }
+
   getData(): IFuture<ZetkinSurveyExtended> {
     return this._repo.getSurvey(this._orgId, this._surveyId);
   }

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -26,6 +26,10 @@ export default class SurveyDataModel extends ModelBase {
     this._repo.addElement(this._orgId, this._surveyId, element);
   }
 
+  addElementOption(elemId: number) {
+    this._repo.addElementOption(this._orgId, this._surveyId, elemId);
+  }
+
   constructor(env: Environment, orgId: number, surveyId: number) {
     super();
     this._orgId = orgId;

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -22,8 +22,16 @@ export default class SurveyDataModel extends ModelBase {
   private _repo: SurveysRepo;
   private _surveyId: number;
 
-  addElement(element: ZetkinSurveyElementPostBody) {
-    this._repo.addElement(this._orgId, this._surveyId, element);
+  async addElement(element: ZetkinSurveyElementPostBody) {
+    const newElement = await this._repo.addElement(
+      this._orgId,
+      this._surveyId,
+      element
+    );
+
+    //Add two options to the newly created element.
+    this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
+    this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
   }
 
   addElementOption(elemId: number) {

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -3,7 +3,11 @@ import dayjs from 'dayjs';
 import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
-import { ZetkinSurveyExtended } from 'utils/types/zetkin';
+import {
+  ELEMENT_TYPE,
+  RESPONSE_TYPE,
+  ZetkinSurveyExtended,
+} from 'utils/types/zetkin';
 import SurveysRepo, {
   OptionsQuestionPatchBody,
   ZetkinSurveyElementPostBody,
@@ -29,9 +33,14 @@ export default class SurveyDataModel extends ModelBase {
       element
     );
 
-    //Add two options to the newly created element.
-    this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
-    this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
+    //Add two options to a newly created options element.
+    if (
+      newElement.type === ELEMENT_TYPE.QUESTION &&
+      newElement.question.response_type === RESPONSE_TYPE.OPTIONS
+    ) {
+      this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
+      this._repo.addElementOption(this._orgId, this._surveyId, newElement.id);
+    }
   }
 
   addElementOption(elemId: number) {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -17,6 +17,7 @@ import {
   elementAdded,
   elementDeleted,
   elementOptionAdded,
+  elementOptionDeleted,
   elementUpdated,
   submissionLoad,
   submissionLoaded,
@@ -97,6 +98,18 @@ export default class SurveysRepo {
   constructor(env: Environment) {
     this._store = env.store;
     this._apiClient = env.apiClient;
+  }
+
+  deleteElementOption(
+    orgId: number,
+    surveyId: number,
+    elemId: number,
+    optionId: number
+  ) {
+    this._apiClient.delete(
+      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}/options/${optionId}`
+    );
+    this._store.dispatch(elementOptionDeleted([surveyId, elemId, optionId]));
   }
 
   async deleteSurveyElement(orgId: number, surveyId: number, elemId: number) {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -18,6 +18,7 @@ import {
   elementDeleted,
   elementOptionAdded,
   elementOptionDeleted,
+  elementOptionUpdated,
   elementUpdated,
   submissionLoad,
   submissionLoaded,
@@ -169,6 +170,22 @@ export default class SurveysRepo {
       ZetkinSurveyElementPatchBody
     >(`/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}`, data);
     this._store.dispatch(elementUpdated([surveyId, elemId, element]));
+  }
+
+  async updateElementOption(
+    orgId: number,
+    surveyId: number,
+    elemId: number,
+    optionId: number,
+    text: string
+  ) {
+    const option = await this._apiClient.patch<ZetkinSurveyOption>(
+      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}/options/${optionId}`,
+      { text }
+    );
+    this._store.dispatch(
+      elementOptionUpdated([surveyId, elemId, optionId, option])
+    );
   }
 
   updateSurvey(

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -78,14 +78,14 @@ export default class SurveysRepo {
     surveyId: number,
     data: ZetkinSurveyElementPostBody
   ) {
-    await this._apiClient
-      .post<ZetkinSurveyElement, ZetkinSurveyElementPostBody>(
-        `/api/orgs/${orgId}/surveys/${surveyId}/elements`,
-        data
-      )
-      .then((newElement) => {
-        this._store.dispatch(elementAdded([surveyId, newElement]));
-      });
+    const newElement = await this._apiClient.post<
+      ZetkinSurveyElement,
+      ZetkinSurveyElementPostBody
+    >(`/api/orgs/${orgId}/surveys/${surveyId}/elements`, data);
+
+    this._store.dispatch(elementAdded([surveyId, newElement]));
+
+    return newElement;
   }
 
   async addElementOption(orgId: number, surveyId: number, elemId: number) {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -8,6 +8,7 @@ import {
   ZetkinSurvey,
   ZetkinSurveyElement,
   ZetkinSurveyExtended,
+  ZetkinSurveyOption,
   ZetkinSurveySubmission,
   ZetkinSurveyTextElement,
   ZetkinTextQuestion,
@@ -44,8 +45,7 @@ type ZetkinSurveyOptionsQuestionElementPostBody = {
 
 export type ZetkinSurveyElementPatchBody =
   | ZetkinSurveyTextElementPatchBody
-  | ZetkinSurveyOptionsQuestionElementPatchBody
-  | Partial<Omit<ZetkinSurveyTextQuestionElementPostBody, 'type'>>;
+  | OptionsQuestionPatchBody;
 
 type ZetkinSurveyTextElementPatchBody = {
   hidden?: boolean;
@@ -55,9 +55,13 @@ type ZetkinSurveyTextElementPatchBody = {
   };
 };
 
-export type ZetkinSurveyOptionsQuestionElementPatchBody = {
-  hidden?: boolean;
-  question?: Partial<Omit<ZetkinOptionsQuestion, 'response_type'>>;
+export type OptionsQuestionPatchBody = {
+  description?: string | null;
+  options?: ZetkinSurveyOption[];
+  question?: string;
+  response_config?: {
+    widget_type: 'checkbox' | 'radio' | 'select';
+  };
 };
 
 export default class SurveysRepo {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -42,9 +42,9 @@ type ZetkinSurveyOptionsQuestionElementPostBody = {
   type: ELEMENT_TYPE.QUESTION;
 };
 
-type ZetkinSurveyElementPatchBody =
+export type ZetkinSurveyElementPatchBody =
   | ZetkinSurveyTextElementPatchBody
-  | Partial<Omit<ZetkinSurveyOptionsQuestionElementPostBody, 'type'>>
+  | ZetkinSurveyOptionsQuestionElementPatchBody
   | Partial<Omit<ZetkinSurveyTextQuestionElementPostBody, 'type'>>;
 
 type ZetkinSurveyTextElementPatchBody = {
@@ -53,6 +53,11 @@ type ZetkinSurveyTextElementPatchBody = {
     content?: string;
     header?: string;
   };
+};
+
+export type ZetkinSurveyOptionsQuestionElementPatchBody = {
+  hidden?: boolean;
+  question?: Partial<Omit<ZetkinOptionsQuestion, 'response_type'>>;
 };
 
 export default class SurveysRepo {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -16,6 +16,7 @@ import {
 import {
   elementAdded,
   elementDeleted,
+  elementOptionAdded,
   elementUpdated,
   submissionLoad,
   submissionLoaded,
@@ -81,6 +82,14 @@ export default class SurveysRepo {
       .then((newElement) => {
         this._store.dispatch(elementAdded([surveyId, newElement]));
       });
+  }
+
+  async addElementOption(orgId: number, surveyId: number, elemId: number) {
+    const option = await this._apiClient.post<ZetkinSurveyOption>(
+      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}/options`,
+      { text: '' }
+    );
+    this._store.dispatch(elementOptionAdded([surveyId, elemId, option]));
   }
 
   constructor(env: Environment) {

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -57,11 +57,13 @@ type ZetkinSurveyTextElementPatchBody = {
 };
 
 export type OptionsQuestionPatchBody = {
-  description?: string | null;
-  options?: ZetkinSurveyOption[];
-  question?: string;
-  response_config?: {
-    widget_type: 'checkbox' | 'radio' | 'select';
+  question: {
+    description?: string | null;
+    options?: ZetkinSurveyOption[];
+    question?: string;
+    response_config?: {
+      widget_type: 'checkbox' | 'radio' | 'select';
+    };
   };
 };
 

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -1,11 +1,15 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
+
 import {
+  ELEMENT_TYPE,
+  RESPONSE_TYPE,
   ZetkinSurvey,
   ZetkinSurveyElement,
   ZetkinSurveyExtended,
+  ZetkinSurveyOption,
   ZetkinSurveySubmission,
 } from 'utils/types/zetkin';
+import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 
 export interface SurveysStoreSlice {
   submissionList: RemoteList<ZetkinSurveySubmission>;
@@ -42,6 +46,28 @@ const surveysSlice = createSlice({
         surveyItem.data.elements = surveyItem.data.elements.filter(
           (elem) => elem.id !== elemId
         );
+      }
+    },
+    elementOptionAdded: (
+      state,
+      action: PayloadAction<[number, number, ZetkinSurveyOption]>
+    ) => {
+      const [surveyId, elemId, newOption] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      if (surveyItem && surveyItem.data) {
+        const elementItem = surveyItem.data.elements.find(
+          (element) => element.id === elemId
+        );
+
+        if (
+          elementItem &&
+          elementItem.type === ELEMENT_TYPE.QUESTION &&
+          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
+        ) {
+          elementItem.question.options?.push(newOption);
+        }
       }
     },
     elementUpdated: (
@@ -121,6 +147,7 @@ export default surveysSlice;
 export const {
   elementAdded,
   elementDeleted,
+  elementOptionAdded,
   elementUpdated,
   submissionLoad,
   submissionLoaded,

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -70,6 +70,30 @@ const surveysSlice = createSlice({
         }
       }
     },
+    elementOptionDeleted: (
+      state,
+      action: PayloadAction<[number, number, number]>
+    ) => {
+      const [surveyId, elemId, optionId] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      if (surveyItem && surveyItem.data) {
+        const elementItem = surveyItem.data.elements.find(
+          (element) => element.id === elemId
+        );
+
+        if (
+          elementItem &&
+          elementItem.type === ELEMENT_TYPE.QUESTION &&
+          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
+        ) {
+          elementItem.question.options = elementItem.question.options?.filter(
+            (option) => option.id !== optionId
+          );
+        }
+      }
+    },
     elementUpdated: (
       state,
       action: PayloadAction<[number, number, ZetkinSurveyElement]>
@@ -148,6 +172,7 @@ export const {
   elementAdded,
   elementDeleted,
   elementOptionAdded,
+  elementOptionDeleted,
   elementUpdated,
   submissionLoad,
   submissionLoaded,

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -94,6 +94,31 @@ const surveysSlice = createSlice({
         }
       }
     },
+    elementOptionUpdated: (
+      state,
+      action: PayloadAction<[number, number, number, ZetkinSurveyOption]>
+    ) => {
+      const [surveyId, elemId, optionId, updatedOption] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      if (surveyItem && surveyItem.data) {
+        const elementItem = surveyItem.data.elements.find(
+          (element) => element.id === elemId
+        );
+
+        if (
+          elementItem &&
+          elementItem.type === ELEMENT_TYPE.QUESTION &&
+          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
+        ) {
+          elementItem.question.options = elementItem.question.options?.map(
+            (oldOption) =>
+              oldOption.id == optionId ? updatedOption : oldOption
+          );
+        }
+      }
+    },
     elementUpdated: (
       state,
       action: PayloadAction<[number, number, ZetkinSurveyElement]>
@@ -173,6 +198,7 @@ export const {
   elementDeleted,
   elementOptionAdded,
   elementOptionDeleted,
+  elementOptionUpdated,
   elementUpdated,
   submissionLoad,
   submissionLoaded,

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -4,6 +4,10 @@ addBlocks:
   textButton: Text
   title: Choose a block type to add more content to your survey
 blocks:
+  common:
+    description: Description
+    empty: Untitled block
+    title: Title
   text:
     content: Description
     empty: Untitled block

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -4,11 +4,16 @@ addBlocks:
   textButton: Text
   title: Choose a block type to add more content to your survey
 blocks:
+  choiceQuestion:
+    checkbox: Multiple choice
+    radio: Single choice
+    select: Dropdown choice list
+    selectLabel: Poll type
   common:
     description: Description
     empty: Untitled block
     title: Title
   text:
     content: Description
-    empty: Untitled block
+    empty: Untitled text block
     header: Title

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -5,6 +5,7 @@ addBlocks:
   title: Choose a block type to add more content to your survey
 blocks:
   choiceQuestion:
+    addOption: Add option
     checkbox: Multiple choice
     empty: Untitled choice question
     radio: Single choice

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -6,6 +6,7 @@ addBlocks:
 blocks:
   choiceQuestion:
     checkbox: Multiple choice
+    empty: Untitled choice question
     radio: Single choice
     select: Dropdown choice list
     selectLabel: Poll type

--- a/src/locale/misc/surveys/en.yml
+++ b/src/locale/misc/surveys/en.yml
@@ -8,6 +8,8 @@ blocks:
     addOption: Add option
     checkbox: Multiple choice
     empty: Untitled choice question
+    emptyOption: Empty option
+    option: Option
     radio: Single choice
     select: Dropdown choice list
     selectLabel: Poll type

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -234,7 +234,7 @@ export interface ZetkinTextQuestion {
 
 export interface ZetkinOptionsQuestion {
   description: string | null;
-  options?: ZetkinSurveyOption[];
+  options: ZetkinSurveyOption[];
   question: string;
   required: boolean;
   response_config: {

--- a/src/zui/ZUIDropdownIcon.tsx
+++ b/src/zui/ZUIDropdownIcon.tsx
@@ -1,0 +1,18 @@
+import { SvgIcon } from '@mui/material';
+
+const ZUIDropdownIcon = () => {
+  return (
+    <SvgIcon>
+      <svg fill="none" height="24" viewBox="0 0 24 24" width="24">
+        <path
+          d="M19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5C21 3.9 20.1 3 19 3ZM19 19H5V5H19V19Z"
+          fill="black"
+          fillOpacity="0.54"
+        />
+        <path d="M7 9.5L12 14.5L17 9.5H7Z" fill="black" fillOpacity="0.54" />
+      </svg>
+    </SvgIcon>
+  );
+};
+
+export default ZUIDropdownIcon;


### PR DESCRIPTION
WIP handover to @richardolsson 

Kvar på att-göra-listan: 
- Det option man klickar på hamnar i fokus i edit-mode
- Första tillagda frågan i en enkät ska hamna i edit mode när man precis lagt till den, men visas i preview mode när man återvänder. 
- onKeyDown funktionalitet: 
      - när man är i ett option betyder Enter nytt option
      - När man är i de övre fälten betyder Enter att man går till nästa fält
      - Modifiera hur Tab beter sig i options = spara och gå till nästa fält, inte fokusera x-knappen, som den gör nu

Notes: 
Jag flyttade precis tillbaka koden för det som är komponenten "Choice" in hit, för jag tror jag tänkt att det skulle behövas för att bättre kontrollera ref:ar och fokus? Men minns inte exakt min tankebana.
Detta betyder att options just nu delar ett state för value, det funkar såklart inte.