### PR TITLE
Issue 1383/consistent property names and lil bug fix

### DIFF
--- a/src/features/calendar/hooks/useDayCalendarNav.ts
+++ b/src/features/calendar/hooks/useDayCalendarNav.ts
@@ -49,9 +49,9 @@ export default function useDayCalendarNav(
             endingActivities: [],
             events: prevEventDay.events.map((event) => ({
               data: event,
-              endDate: null,
               kind: ACTIVITIES.EVENT,
-              startDate: event.published ? new Date(event.published) : null,
+              visibleFrom: event.published ? new Date(event.published) : null,
+              visibleUntil: new Date(event.end_time),
             })),
             startingActivities: [],
           },
@@ -76,11 +76,11 @@ export default function useDayCalendarNav(
             .filter((item) => !!item.data)
             .map((item) => ({
               data: item.data!,
-              endDate: null,
               kind: ACTIVITIES.EVENT,
-              startDate: item.data!.published
+              visibleFrom: item.data!.published
                 ? new Date(item.data!.published)
                 : null,
+              visibleUntil: null,
             })),
           startingActivities: [],
         },

--- a/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
+++ b/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
@@ -43,9 +43,9 @@ function mockEvent(id: number, data: Partial<ZetkinEvent>): EventActivity {
       ...data,
       id,
     },
-    endDate: null,
     kind: ACTIVITIES.EVENT,
-    startDate: null,
+    visibleFrom: null,
+    visibleUntil: null,
   };
 }
 

