### PR TITLE
issue 1492/campaign to project

### DIFF
--- a/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
@@ -28,7 +28,7 @@ const CampaignListItem: React.FunctionComponent<{
         </ListItemAvatar>
         <ResultsListItemText
           primary={campaign.title}
-          secondary={<Msg id={messageIds.results.campaign} />}
+          secondary={<Msg id={messageIds.results.project} />}
         />
       </ListItem>
     </Link>

--- a/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
@@ -17,7 +17,7 @@ const TaskListItem: React.FunctionComponent<{ task: ZetkinTask }> = ({
   const { orgId } = router.query as { orgId: string };
 
   const elements = [
-    messages.results.campaign(),
+    messages.results.project(),
     task.campaign.title,
     messages.results.task(),
   ];

--- a/src/features/search/l10n/messageIds.ts
+++ b/src/features/search/l10n/messageIds.ts
@@ -7,9 +7,9 @@ export default makeMessages('feat.search', {
   placeholder: m('Type to search'),
   results: {
     callassignment: m('Call assignment'),
-    campaign: m('Campaign'),
     people: m('People'),
     person: m('Person'),
+    project: m('Project'),
     survey: m('Survey'),
     task: m('Task'),
     view: m('View'),


### PR DESCRIPTION
## Description
This PR fixes label "campaign" to "project" in `SearchField` 


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/97af457f-e66f-4930-b454-0ae0524ce47d)



## Changes

* Changes "Campaign" to "Project"


## Notes to reviewer


## Related issues
Resolves #1492 
