### PR TITLE
issue-1549/ hidden string

### DIFF
--- a/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Card, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Typography,
+} from '@mui/material';
 
 import { Msg } from 'core/i18n';
 
@@ -32,7 +39,7 @@ const ColumnChoiceCard = ({
   title,
 }: ColumnChoiceCardProps) => {
   return (
-    <Card sx={{ height: '100%' }}>
+    <Card sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <Box
         alignItems="center"
         bgcolor={color}
@@ -42,35 +49,27 @@ const ColumnChoiceCard = ({
       >
         {cardVisual}
       </Box>
-      <Box
-        display="flex"
-        flexDirection="column"
-        height="50%"
-        justifyContent="space-between"
-        p={2}
-      >
-        <Box>
-          <Typography variant="h5">{title}</Typography>
-          <Typography>{description}</Typography>
-        </Box>
-        <Box>
-          {!alreadyInView && showAddButton && (
-            <Button onClick={() => onAdd()} variant="text">
-              <Msg id={messageIds.columnDialog.gallery[addButtonLabel]} />
-            </Button>
-          )}
-          {!alreadyInView && showConfigureButton && (
-            <Button onClick={() => onConfigure()} variant="text">
-              <Msg id={messageIds.columnDialog.gallery[configureButtonLabel]} />
-            </Button>
-          )}
-          {alreadyInView && (
-            <Button disabled variant="text">
-              <Msg id={messageIds.columnDialog.gallery.alreadyInView} />
-            </Button>
-          )}
-        </Box>
-      </Box>
+      <CardContent>
+        <Typography variant="h5">{title}</Typography>
+        <Typography>{description}</Typography>
+      </CardContent>
+      <CardActions disableSpacing sx={{ mt: 'auto' }}>
+        {!alreadyInView && showAddButton && (
+          <Button onClick={() => onAdd()} variant="text">
+            <Msg id={messageIds.columnDialog.gallery[addButtonLabel]} />
+          </Button>
+        )}
+        {!alreadyInView && showConfigureButton && (
+          <Button onClick={() => onConfigure()} variant="text">
+            <Msg id={messageIds.columnDialog.gallery[configureButtonLabel]} />
+          </Button>
+        )}
+        {alreadyInView && (
+          <Button disabled variant="text">
+            <Msg id={messageIds.columnDialog.gallery.alreadyInView} />
+          </Button>
+        )}
+      </CardActions>
     </Card>
   );
 };

--- a/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
@@ -32,12 +32,12 @@ const ColumnChoiceCard = ({
   title,
 }: ColumnChoiceCardProps) => {
   return (
-    <Card sx={{ height: '300px' }}>
+    <Card sx={{ height: '100%' }}>
       <Box
         alignItems="center"
         bgcolor={color}
         display="flex"
-        height="50%"
+        height="150px"
         justifyContent="center"
       >
         {cardVisual}


### PR DESCRIPTION
## Description
This PR fixes a bug where button in `ColumnChoiceCard` is hidden because of different description size in different languages.


## Screenshots
- Swedish (with extra texts)
![bild](https://github.com/zetkin/app.zetkin.org/assets/77925373/366fa868-59bb-43c1-bec7-c70715c9be87)

- Danish
![bild](https://github.com/zetkin/app.zetkin.org/assets/77925373/1e1f349a-f78e-44c6-b8ef-660ec5b65207)

- Norweigan 
![bild](https://github.com/zetkin/app.zetkin.org/assets/77925373/e0da6e72-733e-4d9f-a950-594b457ffcf2)

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes `height` of `Card` and `Box`
* Adds `CardContent` and `CardActions`


## Notes to reviewer


## Related issues
Resolves #1549 
