### PR TITLE
ISSUE1204 allocated targets counted twice

### DIFF
--- a/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusCards.tsx
@@ -156,7 +156,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'green' : 'gray'}
+            chipColor={hasTargets ? 'blue' : 'gray'}
             subtitle={messages.ready.subtitle()}
             title={messages.ready.title()}
             value={stats?.ready}
@@ -176,7 +176,7 @@ const CallAssignmentStatusCards = ({
       <Grid item md={4} xs={12}>
         <Card>
           <StatusCardHeader
-            chipColor={hasTargets ? 'blue' : 'gray'}
+            chipColor={hasTargets ? 'green' : 'gray'}
             subtitle={messages.done.subtitle()}
             title={messages.done.title()}
             value={stats?.done}

--- a/src/pages/api/callAssignments/targets.ts
+++ b/src/pages/api/callAssignments/targets.ts
@@ -50,7 +50,7 @@ export default async function handler(
     data: {
       allTargets: stats.num_target_matches,
       allocated: stats.num_blocked.allocated,
-      blocked: stats.num_blocked.any,
+      blocked: stats.num_blocked.any - stats.num_blocked.allocated,
       callBackLater: stats.num_blocked.call_back_after,
       calledTooRecently: stats.num_blocked.cooldown,
       callsMade: stats.num_calls_made,


### PR DESCRIPTION
## Description
This PR fixes two things:
- Allocated targets on the Call Assignment screen were counted twice, both in "Blocked" and in "Ready". Now it is only counted in "Ready".
- Colours for "Ready" and "Done" were incorrect and was fixed.


## Screenshots
Before PR:
![bild](https://user-images.githubusercontent.com/21238654/230596347-a5290494-c942-40f6-872f-ef2dbfebea40.png)


After PR:
![bild](https://user-images.githubusercontent.com/21238654/230596105-0726b6bf-c601-4d21-8bd7-4b2d860f5322.png)


## Changes
* Fix issue #1204 


## Notes to reviewer
N/A


## Related issues
N/A
