### PR TITLE
Add participant summary card

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -134,7 +134,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
       >
         <Box display="flex" justifyContent="space-between">
           <Box display="flex" flexDirection="column">
-            <Typography color={'secondary'} component="h6" variant="subtitle1">
+            <Typography color={'secondary'}>
               {messages.participantSummaryCard.pending()}
             </Typography>
             <Box display="flex">
@@ -158,7 +158,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
             </Box>
           </Box>
           <Box display="flex" flexDirection="column">
-            <Typography color={'secondary'} component="h6" variant="subtitle1">
+            <Typography color={'secondary'}>
               {messages.participantSummaryCard.booked()}
             </Typography>
             <Box display="flex">

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -1,0 +1,199 @@
+import {
+  Box,
+  Button,
+  ClickAwayListener,
+  Paper,
+  Popper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { Check, Settings } from '@mui/icons-material';
+import { FC, useState } from 'react';
+
+import EventDataModel from 'features/events/models/EventDataModel';
+import messageIds from 'features/events/l10n/messageIds';
+import theme from 'theme';
+import ZUICard from 'zui/ZUICard';
+import ZUINumberChip from 'zui/ZUINumberChip';
+import { Msg, useMessages } from 'core/i18n';
+
+type ParticipantSummaryCardProps = {
+  model: EventDataModel;
+};
+
+const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
+  const eventData = model.getData().data;
+  const participants = model.getParticipants().data;
+  const respondents = model.getRespondents().data;
+  const messages = useMessages(messageIds);
+  const reqParticipants = eventData?.num_participants_required ?? 0;
+  const availParticipants = participants?.length ?? 0;
+  const remindedParticipants =
+    participants?.filter((p) => p.reminder_sent != null).length ?? 0;
+  const signedParticipants =
+    respondents?.filter((r) => !participants?.some((p) => p.id === r.id))
+      .length ?? 0;
+  const contactPerson = eventData?.contact;
+
+  const [newReqParticipants, setNewReqParticipants] = useState<number | null>(
+    reqParticipants
+  );
+  const [anchorEl, setAnchorEl] = useState<
+    null | (EventTarget & SVGSVGElement)
+  >(null);
+
+  if (!eventData) {
+    return null;
+  }
+
+  const getParticipantStatus = () => {
+    const diff = reqParticipants - availParticipants;
+
+    if (diff <= 0) {
+      return theme.palette.statusColors.green;
+    } else if (diff === 1) {
+      return theme.palette.statusColors.orange;
+    } else {
+      return theme.palette.statusColors.red;
+    }
+  };
+
+  return (
+    <Box>
+      <ZUICard
+        header={messages.participantSummaryCard.header()}
+        status={
+          <Box display="flex">
+            <ZUINumberChip
+              color={getParticipantStatus()}
+              outlined={true}
+              size="sm"
+              value={`${availParticipants}/${reqParticipants}`}
+            />
+            <Box ml={1}>
+              <Settings
+                color="secondary"
+                cursor="pointer"
+                onClick={(event) =>
+                  setAnchorEl(anchorEl ? null : event.currentTarget)
+                }
+              />
+            </Box>
+            <Popper anchorEl={anchorEl} open={!!anchorEl}>
+              <ClickAwayListener
+                onClickAway={() => {
+                  setAnchorEl(null);
+                  if (
+                    newReqParticipants != null &&
+                    newReqParticipants != reqParticipants
+                  ) {
+                    model.setReqParticipants(newReqParticipants);
+                  }
+                }}
+              >
+                <Paper elevation={3} variant="elevation">
+                  <Box mt={1} p={2}>
+                    <TextField
+                      helperText={messages.participantSummaryCard.reqParticipantsHelperText()}
+                      label={messages.participantSummaryCard.reqParticipantsLabel()}
+                      onChange={(ev) => {
+                        const val = ev.target.value;
+
+                        if (val == '') {
+                          setNewReqParticipants(null);
+                          return;
+                        }
+
+                        const intVal = parseInt(val);
+                        if (!isNaN(intVal) && intVal.toString() == val) {
+                          setNewReqParticipants(intVal);
+                        }
+                      }}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter') {
+                          setAnchorEl(null);
+                          if (newReqParticipants != null) {
+                            model.setReqParticipants(newReqParticipants);
+                          }
+                        } else if (ev.key === 'Escape') {
+                          setAnchorEl(null);
+                          setNewReqParticipants(reqParticipants);
+                        }
+                      }}
+                      value={
+                        newReqParticipants === null ? '' : newReqParticipants
+                      }
+                      variant="outlined"
+                    />
+                  </Box>
+                </Paper>
+              </ClickAwayListener>
+            </Popper>
+          </Box>
+        }
+      >
+        <Box display="flex" justifyContent="space-between">
+          <Box display="flex" flexDirection="column">
+            <Typography color={'secondary'} component="h6" variant="subtitle1">
+              {messages.participantSummaryCard.pending()}
+            </Typography>
+            <Box display="flex">
+              <Typography variant="h4">{signedParticipants}</Typography>
+              {signedParticipants > 0 && (
+                <Button
+                  onClick={() => {
+                    respondents?.map((r) => {
+                      model.addParticipant(r.person.id);
+                    });
+                  }}
+                  startIcon={<Check />}
+                  sx={{
+                    borderColor: 'statusColors.blue',
+                    color: 'statusColors.blue',
+                    marginLeft: 2,
+                  }}
+                  variant="outlined"
+                >
+                  <Msg id={messageIds.participantSummaryCard.bookButton} />
+                </Button>
+              )}
+            </Box>
+          </Box>
+          <Box display="flex" flexDirection="column">
+            <Typography color={'secondary'} component="h6" variant="subtitle1">
+              {messages.participantSummaryCard.booked()}
+            </Typography>
+            <Box display="flex">
+              <Typography variant="h4">{`${remindedParticipants}/${availParticipants}`}</Typography>
+              {remindedParticipants < availParticipants && (
+                <Button
+                  disabled={contactPerson == null}
+                  onClick={() => {
+                    model.sendReminders();
+                  }}
+                  startIcon={<Check />}
+                  sx={{
+                    borderColor: 'statusColors.blue',
+                    color: 'statusColors.blue',
+                    marginLeft: 2,
+                  }}
+                  variant="outlined"
+                >
+                  <Msg id={messageIds.participantSummaryCard.remindButton} />
+                </Button>
+              )}
+            </Box>
+          </Box>
+          <Box
+            alignItems="center"
+            display="flex"
+            justifyContent="space-between"
+            marginBottom={1}
+          ></Box>
+        </Box>
+      </ZUICard>
+    </Box>
+  );
+};
+
+export default ParticipantSummaryCard;

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -148,8 +148,6 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
                   }}
                   startIcon={<Check />}
                   sx={{
-                    borderColor: 'statusColors.blue',
-                    color: 'statusColors.blue',
                     marginLeft: 2,
                   }}
                   variant="outlined"
