### PR TITLE
Implement localization in call assignments insights page header

### DIFF
--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -58,6 +58,7 @@ export default makeMessages('feat.calendar', {
     },
     type: m('Type to filter content'),
   },
+  insightsHeader: m('Calls and conversations'),
   lastDayWithEvents: m<{ numEvents: number }>(
     'There {numEvents, plural, one {was one event} other {were {numEvents} events}} on the last active day'
   ),

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -58,7 +58,6 @@ export default makeMessages('feat.calendar', {
     },
     type: m('Type to filter content'),
   },
-  insightsHeader: m('Calls and conversations'),
   lastDayWithEvents: m<{ numEvents: number }>(
     'There {numEvents, plural, one {was one event} other {were {numEvents} events}} on the last active day'
   ),

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -83,6 +83,7 @@ export default makeMessages('feat.callAssignments', {
     subtitle: m('Targets that meet the done criteria'),
     title: m('Done'),
   },
+  insightsHeader: m('Calls and conversations'),
   organizerActionPane: {
     markAsSolved: m('Mark as solved'),
     markAsUnsolved: m('Mark as unsolved'),

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -156,7 +156,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
               },
               {
                 id: 'delete-item',
-                label: 'Delete',
+                label: messages.browser.menu.delete(),
                 onSelect: (e) => {
                   e.stopPropagation();
                   showConfirmDialog({

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -25,6 +25,7 @@ export default makeMessages('feat.views', {
       },
     },
     menu: {
+      delete: m('Delete'),
       rename: m('Rename'),
     },
     moveToFolder: m<{ folder: ReactElement }>('Move to {folder}'),

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -50,6 +50,7 @@ feat:
         all: All
         none: None
       type: Type to filter content
+    insightsHeader: Calls and conversations
     lastDayWithEvents: There {numEvents, plural, one {was one event} other {were
       {numEvents} events}} on the last active day
     loadMore: Load more

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1347,6 +1347,7 @@ feat:
           warning: Deleting this view is a permanent action which can't be undone. Are you
             sure you want to continue?
       menu:
+        delete: Delete
         rename: Rename
       moveToFolder: Move to {folder}
       moveToRoot: Move to all views

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -50,7 +50,6 @@ feat:
         all: All
         none: None
       type: Type to filter content
-    insightsHeader: Calls and conversations
     lastDayWithEvents: There {numEvents, plural, one {was one event} other {were
       {numEvents} events}} on the last active day
     loadMore: Load more
@@ -142,6 +141,7 @@ feat:
       defineButton: Edit done criteria
       subtitle: Targets that meet the done criteria
       title: Done
+    insightsHeader: Calls and conversations
     organizerActionPane:
       markAsSolved: Mark as solved
       markAsUnsolved: Mark as unsolved

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/insights.tsx
@@ -16,6 +16,8 @@ import APIError from 'utils/apiError';
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
 import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
 import { callAssignmentQuery } from 'features/callAssignments/api/callAssignments';
+import messageIds from 'features/calendar/l10n/messageIds';
+import { Msg } from 'core/i18n';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useModel from 'core/useModel';
@@ -92,7 +94,9 @@ const AssignmentPage: PageWithLayout<AssignmentPageProps> = ({
       <Head>
         <title>{model.getData().data?.title}</title>
       </Head>
-      <Typography variant="h3">Calls and conversations</Typography>
+      <Typography variant="h3">
+        <Msg id={messageIds.insightsHeader} />
+      </Typography>
       <ZUIQuery queries={{ statsQuery }}>
         {({ queries }) => {
           const data = queries.statsQuery.data.dates.map((d: DateStats) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/insights.tsx
@@ -16,7 +16,7 @@ import APIError from 'utils/apiError';
 import CallAssignmentLayout from 'features/callAssignments/layout/CallAssignmentLayout';
 import CallAssignmentModel from 'features/callAssignments/models/CallAssignmentModel';
 import { callAssignmentQuery } from 'features/callAssignments/api/callAssignments';
-import messageIds from 'features/calendar/l10n/messageIds';
+import messageIds from 'features/callAssignments/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';


### PR DESCRIPTION
## Description
This PR removes a hardcoded string for callAssignments insight header and implements localization

## Changes
* Adds a new message ID in `callAssignment ` to localize insights page header
* Adds a new message ID in `views ` to localized Delete option in EllipsisMenu
* Updates `yaml `autogenerated file with the new entry.


## Notes to reviewer
None


## Related issues
Resolves #1538 
