### PR TITLE
Issue 1140/tweak logo

### DIFF
--- a/src/zui/ZUILogo/index.tsx
+++ b/src/zui/ZUILogo/index.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme) => ({
   beta: {
     backgroundColor: theme.palette.secondary.main,
     borderRadius: theme.spacing(0.25),
-    bottom: theme.spacing(-1.5),
+    bottom: theme.spacing(0.0),
     color: theme.palette.background.paper,
     fontSize: '0.5rem',
     fontWeight: 900,

--- a/src/zui/ZUIOrganizeSidebarNoMenu.tsx
+++ b/src/zui/ZUIOrganizeSidebarNoMenu.tsx
@@ -89,7 +89,7 @@ const ZUIOrganizeSidebarNoMenu = (): JSX.Element => {
                 size="large"
                 style={{ marginBottom: '2rem' }}
               >
-                <ZUILogo htmlColor="#ED1C55" size={40} />
+                <ZUILogo beta={true} htmlColor="#ED1C55" size={40} />
               </IconButton>
             </NextLink>
           </ListItem>


### PR DESCRIPTION
## Description
Adds the Beta text to the Organize page Zetkin logo.
Moves the Beta text up slightly across all pages.


## Screenshots
![image](https://user-images.githubusercontent.com/14234034/227778658-1a1377df-5c4b-403d-a0fb-db2aed1ff611.png)


## Changes
* Adds "beta boolen ={true}" to the ZUILogo on the ZUIOrganizeSidebarNoMenu page
* Changes the beta styles bottom parameter to theme.spacing(0.0)


## Notes to reviewer
* Visit http://localhost:3000/organize and look at the logo. Beta text should be visible.
* Open a project and look at the logo. Beta text should be at a consistent height.


## Related issues
Resolves #1140 
