### PR TITLE
Issue 1067/covered calendar

### DIFF
--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -92,6 +92,7 @@ const ZUIDateRangePicker: FC<ZUIDateRangePickerProps> = ({
         </Typography>
       </Box>
       <ClickAwayListener
+        mouseEvent="onMouseDown"
         onClickAway={() => {
           setAnchorEl(null);
           if (onChange) {

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -253,7 +253,7 @@ const ZUIReorderableItem: FC<{
             showUp={showUpButton}
           />
         </Box>
-        <Box flex="1 0" zIndex={dragging ? '100' : '1'}>
+        <Box flex="1 0" zIndex={dragging ? '100' : '0'}>
           {item.renderContent({
             dragging,
           })}


### PR DESCRIPTION
## Description
This PR fixes the bug that question blocks in survey blocks the calendar 


## Screenshots


https://user-images.githubusercontent.com/77925373/227476000-01c2ad5b-a907-44a4-bae5-11f60891894e.mp4



## Changes

* Changes zIndex in ZUIReorderable
* Adds onMouseDown event to ClickAwayListener


## Notes to reviewer
Adding onMouseDown to fix the bug where the calendar would cover the question blocks when drags the block.


## Related issues
Resolves part of #1067 
