### PR TITLE
Bulk-adding options to a survey question

### DIFF
--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -1,5 +1,6 @@
 import { RPCRouter } from './router';
 
+import { addBulkOptionsDef } from 'features/surveys/rpc/addBulkOptions';
 import { createNewViewRouteDef } from 'features/views/rpc/createNew/server';
 import { deleteFolderRouteDef } from 'features/views/rpc/deleteFolder';
 import { getSurveyStatsDef } from 'features/surveys/rpc/getSurveyStats';
@@ -10,6 +11,7 @@ export function createRPCRouter() {
   rpcRouter.register(deleteFolderRouteDef);
   rpcRouter.register(createNewViewRouteDef);
   rpcRouter.register(getSurveyStatsDef);
+  rpcRouter.register(addBulkOptionsDef);
 
   return rpcRouter;
 }

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -75,8 +75,6 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   );
 
   useEffect(() => {
-    setTitle(elemQuestion.question);
-    setDescription(elemQuestion.description);
     setOptions(elemQuestion.options || []);
   }, [elemQuestion]);
 
@@ -118,6 +116,13 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
         });
       },
     });
+
+  const optionsToShow = options.filter((option) => {
+    // Show all options (including empty ones) in regular mode, but
+    // hide the empty ones while in bulk mode, because they will be
+    // deleted when bulk adding.
+    return !bulkAddingOptions || !!option.text.length;
+  });
 
   return (
     <ClickAwayListener {...clickAwayProps}>
@@ -172,7 +177,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
           centerWidgets
           disableClick
           disableDrag={!editable}
-          items={options.map((option) => ({
+          items={optionsToShow.map((option) => ({
             id: option.id,
             renderContent: () => (
               <ZUIPreviewableInput

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -12,6 +12,12 @@ export default makeMessages('feat.sruveys', {
   blocks: {
     choice: {
       addOption: m('Add option'),
+      addOptionsBulk: m('Add options in bulk'),
+      bulk: {
+        cancelButton: m('Cancel'),
+        placeholder: m('Type or paste one option per line'),
+        submitButton: m('Add all'),
+      },
       description: m('Description'),
       emptyDescription: m('Description'),
       emptyOption: m('Empty option'),

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -34,6 +34,20 @@ export default class SurveyDataModel extends ModelBase {
     this._repo.addElementOption(this._orgId, this._surveyId, elemId);
   }
 
+  async addElementOptionsFromText(elemId: number, bulkText: string) {
+    const lines = bulkText.split('\n');
+    const nonBlankLines = lines
+      .map((str) => str.trim())
+      .filter((str) => !!str.length);
+
+    this._repo.addElementOptions(
+      this._orgId,
+      this._surveyId,
+      elemId,
+      nonBlankLines
+    );
+  }
+
   constructor(env: Environment, orgId: number, surveyId: number) {
     super();
     this._orgId = orgId;

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -123,15 +123,19 @@ export default class SurveysRepo {
     elemId: number,
     options: string[]
   ) {
-    const createdOptions = await this._apiClient.rpc(addBulkOptions, {
+    const result = await this._apiClient.rpc(addBulkOptions, {
       elemId,
       options,
       orgId,
       surveyId,
     });
 
-    createdOptions.forEach((option) => {
+    result.addedOptions.forEach((option) => {
       this._store.dispatch(elementOptionAdded([surveyId, elemId, option]));
+    });
+
+    result.removedOptions.forEach((option) => {
+      this._store.dispatch(elementOptionDeleted([surveyId, elemId, option.id]));
     });
   }
 

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -1,3 +1,4 @@
+import addBulkOptions from '../rpc/addBulkOptions';
 import Environment from 'core/env/Environment';
 import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
@@ -114,6 +115,24 @@ export default class SurveysRepo {
       { text: '' }
     );
     this._store.dispatch(elementOptionAdded([surveyId, elemId, option]));
+  }
+
+  async addElementOptions(
+    orgId: number,
+    surveyId: number,
+    elemId: number,
+    options: string[]
+  ) {
+    const createdOptions = await this._apiClient.rpc(addBulkOptions, {
+      elemId,
+      options,
+      orgId,
+      surveyId,
+    });
+
+    createdOptions.forEach((option) => {
+      this._store.dispatch(elementOptionAdded([surveyId, elemId, option]));
+    });
   }
 
   constructor(env: Environment) {

--- a/src/features/surveys/rpc/addBulkOptions.ts
+++ b/src/features/surveys/rpc/addBulkOptions.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import { ZetkinSurveyOption } from 'utils/types/zetkin';
+
+const paramsSchema = z.object({
+  elemId: z.number(),
+  options: z.array(z.string()),
+  orgId: z.number(),
+  surveyId: z.number(),
+});
+
+type Params = z.input<typeof paramsSchema>;
+
+export const addBulkOptionsDef = {
+  handler: handle,
+  name: 'addBulkOptions',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, ZetkinSurveyOption[]>(addBulkOptionsDef.name);
+
+async function handle(
+  params: Params,
+  apiClient: IApiClient
+): Promise<ZetkinSurveyOption[]> {
+  const { orgId, surveyId, elemId, options } = params;
+
+  const output: ZetkinSurveyOption[] = [];
+
+  for (const optionText of options) {
+    const option = await apiClient.post<ZetkinSurveyOption>(
+      `/api/orgs/${orgId}/surveys/${surveyId}/elements/${elemId}/options`,
+      { text: optionText }
+    );
+
+    output.push(option);
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Description
This PR adds UI for creating survey options in bulk.

When options are added in bulk mode, all empty options are hidden and eventually removed, to accommodate the very common use case where you want to add all options in bulk (and not keep the two empty options that are created by default).

## Screenshots
https://user-images.githubusercontent.com/550212/224250828-5477adfa-92ee-49f2-8b26-4c4d498d6ee1.mov

## Changes
* Creates a new RPC for bulk-adding options
* Adds model logic to bulk-add options, by splitting on newline, trimming whitespace and ignoring any empty lines


## Notes to reviewer
Don't merge this until #1066 has been merged.

I made some changes compared to the designs that I felt were improvements when I was using this:

* I'm hiding the "Add option" and "Add options in bulk" buttons while in bulk mode
* I replaced the regular checkbox icon with the list icon for the special bulk input
* I'm not including the bulk input in the `ZUIReorderable`, so I'm not showing the drag handle


## Related issues
Resolves #1005 
