### PR TITLE
Fix event time and state inconsistencies

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -212,11 +212,13 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                           '&:hover': {
                             zIndex: 100,
                           },
-                          // TODO: This will be replaced with real event components (WIP)
                           left: `${laneOffset * 100}%`,
                           overflow: 'hidden',
+                          // Padding (and offset `top`) make room for the TopBadge
+                          // if there is one, without it overflowing (and clipping)
+                          paddingTop: '20px',
                           position: 'absolute',
-                          top: `${startOffs * 100}%`,
+                          top: `calc(${startOffs * 100}% - 20px)`,
                           width: `${width * 100}%`,
                         }}
                       >

--- a/src/features/calendar/components/EventCluster/Arbitrary.tsx
+++ b/src/features/calendar/components/EventCluster/Arbitrary.tsx
@@ -1,7 +1,9 @@
 import { EventOutlined } from '@mui/icons-material';
 import { FC } from 'react';
 
+import { EventState } from 'features/events/models/EventDataModel';
 import { fieldsToPresent } from './utils';
+import getEventState from 'features/events/utils/getEventState';
 import messageIds from 'features/calendar/l10n/messageIds';
 import TopBadge from './TopBadge';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -107,11 +109,15 @@ const Arbitrary: FC<ArbitraryProps> = ({
     }),
     height
   );
