### PR TITLE
Issue-1367/ Update eventsByDate list after creating a new event

### DIFF
--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -91,6 +91,9 @@ const eventsSlice = createSlice({
       const event = action.payload;
       state.eventList.isLoading = false;
       state.eventList.items.push(remoteItem(event.id, { data: event }));
+      state.eventsByDate[event.start_time.slice(0, 10)].items.push(
+        remoteItem(event.id, { data: event })
+      );
     },
     eventDeleted: (state, action: PayloadAction<number>) => {
       const eventId = action.payload;


### PR DESCRIPTION
## Description
This PR fixes the bug that makes the new created event don't render in the calendar week view.


## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/36491300/d4ec0670-646a-45f9-82c7-c3aa4ab27dbc


## Changes
* Adds the new event in the `eventsByDate `list in the EventCreated store



## Notes to reviewer
None


## Related issues
Resolves #1367 
