### PR TITLE
Add 'overflow: hidden' to box containing event

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -199,6 +199,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                           },
                           // TODO: This will be replaced with real event components (WIP)
                           left: `${laneOffset * 100}%`,
+                          overflow: 'hidden',
                           position: 'absolute',
                           top: `${startOffs * 100}%`,
                           width: `${width * 100}%`,


### PR DESCRIPTION
## Description
This PR adds overflow: hidden to hide horizontal scroll boxes being visible on events in week view when screen width is too narrow. Maybe it should reflow or change the contents to display better on smaller screens, but that was outside the scope of issue #1385 


## Screenshots

![Screen Shot 2023-06-03 at 14 02 53](https://github.com/zetkin/app.zetkin.org/assets/1464855/6d9cbf14-9171-4139-818b-b7b4cd6dfee3)


## Changes
Hides overflowing contents. 

## Related issues
Resolves #1385 
