### PR TITLE
Bump node version to 18 (LTS) when running in Docker

### DIFF
--- a/env/frontend/Dockerfile
+++ b/env/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 WORKDIR /var/app
 


### PR DESCRIPTION
## Description
This PR updates the `Dockerfile` to match the node requirement in `package.json`.


## Screenshots
None


## Changes
* Changes node version in `Dockerfile` to 18.

## Notes to reviewer
None

## Related issues
Undocumented, but related to #1547 