### PR TITLE
Events in activity overviews

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/ActivitiesOverviewCard.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/ActivitiesOverviewCard.tsx
@@ -3,6 +3,7 @@ import { FlagOutlined } from '@mui/icons-material';
 import { Box, Divider, Typography } from '@mui/material';
 
 import CallAssignmentOverviewListItem from './items/CallAssignmentOverviewListItem';
+import EventOverviewListItem from './items/EventOverviewListItem';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import SurveyOverviewListItem from './items/SurveyOverviewListItem';
 import TaskOverviewListItem from './items/TaskOverviewListItem';
@@ -42,6 +43,16 @@ const ActivitiesOverviewCard: FC<OverviewListProps> = ({
             <Box key={`ca-${activity.data.id}`}>
               {index > 0 && <Divider />}
               <CallAssignmentOverviewListItem
+                activity={activity}
+                focusDate={focusDate}
+              />
+            </Box>
+          );
+        } else if (activity.kind === ACTIVITIES.EVENT) {
+          return (
+            <Box key={`ca-${activity.data.id}`}>
+              {index > 0 && <Divider />}
+              <EventOverviewListItem
                 activity={activity}
                 focusDate={focusDate}
               />

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
 import {
   EventOutlined,
   People,
@@ -7,7 +8,10 @@ import {
 } from '@mui/icons-material';
 
 import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
+import EventDataModel from 'features/events/models/EventDataModel';
+import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import OverviewListItem from './OverviewListItem';
+import useModel from 'core/useModel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
 
@@ -21,6 +25,9 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
   focusDate,
 }) => {
   const event = activity.data;
+  const model = useModel(
+    (env) => new EventDataModel(env, event.organization.id, event.id)
+  );
 
   return (
     <OverviewListItem
@@ -52,7 +59,12 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
           ]}
         />
       }
-      title={event.title || event.activity.title}
+      title={
+        <Box alignItems="center" display="flex" justifyContent="space-between">
+          <Typography>{event.title || event.activity.title}</Typography>
+          <EventWarningIcons model={model} />
+        </Box>
+      }
     />
   );
 };

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -1,5 +1,4 @@
 import { FC } from 'react';
-import { Box, Typography } from '@mui/material';
 import {
   EventOutlined,
   People,
@@ -37,6 +36,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
       href={`/organize/${event.organization.id}/projects/${
         event.campaign?.id ?? 'standalone'
       }/events/${event.id}`}
+      meta={<EventWarningIcons compact model={model} />}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={People}
       statusBar={null}
@@ -59,12 +59,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
           ]}
         />
       }
-      title={
-        <Box alignItems="center" display="flex" justifyContent="space-between">
-          <Typography>{event.title || event.activity.title}</Typography>
-          <EventWarningIcons compact model={model} />
-        </Box>
-      }
+      title={event.title || event.activity.title}
     />
   );
 };

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import { EventOutlined, People } from '@mui/icons-material';
+
+import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
+import OverviewListItem from './OverviewListItem';
+
+interface EventOverviewListItemProps {
+  activity: EventActivity;
+  focusDate: Date | null;
+}
+
+const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
+  activity,
+  focusDate,
+}) => {
+  const event = activity.data;
+
+  return (
+    <OverviewListItem
+      activity={activity}
+      endNumber={`${event.num_participants_available} / ${event.num_participants_required}`}
+      focusDate={focusDate}
+      href={`/organize/${event.organization.id}/projects/${
+        event.campaign?.id ?? 'standalone'
+      }/events/${event.id}`}
+      PrimaryIcon={EventOutlined}
+      SecondaryIcon={People}
+      statusBar={null}
+      title={event.title || event.activity.title}
+    />
+  );
+};
+
+export default EventOverviewListItem;

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -1,8 +1,15 @@
 import { FC } from 'react';
