### PR TITLE
Move events to appropriate active/archive list

### DIFF
--- a/src/features/campaigns/models/CampaignActivitiesModel.ts
+++ b/src/features/campaigns/models/CampaignActivitiesModel.ts
@@ -222,10 +222,10 @@ export default class CampaignActivitiesModel extends ModelBase {
       return new ErrorFuture(activities.error);
     }
 
-    const now = new Date();
+    const nowDate = new getUTCDateWithoutTime(new Date());
     const filtered = activities.data?.filter(
       (activity) =>
-        activity.startDate && activity.endDate && activity.endDate < now
+        activity.startDate && activity.endDate && activity.endDate < nowDate
     );
 
     return new ResolvedFuture(filtered || []);
@@ -260,9 +260,9 @@ export default class CampaignActivitiesModel extends ModelBase {
       return new ErrorFuture(activities.error);
     }
 
-    const now = new Date();
+    const nowDate = new getUTCDateWithoutTime(new Date());
     const filtered = activities.data?.filter(
-      (activity) => !activity.endDate || activity.endDate > now
+      (activity) => !activity.endDate || activity.endDate >= nowDate
     );
 
     return new ResolvedFuture(filtered || []);


### PR DESCRIPTION
## Description
This PR solves the bug where the events ended up in archive too early.

## Changes
- the evens start / stop is checked agains date only, not the whole datetime

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1294
