### PR TITLE
WIP Fix issues with assign/link widget in ZUIPersonEditGridCell

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -207,7 +207,7 @@ const SurveySubmissionsList = ({
         cell={row.respondent}
         onUpdate={updateCellValue}
         removePersonLabel={messages.submissions.unlink()}
-        suggestedPeople={respondents}
+        suggestedPeople={row.respondent === null ? [] : respondents} //filter anonymous
         suggestedPeopleLabel={messages.submissions.suggestedPeople()}
       />
     );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -160,12 +160,13 @@ const SurveySubmissionsList = ({
   const EditCell: FC<{ row: ZetkinSurveySubmission }> = ({ row }) => {
     const api = useGridApiContext();
     const { orgId } = useRouter().query;
-    const email = row.respondent?.email || '';
+    const emailOrFirstName =
+      row.respondent?.email || row.respondent?.first_name || '';
     let { data: suggestedPeople } = useQuery(
-      ['peopleSearchResults', email],
-      getPeopleSearchResults(email, orgId as string),
+      ['peopleSearchResults', emailOrFirstName],
+      getPeopleSearchResults(emailOrFirstName, orgId as string),
       {
-        enabled: email.length >= 2,
+        enabled: emailOrFirstName.length >= 2,
         retry: true,
       }
     );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -31,6 +31,10 @@ const SurveySubmissionsList = ({
   const { orgId } = useRouter().query;
   const { openPane } = usePanes();
 
+  const suggestedRespondents = submissions
+    .map((s) => s.respondent as ZetkinPerson)
+    .filter((s) => s !== null);
+
   const sortedSubmissions = useMemo(() => {
     const sorted = [...submissions].sort((subOne, subTwo) => {
       const dateOne = new Date(subOne.submitted);
@@ -107,7 +111,7 @@ const SurveySubmissionsList = ({
           ZetkinSurveySubmission
         >
       ) => {
-        return <EditCell row={params.row} />;
+        return <EditCell respondents={suggestedRespondents} row={params.row} />;
       },
       sortable: true,
     },
@@ -157,9 +161,13 @@ const SurveySubmissionsList = ({
     }
   };
 
-  const EditCell: FC<{ row: ZetkinSurveySubmission }> = ({ row }) => {
+  const EditCell: FC<{
+    respondents: ZetkinPerson[];
+    row: ZetkinSurveySubmission;
+  }> = ({ respondents, row }) => {
     const api = useGridApiContext();
     const { orgId } = useRouter().query;
+
     const emailOrName =
       row.respondent?.email ||
       row.respondent?.first_name ||
@@ -174,7 +182,7 @@ const SurveySubmissionsList = ({
       }
     );
 
-    if (!suggestedPeople) {
+    if (!suggestedPeople || suggestedPeople === undefined) {
       suggestedPeople = [];
     }
 
@@ -195,7 +203,7 @@ const SurveySubmissionsList = ({
         cell={row.respondent}
         onUpdate={updateCellValue}
         removePersonLabel={messages.submissions.unlink()}
-        suggestedPeople={suggestedPeople}
+        suggestedPeople={respondents}
         suggestedPeopleLabel={messages.submissions.suggestedPeople()}
       />
     );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -31,14 +31,6 @@ const SurveySubmissionsList = ({
   const { orgId } = useRouter().query;
   const { openPane } = usePanes();
 
-  const suggestedRespondents = submissions
-    .map((s) => s.respondent as ZetkinPerson)
-    .filter((s) => s !== null);
-
-  const suggestedPeople = [
-    ...new Map(suggestedRespondents.map((p) => [p.id, p])).values(),
-  ];
-
   const sortedSubmissions = useMemo(() => {
     const sorted = [...submissions].sort((subOne, subTwo) => {
       const dateOne = new Date(subOne.submitted);
@@ -115,7 +107,7 @@ const SurveySubmissionsList = ({
           ZetkinSurveySubmission
         >
       ) => {
-        return <EditCell respondents={suggestedPeople} row={params.row} />;
+        return <EditCell row={params.row} />;
       },
       sortable: true,
     },
@@ -166,9 +158,8 @@ const SurveySubmissionsList = ({
   };
 
   const EditCell: FC<{
-    respondents: ZetkinPerson[];
     row: ZetkinSurveySubmission;
-  }> = ({ respondents, row }) => {
+  }> = ({ row }) => {
     const api = useGridApiContext();
     const { orgId } = useRouter().query;
 
@@ -186,7 +177,7 @@ const SurveySubmissionsList = ({
       }
     );
 
-    if (!suggestedPeople || suggestedPeople === undefined) {
+    if (!suggestedPeople) {
       suggestedPeople = [];
     }
 
@@ -207,7 +198,7 @@ const SurveySubmissionsList = ({
         cell={row.respondent}
         onUpdate={updateCellValue}
         removePersonLabel={messages.submissions.unlink()}
-        suggestedPeople={row.respondent === null ? [] : respondents} //filter anonymous
+        suggestedPeople={row.respondent === null ? [] : suggestedPeople} //filter anonymous
         suggestedPeopleLabel={messages.submissions.suggestedPeople()}
       />
     );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -160,13 +160,16 @@ const SurveySubmissionsList = ({
   const EditCell: FC<{ row: ZetkinSurveySubmission }> = ({ row }) => {
     const api = useGridApiContext();
     const { orgId } = useRouter().query;
-    const emailOrFirstName =
-      row.respondent?.email || row.respondent?.first_name || '';
+    const emailOrName =
+      row.respondent?.email ||
+      row.respondent?.first_name ||
+      row.respondent?.last_name ||
+      '';
     let { data: suggestedPeople } = useQuery(
-      ['peopleSearchResults', emailOrFirstName],
-      getPeopleSearchResults(emailOrFirstName, orgId as string),
+      ['peopleSearchResults', emailOrName],
+      getPeopleSearchResults(emailOrName, orgId as string),
       {
-        enabled: emailOrFirstName.length >= 2,
+        enabled: emailOrName.length >= 2,
         retry: true,
       }
     );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -35,6 +35,10 @@ const SurveySubmissionsList = ({
     .map((s) => s.respondent as ZetkinPerson)
     .filter((s) => s !== null);
 
+  const suggestedPeople = [
+    ...new Map(suggestedRespondents.map((p) => [p.id, p])).values(),
+  ];
+
   const sortedSubmissions = useMemo(() => {
     const sorted = [...submissions].sort((subOne, subTwo) => {
       const dateOne = new Date(subOne.submitted);
@@ -111,7 +115,7 @@ const SurveySubmissionsList = ({
           ZetkinSurveySubmission
         >
       ) => {
-        return <EditCell respondents={suggestedRespondents} row={params.row} />;
+        return <EditCell respondents={suggestedPeople} row={params.row} />;
       },
       sortable: true,
     },

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -152,7 +152,7 @@ export default makeMessages('feat.surveys', {
     lastNameColumn: m('Last name'),
     link: m('Link'),
     personRecordColumn: m('Respondent'),
-    suggestedPeople: m('Suggested people'),
+    suggestedPeople: m('Other linked respondents'),
     unlink: m('Unlink'),
   },
   tabs: {

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -152,7 +152,7 @@ export default makeMessages('feat.surveys', {
     lastNameColumn: m('Last name'),
     link: m('Link'),
     personRecordColumn: m('Respondent'),
-    suggestedPeople: m('Other linked respondents'),
+    suggestedPeople: m('Suggested people'),
     unlink: m('Unlink'),
   },
   tabs: {

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -232,7 +232,12 @@ const ZUIPersonGridEditCell: FC<{
                           <ListSubheader sx={{ position: 'relative' }}>
                             {searchResults.length > 0 &&
                               messages.personGridEditCell.searchResults()}
-                            {personSelect.autoCompleteProps.inputValue !== '' &&
+                            {autoComplete.inputValue &&
+                              searchResults.length === 0 &&
+                              autoComplete.inputValue.length < 3 &&
+                              autoComplete.inputValue.length > 0 &&
+                              messages.personGridEditCell.keepTyping()}
+                            {autoComplete.inputValue.length >= 3 &&
                               !personSelect.autoCompleteProps.isLoading &&
                               searchResults.length === 0 &&
                               messages.personGridEditCell.noResult()}

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import {
   Box,
   Button,
+  CircularProgress,
   InputBase,
   List,
   ListItem,
@@ -197,12 +198,20 @@ const ZUIPersonGridEditCell: FC<{
                       </List>
                     )}
                     {searching && (
-                      <List {...autoComplete.getListboxProps()}>
-                        <ListSubheader sx={{ position: 'relative' }}>
-                          {suggestedPeople.length
-                            ? messages.personGridEditCell.otherPeople()
-                            : messages.personGridEditCell.searchResults()}
-                        </ListSubheader>
+                      <List
+                        {...autoComplete.getListboxProps()}
+                        subheader={
+                          <ListSubheader>
+                            {suggestedPeople.length >= 0 &&
+                              messages.personGridEditCell.searchResults()}
+                          </ListSubheader>
+                        }
+                      >
+                        {searchResults.length == 0 && (
+                          <CircularProgress
+                            sx={{ display: 'block', margin: 'auto' }}
+                          />
+                        )}
                         {searchResults.map((option, index) => {
                           const optProps = autoComplete.getOptionProps({
                             index,

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -88,19 +88,13 @@ const ZUIPersonGridEditCell: FC<{
           (p) =>
             p.first_name
               .toLocaleLowerCase()
-              .includes(
-                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
-              ) ||
+              .includes(autoComplete.inputValue.toLocaleLowerCase()) ||
             p.last_name
               .toLocaleLowerCase()
-              .includes(
-                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
-              ) ||
+              .includes(autoComplete.inputValue.toLocaleLowerCase()) ||
             p.email
               ?.toLocaleLowerCase()
-              .includes(
-                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
-              )
+              .includes(autoComplete.inputValue.toLocaleLowerCase())
         );
 
   return (

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -201,7 +201,7 @@ const ZUIPersonGridEditCell: FC<{
                       <List
                         {...autoComplete.getListboxProps()}
                         subheader={
-                          <ListSubheader>
+                          <ListSubheader sx={{ position: 'relative' }}>
                             {suggestedPeople.length >= 0 &&
                               messages.personGridEditCell.searchResults()}
                           </ListSubheader>

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -223,23 +223,28 @@ const ZUIPersonGridEditCell: FC<{
                             person={option}
                           />
                         ))}
-                      </List>
+                      </>
                     )}
                     {searching && (
                       <List
                         {...autoComplete.getListboxProps()}
                         subheader={
                           <ListSubheader sx={{ position: 'relative' }}>
-                            {suggestedPeople.length >= 0 &&
+                            {searchResults.length > 0 &&
                               messages.personGridEditCell.searchResults()}
+                            {personSelect.autoCompleteProps.inputValue !== '' &&
+                              !personSelect.autoCompleteProps.isLoading &&
+                              searchResults.length === 0 &&
+                              messages.personGridEditCell.noResult()}
                           </ListSubheader>
                         }
                       >
-                        {searchResults.length == 0 && (
+                        {personSelect.autoCompleteProps.isLoading && (
                           <CircularProgress
                             sx={{ display: 'block', margin: 'auto' }}
                           />
                         )}
+
                         {searchResults.map((option, index) => {
                           const optProps = autoComplete.getOptionProps({
                             index,

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -96,8 +96,10 @@ const ZUIPersonGridEditCell: FC<{
           inputProps={autoComplete.getInputProps()}
           onChange={() => setSearching(true)}
           placeholder={messages.personSelect.search()}
+          sx={{ paddingLeft: '10px' }}
         ></InputBase>
       </Box>
+
       {searchResults.length || suggestedPeople.length ? (
         <Popper
           anchorEl={anchorEl}

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -118,7 +118,7 @@ const ZUIPersonGridEditCell: FC<{
         ></InputBase>
       </Box>
 
-      {searchResults.length || suggestedPeople.length ? (
+      {suggestedPeople.length || autoComplete.inputValue != '' ? (
         <Popper
           anchorEl={anchorEl}
           open={!!anchorEl}

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -80,6 +80,29 @@ const ZUIPersonGridEditCell: FC<{
     );
   }
 
+  // Filter if the input value exists in suggested people list
+  const filteredSuggestedPeople =
+    personSelect.autoCompleteProps.inputValue === ''
+      ? suggestedPeople
+      : suggestedPeople.filter(
+          (p) =>
+            p.first_name
+              .toLocaleLowerCase()
+              .includes(
+                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
+              ) ||
+            p.last_name
+              .toLocaleLowerCase()
+              .includes(
+                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
+              ) ||
+            p.email
+              ?.toLocaleLowerCase()
+              .includes(
+                personSelect.autoCompleteProps.inputValue!.toLocaleLowerCase()
+              )
+        );
+
   return (
     <Box
       onMouseEnter={(ev) => {
@@ -180,10 +203,15 @@ const ZUIPersonGridEditCell: FC<{
                         showSuggestedPeople || searching ? 'block' : 'none',
                     }}
                   >
-                    {showSuggestedPeople && !!suggestedPeople.length && (
-                      <List>
-                        <ListSubheader>{suggestedPeopleLabel}</ListSubheader>
-                        {suggestedPeople.map((option) => (
+                    {showSuggestedPeople && filteredSuggestedPeople.length > 0 && (
+                      <>
+                        <ListSubheader
+                          disableSticky={true}
+                          sx={{ marginTop: 0, paddingTop: 0 }}
+                        >
+                          {suggestedPeopleLabel}
+                        </ListSubheader>
+                        {filteredSuggestedPeople.map((option) => (
                           <PersonListItem
                             key={option.id}
                             itemProps={{

--- a/src/zui/ZUIPersonSelect.tsx
+++ b/src/zui/ZUIPersonSelect.tsx
@@ -40,6 +40,7 @@ interface UsePersonSelectReturn {
     getOptionValue?: (person: ZetkinPerson) => unknown;
     inputRef: MutableRefObject<HTMLInputElement | undefined> | undefined;
     inputValue: string | undefined;
+    isLoading: boolean;
     label: string | undefined;
     name: string;
     noOptionsText: string;
@@ -131,6 +132,7 @@ export const usePersonSelect: UsePersonSelect = ({
       getOptionValue: (person: ZetkinPerson) => person.id || null,
       inputRef,
       inputValue: searchFieldValue,
+      isLoading,
       label,
       name: name || '',
       noOptionsText: searchLabel,

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -98,6 +98,7 @@ export default makeMessages('zui', {
     showMore: m('Show more...'),
   },
   personGridEditCell: {
+    keepTyping: m('Keep typing..'),
     noResult: m('No matching person found'),
     otherPeople: m('Other people'),
     restrictedMode: m("Can't be edited in shared views."),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -98,6 +98,7 @@ export default makeMessages('zui', {
     showMore: m('Show more...'),
   },
   personGridEditCell: {
+    noResult: m('No matching person found'),
     otherPeople: m('Other people'),
     restrictedMode: m("Can't be edited in shared views."),
     searchResults: m('Search results'),


### PR DESCRIPTION
## Description
This PR fixes different issues related to the performance of the ZUIPersonEditCell component.

## Screenshots
1- Widget in Submission list 

https://user-images.githubusercontent.com/36491300/228483686-7d6880ec-4391-4858-97ed-2d6fc223571d.mp4


2- Widget in Views

https://user-images.githubusercontent.com/36491300/228485177-f6b963c0-31f4-461c-83ba-91c1da7544e4.mp4




## Changes
* Adds the `first_name `and `last_name ` of the respondent as a new query parameter to search for `suggestedPeople` to be able to display the PersonHoverCard in those persons that doesn´t have an email settled.
* Adds a `CircleProgress `component to show to the user that the searching action is not completed.
* Adds padding to the edit cell to make obvious that the user can type and search
* Removes extra paddingTop in the `Popper `element
* Fixes the sticky position of the `subheader` when scrolling.
* Adds filtering in the `suggested people` list to check against the input values
* Adds a "keep typing.." state 
* Adds a "no matching results" message if the results of the search are 0
* In Submission List, if the respondent is anonymous, we don´t show suggested people.

## Notes to reviewer
None


## Related issues
Relates to #1067
