### PR TITLE
Drag and drop to reorder survey elements with `ZUIReorderable`

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/BlockWrapper.tsx
@@ -3,17 +3,24 @@ import { FC, ReactNode } from 'react';
 
 interface BlockWrapperProps {
   children: ReactNode;
+  dragging: boolean;
   hidden: boolean;
 }
 
-const BlockWrapper: FC<BlockWrapperProps> = ({ children, hidden }) => {
+const BlockWrapper: FC<BlockWrapperProps> = ({
+  children,
+  dragging,
+  hidden,
+}) => {
   return (
     <Box
       marginBottom={1}
       sx={{
+        boxShadow: dragging ? '0 0 20px rgba(0,0,0,0.1)' : 'none',
         flex: '1 0',
         opacity: hidden ? 0.5 : 1,
-        transition: 'opacity 0.2s',
+        transform: dragging ? 'scale(101%) translate(0.3%, 0)' : 'none',
+        transition: 'opacity 0.2s, box-shadow 0.1s, transform 0.1s',
       }}
     >
       <Card>

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -55,11 +55,15 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
               <ZUIReorderable
                 items={data.elements.map((elem) => ({
                   id: elem.id,
-                  renderContent: () => {
+                  renderContent: ({ dragging }) => {
                     if (elem.type == ELEMENT_TYPE.QUESTION) {
                       if (elem.question.response_type == RESPONSE_TYPE.TEXT) {
                         return (
-                          <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                          <BlockWrapper
+                            key={elem.id}
+                            dragging={dragging}
+                            hidden={elem.hidden}
+                          >
                             <OpenQuestionBlock
                               editable={elem.id == idOfBlockInEditMode}
                               element={elem as ZetkinSurveyTextQuestionElement}
@@ -77,7 +81,11 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                         elem.question.response_type == RESPONSE_TYPE.OPTIONS
                       ) {
                         return (
-                          <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                          <BlockWrapper
+                            key={elem.id}
+                            dragging={dragging}
+                            hidden={elem.hidden}
+                          >
                             <ChoiceQuestionBlock
                               editable={elem.id == idOfBlockInEditMode}
                               element={
@@ -96,7 +104,11 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                       }
                     } else if (elem.type == ELEMENT_TYPE.TEXT) {
                       return (
-                        <BlockWrapper key={elem.id} hidden={elem.hidden}>
+                        <BlockWrapper
+                          key={elem.id}
+                          dragging={dragging}
+                          hidden={elem.hidden}
+                        >
                           <TextBlock
                             editable={elem.id == idOfBlockInEditMode}
                             element={elem}

--- a/src/zui/ZUIReorderable/index.stories.tsx
+++ b/src/zui/ZUIReorderable/index.stories.tsx
@@ -13,7 +13,7 @@ const Template: ComponentStory<typeof ZUIReorderable> = (args) => {
   const [items, setItems] = useState(args.items);
 
   return (
-    <div style={{ width: 400 }}>
+    <div style={{ marginTop: 100, width: 400 }}>
       <ZUIReorderable
         items={items}
         onReorder={(ids) => {

--- a/src/zui/ZUIReorderable/index.stories.tsx
+++ b/src/zui/ZUIReorderable/index.stories.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { Box, Paper } from '@mui/material';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { ReactNode, useState } from 'react';
 
 import ZUIReorderable from '.';
 
@@ -26,9 +27,19 @@ const Template: ComponentStory<typeof ZUIReorderable> = (args) => {
 export const basic = Template.bind({});
 basic.args = {
   items: [
-    { id: 1, renderContent: () => <h1>Hello</h1> },
-    { id: 2, renderContent: () => <h1>Goodbye</h1> },
-    { id: 3, renderContent: () => <h1>See you later</h1> },
-    { id: 4, renderContent: () => <h1>Good night</h1> },
+    { id: 1, renderContent: () => <Item>Hello</Item> },
+    { id: 2, renderContent: () => <Item>Goodbye</Item> },
+    { id: 3, renderContent: () => <Item>See you later</Item> },
+    { id: 4, renderContent: () => <Item>Good night</Item> },
   ],
 };
+
+function Item({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Paper>
+      <Box my={1} p={3}>
+        <h1>{children}</h1>
+      </Box>
+    </Paper>
+  );
+}

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -12,9 +12,13 @@ import UpDownArrows from './UpDownArrows';
 
 type IDType = number | string;
 
+type ZUIReorderableRenderProps = {
+  dragging: boolean;
+};
+
 type ReorderableItem = {
   id: IDType;
-  renderContent: () => JSX.Element;
+  renderContent: (props: ZUIReorderableRenderProps) => JSX.Element;
 };
 
 type ZUIReorderableProps = {
@@ -213,7 +217,11 @@ const ZUIReorderableItem: FC<{
             showUp={showUpButton}
           />
         </Box>
-        <Box flex="1 0">{item.renderContent()}</Box>
+        <Box flex="1 0">
+          {item.renderContent({
+            dragging,
+          })}
+        </Box>
       </Box>
     </Box>
   );

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -1,5 +1,13 @@
-import { Box } from '@mui/material';
-import { FC } from 'react';
+import { DragIndicatorOutlined } from '@mui/icons-material';
+import { Box, IconButton } from '@mui/material';
+import {
+  FC,
+  MouseEvent as ReactMouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
 import UpDownArrows from './UpDownArrows';
 
 type IDType = number | string;
@@ -15,41 +23,191 @@ type ZUIReorderableProps = {
 };
 
 const ZUIReorderable: FC<ZUIReorderableProps> = ({ items, onReorder }) => {
+  const [order, setOrder] = useState<IDType[]>(items.map((item) => item.id));
+  const [activeId, setActiveId] = useState<IDType | null>(null);
+
+  const activeItemRef = useRef<ReorderableItem>();
+
+  useEffect(() => {
+    setOrder(items.map((item) => item.id));
+  }, [items]);
+
+  const dyRef = useRef<number>();
+  const ctrRef = useRef<HTMLDivElement>();
+  const activeContentRef = useRef<HTMLDivElement>();
+  const nodeByIdRef = useRef<Record<IDType, HTMLDivElement>>({});
+
+  const onMouseMove = (ev: MouseEvent) => {
+    const ctrRect = ctrRef.current?.getBoundingClientRect();
+    const ctrY = ctrRect?.top ?? 0;
+    const targetY = ev.clientY - ctrY - (dyRef.current || 0);
+
+    const activeId = activeItemRef.current?.id ?? 0;
+
+    const prevKeys = order;
+    const reorderedItems = items
+      .map((item) => {
+        const y =
+          activeId == item.id
+            ? targetY
+            : nodeByIdRef.current[item.id].getBoundingClientRect().top;
+
+        return {
+          id: item.id,
+          y: y,
+        };
+      })
+      .sort((item0, item1) => item0.y - item1.y);
+
+    const reorderedKeys = reorderedItems.map((item) => item.id);
+
+    if (prevKeys.join(',') != reorderedKeys.join(',')) {
+      setOrder(reorderedKeys);
+      if (onReorder) {
+        onReorder(reorderedKeys);
+      }
+    }
+
+    if (activeContentRef.current) {
+      activeContentRef.current.style.top = targetY + 'px';
+    }
+  };
+
+  const onMouseUp = () => {
+    setActiveId(null);
+
+    // Reset content width
+    if (activeContentRef.current) {
+      activeContentRef.current.style.width = 'auto';
+    }
+
+    activeItemRef.current = undefined;
+
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  };
+
+  const sortedItems = items.concat().sort((item0, item1) => {
+    return order.indexOf(item0.id) - order.indexOf(item1.id);
+  });
+
   return (
-    <Box>
-      {items.map((item, index) => {
-        return (
-          <Box key={item.id} display="flex">
-            <Box>
-              <UpDownArrows
-                onClickDown={() => {
-                  if (index + 1 < items.length) {
-                    const ids = items.map((item) => item.id);
-                    const current = ids[index];
-                    ids[index] = ids[index + 1];
-                    ids[index + 1] = current;
+    <Box ref={ctrRef} sx={{ position: 'relative' }}>
+      {sortedItems.map((item, index) => (
+        <ZUIReorderableItem
+          key={item.id}
+          dragging={activeId == item.id}
+          item={item}
+          onBeginDrag={(itemNode, contentNode, ev) => {
+            setActiveId(item.id);
+            activeItemRef.current = item;
+            activeContentRef.current = contentNode;
 
-                    onReorder(ids);
-                  }
-                }}
-                onClickUp={() => {
-                  if (index > 0) {
-                    const ids = items.map((item) => item.id);
-                    const current = ids[index];
-                    ids[index] = ids[index - 1];
-                    ids[index - 1] = current;
+            // When dragging starts, "hard-code" the height of the
+            // item container, so that it doesn't collapse once the
+            // item content starts moving.
+            const itemRect = itemNode.getBoundingClientRect();
+            itemNode.style.height = itemRect.height + 'px';
 
-                    onReorder(ids);
-                  }
-                }}
-                showDown={index < items.length - 1}
-                showUp={index > 0}
-              />
-            </Box>
-            {item.renderContent()}
-          </Box>
-        );
-      })}
+            // Also "hard-code" width of item, so that it doesn't
+            // collapse if it's a flex item
+            const contentRect = contentNode.getBoundingClientRect();
+            contentNode.style.width = contentRect.width + 'px';
+
+            dyRef.current = ev.clientY - itemRect.top;
+
+            document.addEventListener('mousemove', onMouseMove);
+            document.addEventListener('mouseup', onMouseUp);
+          }}
+          onClickDown={() => {
+            if (index + 1 < items.length) {
+              const ids = items.map((item) => item.id);
+              const current = ids[index];
+              ids[index] = ids[index + 1];
+              ids[index + 1] = current;
+
+              onReorder(ids);
+            }
+          }}
+          onClickUp={() => {
+            if (index > 0) {
+              const ids = items.map((item) => item.id);
+              const current = ids[index];
+              ids[index] = ids[index - 1];
+              ids[index - 1] = current;
+
+              onReorder(ids);
+            }
+          }}
+          onNodeExists={(div) => (nodeByIdRef.current[item.id] = div)}
+          showDownButton={index < items.length - 1}
+          showUpButton={index > 0}
+        />
+      ))}
+    </Box>
+  );
+};
+
+const ZUIReorderableItem: FC<{
+  dragging: boolean;
+  item: ReorderableItem;
+  onBeginDrag: (
+    itemNode: HTMLDivElement,
+    contentNode: HTMLDivElement,
+    ev: ReactMouseEvent<HTMLElement>
+  ) => void;
+  onClickDown: () => void;
+  onClickUp: () => void;
+  onNodeExists: (node: HTMLDivElement) => void;
+  showDownButton: boolean;
+  showUpButton: boolean;
+}> = ({
+  dragging,
+  item,
+  onBeginDrag,
+  onClickDown,
+  onClickUp,
+  onNodeExists,
+  showDownButton,
+  showUpButton,
+}) => {
+  const itemRef = useRef<HTMLDivElement>();
+  const contentRef = useRef<HTMLDivElement>();
+
+  return (
+    <Box
+      key={item.id}
+      ref={(div: HTMLDivElement) => {
+        itemRef.current = div;
+        onNodeExists(div);
+      }}
+    >
+      <Box
+        ref={contentRef}
+        display="flex"
+        sx={{
+          position: dragging ? 'absolute' : 'static',
+        }}
+      >
+        <Box>
+          <IconButton
+            onMouseDown={(ev) => {
+              if (itemRef.current && contentRef.current) {
+                onBeginDrag(itemRef.current, contentRef.current, ev);
+              }
+            }}
+          >
+            <DragIndicatorOutlined />
+          </IconButton>
+          <UpDownArrows
+            onClickDown={onClickDown}
+            onClickUp={onClickUp}
+            showDown={showDownButton}
+            showUp={showUpButton}
+          />
+        </Box>
+        <Box flex="1 0">{item.renderContent()}</Box>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR implements drag and drop to reorder with `ZUIReorderable`, which is used to reorder survey elements.

## Screenshots
https://user-images.githubusercontent.com/550212/224028145-c9d15186-e38f-411c-9be8-b1037dde7aa5.mov

## Changes
* Implements drag and drop in `ZUIReorderable` using the logic pair programmed with @rebecarubio the other day
* Fixes some glitches in the previous logic
* Adds a shadow and slight transformation when dragging a survey element

## Notes to reviewer
None

## Related issues
Resolves #994 