### PR TITLE
Org icon with unique color.

### DIFF
--- a/src/features/organizations/components/ProceduralColorIcon/index.stories.tsx
+++ b/src/features/organizations/components/ProceduralColorIcon/index.stories.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mui/material';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import ProceduralColorIcon from '.';
+
+export default {
+  component: ProceduralColorIcon,
+  title: 'ProceduralColorIcon',
+} as ComponentMeta<typeof ProceduralColorIcon>;
+
+const Template: ComponentStory<typeof ProceduralColorIcon> = (args) => (
+  <Box display="flex">
+    <ProceduralColorIcon id={args.id} />
+  </Box>
+);
+
+export const basic = Template.bind({});
+basic.args = {
+  id: 234,
+};

--- a/src/features/organizations/components/ProceduralColorIcon/index.tsx
+++ b/src/features/organizations/components/ProceduralColorIcon/index.tsx
@@ -1,0 +1,35 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import { GroupWork } from '@mui/icons-material';
+import randomSeed from 'random-seed';
+
+interface ProceduralColorIconProps {
+  id: number;
+}
+
+const ProceduralColorIcon: FC<ProceduralColorIconProps> = ({ id }) => {
+  const rand = randomSeed.create(id.toString());
+
+  const r = rand(256);
+  const g = rand(256);
+  const b = rand(256);
+  const rgbAverage = (r + g + b) / 3;
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: `rgb(${r},${g},${b})`,
+        borderRadius: 2,
+        display: 'flex',
+        padding: 0.5,
+      }}
+    >
+      <GroupWork
+        fontSize="large"
+        sx={{ color: rgbAverage < 180 ? 'white' : 'black' }}
+      />
+    </Box>
+  );
+};
+
+export default ProceduralColorIcon;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13380,7 +13380,7 @@ ramda@^0.21.0:
 random-seed@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/random-seed/-/random-seed-0.3.0.tgz#d945f2e1f38f49e8d58913431b8bf6bb937556cd"
-  integrity sha1-2UXy4fOPSejViRNDG4v2u5N1Vs0=
+  integrity sha512-y13xtn3kcTlLub3HKWXxJNeC2qK4mB59evwZ5EkeRlolx+Bp2ztF7LbcZmyCnOqlHQrLnfuNbi1sVmm9lPDlDA==
   dependencies:
     json-stringify-safe "^5.0.1"
 


### PR DESCRIPTION
## Description
This PR adds a component that is an icon with a unique color generated based on the organization's id. 
Icon switches main color from white to black if generated color is too bright.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/e807a402-1fe9-4e5c-ab52-fe964a66726b)
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/42edf6b5-7ca8-4ccd-89b3-f4c70196d5da)

## Changes
* Adds random-seed library to genrate numbers.
* Adds ProceduralColorIcon component + story


## Related issues
This is part of #1372  but does not resolve the issue.
