### PR TITLE
Survey block reordering (buttons only, no drag-and-drop)

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
@@ -10,7 +10,11 @@ const BlockWrapper: FC<BlockWrapperProps> = ({ children, hidden }) => {
   return (
     <Box
       marginBottom={1}
-      sx={{ opacity: hidden ? 0.5 : 1, transition: 'opacity 0.2s' }}
+      sx={{
+        flex: '1 0',
+        opacity: hidden ? 0.5 : 1,
+        transition: 'opacity 0.2s',
+      }}
     >
       <Card>
         <Box m={2}>{children}</Box>

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -8,6 +8,7 @@ import OpenQuestionBlock from './blocks/OpenQuestionBlock';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import TextBlock from './blocks/TextBlock';
 import ZUIFuture from 'zui/ZUIFuture';
+import ZUIReorderable from 'zui/ZUIReorderable';
 import {
   ELEMENT_TYPE,
   RESPONSE_TYPE,
@@ -51,59 +52,74 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
         {(data) => {
           return (
             <Box paddingBottom={data.elements.length ? 4 : 0}>
-              {data.elements.map((elem) => {
-                if (elem.type == ELEMENT_TYPE.QUESTION) {
-                  if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
-                    return (
-                      <BlockWrapper key={elem.id} hidden={elem.hidden}>
-                        <OpenQuestionBlock
-                          editable={elem.id == idOfBlockInEditMode}
-                          element={elem as ZetkinSurveyTextQuestionElement}
-                          model={model}
-                          onEditModeEnter={() =>
-                            setIdOfBlockInEditMode(elem.id)
-                          }
-                          onEditModeExit={() => {
-                            setIdOfBlockInEditMode(undefined);
-                          }}
-                        />
-                      </BlockWrapper>
-                    );
-                  } else if (
-                    elem.question.response_type == RESPONSE_TYPE.OPTIONS
-                  ) {
-                    return (
-                      <BlockWrapper key={elem.id} hidden={elem.hidden}>
-                        <ChoiceQuestionBlock
-                          editable={elem.id == idOfBlockInEditMode}
-                          element={elem as ZetkinSurveyOptionsQuestionElement}
-                          model={model}
-                          onEditModeEnter={() => {
-                            setIdOfBlockInEditMode(elem.id);
-                          }}
-                          onEditModeExit={() => {
-                            setIdOfBlockInEditMode(undefined);
-                          }}
-                        />
-                      </BlockWrapper>
-                    );
-                  }
-                } else if (elem.type == ELEMENT_TYPE.TEXT) {
-                  return (
-                    <BlockWrapper key={elem.id} hidden={elem.hidden}>
-                      <TextBlock
-                        editable={elem.id == idOfBlockInEditMode}
-                        element={elem}
-                        model={model}
-                        onEditModeEnter={() => setIdOfBlockInEditMode(elem.id)}
-                        onEditModeExit={() => {
-                          setIdOfBlockInEditMode(undefined);
-                        }}
-                      />
-                    </BlockWrapper>
-                  );
-                }
-              })}
+              <ZUIReorderable
+                items={data.elements.map((elem) => ({
+                  id: elem.id,
+                  renderContent: () => {
+                    if (elem.type == ELEMENT_TYPE.QUESTION) {
+                      if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
+                        return (
+                          <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                            <OpenQuestionBlock
+                              editable={elem.id == idOfBlockInEditMode}
+                              element={elem as ZetkinSurveyTextQuestionElement}
+                              model={model}
+                              onEditModeEnter={() =>
+                                setIdOfBlockInEditMode(elem.id)
+                              }
+                              onEditModeExit={() => {
+                                setIdOfBlockInEditMode(undefined);
+                              }}
+                            />
+                          </BlockWrapper>
+                        );
+                      } else if (
+                        elem.question.response_type == RESPONSE_TYPE.OPTIONS
+                      ) {
+                        return (
+                          <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                            <ChoiceQuestionBlock
+                              editable={elem.id == idOfBlockInEditMode}
+                              element={
+                                elem as ZetkinSurveyOptionsQuestionElement
+                              }
+                              model={model}
+                              onEditModeEnter={() => {
+                                setIdOfBlockInEditMode(elem.id);
+                              }}
+                              onEditModeExit={() => {
+                                setIdOfBlockInEditMode(undefined);
+                              }}
+                            />
+                          </BlockWrapper>
+                        );
+                      }
+                    } else if (elem.type == ELEMENT_TYPE.TEXT) {
+                      return (
+                        <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                          <TextBlock
+                            editable={elem.id == idOfBlockInEditMode}
+                            element={elem}
+                            model={model}
+                            onEditModeEnter={() =>
+                              setIdOfBlockInEditMode(elem.id)
+                            }
+                            onEditModeExit={() => {
+                              setIdOfBlockInEditMode(undefined);
+                            }}
+                          />
+                        </BlockWrapper>
+                      );
+                    }
+
+                    // Only required to satisfy typescript. Should never happen.
+                    return <></>;
+                  },
+                }))}
+                onReorder={(ids) => {
+                  model.updateElementOrder(ids);
+                }}
+              />
             </Box>
           );
         }}

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -216,6 +216,10 @@ export default class SurveyDataModel extends ModelBase {
     );
   }
 
