### PR TITLE
Issue 1380/smart search stats popper

### DIFF
--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
@@ -1,4 +1,4 @@
-import { Alert, useTheme } from '@mui/material';
+import { Alert, Typography, useTheme } from '@mui/material';
 import {
   ArrowForwardOutlined,
   CircleOutlined,
@@ -9,6 +9,7 @@ import { Box, Button, DialogActions, List } from '@mui/material';
 
 import DisplayStartsWith from '../../StartsWith/DisplayStartsWith';
 import { Msg } from 'core/i18n';
+import useSmartSearchStats from 'features/smartSearch/hooks/useSmartSearchStats';
 import {
   AnyFilterConfig,
   FILTER_TYPE,
@@ -51,6 +52,8 @@ const QueryOverview = ({
   startsWithAll,
 }: QueryOverviewProps): JSX.Element => {
   const theme = useTheme();
+  const stats = useSmartSearchStats(filters);
+  const resultCount = stats?.length ? stats[stats.length - 1].result : 0;
   return (
     <Box
       sx={{
@@ -136,11 +139,30 @@ const QueryOverview = ({
       {hasSaveCancelButtons && (
         <DialogActions>
           <Box
+            alignItems="center"
             display="flex"
             justifyContent="flex-end"
             m={1}
             style={{ gap: '1rem' }}
           >
+            <Typography color={theme.palette.text.secondary}>
+              <Msg
+                id={messageIds.resultHint.hint}
+                values={{
+                  count: (
+                    <Typography
+                      color={theme.palette.text.primary}
+                      component="span"
+                    >
+                      <Msg
+                        id={messageIds.resultHint.countLabel}
+                        values={{ count: resultCount }}
+                      />
+                    </Typography>
+                  ),
+                }}
+              />
+            </Typography>
             {readOnly && (
               <Button
                 color="primary"

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeySegment.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeySegment.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import { FC, useEffect, useRef, useState } from 'react';
 
 import { SankeyRenderer } from './drawing';
+import SmartSearchSankeyStatsPopper from './SmartSearchSankeyStatsPopper';
 import useResizeObserver from 'zui/hooks/useResizeObserver';
 import { SankeyConfig, SankeySegment } from './types';
 
@@ -95,6 +96,13 @@ const SmartSearchSankeySegment: FC<SmartSearchSankeySegmentProps> = ({
         }}
         width={canvasWidth}
       />
+      {'stats' in segment && (
+        <SmartSearchSankeyStatsPopper
+          anchorEl={canvasRef.current}
+          open={hovered}
+          stats={segment.stats}
+        />
+      )}
     </Box>
   );
 };

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyStatsPopper.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyStatsPopper.tsx
@@ -1,0 +1,97 @@
+import { FC } from 'react';
+import { Box, Grid, Paper, Popper, Typography, useTheme } from '@mui/material';
+
+import messageIds from 'features/smartSearch/l10n/messageIds';
+import { SankeySegmentStats } from './types';
+import { Msg, useMessages } from 'core/i18n';
+
+type SmartSearchSankeyStatsPopperProps = {
+  anchorEl: HTMLElement | null;
+  open: boolean;
+  stats: SankeySegmentStats;
+};
+
+const SmartSearchSankeyStatsPopper: FC<SmartSearchSankeyStatsPopperProps> = ({
+  anchorEl,
+  open,
+  stats,
+}) => {
+  const messages = useMessages(messageIds);
+  const theme = useTheme();
+  const light = theme.palette.grey[500];
+  const dark = theme.palette.text.primary;
+
+  return (
+    <Popper
+      anchorEl={anchorEl}
+      open={open}
+      placement="left"
+      sx={{ zIndex: 2000 }}
+    >
+      <Paper elevation={2} sx={{ transform: 'translate(-20px, 0)' }}>
+        <Box maxWidth={300} p={2}>
+          <Typography fontWeight={500} variant="h5">
+            <Msg id={messageIds.statsPopper.headline} />
+          </Typography>
+          <Grid container>
+            <Grid item sm={6}>
+              <Metric
+                color={light}
+                label={messages.statsPopper.matches()}
+                value={stats.matches}
+              />
+            </Grid>
+            <Grid item sm={6}>
+              <Metric
+                color={dark}
+                label="CHANGE"
+                value={stats.change > 0 ? `+${stats.change}` : stats.change}
+              />
+            </Grid>
+            <Grid item sm={6}>
+              <Metric
+                color={light}
+                label={messages.statsPopper.input()}
+                value={stats.input}
+              />
+            </Grid>
+            <Grid item sm={6}>
+              <Metric
+                color={light}
+                label={messages.statsPopper.output()}
+                value={stats.output}
+              />
+            </Grid>
+          </Grid>
+          <Typography mt={1} variant="body2">
+            <Msg id={messageIds.statsPopper.info} />
+          </Typography>
+        </Box>
+      </Paper>
+    </Popper>
+  );
+};
+
+const Metric: FC<{ color?: string; label: string; value: number | string }> = ({
+  color,
+  label,
+  value,
+}) => {
+  return (
+    <Box display="flex" flexDirection="column" mt={2}>
+      <Typography fontSize="12px" variant="body2">
+        {label.toUpperCase()}
+      </Typography>
+      <Typography
+        color={color}
+        fontSize="20px"
+        fontWeight={500}
+        variant="body1"
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+};
+
+export default SmartSearchSankeyStatsPopper;

--- a/src/features/smartSearch/components/sankeyDiagram/index.stories.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/index.stories.tsx
@@ -40,12 +40,20 @@ const defaultConfig = {
   segHeight: 100,
 };
 
+const stats = {
+  change: 0,
+  input: 0,
+  matches: 0,
+  output: 0,
+};
+
 export const basic = Template.bind({});
 basic.args = {
   ...defaultConfig,
   segments: [
     {
       kind: SEGMENT_KIND.ENTRY,
+      stats,
       style: SEGMENT_STYLE.FILL,
       width: 0.8,
     },
@@ -59,6 +67,7 @@ basic.args = {
         style: SEGMENT_STYLE.FILL,
         width: 0.2,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.SUB,
@@ -70,9 +79,11 @@ basic.args = {
         style: SEGMENT_STYLE.FILL,
         width: 0.3,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.EXIT,
+      output: 0,
       style: SEGMENT_STYLE.FILL,
       width: 0.7,
     },
@@ -85,6 +96,7 @@ pseudo.args = {
   segments: [
     {
       kind: SEGMENT_KIND.ENTRY,
+      stats,
       style: SEGMENT_STYLE.STROKE,
       width: 1,
     },
@@ -98,6 +110,7 @@ pseudo.args = {
         style: SEGMENT_STYLE.STROKE,
         width: 1,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.PSEUDO_SUB,
@@ -109,9 +122,11 @@ pseudo.args = {
         style: SEGMENT_STYLE.STROKE,
         width: 1,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.EXIT,
+      output: 0,
       style: SEGMENT_STYLE.STROKE,
       width: 1,
     },
@@ -132,6 +147,7 @@ mixed.args = {
         style: SEGMENT_STYLE.STROKE,
         width: 1,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.PSEUDO_ADD,
@@ -143,6 +159,7 @@ mixed.args = {
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.SUB,
@@ -154,9 +171,11 @@ mixed.args = {
         style: SEGMENT_STYLE.FILL,
         width: 0.3,
       },
+      stats,
     },
     {
       kind: SEGMENT_KIND.EXIT,
+      output: 0,
       style: SEGMENT_STYLE.FILL,
       width: 0.7,
     },

--- a/src/features/smartSearch/components/sankeyDiagram/index.stories.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/index.stories.tsx
@@ -21,7 +21,7 @@ const Template: Story<StoryArgs> = (args) => {
   const { segments, ...config } = args;
 
   return (
-    <Box>
+    <Box maxWidth={200}>
       {segments.map((seg, index) => (
         <SmartSearchSankeySegment key={index} config={config} segment={seg} />
       ))}

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -42,9 +42,16 @@ describe('makeSankeySegments()', () => {
           style: SEGMENT_STYLE.FILL,
           width: 1.0,
         },
+        stats: {
+          change: 200,
+          input: 0,
+          matches: 200,
+          output: 200,
+        },
       },
       {
         kind: SEGMENT_KIND.EXIT,
+        output: 200,
         style: SEGMENT_STYLE.FILL,
         width: 1.0,
       },
@@ -68,11 +75,18 @@ describe('makeSankeySegments()', () => {
     expect(result).toEqual(<SankeySegment[]>[
       {
         kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 200,
+          input: 0,
+          matches: 200,
+          output: 200,
+        },
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
       {
         kind: SEGMENT_KIND.EXIT,
+        output: 200,
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
@@ -106,6 +120,12 @@ describe('makeSankeySegments()', () => {
     expect(result).toEqual(<SankeySegment[]>[
       {
         kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 200,
+          input: 0,
+          matches: 200,
+          output: 200,
+        },
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
@@ -119,9 +139,16 @@ describe('makeSankeySegments()', () => {
           style: SEGMENT_STYLE.FILL,
           width: 0.25,
         },
+        stats: {
+          change: -50,
+          input: 200,
+          matches: 100,
+          output: 150,
+        },
       },
       {
         kind: SEGMENT_KIND.EXIT,
+        output: 150,
         style: SEGMENT_STYLE.FILL,
         width: 0.75,
       },
@@ -175,6 +202,12 @@ describe('makeSankeySegments()', () => {
     expect(result).toEqual(<SankeySegment[]>[
       {
         kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
@@ -188,16 +221,11 @@ describe('makeSankeySegments()', () => {
           style: SEGMENT_STYLE.FILL,
           width: 0.2,
         },
-      },
-      {
-        kind: SEGMENT_KIND.PSEUDO_ADD,
-        main: {
-          style: SEGMENT_STYLE.FILL,
-          width: 0.8,
-        },
-        side: {
-          style: SEGMENT_STYLE.STROKE,
-          width: 0.8,
+        stats: {
+          change: -20,
+          input: 100,
+          matches: 20,
+          output: 80,
         },
       },
       {
@@ -209,10 +237,34 @@ describe('makeSankeySegments()', () => {
         side: {
           style: SEGMENT_STYLE.STROKE,
           width: 0.8,
+        },
+        stats: {
+          change: 0,
+          input: 80,
+          matches: 5,
+          output: 80,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.8,
+        },
+        side: {
+          style: SEGMENT_STYLE.STROKE,
+          width: 0.8,
+        },
+        stats: {
+          change: 0,
+          input: 80,
+          matches: 10,
+          output: 80,
         },
       },
       {
         kind: SEGMENT_KIND.EXIT,
+        output: 80,
         style: SEGMENT_STYLE.FILL,
         width: 0.8,
       },
@@ -256,6 +308,12 @@ describe('makeSankeySegments()', () => {
     expect(result).toEqual(<SankeySegment[]>[
       {
         kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
         style: SEGMENT_STYLE.FILL,
         width: 1,
       },
@@ -269,6 +327,12 @@ describe('makeSankeySegments()', () => {
           style: SEGMENT_STYLE.FILL,
           width: 0.2,
         },
+        stats: {
+          change: -20,
+          input: 100,
+          matches: 20,
+          output: 80,
+        },
       },
       {
         kind: SEGMENT_KIND.PSEUDO_SUB,
@@ -280,9 +344,16 @@ describe('makeSankeySegments()', () => {
           style: SEGMENT_STYLE.STROKE,
           width: 0.8,
         },
+        stats: {
+          change: 0,
+          input: 80,
+          matches: 5,
+          output: 80,
+        },
       },
       {
         kind: SEGMENT_KIND.EXIT,
+        output: 80,
         style: SEGMENT_STYLE.FILL,
         width: 0.8,
       },

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
@@ -2,6 +2,7 @@ import { ZetkinSmartSearchFilterStats } from 'features/smartSearch/types';
 import { FILTER_TYPE, OPERATION } from '../types';
 import {
   SankeySegment,
+  SankeySegmentStats,
   SEGMENT_KIND,
   SEGMENT_STYLE,
 } from '../sankeyDiagram/types';
@@ -33,6 +34,12 @@ export default function makeSankeySegments(
     if (entryStats) {
       segments[0] = {
         kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: entryStats.change,
+          input: 0,
+          matches: entryStats.matches,
+          output: entryStats.result,
+        },
         style: SEGMENT_STYLE.FILL,
         width: entryStats.result / maxPeople,
       };
@@ -41,7 +48,7 @@ export default function makeSankeySegments(
     }
   }
 
-  statsCopy.forEach(({ change, filter, result }, index) => {
+  statsCopy.forEach(({ change, filter, matches, result }, index) => {
     // The previous segment is the one with the same index as the
     // filter/stats we're currently handling, because the segments
     // array starts with an entry, so already has one element when
@@ -49,6 +56,13 @@ export default function makeSankeySegments(
     const prevSeg = segments[index];
 
     const prevIsEmpty = prevSeg.kind == SEGMENT_KIND.EMPTY;
+
+    const stats: SankeySegmentStats = {
+      change,
+      input: prevResult,
+      matches,
+      output: result,
+    };
 
     if (prevIsEmpty) {
       segments.push({
@@ -58,6 +72,7 @@ export default function makeSankeySegments(
           style: SEGMENT_STYLE.FILL,
           width: change / maxPeople,
         },
+        stats,
       });
     } else if (change > 0) {
       segments.push({
@@ -70,6 +85,7 @@ export default function makeSankeySegments(
           style: SEGMENT_STYLE.FILL,
           width: change / maxPeople,
         },
+        stats,
       });
     } else if (change < 0) {
       segments.push({
@@ -82,6 +98,7 @@ export default function makeSankeySegments(
           style: SEGMENT_STYLE.FILL,
           width: Math.abs(change) / maxPeople,
         },
+        stats,
       });
     } else {
       if (filter.op == OPERATION.ADD) {
@@ -95,6 +112,7 @@ export default function makeSankeySegments(
             style: SEGMENT_STYLE.STROKE,
             width: result / maxPeople,
           },
+          stats,
         });
       } else {
         segments.push({
@@ -107,6 +125,7 @@ export default function makeSankeySegments(
             style: SEGMENT_STYLE.STROKE,
             width: result / maxPeople,
           },
+          stats,
         });
       }
     }
@@ -123,6 +142,7 @@ export default function makeSankeySegments(
   } else {
     segments.push({
       kind: SEGMENT_KIND.EXIT,
+      output: prevResult,
       style: SEGMENT_STYLE.FILL,
       width: prevResult / maxPeople,
     });

--- a/src/features/smartSearch/components/sankeyDiagram/types.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/types.ts
@@ -17,14 +17,23 @@ type SankeyEmptySegment = {
   kind: SEGMENT_KIND.EMPTY;
 };
 
+export type SankeySegmentStats = {
+  change: number;
+  input: number;
+  matches: number;
+  output: number;
+};
+
 export type SankeyEntrySegment = {
   kind: SEGMENT_KIND.ENTRY;
+  stats: SankeySegmentStats;
   style: SEGMENT_STYLE;
   width: number;
 };
 
 export type SankeyExitSegment = {
   kind: SEGMENT_KIND.EXIT;
+  output: number;
   style: SEGMENT_STYLE;
   width: number;
 };
@@ -43,24 +52,28 @@ export type SankeyAddSegment = {
   kind: SEGMENT_KIND.ADD;
   main: SelectionMainElement<SEGMENT_STYLE.FILL>;
   side: SelectionSideElement<SEGMENT_STYLE.FILL>;
+  stats: SankeySegmentStats;
 };
 
 export type SankeyPseudoAddSegment = {
   kind: SEGMENT_KIND.PSEUDO_ADD;
   main: SelectionMainElement | null;
   side: SelectionSideElement;
+  stats: SankeySegmentStats;
 };
 
 export type SankeySubSegment = {
   kind: SEGMENT_KIND.SUB;
   main: SelectionMainElement<SEGMENT_STYLE.FILL>;
   side: SelectionSideElement<SEGMENT_STYLE.FILL>;
+  stats: SankeySegmentStats;
 };
 
 export type SankeyPseudoSubSegment = {
   kind: SEGMENT_KIND.PSEUDO_SUB;
   main: SelectionMainElement | null;
   side: SelectionSideElement;
+  stats: SankeySegmentStats;
 };
 
 export type SankeySegment =

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -600,6 +600,16 @@ export default makeMessages('feat.smartSearch', {
     'This Smart Search query is in read-only mode and cannot be edited.'
   ),
   smartSearch: m('Smart Search'),
+  statsPopper: {
+    change: m('change'),
+    headline: m('Selection impact'),
+    info: m(
+      'This is a dynamic selection and the numbers may change over time.'
+    ),
+    input: m('input'),
+    matches: m('found'),
+    output: m('output'),
+  },
   timeFrame: {
     edit: {
       afterDate: m<{

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -599,6 +599,14 @@ export default makeMessages('feat.smartSearch', {
   readOnly: m(
     'This Smart Search query is in read-only mode and cannot be edited.'
   ),
+  resultHint: {
+    countLabel: m<{ count: number }>(
+      '{count, plural, =1 {one person} other {# people}}'
+    ),
+    hint: m<{ count: ReactElement }>(
+      'This Smart Search will currently return {count} for you.'
+    ),
+  },
   smartSearch: m('Smart Search'),
   statsPopper: {
     change: m('change'),


### PR DESCRIPTION
## Description
This PR adds a popper to the Sankey diagram introduced in PR #1400.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/c4ab8257-46e8-4137-b1b9-023dd608546d)

## Changes
* Changes the `SankeySegment` types to include stats (when applicable)
* Adds a popper to sankey segments that have stats
* Adds a hint at number of total results to the bottom of the Smart Search overview

## Notes to reviewer
Should not be merged until #1400 is merged, and just like that PR, this one depends on yet-to-be-deployed API changes.

## Related issues
Resolves #1380 