### PR TITLE
Fix incorrect message ID in ConversationSettings

### DIFF
--- a/src/features/callAssignments/components/ConversationSettings.tsx
+++ b/src/features/callAssignments/components/ConversationSettings.tsx
@@ -32,7 +32,7 @@ const ConversationSettings = ({
           marginTop={2}
         >
           <Typography variant="h6">
-            <Msg id={messageIds.conversation.settings.title} />
+            <Msg id={messageIds.conversation.settings.notes.title} />
           </Typography>
           <Switch
             //this looks backwards bc in interface we use the positive "allow"


### PR DESCRIPTION
## Description
This PR fixes an incorrect string in `ConversationSettings` in the conversation tab of call assignments.

## Screenshots
None

## Changes
* Changes the message ID that was incorrectly changed in #1048 

## Notes to reviewer
None

## Related issues
Undocumented