### PR TITLE
Hide horizontal scrollbar in `ZUIOrganizeSidebar`

### DIFF
--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -248,6 +248,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
             sx={{
               flexGrow: 1,
               flexShrink: 1,
+              overflowX: 'hidden',
               overflowY: 'auto',
             }}
           >


### PR DESCRIPTION
## Description
This PR sets the overflowX property in a `<Box>` element inside `ZUIOrganizeSidebar` to `hidden`, thus hiding the horizontal scrollbar which displayed during the expanding animation.

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/50528622/da2aec91-d6d9-45c0-98a8-e7411eec4c69

## Changes

* Hides horizontal scrollbar inside `ZUIOrganizeSidebar`

## Related issues
Resolves #1501 
