### PR TITLE
Journey instance search

### DIFF
--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -5,6 +5,7 @@ import KPD from '../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import RosaLuxemburg from '../../mockData/orgs/KPD/people/RosaLuxemburg';
 import SpeakToFriendAboutReferendum from '../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
+import ClarasOnboarding from '../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 
 test.describe('Search', async () => {
   test.beforeEach(async ({ login, moxy }) => {
@@ -91,6 +92,11 @@ test.describe('Search', async () => {
     const taskSearchReq = moxy.setZetkinApiMock('/orgs/1/search/task', 'post', [
       SpeakToFriendAboutReferendum,
     ]);
+    const journeyInstanceSearchReq = moxy.setZetkinApiMock(
+      '/orgs/1/search/journeyinstance',
+      'post',
+      [ClarasOnboarding]
+    );
 
     await page.goto(appUri + '/organize/1/projects/1');
 
@@ -107,10 +113,11 @@ test.describe('Search', async () => {
     expect(personSearchReq.log()[0].mocked).toEqual(true);
     expect(campaignSearchReq.log()[0].mocked).toEqual(true);
     expect(taskSearchReq.log()[0].mocked).toEqual(true);
+    expect(journeyInstanceSearchReq.log()[0].mocked).toEqual(true);
 
     // Check that results list contains all results
     expect(
       await page.locator('data-testid=SearchDialog-resultsListItem').count()
-    ).toEqual(3);
+    ).toEqual(4);
   });
 });

--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -19,6 +19,7 @@ test.describe('Search', async () => {
     moxy.setZetkinApiMock('/orgs/1/search/view', 'post', []);
     moxy.setZetkinApiMock('/orgs/1/search/callassignment', 'post', []);
     moxy.setZetkinApiMock('/orgs/1/search/survey', 'post', []);
+    moxy.setZetkinApiMock('/orgs/1/search/journeyinstance', 'post', []);
     login();
   });
 

--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from '@playwright/test';
 import test from '../../fixtures/next';
 
+import ClarasOnboarding from '../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import RosaLuxemburg from '../../mockData/orgs/KPD/people/RosaLuxemburg';
 import SpeakToFriendAboutReferendum from '../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
-import ClarasOnboarding from '../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 
 test.describe('Search', async () => {
   test.beforeEach(async ({ login, moxy }) => {

--- a/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
@@ -6,13 +6,9 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 
-import messageIds from '../../../l10n/messageIds';
-import { useMessages } from 'core/i18n';
-
 const JourneyInstanceListItem: React.FunctionComponent<{ journeyInstance: ZetkinJourneyInstance }> = ({
   journeyInstance,
 }) => {
-  const messages = useMessages(messageIds);
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
 
@@ -25,8 +21,8 @@ const JourneyInstanceListItem: React.FunctionComponent<{ journeyInstance: Zetkin
           </Avatar>
         </ListItemAvatar>
         <ResultsListItemText
-          primary={journeyInstance.journey.title}
-          secondary={journeyInstance.title}
+          primary={journeyInstance.title}
+          secondary={journeyInstance.journey.title}
         />
       </ListItem>
     </Link>

--- a/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
@@ -1,0 +1,36 @@
+import { Explore } from '@mui/icons-material';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
+
+import ResultsListItemText from './ResultsListItemText';
+import { ZetkinJourneyInstance } from 'utils/types/zetkin';
+
+import messageIds from '../../../l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+const JourneyInstanceListItem: React.FunctionComponent<{ journeyInstance: ZetkinJourneyInstance }> = ({
+  journeyInstance,
+}) => {
+  const messages = useMessages(messageIds);
+  const router = useRouter();
+  const { orgId } = router.query as { orgId: string };
+
+  return (
+    <Link href={`/organize/${orgId}/journeys/${journeyInstance.journey.id}/${journeyInstance.id}`} passHref>
+      <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
+        <ListItemAvatar>
+          <Avatar>
+            <Explore />
+          </Avatar>
+        </ListItemAvatar>
+        <ResultsListItemText
+          primary={journeyInstance.journey.title}
+          secondary={journeyInstance.title}
+        />
+      </ListItem>
+    </Link>
+  );
+};
+
+export default JourneyInstanceListItem;

--- a/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
@@ -6,14 +6,17 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 
-const JourneyInstanceListItem: React.FunctionComponent<{ journeyInstance: ZetkinJourneyInstance }> = ({
-  journeyInstance,
-}) => {
+const JourneyInstanceListItem: React.FunctionComponent<{
+  journeyInstance: ZetkinJourneyInstance;
+}> = ({ journeyInstance }) => {
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
 
   return (
-    <Link href={`/organize/${orgId}/journeys/${journeyInstance.journey.id}/${journeyInstance.id}`} passHref>
+    <Link
+      href={`/organize/${orgId}/journeys/${journeyInstance.journey.id}/${journeyInstance.id}`}
+      passHref
+    >
       <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
         <ListItemAvatar>
           <Avatar>

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -8,6 +8,7 @@ import PersonListItem from './PersonListItem';
 import SurveyListItem from './SurveyListItem';
 import TaskListItem from './TaskListItem';
 import ViewListItem from './ViewListItem';
+import JourneyInstanceListItem from './JourneyInstanceListItem';
 
 import {
   SEARCH_DATA_TYPE,
@@ -55,6 +56,9 @@ const ResultsList: FunctionComponent<ResultsListProps> = ({
             }
             if (result.type === SEARCH_DATA_TYPE.VIEW) {
               return <ViewListItem view={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.JOURNEY_INSTANCE) {
+              return <JourneyInstanceListItem journeyInstance={result.match} />;
             }
           })}
         </>

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -4,11 +4,11 @@ import { List, ListItem, ListItemText } from '@mui/material';
 
 import CallAssignmentListItem from './CallAssignmentListItem';
 import CampaignListItem from './CampaignListItem';
+import JourneyInstanceListItem from './JourneyInstanceListItem';
 import PersonListItem from './PersonListItem';
 import SurveyListItem from './SurveyListItem';
 import TaskListItem from './TaskListItem';
 import ViewListItem from './ViewListItem';
-import JourneyInstanceListItem from './JourneyInstanceListItem';
 
 import {
   SEARCH_DATA_TYPE,

--- a/src/features/search/components/types.ts
+++ b/src/features/search/components/types.ts
@@ -1,6 +1,7 @@
 import {
   ZetkinCallAssignment,
   ZetkinCampaign,
+  ZetkinJourneyInstance,
   ZetkinPerson,
   ZetkinSurvey,
   ZetkinTask,
@@ -14,6 +15,7 @@ export enum SEARCH_DATA_TYPE {
   VIEW = 'view',
   CALL_ASSIGNMENT = 'callassignment',
   SURVEY = 'survey',
+  JOURNEY_INSTANCE = 'journeyinstance',
 }
 
 export interface PersonSearchResult {
@@ -40,6 +42,10 @@ export interface SurveySearchResult {
   type: SEARCH_DATA_TYPE.SURVEY;
   match: ZetkinSurvey;
 }
+export interface JourneyInstanceSearchResult {
+  type: SEARCH_DATA_TYPE.JOURNEY_INSTANCE;
+  match: ZetkinJourneyInstance;
+}
 
 export type SearchResult =
   | PersonSearchResult
@@ -47,4 +53,5 @@ export type SearchResult =
   | TaskSearchResult
   | ViewSearchResult
   | CallAssignmentSearchResult
-  | SurveySearchResult;
+  | SurveySearchResult
+  | JourneyInstanceSearchResult;

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -54,6 +54,7 @@ const search = async (
       makeSearchRequest(SEARCH_DATA_TYPE.VIEW, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.CALL_ASSIGNMENT, query, apiFetch),
       makeSearchRequest(SEARCH_DATA_TYPE.SURVEY, query, apiFetch),
+      makeSearchRequest(SEARCH_DATA_TYPE.JOURNEY_INSTANCE, query, apiFetch),
     ]);
 
     const searchResults = results.flat();

--- a/src/utils/api/makeSearchRequest.ts
+++ b/src/utils/api/makeSearchRequest.ts
@@ -3,6 +3,7 @@ import handleResponseData from './handleResponseData';
 import {
   CallAssignmentSearchResult,
   CampaignSearchResult,
+  JourneyInstanceSearchResult,
   PersonSearchResult,
   SEARCH_DATA_TYPE,
   SurveySearchResult,
@@ -58,6 +59,14 @@ async function makeSearchRequest(
   },
   apiFetch: ApiFetch
 ): Promise<SurveySearchResult[]>;
+async function makeSearchRequest(
+  dataType: SEARCH_DATA_TYPE.JOURNEY_INSTANCE,
+  query: {
+    orgId: number | string;
+    q: string;
+  },
+  apiFetch: ApiFetch
+): Promise<JourneyInstanceSearchResult[]>;
 async function makeSearchRequest(
   dataType: unknown,
   query: {


### PR DESCRIPTION
## Description
This PR implements the frontend for the Journey instance search.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14962107/03021d2d-ea3f-46d5-a81a-a57bc04e56c6)

## Changes
* Add JourneyInstanceListItem
* Adds journeyinstance to the types searched for by /search.

## Notes to reviewer
Requires backend changes to be merged.

## Related issues
Resolves #739 
