### PR TITLE
Limit Recent Organizations in sidebar to 7 latest

### DIFF
--- a/src/features/organizations/components/RecentOrganizations.tsx
+++ b/src/features/organizations/components/RecentOrganizations.tsx
@@ -17,7 +17,9 @@ const RecentOrganizations: FC<RecentOrganizationProps> = ({
   recentOrganizations,
 }) => {
   const theme = useTheme();
-
+  if (recentOrganizations.length > 7) {
+    recentOrganizations = recentOrganizations.slice(0, 7);
+  }
   return (
     <Box>
       {recentOrganizations.map((org) => {


### PR DESCRIPTION
## Description
This PR changes the Recent Organizations sidebar to only show the 7 latest organizations

## Screenshots
<img width="304" alt="bild" src="https://github.com/zetkin/app.zetkin.org/assets/50528622/23496187-cdc9-4c89-a91f-a4e935d9c906">

## Changes

* Adds a slice function to `RecentOrganizations.tsx` so that the sidebar only displays the 7 first (i.e. most recent) organizations

## Related issues
Resolves #1506 
