### PR TITLE
Issue 1287/participant flickering bug

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -373,8 +373,6 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
             '&:hover svg': { display: 'inline-block' },
             cursor: 'pointer',
           },
-          // '& .MuiDataGrid-virtualScroller::-webkit-scrollbar': {
-          // },
         }}
       />
     </>

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -373,6 +373,8 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
             '&:hover svg': { display: 'inline-block' },
             cursor: 'pointer',
           },
+          // '& .MuiDataGrid-virtualScroller::-webkit-scrollbar': {
+          // },
         }}
       />
     </>

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -1,5 +1,5 @@
 import { GetServerSideProps } from 'next';
-import { Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { useRef, useState } from 'react';
 
 import AddPersonButton from 'features/events/components/AddPersonButton';
@@ -53,7 +53,7 @@ const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
     <ZUIFuture future={dataModel.getData()}>
       {(data) => {
         return (
-          <>
+          <Box sx={{ overflowY: 'auto' }}>
             <Grid container spacing={2}>
               <Grid item md={8} xs={12}>
                 <ParticipantSummaryCard
@@ -97,7 +97,7 @@ const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
               model={dataModel}
               orgId={parseInt(orgId)}
             />
-          </>
+          </Box>
         );
       }}
     </ZUIFuture>


### PR DESCRIPTION
## Description
This PR fixes a bug that scrollbars in participant tab flicker when resizing the window


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/12003f40-eeb7-4a75-92d0-40466ccbe732)



## Changes

* Adds `Box` and `overflowY:auto` to it


## Notes to reviewer
I tried to remove horizontal scrollbar as well. But I feel that it is necessary when the window size is small. So user can scroll to see other elements.

## Related issues
Resolves #1287 
