### PR TITLE
issue 1478/column width

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -31,6 +31,9 @@ import {
   SelectedViewColumn,
   ZetkinView,
 } from 'features/views/components/types';
+import useConfigurableDataGridColumns, {
+  loadConfig,
+} from 'zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns';
 import { VIEW_CONTENT_SOURCE, VIEW_DATA_TABLE_ERROR } from './constants';
 import ViewDataTableColumnMenu, {
   ViewDataTableColumnMenuProps,
@@ -257,6 +260,8 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     width: 50,
   };
 
+  const configStr = loadConfig(localStorage, 'dataGridConfig-viewInstances');
+
   const gridColumns = [
     avatarColumn,
     ...columns.map((col) => ({
@@ -265,10 +270,14 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       minWidth: 100,
       resizable: true,
       sortable: true,
-      width: 150,
+      width: configStr.fieldWidths[`col_${col.id}`] ?? 150,
       ...columnTypes[col.type].getColDef(col, accessLevel),
     })),
   ];
+  const { setColumnWidth } = useConfigurableDataGridColumns(
+    'viewInstances',
+    gridColumns
+  );
 
   const rowsWithSearch = viewQuickSearch(rows, columns, quickSearch);
 
@@ -400,6 +409,9 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
               }
             }
           }
+        }}
+        onColumnResize={(params) => {
+          setColumnWidth(params.colDef.field, params.width);
         }}
         onSelectionModelChange={(model) => setSelection(model as number[])}
         pinnedColumns={{

--- a/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.ts
@@ -98,7 +98,7 @@ export default function useConfigurableDataGridColumns(
   };
 }
 
-function loadConfig(storage: StorageBackend, key: string): ColumnConfig {
+export function loadConfig(storage: StorageBackend, key: string): ColumnConfig {
   let fieldOrder: string[] = [];
   let fieldWidths: Record<string, number> = {};
   try {


### PR DESCRIPTION
## Description
This PR fixes a bug that columns' widths in view is not saved as user set. It goes back to the default width(150) after sorting or refreshing the page.


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/77925373/d234c474-6851-4e6a-9cb2-a539de4ab9ec



## Changes

* Adds `export` to `loadConfig`
* Adds  property `onColumnResize`
* Adds saved widths from localStorage to columns


## Notes to reviewer
I used `loadConfig`. I found another bug(#1039 ) while I work on this, and thought `loadConfig` could be useful for fixing that issue later on


## Related issues
Resolves #1478 
