### PR TITLE
Issue 1027/sub orgs sharing option

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -4,12 +4,6 @@ import { FC, useMemo } from 'react';
 
 import { Box } from '@mui/system';
 import { Link } from '@mui/material';
-import {
-  DataGridPro,
-  GridCellParams,
-  GridRenderCellParams,
-  useGridApiContext,
-} from '@mui/x-data-grid-pro';
 
 import getPeopleSearchResults from 'utils/fetching/getPeopleSearchResults';
 import messageIds from '../l10n/messageIds';
@@ -20,6 +14,12 @@ import { usePanes } from 'utils/panes';
 import ZUIPersonGridCell from 'zui/ZUIPersonGridCell';
 import ZUIPersonGridEditCell from 'zui/ZUIPersonGridEditCell';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+import {
+  DataGridPro,
+  GridCellParams,
+  GridRenderCellParams,
+  useGridApiContext,
+} from '@mui/x-data-grid-pro';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
 

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -1,16 +1,13 @@
-import { useQuery } from 'react-query';
-import { useRouter } from 'next/router';
-import { FC, useMemo } from 'react';
-
 import { Box } from '@mui/system';
-import { Link } from '@mui/material';
-
 import getPeopleSearchResults from 'utils/fetching/getPeopleSearchResults';
+import { Link } from '@mui/material';
 import messageIds from '../l10n/messageIds';
 import SurveySubmissionModel from '../models/SurveySubmissionModel';
 import SurveySubmissionPane from '../panes/SurveySubmissionPane';
 import useModel from 'core/useModel';
 import { usePanes } from 'utils/panes';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
 import ZUIPersonGridCell from 'zui/ZUIPersonGridCell';
 import ZUIPersonGridEditCell from 'zui/ZUIPersonGridEditCell';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
