### PR TITLE
add key in event layout to make the component reload

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -90,6 +90,7 @@ const EventPage: PageWithLayout<EventPageProps> = ({
 EventPage.getLayout = function getLayout(page, props) {
   return (
     <EventLayout
+      key={props.eventId}
       campaignId={props.campId}
       eventId={props.eventId}
       orgId={props.orgId}


### PR DESCRIPTION
## Description
This PR adds a key prop in EventLayout to make the eventLayour reload after clicking the title of a related event.

## Screenshots
https://user-images.githubusercontent.com/36491300/236465993-853378bd-1ecd-4bce-a243-01dee298a5b1.mp4

## Changes
* Adds a key prop to `EventLayout `component

## Notes to reviewer
None


## Related issues
Undocumented
