### PR TITLE
Sort views/lists by title

### DIFF
--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -46,7 +46,9 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
   model,
 }) => {
   const messages = useMessages(messageIds);
-  const [sortModel, setSortModel] = useState<GridSortModel>([]);
+  const [sortModel, setSortModel] = useState<GridSortModel>([
+    { field: 'title', sort: 'asc' },
+  ]);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const isMobile = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')


### PR DESCRIPTION
## Description
This PR sets the sort of views/lists to sort alphabetically by title in `organize/[orgId]/people`


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/94a3467a-8ee2-4979-b65d-724f617f6206)

## Changes
* Changes the sortModel state to initialize to sort by title

## Notes to reviewer
There is a property on the `DataGridPro` called initialState, where you can pass a sortModel. I chose to go with putting it in the state instead, since I thought it could be confusing to have a state called `sortModel` that initializes to an empty array and have it be controlled by a property on the `DataGridPro`


## Related issues
Resolves #1456 
