### PR TITLE
More explicit metadata in `package.json`, eg. specify Node 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -38,7 +38,7 @@ jobs:
         run: exit `grep -ER "(test|describe)\.only" integrationTesting | wc -l`
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile && npx playwright install chromium
@@ -52,7 +52,7 @@ jobs:
         run: exit `grep -ER "(test|describe|it)\.only" src | wc -l`
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/env/frontend/Dockerfile
+++ b/env/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 WORKDIR /var/app
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "app.zetkin.org",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "^18.14.2"
+  },
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app.zetkin.org",
   "version": "0.1.0",
   "private": true,
+  "license": "UNLICENSED",
   "packageManager": "yarn@1.22.19",
   "engines": {
     "node": "^18.14.2"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app.zetkin.org",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.19",
   "engines": {
     "node": "^18.14.2"
   },


### PR DESCRIPTION
## Description
This PR adds some more explicit metadata to `package.json`, to make it clearer for both machines and humans to know how to use this project.

## Changes

* Adds `"license": "UNLICENSED"` according to [npm documentation](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license):
  >  if you do not wish to grant others the right to use a private or unpublished package under any terms
* Adds `"packageManager": "yarn@1.22.19"`, enabling tools to know that `yarn` rather than eg. `pnpm` is what should be used, such as the [node.js `corepack` tool](https://nodejs.org/api/packages.html#packagemanager)
* Adds `engines.node` set to `^18.14.2` in `package.json` and swaps `env/frontend/Dockerfile` to `node:18` to both indicate that Node 18 is what should be used and actually make use of that on the servers.

## Notes to reviewer
Nothing to test, just do a sanity check of the added metadata and judge whether its a sensible addition.
