### PR TITLE
Issue 1067/fix organize page & home icon redirection

### DIFF
--- a/src/pages/organize/index.tsx
+++ b/src/pages/organize/index.tsx
@@ -1,7 +1,7 @@
-import DefaultLayout from 'utils/layout/DefaultLayout';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import messageIds from 'features/organizations/l10n/messageIds';
+import NoMenuLayout from 'utils/layout/NoMenuLayout';
 import OrganizationsDataModel from 'features/organizations/models/OrganizationsDataModel';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
@@ -37,7 +37,7 @@ const OrganizePage: PageWithLayout = () => {
 };
 
 OrganizePage.getLayout = function getLayout(page) {
-  return <DefaultLayout>{page}</DefaultLayout>;
+  return <NoMenuLayout>{page}</NoMenuLayout>;
 };
 
 export default OrganizePage;

--- a/src/utils/layout/NoMenuLayout.tsx
+++ b/src/utils/layout/NoMenuLayout.tsx
@@ -1,0 +1,43 @@
+import { Box } from '@mui/material';
+import { FunctionComponent } from 'react';
+
+import makeStyles from '@mui/styles/makeStyles';
+import ZUIOrganizeSidebarNoMenu from 'zui/ZUIOrganizeSidebarNoMenu';
+
+const useStyles = makeStyles((theme) => ({
+  breadcrumbs: {
+    [theme.breakpoints.down('sm')]: {
+      width: '100%',
+    },
+  },
+  root: {
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: '3.5rem',
+    },
+  },
+}));
+
+interface NoMenuLayoutProps {
+  children?: React.ReactNode;
+}
+
+const NoMenuLayout: FunctionComponent<NoMenuLayoutProps> = ({ children }) => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.root} display="flex" height="100vh">
+      <ZUIOrganizeSidebarNoMenu />
+      <Box
+        display="flex"
+        flexDirection="column"
+        height="100vh"
+        overflow="auto"
+        position="relative"
+        width={1}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+};
+
+export default NoMenuLayout;

--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -101,7 +101,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
             </NextLink>
           </ListItem>
           <ListItem disableGutters>
-            <NextLink href={`/organize/${orgId}`} passHref>
+            <NextLink href="/organize/" passHref>
               <IconButton
                 aria-label="Home"
                 className={classes.roundButton}

--- a/src/zui/ZUIOrganizeSidebarNoMenu.tsx
+++ b/src/zui/ZUIOrganizeSidebarNoMenu.tsx
@@ -1,0 +1,147 @@
+import makeStyles from '@mui/styles/makeStyles';
+import { Menu } from '@mui/icons-material/';
+import NextLink from 'next/link';
+import { useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import {
+  AppBar,
+  Box,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  Toolbar,
+} from '@mui/material';
+
+import ZUILogo from './ZUILogo';
+
+const drawerWidth = '5rem';
+
+const useStyles = makeStyles((theme) => ({
+  appBar: {
+    [theme.breakpoints.up('sm')]: {
+      display: 'none',
+    },
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+  },
+  drawer: {
+    [theme.breakpoints.up('sm')]: {
+      flexShrink: 0,
+      width: drawerWidth,
+    },
+  },
+  drawerPaper: {
+    display: 'none',
+    width: drawerWidth,
+    [theme.breakpoints.up('sm')]: {
+      display: 'block',
+    },
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      display: 'none',
+    },
+  },
+  root: {
+    display: 'flex',
+  },
+  roundButton: {
+    background: 'white',
+    borderRadius: '50%',
+    height: '3rem',
+    width: '3rem',
+  },
+  // necessary for content to be below app bar
+  toolbar: theme.mixins.toolbar,
+}));
+
+const ZUIOrganizeSidebarNoMenu = (): JSX.Element => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const drawer = (
+    <Box
+      alignItems="center"
+      data-testid="organize-sidebar"
+      display="flex"
+      flexDirection="column"
+      height="100%"
+      justifyContent="space-between"
+    >
+      <List disablePadding>
+        <Box display="flex" flexDirection="column">
+          <ListItem disableGutters>
+            <NextLink href="/organize" passHref>
+              <IconButton
+                aria-label="Home"
+                className={classes.roundButton}
+                color={'primary'}
+                data-test="logo-button"
+                size="large"
+                style={{ marginBottom: '2rem' }}
+              >
+                <ZUILogo htmlColor="#ED1C55" size={40} />
+              </IconButton>
+            </NextLink>
+          </ListItem>
+        </Box>
+      </List>
+    </Box>
+  );
+
+  return (
+    <div className={classes.root}>
+      <AppBar className={classes.appBar} position="fixed">
+        <Toolbar>
+          <IconButton
+            aria-label="open drawer"
+            className={classes.menuButton}
+            color="inherit"
+            edge="start"
+            onClick={handleDrawerToggle}
+            size="large"
+          >
+            <Menu data-test="menu-button" />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <nav aria-label="mailbox folders" className={classes.drawer}>
+        <Drawer
+          anchor={theme.direction === 'rtl' ? 'right' : 'left'}
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          ModalProps={{
+            keepMounted: true, // Better open performance on mobile.
+          }}
+          onClose={handleDrawerToggle}
+          open={mobileOpen}
+          variant="temporary"
+        >
+          {drawer}
+        </Drawer>
+
+        <Drawer
+          classes={{
+            paper: classes.drawerPaper,
+          }}
+          open
+          variant="permanent"
+        >
+          {drawer}
+        </Drawer>
+      </nav>
+    </div>
+  );
+};
+
+export default ZUIOrganizeSidebarNoMenu;


### PR DESCRIPTION
## Description
This PR removes the menu from the /organize landing page and also changes the Home icon menu to redirect to /organize page (instead of /organize/{orgId})


## Screenshots
![image](https://user-images.githubusercontent.com/36491300/225327223-007edbba-ae2a-4d3c-b7e9-5d4598802633.png)


## Changes
* Adds new `NoMenuLayout `to display pages without menu
* Adds new `ZUIOrganizeSideBarNoMenu `component (sidebar without menu, only Zetkin logo)
* Changes link of Home menu icon to go to /organize page


## Notes to reviewer
None

## Related issues
Resolves #1067 
