### PR TITLE
Send correct index to onClickWeekHandler

### DIFF
--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -73,7 +73,7 @@ const CalendarMonthView = ({
               return (
                 <WeekNumber
                   key={gridItemKey}
-                  onClick={() => onClickWeekHandler(columnIndex)}
+                  onClick={() => onClickWeekHandler(rowIndex)}
                   weekNr={getWeekNumber(firstDayOfCalendar, rowIndex)}
                 />
               );


### PR DESCRIPTION
## Description
This PR fixed the issue that clicking week number leads to wrong week

## Changes
I passed columnIndex into a function when I meant to pass rowIndex. This has been corrected.

## Related issues
Resolves #1420 
