### PR TITLE
Localize MUI DataGrid strings

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -405,9 +405,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           params.id == addedId ? classes.addedRow : ''
         }
         hideFooter={empty || contentSource == VIEW_CONTENT_SOURCE.DYNAMIC}
-        localeText={{
-          noRowsLabel: messages.empty.notice[contentSource](),
-        }}
         onCellEditStart={(params, event) => {
           if (params.reason == GridCellEditStartReasons.printableKeyDown) {
             // Don't enter edit mode when the user just presses a printable character.

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import NProgress from 'nprogress';
@@ -14,6 +13,7 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';
+import { Link, useTheme } from '@mui/material';
 
 import columnTypes from './columnTypes';
 import EmptyView from 'features/views/components/EmptyView';
@@ -110,6 +110,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   rows,
   view,
 }) => {
+  const theme = useTheme();
   const messages = useMessages(messageIds);
   const classes = useStyles();
   const gridApiRef = useGridApiRef();
@@ -405,6 +406,10 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           params.id == addedId ? classes.addedRow : ''
         }
         hideFooter={empty || contentSource == VIEW_CONTENT_SOURCE.DYNAMIC}
+        localeText={{
+          ...theme.components?.MuiDataGrid?.defaultProps?.localeText,
+          noRowsLabel: messages.empty.notice[contentSource](),
+        }}
         onCellEditStart={(params, event) => {
           if (params.reason == GridCellEditStartReasons.printableKeyDown) {
             // Don't enter edit mode when the user just presses a printable character.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,7 +26,7 @@ import Environment from 'core/env/Environment';
 import { EnvProvider } from 'core/env/EnvContext';
 import { EventPopperProvider } from 'features/events/components/EventPopper/EventPopperProvider';
 import { PageWithLayout } from '../utils/types';
-import theme from '../theme';
+import { themeWithLocale } from '../theme';
 import { UserContext } from 'utils/hooks/useFocusDate';
 import { ZUIConfirmDialogProvider } from 'zui/ZUIConfirmDialogProvider';
 import { ZUISnackbarProvider } from 'zui/ZUISnackbarContext';
@@ -97,7 +97,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
       <EnvProvider env={env}>
         <UserContext.Provider value={pageProps.user}>
           <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={theme}>
+            <ThemeProvider theme={themeWithLocale(lang)}>
               <LocalizationProvider dateAdapter={AdapterDayjs}>
                 <IntlProvider
                   defaultLocale="en"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,8 @@
 import type {} from '@mui/x-data-grid-pro/themeAugmentation';
-
 import { createElement } from 'react';
 import { createTheme } from '@mui/material/styles';
+import { Localization } from '@mui/x-data-grid/utils/getGridLocalization';
+import { daDK, deDE, nbNO, svSE } from '@mui/x-data-grid-pro';
 
 interface PaletteIntensityOptions {
   disabled?: string;
@@ -209,5 +210,15 @@ const theme = createTheme({
     },
   },
 });
+
+const locales: Record<string, Localization> = {};
+locales['da'] = daDK;
+locales['de'] = deDE;
+locales['nn'] = nbNO;
+locales['sv'] = svSE;
+
+export const themeWithLocale = (lang: string) => {
+  return createTheme(theme, locales[lang]);
+};
 
 export default theme;


### PR DESCRIPTION
## Description
This PR adds localization to the MUI components via the Theme.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/8320efa4-4f3f-4c52-a7c3-5a6c127f496e)

## Changes
* Adds a function to add localization to the theme
* Uses this theme with localization in the `ThemeProvider`

## Notes to reviewer
Remember to set your browser language to nn or dk, since this branch is pre-swedish and german translations!

## Related issues
Resolves #1537 
