### PR TITLE
Fix bug in how call history filter was rendered

### DIFF
--- a/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
@@ -59,13 +59,7 @@ const DisplayCallHistory = ({
         minTimes: (
           <UnderlinedMsg
             id={localMessageIds.minTimes}
-            values={{ minTimes: minTimes || 1, minTimesInput: minTimes || 1 }}
-          />
-        ),
-        minTimesInput: (
-          <UnderlinedMsg
-            id={localMessageIds.minTimesInput}
-            values={{ minTimesInput: minTimes || 1 }}
+            values={{ minTimes: minTimes || 1 }}
           />
         ),
         timeFrame: <DisplayTimeFrame config={timeFrame} />,

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -165,16 +165,23 @@ const CallHistory = ({
                 ))}
               </StyledSelect>
             ),
-            minTimes: filter.config.minTimes ?? 1,
-            minTimesInput: (
-              <StyledNumberInput
-                defaultValue={filter.config.minTimes}
-                inputProps={{ min: '1' }}
-                onChange={(e) => {
-                  setConfig({
-                    ...filter.config,
-                    minTimes: +e.target.value,
-                  });
+            minTimes: (
+              <Msg
+                id={localMessageIds.minTimesInput}
+                values={{
+                  input: (
+                    <StyledNumberInput
+                      defaultValue={filter.config.minTimes || 1}
+                      inputProps={{ min: '1' }}
+                      onChange={(e) => {
+                        setConfig({
+                          ...filter.config,
+                          minTimes: +e.target.value,
+                        });
+                      }}
+                    />
+                  ),
+                  minTimes: filter.config.minTimes || 1,
                 }}
               />
             ),

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -79,15 +79,17 @@ export default makeMessages('feat.smartSearch', {
         assignmentSelect: ReactElement;
         callSelect: ReactElement;
         minTimes: ReactElement | number;
-        minTimesInput: ReactElement | number;
         timeFrame: ReactElement;
       }>(
-        '{addRemoveSelect} people who {callSelect} at least {minTimesInput} {minTimes} in {assignmentSelect} {timeFrame}.'
+        '{addRemoveSelect} people who {callSelect} at least {minTimes} in {assignmentSelect} {timeFrame}.'
       ),
-      minTimes: m<{ minTimes: number; minTimesInput: ReactElement | number }>(
-        '{minTimesInput} {minTimes, plural, one {time} other {times}}'
+      minTimes: m<{ minTimes: number }>(
+        '{minTimes, plural, one {once} other {# times}}'
       ),
-      minTimesInput: m<{ minTimesInput: number }>('{minTimesInput}'),
+      minTimesInput: m<{
+        input: ReactElement;
+        minTimes: number;
+      }>('{input} {minTimes, plural, one {time} other {times}}'),
     },
     campaignParticipation: {
       activitySelect: {


### PR DESCRIPTION
## Description
This PR fixes a bug in how call history Smart Search filters were rendered, that was introduced by a recent refactor to the messages. 

## Screenshots
### When `minTimes` is 1
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/aa4d4723-3a07-427b-8991-8a7d159209c9)

### When `minTimes` is greater than 1
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/b4cc767b-ff0f-417a-8136-c4c8a451aea7)

## Changes
* Restructures messages to how (I think) it was structured before refactor

## Notes to reviewer
None

## Related issues
Resolves #1448 