### PR TITLE
Change EditMode on event cards to only fire when expected

### DIFF
--- a/src/features/events/components/EventOverviewCard/EventOverviewCard.tsx
+++ b/src/features/events/components/EventOverviewCard/EventOverviewCard.tsx
@@ -30,18 +30,30 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ model }) => {
   const [link, setLink] = useState(eventData?.url ?? '');
   const [infoText, setInfoText] = useState(eventData?.info_text ?? '');
 
-  const { clickAwayProps, containerProps, previewableProps } =
-    useEditPreviewBlock({
-      editable,
-      onEditModeEnter: () => setEditable(true),
-      onEditModeExit: () => setEditable(false),
-      save: () => {
-        model.updateEventData({
-          info_text: infoText,
-          url: link,
-        });
-      },
-    });
+  const { clickAwayProps, containerProps } = useEditPreviewBlock({
+    editable,
+    onEditModeEnter: () => setEditable(true),
+    onEditModeExit: () => setEditable(false),
+    save: () => {
+      model.updateEventData({
+        info_text: infoText,
+        url: link,
+      });
+    },
+  });
+
+  const { previewableProps } = useEditPreviewBlock({
+    editable,
+    onEditModeEnter: () => setEditable(true),
+    onEditModeExit: () => setEditable(false),
+    readOnly: true,
+    save: () => {
+      model.updateEventData({
+        info_text: infoText,
+        url: link,
+      });
+    },
+  });
 
   if (!eventData) {
     return null;
@@ -49,11 +61,15 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ model }) => {
 
   return (
     <ClickAwayListener {...clickAwayProps}>
-      <Box {...containerProps}>
+      <Box>
         <Card>
           {!editable && (
             <Box display="flex" justifyContent="flex-end" m={2}>
-              <Button startIcon={<EditIcon />} variant="outlined">
+              <Button
+                {...containerProps}
+                startIcon={<EditIcon />}
+                variant="outlined"
+              >
                 {messages.eventOverviewCard.editButton().toUpperCase()}
               </Button>
             </Box>


### PR DESCRIPTION
## Description
This PR fixes a small bug where the edit mode for event overview cards would be fired with a click anywhere on the card, instead of only at the edit button. If that functionality was intended as in other uses of `useEditPreviewBlock` then the edit button should probably be removed.


## Changes
* Changes the listener for `EditMode` to only fire on the edit button instead of the whole card
