### PR TITLE
Use EditTextInPlace to rename view folders

### DIFF
--- a/src/features/views/layout/FolderLayout.tsx
+++ b/src/features/views/layout/FolderLayout.tsx
@@ -5,6 +5,7 @@ import useModel from 'core/useModel';
 import ViewBrowserModel from '../models/ViewBrowserModel';
 import ViewFolderActionButtons from '../components/ViewFolderActionButtons';
 import ViewFolderSubtitle from '../components/ViewFolderSubtitle';
+import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 
 interface FolderLayoutProps {
@@ -40,7 +41,15 @@ const FolderLayout: React.FunctionComponent<FolderLayoutProps> = ({
               )}
             </ZUIFuture>
           }
-          title={data.title}
+          title={
+            <ZUIEditTextinPlace
+              key={data.id}
+              onChange={(newTitle) => {
+                model.renameItem('folder', data.id, newTitle);
+              }}
+              value={data.title}
+            />
+          }
         >
           {children}
         </SimpleLayout>


### PR DESCRIPTION
## Description
This PR uses the `ZUIEditTextInPlace` to allow view folder names to be edited in the header.

## Screenshots
![image](https://user-images.githubusercontent.com/550212/224381829-2c6fd62f-5ceb-470f-82f6-fb0f445989ef.png)

## Changes
* Adds `ZUIEditTextInPlace` in `FolderLayout`

## Notes to reviewer
None

## Related issues
Part of #1067 