### PR TITLE
Remove react-query devtools

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,6 @@ import { IntlProvider } from 'react-intl';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import NProgress from 'nprogress';
-import { ReactQueryDevtools } from 'react-query/devtools';
 import { Provider as ReduxProvider } from 'react-redux';
 import { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -121,7 +120,6 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                         </EventPopperProvider>
                       </ZUIConfirmDialogProvider>
                     </ZUISnackbarProvider>
-                    <ReactQueryDevtools initialIsOpen={false} />
                   </QueryClientProvider>
                 </IntlProvider>
               </LocalizationProvider>


### PR DESCRIPTION
## Description
This PR removes the `react-query` devtools, i.e. that little flower in the bottom left that is used to debug react-query stuff.

I have found that I never use this anymore, since we started moving away from `react-query`, and with the changes to the navbar that are being introduced in #1396, it's super annoying and in the way.

If it's ever necessary for debugging some old query, it's easy enough to add back temporarily.

## Screenshots
### Before
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/392d740d-994f-415d-9068-387541b29d95)

### After
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/e56d465f-af58-4588-8f50-e72c55745b7e)

## Changes
* Removes the `ReactQueryDevtools` element from `_app`

## Notes to reviewer
None

## Related issues
Undocumented