### PR TITLE
Fix timezone issues by removing offset of times when displaying them

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -5,6 +5,7 @@ import { People, PlaceOutlined, Schedule } from '@mui/icons-material';
 import EventDataModel from 'features/events/models/EventDataModel';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import messageIds from 'features/events/l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import theme from 'theme';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
@@ -50,14 +51,14 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
               hour="numeric"
               hour12={false}
               minute="numeric"
-              value={event.start_time}
+              value={removeOffset(event.start_time)}
             />
             &nbsp;-&nbsp;
             <FormattedTime
               hour="numeric"
               hour12={false}
               minute="numeric"
-              value={event.end_time}
+              value={removeOffset(event.end_time)}
             />
           </Box>
         </Typography>

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -10,6 +10,7 @@ import EventDataModel from 'features/events/models/EventDataModel';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import messageIds from 'features/events/l10n/messageIds';
 import OverviewListItem from './OverviewListItem';
+import { removeOffset } from 'utils/dateUtils';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -55,8 +56,8 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
               icon: <ScheduleOutlined fontSize="inherit" />,
               label: (
                 <ZUITimeSpan
-                  end={new Date(event.end_time)}
-                  start={new Date(event.start_time)}
+                  end={new Date(removeOffset(event.end_time))}
+                  start={new Date(removeOffset(event.start_time))}
                 />
               ),
             },

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -9,6 +9,7 @@ import {
 import ActivityListItem from './ActivityListItem';
 import { ClusteredEvent } from 'features/campaigns/hooks/useClusteredActivities';
 import { EventWarningIconsSansModel } from 'features/events/components/EventWarningIcons';
+import { removeOffset } from 'utils/dateUtils';
 import useEventClusterData from 'features/events/hooks/useEventClusterData';
 import { useEventPopper } from 'features/events/components/EventPopper/EventPopperProvider';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
@@ -70,8 +71,8 @@ const EventListItem: FC<EventListeItemProps> = ({ cluster }) => {
               icon: <ScheduleOutlined fontSize="inherit" />,
               label: (
                 <ZUITimeSpan
-                  end={new Date(endTime)}
-                  start={new Date(startTime)}
+                  end={new Date(removeOffset(endTime))}
+                  start={new Date(removeOffset(startTime))}
                 />
               ),
             },

--- a/src/features/events/components/EventPopper/MultiEventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/SingleEvent.tsx
@@ -17,6 +17,7 @@ import { FC, useContext } from 'react';
 import LocationName from '../../LocationName';
 import messageIds from 'features/events/l10n/messageIds';
 import Quota from '../Quota';
+import { removeOffset } from 'utils/dateUtils';
 import StatusDot from '../StatusDot';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -185,8 +186,8 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         </Box>
         <Typography color="secondary" variant="body2">
           <ZUITimeSpan
-            end={new Date(event.end_time)}
-            start={new Date(event.start_time)}
+            end={new Date(removeOffset(event.end_time))}
+            start={new Date(removeOffset(event.start_time))}
           />
         </Typography>
       </Box>

--- a/src/features/events/components/RelatedEvent.tsx
+++ b/src/features/events/components/RelatedEvent.tsx
@@ -4,6 +4,8 @@ import { Box, Link, Typography } from '@mui/material';
 
 import { getParticipantsStatusColor } from 'features/events/utils/eventUtils';
 import messageIds from '../l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
+
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUINumberChip from 'zui/ZUINumberChip';
@@ -44,8 +46,8 @@ const RelatedEvent: FC<RelatedEventProps> = ({ event }) => {
       </Box>
       <Typography color="secondary">
         <ZUITimeSpan
-          end={new Date(event.end_time)}
-          start={new Date(event.start_time)}
+          end={new Date(removeOffset(event.end_time))}
+          start={new Date(removeOffset(event.start_time))}
         />
       </Typography>
     </Box>

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -10,6 +10,7 @@ import EventStatusChip from '../components/EventStatusChip';
 import EventTypeAutocomplete from '../components/EventTypeAutocomplete';
 import EventTypesModel from '../models/EventTypesModel';
 import messageIds from '../l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import useModel from 'core/useModel';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -90,9 +91,8 @@ const EventLayout: React.FC<EventLayoutProps> = ({
           <Box marginX={1}>
             <ZUIFuture future={model.getData()}>
               {(data) => {
-                const startDate = new Date(data.start_time);
-
-                const endDate = new Date(data.end_time);
+                const startDate = new Date(removeOffset(data.start_time));
+                const endDate = new Date(removeOffset(data.end_time));
 
                 const labels: ZUIIconLabelProps[] = [];
 


### PR DESCRIPTION
## Description
This PR fixes the wrong display of time zones by removing the offset after received the data from the API.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/6e32f4c8-2d6b-461e-b960-84009e33d90f)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/fa1fdb02-7bf7-45a7-a9ae-bc0ababf808c)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/e42954da-73f0-4200-b2bc-28c4af9b7bb6)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/0847d019-7577-4a4a-9725-308b91c3eb03)



## Changes
* Adds `removeOffset() `function in all the places that we need to display the event start date or end date to show it with the right values.



## Notes to reviewer
Right now we are ignoring the time zones and just displaying the same time that we have saved in the event. 
We will need to implement a global solution to handle different time zones in the future.

## Related issues
Resolves #1326 
