### PR TITLE
Issue 1184 - Add start and end date & time, fix focus and styles in Event Overview Card

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -32,7 +32,7 @@ import { ZetkinLocation } from 'utils/types/zetkin';
 import ZUIDate from 'zui/ZUIDate';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
 import {
-  endDateIsBeforeStartDate,
+  dateIsBefore,
   isSameDate,
   isValidDate,
   removeOffset,
@@ -258,7 +258,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 if (
                                   startDate &&
                                   newValue &&
-                                  endDateIsBeforeStartDate(
+                                  dateIsBefore(
                                     startDate.toDate(),
                                     newValue.toDate()
                                   )

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -30,13 +30,10 @@ import useEditPreviewBlock from 'zui/hooks/useEditPreviewBlock';
 import { useMessages } from 'core/i18n';
 import { ZetkinLocation } from 'utils/types/zetkin';
 import ZUIDate from 'zui/ZUIDate';
+import ZUIFuture from 'zui/ZUIFuture';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
-import {
-  dateIsBefore,
-  isSameDate,
-  isValidDate,
-  removeOffset,
-} from 'utils/dateUtils';
+
+import { dateIsBefore, isSameDate, isValidDate } from 'utils/dateUtils';
 
 type EventOverviewCardProps = {
   dataModel: EventDataModel;
@@ -47,22 +44,15 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
   dataModel,
   locationsModel,
 }) => {
-  const eventData = dataModel.getData().data;
   const locations = locationsModel.getLocations().data;
   const messages = useMessages(messageIds);
   const [editable, setEditable] = useState(false);
-  const [link, setLink] = useState(eventData?.url ?? '');
-  const [infoText, setInfoText] = useState(eventData?.info_text ?? '');
-  const [locationId, setLocationId] = useState(
-    eventData?.location.id ?? undefined
-  );
+  const [link, setLink] = useState('');
+  const [infoText, setInfoText] = useState('');
+  const [locationId, setLocationId] = useState<number | undefined>();
 
-  const [startDate, setStartDate] = useState<Dayjs | null>(
-    eventData ? dayjs(removeOffset(eventData.start_time)) : null
-  );
-  const [endDate, setEndDate] = useState<Dayjs | undefined>(
-    eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined
-  );
+  const [startDate, setStartDate] = useState<Dayjs | undefined>();
+  const [endDate, setEndDate] = useState<Dayjs | undefined>();
   const [showEndDate, setShowEndDate] = useState(false);
   const [invalidFormat, setInvalidFormat] = useState(false);
 
@@ -93,561 +83,603 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
       },
     });
 
