### PR TITLE
Use gray instead of black on light backgrounds.

### DIFF
--- a/src/features/organizations/components/ProceduralColorIcon/index.tsx
+++ b/src/features/organizations/components/ProceduralColorIcon/index.tsx
@@ -1,7 +1,20 @@
-import { Box } from '@mui/material';
 import { FC } from 'react';
 import { GroupWork } from '@mui/icons-material';
+import { makeStyles } from '@mui/styles';
 import randomSeed from 'random-seed';
+import { Box, Theme } from '@mui/material';
+
+interface StyleProps {
+  rgbAverage: number;
+}
+
+const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
+  icon: {
+    color: ({ rgbAverage }) =>
+      rgbAverage < 180 ? 'white' : theme.palette.grey[800],
+    fontSize: '35px',
+  },
+}));
 
 interface ProceduralColorIconProps {
   id: number;
@@ -9,11 +22,12 @@ interface ProceduralColorIconProps {
 
 const ProceduralColorIcon: FC<ProceduralColorIconProps> = ({ id }) => {
   const rand = randomSeed.create(id.toString());
-
   const r = rand(256);
   const g = rand(256);
   const b = rand(256);
   const rgbAverage = (r + g + b) / 3;
+
+  const classes = useStyles({ rgbAverage });
 
   return (
     <Box
@@ -24,10 +38,7 @@ const ProceduralColorIcon: FC<ProceduralColorIconProps> = ({ id }) => {
         padding: 0.5,
       }}
     >
-      <GroupWork
-        fontSize="large"
-        sx={{ color: rgbAverage < 180 ? 'white' : 'black' }}
-      />
+      <GroupWork className={classes.icon} />
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR changes the icon color from black to gray, as suggested by @yusf 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/f1bcc51a-6b07-4d5f-8a31-056e01d6514c)

## Changes
* Adds class to icon to conditionally use theme color

