### PR TITLE
SurveySubmissionList ZUIPersonHoverCard fix

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -125,10 +125,26 @@ const SurveySubmissionsList = ({
 
     if (row.respondent?.id) {
       return (
-        <ZUIPersonHoverCard personId={row.respondent.id}>
+        <ZUIPersonHoverCard
+          personId={row.respondent.id}
+          popperProps={{
+            modifiers: [
+              {
+                enabled: true,
+                name: 'preventOverflow',
+                options: {
+                  tetherOffset: 230,
+                },
+              },
+            ],
+          }}
+        >
           <ZUIPersonGridCell
             onClick={startEditing}
             personId={row.respondent.id}
+            sx={{
+              cursor: 'pointer',
+            }}
           />
         </ZUIPersonHoverCard>
       );

--- a/src/zui/ZUIPersonGridCell.tsx
+++ b/src/zui/ZUIPersonGridCell.tsx
@@ -1,19 +1,20 @@
 import { FC } from 'react';
 import { Person } from '@mui/icons-material';
 import { useRouter } from 'next/router';
-import { Avatar, Box } from '@mui/material';
+import { Avatar, Box, SxProps } from '@mui/material';
 
 import ZUIAvatar from 'zui/ZUIAvatar';
 
 const ZUIPersonGridCell: FC<{
   onClick?: () => void;
   personId: number | null;
-}> = ({ personId, onClick }) => {
+  sx?: SxProps;
+}> = ({ personId, onClick, sx }) => {
   const query = useRouter().query;
   const orgId = parseInt(query.orgId as string);
 
   return (
-    <Box onClick={onClick}>
+    <Box onClick={onClick} sx={sx}>
       {personId ? (
         <ZUIAvatar orgId={orgId} personId={personId} />
       ) : (

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -8,6 +8,7 @@ import {
   Fade,
   Grid,
   Popper,
+  PopperProps,
   Typography,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
@@ -25,7 +26,8 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
   BoxProps?: BoxProps;
   children: React.ReactNode;
   personId: number;
-}> = ({ BoxProps, children, personId }) => {
+  popperProps?: Partial<PopperProps>;
+}> = ({ BoxProps, children, personId, popperProps = {} }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [open, setOpen] = useState(false);
   const openPopover = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
@@ -82,6 +84,7 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
         ]}
         open={open}
         style={{ zIndex: 9999 }}
+        {...popperProps}
       >
         {person && (
           <Fade in={open} timeout={200}>

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -27,7 +27,7 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
   children: React.ReactNode;
   personId: number;
   popperProps?: Partial<PopperProps>;
-}> = ({ BoxProps, children, personId, popperProps = {} }) => {
+}> = ({ BoxProps, children, personId, popperProps }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [open, setOpen] = useState(false);
   const openPopover = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {


### PR DESCRIPTION
## Description
This PR Fixes the ZUIPersonHoverCard so that it does not cover the avatar in the SurveySubmissionList. Also adds pointer to avatar in SurveySubmissionList to indicate that it's possible to change by clicking.

## Screenshots
![bild](https://user-images.githubusercontent.com/14962107/226498055-a358e908-8e84-406c-a927-45c3cda6f193.png)

## Changes
* Adds popplerProps property to ZUIPersonHoverCard to make it possible to change the behavior of the Poppler to fit the specific context.
* Use this to use custom properties for the SurveySubmissionList so that the ZUIHoverCard does not cover the avatar.
* Adds sx property ZUIPersonGridCell to make it possible to add custom styling
* Use this to add a pointer cursor when hovering avatar.


## Notes to reviewer

## Related issues
Part of #1067 
