### PR TITLE
Reorder options in survey questions using `ZUIReorderable`

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -25,6 +25,7 @@ import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import useEditPreviewBlock from './useEditPreviewBlock';
 import { ZetkinSurveyOptionsQuestionElement } from 'utils/types/zetkin';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
+import ZUIReorderable from 'zui/ZUIReorderable';
 import { Msg, useMessages } from 'core/i18n';
 
 interface ChoiceQuestionBlockProps {
@@ -141,65 +142,79 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
             ))}
           </TextField>
         )}
-        {options.map((option) => (
-          <ZUIPreviewableInput
-            {...previewableProps}
-            key={option.id}
-            renderInput={(props) => (
-              <Box
+        <ZUIReorderable
+          disableClick
+          disableDrag={!editable}
+          items={options.map((option) => ({
+            id: option.id,
+            renderContent: () => (
+              <ZUIPreviewableInput
+                {...previewableProps}
                 key={option.id}
-                alignItems="center"
-                display="flex"
-                justifyContent="center"
-                paddingTop={2}
-                width="100%"
-              >
-                <Box paddingX={2}>{widgetTypes[widgetType].previewIcon}</Box>
-                <TextField
-                  fullWidth
-                  inputProps={props}
-                  onBlur={(ev) => {
-                    model.updateElementOption(
-                      element.id,
-                      option.id,
-                      ev.target.value
-                    );
-                  }}
-                  onChange={(ev) => {
-                    setOptions(
-                      options.map((oldOpt) =>
-                        oldOpt.id == option.id
-                          ? { ...oldOpt, text: ev.target.value }
-                          : oldOpt
-                      )
-                    );
-                  }}
-                  value={option.text}
-                />
-                <IconButton
-                  onClick={() => {
-                    model.deleteElementOption(element.id, option.id);
-                  }}
-                  sx={{ paddingX: 2 }}
-                >
-                  <Close />
-                </IconButton>
-              </Box>
-            )}
-            renderPreview={() => (
-              <Box key={option.id} display="flex" paddingTop={2}>
-                <Box paddingX={2}>{widgetTypes[widgetType].previewIcon}</Box>
-                <Typography
-                  color={option.text ? 'inherit' : 'secondary'}
-                  fontStyle={option.text ? 'inherit' : 'italic'}
-                >
-                  {option.text || messages.blocks.choice.emptyOption()}
-                </Typography>
-              </Box>
-            )}
-            value={option.text}
-          />
-        ))}
+                renderInput={(props) => (
+                  <Box
+                    key={option.id}
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="center"
+                    paddingTop={2}
+                    width="100%"
+                  >
+                    <Box paddingX={2}>
+                      {widgetTypes[widgetType].previewIcon}
+                    </Box>
+                    <TextField
+                      fullWidth
+                      inputProps={props}
+                      onBlur={(ev) => {
+                        model.updateElementOption(
+                          element.id,
+                          option.id,
+                          ev.target.value
+                        );
+                      }}
+                      onChange={(ev) => {
+                        setOptions(
+                          options.map((oldOpt) =>
+                            oldOpt.id == option.id
+                              ? { ...oldOpt, text: ev.target.value }
+                              : oldOpt
+                          )
+                        );
+                      }}
+                      value={option.text}
+                    />
+                    <IconButton
+                      onClick={() => {
+                        model.deleteElementOption(element.id, option.id);
+                      }}
+                      sx={{ paddingX: 2 }}
+                    >
+                      <Close />
+                    </IconButton>
+                  </Box>
+                )}
+                renderPreview={() => (
+                  <Box key={option.id} display="flex" paddingTop={2}>
+                    <Box paddingX={2}>
+                      {widgetTypes[widgetType].previewIcon}
+                    </Box>
+                    <Typography
+                      color={option.text ? 'inherit' : 'secondary'}
+                      fontStyle={option.text ? 'inherit' : 'italic'}
+                    >
+                      {option.text || messages.blocks.choice.emptyOption()}
+                    </Typography>
+                  </Box>
+                )}
+                value={option.text}
+              />
+            ),
+          }))}
+          onReorder={(ids) => {
+            model.updateOptionOrder(element.id, ids);
+          }}
+        />
         <Box
           display="flex"
           justifyContent={editable ? 'space-between' : 'end'}

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -143,6 +143,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
           </TextField>
         )}
         <ZUIReorderable
