### PR TITLE
Rename from Projects to Projects & Activities

### DIFF
--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1710,7 +1710,7 @@ zui:
     home: Home
     journeys: Journeys
     people: People
-    projects: Projects
+    projects: Projects & Activities
   personGridEditCell:
     keepTyping: Keep typing..
     noResult: No matching person found

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -107,7 +107,7 @@ export default makeMessages('zui', {
     home: m('Home'),
     journeys: m('Journeys'),
     people: m('People'),
-    projects: m('Projects'),
+    projects: m('Projects & Activities'),
     signOut: m('Sign out'),
     userSettings: m('User settings'),
   },


### PR DESCRIPTION
## Description
This PR renames the Projects item to Projects & Activities

## Screenshots
<img width="306" alt="bild" src="https://github.com/zetkin/app.zetkin.org/assets/50528622/987abd94-74a8-4164-9f0d-245a19eb3e1c">

## Changes
* Rename from Projects to Projects & Activities in the Sidebar Menu

## Notes to reviewer
None

## Related issues
Resolves #1419 
