### PR TITLE
Issue 1333/display all day

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -5,6 +5,7 @@ import { People, PlaceOutlined, Schedule } from '@mui/icons-material';
 import EventDataModel from 'features/events/models/EventDataModel';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import messageIds from 'features/events/l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import theme from 'theme';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
@@ -18,6 +19,23 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
 
   const needsParticipants =
     event.num_participants_required > event.num_participants_available;
+
+  function isAllDay(event: ZetkinEvent): boolean {
+    const startDate = new Date(removeOffset(event.start_time));
+    const endDate = new Date(removeOffset(event.end_time));
+
+    // Check if the start and end dates are not on the same day
+    if (startDate.toDateString() !== endDate.toDateString()) {
+      // If start time and end time are 00:00:00 return true
+      if (
+        startDate.toString().split(' ')[4] == '00:00:00' &&
+        endDate.toString().split(' ')[4] == '00:00:00'
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   return (
     <Box
@@ -39,6 +57,7 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
           }}
         />
         {/* Title */}
+
         <Typography>
           {event.title || event.activity?.title || messages.common.noTitle()}
         </Typography>
@@ -46,19 +65,26 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
         <Typography color={theme.palette.secondary.main} component={'div'}>
           <Box alignItems="center" display="flex" gap={0.5}>
             <Schedule />
-            <FormattedTime
-              hour="numeric"
-              hour12={false}
-              minute="numeric"
-              value={event.start_time}
-            />
-            &nbsp;-&nbsp;
-            <FormattedTime
-              hour="numeric"
-              hour12={false}
-              minute="numeric"
-              value={event.end_time}
-            />
+            {isAllDay(event) && (
+              <Typography key={event.id}>{messages.common.allDay()}</Typography>
+            )}
+            {!isAllDay(event) && (
+              <>
+                <FormattedTime
+                  hour="numeric"
+                  hour12={false}
+                  minute="numeric"
+                  value={event.start_time}
+                />
+                &nbsp;-&nbsp;
+                <FormattedTime
+                  hour="numeric"
+                  hour12={false}
+                  minute="numeric"
+                  value={event.end_time}
+                />
+              </>
+            )}
           </Box>
         </Typography>
         {/* Location */}

--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -74,14 +74,14 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
                   hour="numeric"
                   hour12={false}
                   minute="numeric"
-                  value={event.start_time}
+                  value={removeOffset(event.start_time)}
                 />
                 &nbsp;-&nbsp;
                 <FormattedTime
                   hour="numeric"
                   hour12={false}
                   minute="numeric"
-                  value={event.end_time}
+                  value={removeOffset(event.end_time)}
                 />
               </>
             )}

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -10,6 +10,7 @@ export default makeMessages('feat.events', {
     },
   },
   common: {
+    allDay: m('All day'),
     noActivity: m('Uncategorized'),
     noLocation: m('No physical location'),
     noTitle: m('Untitled event'),

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -179,11 +179,11 @@ async function fetchElements(
     const event = await apiFetch(`/orgs/${orgId}/actions/${fieldValue}`).then(
       (res) => res.json()
     );
-    if (event.title || event.activity?.title) {
+    if (event.data.title || event.data.activity?.title) {
       return [
         {
           href: basePath + '/' + fieldValue,
-          label: event.title || event.activity?.title,
+          label: event.data.title || event.data.activity?.title,
         },
       ];
     } else {


### PR DESCRIPTION
## Description
This PR adds the localized string "All day" in the calendar day view when the event is running all day instead of display 24-24h.
I also fixes a breadcrumbs bug to display the custom title event or the activity title event (when custom title doesn't exists).


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/7649f844-8ec4-4e34-a8c8-8785a687b246)
Event:
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/f564a239-b42d-40f2-92b9-bdddfee28a44)
Breadcrumbs:
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/e43127d6-4a11-498b-b2f1-d690843938b7)


## Changes
* Adds isAllDay() function to check if event should display "all day" string
* Adds a Typography component to display "all day" when isAllDay() returns true.
* Changes the use of the object "event.title" and "event.activity.title" for "event.data.xxxx" in breadcrumbs file.


## Notes to reviewer
The header of the event displays the wrong times but that is fixed in another PR #1332 


## Related issues
Resolves #1333 
