### PR TITLE
Retain order of organizations in OrgSwitcher during filtering

### DIFF
--- a/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
+++ b/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
@@ -50,6 +50,7 @@ function useOrgSwitcher(orgId: number, searchString: string) {
   const recentOrgsFuse = useMemo(() => {
     return new Fuse(recentOrgs, {
       keys: ['title'],
+      shouldSort: false,
       threshold: 0.4,
     });
   }, [recentOrgs]);
@@ -61,7 +62,11 @@ function useOrgSwitcher(orgId: number, searchString: string) {
   }, [searchString]);
 
   const allOrgsFuse = useMemo(() => {
-    return new Fuse(flatOrgData, { keys: ['title'], threshold: 0.4 });
+    return new Fuse(flatOrgData, {
+      keys: ['title'],
+      shouldSort: false,
+      threshold: 0.4,
+    });
   }, [flatOrgData]);
 
   const filteredAllOrgs = useMemo(() => {


### PR DESCRIPTION
## Description
This PR makes sure the order of the organizations in `OrgSwitcher` does not change when a filter is applied. This affects both the recent orgs and all orgs.


## Screenshots
Before/bugged/fixed
![Screenshot 2023-09-10 at 14 07 48](https://github.com/zetkin/app.zetkin.org/assets/5444360/0c706509-bf83-4941-bc75-78b97292c4d1)![Screenshot 2023-09-10 at 14 07 55](https://github.com/zetkin/app.zetkin.org/assets/5444360/d01f44c9-9fea-4201-833f-289d0a52cd40)![Screenshot 2023-09-10 at 14 51 53](https://github.com/zetkin/app.zetkin.org/assets/5444360/97c8e692-977b-47b3-b0e9-0da88249b1ee)


## Changes

* Changes `shouldSort` option from default value to `false` for Fuse.js-objects in `useOrgSwitcher`.


## Notes to reviewer
None


## Related issues
Resolves #1507 
