### PR TITLE
Issue 1398/location search options

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -18,7 +18,7 @@ import {
   Typography,
 } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 
 import EventDataModel from 'features/events/models/EventDataModel';
 import { EventsModel } from 'features/events/models/EventsModel';
@@ -97,12 +97,19 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
       },
     });
 
+  const sortedLocation = useMemo(() => {
+    const sorted = locations?.sort((a, b) => {
+      return a.title.localeCompare(b.title);
+    });
+    return sorted;
+  }, [locations?.length]);
+
   const options: (
     | ZetkinLocation
     | 'CREATE_NEW_LOCATION'
     | 'NO_PHYSICAL_LOCATION'
-  )[] = locations
-    ? [...locations, 'NO_PHYSICAL_LOCATION', 'CREATE_NEW_LOCATION']
+  )[] = sortedLocation
+    ? [...sortedLocation, 'NO_PHYSICAL_LOCATION', 'CREATE_NEW_LOCATION']
     : ['NO_PHYSICAL_LOCATION', 'CREATE_NEW_LOCATION'];
 
   const events = eventsModel.getParallelEvents(
@@ -468,7 +475,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({
                             currentEventId={data.id}
                             events={events || []}
                             locationId={locationId}
-                            locations={locations || []}
+                            locations={sortedLocation || []}
                             model={locationsModel}
                             onCreateLocation={(
                               newLocation: Partial<ZetkinLocation>

--- a/src/features/events/components/LocationModal/LocationSearch.tsx
+++ b/src/features/events/components/LocationModal/LocationSearch.tsx
@@ -34,6 +34,7 @@ const LocationSearch: FC<LocationSearchProps> = ({
         <TextField
           {...params}
           InputProps={{
+            ...params.InputProps,
             endAdornment: (
               <IconButton onClick={onClickGeolocate}>
                 <MyLocation />

--- a/src/features/events/components/LocationModal/index.tsx
+++ b/src/features/events/components/LocationModal/index.tsx
@@ -3,7 +3,7 @@ import { InfoOutlined } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/system';
 import { Box, Dialog, Typography } from '@mui/material';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 
 import 'leaflet/dist/leaflet.css';
 import CreateLocationCard from './CreateLocationCard';
@@ -87,6 +87,13 @@ const LocationModal: FC<LocationModalProps> = ({
     setPendingLocation(null);
   }, [open]);
 
+  const sortedLocation = useMemo(() => {
+    const sorted = locations.sort((a, b) => {
+      return a.title.localeCompare(b.title);
+    });
+    return sorted;
+  }, [locations]);
+
   return (
     <Dialog fullWidth maxWidth="lg" onClose={onMapClose} open={open}>
       <Box border={1} padding={2}>
@@ -144,7 +151,7 @@ const LocationModal: FC<LocationModalProps> = ({
               }}
               onInputChange={(value) => setSearchString(value || '')}
               onTextFieldChange={(value) => setSearchString(value)}
-              options={locations}
+              options={sortedLocation}
             />
           )}
           {selectedLocation && !inMoveState && (

--- a/src/features/events/components/LocationModal/index.tsx
+++ b/src/features/events/components/LocationModal/index.tsx
@@ -3,7 +3,7 @@ import { InfoOutlined } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/system';
 import { Box, Dialog, Typography } from '@mui/material';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import 'leaflet/dist/leaflet.css';
 import CreateLocationCard from './CreateLocationCard';
@@ -87,13 +87,6 @@ const LocationModal: FC<LocationModalProps> = ({
     setPendingLocation(null);
   }, [open]);
 
-  const sortedLocation = useMemo(() => {
-    const sorted = locations.sort((a, b) => {
-      return a.title.localeCompare(b.title);
-    });
-    return sorted;
-  }, [locations]);
-
   return (
     <Dialog fullWidth maxWidth="lg" onClose={onMapClose} open={open}>
       <Box border={1} padding={2}>
@@ -151,7 +144,7 @@ const LocationModal: FC<LocationModalProps> = ({
               }}
               onInputChange={(value) => setSearchString(value || '')}
               onTextFieldChange={(value) => setSearchString(value)}
-              options={sortedLocation}
+              options={locations}
             />
           )}
           {selectedLocation && !inMoveState && (


### PR DESCRIPTION
## Description
This PR fixes a bug that autocomplete location list doesn't appear on focus in map. I also sorted a location list alphabetically.


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/035945a5-fd26-4320-a124-8e57be654121


## Changes

* Adds `useMemo` for sorting event location list in `EventOveriewCard`
* Spread `params.InputProps` in `TextField` 


## Notes to reviewer
I was thinking it could be nice to have a alphabetically sorted list, so I fixed it together with this issue

## Related issues
Resolves #1398 