-import { EventOutlined, People } from '@mui/icons-material';
+import {
+  EventOutlined,
+  People,
+  PlaceOutlined,
+  ScheduleOutlined,
+} from '@mui/icons-material';
 
 import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
 import OverviewListItem from './OverviewListItem';
+import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
+import ZUITimeSpan from 'zui/ZUITimeSpan';
 
 interface EventOverviewListItemProps {
   activity: EventActivity;
@@ -26,6 +33,25 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
       PrimaryIcon={EventOutlined}
       SecondaryIcon={People}
       statusBar={null}
+      subtitle={
+        <ZUIIconLabelRow
+          iconLabels={[
+            {
+              icon: <ScheduleOutlined fontSize="inherit" />,
+              label: (
+                <ZUITimeSpan
+                  end={new Date(event.end_time)}
+                  start={new Date(event.start_time)}
+                />
+              ),
+            },
+            {
+              icon: <PlaceOutlined fontSize="inherit" />,
+              label: event.location.title,
+            },
+          ]}
+        />
+      }
       title={event.title || event.activity.title}
     />
   );

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -62,7 +62,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
       title={
         <Box alignItems="center" display="flex" justifyContent="space-between">
           <Typography>{event.title || event.activity.title}</Typography>
-          <EventWarningIcons model={model} />
+          <EventWarningIcons compact model={model} />
         </Box>
       }
     />

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -32,6 +32,11 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
     <OverviewListItem
       activity={activity}
       endNumber={`${event.num_participants_available} / ${event.num_participants_required}`}
