### PR TITLE
remove selection bar on delete from event popper

### DIFF
--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -2,6 +2,7 @@ import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { useMessages } from 'core/i18n';
 import { useRouter } from 'next/router';
+import { useStore } from 'react-redux';
 import {
   AccessTime,
   ArrowForward,
@@ -14,12 +15,14 @@ import {
 import { Box, Button, Link, Typography } from '@mui/material';
 import { FC, useContext } from 'react';
 
+import { eventDeselected } from 'features/events/store';
 import EventSelectionCheckBox from '../EventSelectionCheckBox';
 import getEventUrl from 'features/events/utils/getEventUrl';
 import LocationLabel from '../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
 import Quota from './Quota';
 import { removeOffset } from 'utils/dateUtils';
+import { RootState } from 'core/store';
 import StatusDot from './StatusDot';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -59,7 +62,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
   const model = useModel(
     (env) => new EventDataModel(env, event.organization.id, event.id)
   );
-
+  const store = useStore<RootState>();
   const participants = model.getParticipants().data || [];
   const respondents = model.getRespondents().data || [];
   const state = model.state;
@@ -84,6 +87,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         showConfirmDialog({
           onSubmit: () => {
             model.deleteEvent();
+            store.dispatch(eventDeselected(event.id));
             onClickAway();
             router.push(
               `/organize/${event.organization.id}${

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -14,7 +14,7 @@ import {
 import { Box, Button, Link, Typography } from '@mui/material';
 import { FC, useContext } from 'react';
 
-import { eventDeselected } from 'features/events/store';
+import { eventsDeselected } from 'features/events/store';
 import EventSelectionCheckBox from '../EventSelectionCheckBox';
 import getEventUrl from 'features/events/utils/getEventUrl';
 import LocationLabel from '../LocationLabel';
@@ -85,7 +85,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         showConfirmDialog({
           onSubmit: () => {
             model.deleteEvent();
-            store.dispatch(eventDeselected(event.id));
+            store.dispatch(eventsDeselected([event]));
             onClickAway();
           },
           title: messages.eventPopper.confirmDelete(),

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -113,6 +113,12 @@ const eventsSlice = createSlice({
         );
       }
     },
+    eventDeselected: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      state.selectedEventIds = state.selectedEventIds.filter(
+        (selectedEventId) => selectedEventId !== eventId
+      );
+    },
     eventLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const item = state.eventList.items.find((item) => item.id == id);
@@ -467,6 +473,7 @@ export const {
   eventCreate,
   eventCreated,
   eventDeleted,
+  eventDeselected,
   eventLoad,
   eventLoaded,
   eventRangeLoad,

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -113,12 +113,6 @@ const eventsSlice = createSlice({
         );
       }
     },
-    eventDeselected: (state, action: PayloadAction<number>) => {
-      const eventId = action.payload;
-      state.selectedEventIds = state.selectedEventIds.filter(
-        (selectedEventId) => selectedEventId !== eventId
-      );
-    },
     eventLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const item = state.eventList.items.find((item) => item.id == id);
@@ -473,7 +467,6 @@ export const {
   eventCreate,
   eventCreated,
   eventDeleted,
-  eventDeselected,
   eventLoad,
   eventLoaded,
   eventRangeLoad,


### PR DESCRIPTION
## Description
This PR fixes a bug where event selection bar remains even after deleting the event from single event popper.


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/2f227ba6-4b89-46d8-a6f8-f046a1946d69


It has weird error but except for that, the function is working as expected.

## Changes

* Adds `eventDeselected` in store


## Notes to reviewer
I could use existing `eventsDeselected` reducer and dispatch like `store.dispatch(eventsDeselected([event]));` but it is not event"s" and felt weird to send the whole event there when it only needs `eventId`. So I created `eventDeselected` instead.


## Related issues
Resolves #1491 
