### PR TITLE
 Make focusedDate in `features/calendar/index.tsx` use UTC time to support west-of-UTC timezones

### DIFF
--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -65,7 +65,7 @@ const Calendar = () => {
   }, [timeScaleStr]);
 
   useEffect(() => {
-    const focusedDate = dayjs(focusDate).format('YYYY-MM-DD');
+    const focusedDate = dayjs.utc(focusDate).format('YYYY-MM-DD');
     router.push(
       {
         pathname: undefined,


### PR DESCRIPTION
## Description
This PR changes the router code in `features/calendar/index.tsx` to use UTC, since negative UTC timezones would cause the calendar month view to 'run backwards' by itself as documented in #1561. 

## Changes
* Make focusedDate in `features/calendar/index.tsx` use UTC time

## Related issues
Resolves #1561 
