### PR TITLE
prevent string 'undefined' in url

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/index.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/index.tsx
@@ -64,7 +64,9 @@ const ActivitiesOverview: FC<ActivitiesOverviewProps> = ({
             return (
               <Box>
                 <ZUIEmptyState
-                  href={`/organize/${orgId}/projects/${campaignId}/activities`}
+                  href={`/organize/${orgId}/projects/${
+                    campaignId ? campaignId : ''
+                  }/activities`}
                   linkMessage={messages.activitiesOverview.goToActivities()}
                   message={messages.activitiesOverview.noActivities()}
                 />


### PR DESCRIPTION
## Description
This PR fixes minor error that shows 'undefined' string in url when user clicks the `see all upcoming activities.` link on overview tab when there is no project ID


## Screenshots

![image](https://user-images.githubusercontent.com/77925373/227936964-7e24e6b9-4b99-4a6c-b2fc-4ee484a97129.png)


## Changes

* Adds campId condition to the path in ActivitiesOverview



## Related issues
undocumented
