### PR TITLE
Issue 1067/implement loading state

### DIFF
--- a/src/features/campaigns/models/CampaignActivitiesModel.ts
+++ b/src/features/campaigns/models/CampaignActivitiesModel.ts
@@ -127,8 +127,13 @@ export default class CampaignActivitiesModel extends ModelBase {
   }
 
   getCampaignActivities(campId: number): IFuture<CampaignActivity[]> {
-    const activities = this.getCurrentActivities().data;
-    const filtered = activities?.filter(
+    const activities = this.getCurrentActivities();
+    if (activities.isLoading) {
+      return new LoadingFuture();
+    } else if (activities.error) {
+      return new ErrorFuture(activities.error);
+    }
+    const filtered = activities.data?.filter(
       (activity) => activity.data.campaign?.id === campId
     );
     return new ResolvedFuture(filtered || []);
@@ -140,6 +145,14 @@ export default class CampaignActivitiesModel extends ModelBase {
     );
     const surveysFuture = this._surveysRepo.getSurveys(this._orgId);
     const tasksFuture = this._tasksRepo.getTasks(this._orgId);
+
+    if (
+      callAssignmentsFuture.isLoading ||
+      surveysFuture.isLoading ||
+      tasksFuture.isLoading
+    ) {
+      return new LoadingFuture();
+    }
 
     if (
       !callAssignmentsFuture.data ||
@@ -192,10 +205,16 @@ export default class CampaignActivitiesModel extends ModelBase {
   }
 
   getStandaloneActivities(): IFuture<CampaignActivity[]> {
-    const activities = this.getCurrentActivities().data;
-    const filtered = activities?.filter(
+    const activities = this.getCurrentActivities();
+
+    if (activities.isLoading) {
+      return new LoadingFuture();
+    }
+
+    const filtered = activities.data?.filter(
       (activity) => activity.data.campaign === null
     );
+
     return new ResolvedFuture(filtered || []);
   }
 }

--- a/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
@@ -12,6 +12,7 @@ import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import useServerSide from 'core/useServerSide';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
+import ZUIFuture from 'zui/ZUIFuture';
 import CampaignActivitiesModel, {
   ACTIVITIES,
 } from 'features/campaigns/models/CampaignActivitiesModel';
@@ -67,41 +68,45 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
   const onSearchStringChange = (evt: ChangeEvent<HTMLInputElement>) =>
     setSearchString(evt.target.value);
 
-  const activities = model.getCampaignActivities(parseInt(campId)).data;
-  const hasActivities = Array.isArray(activities) && activities.length > 0;
-
-  const activityTypes = activities?.map((activity) => activity.kind);
-  const filterTypes = [...new Set(activityTypes)];
-
   if (onServer) {
     return null;
   }
   return (
     <Box>
-      {!hasActivities && (
-        <ZUIEmptyState message={messages.singleProject.noActivities()} />
-      )}
-      {hasActivities && (
-        <Grid container spacing={2}>
-          <Grid item sm={8}>
-            <ActivityList
-              allActivities={activities}
-              filters={filters}
-              orgId={parseInt(orgId)}
-              searchString={searchString}
-            />
-          </Grid>
-          <Grid item sm={4}>
-            <FilterActivities
-              filters={filters}
-              filterTypes={filterTypes}
-              onFiltersChange={onFiltersChange}
-              onSearchStringChange={onSearchStringChange}
-              value={searchString}
-            />
-          </Grid>
-        </Grid>
-      )}
+      <ZUIFuture future={model.getCampaignActivities(parseInt(campId))}>
+        {(data) => {
+          if (data && data.length === 0) {
+            return (
+              <ZUIEmptyState message={messages.singleProject.noActivities()} />
+            );
+          }
+
+          const activityTypes = data?.map((activity) => activity.kind);
+          const filterTypes = [...new Set(activityTypes)];
+
+          return (
+            <Grid container spacing={2}>
+              <Grid item sm={8}>
+                <ActivityList
+                  allActivities={data}
+                  filters={filters}
+                  orgId={parseInt(orgId)}
+                  searchString={searchString}
+                />
+              </Grid>
+              <Grid item sm={4}>
+                <FilterActivities
+                  filters={filters}
+                  filterTypes={filterTypes}
+                  onFiltersChange={onFiltersChange}
+                  onSearchStringChange={onSearchStringChange}
+                  value={searchString}
+                />
+              </Grid>
+            </Grid>
+          );
+        }}
+      </ZUIFuture>
     </Box>
   );
 };

--- a/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
@@ -75,7 +75,7 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
     <Box>
       <ZUIFuture future={model.getCampaignActivities(parseInt(campId))}>
         {(data) => {
-          if (data && data.length === 0) {
+          if (data.length === 0) {
             return (
               <ZUIEmptyState message={messages.singleProject.noActivities()} />
             );

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -73,7 +73,7 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
     <Box>
       <ZUIFuture future={model.getStandaloneActivities()} skeletonWidth={200}>
         {(data) => {
-          if (data && data.length === 0) {
+          if (data.length === 0) {
             return (
               <ZUIEmptyState
                 href={`/organize/${orgId}/projects`}

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -11,8 +11,10 @@ import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import useServerSide from 'core/useServerSide';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
+import ZUIFuture from 'zui/ZUIFuture';
 import CampaignActivitiesModel, {
   ACTIVITIES,
+  CampaignActivity,
 } from 'features/campaigns/models/CampaignActivitiesModel';
 import { ChangeEvent, useState } from 'react';
 
@@ -63,46 +65,53 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
   const onSearchStringChange = (evt: ChangeEvent<HTMLInputElement>) =>
     setSearchString(evt.target.value);
 
-  const activities = model.getStandaloneActivities().data;
-  const hasActivities = Array.isArray(activities) && activities.length > 0;
-
-  const activityTypes = activities?.map((activity) => activity.kind);
-  const filterTypes = [...new Set(activityTypes)];
-
   if (onServer) {
     return null;
   }
 
   return (
     <Box>
-      {!hasActivities && (
-        <ZUIEmptyState
-          href={`/organize/${orgId}/projects`}
-          linkMessage={messages.allProjects.linkToSummary()}
-          message={messages.allProjects.noActivities()}
-        />
-      )}
-      {hasActivities && (
-        <Grid container spacing={2}>
-          <Grid item sm={8}>
-            <ActivityList
-              allActivities={activities}
-              filters={filters}
-              orgId={parseInt(orgId)}
-              searchString={searchString}
-            />
-          </Grid>
-          <Grid item sm={4}>
-            <FilterActivities
-              filters={filters}
-              filterTypes={filterTypes}
-              onFiltersChange={onFiltersChange}
-              onSearchStringChange={onSearchStringChange}
-              value={searchString}
-            />
-          </Grid>
-        </Grid>
-      )}
+      <ZUIFuture future={model.getStandaloneActivities()} skeletonWidth={200}>
+        {(data) => {
+          if (data && data.length === 0) {
+            return (
+              <ZUIEmptyState
+                href={`/organize/${orgId}/projects`}
+                linkMessage={messages.allProjects.linkToSummary()}
+                message={messages.allProjects.noActivities()}
+              />
+            );
+          }
+
+          const activityTypes = data.map(
+            (activity: CampaignActivity) => activity.kind
+          );
+          const filterTypes = [...new Set(activityTypes)];
+
+          return (
+            <Grid container spacing={2}>
+              <Grid item sm={8}>
+                <ActivityList
+                  allActivities={data}
+                  filters={filters}
+                  orgId={parseInt(orgId)}
+                  searchString={searchString}
+                />
+              </Grid>
+
+              <Grid item sm={4}>
+                <FilterActivities
+                  filters={filters}
+                  filterTypes={filterTypes}
+                  onFiltersChange={onFiltersChange}
+                  onSearchStringChange={onSearchStringChange}
+                  value={searchString}
+                />
+              </Grid>
+            </Grid>
+          );
+        }}
+      </ZUIFuture>
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR implements a loading state for the _activities tab_ in `All projects` and for the _activities tab_ inside an `specific project`.


## Screenshots
/organize/1/projects/activities:

https://user-images.githubusercontent.com/36491300/227026016-e2b703f3-08d5-40a2-abf7-0b0a7484127e.mp4

/organize/1/projects/6/activities:

https://user-images.githubusercontent.com/36491300/227026367-d6485863-7d62-4bad-977d-61dade391022.mp4

## Changes
* Adds `ZUIFuture ` component  in /`projects/activities/index` and in `projects/[campId]/activities`
* Adds a check in the functions `getCampaignActivities`, `getCurrentActivities ` and `getStandaloneActivities` inside the `CampaignActivitiesModel ` to return a `LoadingFuture `when the data is in loading state. 


## Notes to reviewer
None

## Related issues
Relates to #1067 