### PR TITLE
Integrate event filtering

### DIFF
--- a/src/core/caching/shouldLoad.ts
+++ b/src/core/caching/shouldLoad.ts
@@ -1,5 +1,7 @@
 import { RemoteItem, RemoteList } from 'utils/storeUtils';
 
+const DEFAULT_TTL = 5 * 60 * 1000; // 5 minutes
+
 export default function shouldLoad(
   item: RemoteItem<unknown> | RemoteList<unknown> | undefined
 ): boolean {
@@ -20,7 +22,7 @@ export default function shouldLoad(
   } else {
     const loadDate = new Date(item.loaded);
     const age = new Date().getTime() - loadDate.getTime();
-    if (age > 60000) {
+    if (age > DEFAULT_TTL) {
       return true;
     }
   }

--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -1,5 +1,6 @@
 import { AnyClusteredEvent } from '../utils/clusterEventsForWeekCalender';
 import { isSameDate } from 'utils/dateUtils';
+import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
 import useModel from 'core/useModel';
 import CampaignActivitiesModel, {
   ACTIVITIES,
@@ -39,11 +40,14 @@ export default function useMonthCalendarEvents({
     (activity) => activity.kind == ACTIVITIES.EVENT
   ) ?? []) as EventActivity[];
 
+  // Filter events based on user filters
+  const filteredActivities = useFilteredEventActivities(eventActivities);
+
   const dates: UseMonthCalendarEventsReturn = [];
 
   const curDate = new Date(startDate);
   while (curDate.getTime() <= endDate.getTime()) {
-    const relevantActivities = eventActivities.filter((activity) => {
+    const relevantActivities = filteredActivities.filter((activity) => {
       const startTime = new Date(activity.data.start_time);
       const endTime = new Date(activity.data.end_time);
 

--- a/src/features/calendar/hooks/useWeekCalendarEvents.ts
+++ b/src/features/calendar/hooks/useWeekCalendarEvents.ts
@@ -2,6 +2,7 @@ import { ACTIVITIES } from 'features/campaigns/models/CampaignActivitiesModel';
 import CampaignActivitiesModel from 'features/campaigns/models/CampaignActivitiesModel';
 import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
 import { isSameDate } from 'utils/dateUtils';
+import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
 import useModel from 'core/useModel';
 import clusterEventsForWeekCalender, {
   AnyClusteredEvent,
@@ -31,8 +32,10 @@ export default function useWeekCalendarEvents({
     (activity) => activity.kind == ACTIVITIES.EVENT
   ) ?? []) as EventActivity[];
 
+  const filteredActivities = useFilteredEventActivities(eventActivities);
+
   return dates.map((date) => {
-    const relevantActivities = eventActivities.filter((activity) =>
+    const relevantActivities = filteredActivities.filter((activity) =>
       isSameDate(new Date(activity.data.start_time), date)
     );
 

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -27,7 +27,7 @@ export default makeMessages('feat.calendar', {
   eventFilter: {
     collapse: m('Collapse'),
     expand: m<{ numOfOptions: number }>(
-      '{numOfOptions, plural, one {+ 1 more project activity types} other {+ # more project activity types}}'
+      '{numOfOptions, plural, one {+ 1 more event type} other {+ # more event types}}'
     ),
     filter: m('Filter'),
     filterOptions: {

--- a/src/features/events/hooks/useFilteredEventActivities.ts
+++ b/src/features/events/hooks/useFilteredEventActivities.ts
@@ -1,0 +1,143 @@
+import Fuse from 'fuse.js';
+import { useSelector } from 'react-redux';
+
+import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
+import { EventState } from '../models/EventDataModel';
+import getEventState from '../utils/getEventState';
+import { RootState } from 'core/store';
+import { ACTION_FILTER_OPTIONS, STATE_FILTER_OPTIONS } from '../store';
+
+export default function useFilteredEventActivities(
+  input: EventActivity[]
+): EventActivity[] {
+  const filterState = useSelector((state: RootState) => state.events.filters);
+  const statsByEventId = useSelector(
+    (state: RootState) => state.events.statsByEventId
+  );
+
+  const filtered = input.filter((activity) => {
+    const event = activity.data;
+
+    if (filterState.selectedTypes.length) {
+      if (
+        !event.activity ||
+        !filterState.selectedTypes.includes(event.activity.id.toString())
+      ) {
+        return false;
+      }
+    }
+
+    if (filterState.selectedStates.length) {
+      const state = getEventState(event);
+
+      if (
+        state == EventState.CANCELLED &&
+        !filterState.selectedStates.includes(STATE_FILTER_OPTIONS.CANCELLED)
+      ) {
+        return false;
+      }
+
+      if (
+        state == EventState.DRAFT &&
+        !filterState.selectedStates.includes(STATE_FILTER_OPTIONS.DRAFT)
+      ) {
+        return false;
+      }
+
+      if (
+        (state == EventState.OPEN || state == EventState.ENDED) &&
+        !filterState.selectedStates.includes(STATE_FILTER_OPTIONS.PUBLISHED)
+      ) {
+        return false;
+      }
+
+      if (
+        state == EventState.SCHEDULED &&
+        !filterState.selectedStates.includes(STATE_FILTER_OPTIONS.SCHEDULED)
+      ) {
+        return false;
+      }
+    }
+
+    if (filterState.selectedActions.length) {
+      if (
+        filterState.selectedActions.includes(
+          ACTION_FILTER_OPTIONS.CONTACT_MISSING
+        ) &&
+        !!event.contact
+      ) {
+        return false;
+      }
+
+      if (
+        filterState.selectedActions.includes(
+          ACTION_FILTER_OPTIONS.OVERBOOKED
+        ) &&
+        event.num_participants_available < event.num_participants_required * 2
+      ) {
+        return false;
+      }
+
+      const stats = statsByEventId[event.id]?.data;
+      if (
+        filterState.selectedActions.includes(
+          ACTION_FILTER_OPTIONS.SIGNUPS_PENDING
+        ) &&
+        !stats?.numPending
+      ) {
+        return false;
+      }
+
+      if (
+        !stats ||
+        (filterState.selectedActions.includes(
+          ACTION_FILTER_OPTIONS.UNDERBOOKED
+        ) &&
+          stats.numBooked >= event.num_participants_required)
+      ) {
+        return false;
+      }
+
+      if (
+        !stats ||
+        (filterState.selectedActions.includes(
+          ACTION_FILTER_OPTIONS.UNSENT_NOTIFICATIONS
+        ) &&
+          stats.numReminded != stats.numBooked)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  // If there's a free text filter, fuzzy search the remaining matches
+  const searchText = filterState.text.trim();
+  if (searchText.length > 2) {
+    const fuse = new Fuse(filtered, {
+      keys: [
+        'data.title',
+        'data.activity.title',
+        'data.location.title',
+        'data.campaign.title',
+      ],
+      threshold: 0.2,
+    });
+    const tokens = filterState.text.split(/\s/);
+    return fuse
+      .search({
+        $and: tokens.map((token) => ({
+          $or: [
+            { $path: ['data', 'title'], $val: token },
+            { $path: ['data', 'activity', 'title'], $val: token },
+            { $path: ['data', 'location', 'title'], $val: token },
+            { $path: ['data', 'campaign', 'title'], $val: token },
+          ],
+        })),
+      })
+      .map((result) => result.item);
+  }
+
+  return filtered;
+}

--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -1,4 +1,5 @@
 import Environment from 'core/env/Environment';
+import getEventState from '../utils/getEventState';
 import { ModelBase } from 'core/models';
 import theme from 'theme';
 import EventsRepo, {
@@ -251,31 +252,7 @@ export default class EventDataModel extends ModelBase {
       return EventState.UNKNOWN;
     }
 
-    if (!data.published && data.cancelled) {
-      return EventState.CANCELLED;
-    }
-    const now = new Date();
-    if (data.published) {
-      const published = new Date(data.published);
-      if (published > now) {
-        return EventState.SCHEDULED;
-      }
-      if (data.cancelled) {
-        const cancelled = new Date(data.cancelled);
-        if (cancelled > published) {
-          return EventState.CANCELLED;
-        }
-      }
-      if (data.end_time) {
-        const endTime = new Date(data.end_time);
-        if (endTime < now) {
-          return EventState.ENDED;
-        }
-      }
-      return EventState.OPEN;
-    } else {
-      return EventState.DRAFT;
-    }
+    return getEventState(data);
   }
 
   updateEventData(eventData: ZetkinEventPatchBody) {

--- a/src/features/events/utils/getEventState.ts
+++ b/src/features/events/utils/getEventState.ts
@@ -1,0 +1,30 @@
+import { EventState } from '../models/EventDataModel';
+import { ZetkinEvent } from 'utils/types/zetkin';
+
+export default function getEventState(event: ZetkinEvent): EventState {
+  if (!event.published && event.cancelled) {
+    return EventState.CANCELLED;
+  }
+  const now = new Date();
+  if (event.published) {
+    const published = new Date(event.published);
+    if (published > now) {
+      return EventState.SCHEDULED;
+    }
+    if (event.cancelled) {
+      const cancelled = new Date(event.cancelled);
+      if (cancelled > published) {
+        return EventState.CANCELLED;
+      }
+    }
+    if (event.end_time) {
+      const endTime = new Date(event.end_time);
+      if (endTime < now) {
+        return EventState.ENDED;
+      }
+    }
+    return EventState.OPEN;
+  } else {
+    return EventState.DRAFT;
+  }
+}


### PR DESCRIPTION
## Description
This PR integrates the event filtering logic into the month and week views of the calendar. The day view will need some refactoring to work properly.

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/550212/2df439be-5689-43e4-8a96-30b819273012

## Changes
* Adds a new `useFilteredEventActivities()` hook
* Use the new hook in `useMonthCalendarEvents()` and `useWeekCalendarEvents()`
* Move the logic from `EventDataModel.state` to a new `getEventState()` utility
* Tweak text in filter pane
* Increase cache time-to-live to reduce the number of unnecessary API calls made to revalidate cache

## Notes to reviewer
This is not yet working in day view, but I would like to merge it anyway.

## Related issues
Resolves #1246 