### PR TITLE
Handle null locations everywhere

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/icons-material';
 
 import { EventWarningIconsSansModel } from 'features/events/components/EventWarningIcons';
+import LocationLabel from 'features/events/components/LocationLabel';
 import MultiLocationIcon from 'zui/icons/MultiLocation';
 import OverviewListItem from './OverviewListItem';
 import { removeOffset } from 'utils/dateUtils';
@@ -82,7 +83,7 @@ const EventClusterOverviewListItem: FC<EventClusterOverviewListItemProps> = ({
             },
             {
               icon: <PlaceOutlined fontSize="inherit" />,
-              label: location.title,
+              label: <LocationLabel location={location} />,
             },
           ]}
           size="sm"

--- a/src/features/campaigns/components/ActivityList/items/EventClusterListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventClusterListItem.tsx
@@ -8,6 +8,7 @@ import {
 
 import ActivityListItem from './ActivityListItem';
 import { EventWarningIconsSansModel } from 'features/events/components/EventWarningIcons';
+import LocationLabel from 'features/events/components/LocationLabel';
 import MultiLocationIcon from 'zui/icons/MultiLocation';
 import { removeOffset } from 'utils/dateUtils';
 import useEventClusterData from 'features/events/hooks/useEventClusterData';
@@ -77,7 +78,7 @@ const EventClusterListItem: FC<EventListeItemProps> = ({ cluster }) => {
             },
             {
               icon: <PlaceOutlined fontSize="inherit" />,
-              label: location.title,
+              label: <LocationLabel location={location} />,
             },
           ]}
           size="sm"

--- a/src/features/campaigns/hooks/useClusteredActivities.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.ts
@@ -87,7 +87,7 @@ function clusterEvents(eventActivities: EventActivity[]): ClusteredEvent[] {
         }
 
         if (
-          event.location.id == lastClusterEvent.location.id &&
+          event.location?.id == lastClusterEvent.location?.id &&
           event.start_time == lastClusterEvent.end_time
         ) {
           pendingClusters[i] = {
@@ -103,7 +103,7 @@ function clusterEvents(eventActivities: EventActivity[]): ClusteredEvent[] {
         if (
           lastClusterEvent.activity.id == event.activity.id &&
           lastClusterEvent.title == event.title &&
-          lastClusterEvent.location.id == event.location.id &&
+          lastClusterEvent.location?.id == event.location?.id &&
           lastClusterEvent.end_time == event.start_time
         ) {
           pendingClusters[i].events.push(event);

--- a/src/features/events/components/LocationLabel.tsx
+++ b/src/features/events/components/LocationLabel.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react';
+import messageIds from '../l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+interface LocationLabelProps {
+  location: {
+    id: number;
+    lat: number;
+    lng: number;
+    title: string;
+  } | null;
+}
+
+const LocationLabel: FC<LocationLabelProps> = ({ location }) => {
+  const messages = useMessages(messageIds);
+  if (!location) {
+    return <>{messages.common.noLocation()}</>;
+  }
+  return <>{location.title}</>;
+};
+export default LocationLabel;

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -1,6 +1,9 @@
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.events', {
+  common: {
+    noLocation: m('No physical location'),
+  },
   eventOverviewCard: {
     buttonEndDate: m('+ End date'),
     createLocation: m('Create new location'),


### PR DESCRIPTION
## Description
This PR fixes a bug introduced by merging #1227, which allowed `ZetkinEvent.location` to be `null` without handling it everywhere in `main` (which by the time it was merged had introduced more references to `ZetkinEvent.location`).

## Screenshots
None

## Changes
* Adds `LocationLabel` component created by @ziggabyte in his branch, which renders the title of the location if non-null, or a localized "No physical location" string
* Changes all references to `location.title` to use the `LocationLabel` component
* Changes all references to `location.id` to conditional

## Notes to reviewer
None

## Related issues
Undocumented