### PR TITLE
Issue 1354/conistant event url

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -5,6 +5,7 @@ import { People, PlaceOutlined, Schedule } from '@mui/icons-material';
 
 import EventDataModel from 'features/events/models/EventDataModel';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
+import getEventUrl from 'features/events/utils/getEventUrl';
 import messageIds from 'features/events/l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
 import theme from 'theme';
@@ -40,9 +41,7 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
 
   return (
     <NextLink
-      href={`/organize/${event.organization.id}/projects/${
-        event.campaign ? `${event.campaign.id}` : 'standalone'
-      }/events/${event.id}`}
+      href={getEventUrl(event)}
       passHref
     >
       <Link color="inherit" underline="none">

--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -40,10 +40,7 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
   }
 
   return (
-    <NextLink
-      href={getEventUrl(event)}
-      passHref
-    >
+    <NextLink href={getEventUrl(event)} passHref>
       <Link color="inherit" underline="none">
         <Box
           display="flex"

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -9,6 +9,7 @@ import {
 import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
 import EventDataModel from 'features/events/models/EventDataModel';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
+import getEventUrl from 'features/events/utils/getEventUrl';
 import messageIds from 'features/events/l10n/messageIds';
 import OverviewListItem from './OverviewListItem';
 import { removeOffset } from 'utils/dateUtils';
@@ -44,9 +45,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
           : undefined
       }
       focusDate={focusDate}
-      href={`/organize/${event.organization.id}/projects/${
-        event.campaign?.id ?? 'standalone'
-      }/events/${event.id}`}
+      href={getEventUrl(event)}
       meta={<EventWarningIcons compact model={model} />}
       onClick={(x: number, y: number) => {
         openEventPopper(

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -9,11 +9,13 @@ import {
 import ActivityListItem from './ActivityListItem';
 import { ClusteredEvent } from 'features/campaigns/hooks/useClusteredActivities';
 import { EventWarningIconsSansModel } from 'features/events/components/EventWarningIcons';
+import getEventUrl from 'features/events/utils/getEventUrl';
 import { removeOffset } from 'utils/dateUtils';
 import useEventClusterData from 'features/events/hooks/useEventClusterData';
 import { useEventPopper } from 'features/events/components/EventPopper/EventPopperProvider';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
+
 
 interface EventListeItemProps {
   cluster: ClusteredEvent;
@@ -45,9 +47,7 @@ const EventListItem: FC<EventListeItemProps> = ({ cluster }) => {
       endNumberColor={
         numParticipantsAvailable < numParticipantsRequired ? 'error' : undefined
       }
-      href={`/organize/${event.organization.id}/projects/${
-        event.campaign?.id ?? 'standalone'
-      }/events/${event.id}`}
+      href={getEventUrl(event)}
       meta={
         <EventWarningIconsSansModel
           compact={false}

--- a/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EventListItem.tsx
@@ -16,7 +16,6 @@ import { useEventPopper } from 'features/events/components/EventPopper/EventPopp
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
 
-
 interface EventListeItemProps {
   cluster: ClusteredEvent;
 }

--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -14,6 +14,7 @@ import {
 import { FC, useState } from 'react';
 
 import EventDataModel from 'features/events/models/EventDataModel';
+import getEventUrl from '../utils/getEventUrl';
 import { getParticipantsStatusColor } from '../utils/eventUtils';
 import messageIds from 'features/events/l10n/messageIds';
 import theme from 'theme';
@@ -23,13 +24,11 @@ import ZUINumberChip from 'zui/ZUINumberChip';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 
 type EventParticipantsCardProps = {
-  campId: string;
   model: EventDataModel;
 };
 
 const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
   model,
-  campId,
 }) => {
   const eventData = model.getData().data;
   const messages = useMessages(messageIds);
@@ -184,7 +183,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
         <Divider />
         <Box display="flex" justifyContent="center" marginTop={2}>
           <NextLink
-            href={`/organize/${eventData.organization.id}/projects/${campId}/events/${eventData.id}/participants`}
+            href={`${getEventUrl(eventData)}/participants`}
             passHref
           >
             <Link underline="none">

--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -27,9 +27,7 @@ type EventParticipantsCardProps = {
   model: EventDataModel;
 };
 
-const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
-  model,
-}) => {
+const EventParticipantsCard: FC<EventParticipantsCardProps> = ({ model }) => {
   const eventData = model.getData().data;
   const messages = useMessages(messageIds);
   const reqParticipants = eventData?.num_participants_required ?? 0;
@@ -182,10 +180,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
         </Box>
         <Divider />
         <Box display="flex" justifyContent="center" marginTop={2}>
-          <NextLink
-            href={`${getEventUrl(eventData)}/participants`}
-            passHref
-          >
+          <NextLink href={`${getEventUrl(eventData)}/participants`} passHref>
             <Link underline="none">
               <Typography
                 color={theme.palette.info.main}

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -32,7 +32,6 @@ import EventDataModel, {
   EventState,
 } from 'features/events/models/EventDataModel';
 
-
 const useStyles = makeStyles(() => ({
   description: {
     '-webkit-box-orient': 'vertical',
@@ -251,10 +250,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         justifyContent="flex-end"
         marginBottom={2}
       >
-        <NextLink
-          href={getEventUrl(event)}
-          passHref
-        >
+        <NextLink href={getEventUrl(event)} passHref>
           <Link underline="none">
             <Button
               endIcon={<ArrowForward />}

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -14,6 +14,7 @@ import {
 import { Box, Button, Link, Typography } from '@mui/material';
 import { FC, useContext } from 'react';
 
+import getEventUrl from 'features/events/utils/getEventUrl';
 import LocationLabel from '../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
 import Quota from './Quota';
@@ -30,6 +31,7 @@ import ZUITimeSpan from 'zui/ZUITimeSpan';
 import EventDataModel, {
   EventState,
 } from 'features/events/models/EventDataModel';
+
 
 const useStyles = makeStyles(() => ({
   description: {
@@ -250,9 +252,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         marginBottom={2}
       >
         <NextLink
-          href={`/organize/${event.organization.id}/${
-            event.campaign ? `projects/${event.campaign.id}` : 'standalone'
-          }/events/${event.id}`}
+          href={getEventUrl(event)}
           passHref
         >
           <Link underline="none">

--- a/src/features/events/components/RelatedEvent.tsx
+++ b/src/features/events/components/RelatedEvent.tsx
@@ -6,6 +6,7 @@ import { getParticipantsStatusColor } from 'features/events/utils/eventUtils';
 import messageIds from '../l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
 
+import getEventUrl from '../utils/getEventUrl';
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUINumberChip from 'zui/ZUINumberChip';
@@ -21,9 +22,7 @@ const RelatedEvent: FC<RelatedEventProps> = ({ event }) => {
     <Box display="flex" flexDirection="column">
       <Box alignItems="center" display="flex" justifyContent="space-between">
         <NextLink
-          href={`/organize/${event.organization.id}/projects/${
-            event.campaign ? `${event.campaign.id}` : 'standalone'
-          }/events/${event.id}`}
+          href={getEventUrl(event)}
           passHref
         >
           <Link>

--- a/src/features/events/components/RelatedEvent.tsx
+++ b/src/features/events/components/RelatedEvent.tsx
@@ -21,10 +21,7 @@ const RelatedEvent: FC<RelatedEventProps> = ({ event }) => {
   return (
     <Box display="flex" flexDirection="column">
       <Box alignItems="center" display="flex" justifyContent="space-between">
-        <NextLink
-          href={getEventUrl(event)}
-          passHref
-        >
+        <NextLink href={getEventUrl(event)} passHref>
           <Link>
             <Typography>
               {event.title ||

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -9,6 +9,7 @@ import EventDataModel from '../models/EventDataModel';
 import EventStatusChip from '../components/EventStatusChip';
 import EventTypeAutocomplete from '../components/EventTypeAutocomplete';
 import EventTypesModel from '../models/EventTypesModel';
+import getEventUrl from '../utils/getEventUrl';
 import messageIds from '../l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
 import useModel from 'core/useModel';
@@ -24,14 +25,12 @@ interface EventLayoutProps {
   children: React.ReactNode;
   eventId: string;
   orgId: string;
-  campaignId: string;
 }
 
 const EventLayout: React.FC<EventLayoutProps> = ({
   children,
   eventId,
   orgId,
-  campaignId,
 }) => {
   const [editingTypeOrTitle, setEditingTypeOrTitle] = useState(false);
 
@@ -54,7 +53,7 @@ const EventLayout: React.FC<EventLayoutProps> = ({
           }}
         </ZUIFuture>
       }
-      baseHref={`/organize/${orgId}/projects/${campaignId}/events/${eventId}`}
+      baseHref={getEventUrl(model.getData().data)}
       defaultTab="/"
       subtitle={
         <Box alignItems="center" display="flex">

--- a/src/features/events/utils/getEventUrl.tsx
+++ b/src/features/events/utils/getEventUrl.tsx
@@ -1,0 +1,11 @@
+import { ZetkinEvent } from "utils/types/zetkin";
+
+export default function getEventUrl(event: ZetkinEvent | null){
+    if (event){
+        return `/organize/${event.organization.id}/projects/${
+            event.campaign ? `${event.campaign?.id}` : 'standalone'
+        }/events/${event.id}`
+    }else{
+        return ''
+    }
+}

--- a/src/features/events/utils/getEventUrl.tsx
+++ b/src/features/events/utils/getEventUrl.tsx
@@ -1,11 +1,11 @@
-import { ZetkinEvent } from "utils/types/zetkin";
+import { ZetkinEvent } from 'utils/types/zetkin';
 
-export default function getEventUrl(event: ZetkinEvent | null){
-    if (event){
-        return `/organize/${event.organization.id}/projects/${
-            event.campaign ? `${event.campaign?.id}` : 'standalone'
-        }/events/${event.id}`
-    }else{
-        return ''
-    }
+export default function getEventUrl(event: ZetkinEvent | null) {
+  if (event) {
+    return `/organize/${event.organization.id}/projects/${
+      event.campaign ? `${event.campaign?.id}` : 'standalone'
+    }/events/${event.id}`;
+  } else {
+    return '';
+  }
 }

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -48,10 +48,7 @@ interface EventPageProps {
   orgId: string;
 }
 
-const EventPage: PageWithLayout<EventPageProps> = ({
-  orgId,
-  eventId,
-}) => {
+const EventPage: PageWithLayout<EventPageProps> = ({ orgId, eventId }) => {
   const dataModel = useModel(
     (env) => new EventDataModel(env, parseInt(orgId), parseInt(eventId))
   );

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -32,7 +32,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     }
     return {
       props: {
-        campId,
         eventId,
         orgId,
       },
@@ -45,7 +44,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 );
 
 interface EventPageProps {
-  campId: string;
   eventId: string;
   orgId: string;
 }
@@ -53,7 +51,6 @@ interface EventPageProps {
 const EventPage: PageWithLayout<EventPageProps> = ({
   orgId,
   eventId,
-  campId,
 }) => {
   const dataModel = useModel(
     (env) => new EventDataModel(env, parseInt(orgId), parseInt(eventId))
@@ -81,7 +78,7 @@ const EventPage: PageWithLayout<EventPageProps> = ({
               />
             </Grid>
             <Grid item md={4} xs={6}>
-              <EventParticipantsCard campId={campId} model={dataModel} />
+              <EventParticipantsCard model={dataModel} />
               <EventRelatedCard data={data} model={eventsModel} />
             </Grid>
           </Grid>
@@ -95,7 +92,6 @@ EventPage.getLayout = function getLayout(page, props) {
   return (
     <EventLayout
       key={props.eventId}
-      campaignId={props.campId}
       eventId={props.eventId}
       orgId={props.orgId}
     >

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -101,10 +101,7 @@ const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
 
 ParticipantsPage.getLayout = function getLayout(page, props) {
   return (
-    <EventLayout
-      eventId={props.eventId}
-      orgId={props.orgId}
-    >
+    <EventLayout eventId={props.eventId} orgId={props.orgId}>
       {page}
     </EventLayout>
   );

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -102,7 +102,6 @@ const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
 ParticipantsPage.getLayout = function getLayout(page, props) {
   return (
     <EventLayout
-      campaignId={props.campId}
       eventId={props.eventId}
       orgId={props.orgId}
     >


### PR DESCRIPTION
## Description

Every time an event needed to be linked to people had to know the URL format, so now there is a util for that!

## Changes
* Adds `getEventUrl` util
* Removes instances of the URL being directly templated
* Removed unnecessary campaign ID parameters

## Related issues
Resolves #1354 
