### PR TITLE
Adjust to use Dayjs format and handle timezone better.

### DIFF
--- a/src/features/tasks/components/TaskDetailsForm/index.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/index.tsx
@@ -1,7 +1,9 @@
+import dayjs from 'dayjs';
 import { Form } from 'react-final-form';
 import { MenuItem } from '@mui/material';
 import { useQuery } from 'react-query';
 import { useRouter } from 'next/router';
+import utc from 'dayjs/plugin/utc';
 import validator from 'validator';
 import { DateTimePicker, TextField } from 'mui-rff';
 
@@ -9,6 +11,7 @@ import getCampaigns from 'features/campaigns/fetching/getCampaigns';
 import { ZetkinTask } from 'utils/types/zetkin';
 import {
   AnyTaskTypeConfig,
+  NewTaskValues,
   TASK_TYPE,
   VisitLinkConfig,
   ZetkinTaskRequestBody,
@@ -37,6 +40,8 @@ import {
 
 import messageIds from 'features/tasks/l10n/messageIds';
 
+dayjs.extend(utc);
+
 interface TaskDetailsFormProps {
   onSubmit: (task: ZetkinTaskRequestBody) => void;
   onCancel: () => void;
@@ -57,7 +62,7 @@ const TaskDetailsForm = ({
   );
   const taskStatus = task ? getTaskStatus(task) : null;
 
-  const validate = (values: ZetkinTaskRequestBody) => {
+  const validate = (values: NewTaskValues) => {
     const errors: Record<string, string | Record<string, string>> = {};
     if (!values.title) {
       errors.title = messages.form.required();
@@ -101,7 +106,7 @@ const TaskDetailsForm = ({
     return errors;
   };
 
-  const submit = (newTaskValues: ZetkinTaskRequestBody) => {
+  const submit = (newTaskValues: NewTaskValues) => {
     // Change shape of fields to array
     const configWithFieldsArray = {
       ...newTaskValues.config,
@@ -135,9 +140,23 @@ const TaskDetailsForm = ({
         ? parseInt(newTaskValues.reassign_limit.toString())
         : null;
 
+    //Turn dayjs into date strings
+    const deadline = newTaskValues.deadline
+      ? newTaskValues.deadline.toISOString()
+      : undefined;
+    const expires = newTaskValues.expires
+      ? newTaskValues.expires.toISOString()
+      : undefined;
+    const published = newTaskValues.published
+      ? newTaskValues.published.toISOString()
+      : undefined;
+
     onSubmit({
       ...newTaskValues,
       config,
+      deadline,
+      expires,
+      published,
       reassign_interval,
       reassign_limit,
       time_estimate,
@@ -157,10 +176,12 @@ const TaskDetailsForm = ({
               fields: task?.config?.fields[0],
             }),
         },
-        deadline: task?.deadline,
-        expires: task?.expires,
+        deadline: task?.deadline ? dayjs(task.deadline + '.000Z') : undefined,
+        expires: task?.expires ? dayjs(task.expires + '.000Z') : undefined,
         instructions: task?.instructions,
-        published: task?.published,
+        published: task?.published
+          ? dayjs(task.published + '.000Z')
+          : undefined,
         reassign_interval: task?.reassign_interval,
         reassign_limit: task?.reassign_limit,
         time_estimate: task?.time_estimate || DEFAULT_TIME_ESTIMATE,

--- a/src/features/tasks/components/TaskDetailsForm/utils.ts
+++ b/src/features/tasks/components/TaskDetailsForm/utils.ts
@@ -1,18 +1,17 @@
-import dayjs from 'dayjs';
 import {
   AnyTaskTypeConfig,
   CollectDemographicsConfig,
+  NewTaskValues,
   ShareLinkConfig,
   TASK_TYPE,
   VisitLinkConfig,
-  ZetkinTaskRequestBody,
 } from 'features/tasks/components/types';
 
-export const isPublishedFirst = (values: ZetkinTaskRequestBody): boolean => {
+export const isPublishedFirst = (values: NewTaskValues): boolean => {
   const [publishedTime, deadlineTime, expiresTime] = [
-    dayjs(values?.published),
-    dayjs(values?.deadline),
-    dayjs(values?.expires),
+    values?.published,
+    values?.deadline,
+    values?.expires,
   ];
 
   return Boolean(
@@ -21,18 +20,18 @@ export const isPublishedFirst = (values: ZetkinTaskRequestBody): boolean => {
       (!values?.deadline && !values?.expires) ||
       // And it's is before deadline
       ((!values.deadline ||
-        (values?.published && publishedTime.isBefore(deadlineTime))) &&
+        (values?.published && publishedTime?.isBefore(deadlineTime))) &&
         // And it is before expires
         (!values.expires ||
-          (values?.published && publishedTime.isBefore(expiresTime))))
+          (values?.published && publishedTime?.isBefore(expiresTime))))
   );
 };
 
-export const isDeadlineSecond = (values: ZetkinTaskRequestBody): boolean => {
+export const isDeadlineSecond = (values: NewTaskValues): boolean => {
   const [publishedTime, deadlineTime, expiresTime] = [
-    dayjs(values?.published),
-    dayjs(values?.deadline),
-    dayjs(values?.expires),
+    values?.published,
+    values?.deadline,
+    values?.expires,
   ];
 
   return Boolean(
@@ -41,18 +40,18 @@ export const isDeadlineSecond = (values: ZetkinTaskRequestBody): boolean => {
       (!values?.published && !values?.expires) ||
       // If is after published
       ((!values.published ||
-        (values?.deadline && deadlineTime.isAfter(publishedTime))) &&
+        (values?.deadline && deadlineTime?.isAfter(publishedTime))) &&
         // And it is before expires
         (!values.expires ||
-          (values?.deadline && deadlineTime.isBefore(expiresTime))))
+          (values?.deadline && deadlineTime?.isBefore(expiresTime))))
   );
 };
 
-export const isExpiresThird = (values: ZetkinTaskRequestBody): boolean => {
+export const isExpiresThird = (values: NewTaskValues): boolean => {
   const [publishedTime, deadlineTime, expiresTime] = [
-    dayjs(values?.published),
-    dayjs(values?.deadline),
-    dayjs(values?.expires),
+    values?.published,
+    values?.deadline,
+    values?.expires,
   ];
 
   return Boolean(
@@ -61,10 +60,10 @@ export const isExpiresThird = (values: ZetkinTaskRequestBody): boolean => {
       (!values?.published && !values?.deadline) ||
       // If is after published
       ((!values.published ||
-        (values?.expires && expiresTime.isAfter(publishedTime))) &&
+        (values?.expires && expiresTime?.isAfter(publishedTime))) &&
         // And it is after deadline
         (!values.deadline ||
-          (values?.expires && expiresTime.isAfter(deadlineTime))))
+          (values?.expires && expiresTime?.isAfter(deadlineTime))))
   );
 };
 

--- a/src/features/tasks/components/TaskDetailsSection.tsx
+++ b/src/features/tasks/components/TaskDetailsSection.tsx
@@ -48,15 +48,25 @@ const TaskDetailsCard: React.FunctionComponent<TaskDetailsCardProps> = ({
 
           <TaskProperty
             title={messages.taskDetails.publishedTime()}
-            value={task.published && <ZUIDateTime datetime={task.published} />}
+            value={
+              task.published && (
+                <ZUIDateTime datetime={task.published + '.000Z'} />
+              )
+            }
           />
           <TaskProperty
             title={messages.taskDetails.deadlineTime()}
-            value={task.deadline && <ZUIDateTime datetime={task.deadline} />}
+            value={
+              task.deadline && (
+                <ZUIDateTime datetime={task.deadline + '.000Z'} />
+              )
+            }
           />
           <TaskProperty
             title={messages.taskDetails.expiresTime()}
-            value={task.expires && <ZUIDateTime datetime={task.expires} />}
+            value={
+              task.expires && <ZUIDateTime datetime={task.expires + '.000Z'} />
+            }
           />
           <TaskProperty
             title={messages.taskDetails.reassignInterval.label()}

--- a/src/features/tasks/components/TaskStatusText.tsx
+++ b/src/features/tasks/components/TaskStatusText.tsx
@@ -20,7 +20,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
         <Msg
           id={messageIds.taskListItem.relativeTimes.scheduled}
           values={{
-            time: <ZUIRelativeTime datetime={published} />,
+            time: <ZUIRelativeTime datetime={published + '.000Z'} />,
           }}
         />
       )}
@@ -29,7 +29,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
         <Msg
           id={messageIds.taskListItem.relativeTimes.active}
           values={{
-            time: <ZUIRelativeTime datetime={deadline} />,
+            time: <ZUIRelativeTime datetime={deadline + '.000Z'} />,
           }}
         />
       )}
@@ -38,7 +38,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
         <Msg
           id={messageIds.taskListItem.relativeTimes.indefinite}
           values={{
-            time: <ZUIRelativeTime datetime={published} />,
+            time: <ZUIRelativeTime datetime={published + '.000Z'} />,
           }}
         />
       )}
@@ -46,7 +46,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
       {taskStatus === TASK_STATUS.CLOSED && expires && (
         <Msg
           id={messageIds.taskListItem.relativeTimes.expires}
-          values={{ time: <ZUIRelativeTime datetime={expires} /> }}
+          values={{ time: <ZUIRelativeTime datetime={expires + '.000Z'} /> }}
         />
       )}
       {/* Closed and no expiry date */}
@@ -54,7 +54,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
         <Msg
           id={messageIds.taskListItem.relativeTimes.closed}
           values={{
-            time: <ZUIRelativeTime datetime={deadline} />,
+            time: <ZUIRelativeTime datetime={deadline + '.000Z'} />,
           }}
         />
       )}
@@ -62,7 +62,7 @@ const TaskStatusText: React.FunctionComponent<TaskStatusTextProps> = ({
       {taskStatus === TASK_STATUS.EXPIRED && expires && (
         <Msg
           id={messageIds.taskListItem.relativeTimes.expired}
-          values={{ time: <ZUIRelativeTime datetime={expires} /> }}
+          values={{ time: <ZUIRelativeTime datetime={expires + '.000Z'} /> }}
         />
       )}
     </>

--- a/src/features/tasks/components/types.ts
+++ b/src/features/tasks/components/types.ts
@@ -1,3 +1,4 @@
+import { Dayjs } from 'dayjs';
 import { ZetkinFile } from 'utils/types/zetkin';
 import {
   ZetkinQuery,
@@ -66,6 +67,15 @@ export interface ZetkinTask<TaskTypeConfig = AnyTaskTypeConfig> {
     title: string;
   };
 }
+
+export type NewTaskValues = Omit<
+  ZetkinTaskRequestBody,
+  'deadline' | 'expires' | 'published'
+> & {
+  deadline?: Dayjs;
+  expires?: Dayjs;
+  published?: Dayjs;
+};
 
 // POST and PUT requests use this data shape
 export interface ZetkinTaskRequestBody<

--- a/src/features/tasks/utils/getTaskStatus.ts
+++ b/src/features/tasks/utils/getTaskStatus.ts
@@ -13,14 +13,14 @@ const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
   const { published, expires } = task;
   const now = dayjs();
 
-  const expiresDate = dayjs(expires);
+  const expiresDate = dayjs(expires + '.000Z');
   const isExpiresPassed = expiresDate.isBefore(now);
 
   if (isExpiresPassed) {
     return TASK_STATUS.EXPIRED;
   }
 
-  const publishedDate = dayjs(published);
+  const publishedDate = dayjs(published + '.000Z');
   const isPublishedPassed = publishedDate.isBefore(now);
 
   if (isPublishedPassed) {


### PR DESCRIPTION
## Description
This PR addresses a bug where the `DateTimePickers` in tasks were not properly updated to support changes introudcued in MUI X 6. It also attempts to handle timezones better on the frontend. It's not pretty, but it hopefully does what it's supposed to.

## Screenshots
none.


## Changes
* Types the input from the `DateTimePickers` correctly as `Dayjs` format, and adjusts validation and submit functionality accordingly. 
* Changes from UTC to local time in how time is displayed and input by the user.

## Notes to reviewer
I don't know if this is somehow responsible for the bug where assigned people are not retrieved from the server.

## Related issues
none
