### PR TITLE
reorder colors in call assignment

### DIFF
--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -139,7 +139,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'green' : 'gray'}
+            chipColor={hasTargets ? 'blue' : 'gray'}
             subtitle={messages.ready.subtitle()}
             title={messages.ready.title()}
             value={stats?.ready}
@@ -159,7 +159,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'blue' : 'gray'}
+            chipColor={hasTargets ? 'green' : 'gray'}
             subtitle={messages.done.subtitle()}
             title={messages.done.title()}
             value={stats?.done}

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -67,11 +67,11 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
             value: stats.blocked,
           },
           {
-            color: 'statusColors.green',
+            color: 'statusColors.blue',
             value: stats.ready,
           },
           {
-            color: 'statusColors.blue',
+            color: 'statusColors.green',
             value: stats.done,
           },
         ]


### PR DESCRIPTION
## Description
This PR reorders colors in call assignment from `orange - green - blue` to `orange - blue - green`


## Screenshots
![image](https://user-images.githubusercontent.com/77925373/226650495-ba736111-c391-402e-9966-f4f96f48e2ec.png)
before

![image](https://user-images.githubusercontent.com/77925373/226650613-07e1767b-6632-4719-add4-40c4d2e6bd35.png)
after


## Changes
* Changes colors green to blue / blue to green



## Related issues
Resolves part of #1067 
