### PR TITLE
Clustering in month view

### DIFF
--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -3,12 +3,16 @@ import { FormattedDate } from 'react-intl';
 import theme from 'theme';
 import { Box, Typography } from '@mui/material';
 
+import { AnyClusteredEvent } from 'features/calendar/utils/clusterEventsForWeekCalender';
+
 type DayProps = {
+  clusters: AnyClusteredEvent[];
   date: Date;
   isInFocusMonth: boolean;
   onClick: (date: Date) => void;
 };
-const Day = ({ date, isInFocusMonth, onClick }: DayProps) => {
+
+const Day = ({ clusters, date, isInFocusMonth, onClick }: DayProps) => {
   const isToday = dayjs(date).isSame(new Date(), 'day');
 
   let textColor = theme.palette.text.secondary;
@@ -20,24 +24,42 @@ const Day = ({ date, isInFocusMonth, onClick }: DayProps) => {
 
   return (
     <Box
-      alignItems="start"
+      alignItems="stretch"
       bgcolor={isInFocusMonth ? '#eee' : 'none'}
       border="2px solid #eeeeee"
       borderColor={isToday ? theme.palette.primary.main : 'eee'}
       display="flex"
       flexDirection="column"
       height="100%"
-      onClick={() => onClick(date)}
-      sx={{
-        cursor: 'pointer',
-      }}
       width="100%"
     >
       <Box marginLeft="5px">
-        <Typography color={textColor} variant="body2">
+        <Typography
+          color={textColor}
+          onClick={() => onClick(date)}
+          sx={{
+            cursor: 'pointer',
+          }}
+          variant="body2"
+        >
           <FormattedDate day="numeric" value={date} />
         </Typography>
       </Box>
+      {clusters.map((cluster, index) => {
+        return (
+          <Box
+            key={index}
+            sx={{
+              // TODO: Replace this with real component
+              backgroundColor: 'white',
+              height: '20px',
+              margin: '1px',
+            }}
+          >
+            {cluster.kind} ({cluster.events.length})
+          </Box>
+        );
+      })}
     </Box>
   );
 };

--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -31,6 +31,9 @@ const Day = ({ clusters, date, isInFocusMonth, onClick }: DayProps) => {
       display="flex"
       flexDirection="column"
       height="100%"
+      sx={{
+        overflowY: 'hidden',
+      }}
       width="100%"
     >
       <Box marginLeft="5px">

--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import Day from './Day';
 import dayjs from 'dayjs';
 import range from 'utils/range';
+import useMonthCalendarEvents from 'features/calendar/hooks/useMonthCalendarEvents';
+import { useNumericRouteParams } from 'core/hooks';
 import WeekNumber from './WeekNumber';
 import { getDaysBeforeFirstDay, getWeekNumber } from './utils';
 
@@ -34,6 +36,17 @@ const CalendarMonthView = ({
   function onClickWeekHandler(rowIndex: number) {
     onClickWeek(dayjs(firstDayOfCalendar).add(rowIndex, 'week').toDate());
   }
+  const lastDayOfCalendar = new Date(firstDayOfCalendar);
+  lastDayOfCalendar.setDate(lastDayOfCalendar.getDate() + 6 * 7);
+
+  const { orgId, campId } = useNumericRouteParams();
+  const clustersByDate = useMonthCalendarEvents({
+    campaignId: campId,
+    endDate: lastDayOfCalendar,
+    maxPerDay: 5, // TODO: Don't hard-code this
+    orgId,
+    startDate: firstDayOfCalendar,
+  });
 
   return (
     <Box
@@ -67,11 +80,14 @@ const CalendarMonthView = ({
               .add(dayIndex, 'day')
               .toDate();
 
+            const clusters = clustersByDate[dayIndex].clusters;
+
             const isInFocusMonth = date.getMonth() === focusDate.getMonth();
 
             return (
               <Day
                 key={gridItemKey}
+                clusters={clusters}
                 date={date}
                 isInFocusMonth={isInFocusMonth}
                 onClick={onClickDay}

--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import Day from './Day';
 import dayjs from 'dayjs';
@@ -9,9 +9,10 @@ import { useNumericRouteParams } from 'core/hooks';
 import WeekNumber from './WeekNumber';
 import { getDaysBeforeFirstDay, getWeekNumber } from './utils';
 
-export const numberOfRows = 6;
-export const numberOfDayColumns = 7;
-export const numberOfGridColumns = 8;
+const gridGap = 8;
+const numberOfRows = 6;
+const numberOfDayColumns = 7;
+const numberOfGridColumns = 8;
 
 type CalendarMonthViewProps = {
   focusDate: Date;
@@ -24,6 +25,8 @@ const CalendarMonthView = ({
   onClickDay,
   onClickWeek,
 }: CalendarMonthViewProps) => {
+  const { gridRef, maxPerDay } = useFlexibleMaxPerDay();
+
   const firstDayOfMonth: Date = new Date(
     focusDate.getFullYear(),
     focusDate.getMonth(),
@@ -43,18 +46,20 @@ const CalendarMonthView = ({
   const clustersByDate = useMonthCalendarEvents({
     campaignId: campId,
     endDate: lastDayOfCalendar,
-    maxPerDay: 5, // TODO: Don't hard-code this
+    maxPerDay,
     orgId,
     startDate: firstDayOfCalendar,
   });
 
   return (
     <Box
+      ref={gridRef}
       display="grid"
-      flexGrow="1"
-      gap="8px"
+      flexGrow="0"
+      gap={`${gridGap}px`}
       gridTemplateColumns={`auto repeat(${numberOfDayColumns}, 1fr)`}
       gridTemplateRows={`repeat(${numberOfRows}, 1fr)`}
+      height="100%"
     >
       {
         // Creates 6 rows
@@ -101,3 +106,35 @@ const CalendarMonthView = ({
 };
 
 export default CalendarMonthView;
+
+/**
+ * Calculate the maximum number of event clusters that can be displayed
+ * in a day without overflowing the grid.
+ */
+function useFlexibleMaxPerDay() {
+  const gridRef = useRef<HTMLDivElement>();
+  const [maxPerDay, setMaxPerDay] = useState(3);
+
+  useEffect(() => {
+    function update() {
+      if (gridRef.current) {
+        const rect = gridRef.current.getBoundingClientRect();
+        const heightWithoutGaps = rect.height - gridGap * 5;
+        const dayHeight = heightWithoutGaps / 6;
+        const newMaxPerDay = Math.floor(dayHeight / 22) - 1;
+        setMaxPerDay(newMaxPerDay);
+      }
+    }
+
+    update();
+
+    const observer = new ResizeObserver(update);
+    if (gridRef.current) {
+      observer.observe(gridRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [gridRef.current]);
+
+  return { gridRef, maxPerDay };
+}

--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -1,0 +1,83 @@
+import { AnyClusteredEvent } from '../utils/clusterEventsForWeekCalender';
+import { isSameDate } from 'utils/dateUtils';
+import useModel from 'core/useModel';
+import CampaignActivitiesModel, {
+  ACTIVITIES,
+  EventActivity,
+} from 'features/campaigns/models/CampaignActivitiesModel';
+import {
+  CLUSTER_TYPE,
+  clusterEvents,
+} from 'features/campaigns/hooks/useClusteredActivities';
+
+type UseMonthCalendarEventsParams = {
+  campaignId?: number;
+  endDate: Date;
+  maxPerDay: number;
+  orgId: number;
+  startDate: Date;
+};
+
+type UseMonthCalendarEventsReturn = {
+  clusters: AnyClusteredEvent[];
+  date: Date;
+}[];
+
+export default function useMonthCalendarEvents({
+  campaignId,
+  endDate,
+  maxPerDay,
+  orgId,
+
+  startDate,
+}: UseMonthCalendarEventsParams): UseMonthCalendarEventsReturn {
+  const model = useModel((env) => new CampaignActivitiesModel(env, orgId));
+
+  // TODO: Load only the ones necessary here
+  const activities = model.getAllActivities(campaignId);
+  const eventActivities = (activities.data?.filter(
+    (activity) => activity.kind == ACTIVITIES.EVENT
+  ) ?? []) as EventActivity[];
+
+  const dates: UseMonthCalendarEventsReturn = [];
+
+  const curDate = new Date(startDate);
+  while (curDate.getTime() <= endDate.getTime()) {
+    const relevantActivities = eventActivities.filter((activity) => {
+      const startTime = new Date(activity.data.start_time);
+      const endTime = new Date(activity.data.end_time);
+
+      return isSameDate(startTime, curDate) && isSameDate(endTime, curDate);
+    });
+
+    const clusters: AnyClusteredEvent[] = [
+      ...clusterEvents(relevantActivities),
+    ];
+
+    // If the number of clusters N is bigger than the maximum number M
+    // allowed per day, take the last N-M clusters and squash them into a
+    // single big arbitrary cluster at the end.
+    while (clusters.length > maxPerDay) {
+      const clusterToRemove = clusters.pop();
+      const clusterToReplace = clusters.pop();
+
+      // Merge the two and push back onto array as arbitrary cluster
+      clusters.push({
+        events: [
+          ...(clusterToReplace?.events ?? []),
+          ...(clusterToRemove?.events ?? []),
+        ],
+        kind: CLUSTER_TYPE.ARBITRARY,
+      });
+    }
+
+    dates.push({
+      clusters,
+      date: curDate,
+    });
+
+    curDate.setDate(curDate.getDate() + 1);
+  }
+
+  return dates;
+}


### PR DESCRIPTION
## Description
This PR renders events (using temporary components) in the calendar month view. Depending on how big the view is, a varying number of events will be rendered.

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/550212/6beaa3df-0919-4b10-b2be-9c4ef0fc9af2

## Changes
* Adds a new hook, `useMonthCalendarEvents()` which clusters correctly for month view
* Implements the hook and rendering of temporary components in the month view
* Adds logic to update the number of events displayed per day when the calendar resizes

## Notes to reviewer
The event components are temporary, while waiting for #1238 to finish.

## Related issues
Resolves #1240 