### PR TITLE
issue-1469/user-language

### DIFF
--- a/integrationTesting/mockData/users/RosaLuxemburgUser.ts
+++ b/integrationTesting/mockData/users/RosaLuxemburgUser.ts
@@ -3,6 +3,7 @@ import { ZetkinUser } from 'utils/types/zetkin';
 const RosaLuxemburgUser: ZetkinUser = {
   first_name: 'Rosa',
   id: 1,
+  lang: null,
   last_name: 'Luxemburg',
   username: 'red_rosa',
 };

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -189,7 +189,7 @@ export const scaffold =
     const result = (await wrapped(ctx)) || {};
 
     // Figure out browser's preferred language
-    const lang = getBrowserLanguage(contextFromNext.req);
+    const lang = ctx.user?.lang || getBrowserLanguage(contextFromNext.req);
 
     // TODO: Respect scope from options again
     //const localeScope = (options?.localeScope ?? []).concat(['misc', 'zui']);

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -132,6 +132,7 @@ export interface ZetkinUser {
   first_name: string;
   id: number;
   is_superuser?: boolean;
+  lang: string | null;
   last_name: string;
   username: string;
 }


### PR DESCRIPTION
## Description

This PR allows the user lang set in the user settings to override the browser language.

##Changes

* Adds
  * property `lang` to `ZetkinUser` type
* Changes
  * `lang` returned from `scaffold` now first checks for `user.lang` and uses that if there is a value, otherwise defaults to browser language.

## Related issues
Resolves #1469
