### PR TITLE
Blocks home/end in ZUIPersonSelect when shift-key is pressed

### DIFF
--- a/src/zui/ZUIPersonSelect.tsx
+++ b/src/zui/ZUIPersonSelect.tsx
@@ -54,6 +54,7 @@ interface UsePersonSelectReturn {
       props: HTMLAttributes<HTMLLIElement>,
       person: ZetkinPerson
     ) => ReactElement;
+    shiftHeld: boolean;
     value: ZetkinPerson | null;
   };
 }
@@ -81,6 +82,7 @@ export const usePersonSelect: UsePersonSelect = ({
   const [searchFieldValue, setSearchFieldValue] = useState<string>(
     initialValue || ''
   );
+  const [shiftHeld, setShiftHeld] = useState(false);
 
   const {
     isLoading,
@@ -112,6 +114,27 @@ export const usePersonSelect: UsePersonSelect = ({
       debouncedQuery();
     }
   }, [searchFieldValue.length, debouncedQuery]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Shift') {
+      setShiftHeld(true);
+    }
+  };
+
+  const handleKeyUp = (e: KeyboardEvent) => {
+    if (e.key === 'Shift') {
+      setShiftHeld(false);
+    }
+  };
 
   let personOptions = (results || []) as ZetkinPerson[];
   if (
@@ -159,6 +182,7 @@ export const usePersonSelect: UsePersonSelect = ({
           </Box>
         );
       },
+      shiftHeld,
       value: selectedPerson,
     },
   };
@@ -170,13 +194,14 @@ const MUIOnlyPersonSelect: FunctionComponent<ZUIPersonSelectProps> = (
   const { label, size, variant, ...restComponentProps } = props;
   const { autoCompleteProps } = usePersonSelect(restComponentProps);
 
-  const { name, placeholder, inputRef, ...restProps } = autoCompleteProps;
-
+  const { name, placeholder, inputRef, shiftHeld, ...restProps } =
+    autoCompleteProps;
   delete restProps.getOptionValue;
 
   return (
     <MUIAutocomplete
       {...restProps}
+      handleHomeEndKeys={!shiftHeld}
       renderInput={(params) => (
         <TextField
           {...params}


### PR DESCRIPTION
## Description
This PR fixes a problem where the text in ZUIPersonSelect was not able to be marked using shift+home (or end).
I chose to keep home/end being pressed without shift to still choose the first and last entry in the results. This is possible to change so that home/end only affects the input box. LMK if you'd rather have this.

## Changes
* Adds logic for detecting when shift is held down
* Uses this logic to send a prop to MUIAutocomplete choosing whether it should gain control of home/end or not.

## Related issues
Resolves #1157 
