### PR TITLE
issue-1444/hidden selectionbar

### DIFF
--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -7,10 +7,8 @@ import CalendarDayView from './CalendarDayView';
 import CalendarMonthView from './CalendarMonthView';
 import CalendarNavBar from './CalendarNavBar';
 import CalendarWeekView from './CalendarWeekView';
-import { RootState } from 'core/store';
 import SelectionBar from '../../events/components/SelectionBar';
 import useDayCalendarNav from '../hooks/useDayCalendarNav';
-import { useSelector } from 'react-redux';
 
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
@@ -87,9 +85,6 @@ const Calendar = () => {
     setSelectedTimeScale(timeScale);
     setFocusDate(date);
   }
-  const selectedEvents = useSelector(
-    (state: RootState) => state.events.selectedEventIds
-  );
 
   return (
     <>
@@ -152,11 +147,10 @@ const Calendar = () => {
                 onClickWeek={(date) => navigateTo(TimeScale.WEEK, date)}
               />
             )}
-            {selectedEvents.length > 0 && <Box sx={{ height: '68.5px' }} />}
           </Suspense>
         </Box>
+        <SelectionBar />
       </Box>
-      <SelectionBar />
     </>
   );
 };

--- a/src/features/events/components/SelectionBar/index.tsx
+++ b/src/features/events/components/SelectionBar/index.tsx
@@ -35,8 +35,7 @@ const SelectionBar = () => {
               borderRadius: '5px',
               bottom: 15,
               padding: 2,
-              position: 'fixed',
-              width: 'calc(100% - 97px)',
+              width: '100%',
             }}
           >
             <Box display="flex" justifyContent="space-between">


### PR DESCRIPTION
## Description
This PR fix a bug that selectionbar is hidden behind the navigation side bar.


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/41d913f2-d6be-414b-9a9d-969af5599ffd


## Changes
* Adds `width:100%` to `<Paper>`
* Changes position of `Selectionbar` 


## Notes to reviewer
There is one thing I feel uncomfortable. As you can see in the video, it is needed to scroll down to see the late event in the week view. But I'm not sure if it is need to be fixed or if it is natrual in that way so I left it as it is
## Related issues
Resolves #1444 