--- a/src/features/campaigns/components/ActivitiesOverview/items/CallAssignmentOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/CallAssignmentOverviewListItem.tsx
@@ -26,7 +26,7 @@ const CallAssignmentOverviewListItem: FC<
 
   return (
     <OverviewListItem
-      endDate={activity.endDate}
+      endDate={activity.visibleUntil}
       endNumber={callsMade}
       focusDate={focusDate}
       href={`/organize/${assignment.organization.id}/projects/${
@@ -34,7 +34,7 @@ const CallAssignmentOverviewListItem: FC<
       }/callassignments/${assignment.id}`}
       PrimaryIcon={HeadsetMic}
       SecondaryIcon={PhoneOutlined}
-      startDate={activity.startDate}
+      startDate={activity.visibleFrom}
       statusBar={
         stats?.allTargets ? (
           <ZUIStackedStatusBar

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -69,8 +69,8 @@ interface OverviewListItemProps {
   SecondaryIcon: OverridableComponent<
     SvgIconTypeMap<Record<string, unknown>, 'svg'>
   >;
-  endDate: CampaignActivity['endDate'];
-  startDate: CampaignActivity['startDate'];
+  endDate: CampaignActivity['visibleUntil'];
+  startDate: CampaignActivity['visibleFrom'];
   focusDate: Date | null;
   href: string;
   meta?: JSX.Element;

--- a/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
@@ -26,7 +26,7 @@ const SurveyOverviewListItem: FC<SurveyOverviewListItemProps> = ({
 
   return (
     <OverviewListItem
-      endDate={activity.endDate}
+      endDate={activity.visibleUntil}
       endNumber={submissionCount}
       focusDate={focusDate}
       href={`/organize/${survey.organization.id}/projects/${
@@ -34,7 +34,7 @@ const SurveyOverviewListItem: FC<SurveyOverviewListItemProps> = ({
       }/surveys/${survey.id}`}
       PrimaryIcon={AssignmentOutlined}
       SecondaryIcon={ChatBubbleOutline}
-      startDate={activity.startDate}
+      startDate={activity.visibleFrom}
       statusBar={
         stats?.submissionCount ? (
           <ZUIStackedStatusBar

--- a/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
@@ -25,7 +25,7 @@ const TaskOverviewListItem: FC<TasksOverviewListItemProps> = ({
 
   return (
     <OverviewListItem
-      endDate={activity.endDate}
+      endDate={activity.visibleUntil}
       endNumber={stats?.individuals || 0}
       focusDate={focusDate}
       href={`/organize/${task.organization.id}/projects/${
@@ -33,7 +33,7 @@ const TaskOverviewListItem: FC<TasksOverviewListItemProps> = ({
       }/calendar/tasks/${task.id}`}
       PrimaryIcon={CheckBoxOutlined}
       SecondaryIcon={People}
-      startDate={activity.startDate}
+      startDate={activity.visibleFrom}
       statusBar={
         stats?.assigned ? (
           <ZUIStackedStatusBar

--- a/src/features/campaigns/hooks/useClusteredActivities.spec.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.spec.ts
@@ -54,9 +54,9 @@ function mockEvent(id: number, data: Partial<ZetkinEvent>): EventActivity {
       ...data,
       id,
     },
-    endDate: null,
     kind: ACTIVITIES.EVENT,
-    startDate: null,
+    visibleFrom: null,
+    visibleUntil: null,
   };
 }
 
@@ -183,18 +183,18 @@ describe('useClusteredActivities()', () => {
         {
           // Fake data, will never be used
           data: { id: 1 } as ZetkinSurvey,
-          endDate: new Date('1857-07-06T13:37:00.000Z'),
           kind: ACTIVITIES.SURVEY,
           // This should appear first
-          startDate: new Date('1857-07-05T11:37:00.000Z'),
+          visibleFrom: new Date('1857-07-05T11:37:00.000Z'),
+          visibleUntil: new Date('1857-07-06T13:37:00.000Z'),
         },
         {
           // Fake data, will never be used
           data: { id: 2 } as ZetkinCallAssignment,
-          endDate: new Date('1857-07-06T13:37:00.000Z'),
           kind: ACTIVITIES.CALL_ASSIGNMENT,
           // This should appear last
-          startDate: new Date('1857-07-05T13:37:00.000Z'),
+          visibleFrom: new Date('1857-07-05T13:37:00.000Z'),
+          visibleUntil: new Date('1857-07-06T13:37:00.000Z'),
         },
         mockEvent(2, {
           end_time: '1857-07-05T14:00:00.000Z',

--- a/src/features/campaigns/hooks/useClusteredActivities.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.ts
@@ -157,10 +157,10 @@ export default function useClusteredActivities(
   return clusteredEvents.concat(otherActivities).sort((a, b) => {
     const aStart = isEventCluster(a)
       ? new Date(a.events[0].start_time)
-      : a.startDate;
+      : a.visibleFrom;
     const bStart = isEventCluster(b)
       ? new Date(b.events[0].start_time)
-      : b.startDate;
+      : b.visibleFrom;
 
     if (!aStart && !bStart) {
       return 0;

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -65,8 +65,8 @@ export default function useEventsFromDateRange(
     .filter((event) => !campId || event.campaign?.id == campId)
     .map((event) => ({
       data: event,
-      endDate: null,
       kind: ACTIVITIES.EVENT,
-      startDate: event.published ? new Date(event.published) : null,
+      visibleFrom: event.published ? new Date(event.published) : null,
+      visibleUntil: new Date(event.end_time),
     }));
 }

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -91,7 +91,11 @@ const eventsSlice = createSlice({
       const event = action.payload;
       state.eventList.isLoading = false;
       state.eventList.items.push(remoteItem(event.id, { data: event }));
-      state.eventsByDate[event.start_time.slice(0, 10)].items.push(
+      const dateStr = event.start_time.slice(0, 10);
+      if (!state.eventsByDate[dateStr]) {
+        state.eventsByDate[dateStr] = remoteList();
+      }
+      state.eventsByDate[dateStr].items.push(
         remoteItem(event.id, { data: event })
       );
     },

--- a/src/features/tasks/l10n/messageIds.ts
+++ b/src/features/tasks/l10n/messageIds.ts
@@ -183,7 +183,7 @@ export default makeMessages('feat.tasks', {
   },
   taskListItem: {
     relativeTimes: {
-      active: m<{ time: ReactElement }>('Closes {time}'),
+      active: m<{ time: ReactElement }>('Deadline {time}'),
       closed: m<{ time: ReactElement }>('Closed {time}'),
       expired: m<{ time: ReactElement }>('Expired {time}'),
       expires: m<{ time: ReactElement }>('Expires {time}'),

--- a/src/features/tasks/utils/getTaskStatus.ts
+++ b/src/features/tasks/utils/getTaskStatus.ts
@@ -10,7 +10,7 @@ export enum TASK_STATUS {
 }
 
 const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
-  const { published, deadline, expires } = task;
+  const { published, expires } = task;
   const now = dayjs();
 
   const expiresDate = dayjs(expires);
@@ -18,13 +18,6 @@ const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
 
   if (isExpiresPassed) {
     return TASK_STATUS.EXPIRED;
-  }
-
-  const deadlineDate = dayjs(deadline);
-  const isDeadlinePassed = deadlineDate.isBefore(now);
-
-  if (isDeadlinePassed) {
-    return TASK_STATUS.CLOSED;
   }
 
   const publishedDate = dayjs(published);

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -52,6 +52,7 @@ feat:
       type: Type to filter content
     lastDayWithEvents: There {numEvents, plural, one {was one event} other {were
       {numEvents} events}} on the last active day
+    loadMore: Load more
     moreEvents: "{numEvents, plural, one {# more event} other {# more events}}"
     next: NEXT
     prev: PREV
@@ -1308,7 +1309,7 @@ feat:
         summary: Summary
     taskListItem:
       relativeTimes:
-        active: Closes {time}
+        active: Deadline {time}
         closed: Closed {time}
         expired: Expired {time}
         expires: Expires {time}


### PR DESCRIPTION
## Description
This PR enhances the experience of working with activities by giving them consistent property names in regards to time. it also fixes two sneaky bugs that reared their lil heads while working on this - that the status chip on task pages was incorrect, and that the store had a bug in adding new events to a date that did not already have events.

## Changes
- use `visibleFrom` and `visibleUntil` as names in the `CampaignActivityBase` type
- use these properties to calculate what tab acitvities end up on (current or archive)
- update event store logic to add events
- update logic for task status, to exclude "closed" as a status.

## Related issues
Resolves #1383 
