### PR TITLE
Issue 1447/long strings smart search

### DIFF
--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -25,6 +25,7 @@ import {
 
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
+import { truncateIfNecessary } from '../../utils';
 const localMessageIds = messageIds.filters.surveyResponse;
 
 const DEFAULT_VALUE = 'none';
@@ -222,9 +223,11 @@ const SurveyResponse = ({
                       <Msg
                         id={localMessageIds.questionSelect.question}
                         values={{
-                          question:
+                          question: truncateIfNecessary(
                             validQuestions.find((q) => q.id === value)?.question
                               .question ?? '',
+                            30
+                          ),
                         }}
                       />
                     );
@@ -244,7 +247,7 @@ const SurveyResponse = ({
                 )}
                 {validQuestions.map((q) => (
                   <MenuItem key={q.id} value={q.id}>
-                    {q.question.question}
+                    {truncateIfNecessary(q.question.question, 25)}
                   </MenuItem>
                 ))}
               </StyledSelect>
@@ -260,8 +263,10 @@ const SurveyResponse = ({
                       <Msg
                         id={localMessageIds.surveySelect.survey}
                         values={{
-                          surveyTitle:
+                          surveyTitle: truncateIfNecessary(
                             surveys.find((s) => s.id === value)?.title ?? '',
+                            25
+                          ),
                         }}
                       />
                     );
@@ -276,7 +281,7 @@ const SurveyResponse = ({
                 )}
                 {surveys.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
-                    {s.title}
+                    {truncateIfNecessary(s.title, 30)}
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -247,7 +247,7 @@ const SurveyResponse = ({
                 )}
                 {validQuestions.map((q) => (
                   <MenuItem key={q.id} value={q.id}>
-                    {truncateIfNecessary(q.question.question, 25)}
+                    {truncateIfNecessary(q.question.question, 50)}
                   </MenuItem>
                 ))}
               </StyledSelect>
@@ -265,7 +265,7 @@ const SurveyResponse = ({
                         values={{
                           surveyTitle: truncateIfNecessary(
                             surveys.find((s) => s.id === value)?.title ?? '',
-                            25
+                            30
                           ),
                         }}
                       />
@@ -281,7 +281,7 @@ const SurveyResponse = ({
                 )}
                 {surveys.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
-                    {truncateIfNecessary(s.title, 30)}
+                    {s.title}
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/utils.ts
+++ b/src/features/smartSearch/components/utils.ts
@@ -137,3 +137,13 @@ export const getTaskTimeFrameWithConfig = (
     throw 'Unknown task status';
   }
 };
+
+export const truncateIfNecessary = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) {
+    return str;
+  }
+  const halfLength = Math.floor((maxLength - 3) / 2);
+  const firstPart = str.substring(0, halfLength);
+  const lastPart = str.substring(str.length - halfLength);
+  return `${firstPart}...${lastPart}`;
+};


### PR DESCRIPTION
## Description
This PR truncates the long strings belonging to the Survey Responses in the smart search dialog


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/36491300/90c2130c-9839-473b-8529-a033b59b1c26



## Changes
* Adds a new truncate utils function (truncateIfNecessary()) to create an ellipsis in the middle of the string and limit it to a given number of max characters
* Changes the display of the title of survey and questions when they are too long


## Notes to reviewer
@richardolsson mention that we had already utils function for that, but I couldn't find anything that fits the requirements.


## Related issues
Resolves #1447 
