### PR TITLE
Add tabs to an event page

### DIFF
--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -21,4 +21,8 @@ export default makeMessages('feat.events', {
     events: m('Events'),
     noEvents: m('No events...'),
   },
+  tabs: {
+    overview: m('Overview'),
+    participants: m('Participants'),
+  },
 });

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -1,0 +1,40 @@
+import { Box } from '@mui/material';
+import TabbedLayout from 'utils/layout/TabbedLayout';
+
+import messageIds from '../l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+interface SurveyLayoutProps {
+  children: React.ReactNode;
+  eventId: string;
+  orgId: string;
+  campaignId: string;
+}
+
+const EventLayout: React.FC<SurveyLayoutProps> = ({
+  children,
+  eventId,
+  orgId,
+  campaignId,
+}) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <TabbedLayout
+      baseHref={`/organize/${orgId}/projects/${campaignId}/events/${eventId}`}
+      defaultTab="/"
+      subtitle={<Box alignItems="center" display="flex"></Box>}
+      tabs={[
+        { href: '/', label: messages.tabs.overview() },
+        {
+          href: '/participants',
+          label: messages.tabs.participants(),
+        },
+      ]}
+    >
+      {children}
+    </TabbedLayout>
+  );
+};
+
+export default EventLayout;

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -259,6 +259,9 @@ feat:
     list:
       events: Events
       noEvents: No events...
+    tabs:
+      overview: Overview
+      participants: Participants
   journeys:
     instance:
       addAssigneeButton: Add assignee
@@ -1422,51 +1425,6 @@ feat:
         title: Title
       empty: You haven't created any views yet.
 zui:
-  timeline:
-    addNotePlaceholder: Enter text to leave a note
-    email:
-      headers:
-        cc: CC
-        from: From
-        to: To
-    expand: show full timeline
-    filter:
-      byType:
-        all: All
-        files: Files
-        journey: Journey
-        milestones: Milestones
-        notes: Notes
-        people: People
-        tags: Tags
-      filterSelectLabel: "Show: {filter}"
-      warning: The timeline is being filtered. Click here to remove the filter.
-    updates:
-      any:
-        addtags: "{actor} added {count, plural, =1 {a tag} other {# tags}}"
-        removetags: "{actor} removed {count, plural, =1 {a tag} other {# tags}}"
-      journeyinstance:
-        addassignee: "{actor} assigned {assignee}"
-        addnote: "{actor} added a note"
-        addsubject: "{actor} added {subject}"
-        close:
-          header: "{actor} closed the journey"
-        convert: "{actor} converted from {oldLabel} to {newLabel}"
-        create:
-          header: "{actor} started a new journey"
-        open: "{actor} opened the journey again"
-        removeassignee: "{actor} unassigned {assignee}"
-        removesubject: "{actor} removed {subject}"
-        update:
-          readMore: Read more
-          summary: "{actor} edited the summary"
-          title: "{actor} edited the title"
-        updatemilestone:
-          complete: "{actor} completed a milestone"
-          deadline: "{actor} updated a milestone deadline"
-          deadlineRemove: deadline was removed
-          deadlineUpdate: now due {datetime}
-          incomplete: "{actor} marked a milestone as incomplete"
   accessList:
     added: Added by {sharer} {updated}
     removeAccess: Remove access
@@ -1490,6 +1448,7 @@ zui:
     milestones: Milestones
     new: New
     organize: Organize
+    participants: Participants
     people: People
     projects: Projects
     questions: Questions
@@ -1562,3 +1521,48 @@ zui:
     submit: Submit
   suffixedNumber:
     thousands: "{num}K"
