### PR TITLE
Add possibility to select No physical location when editing Event.

### DIFF
--- a/src/features/calendar/components/WeekCalendar/WeekCalendarEvent.tsx
+++ b/src/features/calendar/components/WeekCalendar/WeekCalendarEvent.tsx
@@ -140,7 +140,7 @@ const WeekCalendarEvent = ({
                   </span>
                 </Typography>
               )}
-              {maxNoOfLabels > 1 && event.location.title && (
+              {maxNoOfLabels > 1 && event.location?.title && (
                 <Typography
                   data-testid={`location-${event.id}`}
                   noWrap

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -57,10 +57,14 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
                 />
               ),
             },
-            {
-              icon: <PlaceOutlined fontSize="inherit" />,
-              label: event.location.title,
-            },
+            ...(event.location
+              ? [
+                  {
+                    icon: <PlaceOutlined fontSize="inherit" />,
+                    label: event.location.title,
+                  },
+                ]
+              : []),
           ]}
         />
       }

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -66,10 +66,14 @@ const EventListItem: FC<EventListeItemProps> = ({ eventId, orgId }) => {
                 />
               ),
             },
-            {
-              icon: <PlaceOutlined fontSize="inherit" />,
-              label: data.location.title,
-            },
+            ...(data.location
+              ? [
+                  {
+                    icon: <PlaceOutlined fontSize="inherit" />,
+                    label: data.location.title,
+                  },
+                ]
+              : []),
           ]}
           size="sm"
         />

--- a/src/features/events/components/EventList/EventListItem.tsx
+++ b/src/features/events/components/EventList/EventListItem.tsx
@@ -28,9 +28,11 @@ const EventListItem = ({
             {` - `}
             <ZUIDateTime datetime={removeOffset(end_time)} />
           </Typography>
-          <Typography color="textPrimary" variant="body2">
-            {location.title}
-          </Typography>
+          {location && (
+            <Typography color="textPrimary" variant="body2">
+              {location.title}
+            </Typography>
+          )}
         </ListItemText>
       </ListItem>
     </Link>

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -39,8 +39,8 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
   const [editable, setEditable] = useState(false);
   const [link, setLink] = useState(eventData?.url ?? '');
   const [infoText, setInfoText] = useState(eventData?.info_text ?? '');
-  const [locationId, setLocationId] = useState(
-    eventData?.location.id ?? undefined
+  const [locationId, setLocationId] = useState<number | null | undefined>(
+    eventData?.location === null ? null : eventData?.location.id ?? undefined
   );
   const [locationModalOpen, setLocationModalOpen] = useState(false);
   const { clickAwayProps, containerProps, previewableProps } =
@@ -61,9 +61,13 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
     return null;
   }
 
-  const options: (ZetkinLocation | 'CREATE_NEW_LOCATION')[] = locations
-    ? [...locations, 'CREATE_NEW_LOCATION']
-    : ['CREATE_NEW_LOCATION'];
+  const options: (
+    | ZetkinLocation
+    | 'CREATE_NEW_LOCATION'
+    | 'NO_PHYSICAL_LOCATION'
+  )[] = locations
+    ? [...locations, 'NO_PHYSICAL_LOCATION', 'CREATE_NEW_LOCATION']
+    : ['NO_PHYSICAL_LOCATION', 'CREATE_NEW_LOCATION'];
 
   return (
     <ClickAwayListener {...clickAwayProps}>
@@ -88,11 +92,17 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                       getOptionLabel={(option) =>
                         option === 'CREATE_NEW_LOCATION'
                           ? messages.locationModal.createLocation()
+                          : option === 'NO_PHYSICAL_LOCATION'
+                          ? messages.locationModal.noPhysicalLocation()
                           : option.title
                       }
                       onChange={(ev, option) => {
                         if (option === 'CREATE_NEW_LOCATION') {
                           setLocationModalOpen(true);
+                          return;
+                        }
+                        if (option === 'NO_PHYSICAL_LOCATION') {
+                          setLocationId(null);
                           return;
                         }
                         const location = locations?.find(
@@ -120,15 +130,24 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             <Add sx={{ marginRight: 2 }} />
                             {messages.eventOverviewCard.createLocation()}
                           </li>
+                        ) : option === 'NO_PHYSICAL_LOCATION' ? (
+                          <li {...params}>
+                            {messages.locationModal.noPhysicalLocation()}
+                          </li>
                         ) : (
                           <li {...params}>{option.title}</li>
                         )
                       }
-                      value={options?.find(
-                        (location) =>
-                          location !== 'CREATE_NEW_LOCATION' &&
-                          location.id === locationId
-                      )}
+                      value={
+                        locationId === null
+                          ? 'NO_PHYSICAL_LOCATION'
+                          : options?.find(
+                              (location) =>
+                                location !== 'CREATE_NEW_LOCATION' &&
+                                location !== 'NO_PHYSICAL_LOCATION' &&
+                                location.id === locationId
+                            )
+                      }
                     />
                     <Map
                       color="secondary"

--- a/src/features/events/components/LocationModal/index.tsx
+++ b/src/features/events/components/LocationModal/index.tsx
@@ -43,7 +43,7 @@ interface LocationModalProps {
   onMapClose: () => void;
   onSelectLocation: (location: ZetkinLocation) => void;
   open: boolean;
-  locationId?: number;
+  locationId?: number | null;
 }
 
 const Map = dynamic(() => import('./Map'), { ssr: false });

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -45,6 +45,7 @@ export default makeMessages('feat.events', {
     infoText: m(
       'You can click and drag to pan the map and pinch or scroll to zoom. To create a new location you can click on an empty spot on the map.'
     ),
+    noPhysicalLocation: m('No physical location'),
     save: m('Save'),
     searchBox: m('Find location'),
     title: m('Location name'),

--- a/src/features/events/repo/EventsRepo.ts
+++ b/src/features/events/repo/EventsRepo.ts
@@ -31,7 +31,7 @@ export type ZetkinEventPatchBody = Partial<
 > & {
   activity_id?: number;
   campaign_id?: number;
-  location_id?: number;
+  location_id?: number | null;
   organization_id?: number;
 };
 

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -75,7 +75,7 @@ export interface ZetkinEvent {
     lat: number;
     lng: number;
     title: string;
-  };
+  } | null;
   num_participants_required: number;
   num_participants_available: number;
   start_time: string;


### PR DESCRIPTION
## Description
This PR adds possibility to select "No physical location" when editing Event. This changes locationId to null. Location is also possibly null on all event listings


## Screenshots
![image](https://user-images.githubusercontent.com/46402788/232439527-5ead7195-a7d0-4ccc-9ed9-7ef5c0ab798d.png)


## Changes
* Adds option "No physical location" to location select on EventOverviewCard
* Tries to save locationId as null
* Handles possibility that location is null on Event Items in listings


## Notes to reviewer
This still does not work due to it not being handeled in backend


## Related issues
Resolves #1197 
