### PR TITLE
Allow only existing route ids

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -13,12 +13,25 @@ import useModel from 'core/useModel';
 import useServerSide from 'core/useServerSide';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
 
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import messageIds from 'features/callAssignments/l10n/messageIds';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
     const { orgId, campId, callAssId } = ctx.params!;
-
+    try {
+      const client = new BackendApiClient(ctx.req.headers);
+      const data = await client.get<ZetkinCallAssignment>(
+        `/api/orgs/${orgId}/call_assignments/${callAssId}`
+      );
+      const actualCampaign = data.campaign?.id.toString() ?? 'standalone';
+      if (actualCampaign !== campId) {
+        return { notFound: true };
+      }
+    } catch (error) {
+      return { notFound: true };
+    }
     return {
       props: {
         assignmentId: callAssId,

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -1,3 +1,4 @@
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import { GetServerSideProps } from 'next';
 import { Grid } from '@mui/material';
 import { PageWithLayout } from 'utils/types';
@@ -8,12 +9,24 @@ import EventLayout from 'features/events/layout/EventLayout';
 import EventOverviewCard from 'features/events/components/EventOverviewCard';
 import LocationsModel from 'features/events/models/LocationsModel';
 import useModel from 'core/useModel';
+import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUIFuture from 'zui/ZUIFuture';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
     const { orgId, campId, eventId } = ctx.params!;
-
+    try {
+      const client = new BackendApiClient(ctx.req.headers);
+      const data = await client.get<ZetkinEvent>(
+        `/api/orgs/${orgId}/actions/${eventId}`
+      );
+      const actualCampaign = data.campaign?.id.toString() ?? 'standalone';
+      if (actualCampaign !== campId) {
+        return { notFound: true };
+      }
+    } catch (error) {
+      return { notFound: true };
+    }
     return {
       props: {
         campId,

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -1,3 +1,4 @@
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { Box, Grid } from '@mui/material';
@@ -11,6 +12,7 @@ import SurveyUnlinkedCard from 'features/surveys/components/SurveyUnlinkedCard';
 import SurveyURLCard from 'features/surveys/components/SurveyURLCard';
 import useModel from 'core/useModel';
 import useServerSide from 'core/useServerSide';
+import { ZetkinSurvey } from 'utils/types/zetkin';
 import SurveyDataModel, {
   SurveyState,
 } from 'features/surveys/models/SurveyDataModel';
@@ -18,6 +20,18 @@ import SurveyDataModel, {
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
     const { orgId, campId, surveyId } = ctx.params!;
+    try {
+      const client = new BackendApiClient(ctx.req.headers);
+      const data = await client.get<ZetkinSurvey>(
+        `/api/orgs/${orgId}/surveys/${surveyId}`
+      );
+      const actualCampaign = data.campaign?.id.toString() ?? 'standalone';
+      if (actualCampaign !== campId) {
+        return { notFound: true };
+      }
+    } catch (error) {
+      return { notFound: true };
+    }
 
     return {
       props: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,20 +6175,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001317:
-  version "1.0.30001332"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz#39476d3aa8d83ea76359c70302eafdd4a1d727dd"
-  integrity sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==
-
-caniuse-lite@^1.0.30001280:
-  version "1.0.30001282"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
-  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
-
-caniuse-lite@^1.0.30001332:
-  version "1.0.30001387"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz#90d2b9bdfcc3ab9a5b9addee00a25ef86c9e2e1e"
-  integrity sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001280, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001332:
+  version "1.0.30001474"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz"
+  integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Update for non existing routes to route to the 404 page

## Screenshots
<img width="255" alt="Screenshot 2023-04-07 at 16 40 43" src="https://user-images.githubusercontent.com/10441376/230627633-f4faf01d-fabe-4980-848c-2cec82658693.png"> <img width="256" alt="Screenshot 2023-04-07 at 16 40 56" src="https://user-images.githubusercontent.com/10441376/230627636-69318d71-1118-4b0f-a831-c76183eb3406.png"> <img width="254" alt="Screenshot 2023-04-07 at 16 40 50" src="https://user-images.githubusercontent.com/10441376/230627639-151be1a2-525d-48f2-b9f3-9c878663a038.png">


## Changes

* Adds error screen on non existing URLs


## Notes to reviewer
    Go to each of the following URLs
    a. http://localhost:3000/organize/1/projects/999/surveys/1
    b. http://localhost:3000/organize/1/projects/999/callassignments/1
    c. http://localhost:3000/organize/1/projects/999/events/1

Expected Behaviour
Should show a 404 page.

The following URL, for example, should work fine:
http://localhost:3000/organize/1/projects/standalone/surveys/1

## Related issues
Resolves #1200
