### PR TITLE
issue 1490/fix redirection

### DIFF
--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { useMessages } from 'core/i18n';
-import { useRouter } from 'next/router';
 import {
   AccessTime,
   ArrowForward,
@@ -51,7 +50,6 @@ interface SingleEventProps {
 }
 
 const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
-  const router = useRouter();
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const messages = useMessages(messageIds);
   const classes = useStyles();
@@ -85,11 +83,6 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
           onSubmit: () => {
             model.deleteEvent();
             onClickAway();
-            router.push(
-              `/organize/${event.organization.id}${
-                event.campaign ? `/projects/${event.campaign.id}` : ''
-              }`
-            );
           },
           title: messages.eventPopper.confirmDelete(),
           warningText: messages.eventPopper.deleteWarning(),


### PR DESCRIPTION
## Description
This PR fixes redirection to overview page when user deletes the event from single event popper.


## Screenshots


## Changes

* Remove `useRouter` and its relevant codes.


## Notes to reviewer


## Related issues
Resolves #1490 
