### PR TITLE
Add link to public campaign page to ellipsis in project action buttons

### DIFF
--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -1,6 +1,6 @@
-import { Alert, Link } from '@mui/material';
 import { Box } from '@mui/material';
 import { useRouter } from 'next/router';
+import { Alert, Link } from '@mui/material';
 import {
   AssignmentOutlined,
   CheckBoxOutlined,
@@ -204,7 +204,9 @@ const CampaignActionButtons: React.FunctionComponent<
                   </Link>
                 </>
               ),
-              onSelect: () => {},
+              onSelect: () => {
+                // Do nothing, but without this, the menu will not close
+              },
             },
           ]}
         />

--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@mui/material';
+import { Alert, Link } from '@mui/material';
 import { Box } from '@mui/material';
 import { useRouter } from 'next/router';
 import {
@@ -7,6 +7,7 @@ import {
   Delete,
   Event,
   HeadsetMic,
+  OpenInNew,
   Settings,
 } from '@mui/icons-material';
 import React, { useContext, useState } from 'react';
@@ -32,6 +33,7 @@ import messageIds from '../l10n/messageIds';
 enum CAMPAIGN_MENU_ITEMS {
   EDIT_CAMPAIGN = 'editCampaign',
   DELETE_CAMPAIGN = 'deleteCampaign',
+  SHOW_PUBLIC_PAGE = 'showPublicPage',
 }
 
 interface CampaignActionButtonsProps {
@@ -182,6 +184,27 @@ const CampaignActionButtons: React.FunctionComponent<
                   warningText: messages.form.deleteCampaign.warning(),
                 });
               },
+            },
+            {
+              id: CAMPAIGN_MENU_ITEMS.SHOW_PUBLIC_PAGE,
+              label: (
+                <>
+                  <Box mr={1}>
+                    <OpenInNew />
+                  </Box>
+                  <Link
+                    color="inherit"
+                    display="flex"
+                    href={`https://www.zetk.in/o/${orgId}/campaigns/${campaign.id}`}
+                    sx={{ alignItems: 'center', gap: 1 }}
+                    target="_blank"
+                    underline="none"
+                  >
+                    {<Msg id={messageIds.singleProject.showPublicPage} />}
+                  </Link>
+                </>
+              ),
+              onSelect: () => {},
             },
           ]}
         />

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -142,6 +142,7 @@ export default makeMessages('feat.campaigns', {
     filterActivities: m('Type to filter'),
     noActivities: m('There are no activities in this project yet.'),
     noSearchResults: m('Your filtering yielded no results.'),
+    showPublicPage: m('Show public sign-up page'),
     viewArchive: m('View archive'),
   },
   taskLayout: {


### PR DESCRIPTION
## Description
This PR adds link to public campaign page to the project page.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/14962107/31133e76-a068-4321-bfd0-19b44c3091ff)


## Changes
* Adds external link to campaign project page.

## Notes to reviewer

## Related issues
Resolves #1331 
