### PR TITLE
Issue 1373/recent orgs in switcher

### DIFF
--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -9,10 +9,15 @@ import { ChevronRight, ExpandMore } from '@mui/icons-material';
 
 interface OrganizationTreeProps {
   treeItemData: TreeItemData[];
+  onSwitchOrg: () => void;
   orgId: number;
 }
 
-function renderTree(nodes: TreeItemData[], orgId: number): React.ReactNode {
+function renderTree(
+  nodes: TreeItemData[],
+  onSwitchOrg: () => void,
+  orgId: number
+): React.ReactNode {
   return nodes.map((node) => (
     <TreeItem
       key={node.id}
@@ -39,14 +44,16 @@ function renderTree(nodes: TreeItemData[], orgId: number): React.ReactNode {
         </NextLink>
       }
       nodeId={node.id.toString()}
+      onClick={onSwitchOrg}
     >
-      {node.children ? renderTree(node.children, orgId) : ''}
+      {node.children ? renderTree(node.children, onSwitchOrg, orgId) : ''}
     </TreeItem>
   ));
 }
 
 function OrganizationTree({
   treeItemData,
+  onSwitchOrg,
   orgId,
 }: OrganizationTreeProps): JSX.Element {
   const theme = useTheme();
@@ -73,7 +80,7 @@ function OrganizationTree({
           },
         }}
       >
-        {renderTree(treeItemData, orgId)}
+        {renderTree(treeItemData, onSwitchOrg, orgId)}
       </TreeView>
     </div>
   );

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -13,40 +13,39 @@ interface OrganizationTreeProps {
   orgId: number;
 }
 
