### PR TITLE
Submission pane height

### DIFF
--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -111,7 +111,6 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
           flexGrow={1}
           minHeight={0}
           p={fixedHeight ? 0 : 3}
-          position="relative"
           role="tabpanel"
         >
           <PaneProvider>{children}</PaneProvider>

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
     bottom: 16,
     position: 'absolute',
     right: 16,
-    top: 16,
+    top: '30vh',
     zIndex: 10,
   },
   paper: {

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles({
     zIndex: 10,
   },
   paper: {
-    height: '100%',
+    height: 'calc(100vh - 32vh)',
   },
 });
 


### PR DESCRIPTION
## Description
This PR fix the submission pane's height that was not responsive to window height but page height.


## Screenshots
![sizeFix](https://user-images.githubusercontent.com/77925373/225597447-488ab5dd-4c4f-4a89-be2d-663872cba284.gif)



## Changes
* Changes top 16 to 30vh
* Changes height of paper so it can be changeable depends on window's height


## Notes to reviewer
Does it look okay with top 30vh?


## Related issues
Part of #1067 
