### PR TITLE
Issue 1299/add breadcrumbs to no title events

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -182,7 +182,7 @@ async function fetchElements(
     return [
       {
         href: basePath + '/' + fieldValue,
-        label: event.data.title,
+        label: event.data.title || event.data.activity.title,
       },
     ];
   } else if (fieldName == 'folderId') {


### PR DESCRIPTION
## Description
This PR adds the event activity title as breadcrumbs when the event doesn't have set a custom title.


## Screenshots
![image](https://user-images.githubusercontent.com/36491300/236861160-424a858e-b41c-49a3-8a02-e1d26243a920.png)


## Changes
* Adds the `event.data.activity.title` to be displayed when the event doesn't have a custom title setted.


## Notes to reviewer
This PR contains other commits made by a volunteer because I checkout from his opened branch.


## Related issues
Resolves #1299 
