### PR TITLE
Issue 1458/add columns fix

### DIFF
--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -65,63 +65,6 @@ const SurveyResponseConfig = ({
     ];
   };
 
-  const makeOptionColumns = (
-    selectedOption: string | SURVEY_QUESTION_OPTIONS,
-    surveyId: number
-  ) => {
-    if (
-      selectedQuestion?.type != ELEMENT_TYPE.QUESTION ||
-      selectedQuestion.question.response_type != RESPONSE_TYPE.OPTIONS
-    ) {
-      return [];
-    }
-
-    if (selectedQuestion !== undefined && selectedQuestion !== null) {
-      if (selectedOption === SURVEY_QUESTION_OPTIONS.ALL_OPTIONS) {
-        return [
-          {
-            config: {
-              question_id: selectedQuestion.id,
-            },
-
-            title: selectedQuestion.question.question,
-            type: COLUMN_TYPE.SURVEY_OPTIONS,
-          },
-        ];
-      } else if (
-        selectedOption === SURVEY_QUESTION_OPTIONS.ALL_OPTIONS_SEPARATED
-      ) {
-        return selectedQuestion.question.options?.map((option) => {
-          return {
-            config: {
-              option_id: option.id,
-              survey_id: surveyId,
-            },
-            title: option.text,
-            type: COLUMN_TYPE.SURVEY_OPTION,
-          };
-        });
-      } else {
-        const optionSelected = selectedQuestion.question.options?.find(
-          (option) => option.id === parseInt(selectedOption)
-        );
-        if (optionSelected === undefined) {
-          return [];
-        }
-        return [
-          {
-            config: {
-              option_id: optionSelected.id,
-              survey_id: surveyId,
-            },
-            title: optionSelected.text,
-            type: COLUMN_TYPE.SURVEY_OPTION,
-          },
-        ];
-      }
-    }
-  };
-
   return (
     <ZUIQuery queries={{ surveysQuery }}>
       {({ queries: { surveysQuery: successSurveysQuery } }) => {
@@ -198,6 +141,7 @@ const SurveyResponseConfig = ({
                 onChange={(evt) => {
                   if (surveyId) {
                     const columns = makeOptionColumns(
+                      selectedQuestion,
                       evt.target.value,
                       surveyId
                     );
@@ -251,6 +195,64 @@ const SurveyResponseConfig = ({
       }}
     </ZUIQuery>
   );
+};
+
+const makeOptionColumns = (
+  selectedQuestion: ZetkinSurveyQuestionElement,
+  selectedOption: string | SURVEY_QUESTION_OPTIONS,
+  surveyId: number
+) => {
+  if (
+    selectedQuestion?.type != ELEMENT_TYPE.QUESTION ||
+    selectedQuestion.question.response_type != RESPONSE_TYPE.OPTIONS
+  ) {
+    return [];
+  }
+
+  if (selectedQuestion !== undefined && selectedQuestion !== null) {
+    if (selectedOption === SURVEY_QUESTION_OPTIONS.ALL_OPTIONS) {
+      return [
+        {
+          config: {
+            question_id: selectedQuestion.id,
+          },
+
+          title: selectedQuestion.question.question,
+          type: COLUMN_TYPE.SURVEY_OPTIONS,
+        },
+      ];
+    } else if (
+      selectedOption === SURVEY_QUESTION_OPTIONS.ALL_OPTIONS_SEPARATED
+    ) {
+      return selectedQuestion.question.options?.map((option) => {
+        return {
+          config: {
+            option_id: option.id,
+            survey_id: surveyId,
+          },
+          title: option.text,
+          type: COLUMN_TYPE.SURVEY_OPTION,
+        };
+      });
+    } else {
+      const optionSelected = selectedQuestion.question.options?.find(
+        (option) => option.id === parseInt(selectedOption)
+      );
+      if (optionSelected === undefined) {
+        return [];
+      }
+      return [
+        {
+          config: {
+            option_id: optionSelected.id,
+            survey_id: surveyId,
+          },
+          title: optionSelected.text,
+          type: COLUMN_TYPE.SURVEY_OPTION,
+        },
+      ];
+    }
+  }
 };
 
 export default SurveyResponseConfig;

--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -112,6 +112,20 @@ const SurveyResponseConfig = ({
                         value as ZetkinSurveyTextQuestionElement
                       );
                       onOutputConfigured(columns);
+                    } else if (
+                      value.question.response_type === RESPONSE_TYPE.OPTIONS
+                    ) {
+                      setSelectedColumnOption(
+                        SURVEY_QUESTION_OPTIONS.ALL_OPTIONS
+                      );
+                      const columns = makeOptionColumns(
+                        value,
+                        SURVEY_QUESTION_OPTIONS.ALL_OPTIONS,
+                        surveyId
+                      );
+                      if (columns !== undefined) {
+                        onOutputConfigured(columns);
+                      }
                     }
                   }
                 }}

--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -46,6 +46,9 @@ const SurveyResponseConfig = ({
   const [surveyId, setSurveyId] = useState<number | null>();
   const [selectedQuestion, setSelectedQuestion] =
     useState<ZetkinSurveyQuestionElement | null>(null);
+  const [selectedColumnOption, setSelectedColumnOption] = useState<
+    SURVEY_QUESTION_OPTIONS | string
+  >(SURVEY_QUESTION_OPTIONS.ALL_OPTIONS);
 
   const onSurveyChange: ChangeEventHandler<{ value: unknown }> = (ev) => {
     setSurveyId(ev.target.value as number);
@@ -140,6 +143,7 @@ const SurveyResponseConfig = ({
                 label={messages.columnDialog.choices.surveyResponse.optionsLabel()}
                 onChange={(evt) => {
                   if (surveyId) {
+                    setSelectedColumnOption(evt.target.value);
                     const columns = makeOptionColumns(
                       selectedQuestion,
                       evt.target.value,
@@ -151,6 +155,7 @@ const SurveyResponseConfig = ({
                   }
                 }}
                 select
+                value={selectedColumnOption}
                 variant="standard"
               >
                 <ListSubheader>

--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -30,7 +30,6 @@ interface SurveyResponseConfigProps {
 export enum SURVEY_QUESTION_OPTIONS {
   ALL_OPTIONS = 'allSingle',
   ALL_OPTIONS_SEPARATED = 'allOptionsSeparated',
-  ONE_OPTION = 'oneOption',
 }
 
 const SurveyResponseConfig = ({
@@ -46,9 +45,9 @@ const SurveyResponseConfig = ({
   const [surveyId, setSurveyId] = useState<number | null>();
   const [selectedQuestion, setSelectedQuestion] =
     useState<ZetkinSurveyQuestionElement | null>(null);
-  const [selectedColumnOption, setSelectedColumnOption] = useState<
-    SURVEY_QUESTION_OPTIONS | string
-  >(SURVEY_QUESTION_OPTIONS.ALL_OPTIONS);
+  const [selectedColumnOption, setSelectedColumnOption] = useState<string>(
+    SURVEY_QUESTION_OPTIONS.ALL_OPTIONS
+  );
 
   const onSurveyChange: ChangeEventHandler<{ value: unknown }> = (ev) => {
     setSurveyId(ev.target.value as number);
@@ -218,7 +217,7 @@ const SurveyResponseConfig = ({
 
 const makeOptionColumns = (
   selectedQuestion: ZetkinSurveyQuestionElement,
-  selectedOption: string | SURVEY_QUESTION_OPTIONS,
+  selectedOption: string,
   surveyId: number
 ) => {
   if (


### PR DESCRIPTION
## Description
This PR resets the columns to add option to a "default" option (All Options in a Single Column) when changing the question.


## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/36491300/cfe8fbbe-ebd0-4767-8547-db6f31718ccb



## Changes
* Extracts the `makeOptionsColumns` function to outside the `SurveyResponseConfig` component.
* Adds a `selectedQuestion `parameter to the `makeOptionsColumns` function
* Saves the `selectedColumnOption ` value in the state to be able to added as a default option when changing the question.


## Notes to reviewer
None


## Related issues
Resolves #1458 