+  updateElementOrder(ids: (string | number)[]) {
+    this._repo.updateElementOrder(this._orgId, this._surveyId, ids);
+  }
+
   updateOpenQuestionBlock(elemId: number, data: ZetkinSurveyElementPatchBody) {
     this._repo.updateElement(this._orgId, this._surveyId, elemId, data);
   }

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -7,6 +7,7 @@ import {
   ZetkinOptionsQuestion,
   ZetkinSurvey,
   ZetkinSurveyElement,
+  ZetkinSurveyElementOrder,
   ZetkinSurveyExtended,
   ZetkinSurveyOption,
   ZetkinSurveySubmission,
@@ -19,6 +20,7 @@ import {
   elementOptionAdded,
   elementOptionDeleted,
   elementOptionUpdated,
+  elementsReordered,
   elementUpdated,
   statsLoad,
   statsLoaded,
@@ -229,6 +231,21 @@ export default class SurveysRepo {
     this._store.dispatch(
       elementOptionUpdated([surveyId, elemId, optionId, option])
     );
+  }
+
+  async updateElementOrder(
+    orgId: number,
+    surveyId: number,
+    ids: (string | number)[]
+  ) {
+    const newOrder = await this._apiClient.patch<ZetkinSurveyElementOrder>(
+      `/api/orgs/${orgId}/surveys/${surveyId}/element_order`,
+      {
+        default: ids.map((id) => parseInt(id as string)),
+      }
+    );
+
+    this._store.dispatch(elementsReordered([surveyId, newOrder]));
   }
 
   updateSurvey(

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -6,6 +6,7 @@ import {
   RESPONSE_TYPE,
   ZetkinSurvey,
   ZetkinSurveyElement,
+  ZetkinSurveyElementOrder,
   ZetkinSurveyExtended,
   ZetkinSurveyOption,
   ZetkinSurveySubmission,
@@ -141,6 +142,24 @@ const surveysSlice = createSlice({
         );
       }
     },
+    elementsReordered: (
+      state,
+      action: PayloadAction<[number, ZetkinSurveyElementOrder]>
+    ) => {
+      const [surveyId, newOrder] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      if (surveyItem?.data?.elements) {
+        surveyItem.data.elements = surveyItem.data.elements
+          .concat()
+          .sort(
+            (el0, el1) =>
+              newOrder.default.indexOf(el0.id) -
+              newOrder.default.indexOf(el1.id)
+          );
+      }
+    },
     statsLoad: (state, action: PayloadAction<number>) => {
       const surveyId = action.payload;
       state.statsBySurveyId[surveyId] = remoteItem<SurveyStats>(surveyId, {
@@ -235,6 +254,7 @@ export const {
   elementOptionDeleted,
   elementOptionUpdated,
   elementUpdated,
+  elementsReordered,
   submissionLoad,
   submissionLoaded,
   statsLoad,

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -217,6 +217,10 @@ export enum RESPONSE_TYPE {
   TEXT = 'text',
 }
 
+export type ZetkinSurveyElementOrder = {
+  default: number[];
+};
+
 export enum ELEMENT_TYPE {
   QUESTION = 'question',
   TEXT = 'text',

--- a/src/zui/ZUIReorderable/UpDownArrows.tsx
+++ b/src/zui/ZUIReorderable/UpDownArrows.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import { Box, IconButton } from '@mui/material';
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material';
+
+type UpDownArrowProps = {
+  onClickDown: () => void;
+  onClickUp: () => void;
+  showDown: boolean;
+  showUp: boolean;
+};
+
+const UpDownArrows: FC<UpDownArrowProps> = ({
+  onClickDown,
+  onClickUp,
+  showDown,
+  showUp,
+}) => {
+  return (
+    <Box display="flex" flexDirection="column">
+      {showUp && (
+        <IconButton onClick={() => onClickUp()}>
+          <KeyboardArrowUp />
+        </IconButton>
+      )}
+      {showDown && (
+        <IconButton onClick={() => onClickDown()}>
+          <KeyboardArrowDown />
+        </IconButton>
+      )}
+    </Box>
+  );
+};
+
+export default UpDownArrows;

--- a/src/zui/ZUIReorderable/index.stories.tsx
+++ b/src/zui/ZUIReorderable/index.stories.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUIReorderable from '.';
+
+export default {
+  component: ZUIReorderable,
+  title: 'Atoms/ZUIReorderable',
+} as ComponentMeta<typeof ZUIReorderable>;
+
+const Template: ComponentStory<typeof ZUIReorderable> = (args) => {
+  const [items, setItems] = useState(args.items);
+
+  return (
+    <div style={{ width: 400 }}>
+      <ZUIReorderable
+        items={items}
+        onReorder={(ids) => {
+          setItems(ids.map((id) => args.items.find((item) => item.id == id)!));
+        }}
+      />
+    </div>
+  );
+};
+
+export const basic = Template.bind({});
+basic.args = {
+  items: [
+    { id: 1, renderContent: () => <h1>Hello</h1> },
+    { id: 2, renderContent: () => <h1>Goodbye</h1> },
+    { id: 3, renderContent: () => <h1>See you later</h1> },
+    { id: 4, renderContent: () => <h1>Good night</h1> },
+  ],
+};

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -1,0 +1,57 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import UpDownArrows from './UpDownArrows';
+
+type IDType = number | string;
+
+type ReorderableItem = {
+  id: IDType;
+  renderContent: () => JSX.Element;
+};
+
+type ZUIReorderableProps = {
+  items: ReorderableItem[];
+  onReorder: (ids: IDType[]) => void;
+};
+
+const ZUIReorderable: FC<ZUIReorderableProps> = ({ items, onReorder }) => {
+  return (
+    <Box>
+      {items.map((item, index) => {
+        return (
+          <Box key={item.id} display="flex">
+            <Box>
+              <UpDownArrows
+                onClickDown={() => {
+                  if (index + 1 < items.length) {
+                    const ids = items.map((item) => item.id);
+                    const current = ids[index];
+                    ids[index] = ids[index + 1];
+                    ids[index + 1] = current;
+
+                    onReorder(ids);
+                  }
+                }}
+                onClickUp={() => {
+                  if (index > 0) {
+                    const ids = items.map((item) => item.id);
+                    const current = ids[index];
+                    ids[index] = ids[index - 1];
+                    ids[index - 1] = current;
+
+                    onReorder(ids);
+                  }
+                }}
+                showDown={index < items.length - 1}
+                showUp={index > 0}
+              />
+            </Box>
+            {item.renderContent()}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default ZUIReorderable;


### PR DESCRIPTION
## Description
This PR implements the most basic form of survey element reordering, using up/down arrows that can be clicked to move an element up or down.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/223775182-78862192-a4e1-47a0-999f-515515026a82.png)

## Changes
* Adds a very simple new component called `ZUIReorderable` (to be extended for #994)
* Adds model/repo/store logic for updating the order of survey elements
* Uses `ZUIReorderable` to allow reordering of survey elements

## Notes to reviewer
Do not merge until #1061 has been merged.

## Related issues
Resolves #993 