### PR TITLE
Refactor surveys store

### DIFF
--- a/src/features/campaigns/models/CampaignActivitiesModel.ts
+++ b/src/features/campaigns/models/CampaignActivitiesModel.ts
@@ -12,7 +12,7 @@ import {
 } from 'core/caching/futures';
 import {
   ZetkinCallAssignment,
-  ZetkinSurveyExtended,
+  ZetkinSurvey,
   ZetkinTask,
 } from 'utils/types/zetkin';
 
@@ -33,7 +33,7 @@ export type CallAssignmentActivity = CampaignActivityBase & {
 };
 
 export type SurveyActivity = CampaignActivityBase & {
-  data: ZetkinSurveyExtended;
+  data: ZetkinSurvey;
   kind: ACTIVITIES.SURVEY;
 };
 

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -29,10 +29,8 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model, readOnly }) => {
   const lengthRef = useRef<number>();
 
   useEffect(() => {
-    const data = model.getData().data;
-    if (data) {
-      const elements = data.elements;
-
+    const elements = model.getElements().data;
+    if (elements) {
       // If the previous length is null, it's because it only now loaded for the
       // first time and the length has not really been read before.
       if (
@@ -45,18 +43,18 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ model, readOnly }) => {
 
       lengthRef.current = elements.length;
     }
-  }, [model.getData().data?.elements.length]);
+  }, [model.getElements().data]);
 
   return (
     <>
-      <ZUIFuture future={model.getData()}>
-        {(data) => {
+      <ZUIFuture future={model.getElements()}>
+        {(elements) => {
           return (
-            <Box paddingBottom={data.elements.length ? 4 : 0}>
+            <Box paddingBottom={elements.length ? 4 : 0}>
               <ZUIReorderable
                 disableClick={readOnly}
                 disableDrag={readOnly}
-                items={data.elements.map((elem) => ({
+                items={elements.map((elem) => ({
                   id: elem.id,
                   renderContent: ({ dragging }) => {
                     if (elem.type == ELEMENT_TYPE.QUESTION) {

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,3 +1,4 @@
+import { ELEMENT_TYPE } from 'utils/types/zetkin';
 import SurveyStatusChip from '../components/SurveyStatusChip';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useModel from 'core/useModel';
@@ -32,7 +33,7 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
     (env) => new SurveyDataModel(env, parseInt(orgId), parseInt(surveyId))
   );
 
-  const hasQuestions = !!model.getData().data?.elements.length;
+  const hasQuestions = !!model.getElements().data?.length;
   const dataFuture = model.getData();
 
   return (
@@ -69,13 +70,13 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
           <Box display="flex" marginX={1}>
             <ZUIFutures
               futures={{
+                elements: model.getElements(),
                 stats: model.getStats(),
-                survey: model.getData(),
               }}
             >
-              {({ data: { stats, survey } }) => {
-                const questionLength = survey?.elements?.filter(
-                  (question) => question.type === 'question'
+              {({ data: { elements, stats } }) => {
+                const questionLength = elements.filter(
+                  (elem) => elem.type == ELEMENT_TYPE.QUESTION
                 ).length;
 
                 const labels: ZUIIconLabelProps[] = [];

--- a/src/features/surveys/models/SurveyDataModel.spec.ts
+++ b/src/features/surveys/models/SurveyDataModel.spec.ts
@@ -41,6 +41,7 @@ describe('SurveyDataModel', () => {
       expires: string | null
     ) => ({
       surveys: {
+        elementsBySurveyId: {},
         statsBySurveyId: {},
         submissionList: mockList<ZetkinSurveySubmission>([]),
         surveyList: mockList<ZetkinSurveyExtended>([

--- a/src/features/surveys/models/SurveyDataModel.ts
+++ b/src/features/surveys/models/SurveyDataModel.ts
@@ -9,7 +9,8 @@ import SurveysRepo, {
   ZetkinSurveyElementPostBody,
 } from '../repos/SurveysRepo';
 import {
-  ZetkinSurveyExtended,
+  ZetkinSurvey,
+  ZetkinSurveyElement,
   ZetkinSurveyTextElement,
 } from 'utils/types/zetkin';
 
@@ -68,8 +69,12 @@ export default class SurveyDataModel extends ModelBase {
     );
   }
 
-  getData(): IFuture<ZetkinSurveyExtended> {
+  getData(): IFuture<ZetkinSurvey> {
     return this._repo.getSurvey(this._orgId, this._surveyId);
+  }
+
+  getElements(): IFuture<ZetkinSurveyElement[]> {
+    return this._repo.getSurveyElements(this._orgId, this._surveyId);
   }
 
   getStats(): IFuture<SurveyStats> {
@@ -174,13 +179,13 @@ export default class SurveyDataModel extends ModelBase {
   }
 
   get surveyIsEmpty(): boolean {
-    const { data } = this.getData();
+    const { data } = this.getElements();
 
     if (!data) {
       return true;
     }
 
-    return data.elements?.length ? false : true;
+    return data.length ? false : true;
   }
 
   toggleElementHidden(elemId: number, hidden: boolean) {

--- a/src/features/surveys/models/SurveySubmissionModel.ts
+++ b/src/features/surveys/models/SurveySubmissionModel.ts
@@ -75,19 +75,19 @@ export default class SurveySubmissionModel extends ModelBase {
     }
 
     const submission = submissionFuture.data;
-    const surveyFuture = this._repo.getSurvey(
+    const surveyElementsFuture = this._repo.getSurveyElements(
       this._orgId,
       submission.survey.id
     );
 
-    if (!surveyFuture.data) {
+    if (!surveyElementsFuture.data) {
       return new LoadingFuture();
     }
 
-    const survey = surveyFuture.data;
+    const surveyElements = surveyElementsFuture.data;
     const elements: HydratedElement[] = [];
 
-    survey.elements.forEach((elem) => {
+    surveyElements.forEach((elem) => {
       if (elem.type == ELEMENT_TYPE.TEXT) {
         elements.push({
           header: elem.text_block.header,

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -19,12 +19,14 @@ import {
 } from 'utils/storeUtils';
 
 export interface SurveysStoreSlice {
+  elementsBySurveyId: Record<number, RemoteList<ZetkinSurveyElement>>;
   submissionList: RemoteList<ZetkinSurveySubmission>;
   statsBySurveyId: Record<number, RemoteItem<SurveyStats>>;
-  surveyList: RemoteList<ZetkinSurveyExtended>;
+  surveyList: RemoteList<ZetkinSurvey>;
 }
 
 const initialState: SurveysStoreSlice = {
+  elementsBySurveyId: {},
   statsBySurveyId: {},
   submissionList: remoteList(),
   surveyList: remoteList(),
@@ -39,44 +41,34 @@ const surveysSlice = createSlice({
       action: PayloadAction<[number, ZetkinSurveyElement]>
     ) => {
       const [surveyId, newElement] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
-      );
-      if (surveyItem && surveyItem.data) {
-        surveyItem.data.elements.push(newElement);
+      if (!state.elementsBySurveyId[surveyId]) {
+        state.elementsBySurveyId[surveyId] = remoteList();
       }
+      state.elementsBySurveyId[surveyId].items = [
+        ...state.elementsBySurveyId[surveyId].items,
+        remoteItem(newElement.id, { data: newElement }),
+      ];
     },
     elementDeleted: (state, action: PayloadAction<[number, number]>) => {
       const [surveyId, elemId] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
+      const curItems = state.elementsBySurveyId[surveyId]?.items || [];
+      state.elementsBySurveyId[surveyId].items = curItems.filter(
+        (elem) => elem.id != elemId
       );
-      if (surveyItem && surveyItem.data) {
-        surveyItem.data.elements = surveyItem.data.elements.filter(
-          (elem) => elem.id !== elemId
-        );
-      }
     },
     elementOptionAdded: (
       state,
       action: PayloadAction<[number, number, ZetkinSurveyOption]>
     ) => {
       const [surveyId, elemId, newOption] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
+      const elementItem = state.elementsBySurveyId[surveyId].items.find(
+        (item) => item.id == elemId
       );
-      if (surveyItem && surveyItem.data) {
-        const elementItem = surveyItem.data.elements.find(
-          (element) => element.id === elemId
-        );
-
-        if (
-          elementItem &&
-          elementItem.type === ELEMENT_TYPE.QUESTION &&
-          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
-        ) {
-          elementItem.question.options?.push(newOption);
-        }
+      if (
+        elementItem?.data?.type === ELEMENT_TYPE.QUESTION &&
+        elementItem?.data?.question.response_type === RESPONSE_TYPE.OPTIONS
+      ) {
+        elementItem.data.question.options?.push(newOption);
       }
     },
     elementOptionDeleted: (
@@ -84,23 +76,17 @@ const surveysSlice = createSlice({
       action: PayloadAction<[number, number, number]>
     ) => {
       const [surveyId, elemId, optionId] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
+      const elementItem = state.elementsBySurveyId[surveyId].items.find(
+        (item) => item.id == elemId
       );
-      if (surveyItem && surveyItem.data) {
-        const elementItem = surveyItem.data.elements.find(
-          (element) => element.id === elemId
-        );
-
-        if (
-          elementItem &&
-          elementItem.type === ELEMENT_TYPE.QUESTION &&
-          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
-        ) {
-          elementItem.question.options = elementItem.question.options?.filter(
+      if (
+        elementItem?.data?.type === ELEMENT_TYPE.QUESTION &&
+        elementItem?.data?.question.response_type === RESPONSE_TYPE.OPTIONS
+      ) {
+        elementItem.data.question.options =
+          elementItem.data.question.options?.filter(
             (option) => option.id !== optionId
           );
-        }
       }
     },
     elementOptionUpdated: (
@@ -108,24 +94,17 @@ const surveysSlice = createSlice({
       action: PayloadAction<[number, number, number, ZetkinSurveyOption]>
     ) => {
       const [surveyId, elemId, optionId, updatedOption] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
+      const elementItem = state.elementsBySurveyId[surveyId].items.find(
+        (item) => item.id == elemId
       );
-      if (surveyItem && surveyItem.data) {
-        const elementItem = surveyItem.data.elements.find(
-          (element) => element.id === elemId
-        );
-
-        if (
-          elementItem &&
-          elementItem.type === ELEMENT_TYPE.QUESTION &&
-          elementItem.question.response_type === RESPONSE_TYPE.OPTIONS
-        ) {
-          elementItem.question.options = elementItem.question.options?.map(
-            (oldOption) =>
-              oldOption.id == optionId ? updatedOption : oldOption
+      if (
+        elementItem?.data?.type === ELEMENT_TYPE.QUESTION &&
+        elementItem?.data?.question.response_type === RESPONSE_TYPE.OPTIONS
+      ) {
+        elementItem.data.question.options =
+          elementItem.data.question.options?.map((oldOption) =>
+            oldOption.id == optionId ? updatedOption : oldOption
           );
-        }
       }
     },
     elementOptionsReordered: (
@@ -133,18 +112,15 @@ const surveysSlice = createSlice({
       action: PayloadAction<[number, number, ZetkinSurveyElementOrder]>
     ) => {
       const [surveyId, elemId, newOrder] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
-      );
-      const element = surveyItem?.data?.elements.find(
-        (elem) => elem.id == elemId
+      const elementItem = state.elementsBySurveyId[surveyId].items.find(
+        (item) => item.id == elemId
       );
 
       if (
-        element?.type == ELEMENT_TYPE.QUESTION &&
-        element.question.response_type == RESPONSE_TYPE.OPTIONS
+        elementItem?.data?.type == ELEMENT_TYPE.QUESTION &&
+        elementItem?.data?.question.response_type == RESPONSE_TYPE.OPTIONS
       ) {
-        element.question.options = element.question.options
+        elementItem.data.question.options = elementItem.data.question.options
           ?.concat()
           .sort(
             (o0, o1) =>
@@ -157,32 +133,40 @@ const surveysSlice = createSlice({
       action: PayloadAction<[number, number, ZetkinSurveyElement]>
     ) => {
       const [surveyId, elemId, updatedElement] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
+      state.elementsBySurveyId[surveyId].items = state.elementsBySurveyId[
+        surveyId
+      ].items.map((item) =>
+        item.id == elemId ? remoteItem(elemId, { data: updatedElement }) : item
       );
-      if (surveyItem && surveyItem.data) {
-        surveyItem.data.elements = surveyItem.data.elements.map((oldElement) =>
-          oldElement.id == elemId ? updatedElement : oldElement
-        );
+    },
+    elementsLoad: (state, action: PayloadAction<number>) => {
+      const surveyId = action.payload;
+      if (!state.elementsBySurveyId[surveyId]) {
+        state.elementsBySurveyId[surveyId] = remoteList();
       }
+      state.elementsBySurveyId[surveyId].isLoading = true;
+    },
+    elementsLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinSurveyElement[]]>
+    ) => {
+      const [surveyId, elements] = action.payload;
+      state.elementsBySurveyId[surveyId] = remoteList(elements);
+      state.elementsBySurveyId[surveyId].loaded = new Date().toISOString();
     },
     elementsReordered: (
       state,
       action: PayloadAction<[number, ZetkinSurveyElementOrder]>
     ) => {
       const [surveyId, newOrder] = action.payload;
-      const surveyItem = state.surveyList.items.find(
-        (item) => item.id == surveyId
-      );
-      if (surveyItem?.data?.elements) {
-        surveyItem.data.elements = surveyItem.data.elements
-          .concat()
-          .sort(
-            (el0, el1) =>
-              newOrder.default.indexOf(el0.id) -
-              newOrder.default.indexOf(el1.id)
-          );
-      }
+      const elementList = state.elementsBySurveyId[surveyId];
+      elementList.items = elementList.items
+        .concat()
+        .sort(
+          (el0, el1) =>
+            newOrder.default.indexOf(el0.data?.id ?? 0) -
+            newOrder.default.indexOf(el1.data?.id ?? 0)
+        );
     },
     statsLoad: (state, action: PayloadAction<number>) => {
       const surveyId = action.payload;
@@ -228,10 +212,12 @@ const surveysSlice = createSlice({
       const survey = action.payload;
       state.surveyList.isLoading = false;
       state.surveyList.items.push(remoteItem(survey.id, { data: survey }));
+      state.elementsBySurveyId[survey.id] = remoteList();
     },
     surveyLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const item = state.surveyList.items.find((item) => item.id == id);
+      state.elementsBySurveyId[id] == remoteList();
       state.surveyList.items = state.surveyList.items
         .filter((item) => item.id != id)
         .concat([remoteItem(id, { data: item?.data, isLoading: true })]);
@@ -246,6 +232,8 @@ const surveysSlice = createSlice({
       item.data = survey;
       item.isLoading = false;
       item.loaded = new Date().toISOString();
+
+      state.elementsBySurveyId[survey.id] = remoteList(survey.elements);
     },
     surveySubmissionUpdate: (
       state,
@@ -276,7 +264,7 @@ const surveysSlice = createSlice({
     surveysLoad: (state) => {
       state.surveyList.isLoading = true;
     },
-    surveysLoaded: (state, action: PayloadAction<ZetkinSurveyExtended[]>) => {
+    surveysLoaded: (state, action: PayloadAction<ZetkinSurvey[]>) => {
       const surveys = action.payload;
       const timestamp = new Date().toISOString();
       state.surveyList = remoteList(surveys);
@@ -308,7 +296,7 @@ const surveysSlice = createSlice({
       const survey = action.payload;
       const item = state.surveyList.items.find((item) => item.id == survey.id);
       if (item) {
-        item.data = { ...item.data, ...survey } as ZetkinSurveyExtended;
+        item.data = { ...item.data, ...survey };
         item.mutating = [];
       }
     },
@@ -324,6 +312,8 @@ export const {
   elementOptionUpdated,
   elementOptionsReordered,
   elementUpdated,
+  elementsLoad,
+  elementsLoaded,
   elementsReordered,
   submissionLoad,
   submissionLoaded,

--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -15,6 +15,7 @@ import { scaffold } from 'utils/next';
 import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from 'features/campaigns/l10n/messageIds';
+import useServerSide from 'core/useServerSide';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -85,6 +86,11 @@ const AllCampaignsSummaryPage: PageWithLayout<AllCampaignsSummaryPageProps> = ({
   const messages = useMessages(messageIds);
   const campaignsQuery = useQuery(['campaigns', orgId], getCampaigns(orgId));
   const eventsQuery = useQuery(['events', orgId], getEvents(orgId));
+
+  const onServer = useServerSide();
+  if (onServer) {
+    return null;
+  }
 
   const campaigns = campaignsQuery.data || [];
   const events = eventsQuery.data || [];


### PR DESCRIPTION
## Description
This PR refactors the model, store and repo (as well as any other parts of the code affected) so that survey elements are stored separately in the `surveys` store slice. This is done so that it's never assumed that elements exist on a survey in the `surveyList`, which will not always be the case.

Anyone wanting to use the elements of a survey must instead retrieve them separately, and if they haven't been retrieved already they will be loaded before being returned.

This fixes a number of bugs and potential bugs concerning trying to access elements that have not been loaded.

## Screenshots
None

## Changes
* Adds a `elementsById` object for storing survey elements in the store
* Uses `ZetkinSurvey` instead of `ZetkinSurveyExtended` in all places where it's not guaranteed that the data will be "extended" (i.e. contain elements)


## Notes to reviewer
Don't merge this until #1138 has been merged


## Related issues
Resolves #1137 