### PR TITLE
issue-1469/user-lang

### DIFF
--- a/integrationTesting/mockData/users/RosaLuxemburgUser.ts
+++ b/integrationTesting/mockData/users/RosaLuxemburgUser.ts
@@ -3,6 +3,7 @@ import { ZetkinUser } from 'utils/types/zetkin';
 const RosaLuxemburgUser: ZetkinUser = {
   first_name: 'Rosa',
   id: 1,
+  lang: null,
   last_name: 'Luxemburg',
   username: 'red_rosa',
 };


### PR DESCRIPTION
## Description
This PR allows the user lang set in the user settings to override the browser language.

## Changes

* Adds
  * property `lang` to `ZetkinUser` 
* Changes
 * `lang` property returned from `scaffold` now first checks for `user.lang` and uses that if there is a value, otherwise defaults to browser.

## Related issues
Resolves #1469