### PR TITLE
issue-1448/call history filter fix

### DIFF
--- a/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
@@ -62,12 +62,15 @@ const DisplayCallHistory = ({
             values={{ minTimes: minTimes || 1, minTimesInput: minTimes || 1 }}
           />
         ),
-        minTimesInput: (
-          <UnderlinedMsg
-            id={localMessageIds.minTimesInput}
-            values={{ minTimesInput: minTimes || 1 }}
-          />
-        ),
+        minTimesInput:
+          minTimes === 1 || minTimes === undefined ? (
+            <></>
+          ) : (
+            <UnderlinedMsg
+              id={localMessageIds.minTimesInput}
+              values={{ minTimesInput: minTimes }}
+            />
+          ),
         timeFrame: <DisplayTimeFrame config={timeFrame} />,
       }}
     />

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -165,7 +165,19 @@ const CallHistory = ({
                 ))}
               </StyledSelect>
             ),
-            minTimes: filter.config.minTimes ?? 1,
+            minTimes:
+              filter.config.minTimes === 1 ||
+              filter.config.minTimes === undefined ? (
+                <></>
+              ) : (
+                <Msg
+                  id={localMessageIds.minTimes}
+                  values={{
+                    minTimes: filter.config.minTimes,
+                    minTimesInput: filter.config.minTimes,
+                  }}
+                />
+              ),
             minTimesInput: (
               <StyledNumberInput
                 defaultValue={filter.config.minTimes}

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -85,7 +85,7 @@ export default makeMessages('feat.smartSearch', {
         '{addRemoveSelect} people who {callSelect} at least {minTimesInput} {minTimes} in {assignmentSelect} {timeFrame}.'
       ),
       minTimes: m<{ minTimes: number; minTimesInput: ReactElement | number }>(
-        '{minTimesInput} {minTimes, plural, one {time} other {times}}'
+        '{minTimes, plural, one {once} other {times}}'
       ),
       minTimesInput: m<{ minTimesInput: number }>('{minTimesInput}'),
     },


### PR DESCRIPTION
## Description
This PR fix a bug that shows incorrect states in filter query of call


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/c7bf6071-3cf5-4450-8ae3-ae0028824926


## Changes

* Adds condition to `minTimesInput` for showing underlined numbers or not when input is 1 or undefined
* Changes messageIds


## Notes to reviewer
I tested with `yarn make-yaml` but didn't commit yml file with this PR!


## Related issues
Resolves #1448 
