### PR TITLE
Moved search button to menu

### DIFF
--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -1,13 +1,11 @@
 import { makeStyles } from '@mui/styles';
-import { Search } from '@mui/icons-material';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
-import { Box, Button, Dialog } from '@mui/material';
+import { Box, Dialog } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import defaultFetch from 'utils/fetching/defaultFetch';
 import handleResponseData from 'utils/api/handleResponseData';
-import isUserTyping from 'features/search/utils/isUserTyping';
 import ResultsList from 'features/search/components/SearchDialog/ResultsList';
 import SearchField from './SearchField';
 import { SearchResult } from '../types';
@@ -37,8 +35,15 @@ const getSearchResults = (orgId: string, searchQuery: string) => {
   };
 };
 
-const SearchDialog: React.FunctionComponent = () => {
-  const [open, setOpen] = useState(false);
+interface SearchDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SearchDialog: React.FunctionComponent<SearchDialogProps> = ({
+  open,
+  onClose,
+}) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [isTyping, setIsTyping] = useState(false);
 
@@ -52,24 +57,8 @@ const SearchDialog: React.FunctionComponent = () => {
 
   const handleRouteChange = () => {
     // Close dialog when clicking an item
-    setOpen(false);
+    onClose();
   };
-
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (!isUserTyping(e)) {
-      if (e.key === '/') {
-        e.preventDefault();
-        setOpen(true);
-      }
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('keydown', handleKeydown);
-    return () => {
-      document.removeEventListener('keydown', handleKeydown);
-    };
-  });
 
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChange);
@@ -94,13 +83,6 @@ const SearchDialog: React.FunctionComponent = () => {
   return (
     <>
       {/* Activator */}
-      <Button
-        color="inherit"
-        data-testid="SearchDialog-activator"
-        onClick={() => setOpen(true)}
-      >
-        <Search />
-      </Button>
       <Dialog
         classes={{
           paperScrollBody: classes.topPaperScrollBody,
@@ -108,7 +90,7 @@ const SearchDialog: React.FunctionComponent = () => {
         }}
         fullWidth
         onClose={() => {
-          setOpen(false);
+          onClose();
           setSearchQuery('');
         }}
         open={open}

--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -105,7 +105,6 @@ const Header: React.FC<HeaderProps> = ({
                 </Button>
               </Box>
             )}
-            <SearchDialog />
           </Box>
         </Box>
         {/* Title, subtitle, and action buttons */}

--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -11,7 +11,6 @@ import {
 } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-import SearchDialog from 'features/search/components/SearchDialog';
 import ZUIBreadcrumbTrail from 'zui/ZUIBreadcrumbTrail';
 import ZUIEllipsisMenu, { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
 

--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -199,6 +199,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 <NextLink href={'#'} passHref={false}>
                   <IconButton
                     className={classes.roundButton}
+                    onClick={(ev) => {
+                      ev.preventDefault();
+                      setSearchOpen(true);
+                    }}
                     size="large"
                     sx={{
                       justifyContent: open ? 'initial' : 'center',
@@ -206,10 +210,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                       ml: open ? 1 : 2,
                       mr: open ? 2 : 1,
                       px: 2.5,
-                    }}
-                    onClick={(ev) => {
-                      ev.preventDefault();
-                      setSearchOpen(true);
                     }}
                   >
                     <Avatar
@@ -266,7 +266,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
           ))}
         </List>
       </Drawer>
-      <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
+      <SearchDialog onClose={() => setSearchOpen(false)} open={searchOpen} />
     </Box>
   );
 };

