### PR TITLE
issue-1508/ellipsis menu position

### DIFF
--- a/src/features/events/components/SelectionBarEllipsis.tsx
+++ b/src/features/events/components/SelectionBarEllipsis.tsx
@@ -103,7 +103,16 @@ const SelectionBarEllipsis = () => {
     });
   }
 
-  return <ZUIEllipsisMenu items={ellipsisMenuItems} />;
+  return (
+    <ZUIEllipsisMenu
+      anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+      items={ellipsisMenuItems}
+      transformOrigin={{
+        horizontal: 'right',
+        vertical: 'bottom',
+      }}
+    />
+  );
 };
 
 export default SelectionBarEllipsis;

--- a/src/zui/ZUIEllipsisMenu/index.tsx
+++ b/src/zui/ZUIEllipsisMenu/index.tsx
@@ -10,6 +10,9 @@ import {
 } from '@mui/material';
 import { FunctionComponent, ReactElement, useState } from 'react';
 
+type horizontalType = 'left' | 'center' | 'right';
+type verticalType = 'top' | 'center' | 'bottom';
+
 interface MenuItem {
   disabled?: boolean;
   divider?: boolean;
@@ -23,10 +26,14 @@ interface MenuItem {
 
 export interface ZUIEllipsisMenuProps {
   items: MenuItem[];
+  anchorOrigin?: { horizontal: horizontalType; vertical: verticalType };
+  transformOrigin?: { horizontal: horizontalType; vertical: verticalType };
 }
 
 const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
   items,
+  anchorOrigin,
+  transformOrigin,
 }) => {
   const [menuActivator, setMenuActivator] = useState<null | HTMLElement>(null);
   const [subMenuActivator, setSubMenuActivator] = useState<null | HTMLElement>(
@@ -49,6 +56,9 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
       </Button>
       <Menu
         anchorEl={menuActivator}
+        anchorOrigin={
+          anchorOrigin ?? { horizontal: 'left', vertical: 'bottom' }
+        }
         keepMounted
         onClose={() => setMenuActivator(null)}
         open={Boolean(menuActivator)}
@@ -62,6 +72,9 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
             marginTop: theme.spacing(1),
           },
         }}
+        transformOrigin={
+          transformOrigin ?? { horizontal: 'left', vertical: 'top' }
+        }
       >
         {items.map((item, idx) => (
           <MenuItem

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -341,6 +341,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                     }}
                   >
                     <ZUIEllipsisMenu
+                      anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
                       items={[
                         {
                           label: (
@@ -354,6 +355,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                           startIcon: <Logout />,
                         },
                       ]}
+                      transformOrigin={{
+                        horizontal: 'right',
+                        vertical: 'bottom',
+                      }}
                     />
                   </Box>
                 </>


### PR DESCRIPTION
## Description
This PR fixes a bug where `ZUIEllipsisMenu` covers the ellipsis icon in side bar and event selection bar


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/5c5b906d-5da3-4a39-874c-c25aa30c5c7d)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/5bd90e51-cabc-439a-be37-47645d087c8f)



## Changes

* Adds properties `anchorOrigin` and `transformOrigin`
* Adds types `horizontalType` and `verticalType`
* Adds properties for popover position `ZUIOrganizeSidebar` and `SelectionBarEllipsis`

## Notes to reviewer
I checked every page where using `ZUIEllipsisMenu` to see popover menu's position. Everything looks fine with default position 
```
 anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }},  transformOrigin={{ horizontal: 'left', vertical: 'top' }}
```

## Related issues
Resolves #1508 
