### PR TITLE
Add align-items: center to flex container

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -159,7 +159,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               <Typography color={'secondary'}>
                 {messages.participantSummaryCard.booked()}
               </Typography>
-              <Box display="flex">
+              <Box alignItems="center" display="flex">
                 <Typography variant="h4">{`${remindedParticipants}/${availParticipants}`}</Typography>
                 {remindedParticipants < availParticipants && (
                   <Tooltip


### PR DESCRIPTION
## Description
This PR vertically aligns the "remind all" button.


## Screenshots
![Screen Shot 2023-06-03 at 14 20 02](https://github.com/zetkin/app.zetkin.org/assets/1464855/1b0f91c0-395a-4fb8-aad8-25007042d416)



## Changes
* Adds align-items: center


## Related issues
Resolves #1421 
