### PR TITLE
Issue 1035/create campaign

### DIFF
--- a/src/features/campaigns/components/CampaignsActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignsActionButtons.tsx
@@ -1,0 +1,51 @@
+import { useRouter } from 'next/router';
+import { Box, Button } from '@mui/material';
+import React, { useContext } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+import postCampaign from '../fetching/postCampaign';
+import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+import { Msg, useMessages } from 'core/i18n';
+
+import messageIds from '../l10n/messageIds';
+
+const CampaignActionButtons: React.FunctionComponent = () => {
+  const messages = useMessages(messageIds);
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { showSnackbar } = useContext(ZUISnackbarContext);
+  const { orgId } = router.query;
+
+  // Mutations
+  const postCampaignMutation = useMutation(postCampaign(orgId as string));
+
+  // Event Handlers
+  const handleCreateCampaign = () => {
+    const campaign = {
+      title: messages.form.createCampaign.newCampaign(),
+    };
+    postCampaignMutation.mutate(campaign, {
+      onError: () =>
+        showSnackbar('error', messages.form.createCampaign.error()),
+      onSettled: () => queryClient.invalidateQueries(['campaign']),
+      onSuccess: (data) =>
+        router.push(`/organize/${orgId}/campaigns/${data.id}`),
+    });
+  };
+
+  return (
+    <Box display="flex">
+      <Box mr={1}>
+        <Button
+          color="primary"
+          onClick={handleCreateCampaign}
+          variant="contained"
+        >
+          <Msg id={messageIds.all.create} />
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default CampaignActionButtons;

--- a/src/features/campaigns/components/CampaignsActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignsActionButtons.tsx
@@ -1,36 +1,27 @@
+import React from 'react';
 import { useRouter } from 'next/router';
 import { Box, Button } from '@mui/material';
-import React, { useContext } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
 
-import postCampaign from '../fetching/postCampaign';
-import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+import CampaignBrowserModel from '../models/CampaignBrowserModel';
+import useModel from 'core/useModel';
 import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from '../l10n/messageIds';
 
 const CampaignActionButtons: React.FunctionComponent = () => {
   const messages = useMessages(messageIds);
-  const queryClient = useQueryClient();
   const router = useRouter();
-  const { showSnackbar } = useContext(ZUISnackbarContext);
   const { orgId } = router.query;
-
-  // Mutations
-  const postCampaignMutation = useMutation(postCampaign(orgId as string));
+  const model = useModel(
+    (env) => new CampaignBrowserModel(env, parseInt(orgId as string))
+  );
 
   // Event Handlers
   const handleCreateCampaign = () => {
     const campaign = {
       title: messages.form.createCampaign.newCampaign(),
     };
-    postCampaignMutation.mutate(campaign, {
-      onError: () =>
-        showSnackbar('error', messages.form.createCampaign.error()),
-      onSettled: () => queryClient.invalidateQueries(['campaign']),
-      onSuccess: (data) =>
-        router.push(`/organize/${orgId}/campaigns/${data.id}`),
-    });
+    model.createCampaign(campaign);
   };
 
   return (

--- a/src/features/campaigns/components/EditableCampaignTitle.tsx
+++ b/src/features/campaigns/components/EditableCampaignTitle.tsx
@@ -1,0 +1,57 @@
+import { Box } from '@mui/material';
+import { useMessages } from 'core/i18n';
+import { useRouter } from 'next/router';
+import { FC, useContext } from 'react';
+import { useMutation, useQueryClient } from 'react-query';
+
+import patchCampaign from '../fetching/patchCampaign';
+import { ZetkinCampaign } from 'utils/types/zetkin';
+import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
+import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+
+import messageIds from '../l10n/messageIds';
+
+interface EditableCampaignTitleProps {
+  campaign: ZetkinCampaign;
+}
+
+const EditableCampaignTitle: FC<EditableCampaignTitleProps> = ({
+  campaign,
+}) => {
+  const messages = useMessages(messageIds);
+  const queryClient = useQueryClient();
+  const { orgId } = useRouter().query;
+
+  const { showSnackbar } = useContext(ZUISnackbarContext);
+
+  const patchCampaignMutation = useMutation(
+    patchCampaign(orgId as string, campaign.id)
+  );
+
+  const handleEditCampaignTitle = (newTitle: string) => {
+    patchCampaignMutation.mutate(
+      { title: newTitle },
+      {
+        onError: () =>
+          showSnackbar('error', messages.form.editCampaignTitle.error()),
+        onSettled: () => queryClient.invalidateQueries(['campaign']),
+        onSuccess: () =>
+          showSnackbar('success', messages.form.editCampaignTitle.success()),
+      }
+    );
+  };
+
+  return (
+    <Box>
+      <ZUIEditTextinPlace
+        key={campaign.id}
+        onChange={(newTitle) => {
+          handleEditCampaignTitle(newTitle);
+        }}
+        value={campaign?.title}
+      />
+    </Box>
+  );
+};
+
+export default EditableCampaignTitle;

--- a/src/features/campaigns/components/EditableCampaignTitle.tsx
+++ b/src/features/campaigns/components/EditableCampaignTitle.tsx
@@ -1,10 +1,10 @@
 import { Box } from '@mui/material';
-import { useMessages } from 'core/i18n';
 import { useRouter } from 'next/router';
 import { FC, useContext } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 
 import patchCampaign from '../fetching/patchCampaign';
+import { useMessages } from 'core/i18n';
 import { ZetkinCampaign } from 'utils/types/zetkin';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -28,7 +28,11 @@ export default makeMessages('feat.campaigns', {
     heading: m('Feedback and Surveys (none configured)'),
   },
   form: {
-    create: m('Create new campaign'),
+    createCampaign: {
+      create: m('Create campaign'),
+      error: m('There was an error creating the campaign'),
+      newCampaign: m('My campaign'),
+    },
     deleteCampaign: {
       cancel: m('Cancel'),
       error: m('There was an error deleting the campaign'),

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -44,6 +44,10 @@ export default makeMessages('feat.campaigns', {
     },
     description: m('Description'),
     edit: m('Edit campaign'),
+    editCampaignTitle: {
+      error: m('Error updating campaign title'),
+      success: m('Campaign title updated'),
+    },
     manager: {
       label: m('Campaign manager'),
       selectSelf: m('Set yourself as manager'),

--- a/src/features/campaigns/layout/AllCampaignsLayout.tsx
+++ b/src/features/campaigns/layout/AllCampaignsLayout.tsx
@@ -2,10 +2,10 @@ import { FunctionComponent } from 'react';
 import { useRouter } from 'next/router';
 
 import CampaignsActionButtons from '../components/CampaignsActionButtons';
-import messageIds from '../l10n/messageIds';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
-
 import { useMessages } from 'core/i18n';
+
+import messageIds from '../l10n/messageIds';
 
 interface AllCampaignsLayoutProps {
   children: React.ReactNode;

--- a/src/features/campaigns/layout/AllCampaignsLayout.tsx
+++ b/src/features/campaigns/layout/AllCampaignsLayout.tsx
@@ -1,11 +1,11 @@
 import { FunctionComponent } from 'react';
 import { useRouter } from 'next/router';
 
-import TabbedLayout from '../../../utils/layout/TabbedLayout';
-import { useMessages } from 'core/i18n';
-
-import messageIds from '../l10n/messageIds';
 import CampaignsActionButtons from '../components/CampaignsActionButtons';
+import messageIds from '../l10n/messageIds';
+import TabbedLayout from '../../../utils/layout/TabbedLayout';
+
+import { useMessages } from 'core/i18n';
 
 interface AllCampaignsLayoutProps {
   children: React.ReactNode;

--- a/src/features/campaigns/layout/AllCampaignsLayout.tsx
+++ b/src/features/campaigns/layout/AllCampaignsLayout.tsx
@@ -5,6 +5,7 @@ import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import { useMessages } from 'core/i18n';
 
 import messageIds from '../l10n/messageIds';
+import CampaignsActionButtons from '../components/CampaignsActionButtons';
 
 interface AllCampaignsLayoutProps {
   children: React.ReactNode;
@@ -20,6 +21,7 @@ const AllCampaignsLayout: FunctionComponent<AllCampaignsLayoutProps> = ({
 
   return (
     <TabbedLayout
+      actionButtons={<CampaignsActionButtons />}
       baseHref={`/organize/${orgId}/campaigns`}
       defaultTab="/"
       fixedHeight={fixedHeight}

--- a/src/features/campaigns/layout/SingleCampaignLayout.tsx
+++ b/src/features/campaigns/layout/SingleCampaignLayout.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
 
 import CampaignActionButtons from 'features/campaigns/components/CampaignActionButtons';
+import EditableCampaignTitle from '../components/EditableCampaignTitle';
 import getCampaign from 'features/campaigns/fetching/getCampaign';
 import getCampaignEvents from '../fetching/getCampaignEvents';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
@@ -74,7 +75,7 @@ const SingleCampaignLayout: FunctionComponent<SingleCampaignLayoutProps> = ({
           label: messages.layout.calendar(),
         },
       ]}
-      title={campaign?.title}
+      title={<EditableCampaignTitle campaign={campaign} />}
     >
       {children}
     </TabbedLayout>

--- a/src/features/campaigns/models/CampaignBrowserModel.ts
+++ b/src/features/campaigns/models/CampaignBrowserModel.ts
@@ -1,0 +1,32 @@
+import CampaignsRepo from '../repos/CampaignsRepo';
+import Environment from 'core/env/Environment';
+import { ModelBase } from 'core/models';
+import { IFuture, PromiseFuture } from 'core/caching/futures';
+import { ZetkinCampaign, ZetkinCampaignPostBody } from 'utils/types/zetkin';
+
+export default class CampaignBrowserModel extends ModelBase {
+  private _env: Environment;
+  private _orgId: number;
+  private _repo: CampaignsRepo;
+
+  constructor(env: Environment, orgId: number) {
+    super();
+    this._env = env;
+    this._orgId = orgId;
+    this._repo = new CampaignsRepo(this._env);
+  }
+
+  createCampaign(
+    campaignBody: ZetkinCampaignPostBody
+  ): IFuture<ZetkinCampaign> {
+    const promise = this._repo
+      .createCampaign(campaignBody, this._orgId)
+      .then((campaign: ZetkinCampaign) => {
+        this._env.router.push(
+          `/organize/${campaign.organization?.id}/campaigns/${campaign.id}`
+        );
+        return campaign;
+      });
+    return new PromiseFuture(promise);
+  }
+}

--- a/src/features/campaigns/repos/CampaignsRepo.ts
+++ b/src/features/campaigns/repos/CampaignsRepo.ts
@@ -1,0 +1,29 @@
+import Environment from 'core/env/Environment';
+import IApiClient from 'core/api/client/IApiClient';
+import { Store } from '@reduxjs/toolkit';
+import { campaignCreate, campaignCreated } from '../store';
+import { ZetkinCampaign, ZetkinCampaignPostBody } from 'utils/types/zetkin';
+
+export default class CampaignsRepo {
+  private _apiClient: IApiClient;
+  private _store: Store;
+
+  constructor(env: Environment) {
+    this._apiClient = env.apiClient;
+    this._store = env.store;
+  }
+
+  async createCampaign(
+    campaignBody: ZetkinCampaignPostBody,
+    orgId: number
+  ): Promise<ZetkinCampaign> {
+    this._store.dispatch(campaignCreate());
+    const campaign = await this._apiClient.post<
+      ZetkinCampaign,
+      ZetkinCampaignPostBody
+    >(`/api/orgs/${orgId}/campaigns`, campaignBody);
+
+    this._store.dispatch(campaignCreated(campaign));
+    return campaign;
+  }
+}

--- a/src/features/campaigns/repos/CampaignsRepo.ts
+++ b/src/features/campaigns/repos/CampaignsRepo.ts
@@ -1,6 +1,7 @@
+import { Store } from '@reduxjs/toolkit';
+
 import Environment from 'core/env/Environment';
 import IApiClient from 'core/api/client/IApiClient';
-import { Store } from '@reduxjs/toolkit';
 import { campaignCreate, campaignCreated } from '../store';
 import { ZetkinCampaign, ZetkinCampaignPostBody } from 'utils/types/zetkin';
 

--- a/src/features/campaigns/store.ts
+++ b/src/features/campaigns/store.ts
@@ -1,0 +1,35 @@
+import { ZetkinCampaign } from 'utils/types/zetkin';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { remoteItem, RemoteList, remoteList } from 'utils/storeUtils';
+
+export interface CampaignsStoreSlice {
+  recentlyCreatedCampaign: ZetkinCampaign | null;
+  campaignList: RemoteList<ZetkinCampaign>;
+}
+
+const initialState: CampaignsStoreSlice = {
+  campaignList: remoteList(),
+  recentlyCreatedCampaign: null,
+};
+
+const campaignsSlice = createSlice({
+  initialState,
+  name: 'campaigns',
+  reducers: {
+    campaignCreate: (state) => {
+      state.campaignList.isLoading = true;
+      state.recentlyCreatedCampaign = null;
+    },
+    campaignCreated: (state, action: PayloadAction<ZetkinCampaign>) => {
+      const campaign = action.payload;
+      state.campaignList.isLoading = false;
+      state.campaignList.items.push(
+        remoteItem(campaign.id, { data: campaign })
+      );
+      state.recentlyCreatedCampaign = campaign;
+    },
+  },
+});
+
+export default campaignsSlice;
+export const { campaignCreate, campaignCreated } = campaignsSlice.actions;

--- a/src/features/campaigns/store.ts
+++ b/src/features/campaigns/store.ts
@@ -1,5 +1,6 @@
-import { ZetkinCampaign } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ZetkinCampaign } from 'utils/types/zetkin';
 import { remoteItem, RemoteList, remoteList } from 'utils/storeUtils';
 
 export interface CampaignsStoreSlice {

--- a/src/pages/organize/[orgId]/campaigns/index.tsx
+++ b/src/pages/organize/[orgId]/campaigns/index.tsx
@@ -14,7 +14,6 @@ import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
 import ZUISection from 'zui/ZUISection';
-import ZUISpeedDial, { ACTIONS } from 'zui/ZUISpeedDial';
 
 import messageIds from 'features/campaigns/l10n/messageIds';
 
@@ -113,7 +112,6 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
           })}
         </Box>
       </ZUISection>
-      <ZUISpeedDial actions={[ACTIONS.CREATE_CAMPAIGN]} />
     </>
   );
 };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -29,6 +29,7 @@ export interface ZetkinCampaign {
 export interface ZetkinCampaignPostBody
   extends Partial<Omit<ZetkinCampaign, 'organization' | 'manager'>> {
   title: string;
+  manager_id?: number;
 }
 
 export interface ZetkinMembership {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -26,6 +26,11 @@ export interface ZetkinCampaign {
   published: boolean;
 }
 
+export interface ZetkinCampaignPostBody
+  extends Partial<Omit<ZetkinCampaign, 'organization' | 'manager'>> {
+  title: string;
+}
+
 export interface ZetkinMembership {
   organization: ZetkinOrganization;
   follow?: boolean;

--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -68,7 +68,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
   useEffect(() => {
     // If the value prop changes, set the text
     if (value !== text) {
-      setText(text);
+      setText(value);
     }
   }, [value]);
 


### PR DESCRIPTION
## Description
This PR adds a Create campaign button to the All campaigns page and makes it possible to edit the campaign title in place.

## Screenshots
[Screencast from 2023-03-10 13-37-17.webm](https://user-images.githubusercontent.com/14962107/224318130-79ecd264-6bbc-47b7-8828-c000f513fb13.webm)

## Changes
* Adds Create campaign button to All campaing page
* Adds new component EditableCampaignTitle
* Changes title in SingleCampaignOverview from using a simple string to using EditableCampaignTitle component
* Adds new model, store and repo to create new campaign. Still use react-query for updating title, because using the model would require migrating the entire campaigns feature which there is no time for right now.
* Fixed bug in ZUIEditTextInPlace where text would not update when `value` prop updated. Checked to make sure it still works fine in all the places where it was used.

## Related issues
Resolves #1035 