### PR TITLE
issue-1529/overview card blurring bug

### DIFF
--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -177,11 +177,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
       placement="top"
       title={tooltipText()}
     >
-      <FormControl
-        onClick={(e) => e.stopPropagation()}
-        style={{ overflow: 'hidden' }}
-        variant="standard"
-      >
+      <FormControl style={{ overflow: 'hidden' }} variant="standard">
         <span ref={spanRef} className={classes.span}>
           {text || placeholder}
         </span>


### PR DESCRIPTION
## Description
This PR fixes a bug that event overview card doesn't blur when clicking event title.


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/e3c0f92b-fe69-49cd-86ec-cc482b6f478f


## Changes

* Remove `stopPropagation` in `FormControl`


## Notes to reviewer


## Related issues
Resolves #1529 
