### PR TITLE
Update UI when sending reminders in eventview

### DIFF
--- a/src/features/events/repo/EventsRepo.ts
+++ b/src/features/events/repo/EventsRepo.ts
@@ -77,10 +77,7 @@ export default class EventsRepo {
   async addParticipant(orgId: number, eventId: number, personId: number) {
     const participant = await this._apiClient.put<ZetkinEventParticipant>(
       `/api/orgs/${orgId}/actions/${eventId}/participants/${personId}`,
-      {
-        id: personId,
-        reminder_sent: null,
-      }
+      {}
     );
     this._store.dispatch(participantAdded([eventId, participant]));
   }

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -189,11 +189,10 @@ const eventsSlice = createSlice({
     participantsReminded: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;
       state.participantsByEventId[eventId].items.map((item) => {
-        if (item.data && item.data?.reminder_sent !== null) {
+        if (item.data && item.data?.reminder_sent == null) {
           item.data = { ...item.data, reminder_sent: new Date().toISOString() };
         }
       });
-      state.participantsByEventId[eventId].isStale = true;
     },
     respondentsLoad: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -193,6 +193,7 @@ const eventsSlice = createSlice({
           item.data = { ...item.data, reminder_sent: new Date().toISOString() };
         }
       });
+      state.participantsByEventId[eventId].isStale = true;
     },
     respondentsLoad: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;


### PR DESCRIPTION
## Description
This PR makes sure that the UI is updated after reminders have been sent out for events

## Changes
* Marks the participant list as stale to force a reload


## Notes to reviewer
Merge this AFTER #1307


## Related issues
Resolves #1306
