### PR TITLE
Add events breadcrumb redirect

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
@@ -1,0 +1,15 @@
+import { GetServerSideProps } from 'next';
+import { scaffold } from 'utils/next';
+
+export const getServerSideProps: GetServerSideProps = scaffold(async () => {
+  return {
+    redirect: {
+      destination: '../calendar',
+      permanent: false,
+    },
+  };
+});
+
+export default function NotUsed(): null {
+  return null;
+}

--- a/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
@@ -1,10 +1,11 @@
 import { GetServerSideProps } from 'next';
 import { scaffold } from 'utils/next';
 
-export const getServerSideProps: GetServerSideProps = scaffold(async () => {
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+  const { orgId, campId } = ctx.params!;
   return {
     redirect: {
-      destination: '../calendar',
+      destination: `/organize/${orgId}/projects/${campId}/calendar`,
       permanent: false,
     },
   };


### PR DESCRIPTION
## Description
This PR adds a redirect to the calendar page when clicking the Events breadcumb 

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/50528622/f4b57fbe-7f87-4639-a74e-b3092ffe5005

## Changes
* Clicking the events breadcumb at organize/[id]/projects/[id]/events/[id] now redirects to the calendar page

## Notes to reviewer
None

## Related issues
Resolves #1369 
