### PR TITLE
Undocumented/refactor redux hooks

### DIFF
--- a/src/core/caching/cacheUtils.ts
+++ b/src/core/caching/cacheUtils.ts
@@ -1,6 +1,6 @@
+import { AppDispatch } from 'core/store';
 import { PayloadAction } from '@reduxjs/toolkit';
 import shouldLoad from './shouldLoad';
-import { Store } from 'core/store';
 import {
   IFuture,
   PromiseFuture,
@@ -15,7 +15,7 @@ export function loadListIfNecessary<
   OnSuccessPayload = DataType[]
 >(
   remoteList: RemoteList<DataType> | undefined,
-  store: Store,
+  dispatch: AppDispatch,
   hooks: {
     actionOnLoad: () => PayloadAction<OnLoadPayload>;
     actionOnSuccess: (items: DataType[]) => PayloadAction<OnSuccessPayload>;
@@ -23,9 +23,9 @@ export function loadListIfNecessary<
   }
 ): IFuture<DataType[]> {
   if (!remoteList || shouldLoad(remoteList)) {
-    store.dispatch(hooks.actionOnLoad());
+    dispatch(hooks.actionOnLoad());
     const promise = hooks.loader().then((val) => {
-      store.dispatch(hooks.actionOnSuccess(val));
+      dispatch(hooks.actionOnSuccess(val));
       return val;
     });
 
@@ -41,7 +41,7 @@ export function loadItemIfNecessary<
   OnSuccessPayload = DataType
 >(
   remoteItem: RemoteItem<DataType> | undefined,
-  store: Store,
+  dispatch: AppDispatch,
   hooks: {
     actionOnLoad: () => PayloadAction<OnLoadPayload>;
     actionOnSuccess: (item: DataType) => PayloadAction<OnSuccessPayload>;
@@ -49,9 +49,9 @@ export function loadItemIfNecessary<
   }
 ): IFuture<DataType> {
   if (!remoteItem || shouldLoad(remoteItem)) {
-    store.dispatch(hooks.actionOnLoad());
+    dispatch(hooks.actionOnLoad());
     const promise = hooks.loader().then((val) => {
-      store.dispatch(hooks.actionOnSuccess(val));
+      dispatch(hooks.actionOnSuccess(val));
       return val;
     });
 

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -1,3 +1,11 @@
+import type { AppDispatch, RootState } from '../store';
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
 export { default as useApiClient } from './useApiClient';
 export { default as useEnv } from './useEnv';
 export { default as useNumericRouteParams } from './useNumericRouteParams';
+
+// Use throughout instead of plain `useDispatch` and `useSelector`
+type DispatchFunc = () => AppDispatch;
+export const useAppDispatch: DispatchFunc = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/features/calendar/components/CalendarEventFilter/EventFilterPane.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/EventFilterPane.tsx
@@ -1,12 +1,10 @@
 import { Box, Button } from '@mui/material';
-import { useSelector, useStore } from 'react-redux';
 
 import CheckboxFilterList from './CheckboxFilterList';
 import EventInputFilter from './EventInputFilter';
 import EventTypesModel from 'features/events/models/EventTypesModel';
 import messageIds from 'features/calendar/l10n/messageIds';
 import PaneHeader from 'utils/panes/PaneHeader';
-import { RootState } from 'core/store';
 import useModel from 'core/useModel';
 import { ZetkinActivity } from 'utils/types/zetkin';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -18,14 +16,15 @@ import {
   STATE_FILTER_OPTIONS,
 } from 'features/events/store';
 import { Msg, useMessages } from 'core/i18n';
+import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface EventFilterPaneProps {
   orgId: number;
 }
 const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
+  const dispatch = useAppDispatch();
   const messages = useMessages(messageIds);
-  const store = useStore<RootState>();
-  const state = useSelector((state: RootState) => state.events.filters);
+  const state = useAppSelector((state) => state.events.filters);
   const typesModel = useModel((env) => new EventTypesModel(env, orgId));
 
   const disableReset =
@@ -41,14 +40,14 @@ const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
       'selectedTypes',
     ];
     filterCategories.forEach((filterCategory) =>
-      store.dispatch(
+      dispatch(
         filterUpdated({
           filterCategory: filterCategory,
           selectedFilterValue: [],
         })
       )
     );
-    store.dispatch(filterTextUpdated({ filterText: '' }));
+    dispatch(filterTextUpdated({ filterText: '' }));
   };
 
   return (
@@ -66,7 +65,7 @@ const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
       <Box sx={{ mt: 2 }}>
         <EventInputFilter
           onChangeFilterText={(value: string) =>
-            store.dispatch(filterTextUpdated({ filterText: value }))
+            dispatch(filterTextUpdated({ filterText: value }))
           }
           placeholder={messages.eventFilter.type()}
           reset={disableReset}
@@ -76,7 +75,7 @@ const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
           <CheckboxFilterList
             maxCollapsed={5}
             onFilterChange={(value) =>
-              store.dispatch(
+              dispatch(
                 filterUpdated({
                   filterCategory: 'selectedActions',
                   selectedFilterValue: value,
@@ -93,7 +92,7 @@ const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
           <CheckboxFilterList
             maxCollapsed={4}
             onFilterChange={(value) =>
-              store.dispatch(
+              dispatch(
                 filterUpdated({
                   filterCategory: 'selectedStates',
                   selectedFilterValue: value,
@@ -113,7 +112,7 @@ const EventFilterPane = ({ orgId }: EventFilterPaneProps) => {
                 <CheckboxFilterList
                   maxCollapsed={5}
                   onFilterChange={(value) =>
-                    store.dispatch(
+                    dispatch(
                       filterUpdated({
                         filterCategory: 'selectedTypes',
                         selectedFilterValue: value,

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -2,7 +2,6 @@ import { Box } from '@mui/system';
 import dayjs from 'dayjs';
 import { FormattedTime } from 'react-intl';
 import isoWeek from 'dayjs/plugin/isoWeek';
-import { useStore } from 'react-redux';
 import {
   ListItemIcon,
   ListItemText,
@@ -27,7 +26,7 @@ import theme from 'theme';
 import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from 'features/events/repo/EventsRepo';
-import { useEnv, useNumericRouteParams } from 'core/hooks';
+import { useAppDispatch, useEnv, useNumericRouteParams } from 'core/hooks';
 
 dayjs.extend(isoWeek);
 
@@ -288,7 +287,7 @@ export default CalendarWeekView;
 
 function useCreateEvent() {
   const env = useEnv();
-  const store = useStore();
+  const dispatch = useAppDispatch();
   const { campId, orgId } = useNumericRouteParams();
 
   async function createAndNavigate(startDate: Date, endDate: Date) {
@@ -304,7 +303,7 @@ function useCreateEvent() {
       }
     );
 
-    store.dispatch(eventCreated(event));
+    dispatch(eventCreated(event));
 
     const campaignId = event.campaign?.id ?? 'standalone';
     const url = `/organize/${orgId}/projects/${campaignId}/events/${event.id}`;

--- a/src/features/calendar/components/EventCluster/Event.tsx
+++ b/src/features/calendar/components/EventCluster/Event.tsx
@@ -1,12 +1,11 @@
 import makeStyles from '@mui/styles/makeStyles';
-import { useSelector } from 'react-redux';
 import { useState } from 'react';
 import { Box, Theme, Typography } from '@mui/material';
 
 import EventSelectionCheckBox from 'features/events/components/EventSelectionCheckBox';
 import Field from './Field';
 import FieldGroup from './FieldGroup';
-import { RootState } from 'core/store';
+import { useAppSelector } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { allCollapsedPresentableFields, availableHeightByEvent } from './utils';
 
@@ -172,8 +171,8 @@ const Event = ({
     width,
   });
 
-  const selectedEvents = useSelector(
-    (state: RootState) => state.events.selectedEventIds
+  const selectedEvents = useAppSelector(
+    (state) => state.events.selectedEventIds
   );
 
   return (

--- a/src/features/calendar/hooks/useDayCalendarEvents.ts
+++ b/src/features/calendar/hooks/useDayCalendarEvents.ts
@@ -1,13 +1,15 @@
 import dayjs from 'dayjs';
-import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
 import getNextEventDay from 'features/events/rpc/getNextEventDay';
-import { RootState } from 'core/store';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
 import { DaySummary, getActivitiesByDay } from '../components/utils';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppSelector,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 type UseDayCalendarEventsReturn = {
   activities: [Date, DaySummary][];
@@ -58,7 +60,7 @@ export default function useDayCalendarEvents(
     loadNextLastDate();
   }, [lastDate.toISOString()]);
 
-  const eventsState = useSelector((state: RootState) => state.events);
+  const eventsState = useAppSelector((state) => state.events);
 
   // When user navigates very far in the future (e.g. by changing the year)
   // the focusDate may end up being _after_ the lastDate, which will cause

--- a/src/features/calendar/hooks/useDayCalendarNav.ts
+++ b/src/features/calendar/hooks/useDayCalendarNav.ts
@@ -1,11 +1,13 @@
-import { useSelector } from 'react-redux';
 import { useEffect, useState } from 'react';
 
 import { ACTIVITIES } from 'features/campaigns/models/CampaignActivitiesModel';
 import { DaySummary } from '../components/utils';
 import getPrevEventDay from 'features/events/rpc/getPrevEventDay';
-import { RootState } from 'core/store';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppSelector,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 type ActivityDay = [Date, DaySummary];
 
@@ -24,9 +26,7 @@ export default function useDayCalendarNav(
     null
   );
   const apiClient = useApiClient();
-  const eventsByDate = useSelector(
-    (state: RootState) => state.events.eventsByDate
-  );
+  const eventsByDate = useAppSelector((state) => state.events.eventsByDate);
   const { orgId, campId } = useNumericRouteParams();
 
   const focusDateStr = focusDate.toISOString().slice(0, 10);

--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -32,19 +32,17 @@ const CallerInstructions = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   const {
-    hasEmptyInstructions,
-    hasUnsavedChanges,
+    hasNewText,
     instructions,
+    isSaved,
     isSaving,
+    isUnsaved,
     revert,
     save,
     setInstructions,
   } = useCallerInstructions(orgId, assignmentId);
 
   const [key, setKey] = useState(1);
-
-  const isSaved = !isSaving && !hasUnsavedChanges && instructions !== '';
-  const isUnsaved = !isSaving && hasUnsavedChanges && !hasEmptyInstructions;
 
   return (
     <Paper
@@ -125,7 +123,7 @@ const CallerInstructions = ({
             </Box>
             <Button
               color="primary"
-              disabled={!hasUnsavedChanges}
+              disabled={!hasNewText}
               type="submit"
               variant="contained"
             >

--- a/src/features/callAssignments/hooks/useCall.ts
+++ b/src/features/callAssignments/hooks/useCall.ts
@@ -1,8 +1,7 @@
 import { Call } from '../apiTypes';
 import { PromiseFuture } from 'core/caching/futures';
-import { useApiClient } from 'core/hooks';
-import { useStore } from 'react-redux';
 import { callUpdate, callUpdated } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
 
 interface UseCallReturn {
   setOrganizerActionNeeded: (callId: number) => void;
@@ -10,17 +9,17 @@ interface UseCallReturn {
 }
 
 export default function useCall(orgId: number): UseCallReturn {
-  const store = useStore();
   const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
 
   const updateCall = (callId: number, data: Partial<Call>) => {
     const mutatingAttributes = Object.keys(data);
 
-    store.dispatch(callUpdate([callId, mutatingAttributes]));
+    dispatch(callUpdate([callId, mutatingAttributes]));
     const promise = apiClient
       .patch<Call>(`/api/orgs/${orgId}/calls/${callId}`, data)
       .then((data) => {
-        store.dispatch(callUpdated([data, mutatingAttributes]));
+        dispatch(callUpdated([data, mutatingAttributes]));
         return data;
       });
     return new PromiseFuture(promise);

--- a/src/features/callAssignments/hooks/useCallAssignmentStats.ts
+++ b/src/features/callAssignments/hooks/useCallAssignmentStats.ts
@@ -1,7 +1,5 @@
 import { CallAssignmentStats } from '../apiTypes';
-import { RootState } from 'core/store';
 import shouldLoad from 'core/caching/shouldLoad';
-import { useApiClient } from 'core/hooks';
 import useCallAssignment from './useCallAssignment';
 import {
   IFuture,
@@ -11,7 +9,7 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 import { statsLoad, statsLoaded } from '../store';
-import { useSelector, useStore } from 'react-redux';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseCallAssignmentStatsReturn {
   data: CallAssignmentStats | null;
@@ -25,11 +23,9 @@ export default function useCallAssignmentStats(
   orgId: number,
   assignmentId: number
 ): UseCallAssignmentStatsReturn {
-  const store = useStore<RootState>();
   const apiClient = useApiClient();
-  const callAssignmentSlice = useSelector(
-    (state: RootState) => state.callAssignments
-  );
+  const dispatch = useAppDispatch();
+  const callAssignmentSlice = useAppSelector((state) => state.callAssignments);
   const statsById = callAssignmentSlice.statsById;
   const { isTargeted } = useCallAssignment(orgId, assignmentId);
 
@@ -37,13 +33,13 @@ export default function useCallAssignmentStats(
     const statsItem = statsById[assignmentId];
 
     if (shouldLoad(statsItem)) {
-      store.dispatch(statsLoad(assignmentId));
+      dispatch(statsLoad(assignmentId));
       const promise = apiClient
         .get<CallAssignmentStats>(
           `/api/callAssignments/targets?org=${orgId}&assignment=${assignmentId}`
         )
         .then((data: CallAssignmentStats) => {
-          store.dispatch(statsLoaded({ ...data, id: assignmentId }));
+          dispatch(statsLoaded({ ...data, id: assignmentId }));
           return data;
         });
 

--- a/src/features/callAssignments/hooks/useCallerInstructions.ts
+++ b/src/features/callAssignments/hooks/useCallerInstructions.ts
@@ -1,11 +1,10 @@
 import { CallAssignmentData } from '../apiTypes';
 import { RootState } from 'core/store';
-import { useApiClient } from 'core/hooks';
 import useCallAssignment from './useCallAssignment';
 import { useState } from 'react';
 import { callAssignmentUpdate, callAssignmentUpdated } from '../store';
 import { IFuture, PromiseFuture } from 'core/caching/futures';
-import { useSelector, useStore } from 'react-redux';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseCallerInstructionsReturn {
   hasNewText: boolean;
@@ -22,10 +21,10 @@ export default function useCallerInstructions(
   orgId: number,
   assignmentId: number
 ): UseCallerInstructionsReturn {
-  const store = useStore<RootState>();
   const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
   const key = `callerInstructions-${assignmentId}`;
-  const callAssignmentSlice = useSelector(
+  const callAssignmentSlice = useAppSelector(
     (state: RootState) => state.callAssignments
   );
   const callAssignmentItems = callAssignmentSlice.assignmentList.items;
@@ -76,14 +75,14 @@ export default function useCallerInstructions(
   ): IFuture<CallAssignmentData> => {
     const mutatingAttributes = Object.keys(data);
 
-    store.dispatch(callAssignmentUpdate([assignmentId, mutatingAttributes]));
+    dispatch(callAssignmentUpdate([assignmentId, mutatingAttributes]));
     const promise = apiClient
       .patch<CallAssignmentData>(
         `/api/orgs/${orgId}/call_assignments/${assignmentId}`,
         data
       )
       .then((data: CallAssignmentData) => {
-        store.dispatch(callAssignmentUpdated([data, mutatingAttributes]));
+        dispatch(callAssignmentUpdated([data, mutatingAttributes]));
         return data;
       });
 

--- a/src/features/callAssignments/hooks/useCallerInstructions.ts
+++ b/src/features/callAssignments/hooks/useCallerInstructions.ts
@@ -8,10 +8,11 @@ import { IFuture, PromiseFuture } from 'core/caching/futures';
 import { useSelector, useStore } from 'react-redux';
 
 interface UseCallerInstructionsReturn {
-  hasEmptyInstructions: boolean;
-  hasUnsavedChanges: boolean;
+  hasNewText: boolean;
   instructions: string;
+  isSaved: boolean;
   isSaving: boolean;
+  isUnsaved: boolean;
   revert: () => void;
   setInstructions: (instructions: string) => void;
   save: () => IFuture<CallAssignmentData>;
@@ -114,11 +115,16 @@ export default function useCallerInstructions(
     return item.mutating.includes('instructions');
   };
 
+  const saving = isSaving();
+  const instructions = getInstructions();
+  const unsavedChanges = hasUnsavedChanges();
+
   return {
-    hasEmptyInstructions: hasEmptyInstrunctions(),
-    hasUnsavedChanges: hasUnsavedChanges(),
-    instructions: getInstructions(),
-    isSaving: isSaving(),
+    hasNewText: unsavedChanges,
+    instructions,
+    isSaved: !saving && !unsavedChanges && instructions !== '',
+    isSaving: saving,
+    isUnsaved: !saving && unsavedChanges && !hasEmptyInstrunctions(),
     revert,
     save,
     setInstructions,

--- a/src/features/callAssignments/repos/CallAssignmentsRepo.ts
+++ b/src/features/callAssignments/repos/CallAssignmentsRepo.ts
@@ -48,7 +48,7 @@ export default class CallAssignmentsRepo {
     const state = this._store.getState();
     const assignmentList = state.callAssignments.assignmentList;
 
-    return loadListIfNecessary(assignmentList, this._store, {
+    return loadListIfNecessary(assignmentList, this._store.dispatch, {
       actionOnLoad: () => callAssignmentsLoad(),
       actionOnSuccess: (data) => callAssignmentsLoaded(data),
       loader: () =>

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { useMessages } from 'core/i18n';
-import { useStore } from 'react-redux';
 import {
   AccessTime,
   ArrowForward,
@@ -21,8 +20,8 @@ import LocationLabel from '../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
 import Quota from './Quota';
 import { removeOffset } from 'utils/dateUtils';
-import { RootState } from 'core/store';
 import StatusDot from './StatusDot';
+import { useAppDispatch } from 'core/hooks';
 import useModel from 'core/useModel';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
@@ -60,7 +59,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
   const model = useModel(
     (env) => new EventDataModel(env, event.organization.id, event.id)
   );
-  const store = useStore<RootState>();
+  const dispatch = useAppDispatch();
   const participants = model.getParticipants().data || [];
   const respondents = model.getRespondents().data || [];
   const state = model.state;
@@ -85,7 +84,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         showConfirmDialog({
           onSubmit: () => {
             model.deleteEvent();
-            store.dispatch(eventsDeselected([event]));
+            dispatch(eventsDeselected([event]));
             onClickAway();
           },
           title: messages.eventPopper.confirmDelete(),

--- a/src/features/events/components/EventSelectionCheckBox.tsx
+++ b/src/features/events/components/EventSelectionCheckBox.tsx
@@ -1,18 +1,17 @@
 import { Box, Checkbox } from '@mui/material';
-import { useSelector, useStore } from 'react-redux';
 
-import { RootState } from 'core/store';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { eventsDeselected, eventsSelected } from '../store';
+import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface EventSelectionCheckBoxProps {
   events: ZetkinEvent[];
 }
 
 const EventSelectionCheckBox = ({ events }: EventSelectionCheckBoxProps) => {
-  const store = useStore<RootState>();
-  const selectedEvents = useSelector(
-    (state: RootState) => state.events.selectedEventIds
+  const dispatch = useAppDispatch();
+  const selectedEvents = useAppSelector(
+    (state) => state.events.selectedEventIds
   );
 
   const alreadyExists = events.some((event) =>
@@ -25,19 +24,19 @@ const EventSelectionCheckBox = ({ events }: EventSelectionCheckBoxProps) => {
   const handleChange = (checked: boolean) => {
     if (events.length > 1) {
       if (checked) {
-        store.dispatch(eventsSelected(events));
+        dispatch(eventsSelected(events));
       }
       if (!checked) {
-        store.dispatch(eventsDeselected(events));
+        dispatch(eventsDeselected(events));
       }
     }
 
     if (events.length === 1) {
       if (checked) {
-        store.dispatch(eventsSelected(events));
+        dispatch(eventsSelected(events));
       }
       if (!checked) {
-        store.dispatch(eventsDeselected(events));
+        dispatch(eventsDeselected(events));
       }
     }
   };

--- a/src/features/events/components/SelectionBar/index.tsx
+++ b/src/features/events/components/SelectionBar/index.tsx
@@ -1,6 +1,5 @@
 import { CheckBoxOutlined } from '@mui/icons-material';
 import { Box, Button, Divider, Paper, Typography } from '@mui/material';
-import { useSelector, useStore } from 'react-redux';
 
 import messageIds from '../../../calendar/l10n/messageIds';
 import MoveCopyButtons from './MoveCopyButtons';
@@ -8,15 +7,16 @@ import { Msg } from 'core/i18n';
 import { resetSelection } from 'features/events/store';
 import { RootState } from 'core/store';
 import SelectionBarEllipsis from '../SelectionBarEllipsis';
+import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 const SelectionBar = () => {
-  const store = useStore<RootState>();
-  const selectedEventIds = useSelector(
+  const dispatch = useAppDispatch();
+  const selectedEventIds = useAppSelector(
     (state: RootState) => state.events.selectedEventIds
   );
 
   const handleDeselect = () => {
-    store.dispatch(resetSelection());
+    dispatch(resetSelection());
   };
 
   return (

--- a/src/features/events/components/SelectionBarEllipsis.tsx
+++ b/src/features/events/components/SelectionBarEllipsis.tsx
@@ -1,32 +1,29 @@
 import { useContext } from 'react';
 import { useRouter } from 'next/router';
-import { useSelector, useStore } from 'react-redux';
 
 import { EventsModel } from '../models/EventsModel';
 import messageIds from '../../calendar/l10n/messageIds';
 import { resetSelection } from '../store';
-import { RootState } from 'core/store';
 import { useMessages } from 'core/i18n';
 import useModel from 'core/useModel';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 const SelectionBarEllipsis = () => {
+  const dispatch = useAppDispatch();
   const messages = useMessages(messageIds);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
-  const store = useStore<RootState>();
 
   const handleDeselect = () => {
-    store.dispatch(resetSelection());
+    dispatch(resetSelection());
   };
 
-  const selectedEventIds = useSelector(
-    (state: RootState) => state.events.selectedEventIds
+  const selectedEventIds = useAppSelector(
+    (state) => state.events.selectedEventIds
   );
 
-  const events = useSelector(
-    (state: RootState) => state.events.eventList.items
-  );
+  const events = useAppSelector((state) => state.events.eventList.items);
 
   const unpublishedEvents = events.filter((event) =>
     selectedEventIds.some(

--- a/src/features/events/hooks/useCopyEvents.ts
+++ b/src/features/events/hooks/useCopyEvents.ts
@@ -1,10 +1,12 @@
-import { useDispatch } from 'react-redux';
-
 import copyEvents from '../rpc/copyEvents';
 import getNewEventTimes from '../utils/getNewEventTimes';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { eventsCreate, eventsCreated, resetSelection } from '../store';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppDispatch,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 const makeZetkinEventPatchBody = (e: ZetkinEvent) => {
   return {
@@ -27,7 +29,7 @@ const makeZetkinEventPatchBody = (e: ZetkinEvent) => {
 export default function useCopyEvents() {
   const { orgId } = useNumericRouteParams();
   const apiClient = useApiClient();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const duplicate = async (events: ZetkinEvent[]) => {
     const eventsToDuplicate = events.map((e) => makeZetkinEventPatchBody(e));

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -1,8 +1,6 @@
 import dayjs from 'dayjs';
-import { useDispatch, useSelector } from 'react-redux';
 
 import range from 'utils/range';
-import { RootState } from 'core/store';
 import shouldLoad from 'core/caching/shouldLoad';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import {
@@ -10,7 +8,12 @@ import {
   EventActivity,
 } from 'features/campaigns/models/CampaignActivitiesModel';
 import { eventRangeLoad, eventRangeLoaded } from '../store';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppDispatch,
+  useAppSelector,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 export default function useEventsFromDateRange(
   startDate: Date,
@@ -18,8 +21,8 @@ export default function useEventsFromDateRange(
 ): EventActivity[] {
   const { campId, orgId } = useNumericRouteParams();
   const apiClient = useApiClient();
-  const dispatch = useDispatch();
-  const eventsState = useSelector((state: RootState) => state.events);
+  const dispatch = useAppDispatch();
+  const eventsState = useAppSelector((state) => state.events);
 
   const dateRange = range(dayjs(endDate).diff(startDate, 'day') + 2).map(
     (diff) => {

--- a/src/features/events/hooks/useFilteredEventActivities.ts
+++ b/src/features/events/hooks/useFilteredEventActivities.ts
@@ -1,19 +1,16 @@
 import Fuse from 'fuse.js';
-import { useSelector } from 'react-redux';
 
 import { EventActivity } from 'features/campaigns/models/CampaignActivitiesModel';
 import { EventState } from '../models/EventDataModel';
 import getEventState from '../utils/getEventState';
-import { RootState } from 'core/store';
+import { useAppSelector } from 'core/hooks';
 import { ACTION_FILTER_OPTIONS, STATE_FILTER_OPTIONS } from '../store';
 
 export default function useFilteredEventActivities(
   input: EventActivity[]
 ): EventActivity[] {
-  const filterState = useSelector((state: RootState) => state.events.filters);
-  const statsByEventId = useSelector(
-    (state: RootState) => state.events.statsByEventId
-  );
+  const filterState = useAppSelector((state) => state.events.filters);
+  const statsByEventId = useAppSelector((state) => state.events.statsByEventId);
 
   const filtered = input.filter((activity) => {
     const event = activity.data;

--- a/src/features/events/hooks/useMoveEvents.ts
+++ b/src/features/events/hooks/useMoveEvents.ts
@@ -1,15 +1,17 @@
-import { useDispatch } from 'react-redux';
-
 import getNewEventTimes from '../utils/getNewEventTimes';
 import updateEvents from '../rpc/updateEvents';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { eventsUpdate, eventsUpdated, resetSelection } from '../store';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppDispatch,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 export default function useMoveEvents() {
   const { orgId } = useNumericRouteParams();
   const apiClient = useApiClient();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const moveEvents = async (events: ZetkinEvent[], offset: number) => {
     const eventsWithNewDates = events.map((event) => {

--- a/src/features/events/hooks/useSelectedEvents.ts
+++ b/src/features/events/hooks/useSelectedEvents.ts
@@ -1,12 +1,11 @@
-import { RootState } from 'core/store';
-import { useSelector } from 'react-redux';
+import { useAppSelector } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
 
 export default function useSelectedEvents() {
-  const selectedEventIds = useSelector(
-    (state: RootState) => state.events.selectedEventIds
+  const selectedEventIds = useAppSelector(
+    (state) => state.events.selectedEventIds
   );
-  const events = useSelector((state: RootState) =>
+  const events = useAppSelector((state) =>
     state.events.eventList.items.map((item) => item.data)
   );
   const selectedEvents = selectedEventIds

--- a/src/features/events/repo/EventsRepo.ts
+++ b/src/features/events/repo/EventsRepo.ts
@@ -142,7 +142,7 @@ export default class EventsRepo {
   getAllEvents(orgId: number): IFuture<ZetkinEvent[]> {
     const state = this._store.getState();
 
-    return loadListIfNecessary(state.events.eventList, this._store, {
+    return loadListIfNecessary(state.events.eventList, this._store.dispatch, {
       actionOnLoad: () => eventsLoad(),
       actionOnSuccess: (events) => eventsLoaded(events),
       loader: () =>
@@ -152,7 +152,7 @@ export default class EventsRepo {
 
   getAllTypes(orgId: number) {
     const state = this._store.getState();
-    return loadListIfNecessary(state.events.typeList, this._store, {
+    return loadListIfNecessary(state.events.typeList, this._store.dispatch, {
       actionOnLoad: () => typesLoad(orgId),
       actionOnSuccess: (data) => typesLoaded([orgId, data]),
       loader: () =>
@@ -185,7 +185,7 @@ export default class EventsRepo {
     const state = this._store.getState();
     const list = state.events.participantsByEventId[eventId];
 
-    return loadListIfNecessary(list, this._store, {
+    return loadListIfNecessary(list, this._store.dispatch, {
       actionOnLoad: () => participantsLoad(eventId),
       actionOnSuccess: (participants) =>
         participantsLoaded([eventId, participants]),
@@ -203,7 +203,7 @@ export default class EventsRepo {
     const state = this._store.getState();
     const list = state.events.respondentsByEventId[eventId];
 
-    return loadListIfNecessary(list, this._store, {
+    return loadListIfNecessary(list, this._store.dispatch, {
       actionOnLoad: () => respondentsLoad(eventId),
       actionOnSuccess: (respondents) =>
         respondentsLoaded([eventId, respondents]),
@@ -218,7 +218,7 @@ export default class EventsRepo {
     const state = this._store.getState();
     const locationsList = state.events.locationList;
 
-    return loadListIfNecessary(locationsList, this._store, {
+    return loadListIfNecessary(locationsList, this._store.dispatch, {
       actionOnLoad: () => locationsLoad(),
       actionOnSuccess: (data) => locationsLoaded(data),
       loader: () =>

--- a/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
+++ b/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
@@ -1,10 +1,9 @@
 import Fuse from 'fuse.js';
-import { RootState } from 'core/store';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 
 import notEmpty from 'utils/notEmpty';
 import { TreeItemData } from 'features/organizations/types';
+import { useAppSelector } from 'core/hooks';
 import useLocalStorage from 'zui/hooks/useLocalStorage';
 
 function makeFlatOrgData(orgData: TreeItemData[]): TreeItemData[] {
@@ -22,8 +21,8 @@ function makeFlatOrgData(orgData: TreeItemData[]): TreeItemData[] {
 }
 
 function useOrgSwitcher(orgId: number, searchString: string) {
-  const treeDataList = useSelector(
-    (state: RootState) => state.organizations.treeDataList
+  const treeDataList = useAppSelector(
+    (state) => state.organizations.treeDataList
   );
   const orgData = treeDataList.items.map((item) => item.data).filter(notEmpty);
 

--- a/src/features/organizations/hooks/useOrganization.tsx
+++ b/src/features/organizations/hooks/useOrganization.tsx
@@ -1,9 +1,7 @@
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
-import { useSelector } from 'react-redux';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import { organizationLoad, organizationLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseOrganizationReturn {
   data: ZetkinOrganization | null;
@@ -12,15 +10,13 @@ interface UseOrganizationReturn {
 }
 
 const useOrganization = (orgId: number): UseOrganizationReturn => {
-  const env = useEnv();
+  const dispatch = useAppDispatch();
   const apiClient = useApiClient();
-  const organizationState = useSelector(
-    (state: RootState) => state.organizations
-  );
+  const organizationState = useAppSelector((state) => state.organizations);
 
   const organization = loadItemIfNecessary(
     organizationState.orgData,
-    env.store,
+    dispatch,
     {
       actionOnLoad: () => organizationLoad(),
       actionOnSuccess: (data) => organizationLoaded(data),

--- a/src/features/organizations/hooks/useOrganizations.tsx
+++ b/src/features/organizations/hooks/useOrganizations.tsx
@@ -1,23 +1,19 @@
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
-import { useSelector } from 'react-redux';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { userOrganizationsLoad, userOrganizationsLoaded } from '../store';
 import { ZetkinMembership, ZetkinOrganization } from 'utils/types/zetkin';
 
 const useOrganizations = (): IFuture<
   Pick<ZetkinOrganization, 'title' | 'id'>[] | null
 > => {
-  const env = useEnv();
   const apiClient = useApiClient();
-  const organizationState = useSelector(
-    (state: RootState) => state.organizations
-  );
+  const dispatch = useAppDispatch();
+  const organizationState = useAppSelector((state) => state.organizations);
 
   const organizations = loadListIfNecessary(
     organizationState.userOrgList,
-    env.store,
+    dispatch,
     {
       actionOnLoad: () => userOrganizationsLoad(),
       actionOnSuccess: (data) => userOrganizationsLoaded(data),

--- a/src/features/organizations/hooks/useOrganizationsTree.tsx
+++ b/src/features/organizations/hooks/useOrganizationsTree.tsx
@@ -1,22 +1,18 @@
 import getUserOrganizationsTree from 'features/organizations/rpc/getUserOrgTree';
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
 import { TreeItemData } from '../types';
-import { useSelector } from 'react-redux';
 import { treeDataLoad, treeDataLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 const useOrganizationsTree = (): IFuture<TreeItemData[]> => {
-  const env = useEnv();
   const apiClient = useApiClient();
-  const organizationState = useSelector(
-    (state: RootState) => state.organizations
-  );
+  const dispatch = useAppDispatch();
+  const organizationState = useAppSelector((state) => state.organizations);
 
   const orgsTree = loadListIfNecessary(
     organizationState.treeDataList,
-    env.store,
+    dispatch,
     {
       actionOnLoad: () => treeDataLoad(),
       actionOnSuccess: (data) => treeDataLoaded(data),

--- a/src/features/smartSearch/hooks/useSmartSearchStats.ts
+++ b/src/features/smartSearch/hooks/useSmartSearchStats.ts
@@ -1,11 +1,13 @@
-import { useDispatch, useSelector } from 'react-redux';
-
-import { RootState } from 'core/store';
 import shouldLoad from 'core/caching/shouldLoad';
 import { ZetkinSmartSearchFilter } from '../components/types';
 import { ZetkinSmartSearchFilterStats } from '../types';
 import { statsLoad, statsLoaded } from '../store';
-import { useApiClient, useNumericRouteParams } from 'core/hooks';
+import {
+  useApiClient,
+  useAppDispatch,
+  useAppSelector,
+  useNumericRouteParams,
+} from 'core/hooks';
 
 export default function useSmartSearchStats(
   filters: ZetkinSmartSearchFilter[]
@@ -13,10 +15,10 @@ export default function useSmartSearchStats(
   const { orgId } = useNumericRouteParams();
   const key = JSON.stringify(filters);
   const apiClient = useApiClient();
-  const statsItem = useSelector(
-    (state: RootState) => state.smartSearch.statsByFilterSpec[key]
+  const statsItem = useAppSelector(
+    (state) => state.smartSearch.statsByFilterSpec[key]
   );
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   if (shouldLoad(statsItem)) {
     dispatch(statsLoad(key));

--- a/src/features/surveys/repos/SurveysRepo.ts
+++ b/src/features/surveys/repos/SurveysRepo.ts
@@ -236,7 +236,7 @@ export default class SurveysRepo {
       ZetkinSurveyElement,
       number,
       [number, ZetkinSurveyElement[]]
-    >(state.surveys.elementsBySurveyId[surveyId], this._store, {
+    >(state.surveys.elementsBySurveyId[surveyId], this._store.dispatch, {
       actionOnLoad: () => elementsLoad(surveyId),
       actionOnSuccess: (elements) => elementsLoaded([surveyId, elements]),
       loader: async () => {
@@ -252,7 +252,7 @@ export default class SurveysRepo {
     const state = this._store.getState();
     return loadItemIfNecessary(
       state.surveys.statsBySurveyId[surveyId],
-      this._store,
+      this._store.dispatch,
       {
         actionOnLoad: () => statsLoad(surveyId),
         actionOnSuccess: (stats) => statsLoaded([surveyId, stats]),
@@ -266,21 +266,25 @@ export default class SurveysRepo {
     surveyId: number
   ): IFuture<ZetkinSurveySubmission[]> {
     const state = this._store.getState();
-    return loadListIfNecessary(state.surveys.submissionList, this._store, {
-      actionOnLoad: () => surveySubmissionsLoad(surveyId),
-      actionOnSuccess: (data) => surveySubmissionsLoaded([surveyId, data]),
-      loader: () =>
-        this._apiClient.get<ZetkinSurveySubmission[]>(
-          `/api/orgs/${orgId}/surveys/${surveyId}/submissions`
-        ),
-    });
+    return loadListIfNecessary(
+      state.surveys.submissionList,
+      this._store.dispatch,
+      {
+        actionOnLoad: () => surveySubmissionsLoad(surveyId),
+        actionOnSuccess: (data) => surveySubmissionsLoaded([surveyId, data]),
+        loader: () =>
+          this._apiClient.get<ZetkinSurveySubmission[]>(
+            `/api/orgs/${orgId}/surveys/${surveyId}/submissions`
+          ),
+      }
+    );
   }
 
   getSurveys(orgId: number): IFuture<ZetkinSurvey[]> {
     const state = this._store.getState();
     const surveyList = state.surveys.surveyList;
 
-    return loadListIfNecessary(surveyList, this._store, {
+    return loadListIfNecessary(surveyList, this._store.dispatch, {
       actionOnLoad: () => surveysLoad(),
       actionOnSuccess: (data) => surveysLoaded(data),
       loader: () =>

--- a/src/features/tags/hooks/useTag.ts
+++ b/src/features/tags/hooks/useTag.ts
@@ -1,23 +1,20 @@
-import { useSelector } from 'react-redux';
-
 import { IFuture } from 'core/caching/futures';
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { tagLoad, tagLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseTagReturn {
   tagFuture: IFuture<ZetkinTag>;
 }
 export default function useTag(orgId: number, tagId: number): UseTagReturn {
   const apiClient = useApiClient();
-  const tags = useSelector((state: RootState) => state.tags);
-  const env = useEnv();
+  const dispatch = useAppDispatch();
+  const tags = useAppSelector((state) => state.tags);
 
   const item = tags.tagList.items.find((item) => item.id == tagId);
 
-  const tagFuture = loadItemIfNecessary(item, env.store, {
+  const tagFuture = loadItemIfNecessary(item, dispatch, {
     actionOnLoad: () => tagLoad(tagId),
     actionOnSuccess: (tag) => tagLoaded(tag),
     loader: () =>

--- a/src/features/tags/hooks/useTagMutation.ts
+++ b/src/features/tags/hooks/useTagMutation.ts
@@ -1,8 +1,6 @@
-import { useStore } from 'react-redux';
-
-import { useApiClient } from 'core/hooks';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { tagAssigned, tagUnassigned } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
 
 interface UseTagMutationReturn {
   assignToPerson: (personId: number, value?: string) => void;
@@ -13,8 +11,7 @@ export default function useTagMutation(
   tagId: number
 ): UseTagMutationReturn {
   const apiClient = useApiClient();
-
-  const store = useStore();
+  const dispatch = useAppDispatch();
 
   const assignToPerson = async (personId: number, value?: string) => {
     const data = value ? { value } : undefined;
@@ -22,14 +19,14 @@ export default function useTagMutation(
       `/api/orgs/${orgId}/people/${personId}/tags/${tagId}`,
       data
     );
-    store.dispatch(tagAssigned([personId, tag]));
+    dispatch(tagAssigned([personId, tag]));
   };
 
   const removeFromPerson = async (personId: number) => {
     await apiClient.delete(
       `/api/orgs/${orgId}/people/${personId}/tags/${tagId}`
     );
-    store.dispatch(tagUnassigned([personId, tagId]));
+    dispatch(tagUnassigned([personId, tagId]));
   };
 
   return {

--- a/src/features/tasks/hooks/useTask.ts
+++ b/src/features/tasks/hooks/useTask.ts
@@ -1,10 +1,7 @@
-import { useSelector } from 'react-redux';
-
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
 import { ZetkinTask } from '../components/types';
 import { taskLoad, taskLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseTaskReturn {
   data: ZetkinTask | null;
@@ -12,12 +9,12 @@ interface UseTaskReturn {
 
 export default function useTask(orgId: number, taskId: number): UseTaskReturn {
   const apiClient = useApiClient();
-  const env = useEnv();
-  const tasks = useSelector((state: RootState) => state.tasks);
+  const dispatch = useAppDispatch();
+  const tasks = useAppSelector((state) => state.tasks);
 
   const item = tasks.tasksList.items.find((item) => item.id === taskId);
 
-  const taskFuture = loadItemIfNecessary(item, env.store, {
+  const taskFuture = loadItemIfNecessary(item, dispatch, {
     actionOnLoad: () => taskLoad(taskId),
     actionOnSuccess: (data) => taskLoaded(data),
     loader: () =>

--- a/src/features/tasks/hooks/useTaskStats.ts
+++ b/src/features/tasks/hooks/useTaskStats.ts
@@ -1,10 +1,7 @@
-import { useSelector } from 'react-redux';
-
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
 import getStats, { TaskStats } from '../rpc/getTaskStats';
 import { statsLoad, statsLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseTaskStatsReturn {
   data: TaskStats | null;
@@ -16,12 +13,12 @@ export default function useTaskStats(
   taskId: number
 ): UseTaskStatsReturn {
   const apiClient = useApiClient();
-  const env = useEnv();
-  const tasks = useSelector((state: RootState) => state.tasks);
+  const dispatch = useAppDispatch();
+  const tasks = useAppSelector((state) => state.tasks);
 
   const item = tasks.statsById[taskId!];
 
-  const taskStatsFuture = loadItemIfNecessary(item, env.store, {
+  const taskStatsFuture = loadItemIfNecessary(item, dispatch, {
     actionOnLoad: () => statsLoad(taskId!),
     actionOnSuccess: (data) => statsLoaded([taskId!, data]),
     loader: () => apiClient.rpc(getStats, { orgId, taskId }),

--- a/src/features/tasks/hooks/useTasks.ts
+++ b/src/features/tasks/hooks/useTasks.ts
@@ -1,22 +1,19 @@
-import { useSelector } from 'react-redux';
-
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { RootState } from 'core/store';
 import { ZetkinTask } from '../components/types';
 import { tasksLoad, tasksLoaded } from '../store';
-import { useApiClient, useEnv } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 interface UseTasksReturn {
   tasksFuture: IFuture<ZetkinTask[]>;
 }
 
 export default function useTasks(orgId: number): UseTasksReturn {
-  const taskList = useSelector((state: RootState) => state.tasks.tasksList);
-  const env = useEnv();
   const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const taskList = useAppSelector((state) => state.tasks.tasksList);
 
-  const tasksFuture = loadListIfNecessary(taskList, env.store, {
+  const tasksFuture = loadListIfNecessary(taskList, dispatch, {
     actionOnLoad: () => tasksLoad(),
     actionOnSuccess: (data) => tasksLoaded(data),
     loader: () => apiClient.get<ZetkinTask[]>(`/api/orgs/${orgId}/tasks/`),

--- a/src/features/tasks/repos/TasksRepo.ts
+++ b/src/features/tasks/repos/TasksRepo.ts
@@ -19,7 +19,7 @@ export default class TasksRepo {
     const state = this._store.getState();
     const taskList = state.tasks.tasksList;
 
-    return loadListIfNecessary(taskList, this._store, {
+    return loadListIfNecessary(taskList, this._store.dispatch, {
       actionOnLoad: () => tasksLoad(),
       actionOnSuccess: (data) => tasksLoaded(data),
       loader: () =>

--- a/src/features/user/hooks/useCurrentUser.tsx
+++ b/src/features/user/hooks/useCurrentUser.tsx
@@ -1,15 +1,13 @@
-import { RootState } from 'core/store';
 import shouldLoad from 'core/caching/shouldLoad';
-import { useApiClient } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
 import { ZetkinUser } from 'utils/types/zetkin';
-import { useDispatch, useSelector } from 'react-redux';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { userLoad, userLoaded } from '../store';
 
 const useCurrentUser = () => {
   const apiClient = useApiClient();
-  const dispatch = useDispatch();
-  const userState = useSelector((state: RootState) => state.user);
+  const dispatch = useAppDispatch();
+  const userState = useAppSelector((state) => state.user);
   const isServer = useServerSide();
 
   if (isServer) {

--- a/src/features/views/repos/ViewDataRepo.ts
+++ b/src/features/views/repos/ViewDataRepo.ts
@@ -97,7 +97,7 @@ export default class ViewDataRepo {
     const state = this._store.getState();
     const list = state.views.columnsByViewId[viewId];
 
-    return loadListIfNecessary(list, this._store, {
+    return loadListIfNecessary(list, this._store.dispatch, {
       actionOnLoad: () => columnsLoad(viewId),
       actionOnSuccess: (columns) => columnsLoaded([viewId, columns]),
       loader: () =>
@@ -111,7 +111,7 @@ export default class ViewDataRepo {
     const state = this._store.getState();
     const list = state.views.rowsByViewId[viewId];
 
-    return loadListIfNecessary(list, this._store, {
+    return loadListIfNecessary(list, this._store.dispatch, {
       actionOnLoad: () => rowsLoad(viewId),
       actionOnSuccess: (rows) => rowsLoaded([viewId, rows]),
       loader: () =>
@@ -122,7 +122,7 @@ export default class ViewDataRepo {
   getView(orgId: number, viewId: number): IFuture<ZetkinView> {
     const state = this._store.getState();
     const item = state.views.viewList.items.find((item) => item.id == viewId);
-    return loadItemIfNecessary(item, this._store, {
+    return loadItemIfNecessary(item, this._store.dispatch, {
       actionOnLoad: () => viewLoad(viewId),
       actionOnSuccess: (view) => viewLoaded(view),
       loader: () =>


### PR DESCRIPTION
## Description
This PR refactors to remove the use of `useStore`, by creating custom `useAppDispatch` hook and using the `dispatch` function directly where the store was used before. It also creates a custom `useAppSelector` hook, since it was recommended to do so alongside the `useAppDispatch`. Followed this: https://redux.js.org/usage/usage-with-typescript#define-typed-hooks


## Changes
* Adds typed useAppDispatch and useAppSelector hooks, to use instead of useDispatch and useSelector.
* Removes use of useStore and replaces with the useAppDispatch and its dispatch function.