+      endNumberColor={
+        event.num_participants_available < event.num_participants_required
+          ? 'error'
+          : undefined
+      }
       focusDate={focusDate}
       href={`/organize/${event.organization.id}/projects/${
         event.campaign?.id ?? 'standalone'

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -8,9 +8,9 @@ import { isSameDate } from 'utils/dateUtils';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import theme from 'theme';
-import ZUIIconLabel from 'zui/ZUIIconLabel';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import ZUISuffixedNumber from 'zui/ZUISuffixedNumber';
+import ZUIIconLabel, { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
 
 interface StyleProps {
   color: STATUS_COLORS;
@@ -75,6 +75,7 @@ interface OverviewListItemProps {
   meta?: JSX.Element;
   title: string;
   endNumber: number | string;
+  endNumberColor?: ZUIIconLabelProps['color'];
   statusBar?: JSX.Element | null;
   subtitle?: JSX.Element;
 }
@@ -88,6 +89,7 @@ const OverviewListItem = ({
   meta,
   title,
   endNumber,
+  endNumberColor = 'secondary',
   statusBar,
   subtitle,
 }: OverviewListItemProps) => {
@@ -180,8 +182,8 @@ const OverviewListItem = ({
             {meta && <Box flex="0 0">{meta}</Box>}
             <Box flex="1 0 80px">
               <ZUIIconLabel
-                color="secondary"
-                icon={<SecondaryIcon color="secondary" />}
+                color={endNumberColor}
+                icon={<SecondaryIcon color={endNumberColor} />}
                 label={
                   typeof endNumber === 'number' ? (
                     <ZUISuffixedNumber number={endNumber} />

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -75,6 +75,7 @@ interface OverviewListItemProps {
   title: string;
   endNumber: number | string;
   statusBar?: JSX.Element | null;
+  subtitle?: JSX.Element;
 }
 
 const OverviewListItem = ({
@@ -86,6 +87,7 @@ const OverviewListItem = ({
   title,
   endNumber,
   statusBar,
+  subtitle,
 }: OverviewListItemProps) => {
   const { endDate, startDate } = activity;
   const color = getStatusColor(activity);
@@ -94,7 +96,9 @@ const OverviewListItem = ({
   const now = new Date();
   let label: JSX.Element | null = null;
 
-  if (!focusDate) {
+  if (subtitle) {
+    label = subtitle;
+  } else if (!focusDate) {
     if (startDate) {
       label = getStartsLabel(startDate);
     } else if (endDate) {

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -73,7 +73,7 @@ interface OverviewListItemProps {
   focusDate: Date | null;
   href: string;
   title: string;
-  endNumber: number;
+  endNumber: number | string;
   statusBar?: JSX.Element | null;
 }
 
@@ -169,7 +169,13 @@ const OverviewListItem = ({
               <ZUIIconLabel
                 color="secondary"
                 icon={<SecondaryIcon color="secondary" />}
-                label={<ZUISuffixedNumber number={endNumber} />}
+                label={
+                  typeof endNumber === 'number' ? (
+                    <ZUISuffixedNumber number={endNumber} />
+                  ) : (
+                    endNumber
+                  )
+                }
               />
             </Box>
           </Box>

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -72,7 +72,8 @@ interface OverviewListItemProps {
   activity: CampaignActivity;
   focusDate: Date | null;
   href: string;
-  title: JSX.Element | string;
+  meta?: JSX.Element;
+  title: string;
   endNumber: number | string;
   statusBar?: JSX.Element | null;
   subtitle?: JSX.Element;
@@ -84,6 +85,7 @@ const OverviewListItem = ({
   SecondaryIcon,
   focusDate,
   href,
+  meta,
   title,
   endNumber,
   statusBar,
@@ -148,8 +150,13 @@ const OverviewListItem = ({
     <NextLink href={href} passHref>
       <Link my={2} underline="none">
         <Box my={2}>
-          <Box alignItems="start" display="flex" justifyContent="space-between">
-            <Box width={30}>
+          <Box
+            alignItems="center"
+            display="flex"
+            gap={1}
+            justifyContent="space-between"
+          >
+            <Box flex="0 0" width={30}>
               <PrimaryIcon className={classes.primaryIcon} />
             </Box>
             <Box
@@ -161,6 +168,7 @@ const OverviewListItem = ({
               <Typography
                 color={theme.palette.text.primary}
                 sx={{
+                  margin: 0,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
@@ -169,7 +177,8 @@ const OverviewListItem = ({
                 {title}
               </Typography>
             </Box>
-            <Box width={80}>
+            {meta && <Box flex="0 0">{meta}</Box>}
+            <Box flex="1 0 80px">
               <ZUIIconLabel
                 color="secondary"
                 icon={<SecondaryIcon color="secondary" />}

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -72,7 +72,7 @@ interface OverviewListItemProps {
   activity: CampaignActivity;
   focusDate: Date | null;
   href: string;
-  title: string;
+  title: JSX.Element | string;
   endNumber: number | string;
   statusBar?: JSX.Element | null;
   subtitle?: JSX.Element;

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -1,16 +1,12 @@
 import { FC } from 'react';
-import { Box, CircularProgress, Tooltip } from '@mui/material';
 import {
-  EmojiPeople,
   EventOutlined,
-  FaceRetouchingOff,
   Group,
-  MailOutline,
   PlaceOutlined,
   ScheduleOutlined,
 } from '@mui/icons-material';
 
-import { useMessages } from 'core/i18n';
+import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import useModel from 'core/useModel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
@@ -19,19 +15,15 @@ import EventDataModel, {
   EventState,
 } from 'features/events/models/EventDataModel';
 
-import messageIds from 'features/campaigns/l10n/messageIds';
-
 interface EventListeItemProps {
   orgId: number;
   eventId: number;
 }
 
 const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
-  const messages = useMessages(messageIds);
   const model = useModel((env) => new EventDataModel(env, orgId, eventId));
   const state = model.state;
   const data = model.getData().data;
-  const participants = model.getParticipants();
 
   if (!data) {
     return null;
@@ -46,51 +38,6 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
     color = STATUS_COLORS.BLUE;
   }
 
-  const icons: JSX.Element[] = [
-    <AlertSlot key="contact" />,
-    <AlertSlot key="signups" />,
-    <AlertSlot key="reminders" />,
-  ];
-
-  if (participants.data) {
-    if (!data.contact) {
-      icons[0] = (
-        <AlertSlot
-          key="contact"
-          icon={<FaceRetouchingOff color="error" />}
-          tooltip={messages.activityList.eventItem.contact()}
-        />
-      );
-    }
-
-    const numBooked = participants.data.length;
-    if (data.num_participants_available > numBooked) {
-      icons[1] = (
-        <AlertSlot
-          key="signups"
-          icon={<EmojiPeople color="error" />}
-          tooltip={messages.activityList.eventItem.signups()}
-        />
-      );
-    }
-
-    const reminded = participants.data.filter((p) => !!p.reminder_sent);
-    const numReminded = reminded.length;
-    if (numReminded < participants.data.length) {
-      icons[2] = (
-        <AlertSlot
-          key="reminders"
-          icon={<MailOutline color="error" />}
-          tooltip={messages.activityList.eventItem.reminders({
-            numMissing: participants.data.length - numReminded,
-          })}
-        />
-      );
-    }
-  } else {
-    icons.push(<CircularProgress />);
-  }
-
   return (
     <ActivityListItem
       color={color}
@@ -103,7 +50,7 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       href={`/organize/${orgId}/projects/${
         data.campaign?.id ?? 'standalone'
       }/events/${eventId}`}
-      meta={<Box display="flex">{icons}</Box>}
+      meta={<EventWarningIcons model={model} />}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={Group}
       subtitle={
@@ -129,23 +76,6 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
       }
       title={data.title || data.activity.title}
     />
-  );
-};
-
-const AlertSlot: FC<{
-  icon?: JSX.Element;
-  tooltip?: string;
-}> = ({ icon, tooltip }) => {
-  return (
-    <Box width="1.6em">
-      {tooltip ? (
-        <Tooltip arrow title={tooltip}>
-          <Box>{icon}</Box>
-        </Tooltip>
-      ) : (
-        icon
-      )}
-    </Box>
   );
 };
 

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -1,0 +1,92 @@
+import { FC } from 'react';
+import { Box, CircularProgress, Tooltip } from '@mui/material';
+import {
+  EmojiPeople,
+  FaceRetouchingOff,
+  MailOutline,
+} from '@mui/icons-material';
+
+import EventDataModel from '../models/EventDataModel';
+import messageIds from 'features/campaigns/l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+type EventWarningIconsProps = {
+  model: EventDataModel;
+};
+
+const EventWarningIcons: FC<EventWarningIconsProps> = ({ model }) => {
+  const messages = useMessages(messageIds);
+  const data = model.getData().data;
+
+  if (!data) {
+    return null;
+  }
+
+  const participants = model.getParticipants();
+
+  const icons: JSX.Element[] = [
+    <WarningSlot key="contact" />,
+    <WarningSlot key="signups" />,
+    <WarningSlot key="reminders" />,
+  ];
+
+  if (participants.data) {
+    if (!data.contact) {
+      icons[0] = (
+        <WarningSlot
+          key="contact"
+          icon={<FaceRetouchingOff color="error" />}
+          tooltip={messages.activityList.eventItem.contact()}
+        />
+      );
+    }
+
+    const numBooked = participants.data.length;
+    if (data.num_participants_available > numBooked) {
+      icons[1] = (
+        <WarningSlot
+          key="signups"
+          icon={<EmojiPeople color="error" />}
+          tooltip={messages.activityList.eventItem.signups()}
+        />
+      );
+    }
+
+    const reminded = participants.data.filter((p) => !!p.reminder_sent);
+    const numReminded = reminded.length;
+    if (numReminded < participants.data.length) {
+      icons[2] = (
+        <WarningSlot
+          key="reminders"
+          icon={<MailOutline color="error" />}
+          tooltip={messages.activityList.eventItem.reminders({
+            numMissing: participants.data.length - numReminded,
+          })}
+        />
+      );
+    }
+  } else {
+    icons.push(<CircularProgress />);
+  }
+
+  return <Box display="flex">{icons}</Box>;
+};
+
+const WarningSlot: FC<{
+  icon?: JSX.Element;
+  tooltip?: string;
+}> = ({ icon, tooltip }) => {
+  return (
+    <Box width="1.6em">
+      {tooltip ? (
+        <Tooltip arrow title={tooltip}>
+          <Box>{icon}</Box>
+        </Tooltip>
+      ) : (
+        icon
+      )}
+    </Box>
+  );
+};
+
+export default EventWarningIcons;

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -11,10 +11,11 @@ import messageIds from 'features/campaigns/l10n/messageIds';
 import { useMessages } from 'core/i18n';
 
 type EventWarningIconsProps = {
+  compact?: boolean;
   model: EventDataModel;
 };
 
-const EventWarningIcons: FC<EventWarningIconsProps> = ({ model }) => {
+const EventWarningIcons: FC<EventWarningIconsProps> = ({ compact, model }) => {
   const messages = useMessages(messageIds);
   const data = model.getData().data;
 
@@ -24,11 +25,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({ model }) => {
 
   const participants = model.getParticipants();
 
-  const icons: JSX.Element[] = [
-    <WarningSlot key="contact" />,
-    <WarningSlot key="signups" />,
-    <WarningSlot key="reminders" />,
-  ];
+  const icons: (JSX.Element | null)[] = [null, null, null];
 
   if (participants.data) {
     if (!data.contact) {
@@ -69,7 +66,19 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({ model }) => {
     icons.push(<CircularProgress />);
   }
 
-  return <Box display="flex">{icons}</Box>;
+  return (
+    <Box display="flex">
+      {icons.map((icon, idx) => {
+        if (icon) {
+          return icon;
+        }
+
+        if (!compact) {
+          return <WarningSlot key={idx} />;
+        }
+      })}
+    </Box>
+  );
 };
 
 const WarningSlot: FC<{

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -89,7 +89,7 @@ const WarningSlot: FC<{
     <Box width="1.6em">
       {tooltip ? (
         <Tooltip arrow title={tooltip}>
-          <Box>{icon}</Box>
+          <Box display="flex">{icon}</Box>
         </Tooltip>
       ) : (
         icon

--- a/src/zui/ZUIIconLabel.tsx
+++ b/src/zui/ZUIIconLabel.tsx
@@ -24,11 +24,16 @@ const ZUIIconLabel: FC<ZUIIconLabelProps> = ({
       alignItems="center"
       color={color}
       display="flex"
+      flexShrink="0"
       fontSize={FONT_SIZES[size]}
       gap={1}
     >
       {icon}
-      <Typography color={color ? color : 'inherit'} fontSize="inherit">
+      <Typography
+        color={color ? color : 'inherit'}
+        flexShrink="0"
+        fontSize="inherit"
+      >
         {label}
       </Typography>
     </Box>

--- a/src/zui/ZUIIconLabelRow.tsx
+++ b/src/zui/ZUIIconLabelRow.tsx
@@ -13,7 +13,7 @@ const ZUIIconLabelRow: FC<ZUIIconLabelRowProps> = ({
   ...restProps
 }) => {
   return (
-    <Box display="flex" gap={2}>
+    <Box display="flex" flexShrink="0" gap={2}>
       {iconLabels.map((props, index) => (
         <ZUIIconLabel key={index} {...restProps} {...props} />
       ))}


### PR DESCRIPTION
## Description
This PR adds event rendering to the activities overview.

## Screenshots
See the "Tomorrow" column below.

![image](https://user-images.githubusercontent.com/550212/230637149-c646bf3a-fe42-4464-a421-eaca346b9118.png)

## Changes
* Add component for rendering events in `ActivitiesOverviewCard`
* Create component from the event warning icons introduced in #1199 (and reuse in this PR)

## Notes to reviewer
Don't merge this until #1199 has been merged

## Related issues
Resolves #1191 