### PR TITLE
Use List and ListItem from material/ui component instead of ZUIList component

### DIFF
--- a/src/features/organizations/components/OrganizationsList.tsx
+++ b/src/features/organizations/components/OrganizationsList.tsx
@@ -5,8 +5,7 @@ import { useMessages } from 'core/i18n';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 
 import ZUIFuture from 'zui/ZUIFuture';
-import ZUIList from 'zui/ZUIList';
-import { Avatar, Box, Link, Typography } from '@mui/material';
+import { Avatar, Box, Link, List, ListItem, Typography } from '@mui/material';
 
 interface UserOrganizationsProps {
   model: OrganizationsDataModel;
@@ -21,18 +20,10 @@ const OrganizationsList = ({ model }: UserOrganizationsProps) => {
         return (
           <Box style={{ margin: '30px' }}>
             <Typography variant="h3">{messages.page.title()}</Typography>
-            <ZUIList>
+            <List>
               {data.map((org: ZetkinOrganization) => {
                 return (
-                  <Box
-                    key={org.id}
-                    style={{
-                      alignItems: 'center',
-                      display: 'flex',
-                      justifyContent: 'unset',
-                      marginTop: '15px',
-                    }}
-                  >
+                  <ListItem key={org.id}>
                     <Avatar
                       src={`/api/orgs/${org.id}/avatar`}
                       style={{ margin: '15px' }}
@@ -40,10 +31,10 @@ const OrganizationsList = ({ model }: UserOrganizationsProps) => {
                     <NextLink href={`/organize/${org.id}`} passHref>
                       <Link underline="hover">{org.title}</Link>
                     </NextLink>
-                  </Box>
+                  </ListItem>
                 );
               })}
-            </ZUIList>
+            </List>
           </Box>
         );
       }}


### PR DESCRIPTION
## Description
This PR changes the use of `ZUIList `component to display the organizations in /organize landing page. Instead we implement the organization list using `List `and `ListItem` component from material-ui library.


## Screenshots
Before:
<img src="https://user-images.githubusercontent.com/36491300/226670809-86aea3cb-1f62-425b-a70e-258ec0264b0e.png" width="400"/>


After:
<img src="https://user-images.githubusercontent.com/36491300/226670964-edd565cd-6b16-432f-9051-6786d2b7e2f4.png" width="300"/>


## Changes
* Removes `ZUIList `component
* Adds `List` and `ListItem` to display organizations


## Notes to reviewer
The issue is only visible in development server http://app.dev.zetkin.org/organize


## Related issues
Relates issue 1067
