### PR TITLE
issue 1067/link archive

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/index.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/index.tsx
@@ -64,7 +64,9 @@ const ActivitiesOverview: FC<ActivitiesOverviewProps> = ({
             return (
               <Box>
                 <ZUIEmptyState
-                  href={`/organize/${orgId}/projects/${campaignId}/activities`}
+                  href={`/organize/${orgId}/projects${
+                    campaignId ? `/${campaignId}` : ''
+                  }/activities`}
                   linkMessage={messages.activitiesOverview.goToActivities()}
                   message={messages.activitiesOverview.noActivities()}
                 />

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -43,6 +43,7 @@ export default makeMessages('feat.campaigns', {
     noActivities: m(
       'If your organization has activities that do not belong to a project they will show up here.'
     ),
+    viewArchive: m('View archive'),
   },
   assigneeActions: m('Assignee actions'),
   calendarView: m('See all in calendar'),
@@ -129,8 +130,10 @@ export default makeMessages('feat.campaigns', {
   noManager: m('No Project Manager'),
   singleProject: {
     filterActivities: m('Type to filter'),
+    linkToSummary: m('Go to my active project.'),
     noActivities: m('There are no activities in this project yet.'),
     noSearchResults: m('Your filtering yielded no results.'),
+    viewArchive: m('View archive'),
   },
   taskLayout: {
     tabs: {

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -129,7 +129,6 @@ export default makeMessages('feat.campaigns', {
   noManager: m('No Project Manager'),
   singleProject: {
     filterActivities: m('Type to filter'),
-    linkToSummary: m('Go to my active project.'),
     noActivities: m('There are no activities in this project yet.'),
     noSearchResults: m('Your filtering yielded no results.'),
     viewArchive: m('View archive'),

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -39,7 +39,6 @@ export default makeMessages('feat.campaigns', {
     upcoming: m<{ numEvents: number }>('{numEvents, number} upcoming events.'),
   },
   allProjects: {
-    linkToSummary: m('Go to my active projects.'),
     noActivities: m(
       'If your organization has activities that do not belong to a project they will show up here.'
     ),

--- a/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
@@ -77,7 +77,11 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
         {(data) => {
           if (data.length === 0) {
             return (
-              <ZUIEmptyState message={messages.singleProject.noActivities()} />
+              <ZUIEmptyState
+                href={`/organize/${orgId}/projects/${campId}/archive`}
+                linkMessage={messages.singleProject.viewArchive()}
+                message={messages.singleProject.noActivities()}
+              />
             );
           }
 

--- a/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
@@ -77,7 +77,11 @@ const CampaignArchivePage: PageWithLayout<CampaignArchivePageProps> = ({
         {(data) => {
           if (data.length === 0) {
             return (
-              <ZUIEmptyState message={messages.singleProject.noActivities()} />
+              <ZUIEmptyState
+                href={`/organize/${orgId}/projects/${campId}`}
+                linkMessage={messages.singleProject.linkToSummary()}
+                message={messages.singleProject.noActivities()}
+              />
             );
           }
 

--- a/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
@@ -78,8 +78,8 @@ const CampaignArchivePage: PageWithLayout<CampaignArchivePageProps> = ({
           if (data.length === 0) {
             return (
               <ZUIEmptyState
-                href={`/organize/${orgId}/projects/${campId}`}
-                linkMessage={messages.singleProject.linkToSummary()}
+                href={`/organize/${orgId}/projects/${campId}/activities`}
+                linkMessage={messages.activitiesOverview.goToActivities()}
                 message={messages.singleProject.noActivities()}
               />
             );

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -76,8 +76,8 @@ const CampaignActivitiesPage: PageWithLayout<CampaignActivitiesPageProps> = ({
           if (data.length === 0) {
             return (
               <ZUIEmptyState
-                href={`/organize/${orgId}/projects`}
-                linkMessage={messages.allProjects.linkToSummary()}
+                href={`/organize/${orgId}/projects/archive`}
+                linkMessage={messages.allProjects.viewArchive()}
                 message={messages.allProjects.noActivities()}
               />
             );

--- a/src/pages/organize/[orgId]/projects/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/archive/index.tsx
@@ -76,8 +76,8 @@ const ActivitiesArchivePage: PageWithLayout<ActivitiesArchivePageProps> = ({
           if (data.length === 0) {
             return (
               <ZUIEmptyState
-                href={`/organize/${orgId}/projects`}
-                linkMessage={messages.allProjects.linkToSummary()}
+                href={`/organize/${orgId}/projects/activities`}
+                linkMessage={messages.activitiesOverview.goToActivities()}
                 message={messages.allProjects.noActivities()}
               />
             );


### PR DESCRIPTION
## Description
This PR implements link to archive on activities tab. And link to overview if there are no archive on archive tab.


## Screenshots
![image](https://user-images.githubusercontent.com/77925373/227919062-b84002f6-d470-4b67-aac3-5f980d837b73.png)
Shows `view archive` whether archive exists or not

![image](https://user-images.githubusercontent.com/77925373/227950534-a04ff7b6-4e01-4149-9095-456a6db17eaf.png)
Shows `see all upcoming activities` if archive doesn't exist (empty array)


## Changes

* Adds `link` and `href` to ZUIEmptyState
* Adds `viewArchive` and `linkToSummary` to messageIds

## Notes to reviewer




## Related issues
Resolves part of #1067