@@ -173,8 +171,6 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
                   }}
                   startIcon={<Check />}
                   sx={{
-                    borderColor: 'statusColors.blue',
-                    color: 'statusColors.blue',
                     marginLeft: 2,
                   }}
                   variant="outlined"

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -50,6 +50,15 @@ export default makeMessages('feat.events', {
     title: m('Location name'),
     useLocation: m('Use location'),
   },
+  participantSummaryCard: {
+    bookButton: m('Book all'),
+    booked: m('Notifications'),
+    header: m('Participants'),
+    pending: m('Pending sign-ups'),
+    remindButton: m('Remind all'),
+    reqParticipantsHelperText: m('The minimum number of participants required'),
+    reqParticipantsLabel: m('Required participants'),
+  },
   state: {
     cancelled: m('Cancelled'),
     draft: m('Draft'),

--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -5,6 +5,7 @@ import EventsRepo, { ZetkinEventPatchBody } from '../repo/EventsRepo';
 import {
   ZetkinEvent,
   ZetkinEventParticipant,
+  ZetkinEventResponse,
   ZetkinLocation,
 } from 'utils/types/zetkin';
 
@@ -22,6 +23,10 @@ export default class EventDataModel extends ModelBase {
   private _orgId: number;
   private _repo: EventsRepo;
 
+  addParticipant(personId: number) {
+    this._repo.addParticipant(this._orgId, this._eventId, personId);
+  }
+
   constructor(env: Environment, orgId: number, eventId: number) {
     super();
     this._orgId = orgId;
@@ -35,6 +40,14 @@ export default class EventDataModel extends ModelBase {
 
   getParticipants(): IFuture<ZetkinEventParticipant[]> {
     return this._repo.getEventParticipants(this._orgId, this._eventId);
+  }
+
+  getRespondents(): IFuture<ZetkinEventResponse[]> {
+    return this._repo.getEventRespondents(this._orgId, this._eventId);
+  }
+
+  sendReminders() {
+    this._repo.sendReminders(this._orgId, this._eventId);
   }
 
   setLocation(location: ZetkinLocation) {

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -3,6 +3,7 @@ import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 import {
   ZetkinEvent,
   ZetkinEventParticipant,
+  ZetkinEventResponse,
   ZetkinLocation,
 } from 'utils/types/zetkin';
 
@@ -10,12 +11,14 @@ export interface EventsStoreSlice {
   eventList: RemoteList<ZetkinEvent>;
   locationList: RemoteList<ZetkinLocation>;
   participantsByEventId: Record<number, RemoteList<ZetkinEventParticipant>>;
+  respondentsByEventId: Record<number, RemoteList<ZetkinEventResponse>>;
 }
 
 const initialState: EventsStoreSlice = {
   eventList: remoteList(),
   locationList: remoteList(),
   participantsByEventId: {},
+  respondentsByEventId: {},
 };
 
 const eventsSlice = createSlice({
@@ -78,6 +81,15 @@ const eventsSlice = createSlice({
       state.locationList = remoteList(locations);
       state.locationList.loaded = timestamp;
     },
+    participantAdded: (
+      state,
+      action: PayloadAction<[number, ZetkinEventParticipant]>
+    ) => {
+      const [eventId, participant] = action.payload;
+      state.participantsByEventId[eventId].items
+        .filter((item) => item.id !== participant.id)
+        .concat([remoteItem(participant.id, { data: participant })]);
+    },
     participantsLoad: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;
       if (!state.participantsByEventId[eventId]) {
@@ -94,6 +106,31 @@ const eventsSlice = createSlice({
       state.participantsByEventId[eventId] = remoteList(participants);
       state.participantsByEventId[eventId].loaded = new Date().toISOString();
     },
+
+    participantsReminded: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      state.participantsByEventId[eventId].items.map((item) => {
+        if (item.data && item.data?.reminder_sent !== null) {
+          item.data = { ...item.data, reminder_sent: new Date().toISOString() };
+        }
+      });
+    },
+    respondentsLoad: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      if (!state.respondentsByEventId[eventId]) {
+        state.respondentsByEventId[eventId] = remoteList();
+      }
+
+      state.respondentsByEventId[eventId].isLoading = true;
+    },
+    respondentsLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinEventResponse[]]>
+    ) => {
+      const [eventId, respondents] = action.payload;
+      state.respondentsByEventId[eventId] = remoteList(respondents);
+      state.respondentsByEventId[eventId].loaded = new Date().toISOString();
+    },
   },
 });
 
@@ -108,6 +145,10 @@ export const {
   locationAdded,
   locationsLoad,
   locationsLoaded,
+  participantAdded,
   participantsLoad,
   participantsLoaded,
+  participantsReminded,
+  respondentsLoad,
+  respondentsLoaded,
 } = eventsSlice.actions;

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -1,8 +1,13 @@
 import { GetServerSideProps } from 'next';
-import { PageWithLayout } from 'utils/types';
-import { scaffold } from 'utils/next';
+import { Grid } from '@mui/material';
 
+import EventDataModel from 'features/events/models/EventDataModel';
 import EventLayout from 'features/events/layout/EventLayout';
+import { PageWithLayout } from 'utils/types';
+import ParticipantSummaryCard from 'features/events/components/ParticipantSummaryCard';
+import { scaffold } from 'utils/next';
+import useModel from 'core/useModel';
+import ZUIFuture from 'zui/ZUIFuture';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
@@ -29,8 +34,26 @@ interface ParticipantsProps {
   orgId: string;
 }
 
-const ParticipantsPage: PageWithLayout<ParticipantsProps> = () => {
-  return <>participants page</>;
+const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
+  eventId,
+  orgId,
+}) => {
+  const dataModel = useModel(
+    (env) => new EventDataModel(env, parseInt(orgId), parseInt(eventId))
+  );
+  return (
+    <ZUIFuture future={dataModel.getData()}>
+      {() => {
+        return (
+          <Grid container spacing={2}>
+            <Grid item md={8} xs={12}>
+              <ParticipantSummaryCard model={dataModel} />
+            </Grid>
+          </Grid>
+        );
+      }}
+    </ZUIFuture>
+  );
 };
 
 ParticipantsPage.getLayout = function getLayout(page, props) {


### PR DESCRIPTION
## Description
This PR adds a summary card for event participants in the participant tab.

## Screenshots

Notifications can be sent if a contact person is available
![image](https://user-images.githubusercontent.com/42777637/232208133-b3d4e9de-3103-45a0-9f3b-672c8a485166.png)

If no contact person is available
![image](https://user-images.githubusercontent.com/42777637/232208062-7e16cabb-9b06-4987-96ac-640463228dbf.png)

Notifications sent
![image](https://user-images.githubusercontent.com/42777637/232208083-2523abb8-b9ba-4495-8965-a073358afecd.png)

Pending sign-ups bookable
![image](https://user-images.githubusercontent.com/42777637/232208201-3e1f9ee8-8984-4060-af07-204593fd1ef4.png)

## Changes
* Adds functionality for sending reminders to the API
* Adds functionality for loading all respondents on a specific event
* Adds functionality for converting a respondent to a participant
* Adds an overview card in accordance with #1217 
* Changes participant tab to include the new card

## Notes to reviewer
I chose to add the localised messages for this specific tab, even though a lot of them are duplicates of the ones in `eventParticipantsCard`. Not sure if this is the correct way to do it.

## Related issues
Resolves #1217
