### PR TITLE
undocumented/cancelled event update

### DIFF
--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -79,7 +79,7 @@ export default makeMessages('feat.calendar', {
     ellipsisMenu: {
       cancel: m('Cancel'),
       cancelWarning: m(
-        'If you do, remember to notify all participants and sign-ups that the events has been cancelled!'
+        'If you do, remember to notify all participants and sign-ups that the events have been cancelled!'
       ),
       confirmCancel: m('Are you sure you want to cancel selected events?'),
       confirmDelete: m('Are you sure you want to delete selected events?'),

--- a/src/features/events/models/EventDataModel.ts
+++ b/src/features/events/models/EventDataModel.ts
@@ -202,6 +202,7 @@ export default class EventDataModel extends ModelBase {
 
   publish() {
     this._repo.updateEvent(this._orgId, this._eventId, {
+      cancelled: null,
       published: new Date().toISOString(),
     });
   }


### PR DESCRIPTION
## Description
This PR fixes the bug where cancelled event is not updated when user publishes an event. The calendar continues to display the published event as "cancelled" even after refreshing the page.


## Screenshots
- before

https://github.com/zetkin/app.zetkin.org/assets/77925373/daa8d0a2-04b3-42fc-b661-6276d1f0ae92

- after

https://github.com/zetkin/app.zetkin.org/assets/77925373/b40716ab-81c9-484c-8e7f-a43b75ea1142



## Changes

* Adds `cancelled` to data body
* Changes `has` to `have`


## Notes to reviewer
I also fixed grammar in messages that I wrote wrong in my previous issue..!

## Related issues
undocumented
