### PR TITLE
Scroll to earliest event in week view

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -2,7 +2,6 @@ import { Box } from '@mui/system';
 import dayjs from 'dayjs';
 import { FormattedTime } from 'react-intl';
 import isoWeek from 'dayjs/plugin/isoWeek';
-import { useState } from 'react';
 import { useStore } from 'react-redux';
 import {
   ListItemIcon,
@@ -11,6 +10,7 @@ import {
   MenuItem,
   Typography,
 } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
 
 import DayHeader from './DayHeader';
 import { Event } from '@mui/icons-material';
@@ -22,6 +22,7 @@ import { isSameDate } from 'utils/dateUtils';
 import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import range from 'utils/range';
+import { scrollToEarliestEvent } from './utils';
 import theme from 'theme';
 import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -37,7 +38,6 @@ export interface CalendarWeekViewProps {
   focusDate: Date;
   onClickDay: (date: Date) => void;
 }
-
 const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
   const [creating, setCreating] = useState(false);
   const [pendingEvent, setPendingEvent] = useState<[Date, Date] | null>(null);
@@ -60,6 +60,17 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
     dates: dayDates,
     orgId,
   });
+
+  let laneHeight = 0;
+  const weekGridRef = useRef<HTMLDivElement>();
+  // This should only run when focusDate changes
+  useEffect(() => {
+    scrollToEarliestEvent(
+      weekGridRef.current,
+      laneHeight,
+      eventsByDate.map((a) => a.lanes)
+    );
+  }, [focusDate]);
 
   return (
     <>
@@ -85,6 +96,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
       </Box>
       {/* Week grid */}
       <Box
+        ref={weekGridRef}
         columnGap={1}
         display="grid"
         gridTemplateColumns={`${HOUR_COLUMN_WIDTH} repeat(7, 1fr)`}
@@ -135,6 +147,9 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
           return (
             <Box
               key={date.toISOString()}
+              ref={(elm: HTMLDivElement) =>
+                (laneHeight = elm?.clientHeight ?? 0)
+              }
               flexGrow={1}
               height={`${HOUR_HEIGHT * 24}px`}
               sx={{

--- a/src/features/calendar/components/CalendarWeekView/utils.ts
+++ b/src/features/calendar/components/CalendarWeekView/utils.ts
@@ -1,0 +1,32 @@
+import type { AnyClusteredEvent } from 'features/calendar/utils/clusterEventsForWeekCalender';
+export function scrollToEarliestEvent(
+  weekElement: HTMLDivElement | undefined,
+  laneHeight: number,
+  eventsByDate: AnyClusteredEvent[][][]
+) {
+  if (!weekElement) {
+    return;
+  }
+  // pick out all event start times and sort by time in day
+  const arr = eventsByDate
+    .flat()
+    .flat()
+    .flatMap((e) => e.events)
+    .map((e) => e.start_time)
+    .map((e) => new Date(e))
+    .sort((left, right) => {
+      const leftTime = left.getUTCHours() + left.getUTCMinutes() / 60;
+      const rightTime = right.getUTCHours() + right.getUTCMinutes() / 60;
+      return leftTime - rightTime;
+    });
+  if (arr.length === 0) {
+    return;
+  }
+
+  const earliestTime = arr[0];
+  const timePosition =
+    (earliestTime.getUTCHours() + earliestTime.getUTCMinutes() / 60 - 0.1) / 24;
+  const heightInPixels = timePosition * laneHeight;
+
+  weekElement.scrollTo({ behavior: 'smooth', top: heightInPixels });
+}


### PR DESCRIPTION
## Description
This PR adds scrolling to the earliest (in the day) event per week when navigating to the week view, or when changing weeks.

## Screenshots
[simplescreenrecorder-2023-06-03_12.37.45.webm](https://github.com/zetkin/app.zetkin.org/assets/1464855/7c19f754-cf93-4406-bfa2-87e553a7e019)


## Changes
Adds a useEffect to trigger scroll


## Related issues
Resolves #1388 