-  if (!eventData) {
-    return null;
-  }
-
   const options: (ZetkinLocation | 'CREATE_NEW_LOCATION')[] = locations
     ? [...locations, 'CREATE_NEW_LOCATION']
     : ['CREATE_NEW_LOCATION'];
 
   return (
-    <ClickAwayListener {...clickAwayProps}>
-      <Box {...containerProps}>
-        <Card>
-          {!editable && (
-            <Box display="flex" justifyContent="flex-end" m={2}>
-              <Button startIcon={<EditIcon />} variant="outlined">
-                {messages.eventOverviewCard.editButton().toUpperCase()}
-              </Button>
-            </Box>
-          )}
-          <Grid container spacing={2} sx={{ marginTop: '100px' }}>
-            <Grid
-              container
-              item
-              sm
-              sx={{ justifyContent: 'space-evenly' }}
-              xs={8}
-            >
-              <Grid container direction="row" item spacing={2} xs>
-                <Grid
-                  direction="column"
-                  item
-                  spacing={2}
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'inherit',
-                  }}
-                  xs
-                >
-                  <Grid item>
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={(props) => {
-                        return (
-                          <DatePicker
-                            inputFormat="DD-MM-YYYY"
-                            label={messages.eventOverviewCard.startDate()}
-                            onChange={(newValue) => {
-                              if (newValue && isValidDate(newValue.toDate())) {
-                                setInvalidFormat(false);
-                                setStartDate(dayjs(newValue));
-                                if (
-                                  endDate &&
-                                  dateIsBefore(
-                                    newValue.toDate(),
-                                    endDate.toDate()
-                                  )
-                                ) {
-                                  setEndDate(newValue);
-                                }
-                              } else {
-                                setInvalidFormat(true);
-                              }
-                            }}
-                            renderInput={(params) => {
+    <ZUIFuture future={dataModel.getData()}>
+      {(eventData) => {
+        return (
+          <ClickAwayListener {...clickAwayProps}>
+            <Box {...containerProps}>
+              <Card>
+                {!editable && (
+                  <Box display="flex" justifyContent="flex-end" m={2}>
+                    <Button startIcon={<EditIcon />} variant="outlined">
+                      {messages.eventOverviewCard.editButton().toUpperCase()}
+                    </Button>
+                  </Box>
+                )}
+                <Grid container spacing={2} sx={{ marginTop: '100px' }}>
+                  <Grid
+                    container
+                    item
+                    sm
+                    sx={{ justifyContent: 'space-evenly' }}
+                    xs={8}
+                  >
+                    <Grid container direction="row" item spacing={2} xs>
+                      <Grid
+                        direction="column"
+                        item
+                        spacing={2}
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'inherit',
+                        }}
+                        xs
+                      >
+                        <Grid item>
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={(props) => {
                               return (
-                                <TextField
-                                  {...params}
-                                  error={invalidFormat}
-                                  inputProps={{
-                                    ...params.inputProps,
-                                    ...props,
+                                <DatePicker
+                                  inputFormat="DD-MM-YYYY"
+                                  label={messages.eventOverviewCard.startDate()}
+                                  onChange={(newValue) => {
+                                    if (
+                                      newValue &&
+                                      isValidDate(newValue.toDate())
+                                    ) {
+                                      setInvalidFormat(false);
+                                      setStartDate(dayjs(newValue));
+                                      if (
+                                        endDate &&
+                                        dateIsBefore(
+                                          newValue.toDate(),
+                                          endDate.toDate()
+                                        )
+                                      ) {
+                                        setEndDate(newValue);
+                                      }
+                                    } else {
+                                      setInvalidFormat(true);
+                                    }
                                   }}
-                                  sx={{ marginBottom: '15px' }}
+                                  renderInput={(params) => {
+                                    return (
+                                      <TextField
+                                        {...params}
+                                        error={invalidFormat}
+                                        inputProps={{
+                                          ...params.inputProps,
+                                          ...props,
+                                        }}
+                                        sx={{ marginBottom: '15px' }}
+                                      />
+                                    );
+                                  }}
+                                  value={dayjs(startDate)}
                                 />
                               );
                             }}
-                            value={dayjs(startDate)}
-                          />
-                        );
-                      }}
-                      renderPreview={() => {
-                        if (startDate) {
-                          return (
-                            <Box ml={1}>
-                              <Typography color="secondary" variant="subtitle1">
-                                {messages.eventOverviewCard
-                                  .startDate()
-                                  .toUpperCase()}
-                              </Typography>
-                              <ZUIDate
-                                datetime={new Date(
-                                  dayjs(startDate).format()
-                                ).toISOString()}
-                              />
-                            </Box>
-                          );
-                        } else {
-                          return <></>;
-                        }
-                      }}
-                      value={dayjs(startDate).format() ?? ''}
-                    />
-
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={(props) => {
-                        return (
-                          <TimePicker
-                            ampm={false}
-                            inputFormat="HH:mm"
-                            label={messages.eventOverviewCard.startTime()}
-                            onChange={(newValue) => {
-                              if (newValue && isValidDate(newValue.toDate())) {
-                                setInvalidFormat(false);
-                                setStartDate(dayjs(newValue));
-                              } else {
-                                setInvalidFormat(true);
-                              }
-                            }}
-                            open={false}
-                            renderInput={(params) => {
-                              return (
-                                <TextField
-                                  {...params}
-                                  inputProps={{
-                                    ...params.inputProps,
-                                    ...props,
-                                  }}
-                                />
-                              );
-                            }}
-                            value={dayjs(startDate)}
-                          />
-                        );
-                      }}
-                      renderPreview={() => {
-                        if (startDate) {
-                          return (
-                            <Box ml={1}>
-                              <FormattedTime
-                                hour12={false}
-                                value={startDate.format()}
-                              />
-                            </Box>
-                          );
-                        } else {
-                          return <></>;
-                        }
-                      }}
-                      value={dayjs(startDate).format()}
-                    />
-                  </Grid>
-
-                  <Grid item ml={1}>
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={(props) => {
-                        return (
-                          <DatePicker
-                            inputFormat="DD-MM-YYYY"
-                            label={messages.eventOverviewCard.endDate()}
-                            onChange={(newValue) => {
-                              if (newValue && isValidDate(newValue.toDate())) {
-                                if (
-                                  startDate &&
-                                  newValue &&
-                                  dateIsBefore(
-                                    startDate.toDate(),
-                                    newValue.toDate()
-                                  )
-                                ) {
-                                  setInvalidFormat(false);
-                                  setStartDate(newValue);
-                                  setEndDate(newValue);
-                                } else {
-                                  setInvalidFormat(false);
-                                  setEndDate(newValue);
-                                }
-                              } else {
-                                setInvalidFormat(true);
-                              }
-                            }}
-                            renderInput={(params) => {
-                              if (
-                                (endDate &&
-                                  startDate &&
-                                  !isSameDate(
-                                    startDate.toDate(),
-                                    endDate.toDate()
-                                  )) ||
-                                showEndDate
-                              ) {
+                            renderPreview={() => {
+                              if (startDate) {
                                 return (
-                                  <TextField
-                                    {...params}
-                                    error={invalidFormat}
-                                    inputProps={{
-                                      ...params.inputProps,
-                                      ...props,
-                                    }}
-                                    sx={{ marginBottom: '15px' }}
-                                  />
-                                );
-                              } else if (
-                                endDate &&
-                                startDate &&
-                                !showEndDate &&
-                                isSameDate(startDate.toDate(), endDate.toDate())
-                              ) {
-                                return (
-                                  <Button
-                                    onClick={() => {
-                                      setShowEndDate(true);
-                                    }}
-                                    sx={{ marginBottom: 4.4, width: '100%' }}
-                                    variant="text"
-                                  >
-                                    {messages.eventOverviewCard.buttonEndDate()}
-                                  </Button>
+                                  <Box ml={1}>
+                                    <Typography
+                                      color="secondary"
+                                      variant="subtitle1"
+                                    >
+                                      {messages.eventOverviewCard
+                                        .startDate()
+                                        .toUpperCase()}
+                                    </Typography>
+                                    <ZUIDate
+                                      datetime={new Date(
+                                        dayjs(startDate).format()
+                                      ).toISOString()}
+                                    />
+                                  </Box>
                                 );
                               } else {
                                 return <></>;
                               }
                             }}
-                            value={dayjs(endDate)}
+                            value={dayjs(startDate).format() ?? ''}
                           />
-                        );
-                      }}
-                      renderPreview={() => {
-                        if (
-                          endDate &&
-                          startDate &&
-                          !isSameDate(startDate.toDate(), endDate.toDate())
-                        ) {
-                          return (
-                            <Box ml={10}>
-                              <Typography color="secondary" variant="subtitle1">
-                                {messages.eventOverviewCard
-                                  .endDate()
-                                  .toUpperCase()}
-                              </Typography>
-                              <ZUIDate
-                                datetime={new Date(
-                                  dayjs(endDate).format()
-                                ).toISOString()}
-                              />
-                            </Box>
-                          );
-                        } else if (
-                          endDate &&
-                          startDate &&
-                          isSameDate(startDate.toDate(), endDate.toDate())
-                        ) {
-                          return (
-                            <Box ml={10}>
-                              <Typography color="secondary" variant="subtitle1">
-                                {messages.eventOverviewCard
-                                  .endDate()
-                                  .toUpperCase()}
-                              </Typography>
-                              <Box mb={2.8} />
-                            </Box>
-                          );
-                        } else {
-                          return <></>;
-                        }
-                      }}
-                      value={dayjs(endDate).format() ?? ''}
-                    />
 
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={(props) => {
-                        return (
-                          <TimePicker
-                            ampm={false}
-                            inputFormat="HH:mm"
-                            label={messages.eventOverviewCard.endTime()}
-                            onChange={(newValue) => {
-                              if (newValue && isValidDate(newValue.toDate())) {
-                                setInvalidFormat(false);
-                                setEndDate(newValue);
-                              } else {
-                                setInvalidFormat(false);
-                              }
-                            }}
-                            open={false}
-                            renderInput={(params) => {
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={(props) => {
                               return (
-                                <TextField
-                                  {...params}
-                                  error={invalidFormat}
-                                  inputProps={{
-                                    ...params.inputProps,
-                                    ...props,
+                                <TimePicker
+                                  ampm={false}
+                                  inputFormat="HH:mm"
+                                  label={messages.eventOverviewCard.startTime()}
+                                  onChange={(newValue) => {
+                                    if (
+                                      newValue &&
+                                      isValidDate(newValue.toDate())
+                                    ) {
+                                      setInvalidFormat(false);
+                                      setStartDate(dayjs(newValue));
+                                    } else {
+                                      setInvalidFormat(true);
+                                    }
                                   }}
+                                  open={false}
+                                  renderInput={(params) => {
+                                    return (
+                                      <TextField
+                                        {...params}
+                                        inputProps={{
+                                          ...params.inputProps,
+                                          ...props,
+                                        }}
+                                      />
+                                    );
+                                  }}
+                                  value={dayjs(startDate)}
                                 />
                               );
                             }}
-                            value={dayjs(endDate)}
+                            renderPreview={() => {
+                              if (startDate) {
+                                return (
+                                  <Box ml={1}>
+                                    <FormattedTime
+                                      hour12={false}
+                                      value={startDate.format()}
+                                    />
+                                  </Box>
+                                );
+                              } else {
+                                return <></>;
+                              }
+                            }}
+                            value={dayjs(startDate).format()}
                           />
-                        );
-                      }}
-                      renderPreview={() => {
-                        if (endDate) {
-                          return (
-                            <Box ml={10}>
-                              <FormattedTime
-                                hour12={false}
-                                value={new Date(
-                                  dayjs(endDate).format()
-                                ).toISOString()}
+                        </Grid>
+
+                        <Grid item ml={1}>
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={(props) => {
+                              return (
+                                <DatePicker
+                                  inputFormat="DD-MM-YYYY"
+                                  label={messages.eventOverviewCard.endDate()}
+                                  onChange={(newValue) => {
+                                    if (
+                                      newValue &&
+                                      isValidDate(newValue.toDate())
+                                    ) {
+                                      if (
+                                        startDate &&
+                                        newValue &&
+                                        dateIsBefore(
+                                          startDate.toDate(),
+                                          newValue.toDate()
+                                        )
+                                      ) {
+                                        setInvalidFormat(false);
+                                        setStartDate(newValue);
+                                        setEndDate(newValue);
+                                      } else {
+                                        setInvalidFormat(false);
+                                        setEndDate(newValue);
+                                      }
+                                    } else {
+                                      setInvalidFormat(true);
+                                    }
+                                  }}
+                                  renderInput={(params) => {
+                                    if (
+                                      (endDate &&
+                                        startDate &&
+                                        !isSameDate(
+                                          startDate.toDate(),
+                                          endDate.toDate()
+                                        )) ||
+                                      showEndDate
+                                    ) {
+                                      return (
+                                        <TextField
+                                          {...params}
+                                          error={invalidFormat}
+                                          inputProps={{
+                                            ...params.inputProps,
+                                            ...props,
+                                          }}
+                                          sx={{ marginBottom: '15px' }}
+                                        />
+                                      );
+                                    } else if (
+                                      endDate &&
+                                      startDate &&
+                                      !showEndDate &&
+                                      isSameDate(
+                                        startDate.toDate(),
+                                        endDate.toDate()
+                                      )
+                                    ) {
+                                      return (
+                                        <Button
+                                          onClick={() => {
+                                            setShowEndDate(true);
+                                          }}
+                                          sx={{
+                                            marginBottom: 4.4,
+                                            width: '100%',
+                                          }}
+                                          variant="text"
+                                        >
+                                          {messages.eventOverviewCard.buttonEndDate()}
+                                        </Button>
+                                      );
+                                    } else {
+                                      return <></>;
+                                    }
+                                  }}
+                                  value={dayjs(endDate)}
+                                />
+                              );
+                            }}
+                            renderPreview={() => {
+                              if (
+                                endDate &&
+                                startDate &&
+                                !isSameDate(
+                                  startDate.toDate(),
+                                  endDate.toDate()
+                                )
+                              ) {
+                                return (
+                                  <Box ml={10}>
+                                    <Typography
+                                      color="secondary"
+                                      variant="subtitle1"
+                                    >
+                                      {messages.eventOverviewCard
+                                        .endDate()
+                                        .toUpperCase()}
+                                    </Typography>
+                                    <ZUIDate
+                                      datetime={new Date(
+                                        dayjs(endDate).format()
+                                      ).toISOString()}
+                                    />
+                                  </Box>
+                                );
+                              } else if (
+                                endDate &&
+                                startDate &&
+                                isSameDate(startDate.toDate(), endDate.toDate())
+                              ) {
+                                return (
+                                  <Box ml={10}>
+                                    <Typography
+                                      color="secondary"
+                                      variant="subtitle1"
+                                    >
+                                      {messages.eventOverviewCard
+                                        .endDate()
+                                        .toUpperCase()}
+                                    </Typography>
+                                    <Box mb={2.8} />
+                                  </Box>
+                                );
+                              } else {
+                                return <></>;
+                              }
+                            }}
+                            value={dayjs(endDate).format() ?? ''}
+                          />
+
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={(props) => {
+                              return (
+                                <TimePicker
+                                  ampm={false}
+                                  inputFormat="HH:mm"
+                                  label={messages.eventOverviewCard.endTime()}
+                                  onChange={(newValue) => {
+                                    if (
+                                      newValue &&
+                                      isValidDate(newValue.toDate())
+                                    ) {
+                                      setInvalidFormat(false);
+                                      setEndDate(newValue);
+                                    } else {
+                                      setInvalidFormat(false);
+                                    }
+                                  }}
+                                  open={false}
+                                  renderInput={(params) => {
+                                    return (
+                                      <TextField
+                                        {...params}
+                                        error={invalidFormat}
+                                        inputProps={{
+                                          ...params.inputProps,
+                                          ...props,
+                                        }}
+                                      />
+                                    );
+                                  }}
+                                  value={dayjs(endDate)}
+                                />
+                              );
+                            }}
+                            renderPreview={() => {
+                              if (endDate) {
+                                return (
+                                  <Box ml={10}>
+                                    <FormattedTime
+                                      hour12={false}
+                                      value={new Date(
+                                        dayjs(endDate).format()
+                                      ).toISOString()}
+                                    />
+                                  </Box>
+                                );
+                              } else {
+                                return <></>;
+                              }
+                            }}
+                            value={dayjs(endDate).format()}
+                          />
+                        </Grid>
+                      </Grid>
+
+                      <Divider
+                        flexItem
+                        orientation="vertical"
+                        sx={{ marginBottom: '10px', marginLeft: '10px' }}
+                      />
+
+                      <Grid sx={{ marginLeft: '10px', marginTop: 2 }} xs>
+                        <Grid item>
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={() => {
+                              return (
+                                <Box alignItems="center" display="flex">
+                                  <Autocomplete
+                                    disableClearable
+                                    fullWidth
+                                    getOptionLabel={(option) =>
+                                      option === 'CREATE_NEW_LOCATION'
+                                        ? messages.locationModal.createLocation()
+                                        : option.title
+                                    }
+                                    onChange={(ev, option) => {
+                                      if (option === 'CREATE_NEW_LOCATION') {
+                                        setLocationModalOpen(true);
+                                        return;
+                                      }
+                                      const location = locations?.find(
+                                        (location) => location.id === option.id
+                                      );
+                                      if (!location) {
+                                        return;
+                                      }
+                                      setLocationId(location.id);
+                                    }}
+                                    options={options}
+                                    renderInput={(params) => (
+                                      <TextField
+                                        {...params}
+                                        label={messages.eventOverviewCard.location()}
+                                        sx={{
+                                          backgroundColor: 'white',
+                                          borderRadius: '5px',
+                                        }}
+                                      />
+                                    )}
+                                    renderOption={(params, option) =>
+                                      option === 'CREATE_NEW_LOCATION' ? (
+                                        <li {...params}>
+                                          <Add sx={{ marginRight: 2 }} />
+                                          {messages.eventOverviewCard.createLocation()}
+                                        </li>
+                                      ) : (
+                                        <li {...params}>{option.title}</li>
+                                      )
+                                    }
+                                    value={options?.find(
+                                      (location) =>
+                                        location !== 'CREATE_NEW_LOCATION' &&
+                                        location.id ===
+                                          (locationId || eventData.location.id)
+                                    )}
+                                  />
+                                  <MapIcon
+                                    color="secondary"
+                                    onClick={() => setLocationModalOpen(true)}
+                                    sx={{ cursor: 'pointer', marginLeft: 1 }}
+                                  />
+                                  <LocationModal
+                                    locationId={
+                                      locationId || eventData.location.id
+                                    }
+                                    locations={locations || []}
+                                    onCreateLocation={(
+                                      newLocation: Partial<ZetkinLocation>
+                                    ) => {
+                                      locationsModel.addLocation(newLocation);
+                                    }}
+                                    onMapClose={() => {
+                                      setLocationModalOpen(false);
+                                    }}
+                                    onSelectLocation={(
+                                      location: ZetkinLocation
+                                    ) => setLocationId(location.id)}
+                                    open={locationModalOpen}
+                                  />
+                                </Box>
+                              );
+                            }}
+                            renderPreview={() => {
+                              if (eventData.location) {
+                                return (
+                                  <Box ml={4}>
+                                    <Box
+                                      sx={{
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                      }}
+                                    >
+                                      <Typography
+                                        color="secondary"
+                                        variant="subtitle1"
+                                      >
+                                        {messages.eventOverviewCard
+                                          .location()
+                                          .toUpperCase()}
+                                      </Typography>
+                                    </Box>
+                                    <Typography
+                                      sx={{
+                                        alignItems: 'flex-start',
+                                        display: 'flex',
+                                      }}
+                                      variant="body1"
+                                    >
+                                      {eventData.location.title}
+                                    </Typography>
+                                  </Box>
+                                );
+                              } else {
+                                return (
+                                  <Box ml={4}>
+                                    <Typography
+                                      color="secondary"
+                                      variant="subtitle1"
+                                    >
+                                      {messages.eventOverviewCard
+                                        .location()
+                                        .toUpperCase()}
+                                    </Typography>
+                                    <Typography
+                                      sx={{
+                                        alignItems: 'flex-start',
+                                        display: 'flex',
+                                      }}
+                                      variant="body1"
+                                    >
+                                      {messages.eventOverviewCard.noLocation()}
+                                    </Typography>
+                                  </Box>
+                                );
+                              }
+                            }}
+                            value={locationId || eventData.location.id}
+                          />
+                        </Grid>
+
+                        <Grid item mt={2}>
+                          <ZUIPreviewableInput
+                            {...previewableProps}
+                            renderInput={(props) => (
+                              <TextField
+                                fullWidth
+                                inputProps={props}
+                                label={messages.eventOverviewCard.url()}
+                                onChange={(ev) => setLink(ev.target.value)}
+                                sx={{ marginBottom: 2 }}
+                                value={link}
                               />
-                            </Box>
-                          );
-                        } else {
-                          return <></>;
-                        }
-                      }}
-                      value={dayjs(endDate).format()}
-                    />
+                            )}
+                            renderPreview={() => {
+                              if (eventData.url && eventData.url !== '') {
+                                return (
+                                  <Box ml={4}>
+                                    <Typography
+                                      color={theme.palette.text.secondary}
+                                      variant="subtitle1"
+                                    >
+                                      {messages.eventOverviewCard
+                                        .url()
+                                        .toUpperCase()}
+                                    </Typography>
+                                    <Typography
+                                      sx={{
+                                        alignItems: 'flex-start',
+                                        display: 'flex',
+                                      }}
+                                      variant="body1"
+                                    >
+                                      {eventData.url}
+                                      <Link
+                                        href={getWorkingUrl(eventData.url)}
+                                        sx={{ marginLeft: '8px' }}
+                                        target="_blank"
+                                      >
+                                        <OpenInNewIcon color="primary" />
+                                      </Link>
+                                    </Typography>
+                                  </Box>
+                                );
+                              } else {
+                                return <></>;
+                              }
+                            }}
+                            value={link || ''}
+                          />
+                        </Grid>
+                      </Grid>
+                    </Grid>
                   </Grid>
                 </Grid>
-
-                <Divider
-                  flexItem
-                  orientation="vertical"
-                  sx={{ marginBottom: '10px', marginLeft: '10px' }}
-                />
-
-                <Grid sx={{ marginLeft: '10px', marginTop: 2 }} xs>
-                  <Grid item>
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={() => {
+                <Box p={1}>
+                  <ZUIPreviewableInput
+                    {...previewableProps}
+                    renderInput={(props) => (
+                      <TextField
+                        fullWidth
+                        inputProps={props}
+                        label={messages.eventOverviewCard.description()}
+                        multiline
+                        onChange={(ev) => setInfoText(ev.target.value)}
+                        rows={4}
+                        value={infoText}
+                      />
+                    )}
+                    renderPreview={() => {
+                      if (eventData.info_text !== '') {
                         return (
-                          <Box alignItems="center" display="flex">
-                            <Autocomplete
-                              disableClearable
-                              fullWidth
-                              getOptionLabel={(option) =>
-                                option === 'CREATE_NEW_LOCATION'
-                                  ? messages.locationModal.createLocation()
-                                  : option.title
-                              }
-                              onChange={(ev, option) => {
-                                if (option === 'CREATE_NEW_LOCATION') {
-                                  setLocationModalOpen(true);
-                                  return;
-                                }
-                                const location = locations?.find(
-                                  (location) => location.id === option.id
-                                );
-                                if (!location) {
-                                  return;
-                                }
-                                setLocationId(location.id);
-                              }}
-                              options={options}
-                              renderInput={(params) => (
-                                <TextField
-                                  {...params}
-                                  label={messages.eventOverviewCard.location()}
-                                  sx={{
-                                    backgroundColor: 'white',
-                                    borderRadius: '5px',
-                                  }}
-                                />
-                              )}
-                              renderOption={(params, option) =>
-                                option === 'CREATE_NEW_LOCATION' ? (
-                                  <li {...params}>
-                                    <Add sx={{ marginRight: 2 }} />
-                                    {messages.eventOverviewCard.createLocation()}
-                                  </li>
-                                ) : (
-                                  <li {...params}>{option.title}</li>
-                                )
-                              }
-                              value={options?.find(
-                                (location) =>
-                                  location !== 'CREATE_NEW_LOCATION' &&
-                                  location.id === locationId
-                              )}
-                            />
-                            <MapIcon
-                              color="secondary"
-                              onClick={() => setLocationModalOpen(true)}
-                              sx={{ cursor: 'pointer', marginLeft: 1 }}
-                            />
-                            <LocationModal
-                              locationId={locationId}
-                              locations={locations || []}
-                              onCreateLocation={(
-                                newLocation: Partial<ZetkinLocation>
-                              ) => {
-                                locationsModel.addLocation(newLocation);
-                              }}
-                              onMapClose={() => {
-                                setLocationModalOpen(false);
-                              }}
-                              onSelectLocation={(location: ZetkinLocation) =>
-                                setLocationId(location.id)
-                              }
-                              open={locationModalOpen}
-                            />
+                          <Box p={1}>
+                            <Typography
+                              color={theme.palette.text.secondary}
+                              variant="subtitle1"
+                            >
+                              {messages.eventOverviewCard
+                                .description()
+                                .toUpperCase()}
+                            </Typography>
+                            <Typography variant="body1">
+                              {eventData.info_text}
+                            </Typography>
                           </Box>
                         );
-                      }}
-                      renderPreview={() => {
-                        if (eventData.location) {
-                          return (
-                            <Box ml={4}>
-                              <Box
-                                sx={{
-                                  display: 'flex',
-                                  justifyContent: 'space-between',
-                                }}
-                              >
-                                <Typography
-                                  color="secondary"
-                                  variant="subtitle1"
-                                >
-                                  {messages.eventOverviewCard
-                                    .location()
-                                    .toUpperCase()}
-                                </Typography>
-                              </Box>
-                              <Typography
-                                sx={{
-                                  alignItems: 'flex-start',
-                                  display: 'flex',
-                                }}
-                                variant="body1"
-                              >
-                                {eventData.location.title}
-                              </Typography>
-                            </Box>
-                          );
-                        } else {
-                          return (
-                            <Box ml={4}>
-                              <Typography color="secondary" variant="subtitle1">
-                                {messages.eventOverviewCard
-                                  .location()
-                                  .toUpperCase()}
-                              </Typography>
-                              <Typography
-                                sx={{
-                                  alignItems: 'flex-start',
-                                  display: 'flex',
-                                }}
-                                variant="body1"
-                              >
-                                {messages.eventOverviewCard.noLocation()}
-                              </Typography>
-                            </Box>
-                          );
-                        }
-                      }}
-                      value={locationId || ''}
-                    />
-                  </Grid>
-
-                  <Grid item mt={2}>
-                    <ZUIPreviewableInput
-                      {...previewableProps}
-                      renderInput={(props) => (
-                        <TextField
-                          fullWidth
-                          inputProps={props}
-                          label={messages.eventOverviewCard.url()}
-                          onChange={(ev) => setLink(ev.target.value)}
-                          sx={{ marginBottom: 2 }}
-                          value={link}
-                        />
-                      )}
-                      renderPreview={() => {
-                        if (eventData.url && eventData.url !== '') {
-                          return (
-                            <Box ml={4}>
-                              <Typography
-                                color={theme.palette.text.secondary}
-                                variant="subtitle1"
-                              >
-                                {messages.eventOverviewCard.url().toUpperCase()}
-                              </Typography>
-                              <Typography
-                                sx={{
-                                  alignItems: 'flex-start',
-                                  display: 'flex',
-                                }}
-                                variant="body1"
-                              >
-                                {eventData.url}
-                                <Link
-                                  href={getWorkingUrl(eventData.url)}
-                                  sx={{ marginLeft: '8px' }}
-                                  target="_blank"
-                                >
-                                  <OpenInNewIcon color="primary" />
-                                </Link>
-                              </Typography>
-                            </Box>
-                          );
-                        } else {
-                          return <></>;
-                        }
-                      }}
-                      value={link || ''}
-                    />
-                  </Grid>
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-          <Box p={1}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => (
-                <TextField
-                  fullWidth
-                  inputProps={props}
-                  label={messages.eventOverviewCard.description()}
-                  multiline
-                  onChange={(ev) => setInfoText(ev.target.value)}
-                  rows={4}
-                  value={infoText}
-                />
-              )}
-              renderPreview={() => {
-                if (eventData.info_text !== '') {
-                  return (
-                    <Box p={1}>
-                      <Typography
-                        color={theme.palette.text.secondary}
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.description().toUpperCase()}
-                      </Typography>
-                      <Typography variant="body1">
-                        {eventData.info_text}
-                      </Typography>
-                    </Box>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={infoText}
-            />
-          </Box>
-        </Card>
-      </Box>
-    </ClickAwayListener>
+                      } else {
+                        return <></>;
+                      }
+                    }}
+                    value={infoText}
+                  />
+                </Box>
+              </Card>
+            </Box>
+          </ClickAwayListener>
+        );
+      }}
+    </ZUIFuture>
   );
 };
 

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -65,6 +65,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
   const [endDate, setEndDate] = useState<Dayjs | undefined>(
     eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined
   );
+  const [openButton, setOpenButton] = useState(false);
 
   const [locationModalOpen, setLocationModalOpen] = useState(false);
 
@@ -72,7 +73,10 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
     useEditPreviewBlock({
       editable,
       onEditModeEnter: () => setEditable(true),
-      onEditModeExit: () => setEditable(false),
+      onEditModeExit: () => {
+        setEditable(false);
+        setOpenButton(false);
+      },
       save: () => {
         dataModel.updateEventData({
           end_time: dayjs(endDate)
@@ -248,16 +252,46 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                               }
                             }}
                             renderInput={(params) => {
-                              return (
-                                <TextField
-                                  {...params}
-                                  inputProps={{
-                                    ...params.inputProps,
-                                    ...props,
-                                  }}
-                                  sx={{ marginBottom: '15px' }}
-                                />
-                              );
+                              if (
+                                (endDate &&
+                                  startDate &&
+                                  !isSameDate(
+                                    startDate.toDate(),
+                                    endDate.toDate()
+                                  )) ||
+                                openButton
+                              ) {
+                                return (
+                                  <TextField
+                                    {...params}
+                                    inputProps={{
+                                      ...params.inputProps,
+                                      ...props,
+                                    }}
+                                    sx={{ marginBottom: '15px' }}
+                                  />
+                                );
+                              } else if (
+                                endDate &&
+                                startDate &&
+                                !openButton &&
+                                isSameDate(startDate.toDate(), endDate.toDate())
+                              ) {
+                                return (
+                                  <Button
+                                    onClick={() => {
+                                      console.log('inside button', openButton),
+                                        setOpenButton(true);
+                                    }}
+                                    sx={{ marginBottom: 4.4, width: '100%' }}
+                                    variant="outlined"
+                                  >
+                                    {messages.eventOverviewCard.buttonEndDate()}
+                                  </Button>
+                                );
+                              } else {
+                                return <></>;
+                              }
                             }}
                             value={dayjs(endDate)}
                           />
@@ -293,9 +327,18 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           isSameDate(startDate.toDate(), endDate.toDate())
                         ) {
                           return (
-                            <Button variant="outlined">
-                              {messages.eventOverviewCard.buttonEndDate()}
-                            </Button>
+                            <Box ml={4}>
+                              <Typography
+                                color="secondary"
+                                component="h3"
+                                variant="subtitle1"
+                              >
+                                {messages.eventOverviewCard
+                                  .endDate()
+                                  .toUpperCase()}
+                              </Typography>
+                              <Box mb={2.8} />
+                            </Box>
                           );
                         } else {
                           return <></>;
@@ -332,11 +375,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         );
                       }}
                       renderPreview={() => {
-                        if (
-                          endDate &&
-                          startDate &&
-                          !isSameTime(startDate.unix(), endDate.unix())
-                        ) {
+                        if (endDate) {
                           return (
                             <Box ml={4}>
                               <FormattedTime

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -168,11 +168,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         if (startDate) {
                           return (
                             <Box ml={1}>
-                              <Typography
-                                color="secondary"
-                                component="h3"
-                                variant="subtitle1"
-                              >
+                              <Typography color="secondary" variant="subtitle1">
                                 {messages.eventOverviewCard
                                   .startDate()
                                   .toUpperCase()}
@@ -324,11 +320,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         ) {
                           return (
                             <Box ml={10}>
-                              <Typography
-                                color="secondary"
-                                component="h3"
-                                variant="subtitle1"
-                              >
+                              <Typography color="secondary" variant="subtitle1">
                                 {messages.eventOverviewCard
                                   .endDate()
                                   .toUpperCase()}
@@ -347,11 +339,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         ) {
                           return (
                             <Box ml={10}>
-                              <Typography
-                                color="secondary"
-                                component="h3"
-                                variant="subtitle1"
-                              >
+                              <Typography color="secondary" variant="subtitle1">
                                 {messages.eventOverviewCard
                                   .endDate()
                                   .toUpperCase()}
@@ -517,25 +505,19 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                               >
                                 <Typography
                                   color="secondary"
-                                  component="h3"
                                   variant="subtitle1"
                                 >
                                   {messages.eventOverviewCard
                                     .location()
                                     .toUpperCase()}
                                 </Typography>
-                                <MapIcon
-                                  color="secondary"
-                                  onClick={() => setLocationModalOpen(true)}
-                                  sx={{ cursor: 'pointer' }}
-                                />
                               </Box>
                               <Typography
                                 sx={{
                                   alignItems: 'flex-start',
                                   display: 'flex',
                                 }}
-                                variant="body2"
+                                variant="body1"
                               >
                                 {eventData.location.title}
                               </Typography>
@@ -544,11 +526,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         } else {
                           return (
                             <Box ml={4}>
-                              <Typography
-                                color="secondary"
-                                component="h3"
-                                variant="subtitle1"
-                              >
+                              <Typography color="secondary" variant="subtitle1">
                                 {messages.eventOverviewCard
                                   .location()
                                   .toUpperCase()}
@@ -558,7 +536,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                   alignItems: 'flex-start',
                                   display: 'flex',
                                 }}
-                                variant="body2"
+                                variant="body1"
                               >
                                 {messages.eventOverviewCard.noLocation()}
                               </Typography>
@@ -589,7 +567,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             <Box ml={4}>
                               <Typography
                                 color={theme.palette.text.secondary}
-                                component="h3"
                                 variant="subtitle1"
                               >
                                 {messages.eventOverviewCard.url().toUpperCase()}
@@ -599,7 +576,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                   alignItems: 'flex-start',
                                   display: 'flex',
                                 }}
-                                variant="body2"
+                                variant="body1"
                               >
                                 {eventData.url}
                                 <Link
@@ -623,7 +600,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Grid>
             </Grid>
           </Grid>
-          <Box>
+          <Box p={1}>
             <ZUIPreviewableInput
               {...previewableProps}
               renderInput={(props) => (
@@ -634,22 +611,20 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                   multiline
                   onChange={(ev) => setInfoText(ev.target.value)}
                   rows={4}
-                  sx={{ marginBottom: 2, marginLeft: 1, paddingRight: 2 }}
                   value={infoText}
                 />
               )}
               renderPreview={() => {
                 if (eventData.info_text !== '') {
                   return (
-                    <Box mb={2} ml={2}>
+                    <Box p={1}>
                       <Typography
                         color={theme.palette.text.secondary}
-                        component="h3"
                         variant="subtitle1"
                       >
                         {messages.eventOverviewCard.description().toUpperCase()}
                       </Typography>
-                      <Typography variant="body2">
+                      <Typography variant="body1">
                         {eventData.info_text}
                       </Typography>
                     </Box>

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -57,8 +57,8 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
     eventData?.location.id ?? undefined
   );
 
-  const [startDate, setStartDate] = useState<Dayjs>(
-    dayjs(removeOffset(eventData!.start_time))
+  const [startDate, setStartDate] = useState<Dayjs | null>(
+    eventData ? dayjs(removeOffset(eventData.start_time)) : null
   );
   const [endDate, setEndDate] = useState<Dayjs | undefined>(
     eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -57,10 +57,8 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
     eventData?.location.id ?? undefined
   );
 
-  const [startDate, setStartDate] = useState<Dayjs | undefined>(
-    eventData?.start_time
-      ? dayjs(removeOffset(eventData.start_time))
-      : undefined
+  const [startDate, setStartDate] = useState<Dayjs>(
+    dayjs(removeOffset(eventData!.start_time))
   );
   const [endDate, setEndDate] = useState<Dayjs | undefined>(
     eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined
@@ -231,9 +229,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             <Box ml={1}>
                               <FormattedTime
                                 hour12={false}
-                                value={new Date(
-                                  dayjs(startDate).format()
-                                ).toISOString()}
+                                value={startDate.format()}
                               />
                             </Box>
                           );

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -1,4 +1,6 @@
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import EditIcon from '@mui/icons-material/Edit';
+import { FormattedTime } from 'react-intl';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { Add, Place } from '@mui/icons-material';
 import {
@@ -7,10 +9,12 @@ import {
   Button,
   Card,
   ClickAwayListener,
+  Divider,
   Link,
   TextField,
   Typography,
 } from '@mui/material';
+import dayjs, { Dayjs } from 'dayjs';
 import { FC, useState } from 'react';
 
 import EventDataModel from 'features/events/models/EventDataModel';
@@ -18,11 +22,14 @@ import { getWorkingUrl } from 'features/events/utils/getWorkingUrl';
 import LocationModal from '../LocationModal';
 import LocationsModel from 'features/events/models/LocationsModel';
 import messageIds from 'features/events/l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import theme from 'theme';
 import useEditPreviewBlock from 'zui/hooks/useEditPreviewBlock';
 import { useMessages } from 'core/i18n';
 import { ZetkinLocation } from 'utils/types/zetkin';
+import ZUIDate from 'zui/ZUIDate';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 
 type EventOverviewCardProps = {
   dataModel: EventDataModel;
@@ -42,6 +49,13 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
   const [locationId, setLocationId] = useState(
     eventData?.location.id ?? undefined
   );
+
+  const [startDate, setStartDate] = useState<Dayjs | undefined>(
+    eventData?.start_time
+      ? dayjs(removeOffset(eventData.start_time))
+      : undefined
+  );
+
   const [locationModalOpen, setLocationModalOpen] = useState(false);
 
   const { clickAwayProps, containerProps, previewableProps } =
@@ -53,6 +67,11 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
         dataModel.updateEventData({
           info_text: infoText,
           location_id: locationId,
+          start_time: dayjs(startDate)
+            .hour(startDate ? startDate.hour() : 0)
+            .minute(startDate ? startDate.minute() : 0)
+            .format(),
+
           url: link,
         });
       },
@@ -73,6 +92,82 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Button>
             </Box>
           )}
+          <Box m={2}>
+            <ZUIPreviewableInput
+              {...previewableProps}
+              renderInput={(props) => {
+                return (
+                  <DatePicker
+                    inputFormat="DD-MM-YYYY"
+                    onChange={(newValue) => setStartDate(dayjs(newValue))}
+                    renderInput={(params) => {
+                      return <TextField {...params} />;
+                    }}
+                    value={dayjs(startDate)}
+                  />
+                );
+              }}
+              renderPreview={() => {
+                if (startDate) {
+                  return (
+                    <>
+                      <Typography
+                        color="secondary"
+                        component="h3"
+                        variant="subtitle1"
+                      >
+                        {messages.eventOverviewCard.startDate().toUpperCase()}
+                      </Typography>
+                      <ZUIDate
+                        datetime={new Date(
+                          dayjs(startDate).format()
+                        ).toISOString()}
+                      ></ZUIDate>
+                    </>
+                  );
+                } else {
+                  return <></>;
+                }
+              }}
+              value={dayjs(startDate).format()}
+            />
+          </Box>
+          <Box m={2}>
+            <ZUIPreviewableInput
+              {...previewableProps}
+              renderInput={(props) => {
+                return (
+                  <TimePicker
+                    ampm={false}
+                    inputFormat="HH:mm"
+                    onChange={(newValue) => {
+                      if (newValue) {
+                        setStartDate(dayjs(newValue));
+                      }
+                    }}
+                    open={false}
+                    renderInput={(props) => <TextField {...props}></TextField>}
+                    value={dayjs(startDate)}
+                  />
+                );
+              }}
+              renderPreview={() => {
+                if (startDate) {
+                  return (
+                    <FormattedTime
+                      hour12={false}
+                      value={new Date(dayjs(startDate).format()).toISOString()}
+                    ></FormattedTime>
+                  );
+                } else {
+                  return <></>;
+                }
+              }}
+              value={dayjs(startDate).format()}
+            />
+          </Box>
+          <Divider orientation="vertical"></Divider>
+
           <Box m={2}>
             <ZUIPreviewableInput
               {...previewableProps}

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -143,6 +143,15 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                               if (newValue && isValidDate(newValue.toDate())) {
                                 setInvalidFormat(false);
                                 setStartDate(dayjs(newValue));
+                                if (
+                                  endDate &&
+                                  dateIsBefore(
+                                    newValue.toDate(),
+                                    endDate.toDate()
+                                  )
+                                ) {
+                                  setEndDate(newValue);
+                                }
                               } else {
                                 setInvalidFormat(true);
                               }

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -104,202 +104,215 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Button>
             </Box>
           )}
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => {
-                return (
-                  <DatePicker
-                    inputFormat="DD-MM-YYYY"
-                    label={messages.eventOverviewCard.startDate()}
-                    onChange={(newValue) => {
-                      setStartDate(dayjs(newValue));
-                    }}
-                    renderInput={(params) => {
-                      return (
-                        <TextField
-                          {...params}
-                          inputProps={{ ...params.inputProps, ...props }}
-                        />
-                      );
-                    }}
-                    value={dayjs(startDate)}
-                  />
-                );
-              }}
-              renderPreview={() => {
-                if (startDate) {
+          <Box>
+            <Box m={2}>
+              <ZUIPreviewableInput
+                {...previewableProps}
+                renderInput={(props) => {
                   return (
-                    <>
-                      <Typography
-                        color="secondary"
-                        component="h3"
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.startDate().toUpperCase()}
-                      </Typography>
-                      <ZUIDate
-                        datetime={new Date(
+                    <DatePicker
+                      inputFormat="DD-MM-YYYY"
+                      label={messages.eventOverviewCard.startDate()}
+                      onChange={(newValue) => {
+                        setStartDate(dayjs(newValue));
+                      }}
+                      renderInput={(params) => {
+                        return (
+                          <TextField
+                            {...params}
+                            inputProps={{ ...params.inputProps, ...props }}
+                          />
+                        );
+                      }}
+                      value={dayjs(startDate)}
+                    />
+                  );
+                }}
+                renderPreview={() => {
+                  if (startDate) {
+                    return (
+                      <>
+                        <Typography
+                          color="secondary"
+                          component="h3"
+                          variant="subtitle1"
+                        >
+                          {messages.eventOverviewCard.startDate().toUpperCase()}
+                        </Typography>
+                        <ZUIDate
+                          datetime={new Date(
+                            dayjs(startDate).format()
+                          ).toISOString()}
+                        />
+                      </>
+                    );
+                  } else {
+                    return <></>;
+                  }
+                }}
+                value={dayjs(startDate).format() ?? ''}
+              />
+            </Box>
+
+            <Box m={2}>
+              <ZUIPreviewableInput
+                {...previewableProps}
+                renderInput={(props) => {
+                  return (
+                    <DatePicker
+                      inputFormat="DD-MM-YYYY"
+                      label={messages.eventOverviewCard.endDate()}
+                      onChange={(newValue) => {
+                        setEndDate(dayjs(newValue));
+                        if (
+                          startDate &&
+                          newValue &&
+                          endDateIsBeforeStartDate(
+                            startDate.toDate(),
+                            newValue.toDate()
+                          )
+                        ) {
+                          setStartDate(newValue);
+                        }
+                      }}
+                      renderInput={(params) => {
+                        return (
+                          <TextField
+                            {...params}
+                            inputProps={{ ...params.inputProps, ...props }}
+                          />
+                        );
+                      }}
+                      value={dayjs(endDate)}
+                    />
+                  );
+                }}
+                renderPreview={() => {
+                  if (
+                    endDate &&
+                    startDate &&
+                    !isSameDate(startDate.toDate(), endDate.toDate())
+                  ) {
+                    return (
+                      <>
+                        <Typography
+                          color="secondary"
+                          component="h3"
+                          variant="subtitle1"
+                        >
+                          {messages.eventOverviewCard.endDate().toUpperCase()}
+                        </Typography>
+                        <ZUIDate
+                          datetime={new Date(
+                            dayjs(endDate).format()
+                          ).toISOString()}
+                        />
+                      </>
+                    );
+                  } else if (
+                    endDate &&
+                    startDate &&
+                    isSameDate(startDate.toDate(), endDate.toDate())
+                  ) {
+                    return (
+                      <Button variant="outlined">
+                        {messages.eventOverviewCard.buttonEndDate()}
+                      </Button>
+                    );
+                  } else {
+                    return <></>;
+                  }
+                }}
+                value={dayjs(endDate).format() ?? ''}
+              />
+            </Box>
+
+            <Box m={2}>
+              <ZUIPreviewableInput
+                {...previewableProps}
+                renderInput={(props) => {
+                  return (
+                    <TimePicker
+                      ampm={false}
+                      inputFormat="HH:mm"
+                      label={messages.eventOverviewCard.startTime()}
+                      onChange={(newValue) => {
+                        setStartDate(dayjs(newValue));
+                      }}
+                      open={false}
+                      renderInput={(params) => {
+                        return (
+                          <TextField
+                            {...params}
+                            inputProps={{ ...params.inputProps, ...props }}
+                          />
+                        );
+                      }}
+                      value={dayjs(startDate)}
+                    />
+                  );
+                }}
+                renderPreview={() => {
+                  if (startDate) {
+                    return (
+                      <FormattedTime
+                        hour12={false}
+                        value={new Date(
                           dayjs(startDate).format()
                         ).toISOString()}
                       />
-                    </>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={dayjs(startDate).format() ?? ''}
-            />
-          </Box>
-
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => {
-                return (
-                  <DatePicker
-                    inputFormat="DD-MM-YYYY"
-                    label={messages.eventOverviewCard.endDate()}
-                    onChange={(newValue) => {
-                      setEndDate(dayjs(newValue));
-                      if (
-                        startDate &&
-                        newValue &&
-                        endDateIsBeforeStartDate(
-                          startDate.toDate(),
-                          newValue.toDate()
-                        )
-                      ) {
-                        setStartDate(newValue);
-                      }
-                    }}
-                    renderInput={(params) => {
-                      return (
-                        <TextField
-                          {...params}
-                          inputProps={{ ...params.inputProps, ...props }}
-                        />
-                      );
-                    }}
-                    value={dayjs(endDate)}
-                  />
-                );
-              }}
-              renderPreview={() => {
-                if (
-                  endDate &&
-                  startDate &&
-                  !isSameDate(startDate.toDate(), endDate.toDate())
-                ) {
+                    );
+                  } else {
+                    return <></>;
+                  }
+                }}
+                value={dayjs(startDate).format()}
+              />
+            </Box>
+            <Box m={2}>
+              <ZUIPreviewableInput
+                {...previewableProps}
+                renderInput={(props) => {
                   return (
-                    <>
-                      <Typography
-                        color="secondary"
-                        component="h3"
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.endDate().toUpperCase()}
-                      </Typography>
-                      <ZUIDate
-                        datetime={new Date(
-                          dayjs(endDate).format()
-                        ).toISOString()}
+                    <TimePicker
+                      ampm={false}
+                      inputFormat="HH:mm"
+                      label={messages.eventOverviewCard.endTime()}
+                      onChange={(newValue) => {
+                        setEndDate(dayjs(newValue));
+                      }}
+                      open={false}
+                      renderInput={(params) => {
+                        return (
+                          <TextField
+                            {...params}
+                            inputProps={{ ...params.inputProps, ...props }}
+                          />
+                        );
+                      }}
+                      value={dayjs(endDate)}
+                    />
+                  );
+                }}
+                renderPreview={() => {
+                  if (
+                    endDate &&
+                    startDate &&
+                    !isSameTime(startDate.unix(), endDate.unix())
+                  ) {
+                    return (
+                      <FormattedTime
+                        hour12={false}
+                        value={new Date(dayjs(endDate).format()).toISOString()}
                       />
-                    </>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={dayjs(endDate).format() ?? ''}
-            />
-          </Box>
-
-          {/****** start time */}
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => {
-                return (
-                  <TimePicker
-                    ampm={false}
-                    inputFormat="HH:mm"
-                    label={messages.eventOverviewCard.startTime()}
-                    onChange={(newValue) => {
-                      setStartDate(dayjs(newValue));
-                    }}
-                    open={false}
-                    renderInput={(params) => {
-                      return (
-                        <TextField
-                          {...params}
-                          inputProps={{ ...params.inputProps, ...props }}
-                        />
-                      );
-                    }}
-                    value={dayjs(startDate)}
-                  />
-                );
-              }}
-              renderPreview={() => {
-                if (startDate) {
-                  return (
-                    <FormattedTime
-                      hour12={false}
-                      value={new Date(dayjs(startDate).format()).toISOString()}
-                    />
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={dayjs(startDate).format()}
-            />
-          </Box>
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => {
-                return (
-                  <TimePicker
-                    ampm={false}
-                    inputFormat="HH:mm"
-                    label={messages.eventOverviewCard.endTime()}
-                    onChange={(newValue) => {
-                      setEndDate(dayjs(newValue));
-                    }}
-                    open={false}
-                    renderInput={(params) => {
-                      return (
-                        <TextField
-                          {...params}
-                          inputProps={{ ...params.inputProps, ...props }}
-                        />
-                      );
-                    }}
-                    value={dayjs(endDate)}
-                  />
-                );
-              }}
-              renderPreview={() => {
-                if (
-                  endDate &&
-                  startDate &&
-                  !isSameTime(startDate.unix(), endDate.unix())
-                ) {
-                  return (
-                    <FormattedTime
-                      hour12={false}
-                      value={new Date(dayjs(endDate).format()).toISOString()}
-                    />
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={dayjs(endDate).format()}
-            />
+                    );
+                  } else {
+                    return <></>;
+                  }
+                }}
+                value={dayjs(endDate).format()}
+              />
+            </Box>
           </Box>
           <Divider orientation="vertical"></Divider>
 

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -1,10 +1,10 @@
+import { Add } from '@mui/icons-material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import EditIcon from '@mui/icons-material/Edit';
 import { FormattedTime } from 'react-intl';
 import MapIcon from '@mui/icons-material/Map';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { Add, Map } from '@mui/icons-material';
 import {
   Autocomplete,
   Box,

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -34,7 +34,7 @@ import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
 import {
   endDateIsBeforeStartDate,
   isSameDate,
-  isSameTime,
+  isValidDate,
   removeOffset,
 } from 'utils/dateUtils';
 
@@ -66,6 +66,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
     eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined
   );
   const [openButton, setOpenButton] = useState(false);
+  const [invalidFormat, setInvalidFormat] = useState(false);
 
   const [locationModalOpen, setLocationModalOpen] = useState(false);
 
@@ -138,12 +139,18 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             inputFormat="DD-MM-YYYY"
                             label={messages.eventOverviewCard.startDate()}
                             onChange={(newValue) => {
-                              setStartDate(dayjs(newValue));
+                              if (newValue && isValidDate(newValue.toDate())) {
+                                setInvalidFormat(false);
+                                setStartDate(dayjs(newValue));
+                              } else {
+                                setInvalidFormat(true);
+                              }
                             }}
                             renderInput={(params) => {
                               return (
                                 <TextField
                                   {...params}
+                                  error={invalidFormat}
                                   inputProps={{
                                     ...params.inputProps,
                                     ...props,
@@ -192,7 +199,12 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             inputFormat="HH:mm"
                             label={messages.eventOverviewCard.startTime()}
                             onChange={(newValue) => {
-                              setStartDate(dayjs(newValue));
+                              if (newValue && isValidDate(newValue.toDate())) {
+                                setInvalidFormat(false);
+                                setStartDate(dayjs(newValue));
+                              } else {
+                                setInvalidFormat(true);
+                              }
                             }}
                             open={false}
                             renderInput={(params) => {
@@ -239,16 +251,24 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             inputFormat="DD-MM-YYYY"
                             label={messages.eventOverviewCard.endDate()}
                             onChange={(newValue) => {
-                              setEndDate(dayjs(newValue));
-                              if (
-                                startDate &&
-                                newValue &&
-                                endDateIsBeforeStartDate(
-                                  startDate.toDate(),
-                                  newValue.toDate()
-                                )
-                              ) {
-                                setStartDate(newValue);
+                              if (newValue && isValidDate(newValue.toDate())) {
+                                if (
+                                  startDate &&
+                                  newValue &&
+                                  endDateIsBeforeStartDate(
+                                    startDate.toDate(),
+                                    newValue.toDate()
+                                  )
+                                ) {
+                                  setInvalidFormat(false);
+                                  setStartDate(newValue);
+                                  setEndDate(newValue);
+                                } else {
+                                  setInvalidFormat(false);
+                                  setEndDate(newValue);
+                                }
+                              } else {
+                                setInvalidFormat(true);
                               }
                             }}
                             renderInput={(params) => {
@@ -264,6 +284,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 return (
                                   <TextField
                                     {...params}
+                                    error={invalidFormat}
                                     inputProps={{
                                       ...params.inputProps,
                                       ...props,
@@ -280,8 +301,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 return (
                                   <Button
                                     onClick={() => {
-                                      console.log('inside button', openButton),
-                                        setOpenButton(true);
+                                      setOpenButton(true);
                                     }}
                                     sx={{ marginBottom: 4.4, width: '100%' }}
                                     variant="outlined"
@@ -356,13 +376,20 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             inputFormat="HH:mm"
                             label={messages.eventOverviewCard.endTime()}
                             onChange={(newValue) => {
-                              setEndDate(dayjs(newValue));
+                              if (newValue && isValidDate(newValue.toDate())) {
+                                setInvalidFormat(false);
+
+                                setEndDate(newValue);
+                              } else {
+                                setInvalidFormat(false);
+                              }
                             }}
                             open={false}
                             renderInput={(params) => {
                               return (
                                 <TextField
                                   {...params}
+                                  error={invalidFormat}
                                   inputProps={{
                                     ...params.inputProps,
                                     ...props,

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -304,7 +304,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                       setOpenButton(true);
                                     }}
                                     sx={{ marginBottom: 4.4, width: '100%' }}
-                                    variant="outlined"
+                                    variant="text"
                                   >
                                     {messages.eventOverviewCard.buttonEndDate()}
                                   </Button>
@@ -378,7 +378,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             onChange={(newValue) => {
                               if (newValue && isValidDate(newValue.toDate())) {
                                 setInvalidFormat(false);
-
                                 setEndDate(newValue);
                               } else {
                                 setInvalidFormat(false);
@@ -425,7 +424,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                 <Divider
                   flexItem
                   orientation="vertical"
-                  sx={{ marginLeft: '10px' }}
+                  sx={{ marginBottom: '10px', marginLeft: '10px' }}
                 />
 
                 <Grid sx={{ marginLeft: '10px', marginTop: 2 }} xs>
@@ -502,7 +501,12 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                         if (eventData.location) {
                           return (
                             <Box ml={4}>
-                              <Box sx={{ display: 'flex' }}>
+                              <Box
+                                sx={{
+                                  display: 'flex',
+                                  justifyContent: 'space-between',
+                                }}
+                              >
                                 <Typography
                                   color="secondary"
                                   component="h3"
@@ -515,7 +519,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 <MapIcon
                                   color="secondary"
                                   onClick={() => setLocationModalOpen(true)}
-                                  sx={{ cursor: 'pointer', marginLeft: 2 }}
+                                  sx={{ cursor: 'pointer' }}
                                 />
                               </Box>
                               <Typography

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -65,7 +65,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
   const [endDate, setEndDate] = useState<Dayjs | undefined>(
     eventData?.end_time ? dayjs(removeOffset(eventData.end_time)) : undefined
   );
-  const [openButton, setOpenButton] = useState(false);
+  const [showEndDate, setShowEndDate] = useState(false);
   const [invalidFormat, setInvalidFormat] = useState(false);
 
   const [locationModalOpen, setLocationModalOpen] = useState(false);
@@ -75,7 +75,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
       onEditModeEnter: () => setEditable(true),
       onEditModeExit: () => {
         setEditable(false);
-        setOpenButton(false);
+        setShowEndDate(false);
       },
       save: () => {
         dataModel.updateEventData({
@@ -282,7 +282,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                     startDate.toDate(),
                                     endDate.toDate()
                                   )) ||
-                                openButton
+                                showEndDate
                               ) {
                                 return (
                                   <TextField
@@ -298,13 +298,13 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                               } else if (
                                 endDate &&
                                 startDate &&
-                                !openButton &&
+                                !showEndDate &&
                                 isSameDate(startDate.toDate(), endDate.toDate())
                               ) {
                                 return (
                                   <Button
                                     onClick={() => {
-                                      setOpenButton(true);
+                                      setShowEndDate(true);
                                     }}
                                     sx={{ marginBottom: 4.4, width: '100%' }}
                                     variant="text"

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -1,9 +1,10 @@
+import { Add } from '@mui/icons-material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import EditIcon from '@mui/icons-material/Edit';
 import { FormattedTime } from 'react-intl';
+import MapIcon from '@mui/icons-material/Map';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { Add, Place } from '@mui/icons-material';
 import {
   Autocomplete,
   Box,
@@ -11,6 +12,7 @@ import {
   Card,
   ClickAwayListener,
   Divider,
+  Grid,
   Link,
   TextField,
   Typography,
@@ -104,360 +106,431 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Button>
             </Box>
           )}
-          <Box>
-            <Box m={2}>
-              <ZUIPreviewableInput
-                {...previewableProps}
-                renderInput={(props) => {
-                  return (
-                    <DatePicker
-                      inputFormat="DD-MM-YYYY"
-                      label={messages.eventOverviewCard.startDate()}
-                      onChange={(newValue) => {
-                        setStartDate(dayjs(newValue));
-                      }}
-                      renderInput={(params) => {
-                        return (
-                          <TextField
-                            {...params}
-                            inputProps={{ ...params.inputProps, ...props }}
-                          />
-                        );
-                      }}
-                      value={dayjs(startDate)}
-                    />
-                  );
-                }}
-                renderPreview={() => {
-                  if (startDate) {
-                    return (
-                      <>
-                        <Typography
-                          color="secondary"
-                          component="h3"
-                          variant="subtitle1"
-                        >
-                          {messages.eventOverviewCard.startDate().toUpperCase()}
-                        </Typography>
-                        <ZUIDate
-                          datetime={new Date(
-                            dayjs(startDate).format()
-                          ).toISOString()}
-                        />
-                      </>
-                    );
-                  } else {
-                    return <></>;
-                  }
-                }}
-                value={dayjs(startDate).format() ?? ''}
-              />
-            </Box>
-
-            <Box m={2}>
-              <ZUIPreviewableInput
-                {...previewableProps}
-                renderInput={(props) => {
-                  return (
-                    <DatePicker
-                      inputFormat="DD-MM-YYYY"
-                      label={messages.eventOverviewCard.endDate()}
-                      onChange={(newValue) => {
-                        setEndDate(dayjs(newValue));
-                        if (
-                          startDate &&
-                          newValue &&
-                          endDateIsBeforeStartDate(
-                            startDate.toDate(),
-                            newValue.toDate()
-                          )
-                        ) {
-                          setStartDate(newValue);
-                        }
-                      }}
-                      renderInput={(params) => {
-                        return (
-                          <TextField
-                            {...params}
-                            inputProps={{ ...params.inputProps, ...props }}
-                          />
-                        );
-                      }}
-                      value={dayjs(endDate)}
-                    />
-                  );
-                }}
-                renderPreview={() => {
-                  if (
-                    endDate &&
-                    startDate &&
-                    !isSameDate(startDate.toDate(), endDate.toDate())
-                  ) {
-                    return (
-                      <>
-                        <Typography
-                          color="secondary"
-                          component="h3"
-                          variant="subtitle1"
-                        >
-                          {messages.eventOverviewCard.endDate().toUpperCase()}
-                        </Typography>
-                        <ZUIDate
-                          datetime={new Date(
-                            dayjs(endDate).format()
-                          ).toISOString()}
-                        />
-                      </>
-                    );
-                  } else if (
-                    endDate &&
-                    startDate &&
-                    isSameDate(startDate.toDate(), endDate.toDate())
-                  ) {
-                    return (
-                      <Button variant="outlined">
-                        {messages.eventOverviewCard.buttonEndDate()}
-                      </Button>
-                    );
-                  } else {
-                    return <></>;
-                  }
-                }}
-                value={dayjs(endDate).format() ?? ''}
-              />
-            </Box>
-
-            <Box m={2}>
-              <ZUIPreviewableInput
-                {...previewableProps}
-                renderInput={(props) => {
-                  return (
-                    <TimePicker
-                      ampm={false}
-                      inputFormat="HH:mm"
-                      label={messages.eventOverviewCard.startTime()}
-                      onChange={(newValue) => {
-                        setStartDate(dayjs(newValue));
-                      }}
-                      open={false}
-                      renderInput={(params) => {
-                        return (
-                          <TextField
-                            {...params}
-                            inputProps={{ ...params.inputProps, ...props }}
-                          />
-                        );
-                      }}
-                      value={dayjs(startDate)}
-                    />
-                  );
-                }}
-                renderPreview={() => {
-                  if (startDate) {
-                    return (
-                      <FormattedTime
-                        hour12={false}
-                        value={new Date(
-                          dayjs(startDate).format()
-                        ).toISOString()}
-                      />
-                    );
-                  } else {
-                    return <></>;
-                  }
-                }}
-                value={dayjs(startDate).format()}
-              />
-            </Box>
-            <Box m={2}>
-              <ZUIPreviewableInput
-                {...previewableProps}
-                renderInput={(props) => {
-                  return (
-                    <TimePicker
-                      ampm={false}
-                      inputFormat="HH:mm"
-                      label={messages.eventOverviewCard.endTime()}
-                      onChange={(newValue) => {
-                        setEndDate(dayjs(newValue));
-                      }}
-                      open={false}
-                      renderInput={(params) => {
-                        return (
-                          <TextField
-                            {...params}
-                            inputProps={{ ...params.inputProps, ...props }}
-                          />
-                        );
-                      }}
-                      value={dayjs(endDate)}
-                    />
-                  );
-                }}
-                renderPreview={() => {
-                  if (
-                    endDate &&
-                    startDate &&
-                    !isSameTime(startDate.unix(), endDate.unix())
-                  ) {
-                    return (
-                      <FormattedTime
-                        hour12={false}
-                        value={new Date(dayjs(endDate).format()).toISOString()}
-                      />
-                    );
-                  } else {
-                    return <></>;
-                  }
-                }}
-                value={dayjs(endDate).format()}
-              />
-            </Box>
-          </Box>
-          <Divider orientation="vertical"></Divider>
-
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={() => {
-                return (
-                  <Box alignItems="center" display="flex">
-                    <Autocomplete
-                      disableClearable
-                      fullWidth
-                      onChange={(ev, value) => {
-                        if (value === 'CREATE_NEW_LOCATION') {
-                          setLocationModalOpen(true);
-                        }
-                        const location = locations?.find(
-                          (location) => location.title === value
-                        );
-                        if (!location) {
-                          return;
-                        }
-                        setLocationId(location.id);
-                      }}
-                      options={
-                        locations
-                          ?.map((location) => location.title)
-                          .concat(['CREATE_NEW_LOCATION']) || []
-                      }
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          label={messages.eventOverviewCard.location()}
-                          sx={{
-                            backgroundColor: 'white',
-                            borderRadius: '5px',
+          <Grid container spacing={3} sx={{ marginTop: '100px' }}>
+            <Grid
+              container
+              item
+              sm
+              sx={{ justifyContent: 'space-evenly' }}
+              xs={8}
+            >
+              <Grid container direction="row" item spacing={3} xs>
+                <Grid item xs>
+                  <ZUIPreviewableInput
+                    {...previewableProps}
+                    renderInput={(props) => {
+                      return (
+                        <DatePicker
+                          inputFormat="DD-MM-YYYY"
+                          label={messages.eventOverviewCard.startDate()}
+                          onChange={(newValue) => {
+                            setStartDate(dayjs(newValue));
                           }}
+                          renderInput={(params) => {
+                            return (
+                              <TextField
+                                {...params}
+                                inputProps={{ ...params.inputProps, ...props }}
+                              />
+                            );
+                          }}
+                          value={dayjs(startDate)}
+                        />
+                      );
+                    }}
+                    renderPreview={() => {
+                      if (startDate) {
+                        return (
+                          <>
+                            <Typography
+                              color="secondary"
+                              component="h3"
+                              variant="subtitle1"
+                            >
+                              {messages.eventOverviewCard
+                                .startDate()
+                                .toUpperCase()}
+                            </Typography>
+                            <ZUIDate
+                              datetime={new Date(
+                                dayjs(startDate).format()
+                              ).toISOString()}
+                            />
+                          </>
+                        );
+                      } else {
+                        return <></>;
+                      }
+                    }}
+                    value={dayjs(startDate).format() ?? ''}
+                  />
+                  <Grid item mt={2}>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={(props) => {
+                        return (
+                          <TimePicker
+                            ampm={false}
+                            inputFormat="HH:mm"
+                            label={messages.eventOverviewCard.startTime()}
+                            onChange={(newValue) => {
+                              setStartDate(dayjs(newValue));
+                            }}
+                            open={false}
+                            renderInput={(params) => {
+                              return (
+                                <TextField
+                                  {...params}
+                                  inputProps={{
+                                    ...params.inputProps,
+                                    ...props,
+                                  }}
+                                />
+                              );
+                            }}
+                            value={dayjs(startDate)}
+                          />
+                        );
+                      }}
+                      renderPreview={() => {
+                        if (startDate) {
+                          return (
+                            <FormattedTime
+                              hour12={false}
+                              value={new Date(
+                                dayjs(startDate).format()
+                              ).toISOString()}
+                            />
+                          );
+                        } else {
+                          return <></>;
+                        }
+                      }}
+                      value={dayjs(startDate).format()}
+                    />
+                  </Grid>
+                </Grid>
+
+                <Grid item xs>
+                  <Grid item>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={(props) => {
+                        return (
+                          <DatePicker
+                            inputFormat="DD-MM-YYYY"
+                            label={messages.eventOverviewCard.endDate()}
+                            onChange={(newValue) => {
+                              setEndDate(dayjs(newValue));
+                              if (
+                                startDate &&
+                                newValue &&
+                                endDateIsBeforeStartDate(
+                                  startDate.toDate(),
+                                  newValue.toDate()
+                                )
+                              ) {
+                                setStartDate(newValue);
+                              }
+                            }}
+                            renderInput={(params) => {
+                              return (
+                                <TextField
+                                  {...params}
+                                  inputProps={{
+                                    ...params.inputProps,
+                                    ...props,
+                                  }}
+                                />
+                              );
+                            }}
+                            value={dayjs(endDate)}
+                          />
+                        );
+                      }}
+                      renderPreview={() => {
+                        if (
+                          endDate &&
+                          startDate &&
+                          !isSameDate(startDate.toDate(), endDate.toDate())
+                        ) {
+                          return (
+                            <>
+                              <Typography
+                                color="secondary"
+                                component="h3"
+                                variant="subtitle1"
+                              >
+                                {messages.eventOverviewCard
+                                  .endDate()
+                                  .toUpperCase()}
+                              </Typography>
+                              <ZUIDate
+                                datetime={new Date(
+                                  dayjs(endDate).format()
+                                ).toISOString()}
+                              />
+                            </>
+                          );
+                        } else if (
+                          endDate &&
+                          startDate &&
+                          isSameDate(startDate.toDate(), endDate.toDate())
+                        ) {
+                          return (
+                            <Button variant="outlined">
+                              {messages.eventOverviewCard.buttonEndDate()}
+                            </Button>
+                          );
+                        } else {
+                          return <></>;
+                        }
+                      }}
+                      value={dayjs(endDate).format() ?? ''}
+                    />
+                  </Grid>
+
+                  <Grid item mt={2}>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={(props) => {
+                        return (
+                          <TimePicker
+                            ampm={false}
+                            inputFormat="HH:mm"
+                            label={messages.eventOverviewCard.endTime()}
+                            onChange={(newValue) => {
+                              setEndDate(dayjs(newValue));
+                            }}
+                            open={false}
+                            renderInput={(params) => {
+                              return (
+                                <TextField
+                                  {...params}
+                                  inputProps={{
+                                    ...params.inputProps,
+                                    ...props,
+                                  }}
+                                />
+                              );
+                            }}
+                            value={dayjs(endDate)}
+                          />
+                        );
+                      }}
+                      renderPreview={() => {
+                        if (
+                          endDate &&
+                          startDate &&
+                          !isSameTime(startDate.unix(), endDate.unix())
+                        ) {
+                          return (
+                            <FormattedTime
+                              hour12={false}
+                              value={new Date(
+                                dayjs(endDate).format()
+                              ).toISOString()}
+                            />
+                          );
+                        } else {
+                          return <></>;
+                        }
+                      }}
+                      value={dayjs(endDate).format()}
+                    />
+                  </Grid>
+                </Grid>
+
+                <Divider
+                  flexItem
+                  orientation="vertical"
+                  sx={{ marginLeft: '20px' }}
+                />
+
+                <Grid item xs>
+                  <Grid item>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={() => {
+                        return (
+                          <Box alignItems="center" display="flex">
+                            <Autocomplete
+                              disableClearable
+                              fullWidth
+                              onChange={(ev, value) => {
+                                if (value === 'CREATE_NEW_LOCATION') {
+                                  setLocationModalOpen(true);
+                                }
+                                const location = locations?.find(
+                                  (location) => location.title === value
+                                );
+                                if (!location) {
+                                  return;
+                                }
+                                setLocationId(location.id);
+                              }}
+                              options={
+                                locations
+                                  ?.map((location) => location.title)
+                                  .concat(['CREATE_NEW_LOCATION']) || []
+                              }
+                              renderInput={(params) => (
+                                <TextField
+                                  {...params}
+                                  label={messages.eventOverviewCard.location()}
+                                  sx={{
+                                    backgroundColor: 'white',
+                                    borderRadius: '5px',
+                                  }}
+                                />
+                              )}
+                              renderOption={(params, option) =>
+                                option === 'CREATE_NEW_LOCATION' ? (
+                                  <li {...params}>
+                                    <Add sx={{ marginRight: 2 }} />
+                                    {messages.eventOverviewCard.createLocation()}
+                                  </li>
+                                ) : (
+                                  <li {...params}>{option}</li>
+                                )
+                              }
+                              value={
+                                locations?.find(
+                                  (location) => location.id === locationId
+                                )?.title
+                              }
+                            />
+                            <MapIcon
+                              color="secondary"
+                              onClick={() => setLocationModalOpen(true)}
+                              sx={{ cursor: 'pointer', marginLeft: 2 }}
+                            />
+                            <LocationModal
+                              locationId={locationId}
+                              locations={locations || []}
+                              onMapClose={() => setLocationModalOpen(false)}
+                              onSelectLocation={(location: ZetkinLocation) =>
+                                setLocationId(location.id)
+                              }
+                              open={locationModalOpen}
+                            />
+                          </Box>
+                        );
+                      }}
+                      renderPreview={() => {
+                        if (eventData.location) {
+                          return (
+                            <Box>
+                              <Box sx={{ display: 'flex' }}>
+                                <Typography
+                                  color="secondary"
+                                  component="h3"
+                                  variant="subtitle1"
+                                >
+                                  {messages.eventOverviewCard
+                                    .location()
+                                    .toUpperCase()}
+                                </Typography>
+                                <MapIcon
+                                  color="secondary"
+                                  onClick={() => setLocationModalOpen(true)}
+                                  sx={{ cursor: 'pointer', marginLeft: 2 }}
+                                />
+                              </Box>
+                              <Typography
+                                sx={{
+                                  alignItems: 'flex-start',
+                                  display: 'flex',
+                                }}
+                                variant="body2"
+                              >
+                                {eventData.location.title}
+                              </Typography>
+                            </Box>
+                          );
+                        } else {
+                          return (
+                            <Box>
+                              <Typography
+                                color="secondary"
+                                component="h3"
+                                variant="subtitle1"
+                              >
+                                {messages.eventOverviewCard
+                                  .location()
+                                  .toUpperCase()}
+                              </Typography>
+                              <Typography
+                                sx={{
+                                  alignItems: 'flex-start',
+                                  display: 'flex',
+                                }}
+                                variant="body2"
+                              >
+                                {messages.eventOverviewCard.noLocation()}
+                              </Typography>
+                            </Box>
+                          );
+                        }
+                      }}
+                      value={locationId || ''}
+                    />
+                  </Grid>
+
+                  <Grid item mt={2}>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={(props) => (
+                        <TextField
+                          fullWidth
+                          inputProps={props}
+                          label={messages.eventOverviewCard.url()}
+                          onChange={(ev) => setLink(ev.target.value)}
+                          sx={{ marginBottom: 2 }}
+                          value={link}
                         />
                       )}
-                      renderOption={(params, option) =>
-                        option === 'CREATE_NEW_LOCATION' ? (
-                          <li {...params}>
-                            <Add sx={{ marginRight: 2 }} />
-                            {messages.eventOverviewCard.createLocation()}
-                          </li>
-                        ) : (
-                          <li {...params}>{option}</li>
-                        )
-                      }
-                      value={
-                        locations?.find(
-                          (location) => location.id === locationId
-                        )?.title
-                      }
+                      renderPreview={() => {
+                        if (eventData.url && eventData.url !== '') {
+                          return (
+                            <Box mt={2}>
+                              <Typography
+                                color={theme.palette.text.secondary}
+                                component="h3"
+                                variant="subtitle1"
+                              >
+                                {messages.eventOverviewCard.url().toUpperCase()}
+                              </Typography>
+                              <Typography
+                                sx={{
+                                  alignItems: 'flex-start',
+                                  display: 'flex',
+                                }}
+                                variant="body2"
+                              >
+                                {eventData.url}
+                                <Link
+                                  href={getWorkingUrl(eventData.url)}
+                                  sx={{ marginLeft: '8px' }}
+                                  target="_blank"
+                                >
+                                  <OpenInNewIcon color="primary" />
+                                </Link>
+                              </Typography>
+                            </Box>
+                          );
+                        } else {
+                          return <></>;
+                        }
+                      }}
+                      value={link || ''}
                     />
-                    <Place
-                      color="secondary"
-                      onClick={() => setLocationModalOpen(true)}
-                      sx={{ cursor: 'pointer', marginLeft: 2 }}
-                    />
-                    <LocationModal
-                      locationId={locationId}
-                      locations={locations || []}
-                      onMapClose={() => setLocationModalOpen(false)}
-                      onSelectLocation={(location: ZetkinLocation) =>
-                        setLocationId(location.id)
-                      }
-                      open={locationModalOpen}
-                    />
-                  </Box>
-                );
-              }}
-              renderPreview={() => {
-                if (eventData.location) {
-                  return (
-                    <Box>
-                      <Typography
-                        color="secondary"
-                        component="h3"
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.location().toUpperCase()}
-                      </Typography>
-                      <Typography
-                        sx={{ alignItems: 'flex-start', display: 'flex' }}
-                        variant="body2"
-                      >
-                        {eventData.location.title}
-                      </Typography>
-                    </Box>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={locationId || ''}
-            />
-          </Box>
-          <Box m={2}>
-            <ZUIPreviewableInput
-              {...previewableProps}
-              renderInput={(props) => (
-                <TextField
-                  fullWidth
-                  inputProps={props}
-                  label={messages.eventOverviewCard.url()}
-                  onChange={(ev) => setLink(ev.target.value)}
-                  sx={{ marginBottom: 2 }}
-                  value={link}
-                />
-              )}
-              renderPreview={() => {
-                if (eventData.url && eventData.url !== '') {
-                  return (
-                    <Box>
-                      <Typography
-                        color={theme.palette.text.secondary}
-                        component="h3"
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.url().toUpperCase()}
-                      </Typography>
-                      <Typography
-                        sx={{ alignItems: 'flex-start', display: 'flex' }}
-                        variant="body2"
-                      >
-                        {eventData.url}
-                        <Link
-                          href={getWorkingUrl(eventData.url)}
-                          sx={{ marginLeft: '8px' }}
-                          target="_blank"
-                        >
-                          <OpenInNewIcon color="primary" />
-                        </Link>
-                      </Typography>
-                    </Box>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
-              value={link || ''}
-            />
-          </Box>
-          <Box m={2}>
+                  </Grid>
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Box sx={{ margin: '15px' }}>
             <ZUIPreviewableInput
               {...previewableProps}
               renderInput={(props) => (

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -106,7 +106,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Button>
             </Box>
           )}
-          <Grid container spacing={3} sx={{ marginTop: '100px' }}>
+          <Grid container spacing={2} sx={{ marginTop: '100px' }}>
             <Grid
               container
               item
@@ -114,57 +114,71 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               sx={{ justifyContent: 'space-evenly' }}
               xs={8}
             >
-              <Grid container direction="row" item spacing={3} xs>
-                <Grid item xs>
-                  <ZUIPreviewableInput
-                    {...previewableProps}
-                    renderInput={(props) => {
-                      return (
-                        <DatePicker
-                          inputFormat="DD-MM-YYYY"
-                          label={messages.eventOverviewCard.startDate()}
-                          onChange={(newValue) => {
-                            setStartDate(dayjs(newValue));
-                          }}
-                          renderInput={(params) => {
-                            return (
-                              <TextField
-                                {...params}
-                                inputProps={{ ...params.inputProps, ...props }}
-                              />
-                            );
-                          }}
-                          value={dayjs(startDate)}
-                        />
-                      );
-                    }}
-                    renderPreview={() => {
-                      if (startDate) {
+              <Grid container direction="row" item spacing={2} xs>
+                <Grid
+                  direction="column"
+                  item
+                  spacing={2}
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'inherit',
+                  }}
+                  xs
+                >
+                  <Grid item>
+                    <ZUIPreviewableInput
+                      {...previewableProps}
+                      renderInput={(props) => {
                         return (
-                          <>
-                            <Typography
-                              color="secondary"
-                              component="h3"
-                              variant="subtitle1"
-                            >
-                              {messages.eventOverviewCard
-                                .startDate()
-                                .toUpperCase()}
-                            </Typography>
-                            <ZUIDate
-                              datetime={new Date(
-                                dayjs(startDate).format()
-                              ).toISOString()}
-                            />
-                          </>
+                          <DatePicker
+                            inputFormat="DD-MM-YYYY"
+                            label={messages.eventOverviewCard.startDate()}
+                            onChange={(newValue) => {
+                              setStartDate(dayjs(newValue));
+                            }}
+                            renderInput={(params) => {
+                              return (
+                                <TextField
+                                  {...params}
+                                  inputProps={{
+                                    ...params.inputProps,
+                                    ...props,
+                                  }}
+                                  sx={{ marginBottom: '15px' }}
+                                />
+                              );
+                            }}
+                            value={dayjs(startDate)}
+                          />
                         );
-                      } else {
-                        return <></>;
-                      }
-                    }}
-                    value={dayjs(startDate).format() ?? ''}
-                  />
-                  <Grid item mt={2}>
+                      }}
+                      renderPreview={() => {
+                        if (startDate) {
+                          return (
+                            <Box ml={1}>
+                              <Typography
+                                color="secondary"
+                                component="h3"
+                                variant="subtitle1"
+                              >
+                                {messages.eventOverviewCard
+                                  .startDate()
+                                  .toUpperCase()}
+                              </Typography>
+                              <ZUIDate
+                                datetime={new Date(
+                                  dayjs(startDate).format()
+                                ).toISOString()}
+                              />
+                            </Box>
+                          );
+                        } else {
+                          return <></>;
+                        }
+                      }}
+                      value={dayjs(startDate).format() ?? ''}
+                    />
+
                     <ZUIPreviewableInput
                       {...previewableProps}
                       renderInput={(props) => {
@@ -195,12 +209,14 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       renderPreview={() => {
                         if (startDate) {
                           return (
-                            <FormattedTime
-                              hour12={false}
-                              value={new Date(
-                                dayjs(startDate).format()
-                              ).toISOString()}
-                            />
+                            <Box ml={1}>
+                              <FormattedTime
+                                hour12={false}
+                                value={new Date(
+                                  dayjs(startDate).format()
+                                ).toISOString()}
+                              />
+                            </Box>
                           );
                         } else {
                           return <></>;
@@ -209,10 +225,8 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       value={dayjs(startDate).format()}
                     />
                   </Grid>
-                </Grid>
 
-                <Grid item xs>
-                  <Grid item>
+                  <Grid item ml={1}>
                     <ZUIPreviewableInput
                       {...previewableProps}
                       renderInput={(props) => {
@@ -241,6 +255,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                     ...params.inputProps,
                                     ...props,
                                   }}
+                                  sx={{ marginBottom: '15px' }}
                                 />
                               );
                             }}
@@ -255,7 +270,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           !isSameDate(startDate.toDate(), endDate.toDate())
                         ) {
                           return (
-                            <>
+                            <Box ml={4}>
                               <Typography
                                 color="secondary"
                                 component="h3"
@@ -270,7 +285,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                   dayjs(endDate).format()
                                 ).toISOString()}
                               />
-                            </>
+                            </Box>
                           );
                         } else if (
                           endDate &&
@@ -288,9 +303,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       }}
                       value={dayjs(endDate).format() ?? ''}
                     />
-                  </Grid>
 
-                  <Grid item mt={2}>
                     <ZUIPreviewableInput
                       {...previewableProps}
                       renderInput={(props) => {
@@ -325,12 +338,14 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           !isSameTime(startDate.unix(), endDate.unix())
                         ) {
                           return (
-                            <FormattedTime
-                              hour12={false}
-                              value={new Date(
-                                dayjs(endDate).format()
-                              ).toISOString()}
-                            />
+                            <Box ml={4}>
+                              <FormattedTime
+                                hour12={false}
+                                value={new Date(
+                                  dayjs(endDate).format()
+                                ).toISOString()}
+                              />
+                            </Box>
                           );
                         } else {
                           return <></>;
@@ -344,10 +359,10 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                 <Divider
                   flexItem
                   orientation="vertical"
-                  sx={{ marginLeft: '20px' }}
+                  sx={{ marginLeft: '10px' }}
                 />
 
-                <Grid item xs>
+                <Grid sx={{ marginLeft: '10px', marginTop: 2 }} xs>
                   <Grid item>
                     <ZUIPreviewableInput
                       {...previewableProps}
@@ -403,7 +418,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             <MapIcon
                               color="secondary"
                               onClick={() => setLocationModalOpen(true)}
-                              sx={{ cursor: 'pointer', marginLeft: 2 }}
+                              sx={{ cursor: 'pointer', marginLeft: 1 }}
                             />
                             <LocationModal
                               locationId={locationId}
@@ -420,7 +435,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       renderPreview={() => {
                         if (eventData.location) {
                           return (
-                            <Box>
+                            <Box ml={4}>
                               <Box sx={{ display: 'flex' }}>
                                 <Typography
                                   color="secondary"
@@ -450,7 +465,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           );
                         } else {
                           return (
-                            <Box>
+                            <Box ml={4}>
                               <Typography
                                 color="secondary"
                                 component="h3"
@@ -493,7 +508,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       renderPreview={() => {
                         if (eventData.url && eventData.url !== '') {
                           return (
-                            <Box mt={2}>
+                            <Box ml={4}>
                               <Typography
                                 color={theme.palette.text.secondary}
                                 component="h3"
@@ -530,7 +545,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
               </Grid>
             </Grid>
           </Grid>
-          <Box sx={{ margin: '15px' }}>
+          <Box>
             <ZUIPreviewableInput
               {...previewableProps}
               renderInput={(props) => (
@@ -541,14 +556,14 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                   multiline
                   onChange={(ev) => setInfoText(ev.target.value)}
                   rows={4}
-                  sx={{ marginBottom: 2 }}
+                  sx={{ marginBottom: 2, marginLeft: 1, paddingRight: 2 }}
                   value={infoText}
                 />
               )}
               renderPreview={() => {
                 if (eventData.info_text !== '') {
                   return (
-                    <Box>
+                    <Box mb={2} ml={2}>
                       <Typography
                         color={theme.palette.text.secondary}
                         component="h3"

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -9,6 +9,7 @@ export default makeMessages('feat.events', {
     endDate: m('End'),
     endTime: m('End time'),
     location: m('Location'),
+    noLocation: m('No physical location'),
     startDate: m('Start'),
     startTime: m('Start time'),
     url: m('Link'),

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -2,6 +2,7 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.events', {
   eventOverviewCard: {
+    buttonEndDate: m('+ End date'),
     createLocation: m('Create new location'),
     description: m('Description'),
     editButton: m('Edit event information'),

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -5,8 +5,11 @@ export default makeMessages('feat.events', {
     createLocation: m('Create new location'),
     description: m('Description'),
     editButton: m('Edit event information'),
+    endDate: m('End'),
+    endTime: m('End time'),
     location: m('Location'),
     startDate: m('Start'),
+    startTime: m('Start time'),
     url: m('Link'),
   },
   eventParticipantsCard: {

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -6,6 +6,7 @@ export default makeMessages('feat.events', {
     description: m('Description'),
     editButton: m('Edit event information'),
     location: m('Location'),
+    startDate: m('Start'),
     url: m('Link'),
   },
   eventParticipantsCard: {

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -63,11 +63,12 @@ const EventPage: PageWithLayout<EventPageProps> = ({
 
   return (
     <ZUIFuture future={dataModel.getData()}>
-      {() => {
+      {(data) => {
         return (
           <Grid container spacing={2}>
             <Grid item md={8} xs={12}>
               <EventOverviewCard
+                data={data}
                 dataModel={dataModel}
                 locationsModel={locationsModel}
               />

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -74,6 +74,6 @@ export function isValidDate(date: Date): boolean {
     return false;
   }
 }
-export function endDateIsBeforeStartDate(first: Date, second: Date): boolean {
+export function dateIsBefore(first: Date, second: Date): boolean {
   return first.toISOString().slice(0, 10) > second.toISOString().slice(0, 10);
 }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -66,3 +66,11 @@ export function isInFuture(datestring: string): boolean {
 export function isSameDate(first: Date, second: Date): boolean {
   return first.toISOString().slice(0, 10) == second.toISOString().slice(0, 10);
 }
+
+export function isSameTime(first: number, second: number): boolean {
+  return first == second;
+}
+
+export function endDateIsBeforeStartDate(first: Date, second: Date): boolean {
+  return first.toISOString().slice(0, 10) > second.toISOString().slice(0, 10);
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -67,10 +67,13 @@ export function isSameDate(first: Date, second: Date): boolean {
   return first.toISOString().slice(0, 10) == second.toISOString().slice(0, 10);
 }
 
-export function isSameTime(first: number, second: number): boolean {
-  return first == second;
+export function isValidDate(date: Date): boolean {
+  if (date && !isNaN(date.getTime())) {
+    return true;
+  } else {
+    return false;
+  }
 }
-
 export function endDateIsBeforeStartDate(first: Date, second: Date): boolean {
   return first.toISOString().slice(0, 10) > second.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Description
This PR adds the start and end inputs to handle dates and times in events, in the preview and edit stage. It also fixes the styles to fit the design requirements and adds the focus logic to the different fields in edit stage. 
* Location field autofocus doesn´t work. It will be fixed in the issue -->  #1224


## Screenshots
**Preview mode**
- All fields completed
![image](https://user-images.githubusercontent.com/36491300/232092635-b0a43958-5b66-4f99-88a9-85005295341c.png)

- Empty description and link
![image](https://user-images.githubusercontent.com/36491300/232092781-15a270ae-8d97-48e8-a7af-05d1a9dd0553.png)

- Same start and end date
![image](https://user-images.githubusercontent.com/36491300/232093140-ce965447-b8a6-4aaa-9627-0aaa4480c791.png)

**Edit mode**
- Same start and end date
![image](https://user-images.githubusercontent.com/36491300/232093250-2f5247ca-206a-427a-bbc2-92ccb2bc98a5.png)

- Different start and end date
![image](https://user-images.githubusercontent.com/36491300/232093383-8ce608df-9fe8-4f80-b0c6-77c395787fbb.png)


## Changes
**Edit mode**
- Adds date picker component for start and end date
- Adds timepicker (without popover) for start and end time
- When start date is the same as end date, we show a button that says "end date"
- Adds a validation check with a new function (isValidDate)
- Adds a function to check if end date is before start date called `endDateIsBeforeStartDate`

**Preview mode**
- Adds start and end date info (if they are different, otherwise we only show start date)
- Adds start and end time info
- Changes localization icon for Map

## Notes to reviewer
Some things are still to be discussed, like how to localize date formats etc.


## Related issues
Resolves #1184 
