### PR TITLE
Organizer action view

### DIFF
--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -3,7 +3,7 @@ import { RPCRouter } from './router';
 import { addBulkOptionsDef } from 'features/surveys/rpc/addBulkOptions';
 import { createNewViewRouteDef } from 'features/views/rpc/createNew/server';
 import { deleteFolderRouteDef } from 'features/views/rpc/deleteFolder';
-import { getOrganizerActionViewRouteDef } from 'features/views/rpc/getOrganizerActionView';
+import { getOrganizerActionViewRouteDef } from 'features/views/rpc/getOrganizerActionView/server';
 import { getSurveyStatsDef } from 'features/surveys/rpc/getSurveyStats';
 import { getTaskStatsRouteDef } from 'features/tasks/rpc/getTaskStats';
 

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -16,7 +16,6 @@ export function createRPCRouter() {
   rpcRouter.register(getSurveyStatsDef);
   rpcRouter.register(getTaskStatsRouteDef);
   rpcRouter.register(addBulkOptionsDef);
-  rpcRouter.register(addBulkOptionsDef);
 
   return rpcRouter;
 }

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -3,6 +3,7 @@ import { RPCRouter } from './router';
 import { addBulkOptionsDef } from 'features/surveys/rpc/addBulkOptions';
 import { createNewViewRouteDef } from 'features/views/rpc/createNew/server';
 import { deleteFolderRouteDef } from 'features/views/rpc/deleteFolder';
+import { getOrganizerActionViewRouteDef } from 'features/views/rpc/getOrganizerActionView';
 import { getSurveyStatsDef } from 'features/surveys/rpc/getSurveyStats';
 import { getTaskStatsRouteDef } from 'features/tasks/rpc/getTaskStats';
 
