### PR TITLE
issue-1504/tree expands bug

### DIFF
--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -22,9 +22,7 @@ function renderTree(props: OrganizationTreeProps): React.ReactNode {
         <NextLink href={`/organize/${item.id}`}>
           <Box
             m={1}
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
+            onClick={(e) => e.stopPropagation()}
             sx={{ alignItems: 'center', display: 'inlineFlex' }}
           >
             <Box mr={1}>

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -20,7 +20,13 @@ function renderTree(props: OrganizationTreeProps): React.ReactNode {
       key={item.id}
       label={
         <NextLink href={`/organize/${item.id}`}>
-          <Box m={1} sx={{ alignItems: 'center', display: 'inlineFlex' }}>
+          <Box
+            m={1}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            sx={{ alignItems: 'center', display: 'inlineFlex' }}
+          >
             <Box mr={1}>
               <ProceduralColorIcon id={item.id} />
             </Box>


### PR DESCRIPTION
## Description
This PR fixes a bug that sub organizations tree expands when clicking the organization's title


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/99c59a8f-f74c-41e6-a2b5-a9706e6c8ec0



## Changes

* Adds `stopPropagation` to `Box`


## Notes to reviewer


## Related issues
Resolves #1504 
