### PR TITLE
Bugfix: Diagram when sub from empty

### DIFF
--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -359,4 +359,58 @@ describe('makeSankeySegments()', () => {
       },
     ]);
   });
+
+  it('handles when first filter is a sub', () => {
+    const result = makeSankeySegments([
+      {
+        change: -100,
+        filter: {
+          config: {},
+          op: OPERATION.SUB,
+          type: FILTER_TYPE.RANDOM,
+        },
+        matches: 100,
+        result: 0,
+      },
+      {
+        change: 100,
+        filter: {
+          config: {},
+          op: OPERATION.ADD,
+          type: FILTER_TYPE.RANDOM,
+        },
+        matches: 100,
+        result: 100,
+      },
+    ]);
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.EMPTY,
+      },
+      {
+        kind: SEGMENT_KIND.EMPTY,
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: null,
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 1,
+        },
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 100,
+        style: SEGMENT_STYLE.FILL,
+        width: 1,
+      },
+    ]);
+  });
 });

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
@@ -65,15 +65,21 @@ export default function makeSankeySegments(
     };
 
     if (prevIsEmpty) {
-      segments.push({
-        kind: SEGMENT_KIND.PSEUDO_ADD,
-        main: null,
-        side: {
-          style: SEGMENT_STYLE.FILL,
-          width: change / maxPeople,
-        },
-        stats,
-      });
+      if (filter.op == OPERATION.SUB) {
+        segments.push({
+          kind: SEGMENT_KIND.EMPTY,
+        });
+      } else {
+        segments.push({
+          kind: SEGMENT_KIND.PSEUDO_ADD,
+          main: null,
+          side: {
+            style: SEGMENT_STYLE.FILL,
+            width: change / maxPeople,
+          },
+          stats,
+        });
+      }
     } else if (change > 0) {
       segments.push({
         kind: SEGMENT_KIND.ADD,


### PR DESCRIPTION
## Description
This PR fixes an undocumented issue with the way sankey diagrams are rendered when the first filter is a sub. This is an edge case, and should maybe not even be allowed, but we need to handle it, so this PR makes sure it's handled.


## Screenshots
### Before fix (`main`)
<img width="1271" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/764b4c3a-6b75-4dd1-851d-9ac16a0d1ed4">



### After fix (this PR)
<img width="1228" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/d58401eb-16dd-4628-a54a-7dc670cd2b83">



## Changes
* Adds a test for a scenario where the first filter in a Smart Search query is a sub
* Changes `makeSankeyDiagram()` to handle the new case


## Notes to reviewer
None


## Related issues
Undocumented