### PR TITLE
Issue 1198/create new location in select

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -1,6 +1,6 @@
 import EditIcon from '@mui/icons-material/Edit';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Place } from '@mui/icons-material';
+import { Add, Place } from '@mui/icons-material';
 import {
   Autocomplete,
   Box,
@@ -83,10 +83,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       disableClearable
                       fullWidth
                       onChange={(ev, value) => {
-                        if (
-                          value ===
-                          '+ ' + messages.eventOverviewCard.createLocation()
-                        ) {
+                        if (value === 'CREATE_NEW_LOCATION') {
                           setLocationModalOpen(true);
                         }
                         const location = locations?.find(
@@ -100,9 +97,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       options={
                         locations
                           ?.map((location) => location.title)
-                          .concat([
-                            '+ ' + messages.eventOverviewCard.createLocation(),
-                          ]) || []
+                          .concat(['CREATE_NEW_LOCATION']) || []
                       }
                       renderInput={(params) => (
                         <TextField
@@ -114,6 +109,16 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           }}
                         />
                       )}
+                      renderOption={(params, option) =>
+                        option === 'CREATE_NEW_LOCATION' ? (
+                          <li {...params}>
+                            <Add sx={{ marginRight: 2 }} />
+                            {messages.eventOverviewCard.createLocation()}
+                          </li>
+                        ) : (
+                          <li {...params}>{option}</li>
+                        )
+                      }
                       value={
                         locations?.find(
                           (location) => location.id === locationId

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -83,6 +83,12 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       disableClearable
                       fullWidth
                       onChange={(ev, value) => {
+                        if (
+                          value ===
+                          '+ ' + messages.eventOverviewCard.createLocation()
+                        ) {
+                          setLocationModalOpen(true);
+                        }
                         const location = locations?.find(
                           (location) => location.title === value
                         );
@@ -92,7 +98,11 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         setLocationId(location.id);
                       }}
                       options={
-                        locations?.map((location) => location.title) || []
+                        locations
+                          ?.map((location) => location.title)
+                          .concat([
+                            '+ ' + messages.eventOverviewCard.createLocation(),
+                          ]) || []
                       }
                       renderInput={(params) => (
                         <TextField

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -3,6 +3,7 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.events', {
   eventOverviewCard: {
+    createLocation: m('Create new location'),
     description: m('Description'),
     editButton: m('Edit event information'),
     location: m('Location'),


### PR DESCRIPTION
## Description
This PR adds an extra alternative to the location dropdown when editing an event that allows you to add a new location.


## Screenshots
![image](https://user-images.githubusercontent.com/46402788/230734041-6c6e6a32-a73d-4c54-aa99-b5738ccbd02d.png)



## Changes

* Adds an alternative "Create new location" when selecting location for an event. When clicked it opens the Location Modal


## Related issues
Resolves #1198 
