### PR TITLE
redirect after link the last unlinked submission

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { Grid } from '@mui/material';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
@@ -55,6 +56,7 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
   );
 
   const campaignId = isNaN(parseInt(campId)) ? 'standalone' : parseInt(campId);
+  const router = useRouter();
 
   return (
     <>
@@ -70,8 +72,19 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
                 submissions = data.filter(
                   (sub) => sub.respondent && !sub.respondent.id
                 );
+                if (submissions.length === 0) {
+                  router.push(
+                    `/organize/${orgId}/projects/${campId}/surveys/${surveyId}/submissions`
+                  );
+                }
               }
-              return <SurveySubmissionsList submissions={submissions} />;
+              return (
+                <>
+                  {(submissions.length !== 0 || !showUnlinkedOnly) && (
+                    <SurveySubmissionsList submissions={submissions} />
+                  )}
+                </>
+              );
             }}
           </ZUIFuture>
         </Grid>


### PR DESCRIPTION
## Description
This PR redirects the page after user links the last unlinked submission.


## Screenshots


https://user-images.githubusercontent.com/77925373/226625422-f70e4dea-d6ab-415f-a519-2a38b5a4687d.mp4



## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds router for redirection
* Adds condition to render `SurveySubmissionList` component


## Notes to reviewer
I added condition to render `SurveySubmissionList` because when all unlinked submissions are linked, it shows `no rows` in the table first and then navigates the page back to the submissions. Thought that it would be better not showing `no rows` after links the all unlinked submissions.


## Related issues
Resolves part of #1067 
