### PR TITLE
Add limit operator to smart search dialog.

### DIFF
--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
@@ -6,6 +6,7 @@ import {
   Call,
   CheckBoxOutlined,
   Event,
+  FilterAlt,
   LocalOfferOutlined,
   PersonAddAlt,
   PersonOutlined,
@@ -64,6 +65,8 @@ export default function getFilterComponents(
     filterOperatorIcon = undefined;
   } else if (filter.op === OPERATION.SUB) {
     filterOperatorIcon = <Remove color="secondary" fontSize="small" />;
+  } else if (filter.op === OPERATION.LIMIT) {
+    filterOperatorIcon = <FilterAlt color="secondary" fontSize="small" />;
   }
 
   //Uses CALL_BLOCKED as default

--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -184,6 +184,9 @@ const CampaignParticipation = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={messageIds.operators.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={messageIds.operators.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             bookedSelect: (

--- a/src/features/smartSearch/components/filters/MostActive/index.tsx
+++ b/src/features/smartSearch/components/filters/MostActive/index.tsx
@@ -81,6 +81,9 @@ const MostActive = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={messageIds.operators.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={messageIds.operators.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             numPeople: filter.config?.size,

--- a/src/features/smartSearch/components/filters/PersonData/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/index.tsx
@@ -120,6 +120,9 @@ const PersonData = ({
       <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
         <Msg id={messageIds.operators.sub} />
       </MenuItem>
+      <MenuItem key={OPERATION.SUB} value={OPERATION.LIMIT}>
+        <Msg id={messageIds.operators.limit} />
+      </MenuItem>
     </StyledSelect>
   );
 

--- a/src/features/smartSearch/components/filters/PersonView/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonView/index.tsx
@@ -102,6 +102,9 @@ const PersonView = ({
                   <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                     <Msg id={messageIds.operators.sub} />
                   </MenuItem>
+                  <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                    <Msg id={messageIds.operators.limit} />
+                  </MenuItem>
                 </StyledSelect>
               ),
               inSelect: (

--- a/src/features/smartSearch/components/filters/Random/index.tsx
+++ b/src/features/smartSearch/components/filters/Random/index.tsx
@@ -105,6 +105,9 @@ const Random = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={localMessageIds.addLimitRemoveSelect.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={localMessageIds.addLimitRemoveSelect.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             quantity: (

--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -190,6 +190,9 @@ const SurveyResponse = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={messageIds.operators.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={messageIds.operators.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             freeTextInput: (

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -115,6 +115,9 @@ const SurveySubmission = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={messageIds.operators.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={messageIds.operators.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             surveySelect: (

--- a/src/features/smartSearch/components/filters/User/index.tsx
+++ b/src/features/smartSearch/components/filters/User/index.tsx
@@ -66,6 +66,9 @@ const User = ({
                 <MenuItem key={OPERATION.SUB} value={OPERATION.SUB}>
                   <Msg id={messageIds.operators.sub} />
                 </MenuItem>
+                <MenuItem key={OPERATION.LIMIT} value={OPERATION.LIMIT}>
+                  <Msg id={messageIds.operators.limit} />
+                </MenuItem>
               </StyledSelect>
             ),
             connectedSelect: (

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -475,4 +475,66 @@ describe('makeSankeySegments()', () => {
       },
     ]);
   });
+
+  it('imposes a minimum width of 5% to main when limited', () => {
+    const result = makeSankeySegments([
+      {
+        change: 100,
+        filter: {
+          config: {},
+          op: OPERATION.ADD,
+          type: FILTER_TYPE.ALL,
+        },
+        matches: 100,
+        result: 100,
+      },
+      {
+        change: -99,
+        filter: {
+          config: {},
+          op: OPERATION.LIMIT,
+          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        },
+        matches: 99,
+        result: 1,
+      },
+    ]);
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
+        style: SEGMENT_STYLE.FILL,
+        width: 1.0,
+      },
+      {
+        kind: SEGMENT_KIND.SUB,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.05,
+        },
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.95,
+        },
+        stats: {
+          change: -99,
+          input: 100,
+          matches: 99,
+          output: 1,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 1,
+        style: SEGMENT_STYLE.FILL,
+        width: 0.05,
+      },
+    ]);
+  });
 });

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -413,4 +413,66 @@ describe('makeSankeySegments()', () => {
       },
     ]);
   });
+
+  it('handles a limit like a sub', () => {
+    const result = makeSankeySegments([
+      {
+        change: 100,
+        filter: {
+          config: {},
+          op: OPERATION.ADD,
+          type: FILTER_TYPE.ALL,
+        },
+        matches: 100,
+        result: 100,
+      },
+      {
+        change: -40,
+        filter: {
+          config: {},
+          op: OPERATION.LIMIT,
+          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        },
+        matches: 40,
+        result: 60,
+      },
+    ]);
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
+        style: SEGMENT_STYLE.FILL,
+        width: 1.0,
+      },
+      {
+        kind: SEGMENT_KIND.SUB,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.6,
+        },
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.4,
+        },
+        stats: {
+          change: -40,
+          input: 100,
+          matches: 40,
+          output: 60,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 60,
+        style: SEGMENT_STYLE.FILL,
+        width: 0.6,
+      },
+    ]);
+  });
 });

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
@@ -7,6 +7,8 @@ import {
   SEGMENT_STYLE,
 } from '../sankeyDiagram/types';
 
+const MAIN_MIN_WIDTH = 0.05;
+
 export default function makeSankeySegments(
   stats: ZetkinSmartSearchFilterStats[]
 ): SankeySegment[] {
@@ -81,28 +83,36 @@ export default function makeSankeySegments(
         });
       }
     } else if (change > 0) {
+      const [mainWidth, sideWidth] = normalizeWidths(
+        prevResult / maxPeople,
+        change / maxPeople
+      );
       segments.push({
         kind: SEGMENT_KIND.ADD,
         main: {
           style: SEGMENT_STYLE.FILL,
-          width: prevResult / maxPeople,
+          width: mainWidth,
         },
         side: {
           style: SEGMENT_STYLE.FILL,
-          width: change / maxPeople,
+          width: sideWidth,
         },
         stats,
       });
     } else if (change < 0) {
+      const [mainWidth, sideWidth] = normalizeWidths(
+        result / maxPeople,
+        Math.abs(change) / maxPeople
+      );
       segments.push({
         kind: SEGMENT_KIND.SUB,
         main: {
           style: SEGMENT_STYLE.FILL,
-          width: result / maxPeople,
+          width: mainWidth,
         },
         side: {
           style: SEGMENT_STYLE.FILL,
-          width: Math.abs(change) / maxPeople,
+          width: sideWidth,
         },
         stats,
       });
@@ -150,9 +160,23 @@ export default function makeSankeySegments(
       kind: SEGMENT_KIND.EXIT,
       output: prevResult,
       style: SEGMENT_STYLE.FILL,
-      width: prevResult / maxPeople,
+      width: Math.max(prevResult / maxPeople, MAIN_MIN_WIDTH),
     });
   }
 
   return segments;
