### PR TITLE
Redirect all urls with campaigns to projects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,11 @@ module.exports = {
         destination: 'https://zetk.in/o/:path*',
         permanent: false,
       },
+      {
+        source: '/organize/:orgId/campaigns/:path*',
+        destination: '/organize/:orgId/projects/:path*',
+        permanent: false,
+      }
     ];
   },
 };


### PR DESCRIPTION
## Description
This PR adds a redirect that takes users to project urls when they type in campaign urls.

## Changes
* Adds a redirect object to the Next JS config, that works on all urls that contain campaigns

