### PR TITLE
Issue 1510/views rename to lists

### DIFF
--- a/integrationTesting/tests/organize/views/detail/add-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/add-row.spec.ts
@@ -57,7 +57,7 @@ test.describe('View detail page', () => {
       204
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Add person statically
     await page.click('[name=person]');
@@ -113,7 +113,7 @@ test.describe('View detail page', () => {
       AllMembersRows.slice(0, 1)
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Add person statically
     await page.click('[name=person]');

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -47,7 +47,7 @@ test.describe('View detail page', () => {
       id: 1,
     });
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     await page.locator('[role=cell] >> input[type=checkbox]').nth(0).click();
     await page.locator('[role=cell] >> input[type=checkbox]').nth(1).click();
@@ -78,7 +78,7 @@ test.describe('View detail page', () => {
     expect(columnPostLogs).toHaveLength(2);
 
     // Expect that correctly localised strings sent when posting
-    expect(viewPostLogs[0].data?.title).toEqual('New View');
+    expect(viewPostLogs[0].data?.title).toEqual('New List');
     expect(columnPostLogs[0].data?.title).toEqual('First Name');
     expect(columnPostLogs[1].data?.title).toEqual('Last Name');
 
@@ -88,7 +88,7 @@ test.describe('View detail page', () => {
 
     // Expect that user is navigated to new view's page
     expect(page.url()).toEqual(
-      appUri + `/organize/1/people/views/${NewView.id}`
+      appUri + `/organize/1/people/lists/${NewView.id}`
     );
   });
 });

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -78,7 +78,7 @@ test.describe('View detail page', () => {
     expect(columnPostLogs).toHaveLength(2);
 
     // Expect that correctly localised strings sent when posting
-    expect(viewPostLogs[0].data?.title).toEqual('New List');
+    expect(viewPostLogs[0].data?.title).toEqual('New list');
     expect(columnPostLogs[0].data?.title).toEqual('First Name');
     expect(columnPostLogs[1].data?.title).toEqual('Last Name');
 

--- a/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
@@ -33,7 +33,7 @@ test.describe('View detail page', () => {
       'delete'
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete first column
     await Promise.all([
@@ -73,7 +73,7 @@ test.describe('View detail page', () => {
       400
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete first column
     await Promise.all([
@@ -104,7 +104,7 @@ test.describe('View detail page', () => {
       'delete'
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete local column
     await Promise.all([

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -33,7 +33,7 @@ test.describe('View detail page', () => {
 
     const removeButton = 'data-testid=ViewDataTableToolbar-removeFromSelection';
     const confirmButtonInModal = 'button:has-text("confirm")';
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Show toolbar button on row selection
     await expect(page.locator(removeButton)).toBeHidden();

--- a/integrationTesting/tests/organize/views/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete.spec.ts
@@ -52,7 +52,7 @@ test.describe('View detail page', () => {
     moxy.setZetkinApiMock('/orgs/1/people/views/1', 'delete', undefined, 204);
     moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Wait for navigation after deleting
     await Promise.all([
@@ -90,7 +90,7 @@ test.describe('View detail page', () => {
     );
     moxy.setZetkinApiMock('/orgs/1/people/views/1', 'delete', undefined, 405);
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     await deleteView(page);
     await expectDeleteViewError(page);

--- a/integrationTesting/tests/organize/views/detail/display.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/display.spec.ts
@@ -29,7 +29,7 @@ test.describe('View detail page', () => {
     page,
     appUri,
   }) => {
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
     expect(
       await page.locator('text=All KPD members >> visible=true').count()
     ).toEqual(1);

--- a/integrationTesting/tests/organize/views/detail/jump.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/jump.spec.ts
@@ -27,7 +27,7 @@ test.describe('View detail page', () => {
   });
 
   test('jumps between views using jump menu', async ({ page, appUri }) => {
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Click to open the jump menu
     await page.click('data-testid=view-jump-menu-button');
@@ -48,7 +48,7 @@ test.describe('View detail page', () => {
 
     // Assert that we navigate away to the new view
     expect(page.url()).toEqual(
-      appUri + `/organize/1/people/views/${NewView.id}`
+      appUri + `/organize/1/people/lists/${NewView.id}`
     );
   });
 });

--- a/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
@@ -39,7 +39,7 @@ test.describe('View detail page', () => {
       201
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Rename first column
     await page.hover('[role=columnheader]:has-text("First name")');
@@ -77,7 +77,7 @@ test.describe('View detail page', () => {
       400
     );
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Rename first column
     await page.hover('[role=columnheader]:has-text("First name")');

--- a/integrationTesting/tests/organize/views/detail/rename.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename.spec.ts
@@ -31,7 +31,7 @@ test.describe('View detail page', () => {
     const inputSelector = 'data-testid=page-title >> input';
 
     // Click to edit, fill and submit change
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
     await page.click(inputSelector);
     await page.fill(inputSelector, 'Friends of Zetkin');
     await Promise.all([

--- a/integrationTesting/tests/organize/views/detail/smart-search.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/smart-search.spec.ts
@@ -42,7 +42,7 @@ test.describe('View detail page', () => {
       id: 1,
     });
 
-    await page.goto(appUri + '/organize/1/people/views/1');
+    await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Configure Smart Search query
     await page.click('data-testid=EmptyView-configureButton');

--- a/integrationTesting/tests/organize/views/list/navigate.spec.ts
+++ b/integrationTesting/tests/organize/views/list/navigate.spec.ts
@@ -30,7 +30,7 @@ test.describe('Views list page', () => {
     ]);
 
     await expect(page.url()).toEqual(
-      appUri + `/organize/1/people/views/${AllMembers.id}`
+      appUri + `/organize/1/people/lists/${AllMembers.id}`
     );
   });
 });

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -20,7 +20,7 @@ export default makeMessages('feat.callAssignments', {
     organizerActionNeeded: m('Organizer action needed'),
     subtitle: m('Targets not ready to be called'),
     title: m('Blocked'),
-    viewSheetButton: m('View sheet'),
+    viewSheetButton: m('View list'),
   },
   callers: {
     actions: {

--- a/src/features/search/l10n/messageIds.ts
+++ b/src/features/search/l10n/messageIds.ts
@@ -12,6 +12,6 @@ export default makeMessages('feat.search', {
     project: m('Project'),
     survey: m('Survey'),
     task: m('Task'),
-    view: m('View'),
+    view: m('List'),
   },
 });

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -27,7 +27,7 @@ export default makeMessages('feat.smartSearch', {
     person_data: m('Based on their name, address or other data'),
     person_field: m('Based on custom fields'),
     person_tags: m('Based on their tags'),
-    person_view: m('People from a view'),
+    person_view: m('People from a list'),
     random: m('A random selection of people'),
     sub_query: m('Based on another Smart Search query'),
     survey_option: m(
@@ -264,8 +264,8 @@ export default makeMessages('feat.smartSearch', {
     },
     personView: {
       examples: {
-        one: m('Add people who are in the view "Active Members 2022".'),
-        two: m('Remove people who are not in the view "Active Members 2022".'),
+        one: m('Add people who are in the list "Active Members 2022".'),
+        two: m('Remove people who are not in the list "Active Members 2022".'),
       },
       inSelect: {
         in: m('in'),
@@ -275,9 +275,9 @@ export default makeMessages('feat.smartSearch', {
         addRemoveSelect: ReactElement;
         inSelect: ReactElement;
         viewSelect: ReactElement | string;
-      }>('{addRemoveSelect} people who are {inSelect} the view {viewSelect}.'),
+      }>('{addRemoveSelect} people who are {inSelect} the list {viewSelect}.'),
       viewSelect: {
-        none: m("This organization doesn't have any views yet"),
+        none: m("This organization doesn't have any lists yet"),
       },
     },
     random: {

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -27,7 +27,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
   const selectInputRef = useRef<HTMLInputElement>();
   const [showOfficials, setShowOfficials] = useState(true);
   const shareLinkUrl = useAbsoluteUrl(
-    `/organize/${model.orgId}/people/views/${model.viewId}/shared`
+    `/organize/${model.orgId}/people/lists/${model.viewId}/shared`
   );
 
   const accessFuture = model.getAccessList();
@@ -122,7 +122,7 @@ const ShareViewDialogShareTab: FC<ShareViewDialogShareTabProps> = ({
                       copyText={shareLinkUrl}
                     >
                       <NextLink
-                        href={`/organize/${model.orgId}/people/views/${model.viewId}/shared`}
+                        href={`/organize/${model.orgId}/people/lists/${model.viewId}/shared`}
                         passHref
                       >
                         <Link>

--- a/src/features/views/components/ViewJumpMenu.tsx
+++ b/src/features/views/components/ViewJumpMenu.tsx
@@ -118,7 +118,7 @@ const ViewJumpMenu: FunctionComponent = () => {
             if (selectedView) {
               setJumpMenuAnchor(null);
               setActiveIndex(Infinity);
-              router.push(`/organize/${orgId}/people/views/${selectedView.id}`);
+              router.push(`/organize/${orgId}/people/lists/${selectedView.id}`);
               ev.preventDefault();
             }
           }
@@ -156,7 +156,7 @@ const ViewJumpMenu: FunctionComponent = () => {
                 <Link
                   key={view.id}
                   href={{
-                    pathname: `/organize/${orgId}/people/views/${view.id}`,
+                    pathname: `/organize/${orgId}/people/lists/${view.id}`,
                   }}
                   passHref
                 >

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -2,25 +2,25 @@ import { ReactElement } from 'react';
 
 import { m, makeMessages } from 'core/i18n';
 
-export default makeMessages('feat.views', {
+export default makeMessages('feat.lists', {
   actions: {
     createFolder: m('Create folder'),
-    createView: m('Create view'),
+    createView: m('Create list'),
   },
   browser: {
     backToFolder: m<{ folder: ReactElement }>('Back to {folder}'),
-    backToRoot: m('Back to all views'),
+    backToRoot: m('Back to all lists'),
     confirmDelete: {
       folder: {
         title: m('Delete folder and content'),
         warning: m(
-          'Deleting this folder and all views within is a permanent action that cannot be undone. Are you sure you want to continue?'
+          'Deleting this folder and all lists within is a permanent action that cannot be undone. Are you sure you want to continue?'
         ),
       },
       view: {
-        title: m('Delete view'),
+        title: m('Delete list'),
         warning: m(
-          "Deleting this view is a permanent action which can't be undone. Are you sure you want to continue?"
+          "Deleting this list is a permanent action which can't be undone. Are you sure you want to continue?"
         ),
       },
     },
@@ -28,20 +28,20 @@ export default makeMessages('feat.views', {
       rename: m('Rename'),
     },
     moveToFolder: m<{ folder: ReactElement }>('Move to {folder}'),
-    moveToRoot: m('Move to all views'),
+    moveToRoot: m('Move to all lists'),
   },
   browserLayout: {
     tabs: {
-      views: m('Views'),
+      views: m('Lists'),
     },
     title: m('People'),
   },
   cells: {
     localPerson: {
-      alreadyInView: m('Already in view'),
+      alreadyInView: m('Already in list'),
       clearLabel: m('Unassign'),
       otherPeople: m('Other people'),
-      restrictedMode: m("Can't be edited in shared views."),
+      restrictedMode: m("Can't be edited in shared lists."),
       searchLabel: m('Select a person'),
     },
     organizerAction: {
@@ -205,7 +205,7 @@ export default makeMessages('feat.views', {
         title: m('Survey submit date'),
       },
       tag: {
-        description: m('Toggle a tag for each person in the view'),
+        description: m('Toggle a tag for each person in the list'),
         keywords: m(''),
         title: m('Tag'),
       },
@@ -223,7 +223,7 @@ export default makeMessages('feat.views', {
       phone: m('Phone number'),
     },
     editor: {
-      alreadyInView: m('Already in view'),
+      alreadyInView: m('Already in list'),
       buttonLabels: {
         addColumns: m<{ columns: number }>(
           'Add {columns, plural, one {1 column} other {{columns} columns}}'
@@ -241,10 +241,10 @@ export default makeMessages('feat.views', {
     },
     gallery: {
       add: m('Add'),
-      alreadyInView: m('Already in view'),
+      alreadyInView: m('Already in list'),
       columns: m('Columns'),
       configure: m('Configure'),
-      header: m('Add column to view'),
+      header: m('Add column to list'),
       noSearchResults: m<{ searchString: string }>(
         'There are no column choices that match "{searchString}"'
       ),
@@ -283,10 +283,10 @@ export default makeMessages('feat.views', {
     organizer_action: m('Organizer action needed'),
   },
   deleteDialog: {
-    error: m('There was an error deleting the view'),
-    title: m('Delete view?'),
+    error: m('There was an error deleting the list'),
+    title: m('Delete list?'),
     warningText: m(
-      'Do you really want to delete this view? This will delete any data stored in the view such as notes and toggles (but will not delete the people from the database)?'
+      'Do you really want to delete this list? This will delete any data stored in the list such as notes and toggles (but will not delete the people from the database)?'
     ),
   },
   editViewTitleAlert: {
@@ -297,17 +297,17 @@ export default makeMessages('feat.views', {
     dynamic: {
       configureButton: m('Configure'),
       description: m(
-        'Create a dynamic view where people are added and removed automatically using Smart Search.'
+        'Create a dynamic list where people are added and removed automatically using Smart Search.'
       ),
-      headline: m('Configure Smart Search View'),
+      headline: m('Configure Smart Search List'),
     },
     notice: {
-      dynamic: m('This is a Smart Search View but no people match the query'),
+      dynamic: m('This is a Smart Search List but no people match the query'),
       static: m("You haven't added any rows yet"),
     },
     static: {
       description: m(
-        'Add the first person to create a static view where people are added and removed manually.'
+        'Add the first person to create a static list where people are added and removed manually.'
       ),
       headline: m('Add people manually'),
     },
@@ -324,16 +324,16 @@ export default makeMessages('feat.views', {
     },
   },
   footer: {
-    addPlaceholder: m('Start typing to add person to view'),
-    alreadyInView: m('Already in view'),
+    addPlaceholder: m('Start typing to add person to list'),
+    alreadyInView: m('Already in list'),
   },
   newFolderTitle: m('New Folder'),
   newViewFields: {
-    title: m('New View'),
+    title: m('New List'),
   },
   removeDialog: {
-    action: m('Are you sure you want to remove these rows from this view?'),
-    title: m('Remove people from view'),
+    action: m('Are you sure you want to remove these rows from this list?'),
+    title: m('Remove people from list'),
   },
   shareDialog: {
     download: {
@@ -357,7 +357,7 @@ export default makeMessages('feat.views', {
       ),
       showOfficials: m('Show officials'),
       statusLabel: m<{ collaborators: number; officials: number }>(
-        'Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all views.'
+        'Shared with {collaborators, plural, =1 {1 collaborator} other {# collaborators}}, {officials, plural, =1 {1 official} other {# officials}} can access all lists.'
       ),
       tabLabel: m('Share'),
       viewLink: m('restricted link'),
@@ -384,12 +384,12 @@ export default makeMessages('feat.views', {
   },
   toolbar: {
     createColumn: m('New column'),
-    createFromSelection: m('Create view from selection'),
+    createFromSelection: m('Create list from selection'),
     removeFromSelection: m<{ numSelected: number }>(
-      'Remove {numSelected, plural, one {1 person} other {{numSelected} people} } from view'
+      'Remove {numSelected, plural, one {1 person} other {{numSelected} people} } from list'
     ),
     removeTooltip: m(
-      'Smart search views do not currently support removing rows'
+      'Smart search lists do not currently support removing rows'
     ),
   },
   viewLayout: {
@@ -397,13 +397,13 @@ export default makeMessages('feat.views', {
       share: m('Share'),
     },
     ellipsisMenu: {
-      delete: m('Delete view'),
+      delete: m('Delete list'),
       editQuery: m('Edit Smart Search query'),
-      makeDynamic: m('Convert to Smart Search view'),
-      makeStatic: m('Convert to static view'),
+      makeDynamic: m('Convert to Smart Search List'),
+      makeStatic: m('Convert to static list'),
     },
     jumpMenu: {
-      placeholder: m('Start typing to find view'),
+      placeholder: m('Start typing to find list'),
     },
     subtitle: {
       collaborators: m<{ count: number }>(
@@ -423,6 +423,6 @@ export default makeMessages('feat.views', {
       owner: m('Owner'),
       title: m('Title'),
     },
-    empty: m("You haven't created any views yet."),
+    empty: m("You haven't created any lists yet."),
   },
 });

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -299,10 +299,10 @@ export default makeMessages('feat.lists', {
       description: m(
         'Create a dynamic list where people are added and removed automatically using Smart Search.'
       ),
-      headline: m('Configure Smart Search List'),
+      headline: m('Configure Smart Search list'),
     },
     notice: {
-      dynamic: m('This is a Smart Search List but no people match the query'),
+      dynamic: m('This is a Smart Search list but no people match the query'),
       static: m("You haven't added any rows yet"),
     },
     static: {
@@ -329,7 +329,7 @@ export default makeMessages('feat.lists', {
   },
   newFolderTitle: m('New Folder'),
   newViewFields: {
-    title: m('New List'),
+    title: m('New list'),
   },
   removeDialog: {
     action: m('Are you sure you want to remove these rows from this list?'),
@@ -399,7 +399,7 @@ export default makeMessages('feat.lists', {
     ellipsisMenu: {
       delete: m('Delete list'),
       editQuery: m('Edit Smart Search query'),
-      makeDynamic: m('Convert to Smart Search List'),
+      makeDynamic: m('Convert to Smart Search list'),
       makeStatic: m('Convert to static list'),
     },
     jumpMenu: {

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -319,7 +319,7 @@ export default makeMessages('feat.lists', {
         '{count, plural, =1 {1 folder} other {# folders}}'
       ),
       viewCount: m<{ count: number }>(
-        '{count, plural, =1 {1 view} other {# views}}'
+        '{count, plural, =1 {1 list} other {# lists}}'
       ),
     },
   },

--- a/src/features/views/models/ViewBrowserModel.ts
+++ b/src/features/views/models/ViewBrowserModel.ts
@@ -68,7 +68,7 @@ export default class ViewBrowserModel extends ModelBase {
       .createView(this._orgId, folderId, rows)
       .then((view) => {
         this._env.router.push(
-          `/organize/${view.organization.id}/people/views/${view.id}`
+          `/organize/${view.organization.id}/people/lists/${view.id}`
         );
         return view;
       });
@@ -154,7 +154,7 @@ export default class ViewBrowserModel extends ModelBase {
         items.push({
           data: view,
           folderId: folderId,
-          id: 'views/' + view.id,
+          id: 'lists/' + view.id,
           owner: view.owner.name,
           title: view.title,
           type: 'view',
@@ -169,7 +169,7 @@ export default class ViewBrowserModel extends ModelBase {
       .getOrganizerActionView(this._orgId)
       .then((view) => {
         this._env.router.push(
-          `/organize/${view.organization.id}/people/views/${view.id}`
+          `/organize/${view.organization.id}/people/lists/${view.id}`
         );
         return view;
       });

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -50,7 +50,7 @@ const breadcrumbs = async (
         elements.forEach((elem) => breadcrumbs.push(elem));
         curPath.push(fieldValue);
       } else {
-        if (field == 'views' || field == 'folders') {
+        if (field == 'lists' || field == 'folders') {
           // Ignore "views" and "folders", which are only there
           // for technical reasons, but do not represent any page
           // and shouldn't link to anything.

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -17,7 +17,7 @@ import ZUIFutures from 'zui/ZUIFutures';
 const scaffoldOptions = {
   allowNonOfficials: true,
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people.views'],
+  localeScope: ['layout.organize', 'pages.people.lists'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
@@ -40,7 +40,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
           viewId,
         },
         redirect: {
-          destination: `/organize/${orgId}/people/views/${viewId}/shared`,
+          destination: `/organize/${orgId}/people/lists/${viewId}/shared`,
           permament: false,
         },
       };

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -19,7 +19,7 @@ import ZUIFutures from 'zui/ZUIFutures';
 const scaffoldOptions = {
   allowNonOfficials: true,
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people.views'],
+  localeScope: ['layout.organize', 'pages.people.lists'],
 };
 
 async function getAccessLevel(

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -20,7 +20,7 @@ export default makeMessages('zui', {
     closed: m('Closed'),
     conversation: m('Conversation'),
     events: m('Events'),
-    folders: m('Views'),
+    folders: m('Lists'),
     insights: m('Insights'),
     instances: m('Instances'),
     journeys: m('Journeys'),
@@ -36,7 +36,7 @@ export default makeMessages('zui', {
     surveys: m('Surveys'),
     tasks: m('Tasks'),
     untitledEvent: m('Untitled event'),
-    views: m('Views'),
+    views: m('Lists'),
   },
   collapse: {
     collapse: m('Collapse'),
@@ -132,7 +132,7 @@ export default makeMessages('zui', {
     keepTyping: m('Keep typing..'),
     noResult: m('No matching person found'),
     otherPeople: m('Other people'),
-    restrictedMode: m("Can't be edited in shared views."),
+    restrictedMode: m("Can't be edited in shared lists."),
     searchResults: m('Search results'),
   },
   personSelect: {


### PR DESCRIPTION
## Description
This PR renames "Views" for "Lists" in all user-visible places and updates the urls. It also fixes the tests affected by the change.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/ac38f5d3-e4e9-47ec-b0f3-d34d5a5031ed)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/0b12fce1-035c-4714-a72e-907ccefe308e)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/f6c88fe6-f20d-4b76-8721-460ac6429e40)
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/8e8ab812-aa9e-4671-b5c1-7f741a7ec914)


## Changes
* Changes localize strings that are visible 
* Changes `pages/views` folder for `pages/lists `
* Changes user-visible urls to "/lists"
* Fixes integration tests to follow the change.


## Notes to reviewer
I didn't push the autogenerated yaml file `src/locale/en.yml `. I can do it if that's necessary.

## Related issues
Resolves #1510 
