### PR TITLE
Fix failing tests by adding missing mocks

### DIFF
--- a/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
@@ -10,6 +10,8 @@ test.describe('Campaign detail page', async () => {
     moxy.setZetkinApiMock('/orgs/1/campaigns/1', 'get', ReferendumSignatures);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/actions', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/tasks', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/call_assignments', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/surveys', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/tasks', 'get', []);
     login();
   });

--- a/integrationTesting/tests/organize/campaigns/detail/edit.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/edit.spec.ts
@@ -11,6 +11,8 @@ test.describe('Campaign detail page', async () => {
     moxy.setZetkinApiMock('/orgs/1/campaigns/1', 'get', ReferendumSignatures);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/actions', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/tasks', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/call_assignments', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/surveys', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/tasks', 'get', []);
     login();
   });

--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -12,6 +12,8 @@ test.describe('Search', async () => {
     moxy.setZetkinApiMock('/orgs/1/campaigns/1', 'get', ReferendumSignatures);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/actions', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/campaigns/1/tasks', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/call_assignments', 'get', []);
+    moxy.setZetkinApiMock('/orgs/1/surveys', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/tasks', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/search/view', 'post', []);
     login();


### PR DESCRIPTION
## Description
This PR fixes some failing tests that somehow made it through CI in PR #1106.

## Screenshots
None

## Changes
* Adds mocks for call assignments and surveys for tests that use the new campaign page

## Notes to reviewer
None

## Related issues
Undocumented