### PR TITLE
Reset state when going to event page.

### DIFF
--- a/src/features/events/components/EventPopper/MultiEventPopper/index.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/index.tsx
@@ -104,7 +104,13 @@ const MultiEventPopper: FC<MultiEventPopperProps> = ({
               />
             </Box>
             {singleEvent && (
-              <SingleEvent event={singleEvent} onClickAway={onClickAway} />
+              <SingleEvent
+                event={singleEvent}
+                onClickAway={() => {
+                  onClickAway();
+                  setSingleEvent(null);
+                }}
+              />
             )}
             <Box maxHeight="500px" sx={{ overFlowY: 'auto' }}>
               {!singleEvent && clusterType === CLUSTER_TYPE.MULTI_SHIFT && (


### PR DESCRIPTION
## Description
This PR solves a bug where the state of a popper was never reset, so it would show accidentally show previous state when opening a "new" popper.

## Changes
* Changes the onClickAway-function to also reset the singleEvent state to null.

## Related issues
Resolves #1468 
