### PR TITLE
Issue 1423/autocomplete resize

### DIFF
--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     fontSize: '1rem',
     // But invisible and positioned absolutely to not affect flow
     position: 'absolute',
-    // visibility: 'hidden',
+    visibility: 'hidden',
   },
 }));
 
@@ -75,11 +75,12 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   typesModel,
   value,
 }) => {
+  const messages = useMessages(messageIds);
+  const uncategorizedMsg = messages.type.uncategorized();
   const [createdType, setCreatedType] = useState<string>('');
-  const [text, setText] = useState<string>('');
+  const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
 
   const classes = useStyles({ showBorder });
-  const messages = useMessages(messageIds);
   const spanRef = useRef<HTMLSpanElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -113,8 +114,6 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
     keys: ['title'],
     threshold: 0.4,
   });
-
-  const uncategorizedMsg = messages.type.uncategorized();
 
   return (
     <Tooltip arrow title={showBorder ? '' : messages.type.tooltip()}>
@@ -184,13 +183,14 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                   title: value.title!,
                 }
           );
+          setText(value.title);
         }}
         onFocus={() => onFocus()}
         options={allTypes}
         renderInput={(params) => (
           <>
             <span ref={spanRef} className={classes.span}>
-              {text || (value?.title ?? uncategorizedMsg)}
+              {text}
             </span>
             <TextField
               {...params}

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -26,8 +26,6 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     borderColor: ({ showBorder }) =>
       showBorder ? lighten(theme.palette.primary.main, 0.65) : '',
     borderRadius: 10,
-    //border width
-    // maxWidth: '200px',
     paddingLeft: ({ showBorder }) => (showBorder ? 10 : 0),
     paddingRight: ({ showBorder }) => (showBorder ? 0 : 10),
     transition: 'all 0.2s ease',
@@ -41,11 +39,11 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     },
     border: '2px dotted transparent',
     borderRadius: 10,
-    paddingRight: 10,
     fontSize: '1rem',
+    paddingRight: 10,
     // But invisible and positioned absolutely to not affect flow
     position: 'absolute',
-    // visibility: 'hidden',
+    visibility: 'hidden',
   },
 }));
 
@@ -81,9 +79,8 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
   const [dropdownListWidth, setDropdownListWidth] = useState(0);
 
-  const classes = useStyles({ showBorder });
   const spanRef = useRef<HTMLSpanElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const classes = useStyles({ showBorder });
 
   useEffect(() => {
     //When a user creates a new type, it is missing an event ID.
@@ -97,13 +94,15 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   }, [types.length]);
 
   useEffect(() => {
-    if (spanRef.current && inputRef.current) {
-      // Add some margin to the right while in edit mode
+    if (spanRef.current) {
       const width = spanRef.current.offsetWidth;
       setDropdownListWidth(width);
-      inputRef.current.style.width = width + 'px';
     }
-  }, [spanRef.current, inputRef.current, text]);
+  }, [spanRef.current, text]);
+
+  useEffect(() => {
+    setText(value ? value.title : uncategorizedMsg);
+  }, [value]);
 
   const allTypes: EventTypeOption[] = [
     ...types,
@@ -122,13 +121,13 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
     <Tooltip arrow title={showBorder ? '' : messages.type.tooltip()}>
       <Autocomplete
         blurOnSelect
-        componentsProps={{
-          popper: {
-            style: { minWidth: 180, width: dropdownListWidth, maxWidth: 700 },
-          },
-        }}
         classes={{
           root: classes.inputRoot,
+        }}
+        componentsProps={{
+          popper: {
+            style: { maxWidth: 380, minWidth: 180, width: dropdownListWidth },
+          },
         }}
         disableClearable
         filterOptions={(options, { inputValue }) => {
@@ -168,9 +167,13 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
         getOptionLabel={(option) => option.title!}
         isOptionEqualToValue={(option, value) => option.title === value.title}
         onBlur={() => {
-          // show 'uncategorized' in textField when blur
+          // show 'uncategorized' in textField when blurring
           if (!value && text !== uncategorizedMsg) {
             setText(uncategorizedMsg);
+          }
+          //set text to previous input value when clicking away
+          if (value && text !== value.title) {
+            setText(value.title);
           }
           onBlur();
         }}
@@ -190,9 +193,6 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                 }
           );
         }}
