### PR TITLE
Issue 1337/optimized event loading

### DIFF
--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/system';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 
 import CalendarDayView from './CalendarDayView';
 import CalendarMonthView from './CalendarMonthView';
@@ -132,27 +132,29 @@ const Calendar = () => {
               marginTop={2}
               overflow="auto"
             >
-              {selectedTimeScale === TimeScale.DAY && (
-                <CalendarDayView
-                  activities={futureDays}
-                  focusDate={focusDate}
-                  onClickPreviousDay={(date) => setFocusDate(date)}
-                  previousActivityDay={lastDayWithEvent}
-                />
-              )}
-              {selectedTimeScale === TimeScale.WEEK && (
-                <CalendarWeekView
-                  focusDate={focusDate}
-                  onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
-                />
-              )}
-              {selectedTimeScale === TimeScale.MONTH && (
-                <CalendarMonthView
-                  focusDate={focusDate}
-                  onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
-                  onClickWeek={(date) => navigateTo(TimeScale.WEEK, date)}
-                />
-              )}
+              <Suspense>
+                {selectedTimeScale === TimeScale.DAY && (
+                  <CalendarDayView
+                    activities={futureDays}
+                    focusDate={focusDate}
+                    onClickPreviousDay={(date) => setFocusDate(date)}
+                    previousActivityDay={lastDayWithEvent}
+                  />
+                )}
+                {selectedTimeScale === TimeScale.WEEK && (
+                  <CalendarWeekView
+                    focusDate={focusDate}
+                    onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
+                  />
+                )}
+                {selectedTimeScale === TimeScale.MONTH && (
+                  <CalendarMonthView
+                    focusDate={focusDate}
+                    onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
+                    onClickWeek={(date) => navigateTo(TimeScale.WEEK, date)}
+                  />
+                )}
+              </Suspense>
             </Box>
           </Box>
         );

--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -1,11 +1,7 @@
 import { AnyClusteredEvent } from '../utils/clusterEventsForWeekCalender';
 import { isSameDate } from 'utils/dateUtils';
