### PR TITLE
Change positioning of panes, take in collapsed.

### DIFF
--- a/src/utils/layout/SimpleLayout.tsx
+++ b/src/utils/layout/SimpleLayout.tsx
@@ -72,7 +72,7 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
           p={fixedHeight ? 0 : 3}
           position="relative"
         >
-          <PaneProvider>{children}</PaneProvider>
+          <PaneProvider collapsed={collapsed}>{children}</PaneProvider>
         </Box>
       </Box>
     </DefaultLayout>

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -114,7 +114,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
           position="relative"
           role="tabpanel"
         >
-          <PaneProvider>{children}</PaneProvider>
+          <PaneProvider collapsed={collapsed}>{children}</PaneProvider>
         </Box>
       </Box>
     </DefaultLayout>

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 
 import Pane from './Pane';
+import { Theme } from '@material-ui/core/styles';
 
 type PaneDef = {
   render: () => ReactNode;
@@ -32,25 +33,29 @@ const PaneContext = createContext<PaneContextData>({
 
 type PaneProviderProps = {
   children: ReactNode;
+  collapsed: boolean;
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles<Theme, { collapsed: boolean }>(() => ({
   container: {
     bottom: 16,
-    position: 'absolute',
+    position: 'fixed',
     right: 16,
-    top: 16,
+    top: ({ collapsed }) => (collapsed ? '17vh' : '35vh'),
     zIndex: 10,
   },
   paper: {
     height: '100%',
   },
-});
+}));
 
-export const PaneProvider: FC<PaneProviderProps> = ({ children }) => {
+export const PaneProvider: FC<PaneProviderProps> = ({
+  children,
+  collapsed,
+}) => {
   const paneRef = useRef<PaneDef | null>(null);
   const [open, setOpen] = useState(false);
-  const styles = useStyles();
+  const styles = useStyles({ collapsed });
   const [key, setKey] = useState(0);
 
   return (


### PR DESCRIPTION
## Description
This PR attempts to solve positioning of panes for views and other places, by making their position `fixed` and letting the `collapsed` state of the layout be passed to the `PaneProvider` and used to determine how far from the top the panes should sit.


## Screenshots
![bild](https://user-images.githubusercontent.com/58265097/226366956-8498414c-fa30-4aeb-985e-03b0660f0edf.png)
![bild](https://user-images.githubusercontent.com/58265097/226367025-3f1dab70-3384-4706-8cb0-faf194b63e07.png)


## Changes
* Adds a "collapsed" property to the PaneProvider
* Changes positioning of panes to be fixed
* uses collapsed value to determine how far from the top the pane sits


## Notes to reviewer
very likely this will look weird on different screen sizes, 


## Related issues
Resolves part of polish issue.
