### PR TITLE
Add signature: 'require_signature' when creating a survey

### DIFF
--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -89,6 +89,7 @@ const CampaignActionButtons: React.FunctionComponent<
   };
   const handleCreateSurvey = () => {
     const survey = {
+      signature: 'require_signature',
       title: messages.form.createSurvey.newSurvey(),
     };
     model.createSurvey(survey);

--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -88,11 +88,10 @@ const CampaignActionButtons: React.FunctionComponent<
     model.createCallAssignment(assignment);
   };
   const handleCreateSurvey = () => {
-    const survey = {
+    model.createSurvey({
       signature: 'require_signature',
       title: messages.form.createSurvey.newSurvey(),
-    };
-    model.createSurvey(survey);
+    });
   };
   const handleCreateTask = () => {
     // Open the creat task dialog

--- a/src/features/surveys/models/SurveyDataModel.spec.ts
+++ b/src/features/surveys/models/SurveyDataModel.spec.ts
@@ -46,7 +46,6 @@ describe('SurveyDataModel', () => {
         surveyList: mockList<ZetkinSurveyExtended>([
           {
             access: 'open',
-            allow_anonymous: true,
             callers_only: false,
             campaign: null,
             elements: [],
@@ -59,6 +58,7 @@ describe('SurveyDataModel', () => {
               title: 'Semla lovers',
             },
             published: published,
+            signature: 'require_signature',
             title: 'Semla lovers assemble',
           },
         ]),

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -183,13 +183,13 @@ export interface ZetkinSurvey {
     id: number;
     title: string;
   };
-  allow_anonymous: boolean;
   access: string;
   callers_only: boolean;
   published: string | null;
   expires: string | null;
   campaign: { id: number; title: string } | null;
   org_access: 'sameorg' | 'suborgs';
+  signature: 'require_signature' | 'allow_anonymous' | 'force_anonymous';
 }
 
 export interface ZetkinSurveyPostBody


### PR DESCRIPTION
## Description
This PR sets new surveys to not allow anonymous submissions by default.

## Changes
* Adds parameter `signature: 'require_signature'` to request body when creating a new survey.

## Related issues
Part of #1067 
