### PR TITLE
Survey readonly mode

### DIFF
--- a/src/features/calendar/components/MonthCalendar/index.tsx
+++ b/src/features/calendar/components/MonthCalendar/index.tsx
@@ -128,7 +128,7 @@ const MonthCalendar = ({
       <Box display="flex" mr={0.5}>
         {campaigns.map((c) => {
           const campaignEvents = events
-            .filter((e) => e.campaign.id === c.id)
+            .filter((e) => e.campaign?.id === c.id)
             .sort((a, b) => {
               return (
                 new Date(a.start_time).getTime() -
@@ -198,7 +198,7 @@ const MonthCalendar = ({
               >
                 {tasksAndEvents.map((item, i) => {
                   const campaign = campaigns.find(
-                    (c) => c.id === item.data.campaign.id
+                    (c) => c.id === item.data.campaign?.id
                   );
                   return (
                     <React.Fragment key={i}>
@@ -246,7 +246,7 @@ const MonthCalendar = ({
                       >
                         {tasksAndEvents.map((item, i) => {
                           const campaign = campaigns.find(
-                            (c) => c.id === item.data.campaign.id
+                            (c) => c.id === item.data.campaign?.id
                           );
                           return (
                             <React.Fragment key={i}>

--- a/src/features/calendar/components/WeekCalendar/index.tsx
+++ b/src/features/calendar/components/WeekCalendar/index.tsx
@@ -156,7 +156,7 @@ const WeekCalendar = ({
         <Box display="flex" flexDirection="column" mb={0.5}>
           {campaigns.map((c) => {
             const campaignEvents = events
-              .filter((e) => e.campaign.id === c.id)
+              .filter((e) => e.campaign?.id === c.id)
               .sort((a, b) => {
                 return (
                   new Date(a.start_time).getTime() -
@@ -286,7 +286,7 @@ const WeekCalendar = ({
                     .map((eventWithShiftValue) => {
                       const [shiftValue, event] = eventWithShiftValue;
                       const campaign = campaigns.find(
-                        (c) => c.id === event.campaign.id
+                        (c) => c.id === event.campaign?.id
                       );
                       return (
                         <WeekCalendarEvent

--- a/src/features/campaigns/components/CampaignCard.tsx
+++ b/src/features/campaigns/components/CampaignCard.tsx
@@ -26,7 +26,7 @@ const CampaignCard = ({ campaign, events }: CampaignCardProps): JSX.Element => {
   const { id, title } = campaign;
 
   const campaignEvents = events.filter(
-    (event) => event.campaign.id === campaign.id
+    (event) => event.campaign?.id === campaign.id
   );
   const numOfUpcomingEvents = campaignEvents.filter((event) =>
     dayjs(removeOffset(event.end_time)).isAfter(dayjs())

--- a/src/features/surveys/components/EditWarningCard.tsx
+++ b/src/features/surveys/components/EditWarningCard.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react';
+import { Box, Button } from '@mui/material';
+import { Lock, LockOpen } from '@mui/icons-material';
+
+import messageIds from '../l10n/messageIds';
+import { useMessages } from 'core/i18n';
+import ZUICard from 'zui/ZUICard';
+
+type EditWarningCardProps = {
+  editing: boolean;
+  onToggle: (newValue: boolean) => void;
+};
+
+const EditWarningCard: FC<EditWarningCardProps> = ({ editing, onToggle }) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <ZUICard
+      header={
+        editing
+          ? messages.editWarning.editing.header()
+          : messages.editWarning.locked.header()
+      }
+      status={editing ? <LockOpen color="warning" /> : <Lock color="success" />}
+      subheader={
+        editing
+          ? messages.editWarning.editing.subheader()
+          : messages.editWarning.locked.subheader()
+      }
+    >
+      <Box>
+        <Button onClick={() => onToggle(!editing)} variant="outlined">
+          {editing
+            ? messages.editWarning.editing.lockButton()
+            : messages.editWarning.locked.unlockButton()}
+        </Button>
+      </Box>
+    </ZUICard>
+  );
+};
+
+export default EditWarningCard;

--- a/src/features/surveys/components/EditWarningCard.tsx
+++ b/src/features/surveys/components/EditWarningCard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
-import { Box, Button } from '@mui/material';
-import { Lock, LockOpen } from '@mui/icons-material';
+import { Box, Button, Typography } from '@mui/material';
+import { Lock, LockOpen, ThumbDown, ThumbUp } from '@mui/icons-material';
 
 import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
@@ -34,8 +34,50 @@ const EditWarningCard: FC<EditWarningCardProps> = ({ editing, onToggle }) => {
             ? messages.editWarning.editing.lockButton()
             : messages.editWarning.locked.unlockButton()}
         </Button>
+        {editing && (
+          <Box marginTop={3}>
+            <EditTips
+              bullets={[
+                messages.editWarning.editing.safe.bullet1(),
+                messages.editWarning.editing.safe.bullet2(),
+                messages.editWarning.editing.safe.bullet3(),
+                messages.editWarning.editing.safe.bullet4(),
+              ]}
+              header={messages.editWarning.editing.safe.header()}
+              icon={<ThumbUp color="success" />}
+            />
+            <EditTips
+              bullets={[
+                messages.editWarning.editing.unsafe.bullet1(),
+                messages.editWarning.editing.unsafe.bullet2(),
+              ]}
+              header={messages.editWarning.editing.unsafe.header()}
+              icon={<ThumbDown color="warning" />}
+            />
+          </Box>
+        )}
       </Box>
     </ZUICard>
+  );
+};
+
+const EditTips: FC<{
+  bullets: string[];
+  header: string;
+  icon: JSX.Element;
+}> = ({ bullets, header, icon }) => {
+  return (
+    <Box display="flex" gap={2} marginTop={1}>
+      <Box>{icon}</Box>
+      <Box>
+        <Typography fontWeight="bold">{header}</Typography>
+        <ul style={{ marginTop: 0, paddingLeft: 16 }}>
+          {bullets.map((bullet) => (
+            <li key={bullet}>{bullet}</li>
+          ))}
+        </ul>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -35,6 +35,7 @@ interface ChoiceQuestionBlockProps {
   model: SurveyDataModel;
   onEditModeEnter: () => void;
   onEditModeExit: () => void;
+  readOnly: boolean;
 }
 
 const widgetTypes = {
@@ -60,6 +61,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   model,
   onEditModeEnter,
   onEditModeExit,
+  readOnly,
 }) => {
   const elemQuestion = element.question;
   const messages = useMessages(messageIds);
@@ -104,6 +106,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
       editable,
       onEditModeEnter,
       onEditModeExit,
+      readOnly,
       save: () => {
         model.updateOptionsQuestion(element.id, {
           question: {
@@ -337,7 +340,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
               </>
             )}
           </Box>
-          <DeleteHideButtons element={element} model={model} />
+          {!readOnly && <DeleteHideButtons element={element} model={model} />}
         </Box>
       </Box>
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -71,7 +71,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   const [description, setDescription] = useState(elemQuestion.description);
   const [options, setOptions] = useState(elemQuestion.options || []);
   const [widgetType, setWidgetType] = useState<WidgetTypeValue>(
-    elemQuestion.response_config.widget_type
+    elemQuestion.response_config.widget_type || 'checkbox'
   );
 
   useEffect(() => {

--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -25,6 +25,7 @@ interface OpenQuestionBlockProps {
   model: SurveyDataModel;
   onEditModeEnter: () => void;
   onEditModeExit: () => void;
+  readOnly: boolean;
 }
 
 enum FIELDTYPE {
@@ -38,6 +39,7 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
   model,
   onEditModeEnter,
   onEditModeExit,
+  readOnly,
 }) => {
   const elemQuestion = element.question;
   const messages = useMessages(messageIds);
@@ -63,6 +65,7 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
       editable,
       onEditModeEnter,
       onEditModeExit,
+      readOnly,
       save: () => {
         model.updateOpenQuestionBlock(element.id, {
           question: {
@@ -153,7 +156,7 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
           value=""
         />
         <Box display="flex" justifyContent="end" m={2}>
-          <DeleteHideButtons element={element} model={model} />
+          {!readOnly && <DeleteHideButtons element={element} model={model} />}
         </Box>
       </Box>
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -16,6 +16,7 @@ interface TextBlockProps {
   model: SurveyDataModel;
   onEditModeEnter: () => void;
   onEditModeExit: () => void;
+  readOnly: boolean;
 }
 
 const TextBlock: FC<TextBlockProps> = ({
@@ -24,6 +25,7 @@ const TextBlock: FC<TextBlockProps> = ({
   model,
   onEditModeEnter,
   onEditModeExit,
+  readOnly,
 }) => {
   const messages = useMessages(messageIds);
 
@@ -35,6 +37,7 @@ const TextBlock: FC<TextBlockProps> = ({
       editable,
       onEditModeEnter,
       onEditModeExit,
+      readOnly,
       save: () => {
         model.updateElement(element.id, {
           text_block: {
@@ -66,7 +69,7 @@ const TextBlock: FC<TextBlockProps> = ({
           variant="content"
         />
         <Box display="flex" justifyContent="end" m={2}>
-          <DeleteHideButtons element={element} model={model} />
+          {!readOnly && <DeleteHideButtons element={element} model={model} />}
         </Box>
       </Box>
     </ClickAwayListener>

--- a/src/features/surveys/components/SurveyEditor/blocks/useEditPreviewBlock.ts
+++ b/src/features/surveys/components/SurveyEditor/blocks/useEditPreviewBlock.ts
@@ -6,21 +6,26 @@ type UseEditPreviewBlockProps = {
   editable: boolean;
   onEditModeEnter: () => void;
   onEditModeExit: () => void;
+  readOnly?: boolean;
   save: () => void;
 };
 
 export default function useEditPreviewBlock({
   editable,
-  save,
   onEditModeEnter,
   onEditModeExit,
+  readOnly,
+  save,
 }: UseEditPreviewBlockProps) {
   const [autoFocusDefault, setAutoFocusDefault] = useState(true);
 
   const handleSwitchMode = (newMode: ZUIPreviewableMode) => {
     if (newMode == ZUIPreviewableMode.EDITABLE) {
-      setAutoFocusDefault(false);
-      onEditModeEnter();
+      if (!readOnly) {
+        // Only allow switching if we're not in read-only mode.
+        setAutoFocusDefault(false);
+        onEditModeEnter();
+      }
     } else {
       onEditModeExit();
     }
@@ -38,7 +43,7 @@ export default function useEditPreviewBlock({
     },
     containerProps: {
       onClick: () => {
-        if (!editable) {
+        if (!editable && !readOnly) {
           setAutoFocusDefault(true);
           onEditModeEnter();
         }

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -18,9 +18,10 @@ import {
 
 interface SurveyEditorProps {
   model: SurveyDataModel;
+  readOnly: boolean;
 }
 
-const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
+const SurveyEditor: FC<SurveyEditorProps> = ({ model, readOnly }) => {
   const [idOfBlockInEditMode, setIdOfBlockInEditMode] = useState<
     number | undefined
   >();
@@ -53,6 +54,8 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
           return (
             <Box paddingBottom={data.elements.length ? 4 : 0}>
               <ZUIReorderable
+                disableClick={readOnly}
+                disableDrag={readOnly}
                 items={data.elements.map((elem) => ({
                   id: elem.id,
                   renderContent: ({ dragging }) => {
@@ -74,6 +77,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                               onEditModeExit={() => {
                                 setIdOfBlockInEditMode(undefined);
                               }}
+                              readOnly={readOnly}
                             />
                           </BlockWrapper>
                         );
@@ -98,6 +102,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                               onEditModeExit={() => {
                                 setIdOfBlockInEditMode(undefined);
                               }}
+                              readOnly={readOnly}
                             />
                           </BlockWrapper>
                         );
@@ -119,6 +124,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
                             onEditModeExit={() => {
                               setIdOfBlockInEditMode(undefined);
                             }}
+                            readOnly={readOnly}
                           />
                         </BlockWrapper>
                       );
@@ -136,7 +142,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model }) => {
           );
         }}
       </ZUIFuture>
-      <AddBlocks model={model} />
+      {!readOnly && <AddBlocks model={model} />}
     </>
   );
 };

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -57,6 +57,20 @@ export default makeMessages('feat.surveys', {
       ),
     },
   },
+  editWarning: {
+    editing: {
+      header: m('Survey unlocked'),
+      lockButton: m('Lock'),
+      subheader: m('Be careful editing the survey'),
+    },
+    locked: {
+      header: m('Survey locked'),
+      subheader: m(
+        'This survey has started receiving submissions. Editing the survey now may cause problems with the data. Proceed with caution.'
+      ),
+      unlockButton: m('Unlock'),
+    },
+  },
   layout: {
     actions: {
       publish: m('Publish survey'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -59,9 +59,25 @@ export default makeMessages('feat.surveys', {
   },
   editWarning: {
     editing: {
-      header: m('Survey unlocked'),
+      header: m('Survey can be edited'),
       lockButton: m('Lock'),
-      subheader: m('Be careful editing the survey'),
+      safe: {
+        bullet1: m('Fixing spelling mistakes'),
+        bullet2: m('Reordering blocks'),
+        bullet3: m('Hiding questions'),
+        bullet4: m('Adding questions or options'),
+        header: m('Safe'),
+      },
+      subheader: m(
+        'Be careful not to make changes that may cause response data to be lost or corrupted.'
+      ),
+      unsafe: {
+        bullet1: m('Deleting questions (hide instead)'),
+        bullet2: m(
+          'Renaming questions or options in ways that change their meaning'
+        ),
+        header: m('Unsafe'),
+      },
     },
     locked: {
       header: m('Survey locked'),

--- a/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
+++ b/src/pages/organize/[orgId]/campaigns/[campId]/surveys/[surveyId]/questions.tsx
@@ -8,6 +8,7 @@ import SurveyDataModel from 'features/surveys/models/SurveyDataModel';
 import SurveyEditor from 'features/surveys/components/SurveyEditor';
 import SurveyLayout from 'features/surveys/layout/SurveyLayout';
 import useModel from 'core/useModel';
+import ZUIFuture from 'zui/ZUIFuture';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -46,9 +47,18 @@ const QuestionsPage: PageWithLayout<QuestionsPageProps> = ({
       <Head>
         <title>{model.getData().data?.title}</title>
       </Head>
-      <Box>
-        <SurveyEditor model={model} />
-      </Box>
+      <ZUIFuture future={model.getStats()}>
+        {(stats) => {
+          return (
+            <Box>
+              <SurveyEditor
+                model={model}
+                readOnly={stats.submissionCount > 0}
+              />
+            </Box>
+          );
+        }}
+      </ZUIFuture>
     </>
   );
 };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -65,7 +65,7 @@ export interface ZetkinEvent {
   campaign: {
     id: number;
     title: string;
-  };
+  } | null;
   contact?: string | null;
   end_time: string;
   id: number;
@@ -250,7 +250,7 @@ export interface ZetkinOptionsQuestion {
   question: string;
   required: boolean;
   response_config: {
-    widget_type: 'checkbox' | 'radio' | 'select';
+    widget_type?: 'checkbox' | 'radio' | 'select';
   };
   response_type: RESPONSE_TYPE.OPTIONS;
 }


### PR DESCRIPTION
## Description
This PR implements the survey read-only mode as described in the #999 epic.

## Screenshots

### Locked
<img width="1464" alt="image" src="https://user-images.githubusercontent.com/550212/225999592-3e4a657e-2007-4e8d-9093-405a82cbb7a5.png">

### Unlocked
<img width="1464" alt="image" src="https://user-images.githubusercontent.com/550212/225999647-97fe9490-37b3-4177-960f-f4efc9533de9.png">


## Changes
* Fixes some type issues in old code that was preventing me from using the data I had locally
* Adds a `readOnly` property to `SurveyEditor`, which disables all editing features
* Adds a new `EditWarningCard` component
* Puts editor in read-only mode and shows edit warning when a survey has received submissions

## Notes to reviewer
I took some creative liberty, and reused the `<ZUICard>` instead of creating a new custom design pattern for the card.

## Related issues
Resolves #1000 
Resolves #1001 