### PR TITLE
Fix time picker

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -199,8 +199,10 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           label={messages.eventOverviewCard.startTime()}
                           onChange={(newValue) => {
                             if (newValue && isValidDate(newValue.toDate())) {
-                              setInvalidFormat(false);
-                              setStartDate(dayjs(newValue));
+                              if (dayjs(newValue) < dayjs(endDate)) {
+                                setInvalidFormat(false);
+                                setStartDate(dayjs(newValue));
+                              }
                             } else {
                               setInvalidFormat(true);
                             }
@@ -214,6 +216,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                   ...params.inputProps,
                                   ...props,
                                 }}
+                                sx={{ button: { cursor: 'text' } }}
                               />
                             );
                           }}
@@ -347,8 +350,10 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                           label={messages.eventOverviewCard.endTime()}
                           onChange={(newValue) => {
                             if (newValue && isValidDate(newValue.toDate())) {
-                              setInvalidFormat(false);
-                              setEndDate(newValue);
+                              if (dayjs(newValue) > dayjs(startDate)) {
+                                setInvalidFormat(false);
+                                setEndDate(newValue);
+                              }
                             } else {
                               setInvalidFormat(false);
                             }
@@ -363,6 +368,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                   ...params.inputProps,
                                   ...props,
                                 }}
+                                sx={{ button: { cursor: 'text' } }}
                               />
                             );
                           }}

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -150,8 +150,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                               ) {
                                 setEndDate(newValue);
                               }
-                            } else {
-                              setInvalidFormat(true);
                             }
                           }}
                           renderInput={(params) => {
@@ -259,8 +257,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 setInvalidFormat(false);
                                 setEndDate(newValue);
                               }
-                            } else {
-                              setInvalidFormat(true);
                             }
                           }}
                           renderInput={(params) => {

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -203,8 +203,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 setInvalidFormat(false);
                                 setStartDate(dayjs(newValue));
                               }
-                            } else {
-                              setInvalidFormat(true);
                             }
                           }}
                           open={false}
@@ -354,8 +352,6 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                                 setInvalidFormat(false);
                                 setEndDate(newValue);
                               }
-                            } else {
-                              setInvalidFormat(false);
                             }
                           }}
                           open={false}


### PR DESCRIPTION
## Description
This PR fixes several bugs found in Time Picker and Date Picker components like:
- when deleting last number of a year it doesn't reappear again
- when deleting the last number of the time, it doesn't reappear again
- it can't set a start time after the end time and vice versa 
- cursor doesn't transform in cursor when hovering the clock icon

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/36491300/1d5c033c-f60e-4bfe-afba-a893eeb5887a

## Changes
* Removes else statement from `DatePicker `and `TimePicker`
* Changes cursor of clock icon for "text" instead of "pointer"
* Adds a condition to disable set a start time after the end time and vice versa.


## Notes to reviewer
None

## Related issues
Resolves #1346 
