### PR TITLE
Redirect back to people after removing view

### DIFF
--- a/integrationTesting/tests/organize/views/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete.spec.ts
@@ -73,9 +73,7 @@ test.describe('View detail page', () => {
     ]);
 
     // Check navigates back to views list
-    await expect(page.url()).toEqual(
-      appUri + `/organize/${KPD.id}/people/views`
-    );
+    await expect(page.url()).toEqual(appUri + `/organize/${KPD.id}/people`);
   });
 
   test('shows error snackbar if error deleting view', async ({

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -137,7 +137,7 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
         setDeactivated(false);
         showSnackbar('error', messages.deleteDialog.error());
       } finally {
-        router.push(`/organize/${orgId}/people/views`);
+        router.push(`/organize/${orgId}/people`);
       }
     }
   };


### PR DESCRIPTION
## Description
This PR fixes #1201. Previously, when a view was deleted we were still on the same page, getting errors when trying to display a nonexistent view. After this PR we will navigate back to the people list.

There are still some errors here, but I will leave them for future PR's.


## Screenshots
Before PR: 
<img width="1483" alt="230544347-ba6946b3-b313-4817-ac30-dcc23803435a" src="https://user-images.githubusercontent.com/21238654/230616656-f21ba228-df9e-4d8e-bbee-81d77c0d620f.png">

After PR: 
Navigates back to the people list.

## Changes
Change navigation when removing a view.


## Notes to reviewer
N/A


## Related issues
Resolves #1201