-function renderTree(
-  nodes: TreeItemData[],
-  onSwitchOrg: () => void,
-  orgId: number
-): React.ReactNode {
-  return nodes.map((node) => (
+function renderTree(props: OrganizationTreeProps): React.ReactNode {
+  const { treeItemData, orgId, onSwitchOrg } = props;
+  return treeItemData.map((item) => (
     <TreeItem
-      key={node.id}
+      key={item.id}
       label={
-        <NextLink href={`/organize/${node.id}`}>
+        <NextLink href={`/organize/${item.id}`}>
           <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>
             <Box mr={1}>
-              {orgId == node.id ? (
+              {orgId == item.id ? (
                 <Avatar
-                  src={`/api/orgs/${node.id}/avatar`}
+                  src={`/api/orgs/${item.id}/avatar`}
                   sx={{ height: '28px', width: '28px' }}
                 />
               ) : (
-                <ProceduralColorIcon id={node.id} />
+                <ProceduralColorIcon id={item.id} />
               )}
             </Box>
             <Typography
-              sx={{ fontWeight: orgId == node.id ? 'bold' : 'normal' }}
+              sx={{ fontWeight: orgId == item.id ? 'bold' : 'normal' }}
               variant="body2"
             >
-              {node.title}
+              {item.title}
             </Typography>
           </Box>
         </NextLink>
       }
-      nodeId={node.id.toString()}
+      nodeId={item.id.toString()}
       onClick={onSwitchOrg}
     >
-      {node.children ? renderTree(node.children, onSwitchOrg, orgId) : ''}
+      {item.children
+        ? renderTree({ onSwitchOrg, orgId, treeItemData: item.children })
+        : ''}
     </TreeItem>
   ));
 }
@@ -80,7 +79,7 @@ function OrganizationTree({
           },
         }}
       >
-        {renderTree(treeItemData, onSwitchOrg, orgId)}
+        {renderTree({ onSwitchOrg, orgId, treeItemData })}
       </TreeView>
     </div>
   );

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react';
+import NextLink from 'next/link';
+import { Box, Typography } from '@mui/material';
+
+import ProceduralColorIcon from './ProceduralColorIcon';
+
+interface RecentOrganizationProps {
+  orgId: number;
+  recentOrganizations: { id: number; title: string }[];
+}
+
+const RecentOrganizations: FC<RecentOrganizationProps> = ({
+  orgId,
+  recentOrganizations,
+}) => {
+  return (
+    <Box m={1}>
+      {recentOrganizations.map((org) => (
+        <NextLink key={org.id} href={`/organize/${org.id}`}>
+          <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>
+            <Box mr={1}>
+              <ProceduralColorIcon id={org.id} />
+            </Box>
+            <Typography
+              sx={{ fontWeight: orgId == org.id ? 'bold' : 'normal' }}
+              variant="body2"
+            >
+              {org.title}
+            </Typography>
+          </Box>
+        </NextLink>
+      ))}
+    </Box>
+  );
+};
+
+export default RecentOrganizations;

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -17,7 +17,7 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
   recentOrganizations,
 }) => {
   return (
-    <Box m={1}>
+    <Box m={1} sx={{ cursor: 'pointer' }}>
       {recentOrganizations.map((org) => (
         <NextLink key={org.id} href={`/organize/${org.id}`}>
           <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -8,16 +8,18 @@ import { ZetkinOrganization } from 'utils/types/zetkin';
 export type RecentOrganization = Pick<ZetkinOrganization, 'id' | 'title'>;
 
 interface RecentOrganizationProps {
+  onSwitchOrg: () => void;
   orgId: number;
   recentOrganizations: RecentOrganization[];
 }
 
 const RecentOrganizations: FC<RecentOrganizationProps> = ({
+  onSwitchOrg,
   orgId,
   recentOrganizations,
 }) => {
   return (
-    <Box m={1} sx={{ cursor: 'pointer' }}>
+    <Box m={1} onClick={onSwitchOrg} sx={{ cursor: 'pointer' }}>
       {recentOrganizations.map((org) => (
         <NextLink key={org.id} href={`/organize/${org.id}`}>
           <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -25,9 +25,12 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
           return;
         }
         return (
-          <NextLink key={org.id} href={`/organize/${org.id}`}>
+          <NextLink
+            key={org.id}
+            href={`/organize/${org.id}`}
+            onClick={onSwitchOrg}
+          >
             <Box
-              onClick={onSwitchOrg}
               sx={{
                 '&:hover': {
                   backgroundColor: theme.palette.grey[100],

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import NextLink from 'next/link';
-import { Box, Typography } from '@mui/material';
+import { Box, List, Typography, useTheme } from '@mui/material';
 
 import ProceduralColorIcon from './ProceduralColorIcon';
 import { ZetkinOrganization } from 'utils/types/zetkin';
@@ -18,12 +18,25 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
   orgId,
   recentOrganizations,
 }) => {
+  const theme = useTheme();
   return (
-    <Box m={1} onClick={onSwitchOrg} sx={{ cursor: 'pointer' }}>
+    <List>
       {recentOrganizations.map((org) => (
         <NextLink key={org.id} href={`/organize/${org.id}`}>
-          <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>
-            <Box mr={1}>
+          <Box
+            onClick={onSwitchOrg}
+            sx={{
+              '&:hover': {
+                backgroundColor: theme.palette.grey[100],
+              },
+              alignItems: 'center',
+              cursor: 'pointer',
+              display: 'inlineFlex',
+              marginLeft: 1,
+              padding: 1,
+            }}
+          >
+            <Box marginRight={1}>
               <ProceduralColorIcon id={org.id} />
             </Box>
             <Typography
@@ -35,7 +48,7 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
           </Box>
         </NextLink>
       ))}
-    </Box>
+    </List>
   );
 };
 

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -3,10 +3,13 @@ import NextLink from 'next/link';
 import { Box, Typography } from '@mui/material';
 
 import ProceduralColorIcon from './ProceduralColorIcon';
+import { ZetkinOrganization } from 'utils/types/zetkin';
+
+export type RecentOrganization = Pick<ZetkinOrganization, 'id' | 'title'>;
 
 interface RecentOrganizationProps {
   orgId: number;
-  recentOrganizations: { id: number; title: string }[];
+  recentOrganizations: RecentOrganization[];
 }
 
 const RecentOrganizations: FC<RecentOrganizationProps> = ({

--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -1,16 +1,14 @@
 import { FC } from 'react';
 import NextLink from 'next/link';
-import { Box, List, Typography, useTheme } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 
 import ProceduralColorIcon from './ProceduralColorIcon';
-import { ZetkinOrganization } from 'utils/types/zetkin';
-
-export type RecentOrganization = Pick<ZetkinOrganization, 'id' | 'title'>;
+import { TreeItemData } from '../types';
 
 interface RecentOrganizationProps {
   onSwitchOrg: () => void;
   orgId: number;
-  recentOrganizations: RecentOrganization[];
+  recentOrganizations: (TreeItemData | undefined)[];
 }
 
 const RecentOrganizations: FC<RecentOrganizationProps> = ({
@@ -19,36 +17,43 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
   recentOrganizations,
 }) => {
   const theme = useTheme();
+
   return (
-    <List>
-      {recentOrganizations.map((org) => (
-        <NextLink key={org.id} href={`/organize/${org.id}`}>
-          <Box
-            onClick={onSwitchOrg}
-            sx={{
-              '&:hover': {
-                backgroundColor: theme.palette.grey[100],
-              },
-              alignItems: 'center',
-              cursor: 'pointer',
-              display: 'inlineFlex',
-              marginLeft: 1,
-              padding: 1,
-            }}
-          >
-            <Box marginRight={1}>
-              <ProceduralColorIcon id={org.id} />
-            </Box>
-            <Typography
-              sx={{ fontWeight: orgId == org.id ? 'bold' : 'normal' }}
-              variant="body2"
+    <Box>
+      {recentOrganizations.map((org) => {
+        if (!org) {
+          return;
+        }
+        return (
+          <NextLink key={org.id} href={`/organize/${org.id}`}>
+            <Box
+              onClick={onSwitchOrg}
+              sx={{
+                '&:hover': {
+                  backgroundColor: theme.palette.grey[100],
+                },
+                alignItems: 'center',
+                cursor: 'pointer',
+                display: 'inlineFlex',
+                paddingLeft: 2,
+                paddingRight: 1,
+                paddingY: 1,
+              }}
             >
-              {org.title}
-            </Typography>
-          </Box>
-        </NextLink>
-      ))}
-    </List>
+              <Box marginRight={1}>
+                <ProceduralColorIcon id={org.id} />
+              </Box>
+              <Typography
+                sx={{ fontWeight: orgId == org.id ? 'bold' : 'normal' }}
+                variant="body2"
+              >
+                {org.title}
+              </Typography>
+            </Box>
+          </NextLink>
+        );
+      })}
+    </Box>
   );
 };
 

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -152,6 +152,9 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
     flatOrgData.find((org) => org.id === id)
   );
 
+  const hasRecentOrganizations =
+    recentOrganizations.filter((org) => org?.id != orgId).length > 0;
+
   const menuItemsMap = [
     { icon: <Groups />, name: 'people' },
     { icon: <Architecture />, name: 'projects' },
@@ -266,43 +269,41 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 zIndex: 1000,
               }}
             >
-              {recentOrganizations.filter((org) => org?.id != orgId).length >
-                0 &&
-                flatOrgData.length >= 5 && (
-                  <Box marginBottom={1}>
-                    <Box
-                      alignItems="center"
-                      display="flex"
-                      justifyContent="space-between"
+              {hasRecentOrganizations && flatOrgData.length >= 5 && (
+                <Box marginBottom={1}>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                  >
+                    <Typography fontSize={12} margin={1} variant="body2">
+                      {messages.organizeSidebar.recent
+                        .title()
+                        .toLocaleUpperCase()}
+                    </Typography>
+                    <Button
+                      onClick={() => setRecentOrganizationIds([])}
+                      size="small"
+                      sx={{ marginRight: 2 }}
+                      variant="text"
                     >
-                      <Typography fontSize={12} margin={1} variant="body2">
-                        {messages.organizeSidebar.recent
-                          .title()
-                          .toLocaleUpperCase()}
-                      </Typography>
-                      <Button
-                        onClick={() => setRecentOrganizationIds([])}
-                        size="small"
-                        sx={{ marginRight: 2 }}
-                        variant="text"
-                      >
-                        {messages.organizeSidebar.recent.clear()}
-                      </Button>
-                    </Box>
-                    <RecentOrganizations
-                      onSwitchOrg={() =>
-                        setRecentOrganizationIds([
-                          orgId,
-                          ...recentOrganizationIds.filter((id) => id != orgId),
-                        ])
-                      }
-                      orgId={orgId}
-                      recentOrganizations={recentOrganizations
-                        .filter((org) => org?.id != orgId)
-                        .slice(0, 5)}
-                    />
+                      {messages.organizeSidebar.recent.clear()}
+                    </Button>
                   </Box>
-                )}
+                  <RecentOrganizations
+                    onSwitchOrg={() =>
+                      setRecentOrganizationIds([
+                        orgId,
+                        ...recentOrganizationIds.filter((id) => id != orgId),
+                      ])
+                    }
+                    orgId={orgId}
+                    recentOrganizations={recentOrganizations
+                      .filter((org) => org?.id != orgId)
+                      .slice(0, 5)}
+                  />
+                </Box>
+              )}
               {orgData.length > 0 && (
                 <Box>
                   <Typography fontSize={12} m={1} variant="body2">

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -40,6 +40,7 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 
+import RecentOrganizations from 'features/organizations/components/RecentOrganizations';
 import SearchDialog from 'features/search/components/SearchDialog';
 import SidebarListItem from './SidebarListItem';
 
@@ -119,6 +120,8 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
     return value !== null && value !== undefined;
   }
+
+  const recentOrganizations = [{ id: 165, title: 'katten' }];
 
   const treeDataList = useSelector(
     (state: RootState) => state.organizations.treeDataList
@@ -241,6 +244,20 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 zIndex: 1000,
               }}
             >
+              {recentOrganizations.filter((recentOrg) => recentOrg.id != orgId)
+                .length > 0 && (
+                <Box>
+                  <Typography fontSize={12} m={1} variant="body2">
+                    {messages.organizeSidebar
+                      .recentOrganizations()
+                      .toLocaleUpperCase()}
+                  </Typography>
+                  <RecentOrganizations
+                    orgId={orgId}
+                    recentOrganizations={recentOrganizations}
+                  />
+                </Box>
+              )}
               {orgData.length > 0 && (
                 <Box>
                   <Typography fontSize={12} m={1} variant="body2">

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -129,6 +129,9 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const treeDataList = useSelector(
     (state: RootState) => state.organizations.treeDataList
   );
+  const currentOrg = useSelector(
+    (state: RootState) => state.organizations.orgData
+  ).data;
 
   const orgData = treeDataList.items.map((item) => item.data).filter(notEmpty);
 
@@ -147,7 +150,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   }
 
   const flatOrgData = makeFlatOrgData(orgData);
-  const currentOrg = flatOrgData.find((org) => org.id === orgId);
 
   const recentOrganizations = recentOrganizationIds.map((id) =>
     flatOrgData.find((org) => org.id === id)

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -251,7 +251,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
             >
               {recentOrganizations.filter((recentOrg) => recentOrg.id != orgId)
                 .length > 0 && (
-                <Box>
+                <Box marginBottom={2}>
                   <Box display="flex" justifyContent="space-between">
                     <Typography fontSize={12} m={1} variant="body2">
                       {messages.organizeSidebar
@@ -260,6 +260,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                     </Typography>
                     <Button
                       onClick={() => setRecentOrganizations([])}
+                      size="small"
                       variant="text"
                     >
                       {messages.organizeSidebar.clearRecentOrganizations()}

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -267,9 +267,9 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                   </Box>
                   <RecentOrganizations
                     orgId={orgId}
-                    recentOrganizations={recentOrganizations.filter(
-                      (recentOrg) => recentOrg.id != orgId
-                    )}
+                    recentOrganizations={recentOrganizations
+                      .filter((recentOrg) => recentOrg.id != orgId)
+                      .slice(0, 3)}
                   />
                 </Box>
               )}
@@ -285,8 +285,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                       <OrganizationTree
                         onSwitchOrg={() =>
                           setRecentOrganizations([
-                            ...recentOrganizations,
                             { id: orgId, title: data.title },
+                            ...recentOrganizations.filter(
+                              (org) => org.id != orgId
+                            ),
                           ])
                         }
                         orgId={orgId}

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -44,6 +44,7 @@ import RecentOrganizations from 'features/organizations/components/RecentOrganiz
 import SearchDialog from 'features/search/components/SearchDialog';
 import SidebarListItem from './SidebarListItem';
 import { TreeItemData } from 'features/organizations/types';
+import ZUIFuture from 'zui/ZUIFuture';
 
 const drawerWidth = 300;
 
@@ -129,9 +130,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const treeDataList = useSelector(
     (state: RootState) => state.organizations.treeDataList
   );
-  const currentOrg = useSelector(
-    (state: RootState) => state.organizations.orgData
-  ).data;
 
   const orgData = treeDataList.items.map((item) => item.data).filter(notEmpty);
 
@@ -150,7 +148,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   }
 
   const flatOrgData = makeFlatOrgData(orgData);
-
   const recentOrganizations = recentOrganizationIds.map((id) =>
     flatOrgData.find((org) => org.id === id)
   );
@@ -208,36 +205,43 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 <Avatar alt="icon" src={`/api/orgs/${orgId}/avatar`} />
               )}
               {open && (
-                <>
-                  <Box
-                    sx={{
-                      alignItems: 'center',
-                      display: 'flex',
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        width: '48px',
-                      }}
-                    >
-                      {hover ? (
-                        <IconButton onClick={handleClick}>
-                          <KeyboardDoubleArrowLeftOutlined />
+                <ZUIFuture future={model.getOrganization(orgId)}>
+                  {(data) => (
+                    <>
+                      <Box
+                        sx={{
+                          alignItems: 'center',
+                          display: 'flex',
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'center',
+                            width: '48px',
+                          }}
+                        >
+                          {hover ? (
+                            <IconButton onClick={handleClick}>
+                              <KeyboardDoubleArrowLeftOutlined />
+                            </IconButton>
+                          ) : (
+                            <Avatar
+                              alt="icon"
+                              src={`/api/orgs/${orgId}/avatar`}
+                            />
+                          )}
+                        </Box>
+                        <Typography variant="h6">{data.title}</Typography>
+                      </Box>
+                      <Box sx={{ display: open ? 'flex' : 'none' }}>
+                        <IconButton onClick={handleExpansion}>
+                          {checked ? <ExpandLess /> : <ExpandMore />}
                         </IconButton>
-                      ) : (
-                        <Avatar alt="icon" src={`/api/orgs/${orgId}/avatar`} />
-                      )}
-                    </Box>
-                    <Typography variant="h6">{currentOrg?.title}</Typography>
-                  </Box>
-                  <Box sx={{ display: open ? 'flex' : 'none' }}>
-                    <IconButton onClick={handleExpansion}>
-                      {checked ? <ExpandLess /> : <ExpandMore />}
-                    </IconButton>
-                  </Box>
-                </>
+                      </Box>
+                    </>
+                  )}
+                </ZUIFuture>
               )}
             </Box>
             <Box

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -251,32 +251,44 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
             >
               {recentOrganizations.filter((recentOrg) => recentOrg.id != orgId)
                 .length > 0 && (
-                <Box marginBottom={2}>
-                  <Box
-                    display="flex"
-                    justifyContent="space-between"
-                    marginRight={1}
-                  >
-                    <Typography fontSize={12} m={1} variant="body2">
-                      {messages.organizeSidebar
-                        .recentOrganizations()
-                        .toLocaleUpperCase()}
-                    </Typography>
-                    <Button
-                      onClick={() => setRecentOrganizations([])}
-                      size="small"
-                      variant="text"
-                    >
-                      {messages.organizeSidebar.clearRecentOrganizations()}
-                    </Button>
-                  </Box>
-                  <RecentOrganizations
-                    orgId={orgId}
-                    recentOrganizations={recentOrganizations
-                      .filter((recentOrg) => recentOrg.id != orgId)
-                      .slice(0, 3)}
-                  />
-                </Box>
+                <ZUIFuture future={model.getOrganization(orgId)}>
+                  {(data) => (
+                    <Box marginBottom={2}>
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        marginRight={1}
+                      >
+                        <Typography fontSize={12} m={1} variant="body2">
+                          {messages.organizeSidebar
+                            .recentOrganizations()
+                            .toLocaleUpperCase()}
+                        </Typography>
+                        <Button
+                          onClick={() => setRecentOrganizations([])}
+                          size="small"
+                          variant="text"
+                        >
+                          {messages.organizeSidebar.clearRecentOrganizations()}
+                        </Button>
+                      </Box>
+                      <RecentOrganizations
+                        onSwitchOrg={() =>
+                          setRecentOrganizations([
+                            { id: orgId, title: data.title },
+                            ...recentOrganizations.filter(
+                              (org) => org.id != orgId
+                            ),
+                          ])
+                        }
+                        orgId={orgId}
+                        recentOrganizations={recentOrganizations
+                          .filter((recentOrg) => recentOrg.id != orgId)
+                          .slice(0, 3)}
+                      />
+                    </Box>
+                  )}
+                </ZUIFuture>
               )}
               {orgData.length > 0 && (
                 <ZUIFuture future={model.getOrganization(orgId)}>

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -30,6 +30,7 @@ import {
 import {
   Avatar,
   Box,
+  Button,
   CircularProgress,
   Divider,
   Drawer,
@@ -40,9 +41,11 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 
-import RecentOrganizations from 'features/organizations/components/RecentOrganizations';
 import SearchDialog from 'features/search/components/SearchDialog';
 import SidebarListItem from './SidebarListItem';
+import RecentOrganizations, {
+  RecentOrganization,
+} from 'features/organizations/components/RecentOrganizations';
 
 const drawerWidth = 300;
 
@@ -92,6 +95,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const [checked, setChecked] = useState(false);
 
   const [lastOpen, setLastOpen] = useLocalStorage('orgSidebarOpen', true);
+  const [recentOrganizations, setRecentOrganizations] = useLocalStorage(
+    'recentOrganizations',
+    [] as RecentOrganization[]
+  );
   const [open, setOpen] = useState(false);
   const model: OrganizationsDataModel = useModel(
     (env) => new OrganizationsDataModel(env)
@@ -120,8 +127,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
     return value !== null && value !== undefined;
   }
-
-  const recentOrganizations = [{ id: 165, title: 'katten' }];
 
   const treeDataList = useSelector(
     (state: RootState) => state.organizations.treeDataList
@@ -247,26 +252,49 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
               {recentOrganizations.filter((recentOrg) => recentOrg.id != orgId)
                 .length > 0 && (
                 <Box>
-                  <Typography fontSize={12} m={1} variant="body2">
-                    {messages.organizeSidebar
-                      .recentOrganizations()
-                      .toLocaleUpperCase()}
-                  </Typography>
+                  <Box display="flex" justifyContent="space-between">
+                    <Typography fontSize={12} m={1} variant="body2">
+                      {messages.organizeSidebar
+                        .recentOrganizations()
+                        .toLocaleUpperCase()}
+                    </Typography>
+                    <Button
+                      onClick={() => setRecentOrganizations([])}
+                      variant="text"
+                    >
+                      {messages.organizeSidebar.clearRecentOrganizations()}
+                    </Button>
+                  </Box>
                   <RecentOrganizations
                     orgId={orgId}
-                    recentOrganizations={recentOrganizations}
+                    recentOrganizations={recentOrganizations.filter(
+                      (recentOrg) => recentOrg.id != orgId
+                    )}
                   />
                 </Box>
               )}
               {orgData.length > 0 && (
-                <Box>
-                  <Typography fontSize={12} m={1} variant="body2">
-                    {messages.organizeSidebar
-                      .allOrganizations()
-                      .toLocaleUpperCase()}
-                  </Typography>
-                  <OrganizationTree orgId={orgId} treeItemData={orgData} />
-                </Box>
+                <ZUIFuture future={model.getOrganization(orgId)}>
+                  {(data) => (
+                    <Box>
+                      <Typography fontSize={12} m={1} variant="body2">
+                        {messages.organizeSidebar
+                          .allOrganizations()
+                          .toLocaleUpperCase()}
+                      </Typography>
+                      <OrganizationTree
+                        onSwitchOrg={() =>
+                          setRecentOrganizations([
+                            ...recentOrganizations,
+                            { id: orgId, title: data.title },
+                          ])
+                        }
+                        orgId={orgId}
+                        treeItemData={orgData}
+                      />
+                    </Box>
+                  )}
+                </ZUIFuture>
               )}
               {treeDataList.isLoading && (
                 <Box

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -272,8 +272,8 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                       justifyContent="space-between"
                     >
                       <Typography fontSize={12} margin={1} variant="body2">
-                        {messages.organizeSidebar
-                          .recentOrganizations()
+                        {messages.organizeSidebar.recent
+                          .title()
                           .toLocaleUpperCase()}
                       </Typography>
                       <Button
@@ -282,7 +282,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                         sx={{ marginRight: 2 }}
                         variant="text"
                       >
-                        {messages.organizeSidebar.clearRecentOrganizations()}
+                        {messages.organizeSidebar.recent.clear()}
                       </Button>
                     </Box>
                     <RecentOrganizations

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -252,7 +252,11 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
               {recentOrganizations.filter((recentOrg) => recentOrg.id != orgId)
                 .length > 0 && (
                 <Box marginBottom={2}>
-                  <Box display="flex" justifyContent="space-between">
+                  <Box
+                    display="flex"
+                    justifyContent="space-between"
+                    marginRight={1}
+                  >
                     <Typography fontSize={12} m={1} variant="body2">
                       {messages.organizeSidebar
                         .recentOrganizations()

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -120,12 +120,14 @@ export default makeMessages('zui', {
   organizeSidebar: {
     allOrganizations: m('All organizations'),
     areas: m('Areas'),
-    clearRecentOrganizations: m('Clear'),
     home: m('Home'),
     journeys: m('Journeys'),
     people: m('People'),
     projects: m('Projects & Activities'),
-    recentOrganizations: m('Recent organizations'),
+    recent: {
+      clear: m('Clear'),
+      title: m('Recent organizations'),
+    },
     search: m('Search'),
     signOut: m('Sign out'),
     userSettings: m('User settings'),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -124,6 +124,7 @@ export default makeMessages('zui', {
     journeys: m('Journeys'),
     people: m('People'),
     projects: m('Projects & Activities'),
+    recentOrganizations: m('Recent organizations'),
     search: m('Search'),
     signOut: m('Sign out'),
     userSettings: m('User settings'),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -120,6 +120,7 @@ export default makeMessages('zui', {
   organizeSidebar: {
     allOrganizations: m('All organizations'),
     areas: m('Areas'),
+    clearRecentOrganizations: m('Clear'),
     home: m('Home'),
     journeys: m('Journeys'),
     people: m('People'),


### PR DESCRIPTION
## Description
This PR adds a "Recent organizations" section to the Organization switcher, where the three most recently visited organizations are displayed. A list of recently used organizations are stored in Local Storage.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/930f382b-1629-4c12-983f-bcb849e7af9c)

## Changes
- Adds `RecentOrganizations` component to render the list of organizations. 
- Passes a function to each `TreeItem` in the `OrganizationTree` that adds the title and id of the org to Local storage when switching to a different org. 


## Notes to reviewer
none


## Related issues
Resolves #1373 