+import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
-import useModel from 'core/useModel';
-import CampaignActivitiesModel, {
-  ACTIVITIES,
-  EventActivity,
-} from 'features/campaigns/models/CampaignActivitiesModel';
 import {
   CLUSTER_TYPE,
   clusterEvents,
@@ -25,20 +21,11 @@ type UseMonthCalendarEventsReturn = {
 }[];
 
 export default function useMonthCalendarEvents({
-  campaignId,
   endDate,
   maxPerDay,
-  orgId,
-
   startDate,
 }: UseMonthCalendarEventsParams): UseMonthCalendarEventsReturn {
-  const model = useModel((env) => new CampaignActivitiesModel(env, orgId));
-
-  // TODO: Load only the ones necessary here
-  const activities = model.getAllActivities(campaignId);
-  const eventActivities = (activities.data?.filter(
-    (activity) => activity.kind == ACTIVITIES.EVENT
-  ) ?? []) as EventActivity[];
+  const eventActivities = useEventsFromDateRange(startDate, endDate);
 
   // Filter events based on user filters
   const filteredActivities = useFilteredEventActivities(eventActivities);

--- a/src/features/calendar/hooks/useWeekCalendarEvents.ts
+++ b/src/features/calendar/hooks/useWeekCalendarEvents.ts
@@ -1,9 +1,6 @@
-import { ACTIVITIES } from 'features/campaigns/models/CampaignActivitiesModel';
-import CampaignActivitiesModel from 'features/campaigns/models/CampaignActivitiesModel';
-import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
 import { isSameDate } from 'utils/dateUtils';
+import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
-import useModel from 'core/useModel';
 import clusterEventsForWeekCalender, {
   AnyClusteredEvent,
 } from '../utils/clusterEventsForWeekCalender';
@@ -20,18 +17,12 @@ type UseWeekCalendarEventsReturn = {
 }[];
 
 export default function useWeekCalendarEvents({
-  campaignId,
   dates,
-  orgId,
 }: UseWeekCalendarEventsParams): UseWeekCalendarEventsReturn {
-  const model = useModel((env) => new CampaignActivitiesModel(env, orgId));
-
-  // TODO: Load only the ones necessary here
-  const activities = model.getAllActivities(campaignId);
-  const eventActivities = (activities.data?.filter(
-    (activity) => activity.kind == ACTIVITIES.EVENT
-  ) ?? []) as EventActivity[];
-
+  const eventActivities = useEventsFromDateRange(
+    dates[0],
+    dates[dates.length - 1]
+  );
   const filteredActivities = useFilteredEventActivities(eventActivities);
 
   return dates.map((date) => {

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -1,0 +1,77 @@
+import dayjs from 'dayjs';
+import { useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import range from 'utils/range';
+import { RootState } from 'core/store';
+import shouldLoad from 'core/caching/shouldLoad';
+import { ZetkinEvent } from 'utils/types/zetkin';
+import {
+  ACTIVITIES,
+  EventActivity,
+} from 'features/campaigns/models/CampaignActivitiesModel';
+import { eventRangeLoad, eventRangeLoaded } from '../store';
+import { useApiClient, useNumericRouteParams } from 'core/hooks';
+
+export default function useEventsFromDateRange(
+  startDate: Date,
+  endDate: Date
+): EventActivity[] {
+  const promRef = useRef<Promise<void>>();
+  const { campId, orgId } = useNumericRouteParams();
+  const apiClient = useApiClient();
+  const dispatch = useDispatch();
+  const eventsState = useSelector((state: RootState) => state.events);
+
+  const dateRange = range(dayjs(endDate).diff(startDate, 'day')).map((diff) => {
+    const curDate = new Date(startDate);
+    curDate.setDate(curDate.getDate() + diff);
+    return curDate;
+  });
+
+  const mustLoad = dateRange.some((date) =>
+    shouldLoad(eventsState.eventsByDate[date.toISOString().slice(0, 10)])
+  );
+
+  if (mustLoad) {
+    dispatch(eventRangeLoad(dateRange));
+    const promise = apiClient
+      .get<ZetkinEvent[]>(
+        `/api/orgs/${orgId}/actions?filter=start_time>${startDate
+          .toISOString()
+          .slice(0, 10)}&filter=end_time<=${endDate.toISOString().slice(0, 10)}`
+      )
+      .then((events) => {
+        dispatch(eventRangeLoaded([dateRange, events]));
+      });
+
+    // This will suspend React from rendering this branch
+    // until the promise resolves.
+    throw promise;
+  }
+
+  const isLoading = dateRange.some(
+    (date) =>
+      eventsState.eventsByDate[date.toISOString().slice(0, 10)].isLoading
+  );
+
+  if (isLoading && promRef.current) {
+    throw promRef.current;
+  }
+
+  const events = dateRange.flatMap((date) => {
+    const dateStr = date.toISOString().slice(0, 10);
+    return eventsState.eventsByDate[dateStr].items
+      .filter((item) => !!item.data)
+      .map((item) => item.data) as ZetkinEvent[];
+  });
+
+  return events
+    .filter((event) => !campId || event.campaign?.id == campId)
+    .map((event) => ({
+      data: event,
+      endDate: null,
+      kind: ACTIVITIES.EVENT,
+      startDate: event.published ? new Date(event.published) : null,
+    }));
+}


### PR DESCRIPTION
## Description
This PR introduces a new approach to loading events. Instead of loading all events in one go, it allows loading events by date range, and stores in the store which dates have been loaded already. This improves performance significantly when loading a calendar view.

## Screenshots
None

## Changes
* Adds `useEventsFromDateRange()` hook which loads events if necessary
* Replaces the model/repo loading logic with `useEventsFromDateRange()` in calendar month and week views

## Notes to reviewer
This is work in progress.

## Related issues
Resolves #1337