### PR TITLE
Issue 1077/confirmation dialog

### DIFF
--- a/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
+++ b/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
@@ -32,8 +32,8 @@ const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({ element, model }) => {
           ev.stopPropagation();
           showConfirmDialog({
             onSubmit: () => model.deleteElement(element.id),
-            title: messages.blocks.deleteDialog.deleteBlock.title(),
-            warningText: messages.blocks.deleteDialog.deleteBlock.warningText(),
+            title: messages.blocks.deleteBlockDialog.title(),
+            warningText: messages.blocks.deleteBlockDialog.warningText(),
           });
         }}
       >

--- a/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
+++ b/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
@@ -17,10 +17,6 @@ const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({ element, model }) => {
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const messages = useMessages(messageIds);
 
-  const onClickDelete = () => {
-    model.deleteElement(element.id);
-  };
-
   return (
     <Box display="flex">
       <IconButton
@@ -35,9 +31,9 @@ const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({ element, model }) => {
         onClick={(ev) => {
           ev.stopPropagation();
           showConfirmDialog({
-            onSubmit: onClickDelete,
-            title: messages.blocks.deleteDialog.title(),
-            warningText: messages.blocks.deleteDialog.warningText(),
+            onSubmit: () => model.deleteElement(element.id),
+            title: messages.blocks.deleteDialog.deleteBlock.title(),
+            warningText: messages.blocks.deleteDialog.deleteBlock.warningText(),
           });
         }}
       >

--- a/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
+++ b/src/features/surveys/components/SurveyEditor/DeleteHideButtons.tsx
@@ -1,9 +1,12 @@
-import { FC } from 'react';
 import { Box, IconButton } from '@mui/material';
 import { Delete, RemoveRedEye } from '@mui/icons-material';
+import { FC, useContext } from 'react';
 
+import messageIds from 'features/surveys/l10n/messageIds';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
+import { useMessages } from 'core/i18n';
 import { ZetkinSurveyElement } from 'utils/types/zetkin';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 
 interface DeleteHideButtonsProps {
   element: ZetkinSurveyElement;
@@ -11,6 +14,13 @@ interface DeleteHideButtonsProps {
 }
 
 const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({ element, model }) => {
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+  const messages = useMessages(messageIds);
+
+  const onClickDelete = () => {
+    model.deleteElement(element.id);
+  };
+
   return (
     <Box display="flex">
       <IconButton
@@ -23,8 +33,12 @@ const DeleteHideButtons: FC<DeleteHideButtonsProps> = ({ element, model }) => {
       </IconButton>
       <IconButton
         onClick={(ev) => {
-          model.deleteElement(element.id);
           ev.stopPropagation();
+          showConfirmDialog({
+            onSubmit: onClickDelete,
+            title: messages.blocks.deleteDialog.title(),
+            warningText: messages.blocks.deleteDialog.warningText(),
+          });
         }}
       >
         <Delete />

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useContext, useEffect, useRef, useState } from 'react';
 
 import DeleteHideButtons from '../DeleteHideButtons';
 import DropdownIcon from 'zui/icons/DropDown';
@@ -25,6 +25,7 @@ import PreviewableSurveyInput from '../elements/PreviewableSurveyInput';
 import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import useEditPreviewBlock from './useEditPreviewBlock';
 import { ZetkinSurveyOptionsQuestionElement } from 'utils/types/zetkin';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
 import ZUIReorderable from 'zui/ZUIReorderable';
 import { Msg, useMessages } from 'core/i18n';
@@ -123,6 +124,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
     // deleted when bulk adding.
     return !bulkAddingOptions || !!option.text.length;
   });
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
 
   return (
     <ClickAwayListener {...clickAwayProps}>
@@ -220,7 +222,14 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
                     />
                     <IconButton
                       onClick={() => {
-                        model.deleteElementOption(element.id, option.id);
+                        showConfirmDialog({
+                          onSubmit: () =>
+                            model.deleteElementOption(element.id, option.id),
+                          title:
+                            messages.blocks.deleteDialog.deleteQuestionOpt.title(),
+                          warningText:
+                            messages.blocks.deleteDialog.deleteQuestionOpt.warningText(),
+                        });
                       }}
                       sx={{ paddingX: 2 }}
                     >

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -225,10 +225,9 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
                         showConfirmDialog({
                           onSubmit: () =>
                             model.deleteElementOption(element.id, option.id),
-                          title:
-                            messages.blocks.deleteDialog.deleteQuestionOpt.title(),
+                          title: messages.blocks.deleteOptionDialog.title(),
                           warningText:
-                            messages.blocks.deleteDialog.deleteQuestionOpt.warningText(),
+                            messages.blocks.deleteOptionDialog.warningText(),
                         });
                       }}
                       sx={{ paddingX: 2 }}

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -30,19 +30,17 @@ export default makeMessages('feat.surveys', {
         select: m('Single-choice (drop-down)'),
       },
     },
-    deleteDialog: {
-      deleteBlock: {
-        title: m('Delete question'),
-        warningText: m(
-          'Are you sure you want to delete this question? This action is permanent and cannot be undone.'
-        ),
-      },
-      deleteQuestionOpt: {
-        title: m('Delete option'),
-        warningText: m(
-          'Are you sure you want to delete this option? This action is permanent and cannot be undone.'
-        ),
-      },
+    deleteBlockDialog: {
+      title: m('Delete question'),
+      warningText: m(
+        'Are you sure you want to delete this question? This action is permanent and cannot be undone.'
+      ),
+    },
+    deleteOptionDialog: {
+      title: m('Delete option'),
+      warningText: m(
+        'Are you sure you want to delete this option? This action is permanent and cannot be undone.'
+      ),
     },
     open: {
       description: m('Description'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -30,6 +30,12 @@ export default makeMessages('feat.surveys', {
         select: m('Single-choice (drop-down)'),
       },
     },
+    deleteDialog: {
+      title: m('Delete question'),
+      warningText: m(
+        'Are you sure you want to delete this question? This action is permanent and cannot be undone.'
+      ),
+    },
     open: {
       description: m('Description'),
       empty: m('Untitled open question'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -31,10 +31,18 @@ export default makeMessages('feat.surveys', {
       },
     },
     deleteDialog: {
-      title: m('Delete question'),
-      warningText: m(
-        'Are you sure you want to delete this question? This action is permanent and cannot be undone.'
-      ),
+      deleteBlock: {
+        title: m('Delete question'),
+        warningText: m(
+          'Are you sure you want to delete this question? This action is permanent and cannot be undone.'
+        ),
+      },
+      deleteQuestionOpt: {
+        title: m('Delete option'),
+        warningText: m(
+          'Are you sure you want to delete this option? This action is permanent and cannot be undone.'
+        ),
+      },
     },
     open: {
       description: m('Description'),

--- a/src/zui/ZUISubmitCancelButtons.tsx
+++ b/src/zui/ZUISubmitCancelButtons.tsx
@@ -13,7 +13,12 @@ const ZUISubmitCancelButtons: React.FunctionComponent<{
   return (
     <Box display="flex" justifyContent="flex-end" mt={2} width={1}>
       <Box m={1}>
-        <Button color="primary" onClick={onCancel}>
+        <Button
+          color="primary"
+          onClick={(ev) => {
+            ev.stopPropagation(), onCancel();
+          }}
+        >
           <Msg id={messageIds.submitOrCancel.cancel} />
         </Button>
       </Box>
@@ -22,6 +27,7 @@ const ZUISubmitCancelButtons: React.FunctionComponent<{
           color="primary"
           data-testid="SubmitCancelButtons-submitButton"
           disabled={submitDisabled}
+          onClick={(ev) => ev.stopPropagation()}
           type="submit"
           variant="contained"
           {...submitButtonProps}

--- a/src/zui/ZUISubmitCancelButtons.tsx
+++ b/src/zui/ZUISubmitCancelButtons.tsx
@@ -16,7 +16,8 @@ const ZUISubmitCancelButtons: React.FunctionComponent<{
         <Button
           color="primary"
           onClick={(ev) => {
-            ev.stopPropagation(), onCancel();
+            ev.stopPropagation();
+            onCancel();
           }}
         >
           <Msg id={messageIds.submitOrCancel.cancel} />


### PR DESCRIPTION
## Description
This PR implements confirmation dialog when user clicks the `trashcan` icon or `X` icon in question blocks.


## Screenshots



https://user-images.githubusercontent.com/77925373/225337078-e232d964-4ac2-41d2-a3bc-d7d77e98f3dd.mp4


## Changes

* Adds showConfirmDialog to `<Close>` Icon
* Adds showConfirmDialog to `<Delete>` Icon
* Adds stopPropagation to stop onClickAway


## Notes to reviewer
The data was restored after clicks the `delete` or `close` button. So I checked the Redux, and figured it out that `save()` in `useEditPreviewBlock` was triggered because clicking `cancel` and `confirm` button counts as click away.
So I added stopPropagation to buttons!


## Related issues
Resolves #1077 
