### PR TITLE
Fix pending signups number in Participants Card

### DIFF
--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -139,9 +139,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
             <Typography color={'secondary'} component="h6" variant="subtitle1">
               {messages.eventParticipantsCard.pending()}
             </Typography>
-            <Typography>
-              {Math.max(reqParticipants - availParticipants, 0)}
-            </Typography>
+            <Typography>{model.getPendingSignUps().length ?? 0}</Typography>
           </Box>
           <Box
             alignItems="center"

--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -139,7 +139,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
             <Typography color={'secondary'} component="h6" variant="subtitle1">
               {messages.eventParticipantsCard.pending()}
             </Typography>
-            <Typography>{model.getPendingSignUps().length ?? 0}</Typography>
+            <Typography>{model.getPendingSignUps().length}</Typography>
           </Box>
           <Box
             alignItems="center"


### PR DESCRIPTION
## Description
This PR fixes the number that it's displayed in the Event Participants Card


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/0c9c4288-c0a2-4061-afcb-2f2669823c83)

![11111111](https://github.com/zetkin/app.zetkin.org/assets/36491300/67d0d07c-a93c-4607-80d2-c258d91b5ae9)


## Changes
* Changes the get of pending sign-ups by calling the `getPendingSignUps`() method instead of making an extraction between participants available numbers.


## Notes to reviewer
none


## Related issues
Resolves #1350 
