### PR TITLE
Hide upcoming features

### DIFF
--- a/src/features/events/components/SelectionBar.tsx
+++ b/src/features/events/components/SelectionBar.tsx
@@ -51,13 +51,14 @@ const SelectionBar = () => {
                   <Msg id={messageIds.selectionBar.deselect} />
                 </Button>
                 <Divider orientation="vertical" variant="fullWidth" />
+                {/* TODO: Implement edit events                
                 <Button
                   color="primary"
                   sx={{ borderRadius: '5px', ml: 1.5 }}
                   variant="outlined"
                 >
                   <Msg id={messageIds.selectionBar.editEvents} />
-                </Button>
+                </Button> */}
               </Box>
               <Box
                 alignItems="center"

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
@@ -6,7 +6,6 @@ import {
   Call,
   CheckBoxOutlined,
   Event,
-  FilterAltOutlined,
   LocalOfferOutlined,
   PersonAddAlt,
   PersonOutlined,
@@ -65,10 +64,6 @@ export default function getFilterComponents(
     filterOperatorIcon = undefined;
   } else if (filter.op === OPERATION.SUB) {
     filterOperatorIcon = <Remove color="secondary" fontSize="small" />;
-  } else if (filter.op === OPERATION.LIMIT) {
-    filterOperatorIcon = (
-      <FilterAltOutlined color="secondary" fontSize="small" />
-    );
   }
 
   //Uses CALL_BLOCKED as default

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -45,7 +45,6 @@ export enum CALL_OPERATOR {
 
 export enum OPERATION {
   ADD = 'add',
-  LIMIT = 'limit',
   SUB = 'sub',
 }
 

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -281,7 +281,6 @@ export default makeMessages('feat.smartSearch', {
     random: {
       addLimitRemoveSelect: {
         add: m('add'),
-        limit: m('limit to'),
         sub: m('remove'),
       },
       examples: {
@@ -567,7 +566,6 @@ export default makeMessages('feat.smartSearch', {
   },
   operators: {
     add: m('Add'),
-    limit: m('Limit to'),
     sub: m('Remove'),
   },
   quantity: {


### PR DESCRIPTION
## Description
This PR hides upcoming features from Calendar and SmartSearch

## Changes

* Hides 'Edit events' from from selection bar in calendar
* Removes limit operator Enum and it's uses and localisation

## Related issues
Resolves #1412 
