### PR TITLE
Clearer event chip/state assignment

### DIFF
--- a/src/features/events/utils/getEventState.ts
+++ b/src/features/events/utils/getEventState.ts
@@ -8,9 +8,6 @@ export default function getEventState(event: ZetkinEvent): EventState {
   const now = new Date();
   if (event.published) {
     const published = new Date(event.published);
-    if (published > now) {
-      return EventState.SCHEDULED;
-    }
     if (event.cancelled) {
       const cancelled = new Date(event.cancelled);
       if (cancelled > published) {
@@ -22,6 +19,9 @@ export default function getEventState(event: ZetkinEvent): EventState {
       if (endTime < now) {
         return EventState.ENDED;
       }
+    }
+    if (published > now) {
+      return EventState.SCHEDULED;
     }
     return EventState.OPEN;
   } else {


### PR DESCRIPTION
## Description
This PR changes the order in which event chips are assigned, so that already ended events do not get a 'Scheduled' chip but an 'Ended' chip.

## Screenshots
<img width="1008" alt="bild" src="https://github.com/zetkin/app.zetkin.org/assets/50528622/3ec804e0-136c-4397-892f-87dddece9319">
<img width="1497" alt="bild" src="https://github.com/zetkin/app.zetkin.org/assets/50528622/ed2d623d-d496-4ca4-88c2-1b511e410742">


## Changes
* Events in the past now display an 'Ended' chip, even if the event is scheduled to be visible in the future.

## Related issues
Resolves #1403 