+  timeline:
+    addNotePlaceholder: Enter text to leave a note
+    email:
+      headers:
+        cc: CC
+        from: From
+        to: To
+    expand: show full timeline
+    filter:
+      byType:
+        all: All
+        files: Files
+        journey: Journey
+        milestones: Milestones
+        notes: Notes
+        people: People
+        tags: Tags
+      filterSelectLabel: "Show: {filter}"
+      warning: The timeline is being filtered. Click here to remove the filter.
+    updates:
+      any:
+        addtags: "{actor} added {count, plural, =1 {a tag} other {# tags}}"
+        removetags: "{actor} removed {count, plural, =1 {a tag} other {# tags}}"
+      journeyinstance:
+        addassignee: "{actor} assigned {assignee}"
+        addnote: "{actor} added a note"
+        addsubject: "{actor} added {subject}"
+        close:
+          header: "{actor} closed the journey"
+        convert: "{actor} converted from {oldLabel} to {newLabel}"
+        create:
+          header: "{actor} started a new journey"
+        open: "{actor} opened the journey again"
+        removeassignee: "{actor} unassigned {assignee}"
+        removesubject: "{actor} removed {subject}"
+        update:
+          readMore: Read more
+          summary: "{actor} edited the summary"
+          title: "{actor} edited the title"
+        updatemilestone:
+          complete: "{actor} completed a milestone"
+          deadline: "{actor} updated a milestone deadline"
+          deadlineRemove: deadline was removed
+          deadlineUpdate: now due {datetime}
+          incomplete: "{actor} marked a milestone as incomplete"

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -1,0 +1,47 @@
+import { GetServerSideProps } from 'next';
+import { PageWithLayout } from 'utils/types';
+import { scaffold } from 'utils/next';
+
+import EventLayout from 'features/events/layout/EventLayout';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId, campId, eventId } = ctx.params!;
+
+    return {
+      props: {
+        campId,
+        eventId,
+        orgId,
+      },
+    };
+  },
+  {
+    authLevelRequired: 2,
+    localeScope: ['layout.organize.events', 'pages.organizeEvent'],
+  }
+);
+
+interface EventPageProps {
+  campId: string;
+  eventId: string;
+  orgId: string;
+}
+
+const EventPage: PageWithLayout<EventPageProps> = () => {
+  return <>event page</>;
+};
+
+EventPage.getLayout = function getLayout(page, props) {
+  return (
+    <EventLayout
+      campaignId={props.campId}
+      eventId={props.eventId}
+      orgId={props.orgId}
+    >
+      {page}
+    </EventLayout>
+  );
+};
+
+export default EventPage;

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -18,7 +18,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.events', 'pages.organizeEvent'],
+    localeScope: [],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -1,0 +1,48 @@
+import { GetServerSideProps } from 'next';
+import { PageWithLayout } from 'utils/types';
+import { scaffold } from 'utils/next';
+
+import EventLayout from 'features/events/layout/EventLayout';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId, campId, eventId } = ctx.params!;
+
+    return {
+      props: {
+        campId,
+        eventId,
+        orgId,
+      },
+    };
+  },
+  {
+    authLevelRequired: 2,
+
+    localeScope: ['layout.organize.events', 'pages.organizeEvent'],
+  }
+);
+
+interface ParticipantsProps {
+  campId: string;
+  eventId: string;
+  orgId: string;
+}
+
+const ParticipantsPage: PageWithLayout<ParticipantsProps> = () => {
+  return <>participants page</>;
+};
+
+ParticipantsPage.getLayout = function getLayout(page, props) {
+  return (
+    <EventLayout
+      campaignId={props.campId}
+      eventId={props.eventId}
+      orgId={props.orgId}
+    >
+      {page}
+    </EventLayout>
+  );
+};
+
+export default ParticipantsPage;

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -19,7 +19,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   {
     authLevelRequired: 2,
 
-    localeScope: ['layout.organize.events', 'pages.organizeEvent'],
+    localeScope: [],
   }
 );
 

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -28,6 +28,7 @@ export default makeMessages('zui', {
     milestones: m('Milestones'),
     new: m('New'),
     organize: m('Organize'),
+    participants: m('Participants'),
     people: m('People'),
     projects: m('Projects'),
     questions: m('Questions'),


### PR DESCRIPTION
## Description
This PR adds overview and participants tabs to an Event page


## Screenshots
![image](https://user-images.githubusercontent.com/77925373/228789303-2d9fb976-013f-4e6f-b194-8200a27e8021.png)
![image](https://user-images.githubusercontent.com/77925373/228791093-b573a315-dde5-4b13-a68c-47ab9568a4f9.png)




## Changes

* Adds EventLayout
* Adds Overview and Participants message to messageIds
* Adds index.tsx and participants.tsx to events/[eventId] folder


## Notes to reviewer



## Related issues
Resolves #1159 
