### PR TITLE
Fix location autofocus bug in `EventOverviewCard`

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -393,7 +393,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                 <Grid item sx={{ alignItems: 'center' }}>
                   <ZUIPreviewableInput
                     {...previewableProps}
-                    renderInput={() => {
+                    renderInput={(previewableInputProps) => {
                       return (
                         <Box alignItems="center" display="flex">
                           <Autocomplete
@@ -427,6 +427,10 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             renderInput={(params) => (
                               <TextField
                                 {...params}
+                                inputProps={{
+                                  ...params.inputProps,
+                                  ...previewableInputProps,
+                                }}
                                 label={messages.eventOverviewCard.location()}
                                 sx={{
                                   backgroundColor: 'white',


### PR DESCRIPTION
## Description
This PR adds the missing `inputProps` to the autocomplete used for location, so that clicking it will focus correctly.

## Screenshots
None

## Changes
* Adds missing input props that are required by `ZUIPreviewableInput` to be able to focus the clicked element

## Notes to reviewer
None

## Related issues
Resolves #1224 