### PR TITLE
Issue 1361/today tomorrow

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
@@ -50,7 +50,7 @@ const EventClusterOverviewListItem: FC<EventClusterOverviewListItemProps> = ({
 
   return (
     <OverviewListItem
-      endDate={null} // TODO: Replace with cancelled date
+      endDate={null}
       endNumber={`${numBooked} / ${numParticipantsRequired}`}
       endNumberColor={numBooked < numParticipantsRequired ? 'error' : undefined}
       focusDate={focusDate}
@@ -74,7 +74,11 @@ const EventClusterOverviewListItem: FC<EventClusterOverviewListItemProps> = ({
           : SplitscreenOutlined
       }
       SecondaryIcon={Group}
-      startDate={null} // TODO: Replace with published date
+      startDate={
+        cluster.events[0].published
+          ? new Date(cluster.events[0].published)
+          : null
+      }
       subtitle={
         <ZUIIconLabelRow
           color="secondary"

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -36,7 +36,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
 
   return (
     <OverviewListItem
-      endDate={null}
+      endDate={event.cancelled ? new Date(event.cancelled) : null}
       endNumber={`${event.num_participants_available} / ${event.num_participants_required}`}
       endNumberColor={
         event.num_participants_available < event.num_participants_required
@@ -56,7 +56,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
       }}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={People}
-      startDate={null}
+      startDate={event.published ? new Date(event.published) : null}
       statusBar={null}
       subtitle={
         <ZUIIconLabelRow

--- a/src/features/campaigns/models/CampaignActivitiesModel.ts
+++ b/src/features/campaigns/models/CampaignActivitiesModel.ts
@@ -102,17 +102,30 @@ export default class CampaignActivitiesModel extends ModelBase {
     if (activitiesFuture.data) {
       const currentActivities = activitiesFuture.data;
 
-      overview.today = currentActivities.filter(
-        (activity) =>
-          (activity.startDate && isSameDate(activity.startDate, todayDate)) ||
-          (activity.endDate && isSameDate(activity.endDate, todayDate))
-      );
-      overview.tomorrow = currentActivities.filter(
-        (activity) =>
-          (activity.startDate &&
-            isSameDate(activity.startDate, tomorrowDate)) ||
-          (activity.endDate && isSameDate(activity.endDate, tomorrowDate))
-      );
+      overview.today = currentActivities.filter((activity) => {
+        if (activity.kind == ACTIVITIES.EVENT) {
+          const startDate = new Date(activity.data.start_time);
+          return isSameDate(startDate, todayDate);
+        } else {
+          return (
+            (activity.startDate && isSameDate(activity.startDate, todayDate)) ||
+            (activity.endDate && isSameDate(activity.endDate, todayDate))
+          );
+        }
+      });
+
+      overview.tomorrow = currentActivities.filter((activity) => {
+        if (activity.kind == ACTIVITIES.EVENT) {
+          const startDate = new Date(activity.data.start_time);
+          return isSameDate(startDate, tomorrowDate);
+        } else {
+          return (
+            (activity.startDate &&
+              isSameDate(activity.startDate, tomorrowDate)) ||
+            (activity.endDate && isSameDate(activity.endDate, tomorrowDate))
+          );
+        }
+      });
 
       const startOfToday = new Date(new Date().toISOString().slice(0, 10));
       const weekFromNow = new Date(startOfToday);
@@ -176,9 +189,9 @@ export default class CampaignActivitiesModel extends ModelBase {
       .filter((event) => !campaignId || event.campaign?.id == campaignId)
       .map((event) => ({
         data: event,
-        endDate: getUTCDateWithoutTime(event.end_time), // End date (cancelled) not implemented in backend yet
+        endDate: null,
         kind: ACTIVITIES.EVENT,
-        startDate: new Date(0), // Start date (published) not implemented in backend yet
+        startDate: getUTCDateWithoutTime(event.published),
       }));
 
     const surveys: CampaignActivity[] = surveysFuture.data


### PR DESCRIPTION
## Description
This PR updates the logic for determining which events should go in the Today and Tomorrow columns in the project overview.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/7b44e219-f8c6-4b9b-ab95-c3d609d6dc61)

## Changes
* Adds logic to filter events on different criteria than other activities
* Changes start date property to use publish date, to get correct status dot color for events.


## Related issues
Resolves #1361 
