### PR TITLE
issue-1539/internationalize call history

### DIFF
--- a/src/locale/da.yml
+++ b/src/locale/da.yml
@@ -596,7 +596,7 @@ feat:
             som helst opgave til.
           two: Fjern personer, der er blevet ringet op mindst 1 gang i opgaven 'Aktiver
             gamle medlemmer' i løbet af de sidste 30 dage.
-        inputString: '{addRemoveSelect} personer som {callSelect} mindst {minTimes}
+        inputString: '{addRemoveSelect} personer som {callSelect} mindst
           {minTimes} i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimes} {minTimes, plural, one {gang} other {gange}}'
         minTimesInput: '{input} {minTimes, plural, one {gang} other {gange}}'

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -574,9 +574,9 @@ feat:
             ringeoppdrag når som helst.
           two: Fjern folk som har blitt ringt minst en gang i ringeoppdraget "Valgkamp
             2023" de siste 30 dagene.
-        inputString: '{addRemoveSelect} folk som {callSelect} minst {minTimes} {minTimes,
-          plural, one {gang} other {ganger}} i {assignmentSelect} {timeFrame}.'
+        inputString: '{addRemoveSelect} folk som {callSelect} minst {minTimes} i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimes} {minTimes, plural, one {gang} other {ganger}}'
+        minTimesInput: '{input} {minTimes, plural, one {gang} other {ganger}}'
       campaignParticipation:
         activitySelect:
           activity: aktiviteten "{activity}"

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -701,7 +701,7 @@ feat:
         inputString: '{addRemoveSelect} personer som {callSelect} minst
           {minTimes} i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimesInput} {minTimes, plural, one {gång} other {gånger}}'
-        minTimesInput: '{minTimesInput}'
+        minTimesInput: '{input} {minTimes, plural, one {gång} other {gånger}}'
       campaignParticipation:
         activitySelect:
           activity: typ "{activity}"

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -698,7 +698,7 @@ feat:
             närsomhelt.
           two: Ta bort personer som blivit ringda åtminstone 1 gång i uppdraget 'Aktivera
             gamla medlemmar' under de senaste 30 dagarna.
-        inputString: '{addRemoveSelect} personer som {callSelect} minst {minTimesInput}
+        inputString: '{addRemoveSelect} personer som {callSelect} minst
           {minTimes} i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimesInput} {minTimes, plural, one {gång} other {gånger}}'
         minTimesInput: '{minTimesInput}'


### PR DESCRIPTION
## Description
This PR fixes a bug where smart search filter with call history shows English / wrong description when browser language is Swedish, Danish and Norwegien.


## Screenshots
# Swedish
- Before
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/b2a2f672-a607-4df8-9e57-14485db6eb5d)
- After
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/2afb0922-e461-4ca4-ae43-1dd8e7340a47)

# Danish
- Before
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/d51af0d8-0bb3-46c6-9b48-6f1a0421aba0)

- After
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/6c83e8bb-4792-47a3-9448-95dc8eb39dc0)

# Norwegian
- Before
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/ebf78f89-8041-4bd9-8780-9f33060d9121)

- After
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/3db4a920-3c82-4b12-b7af-01735f903b94)



## Changes

* Removes unused `{minTimesInput}`
* Adds `minTimesInput` to `callHistory`


## Notes to reviewer
I found that usage of `minTimesInput` is different in other languages and it caused weird error. So I fixed it together with this PR. I noticed that en.yaml also has same problem in `smartSearch.filters.callHistory.inputString` but I didn't correct there since `make-yaml` can fix that automatically.

## Related issues
Resolves #1539 

