### PR TITLE
Survey reloads while editing

### DIFF
--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -170,9 +170,10 @@ const surveysSlice = createSlice({
     },
     statsLoad: (state, action: PayloadAction<number>) => {
       const surveyId = action.payload;
-      state.statsBySurveyId[surveyId] = remoteItem<SurveyStats>(surveyId, {
-        isLoading: true,
-      });
+      if (!state.statsBySurveyId[surveyId]) {
+        state.statsBySurveyId[surveyId] = remoteItem(surveyId);
+      }
+      state.statsBySurveyId[surveyId].isLoading = true;
     },
     statsLoaded: (state, action: PayloadAction<[number, SurveyStats]>) => {
       const [surveyId, stats] = action.payload;


### PR DESCRIPTION
## Description
This PR changes the survey store so that the cached survey stats are kept while loading the new version.

## Screenshots
None

## Changes
* Updates the `statsLoad` reducer so that it does not reset the data when it starts loading

## Notes to reviewer
Don't merge this until #1139 has been merged

## Related issues
Resolves #1141