+          centerWidgets
           disableClick
           disableDrag={!editable}
           items={options.map((option) => ({
@@ -157,10 +158,10 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
                     alignItems="center"
                     display="flex"
                     justifyContent="center"
-                    paddingTop={2}
+                    paddingY={1}
                     width="100%"
                   >
-                    <Box paddingX={2}>
+                    <Box paddingTop={0.8} paddingX={2}>
                       {widgetTypes[widgetType].previewIcon}
                     </Box>
                     <TextField

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -224,6 +224,10 @@ export default class SurveyDataModel extends ModelBase {
     this._repo.updateElement(this._orgId, this._surveyId, elemId, data);
   }
 
+  updateOptionOrder(elemId: number, ids: (string | number)[]) {
+    this._repo.updateOptionOrder(this._orgId, this._surveyId, elemId, ids);
+  }
+
   updateOptionsQuestion(
     elemId: number,
     optionsQuestion: OptionsQuestionPatchBody

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -19,6 +19,7 @@ import {
   elementDeleted,
   elementOptionAdded,
   elementOptionDeleted,
+  elementOptionsReordered,
   elementOptionUpdated,
   elementsReordered,
   elementUpdated,
@@ -246,6 +247,22 @@ export default class SurveysRepo {
     );
 
     this._store.dispatch(elementsReordered([surveyId, newOrder]));
+  }
+
+  async updateOptionOrder(
+    orgId: number,
+    surveyId: number,
+    elemId: number,
+    ids: (string | number)[]
+  ) {
+    const newOrder = await this._apiClient.patch<ZetkinSurveyElementOrder>(
+      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}/option_order`,
+      {
+        default: ids.map((id) => parseInt(id as string)),
+      }
+    );
+
+    this._store.dispatch(elementOptionsReordered([surveyId, elemId, newOrder]));
   }
 
   updateSurvey(

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -128,6 +128,30 @@ const surveysSlice = createSlice({
         }
       }
     },
+    elementOptionsReordered: (
+      state,
+      action: PayloadAction<[number, number, ZetkinSurveyElementOrder]>
+    ) => {
+      const [surveyId, elemId, newOrder] = action.payload;
+      const surveyItem = state.surveyList.items.find(
+        (item) => item.id == surveyId
+      );
+      const element = surveyItem?.data?.elements.find(
+        (elem) => elem.id == elemId
+      );
+
+      if (
+        element?.type == ELEMENT_TYPE.QUESTION &&
+        element.question.response_type == RESPONSE_TYPE.OPTIONS
+      ) {
+        element.question.options = element.question.options
+          ?.concat()
+          .sort(
+            (o0, o1) =>
+              newOrder.default.indexOf(o0.id) - newOrder.default.indexOf(o1.id)
+          );
+      }
+    },
     elementUpdated: (
       state,
       action: PayloadAction<[number, number, ZetkinSurveyElement]>
@@ -253,6 +277,7 @@ export const {
   elementOptionAdded,
   elementOptionDeleted,
   elementOptionUpdated,
+  elementOptionsReordered,
   elementUpdated,
   elementsReordered,
   submissionLoad,

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -22,11 +22,18 @@ type ReorderableItem = {
 };
 
 type ZUIReorderableProps = {
+  disableClick?: boolean;
+  disableDrag?: boolean;
   items: ReorderableItem[];
   onReorder: (ids: IDType[]) => void;
 };
 
-const ZUIReorderable: FC<ZUIReorderableProps> = ({ items, onReorder }) => {
+const ZUIReorderable: FC<ZUIReorderableProps> = ({
+  disableClick,
+  disableDrag,
+  items,
+  onReorder,
+}) => {
   const [order, setOrder] = useState<IDType[]>(items.map((item) => item.id));
   const [activeId, setActiveId] = useState<IDType | null>(null);
 
@@ -151,8 +158,9 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({ items, onReorder }) => {
             }
           }}
           onNodeExists={(div) => (nodeByIdRef.current[item.id] = div)}
-          showDownButton={index < items.length - 1}
-          showUpButton={index > 0}
+          showDownButton={!disableClick && index < items.length - 1}
+          showDragHandle={!disableDrag}
+          showUpButton={!disableClick && index > 0}
         />
       ))}
     </Box>
@@ -171,6 +179,7 @@ const ZUIReorderableItem: FC<{
   onClickUp: () => void;
   onNodeExists: (node: HTMLDivElement) => void;
   showDownButton: boolean;
+  showDragHandle: boolean;
   showUpButton: boolean;
 }> = ({
   dragging,
@@ -180,6 +189,7 @@ const ZUIReorderableItem: FC<{
   onClickUp,
   onNodeExists,
   showDownButton,
+  showDragHandle,
   showUpButton,
 }) => {
   const itemRef = useRef<HTMLDivElement>();
@@ -201,15 +211,17 @@ const ZUIReorderableItem: FC<{
         }}
       >
         <Box>
-          <IconButton
-            onMouseDown={(ev) => {
-              if (itemRef.current && contentRef.current) {
-                onBeginDrag(itemRef.current, contentRef.current, ev);
-              }
-            }}
-          >
-            <DragIndicatorOutlined />
-          </IconButton>
+          {showDragHandle && (
+            <IconButton
+              onMouseDown={(ev) => {
+                if (itemRef.current && contentRef.current) {
+                  onBeginDrag(itemRef.current, contentRef.current, ev);
+                }
+              }}
+            >
+              <DragIndicatorOutlined />
+            </IconButton>
+          )}
           <UpDownArrows
             onClickDown={onClickDown}
             onClickUp={onClickUp}

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -68,7 +68,13 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
   const onMouseMove = (ev: MouseEvent) => {
     const ctrRect = ctrRef.current?.getBoundingClientRect();
     const ctrY = ctrRect?.top ?? 0;
-    const newClientY = ev.clientY - (dyRef.current || 0);
+
+    // Only allow dragging 10px beyond the top of the container, and just
+    // beyond the bottom of the container
+    const newClientY = Math.max(
+      ctrY - 10,
+      Math.min(ev.clientY - (dyRef.current || 0), ctrRect?.bottom ?? 0)
+    );
 
     const activeId = activeItemRef.current?.id ?? 0;
 

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -22,6 +22,7 @@ type ReorderableItem = {
 };
 
 type ZUIReorderableProps = {
+  centerWidgets?: boolean;
   disableClick?: boolean;
   disableDrag?: boolean;
   items: ReorderableItem[];
@@ -29,6 +30,7 @@ type ZUIReorderableProps = {
 };
 
 const ZUIReorderable: FC<ZUIReorderableProps> = ({
+  centerWidgets,
   disableClick,
   disableDrag,
   items,
@@ -118,6 +120,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
       {sortedItems.map((item, index) => (
         <ZUIReorderableItem
           key={item.id}
+          centerWidgets={!!centerWidgets}
           dragging={activeId == item.id}
           item={item}
           onBeginDrag={(itemNode, contentNode, ev) => {
@@ -173,6 +176,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
 };
 
 const ZUIReorderableItem: FC<{
+  centerWidgets: boolean;
   dragging: boolean;
   item: ReorderableItem;
   onBeginDrag: (
@@ -187,6 +191,7 @@ const ZUIReorderableItem: FC<{
   showDragHandle: boolean;
   showUpButton: boolean;
 }> = ({
+  centerWidgets,
   dragging,
   item,
   onBeginDrag,
@@ -210,6 +215,7 @@ const ZUIReorderableItem: FC<{
     >
       <Box
         ref={contentRef}
+        alignItems={centerWidgets ? 'center' : 'start'}
         display="flex"
         sx={{
           position: dragging ? 'absolute' : 'static',

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -59,7 +59,8 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
 
   const dyRef = useRef<number>();
   const ctrRef = useRef<HTMLDivElement>();
-  const activeContentRef = useRef<HTMLDivElement>();
+  const activeContentNodeRef = useRef<HTMLDivElement>();
+  const activeItemNodeRef = useRef<HTMLDivElement>();
   const nodeByIdRef = useRef<Record<IDType, HTMLDivElement>>({});
 
   const onMouseMove = (ev: MouseEvent) => {
@@ -86,8 +87,8 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
 
     setOrder(reorderedKeys);
 
-    if (activeContentRef.current) {
-      activeContentRef.current.style.top = newClientY - ctrY + 'px';
+    if (activeContentNodeRef.current) {
+      activeContentNodeRef.current.style.top = newClientY - ctrY + 'px';
     }
   };
 
@@ -95,10 +96,13 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
     setActiveId(null);
 
     // Reset content width
-    if (activeContentRef.current) {
-      activeContentRef.current.style.width = 'auto';
+    if (activeContentNodeRef.current) {
+      activeContentNodeRef.current.style.width = 'auto';
     }
 
+    if (activeItemNodeRef.current) {
+      activeItemNodeRef.current.style.height = 'auto';
+    }
     activeItemRef.current = undefined;
 
     document.removeEventListener('mousemove', onMouseMove);
@@ -119,7 +123,8 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
           onBeginDrag={(itemNode, contentNode, ev) => {
             setActiveId(item.id);
             activeItemRef.current = item;
-            activeContentRef.current = contentNode;
+            activeItemNodeRef.current = itemNode;
+            activeContentNodeRef.current = contentNode;
 
             // When dragging starts, "hard-code" the height of the
             // item container, so that it doesn't collapse once the

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -59,21 +59,24 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
     }
   }, [activeId]);
 
-  const dyRef = useRef<number>();
-  const ctrRef = useRef<HTMLDivElement>();
+  const yOffsetRef = useRef<number>();
+  const containerRef = useRef<HTMLDivElement>();
   const activeContentNodeRef = useRef<HTMLDivElement>();
   const activeItemNodeRef = useRef<HTMLDivElement>();
   const nodeByIdRef = useRef<Record<IDType, HTMLDivElement>>({});
 
   const onMouseMove = (ev: MouseEvent) => {
-    const ctrRect = ctrRef.current?.getBoundingClientRect();
-    const ctrY = ctrRect?.top ?? 0;
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    const containerY = containerRect?.top ?? 0;
 
     // Only allow dragging 10px beyond the top of the container, and just
     // beyond the bottom of the container
     const newClientY = Math.max(
-      ctrY - 10,
-      Math.min(ev.clientY - (dyRef.current || 0), ctrRect?.bottom ?? 0)
+      containerY - 10,
+      Math.min(
+        ev.clientY - (yOffsetRef.current || 0),
+        containerRect?.bottom ?? 0
+      )
     );
 
     const activeId = activeItemRef.current?.id ?? 0;
@@ -96,7 +99,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
     setOrder(reorderedKeys);
 
     if (activeContentNodeRef.current) {
-      activeContentNodeRef.current.style.top = newClientY - ctrY + 'px';
+      activeContentNodeRef.current.style.top = newClientY - containerY + 'px';
     }
   };
 
@@ -122,7 +125,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
   });
 
   return (
-    <Box ref={ctrRef} sx={{ position: 'relative' }}>
+    <Box ref={containerRef} sx={{ position: 'relative' }}>
       {sortedItems.map((item, index) => (
         <ZUIReorderableItem
           key={item.id}
@@ -146,7 +149,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
             const contentRect = contentNode.getBoundingClientRect();
             contentNode.style.width = contentRect.width + 'px';
 
-            dyRef.current = ev.clientY - itemRect.top;
+            yOffsetRef.current = ev.clientY - itemRect.top;
 
             document.addEventListener('mousemove', onMouseMove);
             document.addEventListener('mouseup', onMouseUp);

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -69,13 +69,16 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
     const containerRect = containerRef.current?.getBoundingClientRect();
     const containerY = containerRect?.top ?? 0;
 
+    const itemRect = activeItemNodeRef.current?.getBoundingClientRect();
+    const itemHeight = itemRect?.height ?? 0;
+
     // Only allow dragging 10px beyond the top of the container, and just
     // beyond the bottom of the container
     const newClientY = Math.max(
       containerY - 10,
       Math.min(
         ev.clientY - (yOffsetRef.current || 0),
-        containerRect?.bottom ?? 0
+        (containerRect?.bottom ?? 0) - itemHeight + 20
       )
     );
 


### PR DESCRIPTION
## Description
This PR reuses the recently merged `ZUIReorderable` to make options in survey multiple-choice questions reorderable.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/224086950-9802129b-696c-4506-afb2-ca38c695ea2e.png)

## Changes
* Adds some features to `ZUIReorderable`
  * Arrows can be toggled on/off
  * Drag handle can be toggled on/off
  * Drag/arrow widgets can be centered vertically, instead of being rendered at the top of the item
  * Trying to drag an item "out of bounds" is now prevented
* Adds model, repo, store logic for updating the order of options in a survey question
* Implements `ZUIReorderable` in the `ChoiceQuestionBlock` interface

## Notes to reviewer
None

## Related issues
Resolves #995