### PR TITLE
Issue-1171/ Add event related card 

### DIFF
--- a/src/features/events/components/EventRelatedCard.tsx
+++ b/src/features/events/components/EventRelatedCard.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+import { Box, Divider } from '@mui/material';
+
+import { EventsModel } from '../models/EventsModel';
+import messageIds from 'features/events/l10n/messageIds';
+import RelatedEventCard from './LocationModal/RelatedEventCard';
+import { useMessages } from 'core/i18n';
+import { ZetkinEvent } from 'utils/types/zetkin';
+import ZUICard from 'zui/ZUICard';
+import ZUIFuture from 'zui/ZUIFuture';
+
+interface EventRelatedCardProps {
+  data: ZetkinEvent;
+  model: EventsModel;
+}
+
+const EventRelatedCard: FC<EventRelatedCardProps> = ({ data, model }) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <Box mt={2}>
+      <ZUICard header={messages.eventRelatedCard.header()}>
+        <Divider />
+        <ZUIFuture
+          future={model.getParallelEvents(data.start_time, data.end_time)}
+        >
+          {(data) => {
+            return (
+              <>
+                {data.map((event) => {
+                  return (
+                    <>
+                      <Divider />
+                      <Box m={1}>
+                        <RelatedEventCard event={event} />
+                      </Box>
+                    </>
+                  );
+                })}
+              </>
+            );
+          }}
+        </ZUIFuture>
+        <Divider />
+      </ZUICard>
+    </Box>
+  );
+};
+
+export default EventRelatedCard;

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -62,6 +62,9 @@ export default makeMessages('feat.events', {
     participantTooltip: m('Make contact person'),
     signUps: m('Sign-ups'),
   },
+  eventRelatedCard: {
+    header: m('Related events'),
+  },
   form: {
     activity: m('Activity'),
     campaign: m('Campaign'),

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -8,6 +8,7 @@ import EventDataModel from 'features/events/models/EventDataModel';
 import EventLayout from 'features/events/layout/EventLayout';
 import EventOverviewCard from 'features/events/components/EventOverviewCard';
 import EventParticipantsCard from 'features/events/components/EventParticipantsCard';
+import EventRelatedCard from 'features/events/components/EventRelatedCard';
 import { EventsModel } from 'features/events/models/EventsModel';
 import LocationsModel from 'features/events/models/LocationsModel';
 import useModel from 'core/useModel';
@@ -77,6 +78,7 @@ const EventPage: PageWithLayout<EventPageProps> = ({
             </Grid>
             <Grid item md={4} xs={6}>
               <EventParticipantsCard campId={campId} model={dataModel} />
+              <EventRelatedCard data={data} model={eventsModel} />
             </Grid>
           </Grid>
         );


### PR DESCRIPTION
## Description
This PR adds a Related Events card on the Overview page. The card shows a list of events that are related to the event they're currently working on.

## Screenshots
![image](https://user-images.githubusercontent.com/36491300/236126507-91d3ab26-a8aa-475b-b887-7dcfac414e99.png)
![image](https://user-images.githubusercontent.com/36491300/236126655-bec6a84b-9912-4a0a-a656-971345127814.png)


## Changes
* Adds `EventRelatedCard `component to overview page

## Notes to reviewer
None


## Related issues
Resolves #1171 
