### PR TITLE
Adjust ParticipantsList for smaller screens.

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -41,10 +41,9 @@ const Buttons: FC<{ options: ButtonOption[] }> = ({ options }) => {
   return (
     <FormControl
       sx={{
-        columnGap: '0.5em',
         display: 'flex',
         flexDirection: 'row',
-        justifyContent: 'flex-end',
+        gap: 0.5,
       }}
     >
       {options.map((option) => (
@@ -67,11 +66,7 @@ const Dropdown: FC<{
   value: attendance;
 }> = ({ options, value, label }) => {
   return (
-    <FormControl
-      size="small"
-      sx={{ m: 1, minWidth: '15em' }}
-      variant="outlined"
-    >
+    <FormControl size="small" variant="outlined">
       <InputLabel id={'attendance-select-label'}>{label}</InputLabel>
       <Select
         label={label}
@@ -141,6 +136,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       flex: 1,
       headerName: messages.eventParticipantsList.columnName(),
       hideSortIcons: true,
+      minWidth: 250,
       renderCell: (params) => {
         if (params.row.person) {
           return <Typography>{params.row.person.name}</Typography>;
@@ -192,15 +188,15 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       flex: 1,
       headerName: messages.eventParticipantsList.columnPhone(),
       hideSortIcons: true,
-      renderCell: (params) => {
-        if (params.row.person) {
-          return <Typography>{params.row.person.phone}</Typography>;
-        } else {
-          return <Typography>{params.row.phone}</Typography>;
-        }
-      },
       resizable: false,
       sortable: false,
+      valueGetter: (params) => {
+        if (params.row.person) {
+          return params.row.person.phone;
+        } else {
+          return params.row.phone;
+        }
+      },
     },
     {
       disableColumnMenu: true,
@@ -241,6 +237,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       flex: 1,
       headerName: '',
       hideSortIcons: true,
+      minWidth: 300,
       renderCell: (params) => {
         if (type == 'signups') {
           return (


### PR DESCRIPTION
## Description
This PR adjusts the styling of the ParticipantsList to look neater on a narrow screen.


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/9dbaa8f2-2209-46d9-95dc-1a1990b906ee)

## Changes
* Adds `minWidth`  to name and action columns
* Changes the styling a little to utilise build in features of components like  the grid and `Select`

## Related issues
Resolves #1343 
