### PR TITLE
Added tooltip with localised text

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -5,6 +5,7 @@ import {
   Paper,
   Popper,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { Check, Settings } from '@mui/icons-material';
@@ -151,20 +152,34 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({ model }) => {
             <Box display="flex">
               <Typography variant="h4">{`${remindedParticipants}/${availParticipants}`}</Typography>
               {remindedParticipants < availParticipants && (
-                <Button
-                  disabled={contactPerson == null}
-                  onClick={() => {
-                    model.sendReminders();
-                  }}
-                  size="small"
-                  startIcon={<Check />}
-                  sx={{
-                    marginLeft: 2,
-                  }}
-                  variant="outlined"
+                <Tooltip
+                  arrow
+                  placement="top-start"
+                  title={
+                    contactPerson == null
+                      ? messages.participantSummaryCard.remindButtondisabledTooltip()
+                      : ''
+                  }
                 >
-                  <Msg id={messageIds.participantSummaryCard.remindButton} />
-                </Button>
+                  <span>
+                    <Button
+                      disabled={contactPerson == null}
+                      onClick={() => {
+                        model.sendReminders();
+                      }}
+                      size="small"
+                      startIcon={<Check />}
+                      sx={{
+                        marginLeft: 2,
+                      }}
+                      variant="outlined"
+                    >
+                      <Msg
+                        id={messageIds.participantSummaryCard.remindButton}
+                      />
+                    </Button>
+                  </span>
+                </Tooltip>
               )}
             </Box>
           </Box>

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -122,6 +122,9 @@ export default makeMessages('feat.events', {
     header: m('Participants'),
     pending: m('Pending sign-ups'),
     remindButton: m('Remind all'),
+    remindButtondisabledTooltip: m(
+      'You have to assign a contact person before sending reminders'
+    ),
     reqParticipantsHelperText: m('The minimum number of participants required'),
     reqParticipantsLabel: m('Required participants'),
   },


### PR DESCRIPTION
## Description
There should be a tooltip explaining why the "Remind all" button doesn't work when there is no contact person for an event.

## Screenshots
<img width="421" alt="image" src="https://user-images.githubusercontent.com/736169/236621985-9d5b7214-d6f9-4f61-aed6-f692327e0665.png">


## Changes
* Add
* Toottip to deactiveted button
* Add localised text to messageid file

