### PR TITLE
Render nothing instead of null when participant has no email.

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -209,9 +209,9 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       sortable: false,
       valueGetter: (params) => {
         if (params.row.person) {
-          return `${params.row.person.email}`;
+          return params.row.person.email;
         } else {
-          return `${params.row.email}`;
+          return params.row.email;
         }
       },
     },


### PR DESCRIPTION
## Description
This PR fixes a bug where an event participant with no email would have "null" in the email cell instead of nothing. 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/e259fa48-6275-4ca2-9203-d6e9d8080b7a)

## Changes
- Passes the value and not the value-as-string to be rendered in the cell.

## Notes to reviewer
I did find this GridColDef a bit type unsafe - everything is typed as "any". I'm not sure if this was intentional, and the bug could be solved anyways, but it might need some looking into how to make this column definition typed correctly.

## Related issues
Resolves #1460 