+}
+
+function normalizeWidths(
+  mainWidthIn: number,
+  sideWidthIn: number
+): [number, number] {
+  if (mainWidthIn < MAIN_MIN_WIDTH) {
+    const total = mainWidthIn + sideWidthIn;
+    const mainWidthOut = MAIN_MIN_WIDTH;
+    const sideWidthOut = total - MAIN_MIN_WIDTH;
+    return [mainWidthOut, sideWidthOut];
+  } else {
+    return [mainWidthIn, sideWidthIn];
+  }
 }

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -46,6 +46,7 @@ export enum CALL_OPERATOR {
 export enum OPERATION {
   ADD = 'add',
   SUB = 'sub',
+  LIMIT = 'limit',
 }
 
 export enum QUANTITY {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -283,6 +283,7 @@ export default makeMessages('feat.smartSearch', {
     random: {
       addLimitRemoveSelect: {
         add: m('add'),
+        limit: m('limit to'),
         sub: m('remove'),
       },
       examples: {
@@ -568,6 +569,7 @@ export default makeMessages('feat.smartSearch', {
   },
   operators: {
     add: m('Add'),
+    limit: m('Limit to'),
     sub: m('Remove'),
   },
   quantity: {


### PR DESCRIPTION
## Description
This PR implements the limit operator to the smart search filters.

## Screenshots
![Screenshot from 2023-09-26 23-48-20](https://github.com/zetkin/app.zetkin.org/assets/14962107/54828a17-0f15-4a07-a14c-9b926fda39f0)

## Changes
* Adds limit operator
* Changes all the smart search filters to also use limit operator.
* Adds icon FilterAlt for the limit operator, as indicated by figma.

## Related issues
Resolves #1546 