### PR TITLE
Add subfolders to the breadcrumbs of views

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -4,11 +4,13 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { ZetkinViewFolder } from 'features/views/components/types';
 
 interface LabeledBreadcrumbElement {
+  folderId?: string;
   href: string;
   label: string;
 }
 
 interface LocalizedBreadcrumbElement {
+  folderId?: string;
   href: string;
   labelMsg: string;
 }
@@ -76,57 +78,45 @@ async function fetchElements(
   orgId: string,
   apiFetch: ApiFetch
 ): Promise<BreadcrumbElement[]> {
-  if (fieldName == 'folderId') {
-    const folders = await apiFetch(`/orgs/${orgId}/people/view_folders`)
-      .then((res) => res.json())
-      .then((envelope) => envelope.data as ZetkinViewFolder[]);
-
-    const ancestors: ZetkinViewFolder[] = [];
-    let nextAncestor = folders.find(
-      (folder) => folder.id == parseInt(fieldValue)
-    );
-    while (nextAncestor) {
-      ancestors.push(nextAncestor);
-      const parent = nextAncestor.parent;
-      nextAncestor = parent
-        ? folders.find((folder) => folder.id == parent.id)
-        : undefined;
-    }
-
-    return ancestors.reverse().map((folder) => ({
-      href: basePath + '/' + folder.id,
-      label: folder.title,
-    }));
+  const element = await fetchElement(
+    basePath,
+    fieldName,
+    fieldValue,
+    orgId,
+    apiFetch
+  );
+  const folders = element?.folderId
+    ? await getFolderStack(element?.folderId, basePath, orgId, apiFetch)
+    : [];
+  if (element) {
+    return [...folders, element];
   } else {
-    const label = await fetchLabel(fieldName, fieldValue, orgId, apiFetch);
-    if (label) {
-      return [
-        {
-          href: basePath + '/' + fieldValue,
-          label: label,
-        },
-      ];
-    } else {
-      return [];
-    }
+    return [];
   }
 }
 
-async function fetchLabel(
+async function fetchElement(
+  basePath: string,
   fieldName: string,
   fieldValue: string,
   orgId: string,
   apiFetch: ApiFetch
-): Promise<string | null> {
+): Promise<null | BreadcrumbElement> {
   if (fieldName === 'orgId') {
     const org = await apiFetch(`/orgs/${orgId}`).then((res) => res.json());
-    return org.data.title;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: org.data.title,
+    };
   }
   if (fieldName === 'personId') {
     const person = await apiFetch(`/orgs/${orgId}/people/${fieldValue}`).then(
       (res) => res.json()
     );
-    return `${person.data.first_name} ${person.data.last_name}`;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: `${person.data.first_name} ${person.data.last_name}`,
+    };
   }
   if (fieldName === 'campId') {
     if (fieldValue == 'standalone') {
@@ -135,54 +125,122 @@ async function fetchLabel(
       const campaign = await apiFetch(
         `/orgs/${orgId}/campaigns/${fieldValue}`
       ).then((res) => res.json());
-      return campaign.data.title;
+      return {
+        href: basePath + '/' + fieldValue,
+        label: campaign.data.title,
+      };
     }
   }
   if (fieldName === 'taskId') {
     const task = await apiFetch(`/orgs/${orgId}/tasks/${fieldValue}`).then(
       (res) => res.json()
     );
-    return task.data.title;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: task.data.title,
+    };
   }
   if (fieldName == 'viewId') {
     const view = await apiFetch(
       `/orgs/${orgId}/people/views/${fieldValue}`
     ).then((res) => res.json());
-    return view.data.title;
+    return {
+      folderId: view.data?.folder?.id,
+      href: basePath + '/' + fieldValue,
+      label: view.data.title,
+    };
   }
   if (fieldName == 'instanceId') {
     const journeyInstance = await apiFetch(
       `/orgs/${orgId}/journey_instances/${fieldValue}`
     ).then((res) => res.json());
-    return `${
-      journeyInstance.data.title || journeyInstance.data.journey.title
-    } #${journeyInstance.data.id}`;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: `${
+        journeyInstance.data.title || journeyInstance.data.journey.title
+      } #${journeyInstance.data.id}`,
+    };
   }
   if (fieldName == 'journeyId') {
     const journey = await apiFetch(
       `/orgs/${orgId}/journeys/${fieldValue}`
     ).then((res) => res.json());
-    return journey.data.plural_label;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: journey.data.plural_label,
+    };
   }
   if (fieldName == 'callAssId') {
     const assignment = await apiFetch(
       `/orgs/${orgId}/call_assignments/${fieldValue}`
     ).then((res) => res.json());
-    return assignment.data.title;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: assignment.data.title,
+    };
   }
   if (fieldName == 'surveyId') {
     const survey = await apiFetch(`/orgs/${orgId}/surveys/${fieldValue}`).then(
       (res) => res.json()
     );
-    return survey.data.title;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: survey.data.title,
+    };
   }
   if (fieldName == 'eventId') {
     const event = await apiFetch(`/orgs/${orgId}/actions/${fieldValue}`).then(
       (res) => res.json()
     );
-    return event.data.title;
+    return {
+      href: basePath + '/' + fieldValue,
+      label: event.data.title,
+    };
   }
-  return fieldValue;
+  if (fieldName == 'folderId') {
+    const folders = await apiFetch(`/orgs/${orgId}/people/view_folders`)
+      .then((res) => res.json())
+      .then((envelope) => envelope.data as ZetkinViewFolder[]);
+
+    const folder = folders.find((folder) => folder.id == parseInt(fieldValue));
+
+    if (folder) {
+      return {
+        folderId: `${folder?.parent?.id}`,
+        href: basePath + '/folders/' + fieldValue,
+        label: folder.title,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function getFolderStack(
+  folderId: string,
+  basePath: string,
+  orgId: string,
+  apiFetch: ApiFetch
+) {
+  const folders = await apiFetch(`/orgs/${orgId}/people/view_folders`)
+    .then((res) => res.json())
+    .then((envelope) => envelope.data as ZetkinViewFolder[]);
+
+  const ancestors: ZetkinViewFolder[] = [];
+  let nextAncestor = folders.find((folder) => folder.id == parseInt(folderId));
+
+  while (nextAncestor) {
+    ancestors.push(nextAncestor);
+    const parent = nextAncestor.parent;
+    nextAncestor = parent
+      ? folders.find((folder) => folder.id == parent.id)
+      : undefined;
+  }
+
+  return ancestors.reverse().map((folder) => ({
+    href: basePath + '/folders/' + folder.id,
+    label: folder.title,
+  }));
 }
 
 const validateQuery = (


### PR DESCRIPTION
## Description
Adds the subfolder ancestors to the breadcrumbs of a view.

Also restructured to treat the call for a folder's breadcrumbs more like calls for the other types'. Could maybe reduce some repetition, but this result seemed simplest.

## Related issues
Resolves #1202 
