### PR TITLE
Norwegian translation (partial)

### DIFF
--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -1,0 +1,1364 @@
+core:
+  err404:
+    backToHomePage: Tilbake til startsiden
+    pageNotFound: Fant ikke siden
+  home:
+    welcome: Her kommer Zetkin
+  legacy:
+    continueButton: Tilbake til gammel versjon av Zetkin
+    header: Du blir videresendt
+    info: Du bruker en uferdig versjon av Zetkin som ikke støtter den funksjonen du
+      vil bruke, du blir videresendt til den gamle versjonen av Zetkin som støtter
+      denne funksjonen.
+feat:
+  calendar:
+    moreEvents: '{numEvents, plural, one {# til arrangement} other {# til arrangementer}}'
+    next: NESTE
+    prev: FORRIGE
+    rangeLabel: Velg et alternativ
+    ranges:
+      month: Måned
+      week: Uke
+  callAssignments:
+    actions:
+      end: Avslutt oppdrag
+      start: Start oppdrag
+    blocked:
+      callBackLater: Ba om å bli oppringt senere
+      calledTooRecently: Ringt for kort tid siden
+      cooldownHelperText: Velg hvor lang tid det skal gå mellom hvert forsøk på å
+        nå et mål
+      cooldownLabel: Ventetid i timer
+      hours: '{cooldown, plural, =0 {None} =1 {# time} other {# timer}}'
+      missingPhoneNumber: Mangler telefonnumer
+      organizerActionNeeded: Må følges opp av koordinator
+      subtitle: Mål som ikke er klare til å ringes
+      title: Blokkert
+    callers:
+      actions:
+        customize: Tilpass køen
+        remove: Fjern fra oppdrag
+      add:
+        alreadyAdded: Lagt til tidligere
+        placeholder: Legg til ringer
+      customize:
+        exclude:
+          h: Utelukkede tags
+          intro: Aldri ring personer med disse tægene.
+        prioritize:
+          h: Prioriterte tæger
+          intro: Ting til personer med disse tægene først.
+        title: Tilpass køen til {name}
+      customizeButton: Tilpass
+      excludedTagsColumn: Utelukkede tags
+      nameColumn: Navn
+      prioritizedTagsColumn: Prioriterte tags
+      searchBox: Søk
+      title: Ringere
+    conversation:
+      instructions:
+        confirm: Vil du slette all ulagrede endringer og gå tilbake til de lagrede
+          instruksene?
+        editorPlaceholder: Legg til instruks for ringere
+        revertLink: Tilbakestill til lagret versjon?
+        saveButton: Lagre
+        savedMessage: Alt er oppdatert!
+        savingButton: Lagrer...
+        title: Instruks for ringere
+        unsavedMessage: Du har gjort endringer som ikke er lagret.
+      settings:
+        notes:
+          message: Hvis du skrur av ringenotater kan ringingen gå fortere, men informasjon
+            kan gå tapt.
+          title: La ringere lagre notater
+        targetData:
+          message: Navn og telefonnummer til personer som skal ringes er alltid synlig
+            for ringere. Hvis du skrur på utvidede opplysninger får ringerne se all
+            informasjonen som finnes om den de skal ringe.
+          title: Vis utvidede opplysninger om personer som skal ringes
+        title: Samtaleinnstillinger
+    done:
+      defineButton: Rediger kriterier for fullføring
+      subtitle: Personer som oppfyller fullføringskriteriene
+      title: Ferdig
+    ready:
+      allocated: Personer som er tildelt en ringer
+      queue: Personer som er i kø
+      subtitle: Personer som skal ringes
+      title: Klar
+    state:
+      active: Aktiv
+      closed: Stengt
+      draft: Utkast
+      open: Åpen
+      scheduled: Planlagt
+    stats:
+      callers: '{numCallers, plural, =0 {Ingen ringere} one {En ringer} other {# ringere}}'
+      targets: '{numTargets, plural, =0 {Ingen i målgruppa} one {En person i målgruppa}
+        other {# personer i målgruppa}}'
+    statusSectionTitle: Status
+    tabs:
+      callers: Ringere
+      conversation: Samtale
+      insights: Analyse
+      overview: Oversikt
+    targets:
+      defineButton: Velg målgruppe
+      editButton: Rediger målgruppe
+      subtitle: Bruk smartsøk til å definere målgruppa for dette oppdraget
+      title: Personer i målgruppa
+  campaigns:
+    activitiesOverview:
+      button: Se alle aktiviteter
+      empty: Ingen ting på denne dagen
+      endsTomorrow: Avsluttes i morgen
+      extraActivities: + {numExtra} fler
+      goToActivities: Se alle kommende aktiviteter
+      noActivities: Ingen aktiviteter denne uka
+      nothingTomorrow: Ingen ting planlagt for i morgen
+      startsTomorrow: Begynner i morgen
+      subtitles:
+        endsLater: Avsluttes {relative}
+        endsToday: Avsluttes i dag
+        startsLater: Begynner {relative}
+        startsToday: Begynner i dag
+      thisWeekCard: Også denne uka
+      title: Aktiviteter
+      todayCard: I dag
+      tomorrowCard: I morgen
+    all:
+      cardCTA: Gå til prosjekt
+      create: Nytt prosjekt
+      filter:
+        calls: Ringeoppdrag
+        canvasses: Dørbanking
+        filter: Filtrer resultater
+        standalones: Frittstående arrangementer
+        surveys: Spørreundersøkelser
+      heading: Pågående prosjekter
+      indefinite: Uten sluttdato
+      unsorted: Usorterte prosjekter
+      upcoming: '{numEvents, number} kommende arrangementer.'
+    allProjects:
+      linkToSummary: Gå til mine aktive prosjekter
+      noActivities: Hvis organisasjonen din har aktiviteter som ikke tilhører et prosjekt
+        vises de her.
+    assigneeActions: Klikk i appen
+    calendarView: Se alle i kalender
+    events: Arrangementer
+    feedback:
+      copy: Innsamling av tilbakemeldinger kan hjelpe deg å arbeide mer effektivt.
+      create: Ny spørreundersøkelse
+      heading: Tilbakemeldinger og spørreundersøkelser (ingen satt opp)
+    form:
+      createCallAssignment:
+        newCallAssignment: Mitt ringeoppdrag
+      createCampaign:
+        create: Nytt prosjekt
+        error: Kunne ikke opprette prosjektet
+        newCampaign: Mitt prosjekt
+      createSurvey:
+        newSurvey: Min spørreundersøkelse
+      createTask:
+        title: Ny oppgave
+      deleteCampaign:
+        cancel: Avbryt
+        error: Kunne ikke slette prosjektet
+        submitButton: Bekreft sletting
+        title: Slett prosjekt
+        warning: Er du sikker på at du vil slette dette prosjektet? Kan ikke angres.
+      description: Beskrivelse
+      edit: Rediger prosjekt
+      editCampaignTitle:
+        error: Kunne ikke oppdatere prosjektnavnet
+        success: Prosjektnavn oppdatert
+      manager:
+        label: Prosjektansvarlig
+        selectSelf: Sett deg selv som ansvarlig
+      name: Navn
+      requestError: Noe gikk galt, forsøk gjerne igjen.
+      required: Påkrevd
+      status:
+        draft: Skisse
+        heading: Status
+        published: Publisert
+      visibility:
+        heading: Synlighet
+        private: Privat
+        public: Offentlig
+    indefinite: Uten sluttdato
+    layout:
+      activities: Aktiviteter
+      allCampaigns: Alle prosjekter
+      archive: Arkiv
+      calendar: Kalender
+      insights: Analyse
+      overview: Oversikt
+    linkGroup:
+      createActivity: Ny aktivitet
+      createCallAssignment: Nytt ringeoppdrag
+      createSurvey: Ny spørreundersøkelse
+      createTask: Nytt app-innhold
+      public: Offentlig side
+      settings: Endre innstillinger
+    mobilization:
+      copy: Ringeaksjoner for å mobilisere organisasjonen din vil øke deltakelsen
+        til medlemmene mye
+      create: Nytt ringeoppdrag
+      heading: Mobilisering og kontakt (ingen satt opp)
+    noManager: Ingen prosjektansvarlig
+    singleProject:
+      filterActivities: Skriv her for å filtrere
+      noActivities: Det er ingen aktiviteter i dette prosjektet ennå.
+      noSearchResults: Filtreringen gav ingen resultater.
+    taskLayout:
+      tabs:
+        assignees: Mottakere
+        insights: Analyse
+        summary: Oppsummering
+    tasks: Innhold
+  events:
+    form:
+      activity: Aktivitet
+      campaign: Kampanje
+      cancel: Avbryt
+      create: Nytt arrangement
+      edit: Rediger arrangement
+      end: Slutttidspunkt
+      info: Informasjon ved registrering
+      link: Lenke
+      minNo: Minimum antall deltakere
+      place: Sted
+      required: Påkrevd
+      start: Starttidspunkt
+      submit: Send inn
+      title: Tittel
+    list:
+      events: Arrangementer
+      noEvents: Ingen arrangementer...
+  profile:
+    organizations:
+      add: Legg til underorganisasjon
+      addError: Organisasjonen kunne ikke legges til
+      removeError: Organisasjonen kunne ikke fjernes
+      title: Organisasjoner
+    tabs:
+      manage: Behandle
+      profile: Profil
+      timeline: Tidslinje
+  search:
+    error: Noe gikk galt
+    label: Søk
+    noResults: Ingen resultater
+    placeholder: Skriv for å søke
+    results:
+      campaign: Kampanje
+      people: Folk
+      person: Person
+      task: Innhold
+      view: Visning
+  smartSearch:
+    buttonLabels:
+      add: Lagre utvalg
+      addNewFilter: Legg til / fjern folk
+      cancel: Avbryt
+      close: Lukk
+      goBack: Tilbake til søket
+      save: Lagre
+    filterCategories:
+      campaignActivity: Kampanjeaktivitet
+      misc: Ymse
+      peopleDatabase: Folk
+      phoneBanking: Ringeaksjoner
+      surveys: Spørreundersøkelser
+    filterTitles:
+      all: Alle
+      call_history: Basert på ringehistorikk
+      campaign_participation: Basert på aktivitet
+      most_active: De mest aktive
+      person_data: Basert på navn, adresse, eller annen informasjon
+      person_field: Basert på spesialfelter
+      person_tags: Basert på tags
+      person_view: Folk fra en visning
+      random: Et tilfeldig utvalg av folk
+      sub_query: Basert på et annet smartsøk
+      survey_option: Basert på svar de har valgt i en spørreundersøkelse
+      survey_response: Basert på svar de har skrevet i en spørreundersøkelse
+      survey_submission: Folk som har besvart en spørreundersøkelse
+      task: Folk som har interagert med innhold i SV appen
+      user: Folk som har en Zetkin brukerkonto
+    filters:
+      all:
+        inputString: Begynn med {startWithSelect}.
+        startWithSelect:
+          'false': en tom liste
+          'true': alle i organisasjonen
+      callHistory:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        assignmentSelect:
+          any: et hvilket som helst ringeoppdrag
+          assignment: ringeoppdraget "{assignmentTitle}"
+          none: Denne organisasjonen har ingen ringeoppdrag, ennå!
+        callSelect:
+          called: har blitt ringt
+          notreached: har blitt forsøkt ringt uten hell
+          reached: har blitt nådd
+        examples:
+          one: Legg til folk som har blitt nådd minst 2 ganger i et hvilket som helst
+            ringeoppdrag når som helst.
+          two: Fjern folk som har blitt ringt minst en gang i ringeoppdraget "Valgkamp
+            2023" de siste 30 dagene.
+        inputString: '{addRemoveSelect} folk som {callSelect} minst {minTimesInput}
+          {minTimes, plural, one {en} other {ganger}} in {assignmentSelect} {timeFrame}.'
+      campaignParticipation:
+        activitySelect:
+          activity: aktiviteten "{activity}"
+          any: en aktivitet
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        bookedSelect:
+          booked: blitt påmeldt
+          signed_up: meldt seg på
+        campaignSelect:
+          any: et prosjekt
+          campaign: Prosjektet "{campaign}"
+        examples:
+          one: Legg til folk som har meldt seg på arrangementer i et prosjekt med
+            en aktivitet på plassen 'Torget' når som helst.
+          two: Fjern folk som ikke har blitt påmeldt arrangementer i et prosjekt med
+            aktiviteten "Stå på stand" hvor som helst før i dag.
+        haveSelect:
+          in: har
+          notin: ikke har
+        inputString: '{addRemoveSelect} folk som {haveSelect} {bookedSelect} arrangementer
+          i {campaignSelect} med {activitySelect} på {locationSelect} {timeFrame}'
+        locationSelect:
+          any: et sted
+          location: stedet "{location}"
+      mostActive:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        examples:
+          one: Legg til de 100 mest aktive folka i organisasjonen før i dag.
+          two: Fjern de 5 mest aktive folka i organisasjonen når som helst.
+        inputString: '{addRemoveSelect} de {numPeopleSelect} mest aktive {numPeople,
+          plural, one {person} other {folka}} i organisasjonen {timeFrame}.'
+      personData:
+        addRemoveSelect:
+          add: Legg til
+          sub: fjern
+        ellipsis: '...'
+        examples:
+          one: Legg til en hvilken som helst person med fornavnet 'Clara' og etternavnet
+            'Zetkin'.
+          two: Fjern en hvilken som helst person med poststed Oslo.
+        fieldMatches: '{field} er {value}'
+        fieldSelect:
+          alt_phone: alternativt telefonnummer
+          city: poststed
+          co_address: alternativ adresse
+          email: e-post
+          first_name: fornavn
+          gender: kjønn
+          last_name: etternavn
+          phone: telefonnummer
+          remove: Fjern dette kriteriet
+          street_address: adresse
+          zip_code: postnummer
+        fieldTuple: '{first} og {second}'
+        inputString: '{addRemoveSelect} en hvilken som helst person med {criteria}.'
+      personField:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        edit:
+          date: '{fieldSelect} er {timeFrame}'
+          none: Organisasjonen har ingen spesialfelter
+          text: '{fieldSelect} er {freeTextInput}'
+          url: '{fieldSelect} er {freeTextInput}'
+        fieldSelect:
+          any: spesialfelt
+        inputString: '{addRemoveSelect} en hvilken som helst person med {field}.'
+        preview:
+          date: '{fieldName} er {timeFrame}'
+          text: '{fieldName} er {searchTerm}'
+          url: '{fieldName} er {searchTerm}'
+      personTags:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        condition:
+          conditionSelect:
+            all: alle
+            any: en hvilken som helst
+            minMatching: minst
+            none: ingen
+          preview:
+            all: alle
+            any: en hvilken som helst
+            minMatching: minst
+            none: ingen
+        examples:
+          one: 'Legg til folk med minst en av følgende tags: ''Medlem'', ''Aktivist'''
+          two: 'Fjern folk med alle av følgende tags: ''Styremedlem'''
+        inputString: '{addRemoveSelect} folk med {condition} av følgende: {tags}'
+      personView:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        examples:
+          one: Legg til folk som er i visningen 'Valgkampanje'.
+          two: Fjern folk som ikke er i visningen 'Valgkampanje'.
+        inSelect:
+          in: er i
+          notin: ikke er i
+        inputString: '{addRemoveSelect} folk som {inSelect} visningen {viewSelect}.'
+        viewSelect:
+          none: Denne organisasjonen har ingen visninger ennå
+      random:
+        addRemoveSelect:
+          add: legg til
+          sub: fjern
+        examples:
+          one: Tilfeldig legg til 20 folk i organisasjonen.
+          two: Tilfeldig fjern 15% av folk i organisasjonen.
+        inputString: Tilfeldig {addRemoveSelect} {quantity} i organisasjonen.
+      subQuery:
+        addRemoveSelect:
+          add: Legg til
+          sub: Under
+        examples:
+          one: Fjern folk som er i smartsøket 'Folk som bor i Nordland'.
+          two: Legg til folk som er i målgruppa for ringeoppdraget 'Gjenbetalingsringing'.
+        inputString: '{addRemoveSelect} folk som {matchSelect} {query}.'
+        matchSelect:
+          in: er i
+          notin: ikke er i
+        query:
+          edit:
+            callassignment_goal: '{querySelect} for ringeoppdraget "{titleSelect}"'
+            callassignment_target: '{querySelect} for ringeoppdraget "{titleSelect}"'
+          preview:
+            callassignment_goal: fullføringsgruppa for ringeoppdraget "{queryTitle}"
+            callassignment_target: målgruppa for ringeoppdraget  "{queryTitle}"
+            standalone: Smartsøket
+          selectLabel:
+            callassignment_goal: fullførtgruppa
+            callassignment_target: målgruppa
+            none: et smartsøk
+            standalone: Smartsøk
+          selectOptions:
+            callassignment_goal: fullførtgruppa for et ringeoppdrag
+            callassignment_target: målgruppa for et ringeoppdrag
+            none: Denne organisasjonen har ingen ringeoppdrag eller smartsøk ennå.
+            standalone: et frittstående smartsøk
+      surveyOption:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        conditionSelect:
+          all: alle
+          any: noen
+          none: ingen
+        examples:
+          one: 'Fjern folk som har valgt alle de følgende alternativene i spørreundersøkelsen
+            ''Medlemsundersøkelse'' (spørsmålet ''Hvordan er du interessert i å bidra?''):
+            ''Aksjoner'', ''Praktisk arbeid'''
+          two: 'Legg til folk som har valgt noen av de følgende alternativene i spørreundersøkelsen
+            ''Medlemsundersøkelse'' (spørsmålet ''Hvorfor ble du medlem?): ''Jeg ville
+            hjelpe til i valgkampen'''
+        inputString: '{addRemoveSelect} folk som har valgt {conditionSelect} av de
+          følgende alternativene i {surveySelect} ({questionSelect}): {options}'
+        questionSelect:
+          any: et spørsmål
+          none: Det er ingen flervalgsspørsmål i denne spørreundersøkelsen
+          question: spørsmålet "{question}"
+        surveySelect:
+          any: en spørreundersøkelse
+          none: Denne organisasjonen har ingen spørreundersøkelser ennå
+          survey: spørreundersøkelsen "{surveyTitle}"
+      surveyResponse:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        examples:
+          one: Folk som har skrevet svar på undersøkelsen 'Valgkampundersøkelse' (alle
+            spørsmål) som inneholder 'organisering'.
+          two: Folk som har skrevet svar på undersøkelsen 'Valgkampundersøkelsen'
+            (Hva er du god på?) som er eksakt 'organisering'.
+        inputString: '{addRemoveSelect} folk som har skrevet svar på {surveySelect}
+          ({questionSelect}) {matchSelect} "{freeTextInput}"'
+        matchSelect:
+          eq: som er eksakt
+          in: som innholder
+          noteq: som ikke er
+          notin: som ikke inneholder
+        questionSelect:
+          any: alle spørsmål
+          none: Det er ingen fritekstspørsmål i denne spørreundersøkelsen
+          question: spørsmålet "{question}"
+        surveySelect:
+          any: en spørreundersøkelse
+          none: Denne organisasjonen har ikke noen spørreundersøkelsen ennå
+          survey: spørreundersøkelsen "{surveyTitle}"
+      surveySubmission:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        examples:
+          one: Folk som har besvart spørreundersøkelsen 'Medlemsundersøkelse' før
+            i dag.
+          two: Folk som har besvart spørreundersøkelsen 'Medlemsundersøkelse' de siste
+            30 dagene.
+        inputString: '{addRemoveSelect} folk som har besvart {surveySelect} {timeFrame}.'
+        surveySelect:
+          any: en spørreundersøkelse
+          none: Denne organisasjonen har ikke noen spørreundersøkelsen ennå
+          survey: spørreundersøkelsen "{surveyTitle}"
+      task:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        campaignSelect:
+          any: et prosjekt
+          campaign: prosjektet "{campaign}"
+          in: i
+        examples:
+          one: Legg til folk som har trykket fullført på innholdet 'Verv en venn'
+            minst en gang når som helst
+          two: Legg til folk som har trykket ignorer på innhold i et prosjekt mellom
+            2 og 5 ganger før i dag
+        inputString: '{addRemoveSelect} folk som har {taskStatusSelect} {taskSelect}{campaignSelect}
+          {matchingSelect} {timeFrame}'
+        taskSelect:
+          any: hvilket som helst innhold
+          task: innholdet "{task}"
+        taskStatusSelect:
+          assigned: blitt tilsendt
+          completed: trykket fullført på
+          ignored: trykket ignorer på
+      user:
+        addRemoveSelect:
+          add: Legg til
+          sub: Fjern
+        connectedSelect:
+          'false': ikke har
+          'true': har
+        examples:
+          one: Fjern alle som har en brukerkonto i Zetkin.
+          two: Legg til alle som ikke har en brukerkonto i Zetkin.
+        inputString: '{addRemoveSelect} alle folk som {connectedSelect} en brukerkonto
+          i Zetkin.'
+    headers:
+      examples: Eksempler
+      gallery: Hvordan vil du velge folk?
+    matching:
+      edit:
+        between: '{matchingSelect} {minInput} og {maxInput} ganger'
+        max: '{matchingSelect} {maxInput} {max, plural, one {gang} other {ganger}}'
+        min: '{matchingSelect} {minInput} {min, plural, one {gang} other {ganger}}'
+      labels:
+        between: mellom
+        max: maksimalt
+        min: minst
+        once: minst en gang
+      options:
+        between: mellom
+        max: maksimalt
+        min: minst
+        once: minst en gang
+      preview:
+        between: mellom {min} og {max} ganger
+        max: maksimalt {max} {max, plural, one {gang} other {ganger}}
+        min: minst {max} {max, plural, one {gang} other {ganger}}
+        once: minst en gang
+    misc:
+      noOptions: Ingen like tags
+    quantity:
+      preview:
+        integer: '{people} {people, plural, one {person} other {folk}}'
+        percent: '{people} % av folk'
+      quantitySelectLabel:
+        integer: '{people, plural, one {person} other {folk}}'
+        percent: '% av folk'
+      quantitySelectOptions:
+        integer: et antall folk
+        percent: en prosentandel av folk
+    readOnly: Dette smartsøket er skrivebeskyttet og kan ikke redigeres.
+    timeFrame:
+      edit:
+        between: '{timeFrameSelect} {afterDateSelect} og {beforeDateSelect}'
+        lastFew: '{timeFrameSelect} {daysInput} {days, plural, one {dag} other {dager}}'
+      preview:
+        afterDate: etter {afterDate}
+        beforeDate: før {beforeDate}
+        beforeToday: før i dag
+        between: mellom {afterDate} og {beforeDate}
+        ever: når som helst
+        future: i framtida
+        lastFew: i løpet av siste {days} {days, plural, one {dag} other {dager}}
+      timeFrameSelectLabel:
+        afterDate: etter
+        beforeDate: før
+        beforeToday: før i dag
+        between: mellom
+        ever: når som helst
+        future: i framtida
+        lastFew: i løpet av siste
+      timeFrameSelectOptions:
+        afterDate: etter en gitt dato
+        beforeDate: før en gitt dato
+        beforeToday: før i dag
+        between: mellom to datoer
+        ever: når som helst
+        future: i framtida
+        lastFew: nylig
+  surveys:
+    addBlocks:
+      choiceQuestionButton: Flervalg
+      openQuestionButton: Fritekst
+      textButton: Tekstblokk
+      title: Velg blokktype for å legge til innhold i undersøkelsen
+    blocks:
+      choice:
+        addOption: Legg til ett alternativ
+        addOptionsBulk: Legg til flere alternativer
+        bulk:
+          cancelButton: Avbryt
+          placeholder: Skriv eller lim inn et alternativ per linje
+          submitButton: Legg til alle
+        description: Hjelpetekst
+        emptyDescription: Hjelpetekst
+        emptyOption: Tomt svaralternativ
+        emptyQuestion: Spørsmål
+        question: Spørsmål
+        widget: Widget
+        widgets:
+          checkbox: Avkrysning (flere svar)
+          radio: Knapper (ett svar)
+          select: Rullgardin (ett svar)
+      deleteBlockDialog:
+        title: Slett spørsmål
+        warningText: Er du sikker på at du vil slette spørsmålet? Dette kan ikke angres.
+      deleteOptionDialog:
+        title: Slett alternativ
+        warningText: Er du sikker på at du vil slette alternativet? Dette kan ikke
+          angres.
+      open:
+        description: Hjelpetekst
+        empty: Fritekstspørsmål
+        fieldTypePreview: tekstfelt
+        label: Spørsmål
+        multiLine: Avsnitt
+        singleLine: Setning
+        textFieldType: Tekstfelttype
+      text:
+        content: Hjelpetekst
+        empty: Blokk
+        header: Tittel
+    chart:
+      header: Svar
+      placeholder: Begynn å samle inn svar for å se framgangen her
+      subheader: Innsendte svar siste {days, plural, =1 {dag} other {# dager}}
+      tooltip:
+        submissions: '{count, plural, =1 {ett svar} other {# svar}}'
+    editWarning:
+      editing:
+        header: Spørreundersøkelsen kan redigeres
+        lockButton: Lås
+        safe:
+          bullet1: Rette stavefeil
+          bullet2: Endre rekkefølgen på blokker
+          bullet3: Skjule spørsmål
+          bullet4: Legge til spørsmål eller svaralternativer
+          header: Trygg
+        subheader: Vær forsiktig når du gjør endringer slik at ikke informasjonen
+          i tidligere svar går tapt eller blir ubrukelig.
+        unsafe:
+          bullet1: Slette spørsmål (skjul dem istedet)
+          bullet2: Endre navn på spørsmål eller svaralternativer som forandrer betydningen
+            av dem
+          header: Utrygg
+      locked:
+        header: Spørreundersøkelsen er låst
+        subheader: Denne undersøkelsen har begynt å få inn svar. Hvis du redigerer
+          den nå kan det bli problemer med informasjonen i svarene. Utvis forsiktighet.
+        unlockButton: Lås opp
+    layout:
+      actions:
+        publish: Samle svar
+        unpublish: Steng
+      stats:
+        questions: '{numQuestions, plural, one {ett spørsmål} other {# spørsmål}}'
+        submissions: '{numSubmissions, plural, one {ett svar} other {# svar}}'
+    optionCollapse:
+      collapse: Skjul
+      more: '{numOfOptions, plural, one {Vis ett alternativ til} other {Vis # flere
+        alternativer}}'
+    overview:
+      noQuestions:
+        button: Lag spørsmål
+        title: Det er ingen spørsmål i denne undersøkelsen ennå
+    shareSuborgsCard:
+      caption: Når dette er slått på kan tillitsvalgte i underorganisasjoner se og
+        søke i besvarelser som er levert av folk i sine underorganisasjoner.
+      title: Del med underorganisasjoner
+    state:
+      draft: Utkast
+      published: Åpnet for svar
+      scheduled: Planlagt
+      unpublished: Stengt for svar
+    submissionPane:
+      anonymous: Anonym
+      hidden: Skjult
+      linked: Koblet
+    submissions:
+      anonymous: Anonym
+      dateColumn: Dato
+      emailColumn: E-post
+      firstNameColumn: Fornavn
+      lastNameColumn: Etternavn
+      link: Koble
+      personRecordColumn: Innsender
+      suggestedPeople: Foreslåtte folk
+      unlink: Fjern kobling
+    tabs:
+      overview: Oversikt
+      questions: Spørsmål
+      submissions: Svar
+    unlinkedCard:
+      description: Når noen besvarer en undersøkelse uten å logge inn blir svaret
+        ikke koblet. Zetkin kan ikke søke etter folk basert på svar i undersøkelser
+        uten at svaret er koblet til en person.
+      header: Svar uten kobling
+      openLink: '{numUnlink, plural, one {Koble svar nå} other {Koble svar nå}}'
+    unlinkedWarningAlert:
+      default:
+        description: '{numUnlink, plural, one {Ett av de innsendte svarene er ikke
+          koblet til en person i Zetkin, det vil ikke dukke opp i søk.} other {Fler
+          av de innsendte svarene er ikke koblet til folk i Zetkin, de vil ikke dukke
+          opp i søk.}}'
+        header: Svar uten kobling
+        viewUnlinked: Se kun svar uten kobling
+      filtered:
+        description: Listen er filtrert og viser bare signerte svar som ikke er koblet
+          til folk i Zetkin.
+        header: Viser bare svar uten kobling
+        viewAll: Se alle
+    urlCard:
+      nowAccepting: Åpen for svar fra denne lenken
+      open: Åpen for svar
+      preview: Forhåndsvis spørreundersøkelsen
+      previewPortal: Forhåndsvis spørreundersøkelsen i aktivistportalen
+      visitPortal: Gå til spørreundersøkelsen i aktivistportalen
+      willAccept: Blir åpnet for svar fra denne lenken
+  tags:
+    dialog:
+      colorErrorText: Legg inn en gyldig HEX fargekode
+      colorLabel: Farge
+      createTitle: Ny tæg
+      editTitle: Rediger tæg
+      groupCreatePrompt: Legg til "{groupName}"
+      groupLabel: Gruppe
+      groupSelectPlaceholder: Skriv for å søke eller opprette gruppe
+      submitCreateTagButton: Lagre og bruk
+      titleErrorText: Du må gi tægen et navn
+      titleLabel: Navn
+      typeLabel: Type
+      types:
+        none: Vanlig
+        text: Med tekst
+    manager:
+      addTag: Legg til tæg
+      addValue: Legg til tekst for "{tag}"
+      createNamedTag: 'Opprett tæg: {name}'
+      createTag: Ny tæg
+      groupTags: Gruppér tæger
+      title: Tæger
+      ungroupedHeader: Ingen gruppe
+      valueTagForm:
+        typeHint: '{type, select, text {Legg til tekst} other {Legg til tall}} som
+          vises på tægen.'
+  tasks:
+    assignees:
+      completedStates:
+        completed: Trykket fullført {time}
+        ignored: Trykket ignorer {time}
+        notCompleted: Ikke trykket fullført
+      links:
+        create: Nytt smartsøk
+        edit: Rediger smartsøk
+        readOnly: Se smartsøk
+      queryStates:
+        assigned: Dette innholdet er sendt til alle som velges av smartsøket.
+        editable: Når det sendes vil innholdet gå til alle som velges av smartsøket.
+        new: Dette innholdet vil sendes ut til folk som velges av et smartsøk. Før
+          du kan sende det må du velge en målgruppe med et smartsøk.
+        published: Dette innholdet sendes nå til alle som velges av smartsøket, det
+          kan ta litt tid før de mottar det.
+      title: Sendt til {numPeople, plural, one {en person} other {# folk}}
+    common:
+      notSet: Ikke valgt
+    configs:
+      collectDemographics:
+        fields:
+          demographic: Informasjon som skal spørres etter
+          dempographicOptions:
+            city: Poststed
+            country: Land
+            email: E-post
+            gender: Kjønnsidentitet
+            streetAddress: Adresse
+            zipCode: Postnummer
+        title: 'Spør om personopplysninger: Oppsett'
+      shareLink:
+        fields:
+          defaultMessage: Forslag til tekst mottakeren skal bruke
+          url: Lenke som skal deles
+        title: 'Lenke: Oppsett'
+      visitLink:
+        fields:
+          url: Lenke som skal besøkes
+        title: 'Lenke: Oppsett'
+    deleteTask:
+      cancel: Avbryt
+      error: Kunne ikke slette innholdet
+      submitButton: Bekreft sletting
+      title: Slett innhold
+      warning: Er du sikker på at du vil slette dette innholdet? Dette kan ikke angres.
+    editTask:
+      title: Rediger innhold
+    form:
+      fields:
+        campaign: Prosjekt
+        deadline: Frist
+        expires: Utløpsdato
+        instructions: Instruks
+        published: Utsendelsestidspunkt
+        reassignInterval: Send på nytt etter fullføring
+        reassignIntervalOptions:
+          days: '{days, plural, =1 {Neste dag} other {om # dager}}'
+          hours: Etter {hours, plural, =1 {en time} other {# timer}}
+          noReassign: Aldri send på nytt
+        reassignLimit: 'Antall ganger innholdet sendes på nytt:'
+        timeEstimate: Beregnet tid for å fullføre
+        timeEstimateOptions:
+          hoursAndMinutes: '{hours, plural, =0{} one{en time} other{# timer}} {minutes,
+            plural, =0{} one {ett minutt} other {# minutter}}'
+          lessThanOneMinute: Mindre enn ett minutt
+          noEstimate: Ikke beregnet
+        timeValidationErrors:
+          deadlineNotSecond: Dette må være etter utsendelsestidspunkt og før utløpsdato
+          expiresNotThird: Dette må være det seneste tidspunktet
+          publishedNotFirst: Dette må være det første tidspunktet
+        title: Tittel
+        type: Innholdstype
+        types:
+          demographic: Be om personopplysninger
+          offline: Uten lenke
+          share_link: Del lenke
+          visit_link: Besøk lenke
+          watch_video: Se video
+      invalidUrl: Legg inn en gyldig URL
+      requestError: Noe gik galt, forsøk gjerne igjen.
+      required: Påkrevd
+      title: Nytt innhold
+    noTasksCreatePrompt: Inget innhold... Trykk her for å lage noe.
+    publishButton:
+      publish: Send
+      tooltip:
+        alreadyPublished: Sendt
+        missingAssignees: Mangler målgruppe
+        missingFields: Mangler påkrevde felter
+        missingFieldsAndAssignees: Mangler påkrevde felter og målgruppe
+    publishTask:
+      cancel: Avbryt
+      submitButton: Send nå
+      title: Send innhold
+      warning: Bekreft at du er klar til å sende innholdet. Det vil bli sendt til
+        alle i målgruppa.
+    showExpiredTasksPrompt: Vis utløpt innhold...
+    statuses:
+      active: Aktiv
+      closed: Stengt
+      draft: Utkast
+      expired: Utløpt
+      scheduled: Planlagt
+    taskDetails:
+      deadlineTime: Frist
+      editButton: Rediger
+      expiresTime: Utløpstidspunkt
+      instructionsLabel: Instruks
+      publishedTime: Utsendelsestidspunkt
+      reassignInterval:
+        label: Intervall for å sendes på nytt
+        value: Sendes på nytt {value, plural, =1{en time} other{# timer}} etter mottakeren
+          trykker fullfør
+      reassignLimit:
+        label: Antall ganger innholdet sendes på nytt
+        value: Sendes på nytt {value, plural, =1{en gang} other{# gangers}} per person
+      statusLabel: Status
+      timeEstimateLabel: Beregnet tid for å fullføre
+      title: Detaljer
+      titleLabel: Tittel
+      typeLabel: Type
+    taskLayout:
+      tabs:
+        assignees: Målgruppe
+        insights: Analyse
+        summary: Oppsummering
+    taskListItem:
+      relativeTimes:
+        active: Stenger {time}
+        closed: Stengte {time}
+        expired: Utløp {time}
+        expires: Utløper {time}
+        indefinite: Sendt {time}
+        scheduled: Sendes {time}
+    taskPreview:
+      addImage: Legg til bilde
+      sectionTitle: Forhåndsvisning
+      timeEstimate: '{minutes, plural, =0 {Mindre enn ett minutt} =1 {Ett minutt}
+        other {# minutter}}'
+    taskTypeDetails:
+      demographic:
+        title: Innstillinger for å be om personopplysninger
+      share_link:
+        title: Innstillinger for lenke som skal deles
+      visit_link:
+        title: Instillinger for lenke som skal besøkes
+    types:
+      demographic: Be om personopplysninger
+      offline: Uten lenke
+      share_link: Del lenke
+      visit_link: Besøk lenke
+      watch_video: Se video
+  views:
+    actions:
+      createFolder: Ny mappe
+      createView: Ny visning
+    browser:
+      backToFolder: Tilbake til {folder}
+      backToRoot: Tilbake til forsiden for visninger
+      confirmDelete:
+        folder:
+          title: Slett mappen og innholdet
+          warning: Er du sikker på at du vil slette mappen? Dette kan ikke angres.
+        view:
+          title: Slett visning
+          warning: Er du sikker på at du vil slette visningen? Dette kan ikke angres.
+      menu:
+        rename: Gi nytt navn
+      moveToFolder: Flytt til {folder}
+      moveToRoot: Flytt til forsiden for visninger
+    browserLayout:
+      tabs:
+        views: Visninger
+      title: Folk
+    cells:
+      localPerson:
+        alreadyInView: Finnes i visningen fra før
+        clearLabel: Fjern
+        otherPeople: Andre folk
+        restrictedMode: Kan ikke redigeres i delte visninger
+        searchLabel: Velg en person
+    columnDialog:
+      categories:
+        basic:
+          description: Enkle felter med informasjon om folk
+          title: Grunnleggende informasjon
+        categorizing:
+          description: For å gruppere og kategorisere folk, vilkårlig eller basert
+            på informasjon i Zetkin.
+          title: Kategorisering
+        crossReferencing:
+          description: Kryssreferer med informasjon i Zetkin ved hjelp av et smartsøk.
+          title: Kryssreferering
+        outreach:
+          description: Planlegg, deleger og gjennomfør kontaktarbeid, og rapporter
+            når du er ferdig.
+          title: Kontakt
+        surveys:
+          description: Utforsk, søk, og filtrer basert på folk sine svar på spørreundersøkelser.
+          title: Spørreundersøkelser
+        utility:
+          description: Nyttige verktøy du kan bruke i mange situasjoner.
+          title: Verktøy
+      choices:
+        delegate:
+          columnTitleAssignee: Kontaktperson
+          columnTitleContacted: Kontaktet
+          columnTitleNotes: Notater
+          columnTitleResponded: Har svart
+          description: Legger til flere kolonner som ofte brukes til å delegere arbeid
+            til en kontaktperson.
+          title: Delegering
+        email:
+          description: Legg til en kolonne med e-postadresser
+          keywords: epost e-post
+          title: E-postadresse
+        firstName:
+          description: Legg til en kolonne med fornavn
+          keywords: fornavn
+          title: Fornavn
+        followUp:
+          columnTitleCheckbox: Avkrysningsboks
+          columnTitleNotes: Notater
+          description: Legger til en avkrysningskolonne og en notatkolonne
+          title: Oppfølging
+        fullName:
+          description: To kolonner med fornavn og etternavn
+          keywords: etternavn
+          title: Fullt navn
+        lastName:
+          description: Legg til en kolonne med etternavn
+          keywords: etternavn
+          title: Etternavn
+        localPerson:
+          columnTitle: Kontaktperson
+          description: Lar deg velge en kontaktperson for hver rad.
+          title: Kontaktperson
+        localQuery:
+          columnTitle: I smartsøk?
+          description: Se om en person finnes i et smartsøk.
+          title: Tilpasset kryssreferanse
+        localText:
+          columnTitle: Notater
+          description: Legg til en kolonne for notater.
+          title: Notater
+        personFields:
+          description: Legg til de kolonnene du vil, som e-post, telefonnummer, etc.
+          keywords: adresse postnummer poststed land
+          title: Velg felter
+        phone:
+          description: Legg til en kolonne med telefonnummer
+          keywords: telefonnummer
+          title: Telefonnummer
+        queryBooked:
+          columnTitle: Meldt på
+          description: Er de meldt på noen kommende arrangementer av oss?
+          keywords: påmeldt
+          title: Er påmeldt kommende arrangementer
+        queryParticipated:
+          columnTitle: Deltatt
+          description: Har personen vært påmeldt et arrangement?
+          keywords: påmeldt
+          title: Noensinne deltatt
+        queryReached:
+          columnTitle: Nådd
+          description: Har vi snakket med personen på ringeaksjoner?
+          keywords: telefon
+          title: Nådd på telefon
+        surveyResponse:
+          allOptions: Alle alternativene (Enkelt kolonne)
+          allOptionsHeader: All alternativene
+          allOptionsSeparated: Alle alternativene (Flere kolonner)
+          description: Vis svar på et spørsmål i en undersøkelse
+          keywords: flere felter
+          oneOption: Ett alternativ
+          optionsLabel: Hvilke kolonner vil du legge til?
+          questionField: Spørsmål
+          surveyField: Spørreundersøkelser
+          textField: Svarene er fritekst og vil vises i en enkelt kolonne
+          title: Ett spørsmål fra en undersøkelse
+        surveyResponses:
+          description: Inkluder svar fra flere spørsmål
+          keywords: flerfelt
+          questionField: Spørsmål
+          surveyField: Spørreundersøkelser
+          title: Flere spørsmål
+        surveySubmitDate:
+          description: Se om en person har besvart en spørreundersøkelse, og når.
+          noSurveys: Organisasjonen din har ingen spørreundersøkelser.
+          title: Besvart dato
+        tag:
+          description: Skru av og på en tæg for personer i visningen
+          title: Tæg
+        toggle:
+          columnTitle: Bryter
+          description: Sjekkliste
+          title: Bryter
+      commonHeaders:
+        email: E-postadresse
+        first_name: Fornavn
+        last_name: Etternavn
+        phone: Telefonnummer
+      editor:
+        alreadyInView: Finnes i visningen fra før
+        buttonLabels:
+          addColumns: Legg til {columns, plural, one {en kolonne} other {{columns}
+            kolonner}}
+          change: Endre kolonnetype
+        defaultTitle: Ny kolonne
+        fieldLabels:
+          field: Felt
+          question: Spørsmål
+          smartSearch: Smartsøk
+          survey: Spørreundersøkelse
+          tag: Tæg
+      gallery:
+        add: Legg til
+        alreadyInView: Finnes i visningen fra før
+        columns: Kolonner
+        configure: Sett opp
+        header: Legg til kolonne i visningen
+        noSearchResults: 'Fant ingen kolonner med søket: "{searchString}"'
+        searchPlaceholder: Finn en kolonne
+        searchResults: Resultater for "{searchString}"
+    columnMenu:
+      configure: Instillinger
+      confirmDelete: Er du sikker på at du vil slette kolonnen? Den inneholder informasjon
+        som vil bli slettet permanent, dette kan ikke angres.
+      delete: Slett kolonne
+      rename: Gi nytt navn
+    columnRenameDialog:
+      save: Lagre
+      title: Tittel
+    dataTableErrors:
+      create_column: Kunne ikke opprette kolonnen
+      delete_column: Kunne ikke slette kolonnen
+      modify_column: Kunne ikke redigere kolonnen
+      remove_rows: Kunne ikke fjerne rader
+    defaultColumnTitles:
+      local_bool: Bryter
+      local_person: Personreferanse
+      person_notes: Notater
+    deleteDialog:
+      error: Kunne ikke slette visningen
+      title: Slette visning?
+      warningText: Er du sikker på at du vil slette visningen? All informasjon i den,
+        som notater og brytere (men folkene vil ikke bli slettet fra Zetkin)?
+    editViewTitleAlert:
+      error: Kunne ikke endre tittelen
+      success: Tittelen ble endret!
+    empty:
+      dynamic:
+        configureButton: Innstillinger
+        description: Opprett en dynamisk visning som legger til og fjerner folk automatisk
+          med et smartsøk.
+        headline: Sett opp smartsøkvisning
+      notice:
+        dynamic: Dette er en smartsøkvisning men ingen folk velges av smartsøket
+        static: Du har ikke lagt til noen rader
+      static:
+        description: Legg til en person for å lage en statisk visning der folk legges
+          til og fjernes manuelt.
+        headline: Legg til folk manuelt
+    folder:
+      summary:
+        empty: Tomt
+        folderCount: '{count, plural, =1 {En mappe} other {# mapper}}'
+        viewCount: '{count, plural, =1 {En visning} other {# visninger}}'
+    footer:
+      addPlaceholder: Begynn å skrive for å legge til en person i visningen
+      alreadyInView: Finnes i visningen fra før
+    newFolderTitle: Ny mappe
+    newViewFields:
+      title: Ny visning
+    removeDialog:
+      action: Er du sikker på at du vil fjerne disse radene fra visningen?
+      title: Fjern folk fra visningen
+    shareDialog:
+      download:
+        buttons:
+          csv: Last ned CSV
+          xlsx: Last ned Excel
+        shareLink: dele informasjonen sikkert
+        warning1: Eksporter bare informasjon fra Zetkin hvis det er helt nødvendig.
+          Eksporterte filer skal aldri deles med andre, skal kun lastes ned til en
+          kryptert datamaskin, og skal slettes etter bruk.
+        warning2: Du kan {shareLink} inne i Zetkin, del bare visninger med tillitsvalgte
+          og ansatte som har myndighet til å behandle personopplysninger.
+      share:
+        addPlaceholder: Legg til andre
+        collabInstructions: Når du har lagt til de som skal ha tilgang til visningen,
+          kopier og send dem {viewLink}
+        showOfficials: Vis admin og koordinatorer
+        statusLabel: Shared with {collaborators, plural, =1 {en person} other {# personer}},
+          {officials, plural, =1 {1 admin/koordinator} other {# admin/koordinatorer}}
+          har tilgang til alle visninger.
+        viewLink: sikker lenke
+      title: Del "{title}"
+    suggested:
+      created: Opprettet av {name}
+      sectionTitle: Foreslått
+    surveyOptionCell:
+      notSelected: Ikke valgt
+      selected: Valgt
+    surveyPreview:
+      mostRecent:
+        header: Siste
+        openButton: Vis hele besvarelsen
+      older:
+        header: Eldre besvarelser
+        openButton: Vis
+    toolbar:
+      createColumn: Ny kolonne
+      createFromSelection: Opprett visning av valgte
+      removeFromSelection: Fjern {numSelected, plural, one {1 person} other {{numSelected}
+        folk} } from view
+      removeTooltip: Smartsøk støtter ikke fjerning av rader
+    viewLayout:
+      actions:
+        share: Del
+      ellipsisMenu:
+        delete: Slett visning
+        editQuery: Rediger smartsøk
+        makeDynamic: Konverter til smarsøkvisning
+        makeStatic: Konverter til statisk visning
+      jumpMenu:
+        placeholder: Skriv for å finne visning
+      subtitle:
+        collaborators: '{count, plural, =1 {1 person} other {# personer}}'
+        columns: '{count, plural, =0 {Ingen kolonner} =1 {En kolonne} other {# kolonner}}'
+        people: '{count, plural, =0 {Empty} =1 {1 person} other {# folk}}'
+    viewsList:
+      columns:
+        created: Opprettet dato
+        owner: Eier
+        title: Tittel
+      empty: Du har ikke opprettet noen visninger
+glob:
+  accessLevels:
+    configure: Rediger og sett opp
+    edit: Redigering
+    readonly: Skrivebeskyttet
+  personFields:
+    alt_phone: Alternativt telefonnummer
+    city: Poststed
+    co_address: Alternativ adresse
+    country: Land
+    email: E-post
+    ext_id: Medlemsnummer
+    first_name: Fornavn
+    gender: Kjønn
+    id: Zetkin ID
+    is_user: Har bruker
+    last_name: Etternavn
+    phone: Telefonnummer
+    street_address: Adresse
+    zip_code: Postnummer
+  roles:
+    admin: Admin
+    organizer: Koordinator
+zui:
+  accessList:
+    added: Lagt til av {sharer} {updated}
+    removeAccess: Fjern tilgang
+  breadcrumbs:
+    activities: Aktiviteter
+    areas: Områder
+    assignees: Kontaktpersoner
+    calendar: Kalender
+    callassignments: Ringeoppdrag
+    callers: Ringere
+    campaigns: Prosjekter
+    closed: Stengt
+    conversation: Samtale
+    events: Arrangementer
+    folders: Visninger
+    insights: Analyse
+    manage: Behandle
+    new: Ny
+    organize: Organiser
+    people: Folk
+    projects: Prosjekter
+    questions: Spørsmål
+    submissions: Svar
+    surveys: Spørreundersøkelser
+    tasks: App-innhold
+    views: Visninger
+  collapse:
+    collapse: Skjul
+    expand: Vis
+  confirmDialog:
+    button: Bekreft
+    defaultTitle: Bekreft
+    defaultWarningText: Er du sikker på at du vil gjennomføre denne handlingen? Den
+      kan ikke angres.
+  copyToClipboard:
+    copied: Kopiert
+    copiedValue: Kopierte "{value}"
+    copy: Kopier
+  dataTableSearch:
+    button: Søk
+    helpText: Skriv minst {minSearchLength} tegn
+    idSearchHelpText: Skriv en Zetkin ID (kun tall)
+    placeholder: Søk
+    placeholderWithIdSearch: 'Søk - bruk # for Zetkin IDer, skriv f.eks #123'
+    title: Søk
+  dataTableSorting:
+    addButton: Legg til sorteringskolonne
+    button: Sortér
+    hint: 'Hint: hold inn {shiftKeyIcon} mens du trykker på flere kolonner'
+    title: Sortér
+  dateRange:
+    draft: Ingen startdato
+    finite: Fra {start, date, medium} til {end, date, medium}
+    indefinite: Fra {start, date, medium} og fremover
+  editTextInPlace:
+    tooltip:
+      edit: Klikk for å redigere
+      noEmpty: Dette feltet kan ikke være tomt
+  futures:
+    errorLoading: Kunne ikke laste dataen
+  header:
+    collapseButton:
+      collapse: Skjul
+      expand: Vis
+  imageSelectDialog:
+    instructions: Trekk og slipp et bilde eller en fil, eller klikk for å velge
+  lists:
+    showMore: Vis mer...
+  personGridEditCell:
+    otherPeople: Andre folk
+    restrictedMode: Kan ikke redigeres i delte visninger
+    searchResults: Søkeresultater
+  personSelect:
+    keepTyping: Fortsett å skrive eller start søk
+    noResult: Ingen person ble funnet
+    search: Skriv for å søke
+    searching: Søker...
+  snackbar:
+    error: Å nei! Noe gikk galt.
+    success: Suksess!
+    warning: Advarsel!
+  speedDial:
+    createCampaign: Nytt prosjekt
+    createEvent: Nytt arrangement
+    createTask: Nytt innhold
+    requestError: Noe gikk galt
+  submitOrCancel:
+    cancel: Avbryt
+    submit: Send inn
+  suffixedNumber:
+    thousands: '{num}K'
+  timeline:
+    addNotePlaceholder: Skriv her for å legge inn et notat
+    email:
+      headers:
+        cc: Cc
+        from: Fra
+        to: Til
+    filter:
+      byType:
+        all: Alle
+        files: Filer
+        notes: Notater
+        people: Folk
+        tags: Tægs
+      filterSelectLabel: 'Vis: {filter}'
+    updates:
+      any:
+        addtags: '{actor} la til {count, plural, =1 {en tæg} other {# tæger}}'
+        removetags: '{actor} fjernet {count, plural, =1 {en tæg} other {# tæger}}'
+      journeyinstance:
+        addassignee: '{actor} tildelte kontaktperson {assignee}'
+        addnote: '{actor} la til et notat'
+        addsubject: '{actor} la til {subject}'
+        update:
+          readMore: Les mer

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -108,6 +108,6 @@ export const getBrowserLanguage = (
   req: NextApiRequest | IncomingMessage
 ): SupportedLanguage => {
   const negotiator = new Negotiator(req);
-  const languages = negotiator.languages(['en', 'sv']);
+  const languages = negotiator.languages(['en', 'nn']);
   return languages.length ? (languages[0] as SupportedLanguage) : 'en';
 };


### PR DESCRIPTION
## Description
This PR adds strings for Norwegian, although with only partial covers (mostly excluding Journeys).

## Screenshots
![image](https://user-images.githubusercontent.com/550212/227576945-3e885e66-2b30-494e-8a67-d84912013f85.png)

![image](https://user-images.githubusercontent.com/550212/227576959-3aa7ea7d-85ac-4ada-a7a4-f724d1d9c9d1.png)

## Changes
* Adds Norwegian strings from translate.zetkin.org
* Replaces `sv` with `nn` locale

## Notes to reviewer
The strings here are not actually nynorsk, but "bokmål", another Norwegian accent for which the correct locale should be `nb`, but we are using the wrong one for consistency and will switch over at a later time.

## Related issues
Undocumented