### PR TITLE
Rename lists to views

### DIFF
--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -78,7 +78,7 @@ test.describe('View detail page', () => {
     expect(columnPostLogs).toHaveLength(2);
 
     // Expect that correctly localised strings sent when posting
-    expect(viewPostLogs[0].data?.title).toEqual('New View');
+    expect(viewPostLogs[0].data?.title).toEqual('New list');
     expect(columnPostLogs[0].data?.title).toEqual('First Name');
     expect(columnPostLogs[1].data?.title).toEqual('Last Name');
 

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -78,7 +78,7 @@ test.describe('View detail page', () => {
     expect(columnPostLogs).toHaveLength(2);
 
     // Expect that correctly localised strings sent when posting
-    expect(viewPostLogs[0].data?.title).toEqual('New list');
+    expect(viewPostLogs[0].data?.title).toEqual('New View');
     expect(columnPostLogs[0].data?.title).toEqual('First Name');
     expect(columnPostLogs[1].data?.title).toEqual('Last Name');
 

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 
 import { m, makeMessages } from 'core/i18n';
 
-export default makeMessages('feat.lists', {
+export default makeMessages('feat.views', {
   actions: {
     createFolder: m('Create folder'),
     createView: m('Create list'),

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -101,7 +101,7 @@ feat:
       organizerActionNeeded: Organizer action needed
       subtitle: Targets not ready to be called
       title: Blocked
-      viewSheetButton: View sheet
+      viewSheetButton: View list
     callers:
       actions:
         customize: Customize queue
@@ -650,7 +650,7 @@ feat:
       project: Project
       survey: Survey
       task: Task
-      view: View
+      view: List
   smartSearch:
     buttonLabels:
       add: Save selection
@@ -674,7 +674,7 @@ feat:
       person_data: Based on their name, address or other data
       person_field: Based on custom fields
       person_tags: Based on their tags
-      person_view: People from a view
+      person_view: People from a list
       random: A random selection of people
       sub_query: Based on another Smart Search query
       survey_option: Based on the options they have selected in survey questions
@@ -797,14 +797,14 @@ feat:
           {tags}"
       personView:
         examples:
-          one: Add people who are in the view "Active Members 2022".
-          two: Remove people who are not in the view "Active Members 2022".
+          one: Add people who are in the list "Active Members 2022".
+          two: Remove people who are not in the list "Active Members 2022".
         inSelect:
           in: in
           notin: not in
-        inputString: "{addRemoveSelect} people who are {inSelect} the view {viewSelect}."
+        inputString: "{addRemoveSelect} people who are {inSelect} the list {viewSelect}."
         viewSelect:
-          none: This organization doesn't have any views yet
+          none: This organization doesn't have any lists yet
       random:
         addLimitRemoveSelect:
           add: add
@@ -1349,34 +1349,34 @@ feat:
   views:
     actions:
       createFolder: Create folder
-      createView: Create view
+      createView: Create list
     browser:
       backToFolder: Back to {folder}
-      backToRoot: Back to all views
+      backToRoot: Back to all lists
       confirmDelete:
         folder:
           title: Delete folder and content
-          warning: Deleting this folder and all views within is a permanent action that
+          warning: Deleting this folder and all lists within is a permanent action that
             cannot be undone. Are you sure you want to continue?
         view:
-          title: Delete view
-          warning: Deleting this view is a permanent action which can't be undone. Are you
+          title: Delete list
+          warning: Deleting this list is a permanent action which can't be undone. Are you
             sure you want to continue?
       menu:
         delete: Delete
         rename: Rename
       moveToFolder: Move to {folder}
-      moveToRoot: Move to all views
+      moveToRoot: Move to all lists
     browserLayout:
       tabs:
-        views: Views
+        views: Lists
       title: People
     cells:
       localPerson:
-        alreadyInView: Already in view
+        alreadyInView: Already in list
         clearLabel: Unassign
         otherPeople: Other people
-        restrictedMode: Can't be edited in shared views.
+        restrictedMode: Can't be edited in shared lists.
         searchLabel: Select a person
       organizerAction:
         actionNeeded: Organizer action needed
@@ -1499,7 +1499,7 @@ feat:
           noSurveys: Your organisation does not have any surveys.
           title: Survey submit date
         tag:
-          description: Toggle a tag for each person in the view
+          description: Toggle a tag for each person in the list
           keywords: ""
           title: Tag
         toggle:
@@ -1513,7 +1513,7 @@ feat:
         last_name: Last Name
         phone: Phone number
       editor:
-        alreadyInView: Already in view
+        alreadyInView: Already in list
         buttonLabels:
           addColumns: Add {columns, plural, one {1 column} other {{columns} columns}}
           change: Change column type
@@ -1526,10 +1526,10 @@ feat:
           tag: Tag
       gallery:
         add: Add
-        alreadyInView: Already in view
+        alreadyInView: Already in list
         columns: Columns
         configure: Configure
-        header: Add column to view
+        header: Add column to list
         noSearchResults: There are no column choices that match "{searchString}"
         searchPlaceholder: Find a column
         searchResults: Results for "{searchString}"
@@ -1556,10 +1556,10 @@ feat:
     defaultViewTitles:
       organizer_action: Organizer action needed
     deleteDialog:
-      error: There was an error deleting the view
-      title: Delete view?
-      warningText: Do you really want to delete this view? This will delete any data
-        stored in the view such as notes and toggles (but will not delete the
+      error: There was an error deleting the list
+      title: Delete list?
+      warningText: Do you really want to delete this list? This will delete any data
+        stored in the list such as notes and toggles (but will not delete the
         people from the database)?
     editViewTitleAlert:
       error: Error. Title not updated
@@ -1567,30 +1567,30 @@ feat:
     empty:
       dynamic:
         configureButton: Configure
-        description: Create a dynamic view where people are added and removed
+        description: Create a dynamic list where people are added and removed
           automatically using Smart Search.
-        headline: Configure Smart Search View
+        headline: Configure Smart Search list
       notice:
-        dynamic: This is a Smart Search View but no people match the query
+        dynamic: This is a Smart Search list but no people match the query
         static: You haven't added any rows yet
       static:
-        description: Add the first person to create a static view where people are added
+        description: Add the first person to create a static list where people are added
           and removed manually.
         headline: Add people manually
     folder:
       summary:
         empty: Empty
         folderCount: "{count, plural, =1 {1 folder} other {# folders}}"
-        viewCount: "{count, plural, =1 {1 view} other {# views}}"
+        viewCount: "{count, plural, =1 {1 list} other {# lists}}"
     footer:
-      addPlaceholder: Start typing to add person to view
-      alreadyInView: Already in view
+      addPlaceholder: Start typing to add person to list
+      alreadyInView: Already in list
     newFolderTitle: New Folder
     newViewFields:
-      title: New View
+      title: New list
     removeDialog:
-      action: Are you sure you want to remove these rows from this view?
-      title: Remove people from view
+      action: Are you sure you want to remove these rows from this list?
+      title: Remove people from list
     shareDialog:
       download:
         buttons:
@@ -1608,7 +1608,7 @@ feat:
         showOfficials: Show officials
         statusLabel: Shared with {collaborators, plural, =1 {1 collaborator} other {#
           collaborators}}, {officials, plural, =1 {1 official} other {#
-          officials}} can access all views.
+          officials}} can access all lists.
         tabLabel: Share
         viewLink: restricted link
       title: Share "{title}"
@@ -1627,20 +1627,20 @@ feat:
         openButton: Show
     toolbar:
       createColumn: New column
-      createFromSelection: Create view from selection
+      createFromSelection: Create list from selection
       removeFromSelection: Remove {numSelected, plural, one {1 person} other
-        {{numSelected} people} } from view
-      removeTooltip: Smart search views do not currently support removing rows
+        {{numSelected} people} } from list
+      removeTooltip: Smart search lists do not currently support removing rows
     viewLayout:
       actions:
         share: Share
       ellipsisMenu:
-        delete: Delete view
+        delete: Delete list
         editQuery: Edit Smart Search query
-        makeDynamic: Convert to Smart Search view
-        makeStatic: Convert to static view
+        makeDynamic: Convert to Smart Search list
+        makeStatic: Convert to static list
       jumpMenu:
-        placeholder: Start typing to find view
+        placeholder: Start typing to find list
       subtitle:
         collaborators: "{count, plural, =1 {1 outside collaborator} other {# outside
           collaborators}}"
@@ -1651,7 +1651,7 @@ feat:
         created: Date created
         owner: Owner
         title: Title
-      empty: You haven't created any views yet.
+      empty: You haven't created any lists yet.
 glob:
   accessLevels:
     configure: Edit & Configure
@@ -1691,7 +1691,7 @@ zui:
     closed: Closed
     conversation: Conversation
     events: Events
-    folders: Views
+    folders: Lists
     insights: Insights
     instances: Instances
     journeys: Journeys
@@ -1707,7 +1707,7 @@ zui:
     surveys: Surveys
     tasks: Tasks
     untitledEvent: Untitled event
-    views: Views
+    views: Lists
   collapse:
     collapse: Collapse
     expand: Expand
@@ -1772,7 +1772,7 @@ zui:
     keepTyping: Keep typing..
     noResult: No matching person found
     otherPeople: Other people
-    restrictedMode: Can't be edited in shared views.
+    restrictedMode: Can't be edited in shared lists.
     searchResults: Search results
   personSelect:
     keepTyping: Keep typing to start searching


### PR DESCRIPTION
## Description
This PR fixes a bug where it breaks localization in view


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/331990a9-c220-496e-9d1b-fba5e232fda3)



## Changes

* Changes `lists` to `views`


## Notes to reviewer


## Related issues
Undocumented
