### PR TITLE
Issue 1012/unlinked survey

### DIFF
--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -1,0 +1,22 @@
+import messageIds from '../l10n/messageIds';
+import React from 'react';
+import { useMessages } from 'core/i18n';
+import { useTheme } from '@mui/material';
+import ZUICard from 'zui/ZUICard';
+import ZUINumberChip from 'zui/ZUINumberChip';
+
+const SurveyUnlinkedCard = () => {
+  const messages = useMessages(messageIds);
+  const theme = useTheme();
+
+  return (
+    <ZUICard
+      header={messages.unlinkedCard.header()}
+      status={<ZUINumberChip color={theme.palette.grey[200]} value={9} />}
+    >
+      <h1>weeeee</h1>
+    </ZUICard>
+  );
+};
+
+export default SurveyUnlinkedCard;

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -20,7 +20,7 @@ const SurveyUnlinkedCard = ({ orgId, surveyId }: SurveyUnlinkedCardProps) => {
   return (
     <ZUIFuture future={model.getStats()}>
       {(sub) => {
-        const unlinkedSubmitters = sub.unlinkedSubmitterCount;
+        const unlinkedSubmitters = sub.unlinkedSubmissionCount;
 
         return (
           <>

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -1,21 +1,70 @@
+import { makeStyles } from '@mui/styles';
 import messageIds from '../l10n/messageIds';
-import React from 'react';
+import SurveySubmissionsModel from '../models/SurveySubmissionsModel';
 import { useMessages } from 'core/i18n';
-import { useTheme } from '@mui/material';
+import useModel from 'core/useModel';
 import ZUICard from 'zui/ZUICard';
+import ZUIFuture from 'zui/ZUIFuture';
 import ZUINumberChip from 'zui/ZUINumberChip';
+import { Box, useTheme } from '@mui/material';
 
-const SurveyUnlinkedCard = () => {
+type SurveyUnlinkedCardProps = {
+  orgId: number;
+  surveyId: number;
+};
+
+const useStyles = makeStyles({
+  unlinkedAvatar: { backgroundColor: 'grey' },
+});
+
+const SurveyUnlinkedCard = ({ orgId, surveyId }: SurveyUnlinkedCardProps) => {
+  const styles = useStyles();
   const messages = useMessages(messageIds);
   const theme = useTheme();
+  const subsModel = useModel(
+    (env) => new SurveySubmissionsModel(env, orgId, surveyId)
+  );
 
   return (
-    <ZUICard
-      header={messages.unlinkedCard.header()}
-      status={<ZUINumberChip color={theme.palette.grey[200]} value={9} />}
-    >
-      <h1>weeeee</h1>
-    </ZUICard>
+    <ZUIFuture future={subsModel.getSubmissions()}>
+      {(submissions) => {
+        const unlinkedSubmitters = submissions.filter((sub) => {
+          if (sub.respondent !== null) {
+            return sub.respondent.id === undefined;
+          }
+        });
+        return (
+          <>
+            {unlinkedSubmitters.length > 0 && (
+              <Box paddingTop={2}>
+                <ZUICard
+                  header={messages.unlinkedCard.header()}
+                  status={
+                    <ZUINumberChip
+                      color={theme.palette.grey[200]}
+                      value={unlinkedSubmitters.length}
+                    />
+                  }
+                  subheader={messages.unlinkedCard.description()}
+                >
+                  {unlinkedSubmitters.map((submitter, index) => (
+                    <Box
+                      key={`unsubmitter-${
+                        submitter.respondent!.first_name
+                      }-${index}`}
+                      className={styles.unlinkedAvatar}
+                    >
+                      {`${submitter.respondent!.first_name}
+                      ${submitter.respondent!.last_name}`}
+                    </Box>
+                  ))}
+                </ZUICard>
+              </Box>
+            )}
+          </>
+        );
+      }}
+    </ZUIFuture>
   );
 };
 

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -1,6 +1,5 @@
-import { makeStyles } from '@mui/styles';
 import messageIds from '../l10n/messageIds';
-import SurveySubmissionsModel from '../models/SurveySubmissionsModel';
+import SurveyDataModel from '../models/SurveyDataModel';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import ZUICard from 'zui/ZUICard';
@@ -13,51 +12,31 @@ type SurveyUnlinkedCardProps = {
   surveyId: number;
 };
 
-const useStyles = makeStyles({
-  unlinkedAvatar: { backgroundColor: 'grey' },
-});
-
 const SurveyUnlinkedCard = ({ orgId, surveyId }: SurveyUnlinkedCardProps) => {
-  const styles = useStyles();
   const messages = useMessages(messageIds);
   const theme = useTheme();
-  const subsModel = useModel(
-    (env) => new SurveySubmissionsModel(env, orgId, surveyId)
-  );
+  const model = useModel((env) => new SurveyDataModel(env, orgId, surveyId));
 
   return (
-    <ZUIFuture future={subsModel.getSubmissions()}>
-      {(submissions) => {
-        const unlinkedSubmitters = submissions.filter((sub) => {
-          if (sub.respondent !== null) {
-            return sub.respondent.id === undefined;
-          }
-        });
+    <ZUIFuture future={model.getStats()}>
+      {(sub) => {
+        const unlinkedSubmitters = sub.unlinkedSubmitterCount;
+
         return (
           <>
-            {unlinkedSubmitters.length > 0 && (
+            {unlinkedSubmitters > 0 && (
               <Box paddingTop={2}>
                 <ZUICard
                   header={messages.unlinkedCard.header()}
                   status={
                     <ZUINumberChip
                       color={theme.palette.grey[200]}
-                      value={unlinkedSubmitters.length}
+                      value={unlinkedSubmitters}
                     />
                   }
                   subheader={messages.unlinkedCard.description()}
                 >
-                  {unlinkedSubmitters.map((submitter, index) => (
-                    <Box
-                      key={`unsubmitter-${
-                        submitter.respondent!.first_name
-                      }-${index}`}
-                      className={styles.unlinkedAvatar}
-                    >
-                      {`${submitter.respondent!.first_name}
-                      ${submitter.respondent!.last_name}`}
-                    </Box>
-                  ))}
+                  <></>
                 </ZUICard>
               </Box>
             )}

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -95,8 +95,10 @@ export default makeMessages('feat.surveys', {
     submissions: m('Submissions'),
   },
   unlinkedCard: {
-    description: m('Submissions not linked to person records'),
-    header: m('Unlinked submitters'),
+    description: m(
+      'When someone submits a survey without first logging in,that survey will be unlinked. Searching for people in your database based on their survey responses will not work on unlinked submissions.'
+    ),
+    header: m('Unlinked submissions'),
   },
   urlCard: {
     nowAccepting: m('Now accepting submissions at this link'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 
 import { m, makeMessages } from 'core/i18n';
 
-export default makeMessages('feat.sruveys', {
+export default makeMessages('feat.surveys', {
   addBlocks: {
     choiceQuestionButton: m('Choice question'),
     openQuestionButton: m('Open question'),
@@ -93,6 +93,10 @@ export default makeMessages('feat.sruveys', {
     overview: m('Overview'),
     questions: m('Questions'),
     submissions: m('Submissions'),
+  },
+  unlinkedCard: {
+    description: m('Submissions not linked to person records'),
+    header: m('Unlinked submitters'),
   },
   urlCard: {
     nowAccepting: m('Now accepting submissions at this link'),

--- a/src/features/surveys/rpc/getSurveyStats.ts
+++ b/src/features/surveys/rpc/getSurveyStats.ts
@@ -17,6 +17,7 @@ export type SurveyStats = {
     accumulatedSubmissions: number;
     date: string;
   }[];
+  unlinkedSubmitterCount: number;
 };
 
 export const getSurveyStatsDef = {
@@ -39,7 +40,7 @@ async function handle(
   );
 
   let sum = 0;
-
+  let unlinkedCount = 0;
   if (submissions.length) {
     const sortedSubmissions = submissions
       .filter((sub) => sub.submitted)
@@ -51,6 +52,12 @@ async function handle(
 
     const curDate = new Date(sortedSubmissions[0].submitted.slice(0, 10));
     const lastDate = new Date();
+
+    unlinkedCount = submissions.filter((sub) => {
+      if (sub.respondent !== null) {
+        return sub.respondent.id === undefined;
+      }
+    }).length;
 
     // Rewind one day before starting
     curDate.setDate(curDate.getDate() - 1);
@@ -76,5 +83,6 @@ async function handle(
     id: surveyId,
     submissionCount: sum,
     submissionsByDay: submissionsByDay.slice(-365),
+    unlinkedSubmitterCount: unlinkedCount,
   };
 }

--- a/src/features/surveys/rpc/getSurveyStats.ts
+++ b/src/features/surveys/rpc/getSurveyStats.ts
@@ -17,7 +17,7 @@ export type SurveyStats = {
     accumulatedSubmissions: number;
     date: string;
   }[];
-  unlinkedSubmitterCount: number;
+  unlinkedSubmissionCount: number;
 };
 
 export const getSurveyStatsDef = {
@@ -41,6 +41,7 @@ async function handle(
 
   let sum = 0;
   let unlinkedCount = 0;
+
   if (submissions.length) {
     const sortedSubmissions = submissions
       .filter((sub) => sub.submitted)
@@ -53,11 +54,9 @@ async function handle(
     const curDate = new Date(sortedSubmissions[0].submitted.slice(0, 10));
     const lastDate = new Date();
 
-    unlinkedCount = submissions.filter((sub) => {
-      if (sub.respondent !== null) {
-        return sub.respondent.id === undefined;
-      }
-    }).length;
+    unlinkedCount = submissions.filter(
+      (sub) => sub.respondent && !sub.respondent.id
+    ).length;
 
     // Rewind one day before starting
     curDate.setDate(curDate.getDate() - 1);
@@ -83,6 +82,6 @@ async function handle(
     id: surveyId,
     submissionCount: sum,
     submissionsByDay: submissionsByDay.slice(-365),
-    unlinkedSubmitterCount: unlinkedCount,
+    unlinkedSubmissionCount: unlinkedCount,
   };
 }

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -6,6 +6,7 @@ import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SubmissionChartCard from 'features/surveys/components/SubmissionChartCard';
 import SurveyLayout from 'features/surveys/layout/SurveyLayout';
+import SurveyUnlinkedCard from 'features/surveys/components/SurveyUnlinkedCard';
 import SurveyURLCard from 'features/surveys/components/SurveyURLCard';
 import useModel from 'core/useModel';
 import useServerSide from 'core/useServerSide';
@@ -77,6 +78,7 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
           </Grid>
           <Grid item md={4}>
             <SurveyURLCard isOpen={isOpen} orgId={orgId} surveyId={surveyId} />
+            <SurveyUnlinkedCard />
           </Grid>
         </Grid>
       )}

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -78,7 +78,11 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
           </Grid>
           <Grid item md={4}>
             <SurveyURLCard isOpen={isOpen} orgId={orgId} surveyId={surveyId} />
-            <SurveyUnlinkedCard />
+
+            <SurveyUnlinkedCard
+              orgId={parseInt(orgId)}
+              surveyId={parseInt(surveyId)}
+            />
           </Grid>
         </Grid>
       )}

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/index.tsx
@@ -78,7 +78,6 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
           </Grid>
           <Grid item md={4}>
             <SurveyURLCard isOpen={isOpen} orgId={orgId} surveyId={surveyId} />
-
             <SurveyUnlinkedCard
               orgId={parseInt(orgId)}
               surveyId={parseInt(surveyId)}


### PR DESCRIPTION
## Description
This PR implements unlinked submitters card that shows the number of unlinked submitters


## Screenshots
![image](https://user-images.githubusercontent.com/77925373/224089961-c9ed6ece-a70f-4b95-8837-486a39075aa1.png)



## Changes

* Adds SurveyUnlinkedCard.tsx
* Adds unlinkedCount to rpc/getSurveyStats
* Changes typo in messageIds


## Notes to reviewer
It is supposed to show list of names with avatar in the card, but decided to get rid of names and its avatar after discussed with @richardolsson.

## Related issues
Resolves #1012
