### PR TITLE
Fix pending signups number in Calendar Day View

### DIFF
--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -9,7 +9,6 @@ import {
 import EventDataModel from '../models/EventDataModel';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { useMessages } from 'core/i18n';
-import { ZetkinEvent } from 'utils/types/zetkin';
 
 type EventWarningIconsProps = {
   compact?: boolean;

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -31,7 +31,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({ compact, model }) => {
       numRemindersSent={
         participants.data?.filter((p) => !!p.reminder_sent).length ?? 0
       }
-      numSignups={model.getPendingSignUps().length ?? 0}
+      numSignups={model.getPendingSignUps().length}
       participantsLoading={!participants.data}
     />
   );

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -9,6 +9,7 @@ import {
 import EventDataModel from '../models/EventDataModel';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { useMessages } from 'core/i18n';
+import { ZetkinEvent } from 'utils/types/zetkin';
 
 type EventWarningIconsProps = {
   compact?: boolean;
@@ -23,7 +24,6 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({ compact, model }) => {
   }
 
   const participants = model.getParticipants();
-
   return (
     <EventWarningIconsSansModel
       compact={compact}
@@ -32,7 +32,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({ compact, model }) => {
       numRemindersSent={
         participants.data?.filter((p) => !!p.reminder_sent).length ?? 0
       }
-      numSignups={data.num_participants_available}
+      numSignups={model.getPendingSignUps().length ?? 0}
       participantsLoading={!participants.data}
     />
   );


### PR DESCRIPTION
## Description
This PR fixes the bug in Calendar Day View by showing the pending sign-ups icon only when there is a pending sign-up.


## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/36491300/7469be00-6f7b-47b7-a0f8-43c21db67ff8

## Changes
* Changes the number of sign-ups by calling the method `getPendingSignUps`
* Changes the condition to show the pending sign-up icon by getting it displayed if it's more than 0


## Notes to reviewer
None

## Related issues
Resolves #1353 
