### PR TITLE
Issue 1273/ Add correc survey_id value

### DIFF
--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -66,7 +66,8 @@ const SurveyResponseConfig = ({
   };
 
   const makeOptionColumns = (
-    selectedOption: string | SURVEY_QUESTION_OPTIONS
+    selectedOption: string | SURVEY_QUESTION_OPTIONS,
+    surveyId: number
   ) => {
     if (
       selectedQuestion?.type != ELEMENT_TYPE.QUESTION ||
@@ -94,7 +95,7 @@ const SurveyResponseConfig = ({
           return {
             config: {
               option_id: option.id,
-              survey_id: selectedQuestion.id,
+              survey_id: surveyId,
             },
             title: option.text,
             type: COLUMN_TYPE.SURVEY_OPTION,
@@ -111,7 +112,7 @@ const SurveyResponseConfig = ({
           {
             config: {
               option_id: optionSelected.id,
-              survey_id: selectedQuestion.id,
+              survey_id: surveyId,
             },
             title: optionSelected.text,
             type: COLUMN_TYPE.SURVEY_OPTION,
@@ -195,9 +196,14 @@ const SurveyResponseConfig = ({
               <TextField
                 label={messages.columnDialog.choices.surveyResponse.optionsLabel()}
                 onChange={(evt) => {
-                  const columns = makeOptionColumns(evt.target.value);
-                  if (columns !== undefined) {
-                    onOutputConfigured(columns);
+                  if (surveyId) {
+                    const columns = makeOptionColumns(
+                      evt.target.value,
+                      surveyId
+                    );
+                    if (columns !== undefined) {
+                      onOutputConfigured(columns);
+                    }
                   }
                 }}
                 select


### PR DESCRIPTION
## Description
This PR fixes the bug when creating survey responses columns in a view adding the correct survey id value in the POST call.

## Screenshots
![image](https://user-images.githubusercontent.com/36491300/235907302-9dacf77c-e4c3-47ce-ad7d-d7abf0f2dfa0.png)

## Changes
* Adds a new `surveyId `argument in `makeOptionsColumns `function
* Changes the `survey_id ` prop value for the `surveyId `argument instead of `selectedQuestion.id`


## Notes to reviewer
None

## Related issues
Resolves #1273 
