### PR TITLE
Issue 1399/`null` titles not clustering with empty `string` titles

### DIFF
--- a/src/features/campaigns/hooks/useClusteredActivities.spec.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.spec.ts
@@ -478,4 +478,42 @@ describe('useClusteredActivities()', () => {
     );
     expect(result.current.length).toBe(4);
   });
+  it('Should cluster events in the same location where one title is an empty string and the other title is null', () => {
+    const { result } = renderHook(() =>
+      useClusteredActivities([
+        mockEvent(112, {
+          activity: {
+            id: 5,
+            title: 'Open',
+          },
+          end_time: '1857-07-05T13:00:00.000Z',
+          location: {
+            id: 112,
+            lat: 12321.1,
+            lng: 12321.2,
+            title: 'The square',
+          },
+          start_time: '1857-07-05T12:00:00.000Z',
+          title: null,
+        }),
+        mockEvent(321, {
+          activity: {
+            id: 5,
+            title: 'Open',
+          },
+          end_time: '1857-07-05T14:00:00.000Z',
+          location: {
+            id: 112,
+            lat: 12321.1,
+            lng: 12321.2,
+            title: 'The square',
+          },
+          start_time: '1857-07-05T13:00:00.000Z',
+          title: '',
+        }),
+      ])
+    );
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].kind).toBe(CLUSTER_TYPE.MULTI_SHIFT);
+  });
 });

--- a/src/features/campaigns/hooks/useClusteredActivities.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.ts
@@ -80,11 +80,13 @@ export function clusterEvents(
     for (let i = 0; i < pendingClusters.length; i++) {
       const cluster = pendingClusters[i];
       const lastClusterEvent = cluster.events[cluster.events.length - 1];
+      const lastClusterEventTitle = lastClusterEvent.title || '';
+      const eventTitle = event.title || '';
 
       if (cluster.kind == CLUSTER_TYPE.SINGLE) {
         if (
           event.activity?.id != lastClusterEvent.activity?.id ||
-          event.title != lastClusterEvent.title
+          eventTitle != lastClusterEventTitle
         ) {
           continue;
         }
@@ -113,7 +115,7 @@ export function clusterEvents(
         // the event is part of this cluster.
         if (
           lastClusterEvent.activity?.id == event.activity?.id &&
-          lastClusterEvent.title == event.title &&
+          lastClusterEventTitle == eventTitle &&
           lastClusterEvent.location?.id == event.location?.id &&
           lastClusterEvent.end_time == event.start_time
         ) {

--- a/src/features/events/rpc/copyEvents.ts
+++ b/src/features/events/rpc/copyEvents.ts
@@ -18,7 +18,7 @@ const paramsSchema = z.object({
       num_participants_required: z.number(),
       organization_id: z.optional(z.number()),
       start_time: z.string(),
-      title: z.optional(z.string()),
+      title: z.optional(z.string().or(z.null())),
       url: z.optional(z.string()),
     })
   ),

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -84,7 +84,7 @@ export interface ZetkinEvent {
   num_participants_available: number;
   published: string | null;
   start_time: string;
-  title?: string;
+  title?: string | null;
   organization: {
     id: number;
     title: string;


### PR DESCRIPTION
## Description
This PR makes events with `null` titles be able to cluster with events with empty `string` titles, which they couldn't before.

## Changes
* Changes useClusteredActivities so it now evaluates `null` event titles as empty `string` event titles
* Adds a corresponding test

## Related issues
Resolves #1399 