@@ -11,8 +12,10 @@ export function createRPCRouter() {
 
   rpcRouter.register(deleteFolderRouteDef);
   rpcRouter.register(createNewViewRouteDef);
+  rpcRouter.register(getOrganizerActionViewRouteDef);
   rpcRouter.register(getSurveyStatsDef);
   rpcRouter.register(getTaskStatsRouteDef);
+  rpcRouter.register(addBulkOptionsDef);
   rpcRouter.register(addBulkOptionsDef);
 
   return rpcRouter;

--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -26,3 +26,28 @@ export interface CallAssignmentStats {
   queue: number;
   ready: number;
 }
+
+export interface Call {
+  id: number;
+  allocation_time: string;
+  update_time: string;
+  state: number;
+  notes?: string;
+  call_back_after?: string;
+  organizer_action_needed: boolean;
+  organizer_action_taken: boolean;
+  message_to_organizer: string;
+  assignment_id: number;
+  caller: {
+    first_name?: string;
+    id: number;
+    last_name?: string;
+    name: string;
+  };
+  target: {
+    alt_phone: string;
+    id: number;
+    name: string;
+    phone: string;
+  };
+}

--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -11,15 +11,18 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { Edit, Settings } from '@mui/icons-material';
+import { Edit, Settings, Visibility } from '@mui/icons-material';
 
 import CallAssignmentModel from '../models/CallAssignmentModel';
 import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog';
 import StatusCardHeader from './StatusCardHeader';
 import StatusCardItem from './StatusCardItem';
+import ViewBrowserModel from 'features/views/models/ViewBrowserModel';
 import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from '../l10n/messageIds';
+import useModel from 'core/useModel';
+import { useRouter } from 'next/router';
 
 interface CallAssignmentStatusCardProps {
   model: CallAssignmentModel;
@@ -34,6 +37,12 @@ const CallAssignmentStatusCards = ({
   const cooldown = data?.cooldown ?? null;
   const hasTargets = model.hasTargets;
   const goalQuery = data?.goal;
+
+  const { orgId } = useRouter().query;
+
+  const viewsModel: ViewBrowserModel = useModel(
+    (env) => new ViewBrowserModel(env, parseInt(orgId as string))
+  );
 
   const [anchorEl, setAnchorEl] = useState<
     null | (EventTarget & SVGSVGElement)
@@ -129,6 +138,15 @@ const CallAssignmentStatusCards = ({
               value={stats?.missingPhoneNumber}
             />
             <StatusCardItem
+              action={
+                <Button
+                  onClick={() => viewsModel.getOrganizerActionView()}
+                  startIcon={<Visibility />}
+                  variant="outlined"
+                >
+                  View sheet
+                </Button>
+              }
               title={messages.blocked.organizerActionNeeded()}
               value={stats?.organizerActionNeeded}
             />
@@ -138,7 +156,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'blue' : 'gray'}
+            chipColor={hasTargets ? 'green' : 'gray'}
             subtitle={messages.ready.subtitle()}
             title={messages.ready.title()}
             value={stats?.ready}
@@ -158,7 +176,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'green' : 'gray'}
+            chipColor={hasTargets ? 'blue' : 'gray'}
             subtitle={messages.done.subtitle()}
             title={messages.done.title()}
             value={stats?.done}

--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from '@mui/styles';
 import { useState } from 'react';
 import {
   Box,
@@ -24,6 +25,12 @@ import messageIds from '../l10n/messageIds';
 import useModel from 'core/useModel';
 import { useRouter } from 'next/router';
 
+const useStyles = makeStyles(() => ({
+  button: {
+    height: '2.59em',
+  },
+}));
+
 interface CallAssignmentStatusCardProps {
   model: CallAssignmentModel;
 }
@@ -43,6 +50,7 @@ const CallAssignmentStatusCards = ({
   const viewsModel: ViewBrowserModel = useModel(
     (env) => new ViewBrowserModel(env, parseInt(orgId as string))
   );
+  const styles = useStyles();
 
   const [anchorEl, setAnchorEl] = useState<
     null | (EventTarget & SVGSVGElement)
@@ -140,6 +148,7 @@ const CallAssignmentStatusCards = ({
             <StatusCardItem
               action={
                 <Button
+                  className={styles.button}
                   onClick={() => viewsModel.getOrganizerActionView()}
                   startIcon={<Visibility />}
                   variant="outlined"

--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -144,7 +144,7 @@ const CallAssignmentStatusCards = ({
                   startIcon={<Visibility />}
                   variant="outlined"
                 >
-                  View sheet
+                  <Msg id={messageIds.blocked.viewSheetButton} />
                 </Button>
               }
               title={messages.blocked.organizerActionNeeded()}

--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from '@mui/styles';
 import { useState } from 'react';
 import {
   Box,
@@ -25,12 +24,6 @@ import messageIds from '../l10n/messageIds';
 import useModel from 'core/useModel';
 import { useRouter } from 'next/router';
 
-const useStyles = makeStyles(() => ({
-  button: {
-    height: '2.59em',
-  },
-}));
-
 interface CallAssignmentStatusCardProps {
   model: CallAssignmentModel;
 }
@@ -50,7 +43,6 @@ const CallAssignmentStatusCards = ({
   const viewsModel: ViewBrowserModel = useModel(
     (env) => new ViewBrowserModel(env, parseInt(orgId as string))
   );
-  const styles = useStyles();
 
   const [anchorEl, setAnchorEl] = useState<
     null | (EventTarget & SVGSVGElement)
@@ -148,7 +140,6 @@ const CallAssignmentStatusCards = ({
             <StatusCardItem
               action={
                 <Button
-                  className={styles.button}
                   onClick={() => viewsModel.getOrganizerActionView()}
                   startIcon={<Visibility />}
                   variant="outlined"

--- a/src/features/callAssignments/components/StatusCardItem.tsx
+++ b/src/features/callAssignments/components/StatusCardItem.tsx
@@ -11,7 +11,12 @@ interface StatusCardItemProps {
 const StatusCardItem = ({ action, title, value }: StatusCardItemProps) => {
   return (
     <ListItem>
-      <Box display="flex" justifyContent="space-between" width="100%">
+      <Box
+        alignItems="flex-start"
+        display="flex"
+        justifyContent="space-between"
+        width="100%"
+      >
         <Box display="flex" flexDirection="column">
           <Typography color="secondary" variant="h5">
             {title}

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { m, makeMessages } from 'core/i18n';
+import { ReactElement } from 'react';
 
 export default makeMessages('feat.callAssignments', {
   actions: {
@@ -80,6 +81,15 @@ export default makeMessages('feat.callAssignments', {
     defineButton: m('Edit done criteria'),
     subtitle: m('Targets that meet the done criteria'),
     title: m('Done'),
+  },
+  organizerActionPane: {
+    markAsSolved: m('Mark as solved'),
+    markAsUnsolved: m('Mark as unsolved'),
+    noteByCaller: m<{ person: ReactElement; time: ReactElement }>(
+      'Note by {person} {time}'
+    ),
+    subtitle: m<{ person: ReactElement }>('Notes on {person}'),
+    title: m('Organizer Action Needed'),
   },
   ready: {
     allocated: m('Targets allocated to caller'),

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -1,5 +1,5 @@
-import { m, makeMessages } from 'core/i18n';
 import { ReactElement } from 'react';
+import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.callAssignments', {
   actions: {

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -85,6 +85,7 @@ export default makeMessages('feat.callAssignments', {
   organizerActionPane: {
     markAsSolved: m('Mark as solved'),
     markAsUnsolved: m('Mark as unsolved'),
+    messagePlaceholder: m('Caller did not leave a message'),
     noteByCaller: m<{ person: ReactElement; time: ReactElement }>(
       'Note by {person} {time}'
     ),

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -20,6 +20,7 @@ export default makeMessages('feat.callAssignments', {
     organizerActionNeeded: m('Organizer action needed'),
     subtitle: m('Targets not ready to be called'),
     title: m('Blocked'),
+    viewSheetButton: m('View sheet'),
   },
   callers: {
     actions: {

--- a/src/features/callAssignments/models/CallAssignmentModel.spec.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.spec.ts
@@ -8,6 +8,7 @@ import { FILTER_TYPE } from 'features/smartSearch/components/types';
 import IApiClient from 'core/api/client/IApiClient';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import {
+  Call,
   CallAssignmentCaller,
   CallAssignmentData,
   CallAssignmentStats,
@@ -71,6 +72,7 @@ describe('CallAssignmentModel', () => {
               title: 'My assignment',
             },
           ]),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {},
         },
@@ -117,6 +119,7 @@ describe('CallAssignmentModel', () => {
               title: 'My assignment',
             },
           ]),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {},
         },
@@ -163,6 +166,7 @@ describe('CallAssignmentModel', () => {
             title: 'My assignment',
           },
         ]),
+        callList: mockList<Call>(),
         callersById: {},
         statsById: {
           2: mockItem({
@@ -192,6 +196,7 @@ describe('CallAssignmentModel', () => {
       const store = createStore({
         callAssignments: {
           assignmentList: mockList(),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {},
         },
@@ -317,6 +322,7 @@ describe('CallAssignmentModel', () => {
               title: 'My assignment',
             },
           ]),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {},
         },
@@ -368,6 +374,7 @@ describe('CallAssignmentModel', () => {
               title: 'My assignment',
             },
           ]),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {},
         },
@@ -449,6 +456,7 @@ describe('CallAssignmentModel', () => {
               title: 'My assignment',
             },
           ]),
+          callList: mockList<Call>(),
           callersById: {},
           statsById: {
             2: mockItem({
@@ -502,6 +510,7 @@ describe('CallAssignmentModel', () => {
       const store = createStore({
         callAssignments: {
           assignmentList: mockList(),
+          callList: mockList<Call>(),
           callersById: {
             2: mockList<CallAssignmentCaller>([
               {
@@ -539,6 +548,7 @@ describe('CallAssignmentModel', () => {
       const store = createStore({
         callAssignments: {
           assignmentList: mockList(),
+          callList: mockList<Call>(),
           callersById: {
             2: mockList<CallAssignmentCaller>([
               {
@@ -583,6 +593,7 @@ describe('CallAssignmentModel', () => {
       const store = createStore({
         callAssignments: {
           assignmentList: mockList(),
+          callList: mockList<Call>(),
           callersById: {
             2: mockList<CallAssignmentCaller>([
               {
@@ -619,6 +630,7 @@ describe('CallAssignmentModel', () => {
       const store = createStore({
         callAssignments: {
           assignmentList: mockList(),
+          callList: mockList<Call>(),
           callersById: {
             2: mockList<CallAssignmentCaller>([]),
           },
@@ -669,6 +681,7 @@ describe('CallAssignmentModel', () => {
             title: 'My assignment',
           },
         ]),
+        callList: mockList<Call>(),
         callersById: {},
         statsById: {},
       },
@@ -743,6 +756,7 @@ describe('CallAssignmentModel', () => {
             title: 'My assignment',
           },
         ]),
+        callList: mockList<Call>(),
         callersById: {},
         statsById: {},
       },

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -207,6 +207,18 @@ export default class CallAssignmentModel extends ModelBase {
     }
   }
 
+  setOrganizerActionNeeded(callId: number) {
+    this._repo.updateCall(this._orgId, callId, {
+      organizer_action_taken: false,
+    });
+  }
+
+  setOrganizerActionTaken(callId: number) {
+    this._repo.updateCall(this._orgId, callId, {
+      organizer_action_taken: true,
+    });
+  }
+
   setTargetDetailsExposed(exposeTargetDetails: boolean) {
     this._repo.updateCallAssignment(this._orgId, this._id, {
       expose_target_details: exposeTargetDetails,

--- a/src/features/callAssignments/models/CallAssignmentModel.ts
+++ b/src/features/callAssignments/models/CallAssignmentModel.ts
@@ -207,18 +207,6 @@ export default class CallAssignmentModel extends ModelBase {
     }
   }
 
-  setOrganizerActionNeeded(callId: number) {
-    this._repo.updateCall(this._orgId, callId, {
-      organizer_action_taken: false,
-    });
-  }
-
-  setOrganizerActionTaken(callId: number) {
-    this._repo.updateCall(this._orgId, callId, {
-      organizer_action_taken: true,
-    });
-  }
-
   setTargetDetailsExposed(exposeTargetDetails: boolean) {
     this._repo.updateCallAssignment(this._orgId, this._id, {
       expose_target_details: exposeTargetDetails,

--- a/src/features/callAssignments/models/CallModel.ts
+++ b/src/features/callAssignments/models/CallModel.ts
@@ -1,0 +1,48 @@
+import CallAssignmentsRepo from '../repos/CallAssignmentsRepo';
+import Environment from 'core/env/Environment';
+import { ModelBase } from 'core/models';
+import { Store } from 'core/store';
+import { ZetkinOrganizerAction } from 'utils/types/zetkin';
+
+export default class CallModel extends ModelBase {
+  private _env: Environment;
+  private _orgId: number;
+  private _repo: CallAssignmentsRepo;
+  private _store: Store;
+
+  constructor(env: Environment, orgId: number) {
+    super();
+    this._env = env;
+    this._store = this._env.store;
+    this._orgId = orgId;
+    this._repo = new CallAssignmentsRepo(env);
+  }
+
+  getUpdatedCalls(calls: [ZetkinOrganizerAction]) {
+    const state = this._store.getState();
+    // Return calls that are updated compared to the provided calls
+    return state.callAssignments.callList.items.filter((item) => {
+      const call = calls.find((c) => c.id == item.id);
+      if (call) {
+        return (
+          new Date(item.data?.update_time || 0) >
+          new Date(call?.update_time || 0)
+        );
+      } else {
+        return false;
+      }
+    });
+  }
+
+  setOrganizerActionNeeded(callId: number) {
+    this._repo.updateCall(this._orgId, callId, {
+      organizer_action_taken: false,
+    });
+  }
+
+  setOrganizerActionTaken(callId: number) {
+    this._repo.updateCall(this._orgId, callId, {
+      organizer_action_taken: true,
+    });
+  }
+}

--- a/src/features/callAssignments/models/CallModel.ts
+++ b/src/features/callAssignments/models/CallModel.ts
@@ -1,37 +1,15 @@
 import CallAssignmentsRepo from '../repos/CallAssignmentsRepo';
 import Environment from 'core/env/Environment';
 import { ModelBase } from 'core/models';
-import { Store } from 'core/store';
-import { ZetkinOrganizerAction } from 'utils/types/zetkin';
 
 export default class CallModel extends ModelBase {
-  private _env: Environment;
   private _orgId: number;
   private _repo: CallAssignmentsRepo;
-  private _store: Store;
 
   constructor(env: Environment, orgId: number) {
     super();
-    this._env = env;
-    this._store = this._env.store;
     this._orgId = orgId;
     this._repo = new CallAssignmentsRepo(env);
-  }
-
-  getUpdatedCalls(calls: [ZetkinOrganizerAction]) {
-    const state = this._store.getState();
-    // Return calls that are updated compared to the provided calls
-    return state.callAssignments.callList.items.filter((item) => {
-      const call = calls.find((c) => c.id == item.id);
-      if (call) {
-        return (
-          new Date(item.data?.update_time || 0) >
-          new Date(call?.update_time || 0)
-        );
-      } else {
-        return false;
-      }
-    });
   }
 
   setOrganizerActionNeeded(callId: number) {

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -1,18 +1,19 @@
-import { Box, Button, Typography } from '@mui/material';
-import { CallSharp, Check, PriorityHigh } from '@mui/icons-material';
 import { FC, useMemo } from 'react';
-import { Msg, useMessages } from 'core/i18n';
+import { makeStyles } from '@mui/styles';
+import { Box, Button, Typography } from '@mui/material';
+import { Check, PriorityHigh } from '@mui/icons-material';
 
-import { Call } from '../apiTypes';
 import CallModel from '../models/CallModel';
 import PaneHeader from 'utils/panes/PaneHeader';
+import { personResource } from 'features/profile/api/people';
 import useModel from 'core/useModel';
-import { ZetkinOrganizerAction, ZetkinViewRow } from 'utils/types/zetkin';
+import ViewDataModel from 'features/views/models/ViewDataModel';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from '../l10n/messageIds';
-import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinOrganizerAction } from 'utils/types/zetkin';
 
 interface OrganizerActionPaneProps {
   columnIdx: number;
@@ -20,6 +21,13 @@ interface OrganizerActionPaneProps {
   personId: number;
   viewModel: ViewDataModel;
 }
+
+const useStyles = makeStyles(() => ({
+  buttonBox: {
+    display: 'flex',
+    justifyContent: 'end',
+  },
+}));
 
 export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
   orgId,
@@ -29,57 +37,44 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
 }) => {
   const rows = viewModel.getRows().data;
   const row = rows?.find((r) => r.id == personId);
-  const calls = row?.content[columnIdx];
+  let calls: ZetkinOrganizerAction[] = row?.content[columnIdx];
+  if (!calls) {
+    calls = [];
+  }
 
   const messages = useMessages(messageIds);
-  const recipient = calls[0].recipient;
   const model = useModel((env) => new CallModel(env, orgId));
-
-  //  const viewModel = useModel((env) => new ViewModel(env, orgId, viewId));
-  //const updatedCalls = model.getUpdatedCalls(calls);
-
-  //  const sorted = useMemo(() => {
-  // Replace any calls from view with updated calls where they exist
-  /*
-    const callList = [];
-    for (const call of calls) {
-      const updatedCall = updatedCalls.find((uc) => uc.data?.id == call.id);
-      if (updatedCall?.data) {
-        // A quirk of the API is that calls are returned with call.caller.name,
-        // get the first_name and last_name from the calls provided by the view.
-        const transformedUpdatedCall = {
-          ...updatedCall,
-          caller: {
-            first_name: call.caller.first_name,
-            last_name: call.caller.last_name,
-          },
-        };
-
-        callList.push(transformedUpdatedCall.data as Call);
-      } else {
-        callList.push(call);
-      }
-    }*/
+  const { data: recipient } = personResource(
+    orgId.toString(),
+    personId.toString()
+  ).useQuery();
 
   // Sort first according to date ascending, then organizer action needed first
-  const sorted = [...calls]
-    .sort((call0, call1) => {
-      const d0 = new Date(call0?.update_time || 0);
-      const d1 = new Date(call1?.update_time || 0);
-      return d1.getTime() - d0.getTime();
-    })
-    .sort((call0, call1) => {
-      if (!call0?.organizer_action_taken && !!call1?.organizer_action_taken) {
-        return -1;
-      } else if (
-        !!call0?.organizer_action_taken &&
-        !call1?.organizer_action_taken
-      ) {
-        return 1;
-      } else {
-        return 0;
-      }
-    });
+  const sorted: ZetkinOrganizerAction[] = useMemo(
+    () =>
+      [...calls]
+        .sort((call0, call1) => {
+          const d0 = new Date(call0?.update_time || 0);
+          const d1 = new Date(call1?.update_time || 0);
+          return d1.getTime() - d0.getTime();
+        })
+        .sort((call0, call1) => {
+          if (
+            !call0?.organizer_action_taken &&
+            !!call1?.organizer_action_taken
+          ) {
+            return -1;
+          } else if (
+            !!call0?.organizer_action_taken &&
+            !call1?.organizer_action_taken
+          ) {
+            return 1;
+          } else {
+            return 0;
+          }
+        }),
+    [calls]
+  );
 
   return (
     <>
@@ -87,38 +82,42 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
         subtitle={
           <Msg
             id={messageIds.organizerActionPane.subtitle}
-            values={{ person: <ZUIPersonLink person={recipient} /> }}
+            values={{
+              person: recipient && <ZUIPersonLink person={recipient} />,
+            }}
           />
         }
         title={messages.organizerActionPane.title()}
       />
       {sorted.map((call) => (
         <Box key={call?.id}>
-          <Msg
-            id={messageIds.organizerActionPane.noteByCaller}
-            values={{
-              person: call && (
-                <ZUIPersonLink
-                  person={
-                    call.caller as {
-                      first_name: string;
-                      id: number;
-                      last_name: string;
-                      name?: string;
+          <Typography>
+            <Msg
+              id={messageIds.organizerActionPane.noteByCaller}
+              values={{
+                person: call && (
+                  <ZUIPersonLink
+                    person={
+                      call.caller as {
+                        first_name: string;
+                        id: number;
+                        last_name: string;
+                        name?: string;
+                      }
                     }
-                  }
-                />
-              ),
-              time: call && <ZUIRelativeTime datetime={call.update_time} />,
-            }}
-          />
+                  />
+                ),
+                time: call && <ZUIRelativeTime datetime={call.update_time} />,
+              }}
+            />
+          </Typography>
           <Typography>{call?.message_to_organizer}</Typography>
           {!call?.organizer_action_taken ? (
             <Button
               onClick={() => call && model.setOrganizerActionTaken(call.id)}
+              startIcon={<Check />}
               variant="contained"
             >
-              <Check />
               <Msg id={messageIds.organizerActionPane.markAsSolved} />
             </Button>
           ) : (

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -41,30 +41,13 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
     personId.toString()
   ).useQuery();
 
-  // Sort first according to date ascending, then organizer action needed first
   const sorted: ZetkinOrganizerAction[] = useMemo(
     () =>
-      [...calls]
-        .sort((call0, call1) => {
-          const d0 = new Date(call0?.update_time || 0);
-          const d1 = new Date(call1?.update_time || 0);
-          return d1.getTime() - d0.getTime();
-        })
-        .sort((call0, call1) => {
-          if (
-            !call0?.organizer_action_taken &&
-            !!call1?.organizer_action_taken
-          ) {
-            return -1;
-          } else if (
-            !!call0?.organizer_action_taken &&
-            !call1?.organizer_action_taken
-          ) {
-            return 1;
-          } else {
-            return 0;
-          }
-        }),
+      [...calls].sort((call0, call1) => {
+        const d0 = new Date(call0?.update_time || 0);
+        const d1 = new Date(call1?.update_time || 0);
+        return d1.getTime() - d0.getTime();
+      }),
     [calls]
   );
 

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -37,7 +37,7 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
 }) => {
   const rows = viewModel.getRows().data;
   const row = rows?.find((r) => r.id == personId);
-  let calls: ZetkinOrganizerAction[] = row?.content[columnIdx];
+  let calls = row?.content[columnIdx] as ZetkinOrganizerAction[];
   if (!calls) {
     calls = [];
   }
@@ -80,12 +80,14 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
     <>
       <PaneHeader
         subtitle={
-          <Msg
-            id={messageIds.organizerActionPane.subtitle}
-            values={{
-              person: recipient && <ZUIPersonLink person={recipient} />,
-            }}
-          />
+          recipient && (
+            <Msg
+              id={messageIds.organizerActionPane.subtitle}
+              values={{
+                person: <ZUIPersonLink person={recipient} />,
+              }}
+            />
+          )
         }
         title={messages.organizerActionPane.title()}
       />

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -73,19 +73,21 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
       <PaneHeader
         subtitle={
           recipient && (
-            <Msg
-              id={messageIds.organizerActionPane.subtitle}
-              values={{
-                person: <ZUIPersonLink person={recipient} />,
-              }}
-            />
+            <Typography variant="body2">
+              <Msg
+                id={messageIds.organizerActionPane.subtitle}
+                values={{
+                  person: <ZUIPersonLink person={recipient} />,
+                }}
+              />
+            </Typography>
           )
         }
         title={messages.organizerActionPane.title()}
       />
       {sorted.map((call) => (
-        <Box key={call?.id}>
-          <Typography>
+        <Box key={call?.id} mt={4}>
+          <Typography variant="body2">
             <Msg
               id={messageIds.organizerActionPane.noteByCaller}
               values={{
@@ -105,24 +107,26 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
               }}
             />
           </Typography>
-          <Typography>{call?.message_to_organizer}</Typography>
-          {!call?.organizer_action_taken ? (
-            <Button
-              onClick={() => call && model.setOrganizerActionTaken(call.id)}
-              startIcon={<Check />}
-              variant="contained"
-            >
-              <Msg id={messageIds.organizerActionPane.markAsSolved} />
-            </Button>
-          ) : (
-            <Button
-              onClick={() => call && model.setOrganizerActionNeeded(call.id)}
-              variant="outlined"
-            >
-              <PriorityHigh />
-              <Msg id={messageIds.organizerActionPane.markAsUnsolved} />
-            </Button>
-          )}
+          <Typography my={1}>{call?.message_to_organizer}</Typography>
+          <Box display="flex" justifyContent="flex-end" my={2}>
+            {!call?.organizer_action_taken ? (
+              <Button
+                onClick={() => call && model.setOrganizerActionTaken(call.id)}
+                startIcon={<Check />}
+                variant="contained"
+              >
+                <Msg id={messageIds.organizerActionPane.markAsSolved} />
+              </Button>
+            ) : (
+              <Button
+                onClick={() => call && model.setOrganizerActionNeeded(call.id)}
+                startIcon={<PriorityHigh />}
+                variant="text"
+              >
+                <Msg id={messageIds.organizerActionPane.markAsUnsolved} />
+              </Button>
+            )}
+          </Box>
         </Box>
       ))}
     </>

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -107,7 +107,15 @@ export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
               }}
             />
           </Typography>
-          <Typography my={1}>{call?.message_to_organizer}</Typography>
+          <Box my={1}>
+            {call?.message_to_organizer ? (
+              <Typography>{call.message_to_organizer}</Typography>
+            ) : (
+              <Typography sx={{ color: 'GrayText', fontStyle: 'italic' }}>
+                <Msg id={messageIds.organizerActionPane.messagePlaceholder} />
+              </Typography>
+            )}
+          </Box>
           <Box display="flex" justifyContent="flex-end" my={2}>
             {!call?.organizer_action_taken ? (
               <Button

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -1,7 +1,6 @@
-import { FC, useMemo } from 'react';
-import { makeStyles } from '@mui/styles';
 import { Box, Button, Typography } from '@mui/material';
 import { Check, PriorityHigh } from '@mui/icons-material';
+import { FC, useMemo } from 'react';
 
 import CallModel from '../models/CallModel';
 import PaneHeader from 'utils/panes/PaneHeader';
@@ -21,13 +20,6 @@ interface OrganizerActionPaneProps {
   personId: number;
   viewModel: ViewDataModel;
 }
-
-const useStyles = makeStyles(() => ({
-  buttonBox: {
-    display: 'flex',
-    justifyContent: 'end',
-  },
-}));
 
 export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
   orgId,

--- a/src/features/callAssignments/panes/OrganizerActionPane.tsx
+++ b/src/features/callAssignments/panes/OrganizerActionPane.tsx
@@ -1,0 +1,137 @@
+import { Box, Button, Typography } from '@mui/material';
+import { CallSharp, Check, PriorityHigh } from '@mui/icons-material';
+import { FC, useMemo } from 'react';
+import { Msg, useMessages } from 'core/i18n';
+
+import { Call } from '../apiTypes';
+import CallModel from '../models/CallModel';
+import PaneHeader from 'utils/panes/PaneHeader';
+import useModel from 'core/useModel';
+import { ZetkinOrganizerAction, ZetkinViewRow } from 'utils/types/zetkin';
+import ZUIPersonLink from 'zui/ZUIPersonLink';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+
+import messageIds from '../l10n/messageIds';
+import ViewDataModel from 'features/views/models/ViewDataModel';
+
+interface OrganizerActionPaneProps {
+  columnIdx: number;
+  orgId: number;
+  personId: number;
+  viewModel: ViewDataModel;
+}
+
+export const OrganizerActionPane: FC<OrganizerActionPaneProps> = ({
+  orgId,
+  personId,
+  columnIdx,
+  viewModel,
+}) => {
+  const rows = viewModel.getRows().data;
+  const row = rows?.find((r) => r.id == personId);
+  const calls = row?.content[columnIdx];
+
+  const messages = useMessages(messageIds);
+  const recipient = calls[0].recipient;
+  const model = useModel((env) => new CallModel(env, orgId));
+
+  //  const viewModel = useModel((env) => new ViewModel(env, orgId, viewId));
+  //const updatedCalls = model.getUpdatedCalls(calls);
+
+  //  const sorted = useMemo(() => {
+  // Replace any calls from view with updated calls where they exist
+  /*
+    const callList = [];
+    for (const call of calls) {
+      const updatedCall = updatedCalls.find((uc) => uc.data?.id == call.id);
+      if (updatedCall?.data) {
+        // A quirk of the API is that calls are returned with call.caller.name,
+        // get the first_name and last_name from the calls provided by the view.
+        const transformedUpdatedCall = {
+          ...updatedCall,
+          caller: {
+            first_name: call.caller.first_name,
+            last_name: call.caller.last_name,
+          },
+        };
+
+        callList.push(transformedUpdatedCall.data as Call);
+      } else {
+        callList.push(call);
+      }
+    }*/
+
+  // Sort first according to date ascending, then organizer action needed first
+  const sorted = [...calls]
+    .sort((call0, call1) => {
+      const d0 = new Date(call0?.update_time || 0);
+      const d1 = new Date(call1?.update_time || 0);
+      return d1.getTime() - d0.getTime();
+    })
+    .sort((call0, call1) => {
+      if (!call0?.organizer_action_taken && !!call1?.organizer_action_taken) {
+        return -1;
+      } else if (
+        !!call0?.organizer_action_taken &&
+        !call1?.organizer_action_taken
+      ) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
+  return (
+    <>
+      <PaneHeader
+        subtitle={
+          <Msg
+            id={messageIds.organizerActionPane.subtitle}
+            values={{ person: <ZUIPersonLink person={recipient} /> }}
+          />
+        }
+        title={messages.organizerActionPane.title()}
+      />
+      {sorted.map((call) => (
+        <Box key={call?.id}>
+          <Msg
+            id={messageIds.organizerActionPane.noteByCaller}
+            values={{
+              person: call && (
+                <ZUIPersonLink
+                  person={
+                    call.caller as {
+                      first_name: string;
+                      id: number;
+                      last_name: string;
+                      name?: string;
+                    }
+                  }
+                />
+              ),
+              time: call && <ZUIRelativeTime datetime={call.update_time} />,
+            }}
+          />
+          <Typography>{call?.message_to_organizer}</Typography>
+          {!call?.organizer_action_taken ? (
+            <Button
+              onClick={() => call && model.setOrganizerActionTaken(call.id)}
+              variant="contained"
+            >
+              <Check />
+              <Msg id={messageIds.organizerActionPane.markAsSolved} />
+            </Button>
+          ) : (
+            <Button
+              onClick={() => call && model.setOrganizerActionNeeded(call.id)}
+              variant="outlined"
+            >
+              <PriorityHigh />
+              <Msg id={messageIds.organizerActionPane.markAsUnsolved} />
+            </Button>
+          )}
+        </Box>
+      ))}
+    </>
+  );
+};

--- a/src/features/callAssignments/repos/CallAssignmentsRepo.ts
+++ b/src/features/callAssignments/repos/CallAssignmentsRepo.ts
@@ -5,6 +5,7 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
 import {
+  Call,
   CallAssignmentCaller,
   CallAssignmentData,
   CallAssignmentStats,
@@ -26,6 +27,8 @@ import {
   callerRemoved,
   callersLoad,
   callersLoaded,
+  callUpdate,
+  callUpdated,
   statsLoad,
   statsLoaded,
 } from '../store';
@@ -194,6 +197,20 @@ export default class CallAssignmentsRepo {
       .then((data: CallAssignmentCaller) => {
         this._store.dispatch(callerConfigured([assignmentId, data]));
       });
+  }
+
+  updateCall(orgId: number, id: number, data: Partial<Call>): IFuture<Call> {
+    const mutatingAttributes = Object.keys(data);
+
+    this._store.dispatch(callUpdate([id, mutatingAttributes]));
+    const promise = this._apiClient
+      .patch<Call>(`/api/orgs/${orgId}/calls/${id}`, data)
+      .then((data) => {
+        this._store.dispatch(callUpdated([data, mutatingAttributes]));
+        return data;
+      });
+
+    return new PromiseFuture(promise);
   }
 
   updateCallAssignment(

--- a/src/features/campaigns/models/CampaignActivitiesModel.ts
+++ b/src/features/campaigns/models/CampaignActivitiesModel.ts
@@ -208,6 +208,14 @@ export default class CampaignActivitiesModel extends ModelBase {
     return new ResolvedFuture(filtered || []);
   }
 
+  getArchivedStandaloneActivities(): IFuture<CampaignActivity[]> {
+    const activities = this.getArchivedActivities().data;
+    const filtered = activities?.filter(
+      (activity) => activity.data.campaign === null
+    );
+    return new ResolvedFuture(filtered || []);
+  }
+
   getCampaignActivities(campId: number): IFuture<CampaignActivity[]> {
     const activities = this.getCurrentActivities();
     if (activities.isLoading) {

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterEditor.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterEditor.tsx
@@ -1,3 +1,4 @@
+import CallBlocked from '../filters/CallBlocked';
 import CallHistory from '../filters/CallHistory';
 import CampaignParticipation from '../filters/CampaignParticipation';
 import MostActive from '../filters/MostActive';
@@ -35,6 +36,13 @@ const FilterEditor = ({
 }: FilterEditorProps): JSX.Element => {
   return (
     <>
+      {filter.type === FILTER_TYPE.CALL_BLOCKED && (
+        <CallBlocked
+          filter={filter}
+          onCancel={onCancelSubmitFilter}
+          onSubmit={onSubmitFilter}
+        />
+      )}
       {filter.type === FILTER_TYPE.CALL_HISTORY && (
         <CallHistory
           filter={filter}

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { DeleteOutline, Settings } from '@mui/icons-material';
 
+import DisplayCallBlocked from '../filters/CallBlocked/DisplayCallBlocked';
 import DisplayCallHistory from '../filters/CallHistory/DisplayCallHistory';
 import DisplayCampaignParticipation from '../filters/CampaignParticipation/DisplayCampaignParticipation';
 import DisplayMostActive from '../filters/MostActive/DisplayMostActive';
@@ -29,6 +30,7 @@ import DisplayUser from '../filters/User/DisplayUser';
 import { Msg } from 'core/i18n';
 import {
   AnyFilterConfig,
+  CallBlockedFilterConfig,
   CallHistoryFilterConfig,
   CampaignParticipationConfig,
   FILTER_TYPE,
@@ -128,6 +130,13 @@ const QueryOverview = ({
                   width={1}
                 >
                   <Typography align="center" variant="body2">
+                    {filter.type === FILTER_TYPE.CALL_BLOCKED && (
+                      <DisplayCallBlocked
+                        filter={
+                          filter as SmartSearchFilterWithId<CallBlockedFilterConfig>
+                        }
+                      />
+                    )}
                     {filter.type === FILTER_TYPE.CALL_HISTORY && (
                       <DisplayCallHistory
                         filter={

--- a/src/features/smartSearch/components/filters/CallBlocked/DisplayCallBlocked.tsx
+++ b/src/features/smartSearch/components/filters/CallBlocked/DisplayCallBlocked.tsx
@@ -1,0 +1,30 @@
+import { Msg } from 'core/i18n';
+import {
+  CallBlockedFilterConfig,
+  OPERATION,
+  SmartSearchFilterWithId,
+} from 'features/smartSearch/components/types';
+
+import messageIds from 'features/smartSearch/l10n/messageIds';
+const localMessageIds = messageIds.filters.callBlocked;
+
+interface DisplayCallBlockedProps {
+  filter: SmartSearchFilterWithId<CallBlockedFilterConfig>;
+}
+
+const DisplayCallBlocked = ({
+  filter,
+}: DisplayCallBlockedProps): JSX.Element => {
+  const op = filter.op || OPERATION.ADD;
+
+  return (
+    <Msg
+      id={localMessageIds.inputString}
+      values={{
+        addRemoveSelect: <Msg id={localMessageIds.addRemoveSelect[op]} />,
+      }}
+    />
+  );
+};
+
+export default DisplayCallBlocked;

--- a/src/features/smartSearch/components/filters/CallBlocked/index.tsx
+++ b/src/features/smartSearch/components/filters/CallBlocked/index.tsx
@@ -1,0 +1,89 @@
+import { FormEvent } from 'react';
+import { MenuItem } from '@mui/material';
+import { useQuery } from 'react-query';
+import { useRouter } from 'next/router';
+
+import FilterForm from '../../FilterForm';
+import getAllCallAssignments from 'features/callAssignments/api/getAllCallAssignments';
+import { Msg } from 'core/i18n';
+import StyledSelect from '../../inputs/StyledSelect';
+import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
+import {
+  CallBlockedFilterConfig,
+  NewSmartSearchFilter,
+  OPERATION,
+  SmartSearchFilterWithId,
+  ZetkinSmartSearchFilter,
+} from 'features/smartSearch/components/types';
+
+import messageIds from 'features/smartSearch/l10n/messageIds';
+const localMessageIds = messageIds.filters.callBlocked;
+
+interface CallBlockedProps {
+  filter:
+    | SmartSearchFilterWithId<CallBlockedFilterConfig>
+    | NewSmartSearchFilter;
+  onSubmit: (
+    filter:
+      | SmartSearchFilterWithId<CallBlockedFilterConfig>
+      | ZetkinSmartSearchFilter<CallBlockedFilterConfig>
+  ) => void;
+  onCancel: () => void;
+}
+
+const CallBlocked = ({
+  onSubmit,
+  onCancel,
+  filter: initialFilter,
+}: CallBlockedProps): JSX.Element => {
+  const { orgId } = useRouter().query;
+  const assignmentsQuery = useQuery(
+    ['assignments', orgId],
+    getAllCallAssignments(orgId as string)
+  );
+  const assignments = assignmentsQuery?.data || [];
+  const { filter, setOp } = useSmartSearchFilter<CallBlockedFilterConfig>(
+    initialFilter,
+    {
+      reason: 'any',
+    }
+  );
+
+  // only submit if assignments exist
+  const submittable = !!assignments.length;
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit(filter);
+  };
+
+  return (
+    <FilterForm
+      disableSubmit={!submittable}
+      onCancel={onCancel}
+      onSubmit={(e) => handleSubmit(e)}
+      renderExamples={() => <></>}
+      renderSentence={() => (
+        <Msg
+          id={localMessageIds.inputString}
+          values={{
+            addRemoveSelect: (
+              <StyledSelect
+                onChange={(e) => setOp(e.target.value as OPERATION)}
+                value={filter.op}
+              >
+                {Object.values(OPERATION).map((o) => (
+                  <MenuItem key={o} value={o}>
+                    <Msg id={localMessageIds.addRemoveSelect[o]} />
+                  </MenuItem>
+                ))}
+              </StyledSelect>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default CallBlocked;

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -2,6 +2,7 @@ import { TASK_TYPE } from 'features/tasks/components/types';
 
 export enum FILTER_TYPE {
   ALL = 'all',
+  CALL_BLOCKED = 'call_blocked',
   CALL_HISTORY = 'call_history',
   CAMPAIGN_PARTICIPATION = 'campaign_participation',
   MOST_ACTIVE = 'most_active',
@@ -92,6 +93,16 @@ export enum TASK_STATUS {
  * Filter Configs
  */
 export type DefaultFilterConfig = Record<string, never>; // Default filter config is an empty object
+
+export interface CallBlockedFilterConfig {
+  reason:
+    | 'allocated'
+    | 'organizer_action_needed'
+    | 'call_back_after'
+    | 'cooldown'
+    | 'no_number'
+    | 'any';
+}
 
 export interface CallHistoryFilterConfig {
   operator: CALL_OPERATOR;
@@ -227,6 +238,7 @@ export interface TaskFilterConfig {
 }
 
 export type AnyFilterConfig =
+  | CallBlockedFilterConfig
   | CallHistoryFilterConfig
   | CampaignParticipationConfig
   | DefaultFilterConfig

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -20,6 +20,7 @@ export default makeMessages('feat.smartSearch', {
   },
   filterTitles: {
     all: m('Everyone'),
+    call_blocked: m('Blocked from calling'),
     call_history: m('Based on their call history'),
     campaign_participation: m('Based on their campaign participation'),
     most_active: m('The most active people'),

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -48,6 +48,15 @@ export default makeMessages('feat.smartSearch', {
         true: m('a list of all the people in the organization'),
       },
     },
+    callBlocked: {
+      addRemoveSelect: {
+        add: m('Add'),
+        sub: m('Remove'),
+      },
+      inputString: m<{ addRemoveSelect: ReactElement }>(
+        '{addRemoveSelect} people who are blocked from calling for any reason'
+      ),
+    },
     callHistory: {
       addRemoveSelect: {
         add: m('Add'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -119,6 +119,10 @@ export default makeMessages('feat.surveys', {
       '{numOfOptions, plural, one {Show 1 more option} other {Show # more options}}'
     ),
   },
+  organizerActionPane: {
+    subtitle: m<{ person: ReactElement }>('Notes on calls to {person}'),
+    title: m('Organizer Action Needed'),
+  },
   overview: {
     noQuestions: {
       button: m('Create questions'),

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -1,0 +1,251 @@
+import {
+  Check,
+  ListAlt,
+  PriorityHigh,
+  ViewModuleOutlined,
+} from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Paper,
+  Popper,
+  PopperProps,
+  Typography,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useRouter } from 'next/router';
+import { FC, KeyboardEvent, useMemo, useState } from 'react';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  MuiEvent,
+} from '@mui/x-data-grid-pro';
+
+import { IColumnType } from '.';
+import useAccessLevel from 'features/views/hooks/useAccessLevel';
+import ViewDataModel from 'features/views/models/ViewDataModel';
+import { ZetkinObjectAccess } from 'core/api/types';
+import ZUIFuture from 'zui/ZUIFuture';
+import { OrganizerActionViewColumn, ZetkinViewRow } from '../../types';
+import theme from 'theme';
+
+import { getEllipsedString } from 'utils/stringUtils';
+import messageIds from 'features/views/l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { usePanes } from 'utils/panes';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+import { ZetkinOrganizerAction } from 'utils/types/zetkin';
+import { OrganizerActionPane } from 'features/callAssignments/panes/OrganizerActionPane';
+import { ModelBase } from 'core/models';
+import useViewDataModel from 'features/views/hooks/useViewDataModel';
+
+type OrganizerActionViewCell = null | [ZetkinOrganizerAction];
+
+export default class OrganizerActionColumnType implements IColumnType {
+  cellToString(cell: OrganizerActionViewCell): string {
+    return cell?.value ? cell.value.toString() : Boolean(cell).toString();
+  }
+
+  getColDef(column: OrganizerActionViewColumn): Omit<GridColDef, 'field'> {
+    return {
+      align: 'center',
+      headerAlign: 'center',
+      renderCell: (
+        params: GridRenderCellParams<OrganizerActionViewCell, ZetkinViewRow>
+      ) => {
+        // Get the index of the column
+        const columnIdx = Object.keys(params.row).indexOf(params.field) - 1;
+        return (
+          <Cell
+            cell={params.value}
+            columnIdx={columnIdx}
+            personId={params.row.id}
+          />
+        );
+      },
+    };
+  }
+
+  getSearchableStrings(): string[] {
+    return [];
+  }
+
+  handleKeyDown(
+    model: ViewDataModel,
+    column: OrganizerActionViewColumn,
+    personId: number,
+    data: OrganizerActionViewCell,
+    ev: MuiEvent<KeyboardEvent<HTMLElement>>,
+    accessLevel: ZetkinObjectAccess['level']
+  ): void {
+    if (accessLevel) {
+      // Any non-null value means we're in restricted mode
+      return;
+    }
+
+    if (ev.key == 'Enter' || ev.key == ' ') {
+      model.toggleTag(personId, column.config.tag_id, !data);
+      ev.defaultMuiPrevented = true;
+    }
+  }
+}
+
+const useStyles = makeStyles(() => ({
+  organizerActionContainer: {
+    alignItems: 'center',
+    backgroundColor: (props) =>
+      props.numUnsolved > 0 ? theme.palette.statusColors.orange : 'transparent',
+    cursor: 'pointer',
+    display: 'flex',
+    height: '100%',
+    justifyContent: 'center',
+    width: '100%',
+  },
+}));
+
+const Cell: FC<{
+  cell?: OrganizerActionViewCell;
+  columnIdx: number;
+  personId: number;
+}> = ({ cell, columnIdx, personId }) => {
+  const query = useRouter().query;
+  const orgId = parseInt(query.orgId as string);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const { openPane } = usePanes();
+  const viewModel = useViewDataModel();
+
+  const [isRestricted] = useAccessLevel();
+
+  if (cell?.length) {
+    if (!isRestricted) {
+      // Onclick?
+    }
+    const numUnsolved = cell.filter(
+      (call) => !call.organizer_action_taken
+    ).length;
+    const styles = useStyles({ numUnsolved });
+    return (
+      <Box
+        className={styles.organizerActionContainer}
+        onMouseOut={() => setAnchorEl(null)}
+        onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
+      >
+        {numUnsolved < 1 ? (
+          <Check />
+        ) : (
+          <>
+            <Typography sx={{ fontSize: '1.3em' }}>
+              {numUnsolved > 1 ? numUnsolved : null}
+            </Typography>
+            <PriorityHigh />
+          </>
+        )}
+        <PreviewPopper
+          anchorEl={anchorEl}
+          calls={cell}
+          onOpenCalls={() => {
+            openPane({
+              render() {
+                return (
+                  <OrganizerActionPane
+                    columnIdx={columnIdx}
+                    orgId={orgId}
+                    personId={personId}
+                    viewModel={viewModel}
+                  />
+                );
+              },
+              width: 400,
+            });
+          }}
+        />
+      </Box>
+    );
+  }
+};
+
+interface PreviewPopperProps {
+  anchorEl?: PopperProps['anchorEl'];
+  onOpenCalls?: () => void;
+  calls: OrganizerActionViewCell;
+}
+
+const usePopperStyles = makeStyles(() => ({
+  buttonBox: {
+    display: 'flex',
+    justifyContent: 'end',
+  },
+  buttonIcon: { marginRight: '0.2em' },
+  container: {
+    width: 300,
+  },
+  header: {
+    fontSize: '1.1em',
+  },
+  timestamp: {
+    color: 'grey',
+  },
+}));
+
+const PreviewPopper: FC<PreviewPopperProps> = ({
+  anchorEl,
+  onOpenCalls,
+  calls,
+}) => {
+  const styles = usePopperStyles();
+  const sortedUnsolved = useMemo(
+    () =>
+      calls
+        ?.filter((call) => !call.organizer_action_taken)
+        .sort((call0, call1) => {
+          const d0 = new Date(call0.update_time);
+          const d1 = new Date(call1.update_time);
+          return d1.getTime() - d0.getTime();
+        }),
+    [calls]
+  );
+
+  const numSolved =
+    calls?.filter((call) => !!call.organizer_action_taken).length || 0;
+
+  return (
+    <Popper
+      anchorEl={anchorEl}
+      className={styles.container}
+      open={!!anchorEl}
+      popperOptions={{
+        placement: 'left',
+      }}
+    >
+      <Paper elevation={2}>
+        <Box p={2}>
+          <Typography variant="h6">
+            <Msg id={messageIds.cells.organizerAction.actionNeeded} />
+          </Typography>
+          {sortedUnsolved?.map((call) => (
+            <Box key={call.id}>
+              <ZUIRelativeTime datetime={call.update_time} />
+              <Typography>
+                {getEllipsedString(call.message_to_organizer, 70)}
+              </Typography>
+            </Box>
+          ))}
+          {numSolved > 0 ? (
+            <Typography variant="h6">
+              <Msg
+                id={messageIds.cells.organizerAction.solvedIssues}
+                values={{ count: numSolved }}
+              />
+            </Typography>
+          ) : null}
+          <Box className={styles.buttonBox}>
+            <Button onClick={onOpenCalls}>
+              <ListAlt className={styles.buttonIcon} />
+              <Msg id={messageIds.cells.organizerAction.showDetails} />
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+    </Popper>
+  );
+};

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -20,11 +20,9 @@ import theme from 'theme';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import { usePanes } from 'utils/panes';
 import useViewDataModel from 'features/views/hooks/useViewDataModel';
-import ViewDataModel from 'features/views/models/ViewDataModel';
-import { ZetkinObjectAccess } from 'core/api/types';
 import { ZetkinOrganizerAction } from 'utils/types/zetkin';
+import { ZetkinViewRow } from '../../types';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
-import { OrganizerActionViewColumn, ZetkinViewRow } from '../../types';
 
 import messageIds from 'features/views/l10n/messageIds';
 
@@ -39,7 +37,7 @@ export default class OrganizerActionColumnType implements IColumnType {
     return requiresAction ? 'X' : '';
   }
 
-  getColDef(column: OrganizerActionViewColumn): Omit<GridColDef, 'field'> {
+  getColDef(): Omit<GridColDef, 'field'> {
     return {
       align: 'center',
       headerAlign: 'center',
@@ -89,15 +87,14 @@ const Cell: FC<{
   const viewModel = useViewDataModel();
 
   const [isRestricted] = useAccessLevel();
+  const numUnsolved =
+    cell?.filter((call) => !call.organizer_action_taken).length ?? 0;
+  const styles = useStyles({ numUnsolved });
 
   if (cell?.length) {
     if (!isRestricted) {
       // Onclick?
     }
-    const numUnsolved = cell.filter(
-      (call) => !call.organizer_action_taken
-    ).length;
-    const styles = useStyles({ numUnsolved });
     return (
       <Box
         className={styles.organizerActionContainer}
@@ -158,22 +155,22 @@ const usePopperStyles = makeStyles({
     color: 'grey',
     fontSize: '1em',
     fontWeight: 'bold',
-    textTransform: 'uppercase',
     paddingBottom: '1em',
+    textTransform: 'uppercase',
   },
   messageToOrganizer: {
     paddingBottom: '0.7em',
-  },
-  timestamp: {
-    color: 'grey',
-    paddingBottom: '0.5em',
   },
   solvedIssues: {
     color: 'grey',
     fontSize: '1em',
     fontWeight: 'bold',
-    textTransform: 'uppercase',
     paddingTop: '1em',
+    textTransform: 'uppercase',
+  },
+  timestamp: {
+    color: 'grey',
+    paddingBottom: '0.5em',
   },
 });
 

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -9,12 +9,8 @@ import {
   Typography,
 } from '@mui/material';
 import { Check, ListAlt, PriorityHigh } from '@mui/icons-material';
-import { FC, KeyboardEvent, useMemo, useState } from 'react';
-import {
-  GridColDef,
-  GridRenderCellParams,
-  MuiEvent,
-} from '@mui/x-data-grid-pro';
+import { FC, useMemo, useState } from 'react';
+import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
 
 import { getEllipsedString } from 'utils/stringUtils';
 import { IColumnType } from '.';
@@ -32,11 +28,15 @@ import { OrganizerActionViewColumn, ZetkinViewRow } from '../../types';
 
 import messageIds from 'features/views/l10n/messageIds';
 
-type OrganizerActionViewCell = null | [ZetkinOrganizerAction];
+type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
 export default class OrganizerActionColumnType implements IColumnType {
   cellToString(cell: OrganizerActionViewCell): string {
-    return cell?.value ? cell.value.toString() : Boolean(cell).toString();
+    const requiresAction = cell?.length
+      ? cell.some((oan) => !oan.organizer_action_taken)
+      : false;
+
+    return requiresAction ? 'X' : '';
   }
 
   getColDef(column: OrganizerActionViewColumn): Omit<GridColDef, 'field'> {
@@ -62,28 +62,9 @@ export default class OrganizerActionColumnType implements IColumnType {
   getSearchableStrings(): string[] {
     return [];
   }
-
-  handleKeyDown(
-    model: ViewDataModel,
-    column: OrganizerActionViewColumn,
-    personId: number,
-    data: OrganizerActionViewCell,
-    ev: MuiEvent<KeyboardEvent<HTMLElement>>,
-    accessLevel: ZetkinObjectAccess['level']
-  ): void {
-    if (accessLevel) {
-      // Any non-null value means we're in restricted mode
-      return;
-    }
-
-    if (ev.key == 'Enter' || ev.key == ' ') {
-      model.toggleTag(personId, column.config.tag_id, !data);
-      ev.defaultMuiPrevented = true;
-    }
-  }
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles<typeof theme, { numUnsolved: number }>(() => ({
   organizerActionContainer: {
     alignItems: 'center',
     backgroundColor: (props) =>
@@ -155,6 +136,8 @@ const Cell: FC<{
       </Box>
     );
   }
+
+  return null;
 };
 
 interface PreviewPopperProps {
@@ -163,7 +146,7 @@ interface PreviewPopperProps {
   calls: OrganizerActionViewCell;
 }
 
-const usePopperStyles = makeStyles(() => ({
+const usePopperStyles = makeStyles({
   buttonBox: {
     display: 'flex',
     justifyContent: 'end',
@@ -172,7 +155,7 @@ const usePopperStyles = makeStyles(() => ({
     width: 300,
   },
   header: {
-    color: theme.palette.grey,
+    color: 'grey',
     fontSize: '1em',
     fontWeight: 'bold',
     textTransform: 'uppercase',
@@ -182,17 +165,17 @@ const usePopperStyles = makeStyles(() => ({
     paddingBottom: '0.7em',
   },
   timestamp: {
-    color: theme.palette.grey,
+    color: 'grey',
     paddingBottom: '0.5em',
   },
   solvedIssues: {
-    color: theme.palette.grey,
+    color: 'grey',
     fontSize: '1em',
     fontWeight: 'bold',
     textTransform: 'uppercase',
     paddingTop: '1em',
   },
-}));
+});
 
 const PreviewPopper: FC<PreviewPopperProps> = ({
   anchorEl,

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -1,9 +1,5 @@
-import {
-  Check,
-  ListAlt,
-  PriorityHigh,
-  ViewModuleOutlined,
-} from '@mui/icons-material';
+import { makeStyles } from '@mui/styles';
+import { useRouter } from 'next/router';
 import {
   Box,
   Button,
@@ -12,8 +8,7 @@ import {
   PopperProps,
   Typography,
 } from '@mui/material';
-import { makeStyles } from '@mui/styles';
-import { useRouter } from 'next/router';
+import { Check, ListAlt, PriorityHigh } from '@mui/icons-material';
 import { FC, KeyboardEvent, useMemo, useState } from 'react';
 import {
   GridColDef,
@@ -21,23 +16,21 @@ import {
   MuiEvent,
 } from '@mui/x-data-grid-pro';
 
+import { getEllipsedString } from 'utils/stringUtils';
 import { IColumnType } from '.';
+import { Msg } from 'core/i18n';
+import { OrganizerActionPane } from 'features/callAssignments/panes/OrganizerActionPane';
+import theme from 'theme';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
+import { usePanes } from 'utils/panes';
+import useViewDataModel from 'features/views/hooks/useViewDataModel';
 import ViewDataModel from 'features/views/models/ViewDataModel';
 import { ZetkinObjectAccess } from 'core/api/types';
-import ZUIFuture from 'zui/ZUIFuture';
-import { OrganizerActionViewColumn, ZetkinViewRow } from '../../types';
-import theme from 'theme';
-
-import { getEllipsedString } from 'utils/stringUtils';
-import messageIds from 'features/views/l10n/messageIds';
-import { Msg } from 'core/i18n';
-import { usePanes } from 'utils/panes';
-import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import { ZetkinOrganizerAction } from 'utils/types/zetkin';
-import { OrganizerActionPane } from 'features/callAssignments/panes/OrganizerActionPane';
-import { ModelBase } from 'core/models';
-import useViewDataModel from 'features/views/hooks/useViewDataModel';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+import { OrganizerActionViewColumn, ZetkinViewRow } from '../../types';
+
+import messageIds from 'features/views/l10n/messageIds';
 
 type OrganizerActionViewCell = null | [ZetkinOrganizerAction];
 
@@ -175,15 +168,29 @@ const usePopperStyles = makeStyles(() => ({
     display: 'flex',
     justifyContent: 'end',
   },
-  buttonIcon: { marginRight: '0.2em' },
   container: {
     width: 300,
   },
   header: {
-    fontSize: '1.1em',
+    color: theme.palette.grey,
+    fontSize: '1em',
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+    paddingBottom: '1em',
+  },
+  messageToOrganizer: {
+    paddingBottom: '0.7em',
   },
   timestamp: {
-    color: 'grey',
+    color: theme.palette.grey,
+    paddingBottom: '0.5em',
+  },
+  solvedIssues: {
+    color: theme.palette.grey,
+    fontSize: '1em',
+    fontWeight: 'bold',
+    textTransform: 'uppercase',
+    paddingTop: '1em',
   },
 }));
 
@@ -219,19 +226,21 @@ const PreviewPopper: FC<PreviewPopperProps> = ({
     >
       <Paper elevation={2}>
         <Box p={2}>
-          <Typography variant="h6">
+          <Typography className={styles.header}>
             <Msg id={messageIds.cells.organizerAction.actionNeeded} />
           </Typography>
           {sortedUnsolved?.map((call) => (
             <Box key={call.id}>
-              <ZUIRelativeTime datetime={call.update_time} />
-              <Typography>
-                {getEllipsedString(call.message_to_organizer, 70)}
+              <Typography className={styles.timestamp}>
+                <ZUIRelativeTime datetime={call.update_time} />
+              </Typography>
+              <Typography className={styles.messageToOrganizer}>
+                {getEllipsedString(call.message_to_organizer || '', 70)}
               </Typography>
             </Box>
           ))}
           {numSolved > 0 ? (
-            <Typography variant="h6">
+            <Typography className={styles.header}>
               <Msg
                 id={messageIds.cells.organizerAction.solvedIssues}
                 values={{ count: numSolved }}
@@ -239,8 +248,7 @@ const PreviewPopper: FC<PreviewPopperProps> = ({
             </Typography>
           ) : null}
           <Box className={styles.buttonBox}>
-            <Button onClick={onOpenCalls}>
-              <ListAlt className={styles.buttonIcon} />
+            <Button onClick={onOpenCalls} startIcon={<ListAlt />}>
               <Msg id={messageIds.cells.organizerAction.showDetails} />
             </Button>
           </Box>

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -5,6 +5,7 @@ import LocalBoolColumnType from './LocalBoolColumnType';
 import LocalPersonColumnType from './LocalPersonColumnType';
 import LocalQueryColumnType from './LocalQueryColumnType';
 import LocalTextColumnType from './LocalTextColumnType';
+import OrganizerActionColumnType from './OrganizerActionColumnType';
 import PersonTagColumnType from './PersonTagColumnType';
 import SimpleColumnType from './SimpleColumnType';
 import SurveyOptionColumnType from './SurveyOptionColumnType';
@@ -87,6 +88,7 @@ const columnTypes: Record<COLUMN_TYPE, IColumnType> = {
   [COLUMN_TYPE.LOCAL_BOOL]: new LocalBoolColumnType(),
   [COLUMN_TYPE.LOCAL_PERSON]: new LocalPersonColumnType(),
   [COLUMN_TYPE.LOCAL_QUERY]: new LocalQueryColumnType(),
+  [COLUMN_TYPE.ORGANIZER_ACTION]: new OrganizerActionColumnType(),
   [COLUMN_TYPE.PERSON_FIELD]: new SimpleColumnType(),
   [COLUMN_TYPE.PERSON_QUERY]: new LocalQueryColumnType(),
   [COLUMN_TYPE.PERSON_TAG]: new PersonTagColumnType(),

--- a/src/features/views/components/types.ts
+++ b/src/features/views/components/types.ts
@@ -86,7 +86,7 @@ export interface OrganizerActionViewColumn extends ZetkinViewColumnBase {
   type: COLUMN_TYPE.ORGANIZER_ACTION;
   config: {
     assignment_id?: number;
-    type: 'action_needed' | 'action_taken' | 'all_flagged';
+    state: 'action_needed' | 'action_taken' | 'any';
   };
 }
 

--- a/src/features/views/components/types.ts
+++ b/src/features/views/components/types.ts
@@ -49,6 +49,7 @@ export enum COLUMN_TYPE {
   LOCAL_PERSON = 'local_person',
   LOCAL_QUERY = 'local_query',
   LOCAL_TEXT = 'local_text',
+  ORGANIZER_ACTION = 'organizer_action',
   PERSON_FIELD = 'person_field',
   PERSON_QUERY = 'person_query',
   PERSON_TAG = 'person_tag',
@@ -79,6 +80,14 @@ export interface LocalQueryViewColumn extends ZetkinViewColumnBase {
 export interface LocalTextViewColumn extends ZetkinViewColumnBase {
   type: COLUMN_TYPE.LOCAL_TEXT;
   config?: Record<string, never>;
+}
+
+export interface OrganizerActionViewColumn extends ZetkinViewColumnBase {
+  type: COLUMN_TYPE.ORGANIZER_ACTION;
+  config: {
+    assignment_id?: number;
+    type: 'action_needed' | 'action_taken' | 'all_flagged';
+  };
 }
 
 export interface PersonFieldViewColumn extends ZetkinViewColumnBase {
@@ -141,6 +150,7 @@ export type ZetkinViewColumn =
   | LocalPersonViewColumn
   | LocalQueryViewColumn
   | LocalTextViewColumn
+  | OrganizerActionViewColumn
   | PersonFieldViewColumn
   | PersonQueryViewColumn
   | PersonTagViewColumn

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -276,11 +276,11 @@ export default makeMessages('feat.views', {
     journey_assignee: m('Assigned journeys'),
     local_bool: m('Toggle'),
     local_person: m('Person reference'),
-    organizer_action: m('Organizer action'),
+    organizer_action: m('Flagged calls'),
     person_notes: m('Notes'),
   },
   defaultViewTitles: {
-    organizer_action: m('Organizer action'),
+    organizer_action: m('Organizer action needed'),
   },
   deleteDialog: {
     error: m('There was an error deleting the view'),

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -44,6 +44,13 @@ export default makeMessages('feat.views', {
       restrictedMode: m("Can't be edited in shared views."),
       searchLabel: m('Select a person'),
     },
+    organizerAction: {
+      actionNeeded: m('Organizer action needed'),
+      showDetails: m('Show details'),
+      solvedIssues: m<{ count: number }>(
+        '{count, plural, =1 {1 solved issue} other {# solved issues}}'
+      ),
+    },
   },
   columnDialog: {
     categories: {
@@ -269,7 +276,11 @@ export default makeMessages('feat.views', {
     journey_assignee: m('Assigned journeys'),
     local_bool: m('Toggle'),
     local_person: m('Person reference'),
+    organizer_action: m('Organizer action'),
     person_notes: m('Notes'),
+  },
+  defaultViewTitles: {
+    organizer_action: m('Organizer action'),
   },
   deleteDialog: {
     error: m('There was an error deleting the view'),

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -164,6 +164,19 @@ export default class ViewBrowserModel extends ModelBase {
     return new ResolvedFuture(items);
   }
 
+  getOrganizerActionView(): IFuture<ZetkinView> {
+    const promise = this._repo
+      .getOrganizerActionView(this._orgId)
+      .then((view) => {
+        this._env.router.push(
+          `/organize/${view.organization.id}/people/views/${view.id}`
+        );
+        return view;
+      });
+
+    return new PromiseFuture(promise);
+  }
+
   itemIsRenaming(type: 'folder' | 'view', id: number): boolean {
     const state = this._env.store.getState();
     if (type == 'folder') {

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -32,6 +32,7 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 import { ZetkinView, ZetkinViewFolder } from '../components/types';
+import getOrganizerActionView from '../rpc/getOrganizerActionView';
 
 type ZetkinViewFolderPostBody = {
   parent_id?: number;
@@ -112,6 +113,15 @@ export default class ViewsRepo {
     }
 
     return new RemoteListFuture(state.views.officialList);
+  }
+
+  async getOrganizerActionView(orgId: number): Promise<ZetkinView> {
+    this._store.dispatch(viewCreate());
+    const view = await this._apiClient.rpc(getOrganizerActionView, {
+      orgId,
+    });
+    this._store.dispatch(viewCreated(view));
+    return view;
   }
 
   getViewAccessList(

--- a/src/features/views/repos/ViewsRepo.ts
+++ b/src/features/views/repos/ViewsRepo.ts
@@ -1,6 +1,7 @@
 import createNew from '../rpc/createNew/client';
 import deleteFolder from '../rpc/deleteFolder';
 import Environment from 'core/env/Environment';
+import getOrganizerActionView from '../rpc/getOrganizerActionView/client';
 import IApiClient from 'core/api/client/IApiClient';
 import shouldLoad from 'core/caching/shouldLoad';
 import { Store } from 'core/store';
@@ -32,7 +33,6 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 import { ZetkinView, ZetkinViewFolder } from '../components/types';
-import getOrganizerActionView from '../rpc/getOrganizerActionView';
 
 type ZetkinViewFolderPostBody = {
   parent_id?: number;

--- a/src/features/views/rpc/getOrganizerActionView.ts
+++ b/src/features/views/rpc/getOrganizerActionView.ts
@@ -163,7 +163,7 @@ async function handle(
       `/api/orgs/${orgId}/people/views/${view.id}/columns`,
       {
         config: {
-          field: NATIVE_PERSON_FIELDS.LAST_NAME,
+          type: 'all_flagged',
         },
         // title: messages.defaultColumnTitles.organizer_action(),
         title: 'Organizer action',

--- a/src/features/views/rpc/getOrganizerActionView.ts
+++ b/src/features/views/rpc/getOrganizerActionView.ts
@@ -1,0 +1,166 @@
+import lodash from 'lodash';
+import { NextApiRequest } from 'next';
+import { z } from 'zod';
+
+import { getBrowserLanguage } from 'utils/locale';
+import getServerMessages from 'core/i18n/server';
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import {
+  COLUMN_TYPE,
+  NATIVE_PERSON_FIELDS,
+  PendingZetkinViewColumn,
+  ZetkinView,
+  ZetkinViewColumn,
+} from '../components/types';
+import {
+  FILTER_TYPE,
+  ZetkinSmartSearchFilter,
+} from 'features/smartSearch/components/types';
+
+import messageIds from 'features/views/l10n/messageIds';
+
+const paramsSchema = z.object({
+  orgId: z.number(),
+});
+
+export type GetOrganizerActionViewReport = {
+  view: (number | string)[];
+};
+
+type Params = z.input<typeof paramsSchema>;
+type Result = ZetkinView;
+
+export const getOrganizerActionViewRouteDef = {
+  handler: handle,
+  name: 'getOrganizerActionView',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, Result>('getOrganizerActionView');
+
+async function handle(
+  params: Params,
+  apiClient: IApiClient,
+  req: NextApiRequest
+): Promise<Result> {
+  const { orgId } = params;
+
+  const lang = getBrowserLanguage(req);
+  const messages = await getServerMessages(lang, messageIds);
+
+  const views = await apiClient.get<ZetkinView[]>(
+    `/api/orgs/${orgId}/people/views`
+  );
+
+  // Define an Organizer Action View
+  const targetView = {
+    content_query: {
+      filter_spec: [
+        {
+          config: {
+            type: 'all_flagged',
+          },
+          type: FILTER_TYPE.CALL_BLOCKED,
+        },
+      ],
+    },
+  };
+  const targetColumns: Pick<ZetkinViewColumn, 'config' | 'type'>[] = [
+    {
+      config: {
+        field: 'first_name',
+      },
+      type: COLUMN_TYPE.PERSON_FIELD,
+    },
+    {
+      config: {
+        field: 'last_name',
+      },
+      type: COLUMN_TYPE.PERSON_FIELD,
+    },
+    {
+      config: {
+        type: 'all_flagged',
+      },
+      type: COLUMN_TYPE.ORGANIZER_ACTION,
+    },
+  ];
+
+  // Look for a view that matches the definition of an Organizer Action View
+  let view = views.find(async (v) => {
+    if (
+      v.content_query?.filter_spec.length == 1 &&
+      v.content_query.filter_spec[0].type ==
+        targetView.content_query.filter_spec[0].type &&
+      v.content_query.filter_spec[0].config ==
+        targetView.content_query.filter_spec[0].config
+    ) {
+      // Check the columns
+      const columns = await apiClient.get<ZetkinViewColumn[]>(
+        `/api/orgs/${orgId}/people/views/${v.id}/columns`
+      );
+      return targetColumns.every((targetCol): boolean => {
+        return columns.some(
+          (c: ZetkinViewColumn) =>
+            c.type == targetCol.type &&
+            lodash.isEqual(targetCol.config, c.config)
+        );
+      });
+    }
+  });
+
+  if (view) {
+    return view;
+  } else {
+    view = await apiClient.post<ZetkinView, Partial<ZetkinView>>(
+      `/api/orgs/${orgId}/people/views`,
+      {
+        title: messages.defaultViewTitles.organizer_action(),
+      }
+    );
+    await apiClient.patch<{ filter_spec: ZetkinSmartSearchFilter[] }>(
+      `/api/orgs/${orgId}/people/views/${view.id}/content_query`,
+      {
+        filter_spec: targetView.content_query.filter_spec,
+      }
+    );
+    // Create "First name" column
+    await apiClient.post<ZetkinViewColumn, PendingZetkinViewColumn>(
+      `/api/orgs/${orgId}/people/views/${view.id}/columns`,
+      {
+        config: {
+          field: NATIVE_PERSON_FIELDS.FIRST_NAME,
+        },
+        title: messages.global.personFields.first_name(),
+        type: COLUMN_TYPE.PERSON_FIELD,
+      }
+    );
+
+    // Create "Last name" column
+    await apiClient.post<ZetkinViewColumn, PendingZetkinViewColumn>(
+      `/api/orgs/${orgId}/people/views/${view.id}/columns`,
+      {
+        config: {
+          field: NATIVE_PERSON_FIELDS.LAST_NAME,
+        },
+        title: messages.global.personFields.last_name(),
+        type: COLUMN_TYPE.PERSON_FIELD,
+      }
+    );
+
+    // Create "Organizer action" column
+    await apiClient.post<ZetkinViewColumn, PendingZetkinViewColumn>(
+      `/api/orgs/${orgId}/people/views/${view.id}/columns`,
+      {
+        config: {
+          field: NATIVE_PERSON_FIELDS.LAST_NAME,
+        },
+        title: messages.defaultColumnTitles.organizer_action(),
+        type: COLUMN_TYPE.ORGANIZER_ACTION,
+      }
+    );
+
+    return view;
+  }
+}

--- a/src/features/views/rpc/getOrganizerActionView/client.ts
+++ b/src/features/views/rpc/getOrganizerActionView/client.ts
@@ -1,0 +1,17 @@
+import { makeRPCDef } from 'core/rpc/types';
+import { z } from 'zod';
+
+import { ZetkinView } from 'utils/types/zetkin';
+
+export const paramsSchema = z.object({
+  orgId: z.number(),
+});
+
+export type GetOrganizerActionViewReport = {
+  view: (number | string)[];
+};
+
+export type Params = z.input<typeof paramsSchema>;
+export type Result = ZetkinView;
+
+export default makeRPCDef<Params, Result>('getOrganizerActionView');

--- a/src/features/views/rpc/getOrganizerActionView/server.ts
+++ b/src/features/views/rpc/getOrganizerActionView/server.ts
@@ -65,7 +65,7 @@ async function handle(
     },
     {
       config: {
-        type: 'all_flagged',
+        state: 'any',
       },
       type: COLUMN_TYPE.ORGANIZER_ACTION,
     },
@@ -148,7 +148,7 @@ async function handle(
       `/api/orgs/${orgId}/people/views/${view.id}/columns`,
       {
         config: {
-          type: 'all_flagged',
+          state: 'any',
         },
         title: messages.defaultColumnTitles.organizer_action(),
         type: COLUMN_TYPE.ORGANIZER_ACTION,

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -1,3 +1,5 @@
+import { Call } from 'features/callAssignments/apiTypes';
+import { callUpdated } from 'features/callAssignments/store';
 import columnTypes from './components/ViewDataTable/columnTypes';
 import { DeleteFolderReport } from './rpc/deleteFolder';
 import { ViewTreeData } from 'pages/api/views/tree';
@@ -18,11 +20,6 @@ import {
   ZetkinQuery,
   ZetkinTag,
 } from 'utils/types/zetkin';
-import ViewDataModel from './models/ViewDataModel';
-import useModel from 'core/useModel';
-import useViewDataModel from './hooks/useViewDataModel';
-import { callUpdated } from 'features/callAssignments/store';
-import { Call } from 'features/callAssignments/apiTypes';
 
 type ZetkinObjectAccessWithId = ZetkinObjectAccess & {
   id: number;
@@ -299,13 +296,6 @@ const viewsSlice = createSlice({
         state.rowsByViewId[viewId] = remoteList([row]);
       }
     },
-    rowRemoved: (state, action: PayloadAction<[number, number]>) => {
-      const [viewId, rowId] = action.payload;
-      const list = state.rowsByViewId[viewId];
-      if (list) {
-        list.items = list.items.filter((item) => item.id != rowId);
-      }
-    },
     rowLoaded: (state, action: PayloadAction<[number, ZetkinViewRow]>) => {
       const [viewId, row] = action.payload;
       const list = state.rowsByViewId[viewId];
@@ -315,6 +305,13 @@ const viewsSlice = createSlice({
       }
       state.rowsByViewId[viewId].loaded = new Date().toISOString();
       state.rowsByViewId[viewId].isStale = false;
+    },
+    rowRemoved: (state, action: PayloadAction<[number, number]>) => {
+      const [viewId, rowId] = action.payload;
+      const list = state.rowsByViewId[viewId];
+      if (list) {
+        list.items = list.items.filter((item) => item.id != rowId);
+      }
     },
     rowsLoad: (state, action: PayloadAction<number>) => {
       const viewId = action.payload;

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -296,16 +296,6 @@ const viewsSlice = createSlice({
         state.rowsByViewId[viewId] = remoteList([row]);
       }
     },
-    rowLoaded: (state, action: PayloadAction<[number, ZetkinViewRow]>) => {
-      const [viewId, row] = action.payload;
-      const list = state.rowsByViewId[viewId];
-      if (list) {
-        const idx = list.items.findIndex((item) => item.id == row.id);
-        list.items[idx] = remoteItem(row.id, { data: row });
-      }
-      state.rowsByViewId[viewId].loaded = new Date().toISOString();
-      state.rowsByViewId[viewId].isStale = false;
-    },
     rowRemoved: (state, action: PayloadAction<[number, number]>) => {
       const [viewId, rowId] = action.payload;
       const list = state.rowsByViewId[viewId];

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -311,7 +311,7 @@ const viewsSlice = createSlice({
       const list = state.rowsByViewId[viewId];
       if (list) {
         const idx = list.items.findIndex((item) => item.id == row.id);
-        list.items[idx] = remoteItem(row);
+        list.items[idx] = remoteItem(row.id, { data: row });
       }
       state.rowsByViewId[viewId].loaded = new Date().toISOString();
       state.rowsByViewId[viewId].isStale = false;

--- a/src/pages/api/rpc.ts
+++ b/src/pages/api/rpc.ts
@@ -1,7 +1,10 @@
 import { createRPCRouter } from 'core/rpc';
 import { NextApiRequest, NextApiResponse } from 'next';
 
-export default function handle(req: NextApiRequest, res: NextApiResponse) {
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   const router = createRPCRouter();
-  router.handle(req, res);
+  await router.handle(req, res);
 }

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -111,11 +111,6 @@ export interface ZetkinOrganizerAction {
     id: number;
     last_name: string;
   };
-  recipient: {
-    first_name: string;
-    id: number;
-    last_name: string;
-  };
   id: number;
   message_to_organizer: string;
   organizer_action_needed: boolean;

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -101,6 +101,28 @@ export interface ZetkinFile {
   mime_type: string;
 }
 
+export interface ZetkinOrganizerAction {
+  assigment: {
+    id: number;
+    title: string;
+  };
+  caller: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
+  recipient: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
+  id: number;
+  message_to_organizer: string;
+  organizer_action_needed: boolean;
+  organizer_action_taken: boolean;
+  update_time: string;
+}
+
 export interface ZetkinUser {
   first_name: string;
   id: number;


### PR DESCRIPTION
## Description
This PR adds View features (column and Smart Search filter) to display a list of all people who are being blocked from calling due to "organizer action needed", and a pane for removing the flagging.

## Screenshots
<img width="1356" alt="image" src="https://user-images.githubusercontent.com/550212/229829335-2b724ac5-8faf-4345-8450-71c64fe77335.png">

## Changes
* Adds support for new `organizer_action` view column type
* Adds an RPC to create a special view for this use case, or return an existing one if one exists
* Adds Smart Search filter for `call_blocked`

## Notes to reviewer
Requires changes to backend that are not yet deployed on the dev server.

## Related issues
Resolves #1098 