### PR TITLE
Issue 1371/Make menu expandable

### DIFF
--- a/src/features/organizations/models/OrganizationsDataModel.tsx
+++ b/src/features/organizations/models/OrganizationsDataModel.tsx
@@ -14,4 +14,8 @@ export default class OrganizationsDataModel extends ModelBase {
   getData() {
     return this._repo.getUserOrganizations();
   }
+
+  getOrganization(orgId: number) {
+    return this._repo.getOrganization(orgId);
+  }
 }

--- a/src/features/organizations/repos/OrganizationsRepo.ts
+++ b/src/features/organizations/repos/OrganizationsRepo.ts
@@ -1,9 +1,17 @@
 import Environment from 'core/env/Environment';
 import IApiClient from 'core/api/client/IApiClient';
 import { IFuture } from 'core/caching/futures';
-import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { Store } from 'core/store';
-import { organizationsLoad, organizationsLoaded } from '../store';
+import {
+  loadItemIfNecessary,
+  loadListIfNecessary,
+} from 'core/caching/cacheUtils';
+import {
+  organizationLoad,
+  organizationLoaded,
+  organizationsLoad,
+  organizationsLoaded,
+} from '../store';
 import { ZetkinMembership, ZetkinOrganization } from 'utils/types/zetkin';
 
 export default class OrganizationsRepo {
@@ -13,6 +21,16 @@ export default class OrganizationsRepo {
   constructor(env: Environment) {
     this._store = env.store;
     this._apiClient = env.apiClient;
+  }
+
+  getOrganization(orgId: number): IFuture<ZetkinOrganization> {
+    const state = this._store.getState();
+    return loadItemIfNecessary(state.organizations.orgData, this._store, {
+      actionOnLoad: () => organizationLoad(),
+      actionOnSuccess: (data) => organizationLoaded(data),
+      loader: () =>
+        this._apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`),
+    });
   }
 
   getUserOrganizations(): IFuture<ZetkinOrganization[]> {

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -1,12 +1,19 @@
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { remoteList, RemoteList } from 'utils/storeUtils';
+import {
+  remoteItem,
+  RemoteItem,
+  remoteList,
+  RemoteList,
+} from 'utils/storeUtils';
 
 export interface OrganizationsStoreSlice {
+  orgData: RemoteItem<ZetkinOrganization>;
   userOrgList: RemoteList<ZetkinOrganization>;
 }
 
 const initialState: OrganizationsStoreSlice = {
+  orgData: remoteItem(0),
   userOrgList: remoteList(),
 };
 
@@ -14,6 +21,16 @@ const OrganizationsSlice = createSlice({
   initialState,
   name: 'organizations',
   reducers: {
+    organizationLoad: (state) => {
+      state.orgData.isLoading = true;
+    },
+    organizationLoaded: (state, action: PayloadAction<ZetkinOrganization>) => {
+      const org = action.payload;
+
+      state.orgData.data = org;
+      state.orgData.loaded = new Date().toISOString();
+      state.orgData.isLoading = false;
+    },
     organizationsLoad: (state) => {
       state.userOrgList.isLoading = true;
     },
@@ -31,5 +48,9 @@ const OrganizationsSlice = createSlice({
 });
 
 export default OrganizationsSlice;
-export const { organizationsLoaded, organizationsLoad } =
-  OrganizationsSlice.actions;
+export const {
+  organizationLoaded,
+  organizationLoad,
+  organizationsLoaded,
+  organizationsLoad,
+} = OrganizationsSlice.actions;

--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -1,9 +1,11 @@
 import NextLink from 'next/link';
+import { useNumericRouteParams } from 'core/hooks';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import {
   AppBar,
+  Avatar,
   Box,
   Drawer,
   IconButton,
@@ -14,8 +16,6 @@ import {
 import { Event, Explore, Home, Map, Menu, People } from '@mui/icons-material/';
 
 import makeStyles from '@mui/styles/makeStyles';
-
-import ZUILogo from './ZUILogo';
 
 const drawerWidth = '5rem';
 
@@ -71,7 +71,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   };
 
   const router = useRouter();
-  const { orgId } = router.query as { orgId: string };
+  const { orgId } = useNumericRouteParams();
 
   const key = orgId ? router.pathname.split('[orgId]')[1] : 'organize';
 
@@ -96,7 +96,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 size="large"
                 style={{ marginBottom: '2rem' }}
               >
-                <ZUILogo beta={true} htmlColor="#ED1C55" size={40} />
+                <Avatar alt="icon" src={`/api/orgs/${orgId}/avatar`} />
               </IconButton>
             </NextLink>
           </ListItem>

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -101,6 +101,13 @@ export default makeMessages('zui', {
   lists: {
     showMore: m('Show more...'),
   },
+  organizeSidebar: {
+    areas: m('Areas'),
+    home: m('Home'),
+    journeys: m('Journeys'),
+    people: m('People'),
+    projects: m('Projects'),
+  },
   personGridEditCell: {
     keepTyping: m('Keep typing..'),
     noResult: m('No matching person found'),


### PR DESCRIPTION
## Description
This PR adds the new requirements to be present in the organize side bar component and also make the bar expandable.


## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/36491300/09f0bc4d-939e-462b-b215-dc50bc1f8fb0

## Changes
* Adds localization for menu items
* Adds method to fetch the organization data
* Adds a hover action in the side bar that changes the logo of the organization for a chevron icon
* Adds a expandable drawer that can be toggled with the item menus


## Notes to reviewer
None


## Related issues
Resolves #1371
