### PR TITLE
Align event participants remind button

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -159,7 +159,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               <Typography color={'secondary'}>
                 {messages.participantSummaryCard.booked()}
               </Typography>
-              <Box display="flex">
+              <Box alignItems="center" display="flex">
                 <Typography variant="h4">{`${remindedParticipants}/${availParticipants}`}</Typography>
                 {remindedParticipants < availParticipants && (
                   <Tooltip
@@ -171,7 +171,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                         : ''
                     }
                   >
-                    <Box sx={{margin: "auto"}}>
+                    <Box>
                       <Button
                         disabled={contactPerson == null}
                         onClick={() => {

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -171,7 +171,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                         : ''
                     }
                   >
-                    <span>
+                    <Box sx={{margin: "auto"}}>
                       <Button
                         disabled={contactPerson == null}
                         onClick={() => {
@@ -188,7 +188,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                           id={messageIds.participantSummaryCard.remindButton}
                         />
                       </Button>
-                    </span>
+                    </Box>
                   </Tooltip>
                 )}
               </Box>


### PR DESCRIPTION
## Description
Align remind button under event -> participants


## Screenshots
<img width="805" alt="Skärmavbild 2023-06-03 kl  14 11 51" src="https://github.com/zetkin/app.zetkin.org/assets/11156250/1072332c-cc77-4757-ab87-34b283498478">


## Changes
* Fixed alignment of remind button in event -> participants


## Notes to reviewer
1. Go to http://localhost:3000/organize/1/projects/calendar
2. In the calendar, drag to create
3. Click "Create single event", which will take you to the event page of the new event (may take some time in dev mode)
4. Click "Participants" tab
5. Click "Add people"
6. Search for some name to add a participant, e.g. "Hans"
7. Add a contact person, either by searching in the top right or by hovering "Hans" in the participant list and clicking the little icon that appears
8. Note the participants summary towards the top


## Related issues
Resolves #1421