--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -10,6 +10,7 @@ import {
   KeyboardDoubleArrowRight,
   Map,
   People,
+  Search,
 } from '@mui/icons-material/';
 import {
   Avatar,
@@ -26,6 +27,7 @@ import {
 import makeStyles from '@mui/styles/makeStyles';
 import messageIds from './l10n/messageIds';
 import OrganizationsDataModel from 'features/organizations/models/OrganizationsDataModel';
+import SearchDialog from 'features/search/components/SearchDialog';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import ZUIFuture from './ZUIFuture';
@@ -95,6 +97,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const key = orgId ? router.pathname.split('[orgId]')[1] : 'organize';
 
   const [open, setOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const toggleDrawer = () => {
     setOpen(!open);
   };
@@ -104,6 +107,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   );
 
   const menuItemsMap = [
+    { icon: <Search />, name: 'search', onClick: 'search' },
     { icon: <People />, name: 'people' },
     { icon: <Architecture />, name: 'projects' },
     { icon: <Explore />, name: 'journeys' },
@@ -191,40 +195,78 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 display: 'block',
               }}
             >
-              <NextLink href={`/organize/${orgId}/${item.name}`} passHref>
-                <IconButton
-                  className={classes.roundButton}
-                  size="large"
-                  sx={{
-                    justifyContent: open ? 'initial' : 'center',
-                    minHeight: 48,
-                    ml: open ? 1 : 2,
-                    mr: open ? 2 : 1,
-                    px: 2.5,
-                  }}
-                >
-                  <Avatar
+              {'onClick' in item ? (
+                <NextLink href={'#'} passHref={false}>
+                  <IconButton
+                    className={classes.roundButton}
+                    size="large"
                     sx={{
-                      backgroundColor: key.startsWith('/' + item.name)
-                        ? theme.palette.grey[300]
-                        : 'transparent',
-                      borderRadius: '20%',
-                      color: theme.palette.grey[500],
+                      justifyContent: open ? 'initial' : 'center',
+                      minHeight: 48,
+                      ml: open ? 1 : 2,
+                      mr: open ? 2 : 1,
+                      px: 2.5,
                     }}
-                    variant="square"
+                    onClick={(ev) => {
+                      ev.preventDefault();
+                      setSearchOpen(true);
+                    }}
                   >
-                    {item.icon}
-                  </Avatar>
-                  <ListItemText
-                    primary={messages.organizeSidebar[item.name]()}
-                    sx={{ marginLeft: 2, opacity: open ? 1 : 0 }}
-                  />
-                </IconButton>
-              </NextLink>
+                    <Avatar
+                      sx={{
+                        backgroundColor: searchOpen
+                          ? theme.palette.grey[300]
+                          : 'transparent',
+                        borderRadius: '20%',
+                        color: theme.palette.grey[500],
+                      }}
+                      variant="square"
+                    >
+                      {item.icon}
+                    </Avatar>
+                    <ListItemText
+                      primary={messages.organizeSidebar[item.name]()}
+                      sx={{ marginLeft: 2, opacity: open ? 1 : 0 }}
+                    />
+                  </IconButton>
+                </NextLink>
+              ) : (
+                <NextLink href={`/organize/${orgId}/${item.name}`} passHref>
+                  <IconButton
+                    className={classes.roundButton}
+                    size="large"
+                    sx={{
+                      justifyContent: open ? 'initial' : 'center',
+                      minHeight: 48,
+                      ml: open ? 1 : 2,
+                      mr: open ? 2 : 1,
+                      px: 2.5,
+                    }}
+                  >
+                    <Avatar
+                      sx={{
+                        backgroundColor: key.startsWith('/' + item.name)
+                          ? theme.palette.grey[300]
+                          : 'transparent',
+                        borderRadius: '20%',
+                        color: theme.palette.grey[500],
+                      }}
+                      variant="square"
+                    >
+                      {item.icon}
+                    </Avatar>
+                    <ListItemText
+                      primary={messages.organizeSidebar[item.name]()}
+                      sx={{ marginLeft: 2, opacity: open ? 1 : 0 }}
+                    />
+                  </IconButton>
+                </NextLink>
+              )}
             </ListItem>
           ))}
         </List>
       </Drawer>
+      <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
     </Box>
   );
 };

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -107,6 +107,7 @@ export default makeMessages('zui', {
     journeys: m('Journeys'),
     people: m('People'),
     projects: m('Projects'),
+    search: m('Search'),
   },
   personGridEditCell: {
     keepTyping: m('Keep typing..'),


### PR DESCRIPTION
## Description
Moved search icon from header to sidebar

Note: Should be cleaned up by merging identical code to previous menu items

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/5add35c1-e892-4ed7-940f-4d31bc5b19fd)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/16ea6029-76da-4cf3-acf3-f163eb60ddce)

## Changes
Moved functionality from \<SearchDialog/\> to ListItem
Removed key stroke code from \<SearchDialog/\>
Removed unused imports

## Notes to reviewer
Go to any page with side bar menu.
Search button should be in menu and appear identical to other menu items.
Functionality should remain the same as before

## Related issues
Resolves #1376 
