### PR TITLE
Add "size" section to issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -4,22 +4,28 @@ about: Features, improvements, etc.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ## Description
+
 A user should be able to...
 
 ## Relevant Job Stories
 
+## Estimated size (S, M, L)
+
+I think this issue is {size} because...
+
 ## Prerequisites
 
 ## Requirements
+
 - [ ] Requirement 1
 
 ## Possible implementations
 
 ## Design specifications
+
 (Put any links to wireframes, figma, or other designs here etc here.)
 
 ## Open questions


### PR DESCRIPTION
## Description
This PR adds a "size" section to the task issue template, where the person creating the issue will give context for why they chose the size tag they did.

Resolves #1394 