### PR TITLE
Truncate title and location in day view

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -12,10 +12,10 @@ import messageIds from 'features/events/l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from 'features/events/components/EventPopper/StatusDot';
 import theme from 'theme';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
-import { truncateOnMiddle } from 'utils/stringUtils';
 
 const Event = ({ event }: { event: ZetkinEvent }) => {
   const messages = useMessages(messageIds);
@@ -62,10 +62,10 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
             <StatusDot state={getEventState(event)} />
             {/* Title */}
             <Typography
+              noWrap
               sx={{
                 color: theme.palette.secondary.main,
               }}
-              noWrap
             >
               {truncateOnMiddle(
                 event.title ||

--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -107,6 +107,7 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
               <Typography
                 color={theme.palette.secondary.main}
                 component={'div'}
+                noWrap
               >
                 <Box alignItems="center" display="flex" gap={0.5}>
                   <PlaceOutlined />

--- a/src/features/calendar/components/CalendarDayView/Day/Event.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/Event.tsx
@@ -15,6 +15,7 @@ import theme from 'theme';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
+import { truncateOnMiddle } from 'utils/stringUtils';
 
 const Event = ({ event }: { event: ZetkinEvent }) => {
   const messages = useMessages(messageIds);
@@ -64,10 +65,14 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
               sx={{
                 color: theme.palette.secondary.main,
               }}
+              noWrap
             >
-              {event.title ||
-                event.activity?.title ||
-                messages.common.noTitle()}
+              {truncateOnMiddle(
+                event.title ||
+                  event.activity?.title ||
+                  messages.common.noTitle(),
+                50
+              )}
             </Typography>
             {/* Time */}
             <Typography color={theme.palette.secondary.main} component={'div'}>
@@ -105,7 +110,7 @@ const Event = ({ event }: { event: ZetkinEvent }) => {
               >
                 <Box alignItems="center" display="flex" gap={0.5}>
                   <PlaceOutlined />
-                  {event.location?.title}
+                  {truncateOnMiddle(event.location?.title, 40)}
                 </Box>
               </Typography>
             )}


### PR DESCRIPTION
## Description
This PR changes the day view for events to truncate the titles and locations to a more reasonable length.


## Screenshots
<img width="1502" alt="Skärmbild som visar förändringen" src="https://github.com/zetkin/app.zetkin.org/assets/50528622/f0974cea-c0f0-44db-ac1f-6648addd707f">


## Changes
* Truncate event titles to a maximum length of 50 characters in day view
* Truncate location names to a maximum length of 40 characters in day view
* Add noWrap to the event title

## Related issues
Resolves #1438 
