### PR TITLE
Remove reference to MUIv4 in ZUITextfieldToClipboard

### DIFF
--- a/src/zui/ZUITextfieldToClipboard.tsx
+++ b/src/zui/ZUITextfieldToClipboard.tsx
@@ -1,11 +1,10 @@
 import copy from 'copy-to-clipboard';
-import { Box, Button } from '@mui/material';
+import { Box, Button, TextField } from '@mui/material';
 import React, { useState } from 'react';
 
 import { Msg } from 'core/i18n';
 
 import messageIds from './l10n/messageIds';
-import { TextField } from '@material-ui/core';
 
 const ZUITextfieldToClipboard: React.FunctionComponent<{
   children: React.ReactNode;


### PR DESCRIPTION
## Description
This PR removes a mistake from an earlier PR which referenced the old MUIv4 version of `TextField` instead of the v5 one, which was causing styling issues on the survey overview page (even worse when running in production).

## Screenshots
None

## Changes
* Replaces reference to MUIv4 `TextField` with the v5 equivalent

## Notes to reviewer
None

## Related issues
Resolves #1085 