### PR TITLE
Set statistics as stale after linking a submission.

### DIFF
--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -195,6 +195,7 @@ const surveysSlice = createSlice({
       state.statsBySurveyId[surveyId].data = stats;
       state.statsBySurveyId[surveyId].isLoading = false;
       state.statsBySurveyId[surveyId].loaded = new Date().toISOString();
+      state.statsBySurveyId[surveyId].isStale = false;
     },
     submissionLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
@@ -261,6 +262,7 @@ const surveysSlice = createSlice({
       if (item) {
         item.data = { ...item.data, ...submission };
         item.mutating = [];
+        state.statsBySurveyId[submission.survey.id].isStale = true;
       }
     },
     surveysLoad: (state) => {


### PR DESCRIPTION
## Description
This PR invlidates survey statistics after updating a survey submission.

## Changes
* Adds `isStale=true` when updating a survey submission. Once the statistics have been reloaded, state is again set to false.


## Notes to reviewer


## Related issues
Part of #1067 
