### PR TITLE
Remove .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["next/babel"],
-}


### PR DESCRIPTION
## Description
This PR removes the old `.babelrc` file, which means that NEXT will no longer fall back to using babel and instead use SWC which should be much faster to compile. 

## Screenshots
None

## Changes
* Removes `.babelrc`

## Notes to reviewer
Try this and see if you feel like navigating around in dev mode is faster.

## Related issues
Undocumented