-        onInputChange={(e, inputValue) => {
-          setText(inputValue);
-        }}
         onFocus={() => onFocus()}
         options={allTypes}
         renderInput={(params) => (
@@ -202,16 +202,19 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
             </span>
             <TextField
               {...params}
-              inputRef={inputRef}
               InputLabelProps={{
                 shrink: false,
               }}
               InputProps={{
                 ...params.InputProps,
-                style: { maxWidth: 700 },
+                style: {
+                  maxWidth: 380,
+                  minWidth: 60,
+                  width: dropdownListWidth + 50,
+                },
               }}
-              size="small"
               onChange={(e) => setText(e.target.value)}
+              size="small"
             />
           </>
         )}

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -89,8 +89,9 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
     //In here, when the length of the type changes,
     //it searches for the created event and updates event with an ID.
     if (createdType !== '') {
-      const newId = types.find((item) => item.title === createdType)!.id;
-      onChangeNewOption(newId!);
+      const newEventType = types.find((item) => item.title === createdType);
+      setText(newEventType!.title);
+      onChangeNewOption(newEventType!.id);
     }
   }, [types.length]);
 
@@ -234,7 +235,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
             ? value
             : {
                 id: 'UNCATEGORIZED',
-                title: text !== '' ? text : uncategorizedMsg,
+                title: text,
               }
         }
       />

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -126,6 +126,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
         }}
         componentsProps={{
           popper: {
+            placement: 'bottom-start',
             style: { maxWidth: 380, minWidth: 180, width: dropdownListWidth },
           },
         }}

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
     fontSize: '1rem',
     // But invisible and positioned absolutely to not affect flow
     position: 'absolute',
-    visibility: 'hidden',
+    // visibility: 'hidden',
   },
 }));
 
@@ -79,6 +79,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   const uncategorizedMsg = messages.type.uncategorized();
   const [createdType, setCreatedType] = useState<string>('');
   const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
+  const [dropdownListWidth, setDropdownListWidth] = useState(0);
 
   const classes = useStyles({ showBorder });
   const spanRef = useRef<HTMLSpanElement>(null);
@@ -98,10 +99,11 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   useEffect(() => {
     if (spanRef.current && inputRef.current) {
       // Add some margin to the right while in edit mode
-      const width = spanRef.current.offsetWidth + (showBorder ? 10 : -5);
+      const width = spanRef.current.offsetWidth;
+      setDropdownListWidth(width);
       inputRef.current.style.width = width + 'px';
     }
-  }, [spanRef.current, inputRef.current, text, showBorder]);
+  }, [spanRef.current, inputRef.current, text]);
 
   const allTypes: EventTypeOption[] = [
     ...types,
@@ -120,7 +122,11 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
     <Tooltip arrow title={showBorder ? '' : messages.type.tooltip()}>
       <Autocomplete
         blurOnSelect
-        // componentsProps={{ popper: { style: { minWidth: 170, width: width } } }}
+        componentsProps={{
+          popper: {
+            style: { minWidth: 180, width: dropdownListWidth, maxWidth: 700 },
+          },
+        }}
         classes={{
           root: classes.inputRoot,
         }}
@@ -162,15 +168,14 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
         getOptionLabel={(option) => option.title!}
         isOptionEqualToValue={(option, value) => option.title === value.title}
         onBlur={() => {
+          // show 'uncategorized' in textField when blur
           if (!value && text !== uncategorizedMsg) {
             setText(uncategorizedMsg);
-          }
-          if (value && text !== value.title) {
-            setText(value.title);
           }
           onBlur();
         }}
         onChange={(_, value) => {
+          setText(value.title);
           if (value.id == 'CREATE') {
             typesModel.addType(value.title!);
             setCreatedType(value.title!);
@@ -184,7 +189,9 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                   title: value.title!,
                 }
           );
-          setText(value.title);
+        }}
+        onInputChange={(e, inputValue) => {
+          setText(inputValue);
         }}
         onFocus={() => onFocus()}
         options={allTypes}
@@ -195,14 +202,13 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
             </span>
             <TextField
               {...params}
-              // fullWidth
               inputRef={inputRef}
               InputLabelProps={{
                 shrink: false,
               }}
               InputProps={{
                 ...params.InputProps,
-                style: { maxWidth: 1000 },
+                style: { maxWidth: 700 },
               }}
               size="small"
               onChange={(e) => setText(e.target.value)}


### PR DESCRIPTION
## Description
This PR implements dynamic changing width of `EventTypeAutocomplete` so that it can show the entire event type text when user types inside of the text field. The text field will be stretched just as same size as input text.


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/6cd5b2c6-12ec-47c3-8bdd-de661a1abac8


## Changes

* Adds `useEffect` to fetch value after `onBlur`
* Adds `useEffect` for resizing autocomplete
* Adds `span`
* Changes `messages.type.uncategorized()` to `text` in `value` property


## Notes to reviewer


## Related issues
Resolves #1423 
