### PR TITLE
reorder assigned numbers and its color

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
@@ -44,11 +44,11 @@ const TaskOverviewListItem: FC<TasksOverviewListItemProps> = ({
               },
               {
                 color: 'statusColors.blue',
-                value: stats.completed,
+                value: stats.assigned - stats.completed - stats.ignored,
               },
               {
                 color: 'statusColors.green',
-                value: stats.assigned - stats.completed - stats.ignored,
+                value: stats.completed,
               },
             ]}
           />


### PR DESCRIPTION
## Description
This PR corrects the order of value in task overview list item


## Screenshots

before
![image](https://user-images.githubusercontent.com/77925373/226674059-d511fedb-95bf-4317-ab71-429427a9bf2a.png)
orange -  blue (completed) - green (not completed) order

after
![image](https://user-images.githubusercontent.com/77925373/226674285-8866326b-8411-4c6b-9966-e83ed119c153.png)
orange - blue (not completed) - green (completed) order

## Changes
* Changes colors and order of value in `TaskOverviewListItem` 



## Related issues
Resolves part of #1067 
