### PR TITLE
Add call assignment and survey to search results

### DIFF
--- a/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
@@ -1,0 +1,40 @@
+import { HeadsetMic } from '@mui/icons-material';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
+
+import ResultsListItemText from './ResultsListItemText';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
+
+import messageIds from '../../../l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+const CallassigmentListItem: React.FunctionComponent<{
+  callAssignment: ZetkinCallAssignment;
+}> = ({ callAssignment }) => {
+  const router = useRouter();
+  const { orgId } = router.query as { orgId: string };
+  return (
+    <Link
+      key={callAssignment.id}
+      href={`/organize/${orgId}/projects/${
+        callAssignment.campaign?.id ?? 'standalone'
+      }/callassignments/${callAssignment.id}`}
+      passHref
+    >
+      <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
+        <ListItemAvatar>
+          <Avatar>
+            <HeadsetMic />
+          </Avatar>
+        </ListItemAvatar>
+        <ResultsListItemText
+          primary={callAssignment.title}
+          secondary={<Msg id={messageIds.results.callassignment} />}
+        />
+      </ListItem>
+    </Link>
+  );
+};
+
+export default CallassigmentListItem;

--- a/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
@@ -1,0 +1,40 @@
+import { AssignmentOutlined } from '@mui/icons-material';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
+
+import ResultsListItemText from './ResultsListItemText';
+import { ZetkinSurvey } from 'utils/types/zetkin';
+
+import messageIds from '../../../l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+const SurveyListItem: React.FunctionComponent<{
+  survey: ZetkinSurvey;
+}> = ({ survey }) => {
+  const router = useRouter();
+  const { orgId } = router.query as { orgId: string };
+  return (
+    <Link
+      key={survey.id}
+      href={`/organize/${orgId}/projects/${
+        survey.campaign?.id ?? 'standalone'
+      }/surveys/${survey.id}`}
+      passHref
+    >
+      <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
+        <ListItemAvatar>
+          <Avatar>
+            <AssignmentOutlined />
+          </Avatar>
+        </ListItemAvatar>
+        <ResultsListItemText
+          primary={survey.title}
+          secondary={<Msg id={messageIds.results.survey} />}
+        />
+      </ListItem>
+    </Link>
+  );
+};
+
+export default SurveyListItem;

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -2,10 +2,13 @@ import { FunctionComponent } from 'react';
 
 import { List, ListItem, ListItemText } from '@mui/material';
 
+import CallAssignmentListItem from './CallAssignmentListItem';
 import CampaignListItem from './CampaignListItem';
 import PersonListItem from './PersonListItem';
+import SurveyListItem from './SurveyListItem';
 import TaskListItem from './TaskListItem';
 import ViewListItem from './ViewListItem';
+
 import {
   SEARCH_DATA_TYPE,
   SearchResult,
@@ -43,6 +46,12 @@ const ResultsList: FunctionComponent<ResultsListProps> = ({
             }
             if (result.type === SEARCH_DATA_TYPE.TASK) {
               return <TaskListItem task={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.CALL_ASSIGNMENT) {
+              return <CallAssignmentListItem callAssignment={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.SURVEY) {
+              return <SurveyListItem survey={result.match} />;
             }
             if (result.type === SEARCH_DATA_TYPE.VIEW) {
               return <ViewListItem view={result.match} />;

--- a/src/features/search/components/types.ts
+++ b/src/features/search/components/types.ts
@@ -1,6 +1,8 @@
 import {
+  ZetkinCallAssignment,
   ZetkinCampaign,
   ZetkinPerson,
+  ZetkinSurvey,
   ZetkinTask,
   ZetkinView,
 } from 'utils/types/zetkin';
@@ -10,6 +12,8 @@ export enum SEARCH_DATA_TYPE {
   CAMPAIGN = 'campaign',
   TASK = 'task',
   VIEW = 'view',
+  CALL_ASSIGNMENT = 'callassignment',
+  SURVEY = 'survey',
 }
 
 export interface PersonSearchResult {
@@ -28,9 +32,19 @@ export interface ViewSearchResult {
   type: SEARCH_DATA_TYPE.VIEW;
   match: ZetkinView;
 }
+export interface CallAssignmentSearchResult {
+  type: SEARCH_DATA_TYPE.CALL_ASSIGNMENT;
+  match: ZetkinCallAssignment;
+}
+export interface SurveySearchResult {
+  type: SEARCH_DATA_TYPE.SURVEY;
+  match: ZetkinSurvey;
+}
 
 export type SearchResult =
   | PersonSearchResult
   | CampaignSearchResult
   | TaskSearchResult
-  | ViewSearchResult;
+  | ViewSearchResult
+  | CallAssignmentSearchResult
+  | SurveySearchResult;

--- a/src/features/search/l10n/messageIds.ts
+++ b/src/features/search/l10n/messageIds.ts
@@ -6,9 +6,11 @@ export default makeMessages('feat.search', {
   noResults: m('No results'),
   placeholder: m('Type to search'),
   results: {
+    callassignment: m('Call assignment'),
     campaign: m('Campaign'),
     people: m('People'),
     person: m('Person'),
+    survey: m('Survey'),
     task: m('Task'),
     view: m('View'),
   },

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -52,6 +52,8 @@ const search = async (
       makeSearchRequest(SEARCH_DATA_TYPE.CAMPAIGN, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.TASK, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.VIEW, query, apiFetch),
+      makeSearchRequest(SEARCH_DATA_TYPE.CALL_ASSIGNMENT, query, apiFetch),
+      makeSearchRequest(SEARCH_DATA_TYPE.SURVEY, query, apiFetch),
     ]);
 
     const searchResults = results.flat();

--- a/src/utils/api/makeSearchRequest.ts
+++ b/src/utils/api/makeSearchRequest.ts
@@ -1,9 +1,11 @@
 import { ApiFetch } from 'utils/apiFetch';
 import handleResponseData from './handleResponseData';
 import {
+  CallAssignmentSearchResult,
   CampaignSearchResult,
   PersonSearchResult,
   SEARCH_DATA_TYPE,
+  SurveySearchResult,
   TaskSearchResult,
   ViewSearchResult,
 } from 'features/search/components/types';
@@ -40,6 +42,22 @@ async function makeSearchRequest(
   },
   apiFetch: ApiFetch
 ): Promise<PersonSearchResult[]>;
+async function makeSearchRequest(
+  dataType: SEARCH_DATA_TYPE.CALL_ASSIGNMENT,
+  query: {
+    orgId: number | string;
+    q: string;
+  },
+  apiFetch: ApiFetch
+): Promise<CallAssignmentSearchResult[]>;
+async function makeSearchRequest(
+  dataType: SEARCH_DATA_TYPE.SURVEY,
+  query: {
+    orgId: number | string;
+    q: string;
+  },
+  apiFetch: ApiFetch
+): Promise<SurveySearchResult[]>;
 async function makeSearchRequest(
   dataType: unknown,
   query: {


### PR DESCRIPTION
## Description
This PR enables searching for surveys and call assignments via the search widget


## Screenshots
![Screenshot of the search widget](https://user-images.githubusercontent.com/1464855/227774475-83792660-9bf9-4d10-be5f-d08810fd90ed.png)


## Changes
* Changes the search to return surveys and call assignments.
* Adds two components for showing the returned results in the search result list.

## Related issues
Resolves #1143
