### PR TITLE
Handle null cell values in all view column types

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -17,8 +17,8 @@ import {
 } from '../../types';
 
 export default class LocalBoolColumnType implements IColumnType {
-  cellToString(cell: boolean): string {
-    return String(cell);
+  cellToString(cell: boolean | null): string {
+    return String(!!cell);
   }
 
   getColDef(column: LocalBoolViewColumn): Omit<GridColDef, 'field'> {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -18,7 +18,7 @@ type LocalPersonViewCell = null | ZetkinPerson;
 export default class LocalPersonColumnType
   implements IColumnType<LocalPersonViewColumn, LocalPersonViewCell>
 {
-  cellToString(cell: ZetkinPerson | null): string {
+  cellToString(cell: LocalPersonViewCell): string {
     return cell ? `${cell.first_name} ${cell.last_name}` : '';
   }
   getColDef(

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
@@ -8,12 +8,12 @@ import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog
 import theme from '../../../../../theme';
 import { LocalQueryViewColumn, ZetkinViewColumn } from '../../types';
 
-type LocalQueryViewCell = boolean;
+type LocalQueryViewCell = boolean | null;
 
 export default class LocalQueryColumnType
   implements IColumnType<ZetkinViewColumn, LocalQueryViewCell>
 {
-  cellToString(cell: LocalQueryViewCell | null): string {
+  cellToString(cell: LocalQueryViewCell): string {
     return cell ? cell.toString() : '';
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
@@ -24,8 +24,8 @@ type PersonTagViewCell = null | {
 };
 
 export default class PersonTagColumnType implements IColumnType {
-  cellToString(cell: ZetkinTag): string {
-    return cell.value ? cell.value.toString() : Boolean(cell).toString();
+  cellToString(cell: PersonTagViewCell): string {
+    return cell?.value ? cell.value.toString() : Boolean(cell).toString();
   }
 
   getColDef(column: PersonTagViewColumn): Omit<GridColDef, 'field'> {

--- a/src/features/views/components/ViewDataTable/columnTypes/SimpleColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SimpleColumnType.tsx
@@ -3,7 +3,7 @@ import { GridColDef } from '@mui/x-data-grid-pro';
 import { IColumnType } from '.';
 import { ZetkinViewColumn } from '../../types';
 
-type SimpleData = string | number | boolean;
+type SimpleData = string | number | boolean | null;
 
 export default class SimpleColumnType
   implements IColumnType<ZetkinViewColumn, SimpleData>

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -14,18 +14,20 @@ import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
 
 import messageIds from 'features/views/l10n/messageIds';
 
-type SurveyOptionViewCell = {
-  selected: boolean;
-  submission_id: number;
-  submitted: string;
-}[];
+type SurveyOptionViewCell =
+  | {
+      selected: boolean;
+      submission_id: number;
+      submitted: string;
+    }[]
+  | null;
 
 export default class SurveyOptionColumnType
   implements IColumnType<SurveyOptionViewColumn, SurveyOptionViewCell>
 {
   cellToString(cell: SurveyOptionViewCell): string {
-    const pickedThisOption = cell.filter((submission) => submission.selected);
-    return pickedThisOption.length ? pickedThisOption[0].submitted : '';
+    const pickedThisOption = cell?.filter((submission) => submission.selected);
+    return pickedThisOption?.length ? pickedThisOption[0].submitted : '';
   }
 
   getColDef(): Omit<GridColDef<SurveyOptionViewColumn>, 'field'> {
@@ -48,7 +50,7 @@ const Cell: FC<{ cell: SurveyOptionViewCell }> = ({ cell }) => {
   const { openPane } = usePanes();
   const { orgId } = useRouter().query;
 
-  if (!cell.length) {
+  if (!cell?.length) {
     return null;
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -11,17 +11,19 @@ import { FC, useState } from 'react';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
 
-export type SurveyOptionsViewCell = {
-  selected: ZetkinSurveyOption[];
-  submission_id: number;
-  submitted: string;
-}[];
+export type SurveyOptionsViewCell =
+  | {
+      selected: ZetkinSurveyOption[];
+      submission_id: number;
+      submitted: string;
+    }[]
+  | null;
 
 export default class SurveyOptionsColumnType
   implements IColumnType<ZetkinViewColumn, SurveyOptionsViewCell>
 {
   cellToString(cell: SurveyOptionsViewCell): string {
-    return cell.length ? cell[0].selected.map((o) => o.text).toString() : '';
+    return cell?.length ? cell[0].selected.map((o) => o.text).toString() : '';
   }
 
   getColDef(): Omit<GridColDef, 'field'> {
@@ -50,7 +52,7 @@ export default class SurveyOptionsColumnType
     };
   }
   getSearchableStrings(cell: SurveyOptionsViewCell): string[] {
-    return cell.length ? cell[0].selected.map((o) => o.text) : [];
+    return cell?.length ? cell[0].selected.map((o) => o.text) : [];
   }
 }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -66,7 +66,7 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
     return null;
   }
 
-  const sorted = cell.sort((sub0, sub1) => {
+  const sorted = cell.concat().sort((sub0, sub1) => {
     const d0 = new Date(sub0.submitted);
     const d1 = new Date(sub1.submitted);
     return d1.getTime() - d0.getTime();

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -10,18 +10,20 @@ import { usePanes } from 'utils/panes';
 import { useRouter } from 'next/router';
 import ZUIRelativeTime from '../../../../../zui/ZUIRelativeTime';
 
-type SurveySubmittedViewCell = {
-  submission_id: number;
-  submitted: string;
-}[];
+type SurveySubmittedViewCell =
+  | {
+      submission_id: number;
+      submitted: string;
+    }[]
+  | null;
 
 export default class SurveySubmittedColumnType
   implements IColumnType<SurveySubmittedViewColumn, SurveySubmittedViewCell>
 {
   cellToString(cell: SurveySubmittedViewCell): string {
-    return cell.length ? new Date(cell[0].submitted).toLocaleDateString() : '';
+    return cell?.length ? new Date(cell[0].submitted).toLocaleDateString() : '';
   }
-  getColDef(): Omit<GridColDef<SurveySubmittedViewCell>, 'field'> {
+  getColDef(): Omit<GridColDef<NonNullable<SurveySubmittedViewCell>>, 'field'> {
     return {
       renderCell: (params) => {
         return <Cell cell={params.value} />;


### PR DESCRIPTION
## Description
This PR fixes at least two known bugs, and a number of potential (undisclosed) bugs caused by the fact that cells can sometimes be null, which was not handled by many of the column types.

## Screenshots
None

## Changes
* Adds `null` as a valid cell type to all column types
* Adapts all column types to handle the potential `null` values

## Notes to reviewer
The bugs were:

* Trying to download a view with a tag column would often fail
* Some survey columns would cause a crash in live data

## Related issues
Part of #1067 
