### PR TITLE
Add loading animation for ActivityListItem

### DIFF
--- a/src/features/campaigns/components/ActivityList/ActivityListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/ActivityListItem.tsx
@@ -3,6 +3,7 @@ import NextLink from 'next/link';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import {
   Box,
+  CircularProgress,
   Grid,
   Link,
   SvgIconTypeMap,
@@ -76,6 +77,7 @@ interface AcitivityListItemProps {
   color: STATUS_COLORS;
   title: string;
   endNumber: string | number;
+  statsLoading: boolean;
 }
 
 const ActivityListItem = ({
@@ -88,6 +90,7 @@ const ActivityListItem = ({
   color,
   title,
   endNumber,
+  statsLoading,
 }: AcitivityListItemProps) => {
   const classes = useStyles({ color });
 
@@ -110,11 +113,15 @@ const ActivityListItem = ({
         </Box>
       </Grid>
       <Grid item lg={2} md={3} xs={4}>
-        <ZUIMultiNumberChip
-          blueValue={blueChipValue}
-          greenValue={greenChipValue}
-          orangeValue={orangeChipValue}
-        />
+        {statsLoading ? (
+          <CircularProgress size={26} />
+        ) : (
+          <ZUIMultiNumberChip
+            blueValue={blueChipValue}
+            greenValue={greenChipValue}
+            orangeValue={orangeChipValue}
+          />
+        )}
       </Grid>
       <Grid item xs={2}>
         <Box className={classes.endNumber}>

--- a/src/features/campaigns/components/ActivityList/CallAssignmentListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/CallAssignmentListItem.tsx
@@ -41,6 +41,7 @@ const CallAssignmentListItem: FC<CallAssignmentListItemProps> = ({
   const ready = stats?.ready || 0;
   const done = stats?.done || 0;
   const callsMade = stats?.callsMade.toString() || '0';
+  const statsLoading = model.getStats().isLoading;
 
   return (
     <ActivityListItem
@@ -55,6 +56,7 @@ const CallAssignmentListItem: FC<CallAssignmentListItemProps> = ({
       PrimaryIcon={HeadsetMic}
       SecondaryIcon={PhoneOutlined}
       title={data.title}
+      statsLoading={statsLoading}
     />
   );
 };

--- a/src/features/campaigns/components/ActivityList/CallAssignmentListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/CallAssignmentListItem.tsx
@@ -55,8 +55,8 @@ const CallAssignmentListItem: FC<CallAssignmentListItemProps> = ({
       orangeChipValue={blocked}
       PrimaryIcon={HeadsetMic}
       SecondaryIcon={PhoneOutlined}
-      title={data.title}
       statsLoading={statsLoading}
+      title={data.title}
     />
   );
 };

--- a/src/features/campaigns/components/ActivityList/SurveyListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/SurveyListItem.tsx
@@ -46,6 +46,7 @@ const SurveyListItem: FC<SurveyListItemProps> = ({ orgId, surveyId }) => {
   const submissionCount = stats?.submissionCount || 0;
   const unlinkedSubmissionCount = stats?.unlinkedSubmissionCount || 0;
   const linkedSubmissionCount = submissionCount - unlinkedSubmissionCount || 0;
+  const statsLoading = dataModel.getStats().isLoading;
 
   return (
     <ActivityListItem
@@ -59,6 +60,7 @@ const SurveyListItem: FC<SurveyListItemProps> = ({ orgId, surveyId }) => {
       PrimaryIcon={AssignmentOutlined}
       SecondaryIcon={ChatBubbleOutline}
       title={data.title}
+      statsLoading={statsLoading}
     />
   );
 };

--- a/src/features/campaigns/components/ActivityList/SurveyListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/SurveyListItem.tsx
@@ -59,8 +59,8 @@ const SurveyListItem: FC<SurveyListItemProps> = ({ orgId, surveyId }) => {
       orangeChipValue={unlinkedSubmissionCount}
       PrimaryIcon={AssignmentOutlined}
       SecondaryIcon={ChatBubbleOutline}
-      title={data.title}
       statsLoading={statsLoading}
+      title={data.title}
     />
   );
 };

--- a/src/features/campaigns/components/ActivityList/TaskListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/TaskListItem.tsx
@@ -44,8 +44,8 @@ const TaskListItem = ({ orgId, taskId }: TaskListItemProps) => {
       orangeChipValue={stats?.ignored}
       PrimaryIcon={CheckBoxOutlined}
       SecondaryIcon={People}
-      title={task.title}
       statsLoading={statsLoading}
+      title={task.title}
     />
   );
 };

--- a/src/features/campaigns/components/ActivityList/TaskListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/TaskListItem.tsx
@@ -30,6 +30,8 @@ const TaskListItem = ({ orgId, taskId }: TaskListItemProps) => {
     color = STATUS_COLORS.BLUE;
   }
 
+  const statsLoading = model.getTaskStats().isLoading;
+
   return (
     <ActivityListItem
       blueChipValue={stats?.assigned}
@@ -43,6 +45,7 @@ const TaskListItem = ({ orgId, taskId }: TaskListItemProps) => {
       PrimaryIcon={CheckBoxOutlined}
       SecondaryIcon={People}
       title={task.title}
+      statsLoading={statsLoading}
     />
   );
 };


### PR DESCRIPTION
## Description
This PR adds a loading animation using `<CircularProgress>` when loading the activity stats in `ActivityListItem`.

## Screenshots
### While loading
![image](https://user-images.githubusercontent.com/42777637/227987039-12cb550c-f4e9-4d92-951f-3de670c91730.png)

### After loading
![image](https://user-images.githubusercontent.com/42777637/227986837-17f7eb48-07e2-439b-8011-8213b9a58843.png)


## Changes
* Adds a `statsLoading` property for `ActivityListItem`
* Changes the three components using `ActivityListItem` to also send the extracted prop `statsLoading`
* Adds a `CircularProgress` to `ActivityListItem` when stats are loading

## Related issues
Resolves #1142 
