### PR TITLE
Issue 1080: Columns scrambled when bulk adding

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -435,9 +435,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           columns={columns}
           onClose={onCreateColumnCancel}
           onSave={async (columns) => {
-            // TODO: Handle these async calls better
-            // (maybe custom API endpoint to bulk create/edit columns?)
-            // HERE WE ARE
             for (const col of columns) {
               await onCreateColumnSave(col);
             }

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -145,7 +145,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const onCreateColumnSave = async (colSpec: SelectedViewColumn) => {
     setColumnToCreate(null);
     try {
-      model.addColumn({
+      await model.addColumn({
         config: colSpec.config,
         title: colSpec.title,
         type: colSpec.type,
@@ -437,6 +437,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           onSave={async (columns) => {
             // TODO: Handle these async calls better
             // (maybe custom API endpoint to bulk create/edit columns?)
+            // HERE WE ARE
             for (const col of columns) {
               await onCreateColumnSave(col);
             }

--- a/src/features/views/repos/ViewDataRepo.ts
+++ b/src/features/views/repos/ViewDataRepo.ts
@@ -43,7 +43,7 @@ export default class ViewDataRepo {
     orgId: number,
     viewId: number,
     data: Omit<ZetkinViewColumn, 'id'>
-  ) {
+  ): Promise<void> {
     const column = await this._apiClient.post<
       ZetkinViewColumn,
       Omit<ZetkinViewColumn, 'id'>


### PR DESCRIPTION
## Description
This PR makes sure that we await server responses for adding columns in bulk, before proceeding to add the next.

## Changes
* Fixes bug that causes the columns to be potentially scrambled when bulk adding to a people view.

## Notes to reviewer
Is it enough to handle the issue client side only?

## Related issues
Resolves #1080
