### PR TITLE
Pin/freeze avatar and selection columns in views

### DIFF
--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -50,7 +50,7 @@ test.describe('View detail page', () => {
     await page.goto(appUri + '/organize/1/people/views/1');
 
     await page.locator('[role=cell] >> input[type=checkbox]').nth(0).click();
-    await page.locator('[role=cell] >> input[type=checkbox]').nth(2).click();
+    await page.locator('[role=cell] >> input[type=checkbox]').nth(1).click();
 
     await Promise.all([
       page.waitForNavigation(),

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -37,10 +37,7 @@ test.describe('View detail page', () => {
 
     // Show toolbar button on row selection
     await expect(page.locator(removeButton)).toBeHidden();
-    await page
-      .locator('[role=row]:has-text("Clara") input[type=checkbox]')
-      .first()
-      .click();
+    await page.locator('[role=row] input[type=checkbox]').first().click();
     await page.locator(removeButton).waitFor();
     await expect(page.locator(removeButton)).toBeVisible();
 

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -5,6 +5,7 @@ import NProgress from 'nprogress';
 import { useRouter } from 'next/router';
 import {
   DataGridPro,
+  GRID_CHECKBOX_SELECTION_COL_DEF,
   GridCellEditStartReasons,
   GridCellParams,
   GridColDef,
@@ -401,6 +402,9 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           }
         }}
         onSelectionModelChange={(model) => setSelection(model as number[])}
+        pinnedColumns={{
+          left: ['id', GRID_CHECKBOX_SELECTION_COL_DEF.field],
+        }}
         processRowUpdate={(after, before) => {
           const changedField = Object.keys(after).find(
             (key) => after[key] != before[key]


### PR DESCRIPTION
## Description
This PR modifies the View data table to pin ("freeze" as it's called in spreadsheets) the avatar and checkbox/selection columns to the left of the table, so that even if you scroll horizontally, you still see the avatar and checkbox of each line.

This is to make it easier to keep track of where you are in a wide table, which is virtually impossible today.

Relevant job story:

* When I have a very wide view, I want to know which person each row belongs to, so that I don’t have to scroll back and forth to figure that out

## Screenshots
![image](https://user-images.githubusercontent.com/550212/224368878-e7a58b65-4150-4bd4-9fb6-edcc86feaa9a.png)

## Changes
* Configures the `pinnedColumns` property of `DataGridPro` to pin the avatar (`id`) and selection columns

## Notes to reviewer
None

## Related issues
Part of #1067 