### PR TITLE
Localize tab lables in ShareViewDialog.

### DIFF
--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -46,8 +46,11 @@ const ShareViewDialog: FC<ShareViewDialogProps> = ({
     >
       <TabContext value={tab}>
         <TabList onChange={(ev, newValue) => setTab(newValue)} value={tab}>
-          <Tab label="Share" value="share" />
-          <Tab label="Download" value="download" />
+          <Tab label={messages.shareDialog.share.tabLabel()} value="share" />
+          <Tab
+            label={messages.shareDialog.download.tabLabel()}
+            value="download"
+          />
         </TabList>
         <TabPanel className={styles.tabPanel} value="share">
           <ShareViewDialogShareTab model={model} />

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -331,6 +331,7 @@ export default makeMessages('feat.views', {
         xlsx: m('Download Excel file'),
       },
       shareLink: m('share data securely'),
+      tabLabel: m('Download'),
       warning1: m(
         'Avoid exporting data from Zetkin when you can, to ensure that all data is kept in order.'
       ),
@@ -347,6 +348,7 @@ export default makeMessages('feat.views', {
       statusLabel: m<{ collaborators: number; officials: number }>(
         'Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.'
       ),
+      tabLabel: m('Share'),
       viewLink: m('restricted link'),
     },
     title: m<{ title: string }>('Share "{title}"'),


### PR DESCRIPTION
## Description
This PR localizes the tab lables in the `ShareViewDialog`.

## Changes
* Adds localization + messags for "share" and "download" tabs.
