### PR TITLE
Add navigation in calendar & get date/time scale from query param

### DIFF
--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -6,8 +6,9 @@ import { Box, Typography } from '@mui/material';
 type DayProps = {
   date: Date;
   isInFocusMonth: boolean;
+  onClick: (date: Date) => void;
 };
-const Day = ({ date, isInFocusMonth }: DayProps) => {
+const Day = ({ date, isInFocusMonth, onClick }: DayProps) => {
   const isToday = dayjs(date).isSame(new Date(), 'day');
 
   let textColor = theme.palette.text.secondary;
@@ -26,6 +27,10 @@ const Day = ({ date, isInFocusMonth }: DayProps) => {
       display="flex"
       flexDirection="column"
       height="100%"
+      onClick={() => onClick(date)}
+      sx={{
+        cursor: 'pointer',
+      }}
       width="100%"
     >
       <Box marginLeft="5px">

--- a/src/features/calendar/components/CalendarMonthView/WeekNumber.tsx
+++ b/src/features/calendar/components/CalendarMonthView/WeekNumber.tsx
@@ -2,12 +2,19 @@ import theme from 'theme';
 import { Box, Typography } from '@mui/material';
 
 type CalendarWeekNumberProps = {
+  onClick: () => void;
   weekNr: number;
 };
 
-const WeekNumber = ({ weekNr }: CalendarWeekNumberProps) => {
+const WeekNumber = ({ onClick, weekNr }: CalendarWeekNumberProps) => {
   return (
-    <Box marginTop="2px">
+    <Box
+      marginTop="2px"
+      onClick={() => onClick()}
+      sx={{
+        cursor: 'pointer',
+      }}
+    >
       <Typography
         color={theme.palette.secondary.light}
         fontStyle="bold"

--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -13,9 +13,15 @@ export const numberOfGridColumns = 8;
 
 type CalendarMonthViewProps = {
   focusDate: Date;
+  onClickDay: (date: Date) => void;
+  onClickWeek: (date: Date) => void;
 };
 
-const CalendarMonthView = ({ focusDate }: CalendarMonthViewProps) => {
+const CalendarMonthView = ({
+  focusDate,
+  onClickDay,
+  onClickWeek,
+}: CalendarMonthViewProps) => {
   const firstDayOfMonth: Date = new Date(
     focusDate.getFullYear(),
     focusDate.getMonth(),
@@ -24,6 +30,10 @@ const CalendarMonthView = ({ focusDate }: CalendarMonthViewProps) => {
   const firstDayOfCalendar: Date = dayjs(firstDayOfMonth)
     .subtract(getDaysBeforeFirstDay(firstDayOfMonth), 'day')
     .toDate();
+
+  function onClickWeekHandler(rowIndex: number) {
+    onClickWeek(dayjs(firstDayOfCalendar).add(rowIndex, 'week').toDate());
+  }
 
   return (
     <Box
@@ -45,6 +55,7 @@ const CalendarMonthView = ({ focusDate }: CalendarMonthViewProps) => {
               return (
                 <WeekNumber
                   key={gridItemKey}
+                  onClick={() => onClickWeekHandler(columnIndex)}
                   weekNr={getWeekNumber(firstDayOfCalendar, rowIndex)}
                 />
               );
@@ -63,6 +74,7 @@ const CalendarMonthView = ({ focusDate }: CalendarMonthViewProps) => {
                 key={gridItemKey}
                 date={date}
                 isInFocusMonth={isInFocusMonth}
+                onClick={onClickDay}
               />
             );
           })

--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -6,14 +6,19 @@ import theme from 'theme';
 export interface DayHeaderProps {
   date: Date;
   focused: boolean;
+  onClick: () => void;
 }
 
-const DayHeader = ({ date, focused }: DayHeaderProps) => {
+const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
   return (
     <Box
       display="grid"
       gridTemplateColumns="repeat(3, 1fr)"
       gridTemplateRows="1fr"
+      onClick={() => onClick()}
+      sx={{
+        cursor: 'pointer',
+      }}
       width="100%"
     >
       {/* Day string */}

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -33,9 +33,10 @@ const HOUR_COLUMN_WIDTH = '50px';
 
 export interface CalendarWeekViewProps {
   focusDate: Date;
+  onClickDay: (date: Date) => void;
 }
 
-const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
+const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
   const [creating, setCreating] = useState(false);
   const [pendingEvent, setPendingEvent] = useState<[Date, Date] | null>(null);
   const [ghostAnchorEl, setGhostAnchorEl] = useState<HTMLDivElement | null>(
@@ -68,6 +69,7 @@ const CalendarWeekView = ({ focusDate }: CalendarWeekViewProps) => {
               key={weekday}
               date={weekdayDate}
               focused={new Date().toDateString() == weekdayDate.toDateString()}
+              onClick={() => onClickDay(weekdayDate)}
             />
           );
         })}


### PR DESCRIPTION
## Description
This PR implements navigation in the calendar. You can click a day or week in the month view to go there, and also clicking on days in the week view.
It also uses the query parameters set the focusDate and timeScale, which enables the use of the browser back/forward buttons.


## Screenshots
[calendar_nav.webm](https://user-images.githubusercontent.com/1464855/236632216-61b17d20-8d5a-4442-a379-802d3506db94.webm)


## Changes

* Adds navigation to calendar
* Adds query-parameters for focus date and time scale


## Related issues
Resolves #1297 
