### PR TITLE
issue-1503/org-icon

### DIFF
--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import TreeItem from '@mui/lab/TreeItem';
 import { TreeItemData } from '../types';
 import TreeView from '@mui/lab/TreeView';
-import { Avatar, Box, Typography, useTheme } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import { ChevronRight, ExpandMore } from '@mui/icons-material';
 
 interface OrganizationTreeProps {

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -22,14 +22,7 @@ function renderTree(props: OrganizationTreeProps): React.ReactNode {
         <NextLink href={`/organize/${item.id}`}>
           <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>
             <Box mr={1}>
-              {orgId == item.id ? (
-                <Avatar
-                  src={`/api/orgs/${item.id}/avatar`}
-                  sx={{ height: '28px', width: '28px' }}
-                />
-              ) : (
-                <ProceduralColorIcon id={item.id} />
-              )}
+              <ProceduralColorIcon id={item.id} />
             </Box>
             <Typography
               sx={{ fontWeight: orgId == item.id ? 'bold' : 'normal' }}


### PR DESCRIPTION
## Description
This PR fixes a bug that organizations in organization tree uses Avatar instead of procedural icon


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/ee95166c-13f0-4338-a680-53e0216521f1)




## Changes

* Remove `Avatar`


## Notes to reviewer


## Related issues
Resolves #1503 
