### PR TITLE
SurveryURLCard: make copy button responsive

### DIFF
--- a/src/features/surveys/components/SurveyURLCard.tsx
+++ b/src/features/surveys/components/SurveyURLCard.tsx
@@ -35,7 +35,7 @@ const SurveyURLCard = ({ isOpen, orgId, surveyId }: SurveyURLCardProps) => {
         isOpen ? messages.urlCard.nowAccepting() : messages.urlCard.willAccept()
       }
     >
-      <Box display="flex" flexDirection="row" paddingBottom={2}>
+      <Box display="flex" paddingBottom={2}>
         <ZUITextfieldToClipboard
           copyText={`${process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN}o/${orgId}/surveys/${surveyId}`}
         >

--- a/src/zui/ZUITextfieldToClipboard.tsx
+++ b/src/zui/ZUITextfieldToClipboard.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { Msg } from 'core/i18n';
 
 import messageIds from './l10n/messageIds';
+import { TextField } from '@material-ui/core';
 
 const ZUITextfieldToClipboard: React.FunctionComponent<{
   children: React.ReactNode;
@@ -19,17 +20,15 @@ const ZUITextfieldToClipboard: React.FunctionComponent<{
   };
 
   return (
-    <Box display="flex" flexWrap="wrap" gap={1}>
-      <Box
-        alignItems="center"
-        border={1}
-        borderColor="lightgray"
-        borderRadius={1}
-        display="flex"
-        paddingX={1}
-      >
-        {children}
-      </Box>
+    <Box display="flex" gap={1} width="100%">
+      <TextField
+        defaultValue={children}
+        fullWidth
+        InputProps={{
+          readOnly: true,
+        }}
+        variant="outlined"
+      />
       <Button onClick={handleClick} variant="outlined">
         {copied ? (
           <Msg id={messageIds.copyToClipboard.copied} />

--- a/src/zui/ZUITextfieldToClipboard.tsx
+++ b/src/zui/ZUITextfieldToClipboard.tsx
@@ -19,7 +19,7 @@ const ZUITextfieldToClipboard: React.FunctionComponent<{
   };
 
   return (
-    <Box display="flex" gap={1}>
+    <Box display="flex" flexWrap="wrap" gap={1}>
       <Box
         alignItems="center"
         border={1}


### PR DESCRIPTION
## Description
Make sure that the copy button is shown on screen sizes ranging around 1200px wide.

## Screenshots
https://user-images.githubusercontent.com/10441376/224548765-9bcb6a96-ba75-46fd-8e38-9385968f6ec3.mov


## Changes
* Fixes: you can now see the copy button
* Bonus: the (now) read only input field shrinks, and is scroll-able when there's a lot of text or the screen is width is low


## Notes to reviewer
- Video shows result after adding the property


## Related issues
Resolves #1079