### PR TITLE
Remove broken isAnyOf filter in lists/views

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const getFilterOperators = (col: Omit<GridColDef<any, any, any>, 'field'>) => {
+const getFilterOperators = (col: Omit<GridColDef, 'field'>) => {
   const stringOperators = getGridStringOperators().filter(
     (op) => op.value !== 'isAnyOf'
   );

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -6,15 +6,13 @@ import { useRouter } from 'next/router';
 import {
   DataGridPro,
   DataGridProProps,
+  getGridBooleanOperators,
+  getGridStringOperators,
   GRID_CHECKBOX_SELECTION_COL_DEF,
   GridCellEditStartReasons,
   GridCellParams,
   GridColDef,
   GridSortModel,
-  getGridBooleanOperators,
-  getGridDateOperators,
-  getGridNumericOperators,
-  getGridStringOperators,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -11,6 +11,10 @@ import {
   GridCellParams,
   GridColDef,
   GridSortModel,
+  getGridBooleanOperators,
+  getGridDateOperators,
+  getGridNumericOperators,
+  getGridStringOperators,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';
@@ -31,6 +35,7 @@ import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import { colIdFromFieldName, viewQuickSearch } from './utils';
 import {
+  COLUMN_TYPE,
   SelectedViewColumn,
   ZetkinView,
 } from 'features/views/components/types';
@@ -92,6 +97,14 @@ const useStyles = makeStyles((theme) => ({
     animation: '$addedRowAnimation 2s',
   },
 }));
+
+const getFilterOperators = (col: ZetkinViewColumn) => {
+  if (COLUMN_TYPE.LOCAL_BOOL === col.type) {
+    return getGridBooleanOperators();
+  } else {
+    return getGridStringOperators().filter((op) => op.value !== 'isAnyOf');
+  }
+};
 
 interface ViewDataTableProps {
   columns: ZetkinViewColumn[];
@@ -295,6 +308,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     avatarColumn,
     ...columns.map((col) => ({
       field: `col_${col.id}`,
+      filterOperators: getFilterOperators(col),
       headerName: col.title,
       minWidth: 100,
       resizable: true,


### PR DESCRIPTION
## Description
This PR removes the broken isAnyOf filter in lists, and customizes the filter type for the local_bool type. In the future we should probably have the filterOperators based on the type of column, but a lot of these seem to need custom functions because e.g. dates are not stored as dates in the cells.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14962107/89d18ecc-ac45-4845-a2d8-5f87814f63a3)
![image](https://github.com/zetkin/app.zetkin.org/assets/14962107/359f6027-651f-4958-8723-ef70f4b6e372)

## Notes to reviewer
I tried to solve the underlying issue, which is that `GridFilterInputMultipleValues` sometimes receives a single string rather than an array of strings, which crashes the page. Perhaps this could be solved in the future if we think the "any of" filter is important.

## Related issues
Resolves #1544 
