### PR TITLE
Events in activities list

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -167,9 +167,9 @@ const OverviewListItem = ({
             </Box>
             <Box width={80}>
               <ZUIIconLabel
+                color="secondary"
                 icon={<SecondaryIcon color="secondary" />}
                 label={<ZUISuffixedNumber number={endNumber} />}
-                labelColor="secondary"
               />
             </Box>
           </Box>

--- a/src/features/campaigns/components/ActivityList/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/EventListItem.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+import { EventOutlined, Group } from '@mui/icons-material';
+
+import useModel from 'core/useModel';
+import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
+import EventDataModel, {
+  EventState,
+} from 'features/events/models/EventDataModel';
+
+interface EventListeItemProps {
+  orgId: number;
+  eventId: number;
+}
+
+const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
+  const model = useModel((env) => new EventDataModel(env, orgId, eventId));
+  const state = model.state;
+  const data = model.getData().data;
+
+  if (!data) {
+    return null;
+  }
+
+  let color = STATUS_COLORS.GRAY;
+  if (state === EventState.OPEN) {
+    color = STATUS_COLORS.GREEN;
+  } else if (state === EventState.ENDED) {
+    color = STATUS_COLORS.RED;
+  } else if (state === EventState.SCHEDULED) {
+    color = STATUS_COLORS.BLUE;
+  }
+
+  return (
+    <ActivityListItem
+      color={color}
+      endNumber={`${data.num_participants_available} / ${data.num_participants_required}`}
+      greenChipValue={undefined}
+      href={`/organize/${orgId}/projects/${
+        data.campaign?.id ?? 'standalone'
+      }/callassignments/${eventId}`}
+      orangeChipValue={undefined}
+      PrimaryIcon={EventOutlined}
+      SecondaryIcon={Group}
+      statsLoading={false}
+      title={data.title || data.activity.title}
+    />
+  );
+};
+
+export default EventListItem;

--- a/src/features/campaigns/components/ActivityList/FilterActivities.tsx
+++ b/src/features/campaigns/components/ActivityList/FilterActivities.tsx
@@ -81,6 +81,17 @@ const FilterActivities = ({
             }
             label={messages.tasks()}
           />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={filters.includes(ACTIVITIES.EVENT)}
+                disabled={!filterTypes.includes(ACTIVITIES.EVENT)}
+                onChange={onFiltersChange}
+                value={ACTIVITIES.EVENT}
+              />
+            }
+            label={messages.events()}
+          />
         </FormGroup>
       </Box>
     </Card>

--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -3,11 +3,11 @@ import Fuse from 'fuse.js';
 import { useMemo } from 'react';
 import { Box, Card, Divider, Typography } from '@mui/material';
 
-import CallAssignmentListItem from './CallAssignmentListItem';
-import EventListItem from './EventListItem';
+import CallAssignmentListItem from './items/CallAssignmentListItem';
+import EventListItem from './items/EventListItem';
 import messageIds from 'features/campaigns/l10n/messageIds';
-import SurveyListItem from './SurveyListItem';
-import TaskListItem from './TaskListItem';
+import SurveyListItem from './items/SurveyListItem';
+import TaskListItem from './items/TaskListItem';
 import { useMessages } from 'core/i18n';
 import {
   ACTIVITIES,

--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { Box, Card, Divider, Typography } from '@mui/material';
 
 import CallAssignmentListItem from './CallAssignmentListItem';
+import EventListItem from './EventListItem';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import SurveyListItem from './SurveyListItem';
 import TaskListItem from './TaskListItem';
@@ -27,6 +28,13 @@ const Activities = ({ activities, orgId }: ActivitiesProps) => {
             <Box key={`ca-${activity.data.id}`}>
               {index > 0 && <Divider />}
               <CallAssignmentListItem caId={activity.data.id} orgId={orgId} />
+            </Box>
+          );
+        } else if (activity.kind === ACTIVITIES.EVENT) {
+          return (
+            <Box key={`event-${activity.data.id}`}>
+              {index > 0 && <Divider />}
+              <EventListItem eventId={activity.data.id} orgId={orgId} />
             </Box>
           );
         } else if (activity.kind === ACTIVITIES.SURVEY) {

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
@@ -3,7 +3,6 @@ import NextLink from 'next/link';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 import {
   Box,
-  CircularProgress,
   Grid,
   Link,
   SvgIconTypeMap,
@@ -13,7 +12,6 @@ import {
 
 import theme from 'theme';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
-import ZUIMultiNumberChip from 'zui/ZUIMultiNumberChip';
 
 interface StyleProps {
   color: STATUS_COLORS;
@@ -63,34 +61,28 @@ export enum STATUS_COLORS {
   RED = 'red',
 }
 
-interface AcitivityListItemProps {
+export type AcitivityListItemProps = {
   PrimaryIcon: OverridableComponent<
     SvgIconTypeMap<Record<string, unknown>, 'svg'>
   >;
   SecondaryIcon: OverridableComponent<
     SvgIconTypeMap<Record<string, unknown>, 'svg'>
   >;
-  blueChipValue?: string | number;
-  href: string;
-  orangeChipValue: string | number | undefined;
-  greenChipValue: string | number | undefined;
   color: STATUS_COLORS;
-  title: string;
   endNumber: string | number;
-  statsLoading: boolean;
-}
+  href: string;
+  meta?: JSX.Element;
+  title: string;
+};
 
 const ActivityListItem = ({
   PrimaryIcon,
   SecondaryIcon,
   href,
-  blueChipValue,
-  greenChipValue,
-  orangeChipValue,
   color,
+  meta,
   title,
   endNumber,
-  statsLoading,
 }: AcitivityListItemProps) => {
   const classes = useStyles({ color });
 
@@ -113,15 +105,7 @@ const ActivityListItem = ({
         </Box>
       </Grid>
       <Grid item lg={2} md={3} xs={4}>
-        {statsLoading ? (
-          <CircularProgress size={26} />
-        ) : (
-          <ZUIMultiNumberChip
-            blueValue={blueChipValue}
-            greenValue={greenChipValue}
-            orangeValue={orangeChipValue}
-          />
-        )}
+        {meta}
       </Grid>
       <Grid item xs={2}>
         <Box className={classes.endNumber}>

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
@@ -1,14 +1,7 @@
 import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
-import {
-  Box,
-  Grid,
-  Link,
-  SvgIconTypeMap,
-  Theme,
-  Typography,
-} from '@mui/material';
+import { Box, Link, SvgIconTypeMap, Theme, Typography } from '@mui/material';
 
 import theme from 'theme';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
@@ -21,23 +14,31 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   container: {
     alignItems: 'center',
     display: 'flex',
-    padding: '1em',
+    justifyContent: 'space-between',
+    padding: '1.0em 0.5em',
   },
   dot: {
     backgroundColor: ({ color }) => theme.palette.statusColors[color],
     borderRadius: '100%',
     height: '10px',
-    marginRight: '1em',
+    marginLeft: '0.5em',
+    marginRight: '0.5em',
     width: '10px',
   },
   endNumber: {
     alignItems: 'center',
     display: 'flex',
     justifyContent: 'flex-start',
+    width: '7em',
   },
   left: {
     alignItems: 'center',
     display: 'flex',
+    flex: '1 0',
+    gap: '1em',
+  },
+  meta: {
+    width: '8em',
   },
   primaryIcon: {
     color: theme.palette.grey[500],
@@ -72,6 +73,7 @@ export type AcitivityListItemProps = {
   endNumber: string | number;
   href: string;
   meta?: JSX.Element;
+  subtitle?: JSX.Element;
   title: string;
 };
 
@@ -81,42 +83,43 @@ const ActivityListItem = ({
   href,
   color,
   meta,
+  subtitle,
   title,
   endNumber,
 }: AcitivityListItemProps) => {
   const classes = useStyles({ color });
 
   return (
-    <Grid className={classes.container} container>
-      <Grid item lg={8} md={7} xs={6}>
-        <Box className={classes.left}>
-          <Box className={classes.dot}></Box>
-          <PrimaryIcon className={classes.primaryIcon} />
+    <Box className={classes.container}>
+      <Box className={classes.left}>
+        <Box className={classes.dot}></Box>
+        <PrimaryIcon className={classes.primaryIcon} />
+        <Box>
           <NextLink href={href} passHref>
             <Link underline="none">
-              <Typography
-                color={theme.palette.text.primary}
-                sx={{ paddingX: 2 }}
-              >
+              <Typography color={theme.palette.text.primary}>
                 {title}
               </Typography>
             </Link>
           </NextLink>
+          {subtitle && (
+            <Box>
+              <Typography variant="body2">{subtitle}</Typography>
+            </Box>
+          )}
         </Box>
-      </Grid>
-      <Grid item lg={2} md={3} xs={4}>
-        {meta}
-      </Grid>
-      <Grid item xs={2}>
+      </Box>
+      <Box className={classes.meta}>{meta}</Box>
+      <Box>
         <Box className={classes.endNumber}>
           <ZUIIconLabel
+            color="secondary"
             icon={<SecondaryIcon color="secondary" />}
             label={endNumber.toString()}
-            labelColor="secondary"
           />
         </Box>
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
@@ -4,7 +4,7 @@ import { OverridableComponent } from '@mui/material/OverridableComponent';
 import { Box, Link, SvgIconTypeMap, Theme, Typography } from '@mui/material';
 
 import theme from 'theme';
-import ZUIIconLabel from 'zui/ZUIIconLabel';
+import ZUIIconLabel, { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
 
 interface StyleProps {
   color: STATUS_COLORS;
@@ -71,6 +71,7 @@ export type AcitivityListItemProps = {
   >;
   color: STATUS_COLORS;
   endNumber: string | number;
+  endNumberColor?: ZUIIconLabelProps['color'];
   href: string;
   meta?: JSX.Element;
   subtitle?: JSX.Element;
@@ -86,6 +87,7 @@ const ActivityListItem = ({
   subtitle,
   title,
   endNumber,
+  endNumberColor = 'secondary',
 }: AcitivityListItemProps) => {
   const classes = useStyles({ color });
 
@@ -113,8 +115,8 @@ const ActivityListItem = ({
       <Box>
         <Box className={classes.endNumber}>
           <ZUIIconLabel
-            color="secondary"
-            icon={<SecondaryIcon color="secondary" />}
+            color={endNumberColor}
+            icon={<SecondaryIcon color={endNumberColor} />}
             label={endNumber.toString()}
           />
         </Box>

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItemWithStats.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItemWithStats.tsx
@@ -1,0 +1,38 @@
+import { CircularProgress } from '@mui/material';
+import { FC } from 'react';
+import ZUIMultiNumberChip from 'zui/ZUIMultiNumberChip';
+import ActivityListItem, { AcitivityListItemProps } from './ActivityListItem';
+
+type ActivityListItemWithStatsProps = AcitivityListItemProps & {
+  blueChipValue?: string | number;
+  greenChipValue: string | number | undefined;
+  orangeChipValue: string | number | undefined;
+  statsLoading: boolean;
+};
+
+const ActivityListItemWithStats: FC<ActivityListItemWithStatsProps> = ({
+  blueChipValue,
+  greenChipValue,
+  orangeChipValue,
+  statsLoading,
+  ...restProps
+}) => {
+  return (
+    <ActivityListItem
+      {...restProps}
+      meta={
+        statsLoading ? (
+          <CircularProgress size={26} />
+        ) : (
+          <ZUIMultiNumberChip
+            blueValue={blueChipValue}
+            greenValue={greenChipValue}
+            orangeValue={orangeChipValue}
+          />
+        )
+      }
+    />
+  );
+};
+
+export default ActivityListItemWithStats;

--- a/src/features/campaigns/components/ActivityList/items/CallAssignmentListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/CallAssignmentListItem.tsx
@@ -1,11 +1,12 @@
 import { FC } from 'react';
+import { HeadsetMic, PhoneOutlined } from '@mui/icons-material';
+
+import ActivityListItemWithStats from './ActivityListItemWithStats';
+import { STATUS_COLORS } from './ActivityListItem';
+import useModel from 'core/useModel';
 import CallAssignmentModel, {
   CallAssignmentState,
 } from 'features/callAssignments/models/CallAssignmentModel';
-import { HeadsetMic, PhoneOutlined } from '@mui/icons-material';
-
-import useModel from 'core/useModel';
-import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
 
 interface CallAssignmentListItemProps {
   orgId: number;
@@ -44,7 +45,7 @@ const CallAssignmentListItem: FC<CallAssignmentListItemProps> = ({
   const statsLoading = model.getStats().isLoading;
 
   return (
-    <ActivityListItem
+    <ActivityListItemWithStats
       blueChipValue={ready}
       color={color}
       endNumber={callsMade}

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -95,6 +95,11 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
     <ActivityListItem
       color={color}
       endNumber={`${data.num_participants_available} / ${data.num_participants_required}`}
+      endNumberColor={
+        data.num_participants_available < data.num_participants_required
+          ? 'error'
+          : undefined
+      }
       href={`/organize/${orgId}/projects/${
         data.campaign?.id ?? 'standalone'
       }/events/${eventId}`}
@@ -103,7 +108,7 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       SecondaryIcon={Group}
       subtitle={
         <ZUIIconLabelRow
-          color="gray"
+          color="secondary"
           iconLabels={[
             {
               icon: <ScheduleOutlined fontSize="inherit" />,

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -1,7 +1,14 @@
 import { FC } from 'react';
-import { EventOutlined, Group } from '@mui/icons-material';
+import {
+  EventOutlined,
+  Group,
+  PlaceOutlined,
+  ScheduleOutlined,
+} from '@mui/icons-material';
 
 import useModel from 'core/useModel';
+import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
+import ZUITimeSpan from 'zui/ZUITimeSpan';
 import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
 import EventDataModel, {
   EventState,
@@ -36,9 +43,30 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       endNumber={`${data.num_participants_available} / ${data.num_participants_required}`}
       href={`/organize/${orgId}/projects/${
         data.campaign?.id ?? 'standalone'
-      }/callassignments/${eventId}`}
+      }/events/${eventId}`}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={Group}
+      subtitle={
+        <ZUIIconLabelRow
+          color="gray"
+          iconLabels={[
+            {
+              icon: <ScheduleOutlined fontSize="inherit" />,
+              label: (
+                <ZUITimeSpan
+                  end={new Date(data.end_time)}
+                  start={new Date(data.start_time)}
+                />
+              ),
+            },
+            {
+              icon: <PlaceOutlined fontSize="inherit" />,
+              label: data.location.title,
+            },
+          ]}
+          size="sm"
+        />
+      }
       title={data.title || data.activity.title}
     />
   );

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -34,14 +34,11 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
     <ActivityListItem
       color={color}
       endNumber={`${data.num_participants_available} / ${data.num_participants_required}`}
-      greenChipValue={undefined}
       href={`/organize/${orgId}/projects/${
         data.campaign?.id ?? 'standalone'
       }/callassignments/${eventId}`}
-      orangeChipValue={undefined}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={Group}
-      statsLoading={false}
       title={data.title || data.activity.title}
     />
   );

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -1,11 +1,16 @@
 import { FC } from 'react';
+import { Box, CircularProgress, Tooltip } from '@mui/material';
 import {
+  EmojiPeople,
   EventOutlined,
+  FaceRetouchingOff,
   Group,
+  MailOutline,
   PlaceOutlined,
   ScheduleOutlined,
 } from '@mui/icons-material';
 
+import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
@@ -14,15 +19,19 @@ import EventDataModel, {
   EventState,
 } from 'features/events/models/EventDataModel';
 
+import messageIds from 'features/campaigns/l10n/messageIds';
+
 interface EventListeItemProps {
   orgId: number;
   eventId: number;
 }
 
 const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
+  const messages = useMessages(messageIds);
   const model = useModel((env) => new EventDataModel(env, orgId, eventId));
   const state = model.state;
   const data = model.getData().data;
+  const participants = model.getParticipants();
 
   if (!data) {
     return null;
@@ -37,6 +46,51 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
     color = STATUS_COLORS.BLUE;
   }
 
+  const icons: JSX.Element[] = [
+    <AlertSlot key="contact" />,
+    <AlertSlot key="signups" />,
+    <AlertSlot key="reminders" />,
+  ];
+
+  if (participants.data) {
+    if (!data.contact) {
+      icons[0] = (
+        <AlertSlot
+          key="contact"
+          icon={<FaceRetouchingOff color="error" />}
+          tooltip={messages.activityList.eventItem.contact()}
+        />
+      );
+    }
+
+    const numBooked = participants.data.length;
+    if (data.num_participants_available > numBooked) {
+      icons[1] = (
+        <AlertSlot
+          key="signups"
+          icon={<EmojiPeople color="error" />}
+          tooltip={messages.activityList.eventItem.signups()}
+        />
+      );
+    }
+
+    const reminded = participants.data.filter((p) => !!p.reminder_sent);
+    const numReminded = reminded.length;
+    if (numReminded < participants.data.length) {
+      icons[2] = (
+        <AlertSlot
+          key="reminders"
+          icon={<MailOutline color="error" />}
+          tooltip={messages.activityList.eventItem.reminders({
+            numMissing: participants.data.length - numReminded,
+          })}
+        />
+      );
+    }
+  } else {
+    icons.push(<CircularProgress />);
+  }
+
   return (
     <ActivityListItem
       color={color}
@@ -44,6 +98,7 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       href={`/organize/${orgId}/projects/${
         data.campaign?.id ?? 'standalone'
       }/events/${eventId}`}
+      meta={<Box display="flex">{icons}</Box>}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={Group}
       subtitle={
@@ -69,6 +124,23 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       }
       title={data.title || data.activity.title}
     />
+  );
+};
+
+const AlertSlot: FC<{
+  icon?: JSX.Element;
+  tooltip?: string;
+}> = ({ icon, tooltip }) => {
+  return (
+    <Box width="1.6em">
+      {tooltip ? (
+        <Tooltip arrow title={tooltip}>
+          <Box>{icon}</Box>
+        </Tooltip>
+      ) : (
+        icon
+      )}
+    </Box>
   );
 };
 

--- a/src/features/campaigns/components/ActivityList/items/SurveyListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/SurveyListItem.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
 import { AssignmentOutlined, ChatBubbleOutline } from '@mui/icons-material';
 
+import ActivityListItemWithStats from './ActivityListItemWithStats';
+import { STATUS_COLORS } from './ActivityListItem';
 import useModel from 'core/useModel';
-import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
 import SurveyDataModel, {
   SurveyState,
 } from 'features/surveys/models/SurveyDataModel';
@@ -49,7 +50,7 @@ const SurveyListItem: FC<SurveyListItemProps> = ({ orgId, surveyId }) => {
   const statsLoading = dataModel.getStats().isLoading;
 
   return (
-    <ActivityListItem
+    <ActivityListItemWithStats
       color={color}
       endNumber={submissionCount.toString()}
       greenChipValue={linkedSubmissionCount}

--- a/src/features/campaigns/components/ActivityList/items/TaskListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/TaskListItem.tsx
@@ -1,8 +1,9 @@
-import TaskModel from 'features/tasks/models/TaskModel';
-import useModel from 'core/useModel';
 import { CheckBoxOutlined, People } from '@mui/icons-material';
 
-import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
+import ActivityListItemWithStats from './ActivityListItemWithStats';
+import { STATUS_COLORS } from './ActivityListItem';
+import TaskModel from 'features/tasks/models/TaskModel';
+import useModel from 'core/useModel';
 import getTaskStatus, { TASK_STATUS } from 'features/tasks/utils/getTaskStatus';
 
 interface TaskListItemProps {
@@ -33,7 +34,7 @@ const TaskListItem = ({ orgId, taskId }: TaskListItemProps) => {
   const statsLoading = model.getTaskStats().isLoading;
 
   return (
-    <ActivityListItem
+    <ActivityListItemWithStats
       blueChipValue={stats?.assigned}
       color={color}
       endNumber={stats?.individuals ?? 0}

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -23,6 +23,15 @@ export default makeMessages('feat.campaigns', {
     todayCard: m('Today'),
     tomorrowCard: m('Tomorrow'),
   },
+  activityList: {
+    eventItem: {
+      contact: m('No contact person has been assigned'),
+      reminders: m<{ numMissing: number }>(
+        '{numMissing, plural, =1 {One participant} other {# participants}} have not yet received reminders'
+      ),
+      signups: m('There are pending signups'),
+    },
+  },
   all: {
     cardCTA: m('Go to project'),
     create: m('Create new project'),

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -1,4 +1,3 @@
-import { ReactElement } from 'react';
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.events', {
@@ -43,27 +42,9 @@ export default makeMessages('feat.events', {
     scheduled: m('Scheduled'),
   },
   stats: {
-    multiDay: m<{
-      end: string;
-      endDate: ReactElement;
-      start: string;
-      startDate: ReactElement;
-    }>('{startDate}, {start} - {endDate}, {end}'),
-    multiDayEndsToday: m<{
-      end: string;
-      start: string;
-      startDate: ReactElement;
-    }>('{startDate}, {start} - Today, {end}'),
-    multiDayToday: m<{ end: string; endDate: ReactElement; start: string }>(
-      'Today, {start} - {endDate}, {end}'
-    ),
     participants: m<{ participants: number }>(
       '{participants, plural, one {1 participant} other {# participants}}'
     ),
-    singleDay: m<{ date: ReactElement; end: string; start: string }>(
-      '{date}, {start} - {end}'
-    ),
-    singleDayToday: m<{ end: string; start: string }>('Today, {start} - {end}'),
   },
   tabs: {
     overview: m('Overview'),

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@mui/material';
 import EventIcon from '@mui/icons-material/Event';
-import { FormattedDate } from 'react-intl';
 import PeopleIcon from '@mui/icons-material/People';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 
@@ -12,6 +11,7 @@ import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
+import ZUITimeSpan from 'zui/ZUITimeSpan';
 import { Msg, useMessages } from 'core/i18n';
 
 interface EventLayoutProps {
@@ -33,15 +33,6 @@ const EventLayout: React.FC<EventLayoutProps> = ({
     (env) => new EventDataModel(env, parseInt(orgId), parseInt(eventId))
   );
 
-  const showTimeOnly = (value: Date) => {
-    return value.toLocaleTimeString('en-Us', {
-      hour: '2-digit',
-      hour12: false,
-      minute: '2-digit',
-      timeZone: 'UTC',
-    });
-  };
-
   return (
     <TabbedLayout
       baseHref={`/organize/${orgId}/projects/${campaignId}/events/${eventId}`}
@@ -53,116 +44,15 @@ const EventLayout: React.FC<EventLayoutProps> = ({
             <ZUIFuture future={model.getData()}>
               {(data) => {
                 const startDate = new Date(data.start_time);
-                const startTime = showTimeOnly(startDate);
 
                 const endDate = new Date(data.end_time);
-                const endTime = showTimeOnly(endDate);
-
-                const isToday =
-                  startDate.toDateString() === new Date().toDateString();
-                const endsOnSameDay =
-                  startDate.toDateString() === endDate.toDateString();
-                const endsOnToday =
-                  endDate.toDateString() === new Date().toDateString();
 
                 const labels: ZUIIconLabelProps[] = [];
 
                 if (startDate && endDate) {
                   labels.push({
                     icon: <EventIcon />,
-                    label: (
-                      <>
-                        {isToday && (
-                          <>
-                            {endsOnSameDay && (
-                              <Msg
-                                id={messageIds.stats.singleDayToday}
-                                values={{ end: endTime, start: startTime }}
-                              />
-                            )}
-                            {!endsOnSameDay && (
-                              <Msg
-                                id={messageIds.stats.multiDayToday}
-                                values={{
-                                  end: endTime,
-                                  endDate: (
-                                    <FormattedDate
-                                      day="numeric"
-                                      month="long"
-                                      value={data.end_time}
-                                    />
-                                  ),
-                                  start: startTime,
-                                }}
-                              />
-                            )}
-                          </>
-                        )}
-                        {!isToday && (
-                          <>
-                            {endsOnSameDay && (
-                              <Msg
-                                id={messageIds.stats.singleDay}
-                                values={{
-                                  date: (
-                                    <FormattedDate
-                                      day="numeric"
-                                      month="long"
-                                      value={data.start_time}
-                                    />
-                                  ),
-                                  end: endTime,
-                                  start: startTime,
-                                }}
-                              />
-                            )}
-                            {!endsOnSameDay && (
-                              <>
-                                {endsOnToday && (
-                                  <Msg
-                                    id={messageIds.stats.multiDayEndsToday}
-                                    values={{
-                                      end: endTime,
-                                      start: startTime,
-                                      startDate: (
-                                        <FormattedDate
-                                          day="numeric"
-                                          month="long"
-                                          value={data.start_time}
-                                        />
-                                      ),
-                                    }}
-                                  />
-                                )}
-                                {!endsOnToday && (
-                                  <Msg
-                                    id={messageIds.stats.multiDay}
-                                    values={{
-                                      end: endTime,
-                                      endDate: (
-                                        <FormattedDate
-                                          day="numeric"
-                                          month="long"
-                                          value={data.end_time}
-                                        />
-                                      ),
-                                      start: startTime,
-                                      startDate: (
-                                        <FormattedDate
-                                          day="numeric"
-                                          month="long"
-                                          value={data.start_time}
-                                        />
-                                      ),
-                                    }}
-                                  />
-                                )}
-                              </>
-                            )}
-                          </>
-                        )}
-                      </>
-                    ),
+                    label: <ZUITimeSpan end={endDate} start={startDate} />,
                   });
                   if (data.num_participants_available) {
                     labels.push({

--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -2,7 +2,11 @@ import Environment from 'core/env/Environment';
 import { IFuture } from 'core/caching/futures';
 import { ModelBase } from 'core/models';
 import EventsRepo, { ZetkinEventPatchBody } from '../repo/EventsRepo';
-import { ZetkinEvent, ZetkinLocation } from 'utils/types/zetkin';
+import {
+  ZetkinEvent,
+  ZetkinEventParticipant,
+  ZetkinLocation,
+} from 'utils/types/zetkin';
 
 export enum EventState {
   CANCELLED = 'cancelled',
@@ -27,6 +31,10 @@ export default class EventDataModel extends ModelBase {
 
   getData(): IFuture<ZetkinEvent> {
     return this._repo.getEvent(this._orgId, this._eventId);
+  }
+
+  getParticipants(): IFuture<ZetkinEventParticipant[]> {
+    return this._repo.getEventParticipants(this._orgId, this._eventId);
   }
 
   setLocation(location: ZetkinLocation) {

--- a/src/features/events/repo/EventsRepo.ts
+++ b/src/features/events/repo/EventsRepo.ts
@@ -6,6 +6,8 @@ import { Store } from 'core/store';
 import {
   eventLoad,
   eventLoaded,
+  eventsLoad,
+  eventsLoaded,
   eventUpdate,
   eventUpdated,
   locationsLoad,
@@ -33,6 +35,17 @@ export default class EventsRepo {
   constructor(env: Environment) {
     this._store = env.store;
     this._apiClient = env.apiClient;
+  }
+
+  getAllEvents(orgId: number): IFuture<ZetkinEvent[]> {
+    const state = this._store.getState();
+
+    return loadListIfNecessary(state.events.eventList, this._store, {
+      actionOnLoad: () => eventsLoad(),
+      actionOnSuccess: (events) => eventsLoaded(events),
+      loader: () =>
+        this._apiClient.get<ZetkinEvent[]>(`/api/orgs/${orgId}/actions`),
+    });
   }
 
   getEvent(orgId: number, id: number): IFuture<ZetkinEvent> {

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -50,6 +50,13 @@ const eventsSlice = createSlice({
         item.mutating = [];
       }
     },
+    eventsLoad: (state) => {
+      state.eventList.isLoading = true;
+    },
+    eventsLoaded: (state, action: PayloadAction<ZetkinEvent[]>) => {
+      state.eventList = remoteList(action.payload);
+      state.eventList.loaded = new Date().toISOString();
+    },
     locationsLoad: (state) => {
       state.locationList.isLoading = true;
     },
@@ -66,6 +73,8 @@ export default eventsSlice;
 export const {
   eventLoad,
   eventLoaded,
+  eventsLoad,
+  eventsLoaded,
   eventUpdate,
   eventUpdated,
   locationsLoad,

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -1,15 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
-import { ZetkinEvent, ZetkinLocation } from 'utils/types/zetkin';
+import {
+  ZetkinEvent,
+  ZetkinEventParticipant,
+  ZetkinLocation,
+} from 'utils/types/zetkin';
 
 export interface EventsStoreSlice {
   eventList: RemoteList<ZetkinEvent>;
   locationList: RemoteList<ZetkinLocation>;
+  participantsByEventId: Record<number, RemoteList<ZetkinEventParticipant>>;
 }
 
 const initialState: EventsStoreSlice = {
   eventList: remoteList(),
   locationList: remoteList(),
+  participantsByEventId: {},
 };
 
 const eventsSlice = createSlice({
@@ -66,6 +72,22 @@ const eventsSlice = createSlice({
       state.locationList = remoteList(locations);
       state.locationList.loaded = timestamp;
     },
+    participantsLoad: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      if (!state.participantsByEventId[eventId]) {
+        state.participantsByEventId[eventId] = remoteList();
+      }
+
+      state.participantsByEventId[eventId].isLoading = true;
+    },
+    participantsLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinEventParticipant[]]>
+    ) => {
+      const [eventId, participants] = action.payload;
+      state.participantsByEventId[eventId] = remoteList(participants);
+      state.participantsByEventId[eventId].loaded = new Date().toISOString();
+    },
   },
 });
 
@@ -79,4 +101,6 @@ export const {
   eventUpdated,
   locationsLoad,
   locationsLoaded,
+  participantsLoad,
+  participantsLoaded,
 } = eventsSlice.actions;

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -89,6 +89,10 @@ export interface ZetkinEvent {
   url?: string;
 }
 
+export type ZetkinEventParticipant = ZetkinPerson & {
+  reminder_sent: null | string;
+};
+
 export interface ZetkinFile {
   id: number;
   original_name: string;

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -76,8 +76,8 @@ export interface ZetkinEvent {
     lng: number;
     title: string;
   };
-  num_participants_required?: number;
-  num_participants_available?: number;
+  num_participants_required: number;
+  num_participants_available: number;
   start_time: string;
   title?: string;
   organization: {

--- a/src/zui/ZUIIconLabel.tsx
+++ b/src/zui/ZUIIconLabel.tsx
@@ -4,14 +4,31 @@ import { Box, Typography } from '@mui/material';
 export interface ZUIIconLabelProps {
   icon: JSX.Element;
   label: string | JSX.Element;
-  labelColor?: string;
+  color?: string;
+  size?: 'sm' | 'md';
 }
 
-const ZUIIconLabel: FC<ZUIIconLabelProps> = ({ icon, label, labelColor }) => {
+const FONT_SIZES = {
+  md: '1.1em',
+  sm: '1em',
+} as const;
+
+const ZUIIconLabel: FC<ZUIIconLabelProps> = ({
+  icon,
+  label,
+  color,
+  size = 'md',
+}) => {
   return (
-    <Box display="flex" gap={1}>
+    <Box
+      alignItems="center"
+      color={color}
+      display="flex"
+      fontSize={FONT_SIZES[size]}
+      gap={1}
+    >
       {icon}
-      <Typography color={labelColor ? labelColor : 'inherit'}>
+      <Typography color={color ? color : 'inherit'} fontSize="inherit">
         {label}
       </Typography>
     </Box>

--- a/src/zui/ZUIIconLabel.tsx
+++ b/src/zui/ZUIIconLabel.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from '@mui/material';
 export interface ZUIIconLabelProps {
   icon: JSX.Element;
   label: string | JSX.Element;
-  color?: string;
+  color?: 'error' | 'secondary';
   size?: 'sm' | 'md';
 }
 

--- a/src/zui/ZUIIconLabelRow.tsx
+++ b/src/zui/ZUIIconLabelRow.tsx
@@ -3,14 +3,19 @@ import { FC } from 'react';
 import ZUIIconLabel, { ZUIIconLabelProps } from './ZUIIconLabel';
 
 interface ZUIIconLabelRowProps {
+  color?: ZUIIconLabelProps['color'];
   iconLabels: ZUIIconLabelProps[];
+  size?: ZUIIconLabelProps['size'];
 }
 
-const ZUIIconLabelRow: FC<ZUIIconLabelRowProps> = ({ iconLabels }) => {
+const ZUIIconLabelRow: FC<ZUIIconLabelRowProps> = ({
+  iconLabels,
+  ...restProps
+}) => {
   return (
     <Box display="flex" gap={2}>
       {iconLabels.map((props, index) => (
-        <ZUIIconLabel key={index} {...props} />
+        <ZUIIconLabel key={index} {...restProps} {...props} />
       ))}
     </Box>
   );

--- a/src/zui/ZUITimeSpan/index.stories.tsx
+++ b/src/zui/ZUITimeSpan/index.stories.tsx
@@ -1,0 +1,57 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ZUITimeSpan from '.';
+
+export default {
+  component: ZUITimeSpan,
+  title: 'ZUITimeSpan',
+} as ComponentMeta<typeof ZUITimeSpan>;
+
+const Template: ComponentStory<typeof ZUITimeSpan> = (args) => {
+  return <ZUITimeSpan end={args.end} start={args.start} />;
+};
+
+const now = new Date();
+
+const todayAt12 = new Date(
+  now.getFullYear(),
+  now.getMonth(),
+  now.getDate(),
+  12
+);
+
+const todayAt14 = new Date(todayAt12);
+todayAt14.setHours(14);
+
+const tomorrowAt12 = new Date(todayAt12);
+tomorrowAt12.setDate(tomorrowAt12.getDate() + 1);
+
+const tomorrowAt14 = new Date(todayAt14);
+tomorrowAt14.setDate(tomorrowAt14.getDate() + 1);
+
+const nextDayAt14 = new Date(todayAt14);
+nextDayAt14.setDate(nextDayAt14.getDate() + 2);
+
+export const today = Template.bind({});
+today.args = {
+  end: todayAt14,
+  start: todayAt12,
+};
+
+export const tomorrow = Template.bind({});
+tomorrow.args = {
+  end: tomorrowAt14,
+  start: tomorrowAt12,
+};
+
+export const todayAndTomorrow = Template.bind({});
+todayAndTomorrow.args = {
+  end: tomorrowAt12,
+  start: todayAt12,
+};
+
+export const multiDay = Template.bind({});
+multiDay.args = {
+  end: nextDayAt14,
+  start: tomorrowAt12,
+};

--- a/src/zui/ZUITimeSpan/index.tsx
+++ b/src/zui/ZUITimeSpan/index.tsx
@@ -1,0 +1,95 @@
+import { FC } from 'react';
+import { FormattedDate, FormattedTime } from 'react-intl';
+
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+type ZUITimeSpanProps = {
+  end: Date;
+  start: Date;
+};
+
+const ZUITimeSpan: FC<ZUITimeSpanProps> = ({ end, start }) => {
+  const isToday = start.toDateString() === new Date().toDateString();
+  const endsOnSameDay = start.toDateString() === end.toDateString();
+  const endsOnToday = end.toDateString() === new Date().toDateString();
+
+  const startTime = <FormattedTime value={start} />;
+  const endTime = <FormattedTime value={end} />;
+
+  return (
+    <>
+      {isToday && (
+        <>
+          {endsOnSameDay && (
+            <Msg
+              id={messageIds.timeSpan.singleDayToday}
+              values={{ end: endTime, start: startTime }}
+            />
+          )}
+          {!endsOnSameDay && (
+            <Msg
+              id={messageIds.timeSpan.multiDayToday}
+              values={{
+                end: endTime,
+                endDate: (
+                  <FormattedDate day="numeric" month="long" value={end} />
+                ),
+                start: startTime,
+              }}
+            />
+          )}
+        </>
+      )}
+      {!isToday && (
+        <>
+          {endsOnSameDay && (
+            <Msg
+              id={messageIds.timeSpan.singleDay}
+              values={{
+                date: (
+                  <FormattedDate day="numeric" month="long" value={start} />
+                ),
+                end: endTime,
+                start: startTime,
+              }}
+            />
+          )}
+          {!endsOnSameDay && (
+            <>
+              {endsOnToday && (
+                <Msg
+                  id={messageIds.timeSpan.multiDayEndsToday}
+                  values={{
+                    end: endTime,
+                    start: startTime,
+                    startDate: (
+                      <FormattedDate day="numeric" month="long" value={start} />
+                    ),
+                  }}
+                />
+              )}
+              {!endsOnToday && (
+                <Msg
+                  id={messageIds.timeSpan.multiDay}
+                  values={{
+                    end: endTime,
+                    endDate: (
+                      <FormattedDate day="numeric" month="long" value={end} />
+                    ),
+                    start: startTime,
+                    startDate: (
+                      <FormattedDate day="numeric" month="long" value={start} />
+                    ),
+                  }}
+                />
+              )}
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default ZUITimeSpan;

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -132,4 +132,30 @@ export default makeMessages('zui', {
   suffixedNumber: {
     thousands: m<{ num: number }>('{num}K'),
   },
+  timeSpan: {
+    multiDay: m<{
+      end: ReactElement;
+      endDate: ReactElement;
+      start: ReactElement;
+      startDate: ReactElement;
+    }>('{startDate}, {start} - {endDate}, {end}'),
+    multiDayEndsToday: m<{
+      end: ReactElement;
+      start: ReactElement;
+      startDate: ReactElement;
+    }>('{startDate}, {start} - Today, {end}'),
+    multiDayToday: m<{
+      end: ReactElement;
+      endDate: ReactElement;
+      start: ReactElement;
+    }>('Today, {start} - {endDate}, {end}'),
+    singleDay: m<{
+      date: ReactElement;
+      end: ReactElement;
+      start: ReactElement;
+    }>('{date}, {start} - {end}'),
+    singleDayToday: m<{ end: ReactElement; start: ReactElement }>(
+      'Today, {start} - {end}'
+    ),
+  },
 });


### PR DESCRIPTION
## Description
This PR introduces an `EventListItem` to the activities lists.

## Screenshots
<img width="1667" alt="image" src="https://user-images.githubusercontent.com/550212/230425866-fa1b0c08-ac1a-424c-b7fa-331fbc3caddc.png">

## Changes
* Adds model, repo, store logic for retrieving a list of events
* Adds model, repo, store logic for retrieving the participants of an event
* Refactors the list items to allow for more flexibility without making the existing list item components too complex
* Add `size` and `color` properties to the `ZUIIconLabelRow` and `ZUIIconLabel` components
* Create new `ZUITimeSpan` component from the logic created by @kaulfield23 in #1188 

## Notes to reviewer
The implemented design deviates a little from the design handover, because I could not realistically fit the "subtitle" inline with the title without breaking, so I put it below.

I also made another change that was more subjective, which is that the three status icons (contact, sign-ups and reminders) are always in the same position. My hope is that this makes them easier to make sense of when scrolling through a list.

There are still some shortcomings here, such as:

* I'm loading _all_ events, which is not going to be practical for large, existing organizations. We need to come up with a general-purpose solution for dealing with things like pagination and filtering when retrieving data. This exists in the API, but the challenge is to make it work within the repo/store logic of the frontend.
* All list items will load the event participants immediately when rendered. This should be replaced with logic for loading stuff only when it scrolls into view. That's something to look into separately.

## Related issues
Resolves #1190 