-  const anyEventIsCancelled = events.some((event) => event.cancelled);
+
+  const statuses = events.map((event) => getEventState(event));
+  const anyEventIsCancelled = statuses.includes(EventState.CANCELLED);
+  const anyEventIsDraft = statuses.includes(EventState.DRAFT);
 
   return (
     <Event
       cancelled={anyEventIsCancelled}
+      draft={anyEventIsDraft}
       events={events}
       fieldGroups={[fields]}
       height={height}
@@ -120,6 +126,7 @@ const Arbitrary: FC<ArbitraryProps> = ({
         showTopBadge && (
           <TopBadge
             cancelled={anyEventIsCancelled}
+            draft={anyEventIsDraft}
             icon={<EventOutlined color="inherit" fontSize="inherit" />}
             text={events.length.toString()}
           />

--- a/src/features/calendar/components/EventCluster/Event.tsx
+++ b/src/features/calendar/components/EventCluster/Event.tsx
@@ -12,6 +12,7 @@ import { allCollapsedPresentableFields, availableHeightByEvent } from './utils';
 
 interface StyleProps {
   cancelled: boolean;
+  draft: boolean;
   collapsed: boolean;
   hasTopBadge: boolean;
   height: number;
@@ -33,9 +34,11 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   },
   container: {
     alignItems: ({ collapsed }) => (collapsed ? 'center' : ''),
-    background: ({ cancelled }) =>
+    background: ({ cancelled, draft }) =>
       `linear-gradient(to right, ${
-        cancelled ? theme.palette.secondary.main : theme.palette.primary.main
+        cancelled || draft
+          ? theme.palette.secondary.main
+          : theme.palette.primary.main
       } 4px, white 4px)`,
     border: `1px solid ${theme.palette.grey[300]}`,
     borderBottomLeftRadius: 4,
@@ -129,6 +132,7 @@ export type PresentableField = Field & {
 
 interface EventProps {
   cancelled: boolean;
+  draft: boolean;
   events: ZetkinEvent[];
   fieldGroups: PresentableField[][];
   height: number;
@@ -139,6 +143,7 @@ interface EventProps {
 
 const Event = ({
   cancelled,
+  draft,
   events,
   fieldGroups,
   height,
@@ -161,6 +166,7 @@ const Event = ({
   const classes = useStyles({
     cancelled,
     collapsed,
+    draft,
     hasTopBadge: !!topBadge,
     height,
     width,

--- a/src/features/calendar/components/EventCluster/MultiLocation.tsx
+++ b/src/features/calendar/components/EventCluster/MultiLocation.tsx
@@ -2,7 +2,9 @@ import { FC } from 'react';
 
 import calendarMessageIds from 'features/calendar/l10n/messageIds';
 import eventMessageIds from 'features/events/l10n/messageIds';
+import { EventState } from 'features/events/models/EventDataModel';
 import { fieldsToPresent } from './utils';
+import getEventState from 'features/events/utils/getEventState';
 import MultiLocationIcon from 'zui/icons/MultiLocation';
 import TopBadge from './TopBadge';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -109,11 +111,14 @@ const MultiLocation: FC<MultiLocationProps> = ({
   const messages = useMessages(eventMessageIds);
   const firstEventTitle =
     events[0].title || events[0].activity?.title || messages.common.noTitle();
-  const anyEventIsCancelled = events.some((event) => event.cancelled);
+  const statuses = events.map((event) => getEventState(event));
+  const anyEventIsCancelled = statuses.includes(EventState.CANCELLED);
+  const anyEventIsDraft = statuses.includes(EventState.DRAFT);
 
   return (
     <Event
       cancelled={anyEventIsCancelled}
+      draft={anyEventIsDraft}
       events={events}
       fieldGroups={[fields]}
       height={height}
@@ -122,6 +127,7 @@ const MultiLocation: FC<MultiLocationProps> = ({
         showTopBadge && (
           <TopBadge
             cancelled={anyEventIsCancelled}
+            draft={anyEventIsDraft}
             icon={<MultiLocationIcon color="inherit" fontSize="inherit" />}
             text={events.length.toString()}
           />

--- a/src/features/calendar/components/EventCluster/MultiShift.tsx
+++ b/src/features/calendar/components/EventCluster/MultiShift.tsx
@@ -40,9 +40,9 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime value={event.start_time} />
+              <FormattedTime value={removeOffset(event.start_time)} />
               {'-'}
-              <FormattedTime value={event.end_time} />
+              <FormattedTime value={removeOffset(event.end_time)} />
             </>
           ),
           requiresAction: false,

--- a/src/features/calendar/components/EventCluster/MultiShift.tsx
+++ b/src/features/calendar/components/EventCluster/MultiShift.tsx
@@ -4,7 +4,10 @@ import { ScheduleOutlined } from '@mui/icons-material';
 
 import calendarMessageIds from 'features/calendar/l10n/messageIds';
 import eventMessageIds from 'features/events/l10n/messageIds';
+import { EventState } from 'features/events/models/EventDataModel';
+import getEventState from 'features/events/utils/getEventState';
 import LocationLabel from 'features/events/components/LocationLabel';
+import { removeOffset } from 'utils/dateUtils';
 import TopBadge from './TopBadge';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { availableHeightByEvent, fieldsToPresent } from './utils';
@@ -158,7 +161,10 @@ const MultiShift: FC<MultiShiftProps> = ({
   const firstEventTitle =
     events[0].title || events[0].activity?.title || messages.common.noTitle();
 
-  const anyEventIsCancelled = events.some((event) => event?.cancelled);
+  const statuses = events.map((event) => getEventState(event));
+  const anyEventIsCancelled = statuses.includes(EventState.CANCELLED);
+  const anyEventIsDraft = statuses.includes(EventState.DRAFT);
+
   const availableHeightPerFieldGroup = availableHeightByEvent(
     height,
     events.length
@@ -187,6 +193,7 @@ const MultiShift: FC<MultiShiftProps> = ({
   return (
     <Event
       cancelled={anyEventIsCancelled}
+      draft={anyEventIsDraft}
       events={events}
       fieldGroups={fieldGroups}
       height={height}
@@ -195,6 +202,7 @@ const MultiShift: FC<MultiShiftProps> = ({
         showTopBadge && (
           <TopBadge
             cancelled={anyEventIsCancelled}
+            draft={anyEventIsDraft}
             icon={<ScheduleOutlined color="inherit" fontSize="inherit" />}
             text={events.length.toString()}
           />

--- a/src/features/calendar/components/EventCluster/Single.tsx
+++ b/src/features/calendar/components/EventCluster/Single.tsx
@@ -2,7 +2,9 @@ import { FC } from 'react';
 
 import calendarMessageIds from 'features/calendar/l10n/messageIds';
 import eventMessageIds from 'features/events/l10n/messageIds';
+import { EventState } from 'features/events/models/EventDataModel';
 import { fieldsToPresent } from './utils';
+import getEventState from 'features/events/utils/getEventState';
 import LocationLabel from 'features/events/components/LocationLabel';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import Event, { Field } from './Event';
@@ -93,9 +95,12 @@ const Single: FC<SingleProps> = ({
   const eventTitle =
     event.title || event.activity?.title || messages.common.noTitle();
 
+  const state = getEventState(event);
+
   return (
     <Event
-      cancelled={Boolean(event?.cancelled)}
+      cancelled={state == EventState.CANCELLED}
+      draft={state == EventState.DRAFT}
       events={[event]}
       fieldGroups={[fields]}
       height={height}

--- a/src/features/calendar/components/EventCluster/TopBadge.tsx
+++ b/src/features/calendar/components/EventCluster/TopBadge.tsx
@@ -4,13 +4,16 @@ import { Theme } from '@mui/material';
 
 interface StyleProps {
   cancelled: boolean;
+  draft: boolean;
 }
 
 const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
   topBadge: {
     alignItems: 'center',
-    backgroundColor: ({ cancelled }) =>
-      cancelled ? theme.palette.secondary.main : theme.palette.primary.main,
+    backgroundColor: ({ cancelled, draft }) =>
+      cancelled || draft
+        ? theme.palette.secondary.main
+        : theme.palette.primary.main,
     borderLeft: `1px solid ${theme.palette.grey[300]}`,
     borderRight: `1px solid ${theme.palette.grey[300]}`,
     borderTop: `1px solid ${theme.palette.grey[300]}`,
@@ -30,12 +33,13 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
 
 interface TopBadgeProps {
   cancelled: boolean;
+  draft: boolean;
   icon: JSX.Element;
   text: string;
 }
 
-const TopBadge: FC<TopBadgeProps> = ({ cancelled, icon, text }) => {
-  const classes = useStyles({ cancelled });
+const TopBadge: FC<TopBadgeProps> = ({ cancelled, draft, icon, text }) => {
+  const classes = useStyles({ cancelled, draft });
 
   return (
     <div className={classes.topBadge}>

--- a/src/features/events/components/EventPopper/MultiEventPopper/ClusterBody.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/ClusterBody.tsx
@@ -6,6 +6,7 @@ import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
 import EventSelectionCheckBox from '../../EventSelectionCheckBox';
 import LocationLabel from '../../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
@@ -40,8 +41,8 @@ const ClusterBody: FC<ClusterBodyProps> = ({ clusterType, events }) => {
           <ScheduleOutlined color="secondary" fontSize="small" />
           <Typography color="secondary" paddingLeft={1} variant="body2">
             <ZUITimeSpan
-              end={new Date(events[events.length - 1].end_time)}
-              start={new Date(events[0].start_time)}
+              end={new Date(removeOffset(events[events.length - 1].end_time))}
+              start={new Date(removeOffset(events[0].start_time))}
             />
           </Typography>
         </Box>

--- a/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
@@ -9,6 +9,7 @@ import EventSelectionCheckBox from '../../EventSelectionCheckBox';
 import EventWarningIcons from '../../EventWarningIcons';
 import LocationLabel from '../../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
+import { removeOffset } from 'utils/dateUtils';
 import StatusDot from '../StatusDot';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
@@ -32,9 +33,9 @@ const MultiEventListItem: FC<MultiEventListItemProps> = ({
     (env) => new EventDataModel(env, event.organization.id, event.id)
   );
   const state = model.state;
-  const timeSpan = `${intl.formatTime(event.start_time)}-${intl.formatTime(
-    event.end_time
-  )}`;
+  const timeSpan = `${intl.formatTime(
+    removeOffset(event.start_time)
+  )}-${intl.formatTime(removeOffset(event.end_time))}`;
 
   return (
     <Box display="flex" flexDirection="column" paddingBottom={1} width="100%">


### PR DESCRIPTION
## Description
This PR fixes a number of event and state inconsistencies between how events are rendered in calendars and in the poppers. 

## Screenshots
The draft state is new, the times are now consistent across calendar view (vertical position), popper and labels on the event, and the top badge also respects the draft/cancelled state now.

![image](https://github.com/zetkin/app.zetkin.org/assets/550212/b0bba283-0722-48c5-9b1b-5721e551fad0)

## Changes
* Fixes incorrectly rendered times in popper and calendar event components
* Fixes a bug introduced in #1430 that I somehow missed in my review that was causing the badge on top of clustered events to be clipped by the `overflow: hidden` on the container (ping @Jrende FYI)
* Adds draft state for the rendering of calendar events
* Consistently uses the `getEventState()` utility to decide how to render events in calendar

## Notes to reviewer
None

## Related issues
Resolves #1415 