@@ -20,6 +17,7 @@ import {
   GridRenderCellParams,
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
+import { FC, useMemo } from 'react';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
 

--- a/src/features/surveys/components/SurveySuborgsCard.tsx
+++ b/src/features/surveys/components/SurveySuborgsCard.tsx
@@ -1,0 +1,48 @@
+import { ChangeEvent } from 'react';
+import messageIds from '../l10n/messageIds';
+import SurveyDataModel from '../models/SurveyDataModel';
+import { useMessages } from 'core/i18n';
+import useModel from 'core/useModel';
+import ZUICard from 'zui/ZUICard';
+
+import { Box, Switch } from '@mui/material';
+
+const SurveySuborgsCard = ({
+  orgId,
+  surveyId,
+}: {
+  orgId: number;
+  surveyId: number;
+}) => {
+  const messages = useMessages(messageIds);
+  const model = useModel((env) => new SurveyDataModel(env, orgId, surveyId));
+  const { data } = model.getData();
+  const orgAccess = data?.org_access === 'sameorg' ? false : true;
+
+  const handleChange = (ev: ChangeEvent<HTMLInputElement>) => {
+    if (ev.target.checked) {
+      model.updateSurveyAccess('suborgs');
+    } else {
+      model.updateSurveyAccess('sameorg');
+    }
+  };
+
+  return (
+    <Box paddingTop={2}>
+      <ZUICard
+        header={messages.shareSuborgsCard.title()}
+        status={
+          <Switch
+            checked={orgAccess}
+            onChange={(ev) => handleChange(ev)}
+          ></Switch>
+        }
+        subheader={messages.shareSuborgsCard.caption()}
+      >
+        {}
+      </ZUICard>
+    </Box>
+  );
+};
+
+export default SurveySuborgsCard;

--- a/src/features/surveys/components/SurveySuborgsCard.tsx
+++ b/src/features/surveys/components/SurveySuborgsCard.tsx
@@ -1,10 +1,8 @@
-import { ChangeEvent } from 'react';
 import messageIds from '../l10n/messageIds';
 import SurveyDataModel from '../models/SurveyDataModel';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import ZUICard from 'zui/ZUICard';
-
 import { Box, Switch } from '@mui/material';
 
 const SurveySuborgsCard = ({
@@ -19,14 +17,6 @@ const SurveySuborgsCard = ({
   const { data } = model.getData();
   const orgAccess = data?.org_access === 'sameorg' ? false : true;
 
-  const handleChange = (ev: ChangeEvent<HTMLInputElement>) => {
-    if (ev.target.checked) {
-      model.updateSurveyAccess('suborgs');
-    } else {
-      model.updateSurveyAccess('sameorg');
-    }
-  };
-
   return (
     <Box paddingTop={2}>
       <ZUICard
@@ -34,12 +24,16 @@ const SurveySuborgsCard = ({
         status={
           <Switch
             checked={orgAccess}
-            onChange={(ev) => handleChange(ev)}
+            onChange={(ev) =>
+              ev.target.checked
+                ? model.updateSurveyAccess('suborgs')
+                : model.updateSurveyAccess('sameorg')
+            }
           ></Switch>
         }
         subheader={messages.shareSuborgsCard.caption()}
       >
-        {}
+        <></>
       </ZUICard>
     </Box>
   );

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -77,6 +77,12 @@ export default makeMessages('feat.surveys', {
       title: m('There are no questions in this survey yet'),
     },
   },
+  shareSuborgsCard: {
+    caption: m(
+      'When this is enabled, officials in sub-organizations can read and search surveys submitted by people connected to their organization.'
+    ),
+    title: m('Share with suborganizations'),
+  },
   state: {
     draft: m('Draft'),
     published: m('Published'),

--- a/src/features/surveys/models/SurveyDataModel.spec.ts
+++ b/src/features/surveys/models/SurveyDataModel.spec.ts
@@ -52,6 +52,7 @@ describe('SurveyDataModel', () => {
             expires: expires,
             id: 1,
             info_text: 'Semla',
+            org_access: 'sameorg',
             organization: {
               id: 1,
               title: 'Semla lovers',

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -239,7 +239,7 @@ export default class SurveyDataModel extends ModelBase {
     );
   }
 
-  updateSurveyAccess(access: string) {
+  updateSurveyAccess(access: 'sameorg' | 'suborgs') {
     this._repo.updateSurvey(this._orgId, this._surveyId, {
       org_access: access,
     });

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -239,6 +239,12 @@ export default class SurveyDataModel extends ModelBase {
     );
   }
 
+  updateSurveyAccess(access: string) {
+    this._repo.updateSurvey(this._orgId, this._surveyId, {
+      org_access: access,
+    });
+  }
+
   updateTextBlock(
     elemId: number,
     textBlock: ZetkinSurveyTextElement['text_block']

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/submissions.tsx
@@ -1,9 +1,11 @@
 import { GetServerSideProps } from 'next';
+import { Grid } from '@mui/material';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SurveyLayout from 'features/surveys/layout/SurveyLayout';
 import SurveySubmissionsList from 'features/surveys/components/SurveySubmissionsList';
 import SurveySubmissionsModel from 'features/surveys/models/SurveySubmissionsModel';
+import SurveySuborgsCard from 'features/surveys/components/SurveySuborgsCard';
 import useModel from 'core/useModel';
 import ZUIFuture from 'zui/ZUIFuture';
 
@@ -43,7 +45,19 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
   return (
     <ZUIFuture future={subsModel.getSubmissions()}>
       {(data) => {
-        return <SurveySubmissionsList submissions={data} />;
+        return (
+          <Grid container spacing={2}>
+            <Grid item md={8} sm={12} xs={12}>
+              <SurveySubmissionsList submissions={data} />
+            </Grid>
+            <Grid item md={4} sm={12} xs={12}>
+              <SurveySuborgsCard
+                orgId={parseInt(orgId)}
+                surveyId={parseInt(surveyId)}
+              />
+            </Grid>
+          </Grid>
+        );
       }}
     </ZUIFuture>
   );

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -174,6 +174,7 @@ export interface ZetkinSurvey {
   callers_only: boolean;
   published: string | null;
   expires: string | null;
+  org_access: string;
 }
 
 export interface ZetkinSurveyExtended extends ZetkinSurvey {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -174,7 +174,7 @@ export interface ZetkinSurvey {
   callers_only: boolean;
   published: string | null;
   expires: string | null;
-  org_access: string;
+  org_access: 'sameorg' | 'suborgs';
 }
 
 export interface ZetkinSurveyExtended extends ZetkinSurvey {


### PR DESCRIPTION
## Description
This PR adds a card in the submissions page to allow the survey to be shared with sub-organizations or not.


## Screenshots
![image](https://user-images.githubusercontent.com/36491300/225117235-8ce0a3d3-b36c-406d-8f3d-9a1c71a6f977.png)


## Changes
* Adds `SurveySuborgsCard `component
* Adds a new property called `org_access `to `ZetkinSurvey `interface 
* Adds `org_access `new property to `SurveyDataModel `test.
* Adds a new method to update the value of `org_access `in surveys submissions. The method is called `updateSurveyAccess`
* Adds the necessary strings to be localized in messageIds file


## Notes to reviewer

## Related issues
Resolves #1027 
