### PR TITLE
Issue 1479/call instructions bug

### DIFF
--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -87,36 +87,44 @@ const CallerInstructions = ({
           </Box>
           <Box alignItems="center" display="flex" justifyContent="flex-end">
             <Box marginRight={2}>
-              {!model.isSaving && !model.hasUnsavedChanges && (
-                <Typography>
-                  <Msg id={messageIds.conversation.instructions.savedMessage} />
-                </Typography>
-              )}
-              {!model.isSaving && model.hasUnsavedChanges && (
-                <Typography component="span">
-                  <Msg
-                    id={messageIds.conversation.instructions.unsavedMessage}
-                  />{' '}
-                  <Link
-                    color="textPrimary"
-                    component="span"
-                    onClick={() => {
-                      showConfirmDialog({
-                        onSubmit: () => {
-                          model.revert();
-                          //Force Slate to re-mount
-                          setKey((current) => current + 1);
-                        },
-                        warningText:
-                          messages.conversation.instructions.confirm(),
-                      });
-                    }}
-                    style={{ cursor: 'pointer', fontFamily: 'inherit' }}
-                  >
-                    <Msg id={messageIds.conversation.instructions.revertLink} />
-                  </Link>
-                </Typography>
-              )}
+              {!model.isSaving &&
+                !model.hasUnsavedChanges &&
+                model.getInstructions() !== '' && (
+                  <Typography>
+                    <Msg
+                      id={messageIds.conversation.instructions.savedMessage}
+                    />
+                  </Typography>
+                )}
+              {!model.isSaving &&
+                model.hasUnsavedChanges &&
+                !model.emptyInstrunctions && (
+                  <Typography component="span">
+                    <Msg
+                      id={messageIds.conversation.instructions.unsavedMessage}
+                    />{' '}
+                    <Link
+                      color="textPrimary"
+                      component="span"
+                      onClick={() => {
+                        showConfirmDialog({
+                          onSubmit: () => {
+                            model.revert();
+                            //Force Slate to re-mount
+                            setKey((current) => current + 1);
+                          },
+                          warningText:
+                            messages.conversation.instructions.confirm(),
+                        });
+                      }}
+                      style={{ cursor: 'pointer', fontFamily: 'inherit' }}
+                    >
+                      <Msg
+                        id={messageIds.conversation.instructions.revertLink}
+                      />
+                    </Link>
+                  </Typography>
+                )}
             </Box>
             <Button
               color="primary"

--- a/src/features/callAssignments/models/CallerInstructionsModel.ts
+++ b/src/features/callAssignments/models/CallerInstructionsModel.ts
@@ -24,6 +24,11 @@ export default class CallerInstructionsModel extends ModelBase {
     this._store = env.store;
   }
 
+  get emptyInstrunctions(): boolean {
+    const { data } = this._repo.getCallAssignment(this._orgId, this._id);
+    return data?.instructions === '';
+  }
+
   getInstructions(): string {
     const lsInstructions = localStorage.getItem(this._key) || '';
 

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -109,7 +109,13 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
   }, [clear]);
 
   return (
-    <ClickAwayListener onClickAway={onClickAway}>
+    <ClickAwayListener
+      onClickAway={() => {
+        if (!isEqual(editor.children, emptySlate)) {
+          onClickAway();
+        }
+      }}
+    >
       <Box
         className={classes.container}
         onClick={() => ReactEditor.focus(editor)}

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -109,13 +109,7 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
   }, [clear]);
 
   return (
-    <ClickAwayListener
-      onClickAway={() => {
-        if (!isEqual(editor.children, emptySlate)) {
-          onClickAway();
-        }
-      }}
-    >
+    <ClickAwayListener onClickAway={onClickAway}>
       <Box
         className={classes.container}
         onClick={() => ReactEditor.focus(editor)}
@@ -129,7 +123,11 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
         {initialValueSlate && (
           <Slate
             editor={editor}
-            onChange={(slateArray) => onChange(slateToMarkdown(slateArray))}
+            onChange={(slateArray) => {
+              if (!isEqual(editor.children, emptySlate)) {
+                onChange(slateToMarkdown(slateArray));
+              }
+            }}
             value={initialValueSlate}
           >
             <Editable

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -123,11 +123,7 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
         {initialValueSlate && (
           <Slate
             editor={editor}
-            onChange={(slateArray) => {
-              if (!isEqual(editor.children, emptySlate)) {
-                onChange(slateToMarkdown(slateArray));
-              }
-            }}
+            onChange={(slateArray) => onChange(slateToMarkdown(slateArray))}
             value={initialValueSlate}
           >
             <Editable


### PR DESCRIPTION
## Description
This PR fixes a bug in call assignment instructions which shows irrelevant HTML tag. For example "Everything is up to date!" when there is no text in `TextField`. etc


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/535be0bd-9b04-447d-b8f7-fae5a8cbd77f



## Changes

* Adds `emptyInstructions`


## Notes to reviewer
It seems like I made a lot of changes, but only added line 92 and line 101 in `CallerInstructions`
There are lots of bugs related with `Slate`, but this issue is not related with that so I will investigate how and when those bugs happen and then will create a separate issue for it. So please test this with normal texts (without text styles in Slate)!


## Related issues
Resolves #1479 
