### PR TITLE
Create event from week calendar

### DIFF
--- a/src/core/api/client/FetchApiClient.ts
+++ b/src/core/api/client/FetchApiClient.ts
@@ -4,7 +4,7 @@ import { RPCDef, RPCRequestBody, RPCResponseBody } from 'core/rpc/types';
 
 function assertOk(res: Response) {
   if (!res.ok) {
-    throw new Error('Error during request');
+    throw new Error(`Error during request: ${res.status}, ${res.url}`);
   }
 }
 

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -1,0 +1,3 @@
+export { default as useApiClient } from './useApiClient';
+export { default as useEnv } from './useEnv';
+export { default as useNumericRouteParams } from './useNumericRouteParams';

--- a/src/core/hooks/useApiClient.ts
+++ b/src/core/hooks/useApiClient.ts
@@ -1,0 +1,5 @@
+import useEnv from './useEnv';
+
+export default function useApiClient() {
+  return useEnv().apiClient;
+}

--- a/src/core/hooks/useEnv.ts
+++ b/src/core/hooks/useEnv.ts
@@ -1,0 +1,11 @@
+import { EnvContext } from 'core/env/EnvContext';
+import { useContext } from 'react';
+
+export default function useEnv() {
+  const env = useContext(EnvContext);
+  if (!env) {
+    throw new Error('EnvContext missing');
+  }
+
+  return env;
+}

--- a/src/core/hooks/useNumericRouteParams.ts
+++ b/src/core/hooks/useNumericRouteParams.ts
@@ -1,0 +1,11 @@
+import { useRouter } from 'next/router';
+
+export default function useNumericRouteParams(): Record<string, number> {
+  const input = useRouter().query;
+  const output: Record<string, number> = {};
+  Object.keys(input).forEach((key: string) => {
+    output[key] = parseInt(input[key] as string);
+  });
+
+  return output;
+}

