### PR TITLE
Add ZUIPersonHoverCard to Event participants and contact

### DIFF
--- a/src/features/events/components/EventContactCard.tsx
+++ b/src/features/events/components/EventContactCard.tsx
@@ -13,6 +13,7 @@ import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
 import ZUICard from 'zui/ZUICard';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
+import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import { MUIOnlyPersonSelect as ZUIPersonSelect } from 'zui/ZUIPersonSelect';
 
 interface EventContactCardProps {
@@ -38,7 +39,9 @@ const ContactDetails: FC<ContactDetailsProps> = ({ contact, model, orgId }) => {
   return (
     <>
       <Box m={1} sx={{ display: 'inline-block', verticalAlign: 'middle' }}>
-        <ZUIAvatar orgId={orgId} personId={contact.id} />
+        <ZUIPersonHoverCard personId={contact.id}>
+          <ZUIAvatar orgId={orgId} personId={contact.id} />
+        </ZUIPersonHoverCard>
       </Box>
       <Typography sx={{ display: 'inline-block', verticalAlign: 'middle' }}>
         {contact.name}

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -18,6 +18,7 @@ import noPropagate from 'utils/noPropagate';
 import { useMessages } from 'core/i18n';
 import ZUIAvatar from 'zui/ZUIAvatar';
 import ZUINumberChip from '../../../zui/ZUINumberChip';
+import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import {
   ZetkinEventParticipant,
@@ -126,7 +127,9 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       headerName: '',
       hideSortIcons: true,
       renderCell: (params) => (
-        <ZUIAvatar orgId={orgId} personId={params.row.id} />
+        <ZUIPersonHoverCard personId={params.row.id}>
+          <ZUIAvatar orgId={orgId} personId={params.row.id} />
+        </ZUIPersonHoverCard>
       ),
       resizable: false,
       sortable: false,


### PR DESCRIPTION
## Description
This PR adds a Person hover card to the event participants and contact avatars.


## Screenshots
![Screenshot from 2023-05-12 15-22-02](https://github.com/zetkin/app.zetkin.org/assets/14962107/d423d156-4ea6-4cd4-800b-b2250e6771a1)
![Screenshot from 2023-05-12 15-21-52](https://github.com/zetkin/app.zetkin.org/assets/14962107/b60b456f-03f8-4fc4-b0f6-ee3965c20284)


## Changes
* Adds ZUIPersonHoverCard to event participant avatars
* Adds ZUIPersonHoverCard to event contact avatar


## Notes to reviewer
The hover cards hover over the avatar, this is universal, but should perhaps be reported as a separate issue?

## Related issues
Resolves #1323 
