### PR TITLE
Issue-1255/Local person tooltip

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -141,7 +141,10 @@ const SurveySubmissionsList = ({
         >
           <ZUIPersonGridCell
             onClick={startEditing}
-            person={row.respondent}
+            person={{
+              ...row.respondent,
+              id: row.respondent.id, // Telling typescript that there is an id
+            }}
             sx={{
               cursor: 'pointer',
             }}

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -145,6 +145,7 @@ const SurveySubmissionsList = ({
             sx={{
               cursor: 'pointer',
             }}
+            tooltip={false}
           />
         </ZUIPersonHoverCard>
       );

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -141,7 +141,7 @@ const SurveySubmissionsList = ({
         >
           <ZUIPersonGridCell
             onClick={startEditing}
-            personId={row.respondent.id}
+            person={row.respondent}
             sx={{
               cursor: 'pointer',
             }}

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -31,7 +31,7 @@ export default class LocalPersonColumnType
       headerAlign: 'center',
 
       renderCell: (params) => {
-        return <ZUIPersonGridCell personId={params.value?.id} />;
+        return <ZUIPersonGridCell person={params.value} />;
       },
       renderEditCell: (params) => {
         return <EditCell cell={params.value} column={col} row={params.row} />;

--- a/src/zui/ZUIAvatar/index.tsx
+++ b/src/zui/ZUIAvatar/index.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable react/display-name */
 import { Avatar } from '@mui/material';
-import { FC } from 'react';
+import { forwardRef } from 'react';
 
 interface ZUIAvatarProps {
   orgId: number;
@@ -12,13 +13,17 @@ const SIZES = {
   sm: 30,
 };
 
-const ZUIAvatar: FC<ZUIAvatarProps> = ({ orgId, personId, size = 'md' }) => {
-  return (
-    <Avatar
-      src={`/api/orgs/${orgId}/people/${personId}/avatar`}
-      style={{ height: SIZES[size], width: SIZES[size] }}
-    />
-  );
-};
+const ZUIAvatar = forwardRef<HTMLDivElement, ZUIAvatarProps>(
+  ({ orgId, personId, size = 'md', ...restProps }, ref) => {
+    return (
+      <Avatar
+        ref={ref}
+        {...restProps}
+        src={`/api/orgs/${orgId}/people/${personId}/avatar`}
+        style={{ height: SIZES[size], width: SIZES[size] }}
+      />
+    );
+  }
+);
 
 export default ZUIAvatar;

--- a/src/zui/ZUIPersonGridCell.tsx
+++ b/src/zui/ZUIPersonGridCell.tsx
@@ -1,22 +1,25 @@
 import { FC } from 'react';
 import { Person } from '@mui/icons-material';
 import { useRouter } from 'next/router';
-import { Avatar, Box, SxProps } from '@mui/material';
+import { Avatar, Box, SxProps, Tooltip } from '@mui/material';
 
 import ZUIAvatar from 'zui/ZUIAvatar';
+import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
 
 const ZUIPersonGridCell: FC<{
   onClick?: () => void;
-  personId: number | null;
+  person: ZetkinPerson | ZetkinSurveySubmission['respondent'] | null;
   sx?: SxProps;
-}> = ({ personId, onClick, sx }) => {
+}> = ({ person, onClick, sx }) => {
   const query = useRouter().query;
   const orgId = parseInt(query.orgId as string);
 
   return (
     <Box onClick={onClick} sx={sx}>
-      {personId ? (
-        <ZUIAvatar orgId={orgId} personId={personId} />
+      {person && person.id ? (
+        <Tooltip title={`${person.first_name} ${person.last_name}`}>
+          <ZUIAvatar orgId={orgId} personId={person.id} />
+        </Tooltip>
       ) : (
         <Avatar>
           <Person />

--- a/src/zui/ZUIPersonGridCell.tsx
+++ b/src/zui/ZUIPersonGridCell.tsx
@@ -10,7 +10,7 @@ const ZUIPersonGridCell: FC<{
   onClick?: () => void;
   person: Pick<ZetkinPerson, 'first_name' | 'last_name' | 'id'> | null;
   sx?: SxProps;
-  tooltip: boolean;
+  tooltip?: boolean;
 }> = ({ person, onClick, sx, tooltip = true }) => {
   const query = useRouter().query;
   const orgId = parseInt(query.orgId as string);

--- a/src/zui/ZUIPersonGridCell.tsx
+++ b/src/zui/ZUIPersonGridCell.tsx
@@ -3,27 +3,43 @@ import { Person } from '@mui/icons-material';
 import { useRouter } from 'next/router';
 import { Avatar, Box, SxProps, Tooltip } from '@mui/material';
 
+import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
-import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
+
+type PersonGridCellPerson = Pick<ZetkinPerson, 'first_name' | 'last_name'> & {
+  id: number | null;
+};
 
 const ZUIPersonGridCell: FC<{
   onClick?: () => void;
-  person: ZetkinPerson | ZetkinSurveySubmission['respondent'] | null;
+  person: PersonGridCellPerson | null;
   sx?: SxProps;
-}> = ({ person, onClick, sx }) => {
+  tooltip: boolean;
+}> = ({ person, onClick, sx, tooltip = true }) => {
   const query = useRouter().query;
   const orgId = parseInt(query.orgId as string);
 
+  // If no person provided
+  if (!person || !person.id) {
+    return (
+      <Box onClick={onClick} sx={sx}>
+        <Avatar>
+          <Person />
+        </Avatar>
+      </Box>
+    );
+  }
+
   return (
     <Box onClick={onClick} sx={sx}>
-      {person && person.id ? (
+      {tooltip ? (
+        // Person with tooltip
         <Tooltip title={`${person.first_name} ${person.last_name}`}>
           <ZUIAvatar orgId={orgId} personId={person.id} />
         </Tooltip>
       ) : (
-        <Avatar>
-          <Person />
-        </Avatar>
+        // Person without tooltip
+        <ZUIAvatar orgId={orgId} personId={person.id} />
       )}
     </Box>
   );

--- a/src/zui/ZUIPersonGridCell.tsx
+++ b/src/zui/ZUIPersonGridCell.tsx
@@ -6,13 +6,9 @@ import { Avatar, Box, SxProps, Tooltip } from '@mui/material';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
 
-type PersonGridCellPerson = Pick<ZetkinPerson, 'first_name' | 'last_name'> & {
-  id: number | null;
-};
-
 const ZUIPersonGridCell: FC<{
   onClick?: () => void;
-  person: PersonGridCellPerson | null;
+  person: Pick<ZetkinPerson, 'first_name' | 'last_name' | 'id'> | null;
   sx?: SxProps;
   tooltip: boolean;
 }> = ({ person, onClick, sx, tooltip = true }) => {
@@ -20,7 +16,7 @@ const ZUIPersonGridCell: FC<{
   const orgId = parseInt(query.orgId as string);
 
   // If no person provided
-  if (!person || !person.id) {
+  if (!person) {
     return (
       <Box onClick={onClick} sx={sx}>
         <Avatar>


### PR DESCRIPTION
## Description
This PR displays a tooltip when hovering a person in Views and on the Survey Results. When there is no one assigned, then nothing is displayed on hover.

## Changes
* Adds forwarded ref to `ZUIAvatar` so that it can take a Tooltip
* `ZUIPersonGridCell` now takes a subset of `ZetkinPerson` in order to render the tooltip with the person's name
  * Changes props where this is used 
* Tooltip is an optional prop. It's enabled by default.

## Notes to reviewer
Check it out here
* [Views](http://localhost:3000/organize/7/people/views/8)
* [Surveys](http://localhost:3000/organize/7/projects/standalone/surveys/15/submissions)

## Related issues
Resolves #1255 
