### PR TITLE
1443: Add a check statement to avoid calendar crash

### DIFF
--- a/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
+++ b/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
@@ -17,6 +17,10 @@ export default function getOffsetStartEnd(
     }
   });
 
+  if (sortedEvents.length == 0) {
+    return [];
+  }
+
   const firstEventDate = new Date(sortedEvents[0].start_time);
   const lastEventDate = new Date(
     sortedEvents[sortedEvents.length - 1].start_time

--- a/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
+++ b/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
@@ -17,7 +17,7 @@ export default function getOffsetStartEnd(
     }
   });
 
-  if (sortedEvents.length == 0) {
+  if (sortedEvents.length === 0) {
     return [];
   }
 


### PR DESCRIPTION
## Description
This PR adds a check statement of the `sortedEvents `array to avoid the calendar crashed after deleting an event.


## Screenshots
Before:

https://github.com/zetkin/app.zetkin.org/assets/36491300/b66f6d35-121f-4767-a1c9-846fcd6363de


After:

https://github.com/zetkin/app.zetkin.org/assets/36491300/f0a2c420-0f55-4741-af8f-7f72daf5fc9a



## Changes
* Adds an IF statement before reading properties from empty array in `getOffsetStartEnd`()

## Notes to reviewer
The deleting exception still there but that was not the reason for crashing

## Related issues
Resolves #1443 
