### PR TITLE
Event header buttons and publish dates

### DIFF
--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -1,0 +1,67 @@
+import { Box } from '@mui/material';
+import { Button } from '@mui/material';
+import React from 'react';
+
+import EventDataModel from '../models/EventDataModel';
+import { useMessages } from 'core/i18n';
+import useModel from 'core/useModel';
+import { ZetkinEvent } from 'utils/types/zetkin';
+import ZUIDateRangePicker from 'zui/ZUIDateRangePicker/ZUIDateRangePicker';
+
+import messageIds from '../l10n/messageIds';
+
+interface EventActionButtonsProps {
+  event: ZetkinEvent;
+}
+
+const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
+  event,
+}) => {
+  const messages = useMessages(messageIds);
+  const eventId = event.id;
+  const orgId = event.organization.id;
+
+  const model = useModel((env) => new EventDataModel(env, orgId, eventId));
+
+  const published =
+    !!event.published && new Date(event.published) <= new Date();
+
+  const handlePublish = () => {
+    model.setPublished(new Date().toISOString());
+  };
+
+  const handleUnpublish = () => {
+    model.setPublished(null);
+  };
+  const handleChangeDates = (
+    startDate: string | null,
+    endDate: string | null
+  ) => {
+    model.setPublishedCancelled(startDate, endDate);
+  };
+
+  return (
+    <Box alignItems="flex-end" display="flex" flexDirection="column" gap={1}>
+      <Box>
+        {published ? (
+          <Button onClick={handleUnpublish} variant="outlined">
+            {messages.eventActionButtons.unpublish()}
+          </Button>
+        ) : (
+          <Button onClick={handlePublish} variant="contained">
+            {messages.eventActionButtons.publish()}
+          </Button>
+        )}
+      </Box>
+      <Box>
+        <ZUIDateRangePicker
+          endDate={event.cancelled}
+          onChange={handleChangeDates}
+          startDate={event.published}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default EventActionButtons;

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -12,6 +12,10 @@ export default makeMessages('feat.events', {
   common: {
     noLocation: m('No physical location'),
   },
+  eventActionButtons: {
+    publish: m('Publish'),
+    unpublish: m('Unpublish'),
+  },
   eventOverviewCard: {
     buttonEndDate: m('+ End date'),
     createLocation: m('Create new location'),

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -4,6 +4,7 @@ import PeopleIcon from '@mui/icons-material/People';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import { useState } from 'react';
 
+import EventActionButtons from '../components/EventActionButtons';
 import EventDataModel from '../models/EventDataModel';
 import EventStatusChip from '../components/EventStatusChip';
 import EventTypeAutocomplete from '../components/EventTypeAutocomplete';
@@ -45,6 +46,13 @@ const EventLayout: React.FC<EventLayoutProps> = ({
 
   return (
     <TabbedLayout
+      actionButtons={
+        <ZUIFuture future={model.getData()}>
+          {(data) => {
+            return <EventActionButtons event={data} />;
+          }}
+        </ZUIFuture>
+      }
       baseHref={`/organize/${orgId}/projects/${campaignId}/events/${eventId}`}
       defaultTab="/"
       subtitle={

--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -56,6 +56,20 @@ export default class EventDataModel extends ModelBase {
     });
   }
 
+  setPublished(published: string | null) {
+    this._repo.updateEvent(this._orgId, this._eventId, {
+      cancelled: null,
+      published: published ? new Date(published).toISOString() : null,
+    });
+  }
+
+  setPublishedCancelled(startDate: string | null, endDate: string | null) {
+    this._repo.updateEvent(this._orgId, this._eventId, {
+      cancelled: endDate ? new Date(endDate).toISOString() : null,
+      published: startDate ? new Date(startDate).toISOString() : null,
+    });
+  }
+
   setReqParticipants(reqParticipants: number) {
     this._repo.updateEvent(this._orgId, this._eventId, {
       num_participants_required: reqParticipants,

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -69,6 +69,7 @@ export interface ZetkinEvent {
     id: number;
     title: string;
   } | null;
+  cancelled: string | null;
   contact?: null | { id: number; name: string };
   end_time: string;
   id: number;
@@ -81,6 +82,7 @@ export interface ZetkinEvent {
   } | null;
   num_participants_required: number;
   num_participants_available: number;
+  published: string | null;
   start_time: string;
   title?: string;
   organization: {


### PR DESCRIPTION
## Description
This PR implements event header buttons and publish dates.


## Screenshots
![bild](https://user-images.githubusercontent.com/14962107/235785318-3d4645c2-b5e7-4554-b519-0357f647ba62.png)

## Changes
* Adds Publish/Unpublish button to Event header
* Adds visible dates using published/cancelled.

## Notes to reviewer
This is not yet done due to the date range being unclear. Right now this uses published and cancelled dates as the start and end times, but it really doesn't make any sense.

## Related issues
Resolves #1162 