### PR TITLE
Issue 1454/Truncate Util Refactor

### DIFF
--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -25,7 +25,7 @@ import {
 
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { truncateIfNecessary } from '../../utils';
+import { truncateOnMiddle } from 'utils/stringUtils';
 const localMessageIds = messageIds.filters.surveyResponse;
 
 const DEFAULT_VALUE = 'none';
@@ -223,7 +223,7 @@ const SurveyResponse = ({
                       <Msg
                         id={localMessageIds.questionSelect.question}
                         values={{
-                          question: truncateIfNecessary(
+                          question: truncateOnMiddle(
                             validQuestions.find((q) => q.id === value)?.question
                               .question ?? '',
                             30
@@ -247,7 +247,7 @@ const SurveyResponse = ({
                 )}
                 {validQuestions.map((q) => (
                   <MenuItem key={q.id} value={q.id}>
-                    {truncateIfNecessary(q.question.question, 50)}
+                    {truncateOnMiddle(q.question.question, 50)}
                   </MenuItem>
                 ))}
               </StyledSelect>
@@ -263,7 +263,7 @@ const SurveyResponse = ({
                       <Msg
                         id={localMessageIds.surveySelect.survey}
                         values={{
-                          surveyTitle: truncateIfNecessary(
+                          surveyTitle: truncateOnMiddle(
                             surveys.find((s) => s.id === value)?.title ?? '',
                             30
                           ),

--- a/src/features/smartSearch/components/utils.ts
+++ b/src/features/smartSearch/components/utils.ts
@@ -137,13 +137,3 @@ export const getTaskTimeFrameWithConfig = (
     throw 'Unknown task status';
   }
 };
-
-export const truncateIfNecessary = (str: string, maxLength: number) => {
-  if (str.length <= maxLength) {
-    return str;
-  }
-  const halfLength = Math.floor((maxLength - 3) / 2);
-  const firstPart = str.substring(0, halfLength);
-  const lastPart = str.substring(str.length - halfLength);
-  return `${firstPart}...${lastPart}`;
-};

--- a/src/utils/stringUtils.spec.ts
+++ b/src/utils/stringUtils.spec.ts
@@ -1,4 +1,5 @@
 import { stringToBool } from './stringUtils';
+import { truncateOnMiddle } from './stringUtils';
 
 describe('stringToBool()', () => {
   // Returns false
@@ -27,5 +28,26 @@ describe('stringToBool()', () => {
     expect(stringToBool('true')).toEqual(true);
     expect(stringToBool('TRUE')).toEqual(true);
     expect(stringToBool('TrUe')).toEqual(true);
+  });
+});
+
+describe('truncateOnMiddle()', () => {
+  it('Truncates a string on whitespaces if possible', () => {
+    expect(
+      truncateOnMiddle(
+        'Do you have fascinating facts about feminist political beliefs?',
+        40
+      )
+    ).toEqual('Do you have...beliefs?');
+  });
+  it("Doesn't truncate if the string is below the length", () => {
+    expect(
+      truncateOnMiddle(
+        'Do you have fascinating facts about feminist political beliefs?',
+        500
+      )
+    ).toEqual(
+      'Do you have fascinating facts about feminist political beliefs?'
+    );
   });
 });

--- a/src/utils/stringUtils.spec.ts
+++ b/src/utils/stringUtils.spec.ts
@@ -50,4 +50,9 @@ describe('truncateOnMiddle()', () => {
       'Do you have fascinating facts about feminist political beliefs?'
     );
   });
+  it('Falls back to old behaviour if no whitespaces are found', () => {
+    expect(truncateOnMiddle('Supercalifragilisticexpialidocious', 20)).toEqual(
+      'Supercal...idocious'
+    );
+  });
 });

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -23,4 +23,24 @@ const getEllipsedString = (string: string, maxLength: number): string => {
   return string.slice(0, ellipseIndex) + '...';
 };
 
-export { getEllipsedString, stringToBool };
+const truncateOnMiddle = (str: string, maxLength: number) => {
+  if (str.length <= maxLength) {
+    return str;
+  }
+  const halfLength = Math.floor((maxLength - 3) / 2);
+  const firstPartBase = str.substring(0, halfLength);
+  const lastPartBase = str.substring(str.length - halfLength);
+  const lastWhitespaceOfFirst = firstPartBase.lastIndexOf(' ');
+  const firstWhitespaceOfLast = lastPartBase.indexOf(' ');
+  if (lastWhitespaceOfFirst == -1 || firstWhitespaceOfLast == -1) {
+    return `${firstPartBase}...${lastPartBase}`;
+  }
+  const firstPart = firstPartBase.substring(0, lastWhitespaceOfFirst);
+  const lastPart = lastPartBase.substring(
+    firstWhitespaceOfLast + 1,
+    lastPartBase.length
+  );
+  return `${firstPart}...${lastPart}`;
+};
+
+export { getEllipsedString, stringToBool, truncateOnMiddle };


### PR DESCRIPTION
## Description
This PR refactors the old 'truncate on middle' util and moves it to stringUtils.

## Changes
* Moves the old truncateIfNecessary function in smartSearch to a new truncateOnMiddle function in stringUtils
* The new function truncates on whitespaces where possible
* Implements tests for the new function

## Related issues
Resolves #1454 
