### PR TITLE
Add tooltips when side menubar collapsed

### DIFF
--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -40,7 +40,6 @@ import {
   Typography,
 } from '@mui/material';
 import { cloneElement, useState } from 'react';
-import { wrap } from 'module';
 
 const drawerWidth = 300;
 

--- a/src/zui/ZUIOrganizeSidebar.tsx
+++ b/src/zui/ZUIOrganizeSidebar.tsx
@@ -36,9 +36,11 @@ import {
   List,
   ListItemButton,
   ListItemIcon,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { cloneElement, useState } from 'react';
+import { wrap } from 'module';
 
 const drawerWidth = 300;
 
@@ -274,50 +276,117 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                     href={`/organize/${orgId}/${item.name}`}
                     passHref
                   >
-                    <ListItemButton
-                      disableGutters
-                      sx={{
-                        '&:hover': {
-                          background: theme.palette.grey[100],
-                          pointer: 'cursor',
-                        },
-                        backgroundColor: selected
-                          ? theme.palette.grey[200]
-                          : 'transparent',
-                        borderRadius: '3px',
-                        my: 0.5,
-                        py: open ? 1.25 : 1.5,
-                        transition: theme.transitions.create(
-                          ['padding-top', 'padding-bottom', 'background-color'],
-                          {
-                            duration: theme.transitions.duration.leavingScreen,
-                            easing: theme.transitions.easing.sharp,
-                          }
-                        ),
-                      }}
-                    >
-                      <ListItemIcon
-                        sx={{
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          minWidth: '48px',
-                          width: '48px',
-                        }}
-                      >
-                        {icon}
-                      </ListItemIcon>
-                      <Typography
-                        sx={{
-                          alignItems: 'center',
-                          display: open ? 'block' : 'none',
-                          fontWeight: key.startsWith('/' + item.name)
-                            ? 700
-                            : 'normal',
-                        }}
-                      >
-                        {messages.organizeSidebar[item.name]()}
-                      </Typography>
-                    </ListItemButton>
+                    <>
+                      {/* Add tooltip if menu is collapsed */}
+                      {!open && (
+                        <Tooltip
+                          placement="right"
+                          title={messages.organizeSidebar[item.name]()}
+                        >
+                          <ListItemButton
+                            disableGutters
+                            sx={{
+                              '&:hover': {
+                                background: theme.palette.grey[100],
+                                pointer: 'cursor',
+                              },
+                              backgroundColor: selected
+                                ? theme.palette.grey[200]
+                                : 'transparent',
+                              borderRadius: '3px',
+                              my: 0.5,
+                              py: open ? 1.25 : 1.5,
+                              transition: theme.transitions.create(
+                                [
+                                  'padding-top',
+                                  'padding-bottom',
+                                  'background-color',
+                                ],
+                                {
+                                  duration:
+                                    theme.transitions.duration.leavingScreen,
+                                  easing: theme.transitions.easing.sharp,
+                                }
+                              ),
+                            }}
+                          >
+                            <ListItemIcon
+                              sx={{
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                minWidth: '48px',
+                                width: '48px',
+                              }}
+                            >
+                              {icon}
+                            </ListItemIcon>
+                            <Typography
+                              sx={{
+                                alignItems: 'center',
+                                display: open ? 'block' : 'none',
+                                fontWeight: key.startsWith('/' + item.name)
+                                  ? 700
+                                  : 'normal',
+                              }}
+                            >
+                              {messages.organizeSidebar[item.name]()}
+                            </Typography>
+                          </ListItemButton>
+                        </Tooltip>
+                      )}
+                      {/* Don't add tooltip if menu isn't collapsed */}
+                      {open && (
+                        <ListItemButton
+                          disableGutters
+                          sx={{
+                            '&:hover': {
+                              background: theme.palette.grey[100],
+                              pointer: 'cursor',
+                            },
+                            backgroundColor: selected
+                              ? theme.palette.grey[200]
+                              : 'transparent',
+                            borderRadius: '3px',
+                            my: 0.5,
+                            py: open ? 1.25 : 1.5,
+                            transition: theme.transitions.create(
+                              [
+                                'padding-top',
+                                'padding-bottom',
+                                'background-color',
+                              ],
+                              {
+                                duration:
+                                  theme.transitions.duration.leavingScreen,
+                                easing: theme.transitions.easing.sharp,
+                              }
+                            ),
+                          }}
+                        >
+                          <ListItemIcon
+                            sx={{
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              minWidth: '48px',
+                              width: '48px',
+                            }}
+                          >
+                            {icon}
+                          </ListItemIcon>
+                          <Typography
+                            sx={{
+                              alignItems: 'center',
+                              display: open ? 'block' : 'none',
+                              fontWeight: key.startsWith('/' + item.name)
+                                ? 700
+                                : 'normal',
+                            }}
+                          >
+                            {messages.organizeSidebar[item.name]()}
+                          </Typography>
+                        </ListItemButton>
+                      )}
+                    </>
                   </NextLink>
                 );
               })}


### PR DESCRIPTION
## Description
This PR adds tooltips to icons on the collapsed sidebar menu


## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/50528622/7250c4da-ac49-4493-8a61-b9ea9999c4f3

## Changes
* Tooltip pops up to the right when hovering over sidebar icons when the menu is collapsed


## Notes to reviewer
None


## Related issues
Resolves #1406 