--- a/src/core/hooks/useNumericRouteParams.ts
+++ b/src/core/hooks/useNumericRouteParams.ts
@@ -4,7 +4,10 @@ export default function useNumericRouteParams(): Record<string, number> {
   const input = useRouter().query;
   const output: Record<string, number> = {};
   Object.keys(input).forEach((key: string) => {
-    output[key] = parseInt(input[key] as string);
+    const value = parseInt(input[key] as string);
+    if (!isNaN(value)) {
+      output[key] = value;
+    }
   });
 
   return output;

--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -1,10 +1,10 @@
-import { Dayjs } from 'dayjs';
+import { FormattedDate } from 'react-intl';
 import { Box, Typography } from '@mui/material';
 
 import theme from 'theme';
 
 export interface DayHeaderProps {
-  date: Dayjs;
+  date: Date;
   focused: boolean;
 }
 
@@ -19,10 +19,7 @@ const DayHeader = ({ date, focused }: DayHeaderProps) => {
       {/* Day string */}
       <Box alignItems="center" display="flex" justifyContent="flex-start">
         <Typography color={theme.palette.grey[500]} variant="subtitle2">
-          {
-            // Localized short-format weeekday
-            date.toDate().toLocaleDateString(undefined, { weekday: 'short' })
-          }
+          <FormattedDate value={date} weekday="short" />
         </Typography>
       </Box>
       {/* Day number */}
@@ -41,7 +38,7 @@ const DayHeader = ({ date, focused }: DayHeaderProps) => {
           }}
         >
           <Typography color={focused ? 'white' : 'inherit'} fontSize="1.2em">
-            {date.format('D')}
+            <FormattedDate day="numeric" value={date} />
           </Typography>
         </Box>
       </Box>

--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -24,7 +24,7 @@ const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
     function handleMouseDown(ev: MouseEvent) {
       const div = ev.currentTarget as HTMLDivElement;
       const rect = div.getBoundingClientRect();
-      startRatio = (ev.clientY - rect.top) / rect.height;
+      startRatio = snapToGrid((ev.clientY - rect.top) / rect.height);
 
       setDragging(true);
 
@@ -37,7 +37,7 @@ const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
       if (div) {
         const rect = div.getBoundingClientRect();
         const dragRatio = (ev.clientY - rect.top) / rect.height;
-        height = dragRatio - startRatio;
+        height = snapToGrid(dragRatio - startRatio);
 
         if (ghostRef.current) {
           ghostRef.current.style.top = startRatio * 100 + '%';
@@ -92,5 +92,9 @@ const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
     </Box>
   );
 };
+
+function snapToGrid(ratio: number, gridSteps: number = 24 * 6) {
+  return Math.round(ratio * gridSteps) / gridSteps;
+}
 
 export default EventDayLane;

--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -4,13 +4,19 @@ import { FC, ReactNode, useEffect, useRef, useState } from 'react';
 type EventDayLaneProps = {
   children?: ReactNode;
   onCreate: (startTime: [number, number], endTime: [number, number]) => void;
+  onDragStart?: () => void;
 };
 
-const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
+const EventDayLane: FC<EventDayLaneProps> = ({
+  children,
+  onCreate,
+  onDragStart,
+}) => {
   const [dragging, setDragging] = useState(false);
   const laneRef = useRef<HTMLDivElement>();
   const ghostRef = useRef<HTMLDivElement>();
   const onCreateRef = useRef(onCreate);
+  const onDragStartRef = useRef(onDragStart);
   const theme = useTheme();
 
   useEffect(() => {
@@ -25,6 +31,10 @@ const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
       const div = ev.currentTarget as HTMLDivElement;
       const rect = div.getBoundingClientRect();
       startRatio = snapToGrid((ev.clientY - rect.top) / rect.height);
+
+      if (onDragStartRef.current) {
+        onDragStartRef.current();
+      }
 
       setDragging(true);
 

--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -1,0 +1,96 @@
+import { Box, useTheme } from '@mui/material';
+import { FC, ReactNode, useEffect, useRef, useState } from 'react';
+
+type EventDayLaneProps = {
+  children?: ReactNode;
+  onCreate: (startTime: [number, number], endTime: [number, number]) => void;
+};
+
+const EventDayLane: FC<EventDayLaneProps> = ({ children, onCreate }) => {
+  const [dragging, setDragging] = useState(false);
+  const laneRef = useRef<HTMLDivElement>();
+  const ghostRef = useRef<HTMLDivElement>();
+  const onCreateRef = useRef(onCreate);
+  const theme = useTheme();
+
+  useEffect(() => {
+    onCreateRef.current = onCreate;
+  }, [onCreate]);
+
+  useEffect(() => {
+    let startRatio = 0;
+    let height = 0;
+
+    function handleMouseDown(ev: MouseEvent) {
+      const div = ev.currentTarget as HTMLDivElement;
+      const rect = div.getBoundingClientRect();
+      startRatio = (ev.clientY - rect.top) / rect.height;
+
+      setDragging(true);
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    }
+
+    function handleMouseMove(ev: MouseEvent) {
+      const div = laneRef.current;
+      if (div) {
+        const rect = div.getBoundingClientRect();
+        const dragRatio = (ev.clientY - rect.top) / rect.height;
+        height = dragRatio - startRatio;
+
+        if (ghostRef.current) {
+          ghostRef.current.style.top = startRatio * 100 + '%';
+          ghostRef.current.style.height = height * 100 + '%';
+        }
+      }
+    }
+
+    function handleMouseUp() {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      setDragging(false);
+
+      if (height > 0) {
+        const startMinutes = Math.round(startRatio * (24 * 60));
+        const endMinutes = startMinutes + Math.round(height * 24 * 60);
+
+        onCreateRef.current(
+          [Math.floor(startMinutes / 60), startMinutes % 60],
+          [Math.floor(endMinutes / 60), endMinutes % 60]
+        );
+      }
+    }
+
+    laneRef.current?.addEventListener('mousedown', handleMouseDown);
+
+    return () => {
+      laneRef.current?.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [laneRef.current]);
+
+  return (
+    <Box ref={laneRef} height="100%" sx={{ position: 'relative' }} width="100%">
+      {children}
+      <Box
+        ref={ghostRef}
+        sx={{
+          backgroundColor: 'white',
+          borderColor: theme.palette.grey['500'],
+          borderRadius: '0.5em',
+          borderStyle: 'solid',
+          borderWidth: 2,
+          boxShadow: '4px 4px 10px rgba(0,0,0,0.2)',
+          left: 0,
+          opacity: dragging ? 0.7 : 0,
+          pointerEvents: 'none',
+          position: 'absolute',
+          right: 0,
+          transition: 'opacity 0.2s',
+        }}
+      />
+    </Box>
+  );
+};
+
+export default EventDayLane;

--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -1,5 +1,7 @@
-import { Box, useTheme } from '@mui/material';
+import { Box } from '@mui/material';
 import { FC, ReactNode, useEffect, useRef, useState } from 'react';
+
+import EventGhost from './EventGhost';
 
 type EventDayLaneProps = {
   children?: ReactNode;
@@ -14,10 +16,9 @@ const EventDayLane: FC<EventDayLaneProps> = ({
 }) => {
   const [dragging, setDragging] = useState(false);
   const laneRef = useRef<HTMLDivElement>();
-  const ghostRef = useRef<HTMLDivElement>();
+  const ghostRef = useRef<HTMLDivElement>(null);
   const onCreateRef = useRef(onCreate);
   const onDragStartRef = useRef(onDragStart);
-  const theme = useTheme();
 
   useEffect(() => {
     onCreateRef.current = onCreate;
@@ -82,23 +83,7 @@ const EventDayLane: FC<EventDayLaneProps> = ({
   return (
     <Box ref={laneRef} height="100%" sx={{ position: 'relative' }} width="100%">
       {children}
-      <Box
-        ref={ghostRef}
-        sx={{
-          backgroundColor: 'white',
-          borderColor: theme.palette.grey['500'],
-          borderRadius: '0.5em',
-          borderStyle: 'solid',
-          borderWidth: 2,
-          boxShadow: '4px 4px 10px rgba(0,0,0,0.2)',
-          left: 0,
-          opacity: dragging ? 0.7 : 0,
-          pointerEvents: 'none',
-          position: 'absolute',
-          right: 0,
-          transition: 'opacity 0.2s',
-        }}
-      />
+      <EventGhost ref={ghostRef} elevated opacity={dragging ? 0.7 : 0} />
     </Box>
   );
 };

--- a/src/features/calendar/components/CalendarWeekView/EventGhost.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventGhost.tsx
@@ -1,0 +1,38 @@
+import { forwardRef } from 'react';
+import { Box, useTheme } from '@mui/material';
+
+type EventGhostProps = {
+  elevated?: boolean;
+  height?: number | string;
+  opacity?: number;
+  y?: number | string;
+};
+
+const EventGhost = forwardRef<HTMLDivElement, EventGhostProps>(
+  function EventGhost({ elevated, height, opacity = 0.7, y }, ref) {
+    const theme = useTheme();
+    return (
+      <Box
+        ref={ref}
+        sx={{
+          backgroundColor: 'white',
+          borderColor: theme.palette.grey['500'],
+          borderRadius: '0.5em',
+          borderStyle: 'solid',
+          borderWidth: 2,
+          boxShadow: elevated ? '4px 4px 10px rgba(0,0,0,0.2)' : undefined,
+          height: height,
+          left: 0,
+          opacity: opacity,
+          pointerEvents: 'none',
+          position: 'absolute',
+          right: 0,
+          top: y,
+          transition: 'opacity 0.2s',
+        }}
+      />
+    );
+  }
+);
+
+export default EventGhost;

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -22,6 +22,10 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
       ? dayjs(focusDate).add(-1, 'day')
       : dayjs(focusDate);
 
+  const dayDates = range(7).map((weekday) => {
+    return focusWeekStartDay.day(weekday + 1).toDate();
+  });
+
   return (
     <Box
       columnGap={1}
@@ -37,15 +41,12 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
         </Typography>
       </Box>
       {/* Day headers across the top */}
-      {range(7).map((weekday: number) => {
-        const weekdayDate = focusWeekStartDay.day(weekday + 1);
+      {dayDates.map((weekdayDate) => {
         return (
           <DayHeader
-            key={weekday}
+            key={weekdayDate.toISOString()}
             date={weekdayDate}
-            focused={
-              new Date().toDateString() == weekdayDate.toDate().toDateString()
-            }
+            focused={new Date().toDateString() == weekdayDate.toDateString()}
           />
         );
       })}
@@ -68,10 +69,10 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
         })}
       </Box>
       {/* Day columns */}
-      {range(7).map((weekday: number) => {
+      {dayDates.map((date) => {
         return (
           <Box
-            key={weekday}
+            key={date.toISOString()}
             flexGrow={1}
             height={`${HOUR_HEIGHT * 24}em`}
             sx={{

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -35,6 +35,7 @@ export interface CalendarWeekViewProps {
 }
 
 const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
+  const [creating, setCreating] = useState(false);
   const [pendingEvent, setPendingEvent] = useState<[Date, Date] | null>(null);
   const [ghostAnchorEl, setGhostAnchorEl] = useState<HTMLDivElement | null>(
     null
@@ -172,7 +173,7 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
                         transition: 'opacity 0.2s',
                       }}
                     />
-                    {ghostAnchorEl && (
+                    {ghostAnchorEl && !creating && (
                       <Menu
                         anchorEl={ghostAnchorEl}
                         anchorOrigin={{
@@ -190,9 +191,15 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
                         }}
                       >
                         <MenuItem
-                          onClick={() => {
+                          onClick={async () => {
+                            setCreating(true);
                             setGhostAnchorEl(null);
-                            createAndNavigate(pendingEvent[0], pendingEvent[1]);
+                            await createAndNavigate(
+                              pendingEvent[0],
+                              pendingEvent[1]
+                            );
+                            setPendingEvent(null);
+                            setCreating(false);
                           }}
                         >
                           <ListItemIcon>

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -15,6 +15,7 @@ import DayHeader from './DayHeader';
 import { Event } from '@mui/icons-material';
 import { eventCreated } from 'features/events/store';
 import EventDayLane from './EventDayLane';
+import EventGhost from './EventGhost';
 import { isSameDate } from 'utils/dateUtils';
 import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
@@ -155,23 +156,10 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
               >
                 {pendingEvent && isSameDate(date, pendingEvent[0]) && (
                   <>
-                    <Box
+                    <EventGhost
                       ref={(div: HTMLDivElement) => setGhostAnchorEl(div)}
-                      sx={{
-                        backgroundColor: 'white',
-                        borderColor: theme.palette.grey['500'],
-                        borderRadius: '0.5em',
-                        borderStyle: 'solid',
-                        borderWidth: 2,
-                        height: pendingHeight * 100 + '%',
-                        left: 0,
-                        opacity: 0.7,
-                        pointerEvents: 'none',
-                        position: 'absolute',
-                        right: 0,
-                        top: pendingTop * 100 + '%',
-                        transition: 'opacity 0.2s',
-                      }}
+                      height={pendingHeight * 100 + '%'}
+                      y={pendingTop * 100 + '%'}
                     />
                     {ghostAnchorEl && !creating && (
                       <Menu

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -1,6 +1,9 @@
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.calendar', {
+  createMenu: {
+    singleEvent: m('Create single event'),
+  },
   moreEvents: m<{ numEvents: number }>(
     '{numEvents, plural, one {# more event} other {# more events}}'
   ),

--- a/src/pages/organize/[orgId]/projects/[campId]/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/calendar/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 
-import Calendar from 'features/calendar/oldComponents';
+import Calendar from 'features/calendar/components';
 import getCampaign from 'features/campaigns/fetching/getCampaign';
 import getCampaignEvents from 'features/campaigns/fetching/getCampaignEvents';
 import getOrg from 'utils/fetching/getOrg';
@@ -92,19 +92,10 @@ const CampaignCalendarPage: PageWithLayout<OrganizeCalendarPageProps> = ({
   campId,
 }) => {
   const messages = useMessages(messageIds);
-  const eventsQuery = useQuery(
-    ['campaignEvents', orgId, campId],
-    getCampaignEvents(orgId, campId)
-  );
   const campaignQuery = useQuery(
     ['campaign', orgId, campId],
     getCampaign(orgId, campId)
   );
-  const tasksQuery = campaignTasksResource(orgId, campId).useQuery();
-
-  const events = eventsQuery.data || [];
-  const tasks = tasksQuery.data || [];
-  const campaigns = campaignQuery.data ? [campaignQuery.data] : [];
 
   return (
     <>
@@ -113,12 +104,7 @@ const CampaignCalendarPage: PageWithLayout<OrganizeCalendarPageProps> = ({
           {`${campaignQuery.data?.title} - ${messages.layout.calendar()}`}
         </title>
       </Head>
-      <Calendar
-        baseHref={`/organize/${orgId}/projects/${campId}/calendar`}
-        campaigns={campaigns}
-        events={events}
-        tasks={tasks}
-      />
+      <Calendar />
     </>
   );
 };


### PR DESCRIPTION
## Description
This PR adds support for creating a single event by dragging in the week calendar view.

## Screenshots
https://user-images.githubusercontent.com/550212/235339975-5d4af1d8-a5f8-47c9-b6e4-fad5c593268b.mov

## Changes
* Adds a new `WeekDayLane` component with support for dragging to "draw" an event
* Refactors `CalendarWeekView` to iterate over dates instead of iterating over arbitrary indices
* Adds support to `CalendarWeekView` to display a pending event and associated menu after drawing in `WeekDayLane`
* Adds reusable hooks `useEnv()`, `useApiClient()` and `useNumericRouteParams()`
* Adds the new calendar component to the per-project calendar pages
* Improves error messages in `FetchApiClient` (includes URL and status)


## Notes to reviewer
None

## Related issues
Resolves #1242 