### PR TITLE
Create crude implementation of dynamic pane height

### DIFF
--- a/src/utils/layout/DefaultLayout.tsx
+++ b/src/utils/layout/DefaultLayout.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
-import { createContext, FunctionComponent, useState } from 'react';
-
 import makeStyles from '@mui/styles/makeStyles';
+import { FunctionComponent, useState } from 'react';
 
+import { PageContainerContext } from 'utils/panes/PageContainerContext';
 import ZUIOrganizeSidebar from 'zui/ZUIOrganizeSidebar';
 
 const useStyles = makeStyles((theme) => ({
@@ -22,12 +22,6 @@ interface DefaultLayoutProps {
   children: React.ReactNode;
   onScroll?: () => void;
 }
-
-const UglyContext = createContext<{
-  container: HTMLDivElement | null;
-}>({ container: null });
-
-export { UglyContext };
 
 const DefaultLayout: FunctionComponent<DefaultLayoutProps> = ({
   children,
@@ -49,9 +43,9 @@ const DefaultLayout: FunctionComponent<DefaultLayoutProps> = ({
         position="relative"
         width={1}
       >
-        <UglyContext.Provider value={{ container }}>
+        <PageContainerContext.Provider value={{ container }}>
           {children}
-        </UglyContext.Provider>
+        </PageContainerContext.Provider>
       </Box>
     </Box>
   );

--- a/src/utils/layout/DefaultLayout.tsx
+++ b/src/utils/layout/DefaultLayout.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { FunctionComponent } from 'react';
+import { createContext, FunctionComponent, useState } from 'react';
 
 import makeStyles from '@mui/styles/makeStyles';
 
@@ -20,22 +20,38 @@ const useStyles = makeStyles((theme) => ({
 
 interface DefaultLayoutProps {
   children: React.ReactNode;
+  onScroll?: () => void;
 }
 
-const DefaultLayout: FunctionComponent<DefaultLayoutProps> = ({ children }) => {
+const UglyContext = createContext<{
+  container: HTMLDivElement | null;
+}>({ container: null });
+
+export { UglyContext };
+
+const DefaultLayout: FunctionComponent<DefaultLayoutProps> = ({
+  children,
+  onScroll,
+}) => {
   const classes = useStyles();
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+
   return (
     <Box className={classes.root} display="flex" height="100vh">
       <ZUIOrganizeSidebar />
       <Box
+        ref={(div: HTMLDivElement) => setContainer(div)}
         display="flex"
         flexDirection="column"
         height="100vh"
+        onScroll={onScroll}
         overflow="auto"
         position="relative"
         width={1}
       >
-        {children}
+        <UglyContext.Provider value={{ container }}>
+          {children}
+        </UglyContext.Provider>
       </Box>
     </Box>
   );

--- a/src/utils/layout/SimpleLayout.tsx
+++ b/src/utils/layout/SimpleLayout.tsx
@@ -72,7 +72,7 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
           p={fixedHeight ? 0 : 3}
           position="relative"
         >
-          <PaneProvider>{children}</PaneProvider>
+          <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
         </Box>
       </Box>
     </DefaultLayout>

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -117,7 +117,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
           position="relative"
           role="tabpanel"
         >
-          <PaneProvider>{children}</PaneProvider>
+          <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
         </Box>
       </Box>
     </DefaultLayout>

--- a/src/utils/panes/PageContainerContext.tsx
+++ b/src/utils/panes/PageContainerContext.tsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+const PageContainerContext = createContext<{
+  container: HTMLDivElement | null;
+}>({ container: null });
+
+export { PageContainerContext };

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -5,13 +5,12 @@ import {
   FC,
   ReactNode,
   useContext,
-  useEffect,
   useRef,
   useState,
 } from 'react';
 
-import { PageContainerContext } from './PageContainerContext';
 import Pane from './Pane';
+import useResizablePane from 'utils/panes/useResizablePane';
 
 type PaneDef = {
   render: () => ReactNode;
@@ -59,45 +58,8 @@ export const PaneProvider: FC<PaneProviderProps> = ({
   const styles = useStyles();
   const [key, setKey] = useState(0);
 
-  const paneContainerRef = useRef<HTMLDivElement>();
-  const slideRef = useRef<HTMLDivElement>();
-
-  const { container } = useContext(PageContainerContext);
-
-  const update = () => {
-    const paneContainer = paneContainerRef.current;
-    if (paneContainer) {
-      const rect = paneContainer.getBoundingClientRect();
-      if (slideRef.current) {
-        if (rect.top <= 16 && !fixedHeight) {
-          slideRef.current.style.position = 'fixed';
-          slideRef.current.style.height = 'auto';
-        } else {
-          slideRef.current.style.position = 'absolute';
-          if (!fixedHeight) {
-            slideRef.current.style.height =
-              Math.min(window.innerHeight - rect.top - 32, rect.height) + 'px';
-          }
-        }
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (container) {
-      window.addEventListener('resize', update);
-      container.addEventListener('scroll', update);
-
-      return () => {
-        window.removeEventListener('resize', update);
-        container.removeEventListener('scroll', update);
-      };
-    }
-  }, [container]);
-
-  useEffect(() => {
-    update();
-  }, []);
+  const { paneContainerRef, slideRef, updatePaneHeight } =
+    useResizablePane(fixedHeight);
 
   return (
     <PaneContext.Provider
@@ -123,10 +85,10 @@ export const PaneProvider: FC<PaneProviderProps> = ({
           direction="left"
           in={!!paneRef.current && open}
           onEnter={() => {
-            update();
+            updatePaneHeight();
           }}
           onEntered={() => {
-            update();
+            updatePaneHeight();
           }}
         >
           <Box>

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -5,11 +5,13 @@ import {
   FC,
   ReactNode,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react';
 
 import Pane from './Pane';
+import { UglyContext } from 'utils/layout/DefaultLayout';
 
 type PaneDef = {
   render: () => ReactNode;
@@ -32,6 +34,7 @@ const PaneContext = createContext<PaneContextData>({
 
 type PaneProviderProps = {
   children: ReactNode;
+  fixedHeight: boolean;
 };
 
 const useStyles = makeStyles({
@@ -47,11 +50,54 @@ const useStyles = makeStyles({
   },
 });
 
-export const PaneProvider: FC<PaneProviderProps> = ({ children }) => {
+export const PaneProvider: FC<PaneProviderProps> = ({
+  children,
+  fixedHeight,
+}) => {
   const paneRef = useRef<PaneDef | null>(null);
   const [open, setOpen] = useState(false);
   const styles = useStyles();
   const [key, setKey] = useState(0);
+
+  const paneContainerRef = useRef<HTMLDivElement>();
+  const slideRef = useRef<HTMLDivElement>();
+
+  const { container } = useContext(UglyContext);
+
+  const update = () => {
+    const paneContainer = paneContainerRef.current;
+    if (paneContainer) {
+      const rect = paneContainer.getBoundingClientRect();
+      if (slideRef.current) {
+        if (rect.top <= 16 && !fixedHeight) {
+          slideRef.current.style.position = 'fixed';
+          slideRef.current.style.height = 'auto';
+        } else {
+          slideRef.current.style.position = 'absolute';
+          if (!fixedHeight) {
+            slideRef.current.style.height =
+              Math.min(window.innerHeight - rect.top - 32, rect.height) + 'px';
+          }
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (container) {
+      window.addEventListener('resize', update);
+      container.addEventListener('scroll', update);
+
+      return () => {
+        window.removeEventListener('resize', update);
+        container.removeEventListener('scroll', update);
+      };
+    }
+  }, [container]);
+
+  useEffect(() => {
+    update();
+  }, []);
 
   return (
     <PaneContext.Provider
@@ -64,33 +110,47 @@ export const PaneProvider: FC<PaneProviderProps> = ({ children }) => {
         },
       }}
     >
-      <Slide
-        key={key}
-        className={styles.container}
-        direction="left"
-        in={!!paneRef.current && open}
+      <Box
+        ref={paneContainerRef}
+        style={{
+          height: fixedHeight ? '100%' : 'auto',
+        }}
       >
-        <Box>
-          <Paper
-            className={styles.paper}
-            elevation={2}
-            sx={{
-              width: paneRef.current?.width ?? 200,
-            }}
-          >
-            {paneRef.current && (
-              <Pane
-                onClose={() => {
-                  setOpen(false);
-                }}
-              >
-                {paneRef.current.render()}
-              </Pane>
-            )}
-          </Paper>
-        </Box>
-      </Slide>
-      {children}
+        <Slide
+          key={key}
+          ref={slideRef}
+          className={styles.container}
+          direction="left"
+          in={!!paneRef.current && open}
+          onEnter={() => {
+            update();
+          }}
+          onEntered={() => {
+            update();
+          }}
+        >
+          <Box>
+            <Paper
+              className={styles.paper}
+              elevation={2}
+              sx={{
+                width: paneRef.current?.width ?? 200,
+              }}
+            >
+              {paneRef.current && (
+                <Pane
+                  onClose={() => {
+                    setOpen(false);
+                  }}
+                >
+                  {paneRef.current.render()}
+                </Pane>
+              )}
+            </Paper>
+          </Box>
+        </Slide>
+        {children}
+      </Box>
     </PaneContext.Provider>
   );
 };

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles({
     position: 'absolute',
     right: 16,
     top: 16,
-    zIndex: 10,
+    zIndex: 9999,
   },
   paper: {
     height: '100%',

--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -10,8 +10,8 @@ import {
   useState,
 } from 'react';
 
+import { PageContainerContext } from './PageContainerContext';
 import Pane from './Pane';
-import { UglyContext } from 'utils/layout/DefaultLayout';
 
 type PaneDef = {
   render: () => ReactNode;
@@ -62,7 +62,7 @@ export const PaneProvider: FC<PaneProviderProps> = ({
   const paneContainerRef = useRef<HTMLDivElement>();
   const slideRef = useRef<HTMLDivElement>();
 
-  const { container } = useContext(UglyContext);
+  const { container } = useContext(PageContainerContext);
 
   const update = () => {
     const paneContainer = paneContainerRef.current;

--- a/src/utils/panes/useResizablePane.ts
+++ b/src/utils/panes/useResizablePane.ts
@@ -1,0 +1,52 @@
+import { RefObject, useContext, useEffect, useRef } from 'react';
+
+import { PageContainerContext } from './PageContainerContext';
+
+type ResizablePane = {
+  paneContainerRef: RefObject<HTMLDivElement | undefined>;
+  slideRef: RefObject<HTMLDivElement | undefined>;
+  updatePaneHeight: () => void;
+};
+
+export default function useResizablePane(fixedHeight: boolean): ResizablePane {
+  const paneContainerRef = useRef<HTMLDivElement>();
+  const slideRef = useRef<HTMLDivElement>();
+  const { container } = useContext(PageContainerContext);
+
+  const updatePaneHeight = () => {
+    const paneContainer = paneContainerRef.current;
+    if (paneContainer) {
+      const rect = paneContainer.getBoundingClientRect();
+      if (slideRef.current) {
+        if (rect.top <= 16 && !fixedHeight) {
+          slideRef.current.style.position = 'fixed';
+          slideRef.current.style.height = 'auto';
+        } else {
+          slideRef.current.style.position = 'absolute';
+          if (!fixedHeight) {
+            slideRef.current.style.height =
+              Math.min(window.innerHeight - rect.top - 32, rect.height) + 'px';
+          }
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (container) {
+      window.addEventListener('resize', updatePaneHeight);
+      container.addEventListener('scroll', updatePaneHeight);
+
+      return () => {
+        window.removeEventListener('resize', updatePaneHeight);
+        container.removeEventListener('scroll', updatePaneHeight);
+      };
+    }
+  }, [container]);
+
+  useEffect(() => {
+    updatePaneHeight();
+  }, []);
+
+  return { paneContainerRef, slideRef, updatePaneHeight };
+}


### PR DESCRIPTION
## Description
This PR is the start of a solution to the dynamic pane height problem. I'm creating this PR as a way of discussing a solution and handing ot over to someone else (if possible).

## Screenshots
NOne

## Changes
* Adds `UglyContext` as a way of passing the container `div` element through context down to the pane provider
* Adds a `useEffect()` in pane provider to listen for events and update DOM directly (without React)

## To whomever takes this over
I think this could be good enough, if the logic would be properly encapsulated, maybe in a hook and a context that is actually defined and exported as part of the pane framework instead of randomly inside `DefaultLayout`.

## Related issues
Part of #1067 