### PR TITLE
Contact persons actually gets removed

### DIFF
--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -41,6 +41,14 @@ export default class EventDataModel extends ModelBase {
         status: 'cancelled',
       }
     );
+
+    const contactId = this.getData().data?.contact?.id;
+    if (contactId == personId) {
+      this._repo.updateEvent(this._orgId, this._eventId, {
+        contact_id: null,
+      });
+    }
+
     return new PromiseFuture(promise);
   }
 

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -159,16 +159,6 @@ const eventsSlice = createSlice({
           remoteItem(participant.id, { data: participant })
         );
       }
-
-      if (participant.cancelled) {
-        // If cancelled participant was contact for event, also remove contact
-        const event = state.eventList.items.find(
-          (e) => e?.data?.id === eventId
-        );
-        if (event?.data && event?.data?.contact?.id == participant.id) {
-          event.data.contact = null;
-        }
-      }
     },
     participantsLoad: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;


### PR DESCRIPTION
## Description
This PR fixes a bug; when a contact person was cancelled from the participants tab, it looked like they were removed. When the page was reloaded, though, the contact person was still there.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/42777637/236617510-5010910c-b41f-4dcf-812b-b08d844d79e5.png)

## Changes
* Adds logic in eventDataModel to remove a contact if that person is cancelled.
* Removes outdated logic from the event store
