### PR TITLE
Change End assignment button to secondary/outlined

### DIFF
--- a/src/features/callAssignments/layout/CallAssignmentLayout.tsx
+++ b/src/features/callAssignments/layout/CallAssignmentLayout.tsx
@@ -46,7 +46,7 @@ const CallAssignmentLayout: React.FC<CallAssignmentLayoutProps> = ({
       actionButtons={
         model.state == CallAssignmentState.OPEN ||
         model.state == CallAssignmentState.ACTIVE ? (
-          <Button onClick={() => model.end()} variant="contained">
+          <Button onClick={() => model.end()} variant="outlined">
             <Msg id={messageIds.actions.end} />
           </Button>
         ) : (


### PR DESCRIPTION
## Description
This PR changes the End assignment button to use the secondary/outlined button style.

## Screenshots
![Skärmavbild 2023-03-16 kl  15 31 26](https://user-images.githubusercontent.com/50528622/225650538-ead96a51-a00c-4f06-8871-4bb6639b5802.png)

## Changes
* Changes End assignment button to use secondary button style

## Related issues
Resolves #1004 
