### PR TITLE
Prevent Chrome from navigating when scrolling horizontally

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -9,7 +9,7 @@ import Document, { Head, Html, Main, NextScript } from 'next/document';
 export default class MyDocument extends Document {
   render(): JSX.Element {
     return (
-      <Html lang="en">
+      <Html lang="en" style={{ overscrollBehaviorX: 'none' }}>
         <Head>
           {/* PWA primary color */}
           <meta content={theme.palette.primary.main} name="theme-color" />
@@ -17,7 +17,7 @@ export default class MyDocument extends Document {
           <script>{'try{Typekit.load({ async: true })}catch(e){}'}</script>
           <link href="/logo-zetkin.png" rel="shortcut icon" />
         </Head>
-        <body>
+        <body style={{ overscrollBehaviorX: 'none' }}>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
## Description
This PR prevents Google Chrome from navigating back/forward when scrolling "too far" left or right. This is a very annoying Chrome feature that some users may like, but many users run into accidentally for the first time when they scroll some big document horizontally.

It's often triggered when scrolling horizontally in a View.

## Screenshots
None


## Changes
* Adds the `overscroll-behavior-x` CSS property to `<html>` and `<body>`

## Notes to reviewer
To reproduce the issue:

1. Check out `main`
2. Navigate to any View in Google Chrome
3. Add enough columns for the view to get too wide for the viewport 
4. Scroll right and then left, but scroll a little bit "too far"

Expected results: Just scrolling
Actual results: Chrome will navigate back to the previous page

## Related issues
Undocumented