### PR TITLE
Refactor search

### DIFF
--- a/src/core/caching/cacheUtils.ts
+++ b/src/core/caching/cacheUtils.ts
@@ -17,6 +17,7 @@ export function loadListIfNecessary<
   remoteList: RemoteList<DataType> | undefined,
   dispatch: AppDispatch,
   hooks: {
+    actionOnError?: (err: unknown) => PayloadAction<unknown>;
     actionOnLoad: () => PayloadAction<OnLoadPayload>;
     actionOnSuccess: (items: DataType[]) => PayloadAction<OnSuccessPayload>;
     loader: () => Promise<DataType[]>;
@@ -24,10 +25,20 @@ export function loadListIfNecessary<
 ): IFuture<DataType[]> {
   if (!remoteList || shouldLoad(remoteList)) {
     dispatch(hooks.actionOnLoad());
-    const promise = hooks.loader().then((val) => {
-      dispatch(hooks.actionOnSuccess(val));
-      return val;
-    });
+    const promise = hooks
+      .loader()
+      .then((val) => {
+        dispatch(hooks.actionOnSuccess(val));
+        return val;
+      })
+      .catch((err: unknown) => {
+        if (hooks.actionOnError) {
+          dispatch(hooks.actionOnError(err));
+          return null;
+        } else {
+          throw err;
+        }
+      });
 
     return new PromiseFuture(promise);
   }

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -18,6 +18,7 @@ import eventsSlice, { EventsStoreSlice } from 'features/events/store';
 import organizationsSlice, {
   OrganizationsStoreSlice,
 } from 'features/organizations/store';
+import searchSlice, { SearchStoreSlice } from 'features/search/store';
 import smartSearchSlice, {
   smartSearchStoreSlice,
 } from 'features/smartSearch/store';
@@ -34,6 +35,7 @@ export interface RootState {
   callAssignments: CallAssignmentSlice;
   campaigns: CampaignsStoreSlice;
   events: EventsStoreSlice;
+  search: SearchStoreSlice;
   smartSearch: smartSearchStoreSlice;
   surveys: SurveysStoreSlice;
   tags: TagsStoreSlice;
@@ -48,6 +50,7 @@ const reducer = {
   campaigns: campaignsSlice.reducer,
   events: eventsSlice.reducer,
   organizations: organizationsSlice.reducer,
+  search: searchSlice.reducer,
   smartSearch: smartSearchSlice.reducer,
   surveys: surveysSlice.reducer,
   tags: tagsSlice.reducer,

--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -28,12 +28,7 @@ const SearchDialog: React.FunctionComponent<{
   const router = useRouter();
   const { orgId } = useNumericRouteParams();
 
-  const {
-    error: isError,
-    results: searchResults,
-    isLoading: isFetching,
-    setQuery: setSearchQuery,
-  } = useSearch(orgId);
+  const { error, results, isLoading, setQuery } = useSearch(orgId);
 
   const handleRouteChange = () => {
     // Close dialog when clicking an item
@@ -74,23 +69,23 @@ const SearchDialog: React.FunctionComponent<{
         fullWidth
         onClose={() => {
           setOpen(false);
-          setSearchQuery('');
+          setQuery('');
         }}
         open={open}
       >
         <Box p={1}>
           <SearchField
-            error={!!isError}
-            loading={isFetching}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            error={!!error}
+            loading={isLoading}
+            onChange={(e) => setQuery(e.target.value)}
             onKeyDown={() => {
               if (!isTyping) {
                 setIsTyping(true);
               }
             }}
           />
-          {searchResults && (
-            <ResultsList results={searchResults.map((item) => item.result)} />
+          {results && (
+            <ResultsList results={results.map((item) => item.result)} />
           )}
         </Box>
       </Dialog>

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -1,0 +1,65 @@
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+import { SearchResult } from '../components/types';
+import useDebounce from 'utils/hooks/useDebounce';
+import { useState } from 'react';
+import { resultsLoad, resultsLoaded, SearchResultItem } from '../store';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+
+type UseSearchReturn = {
+  error: unknown;
+  isLoading: boolean;
+  results: SearchResultItem[];
+  setQuery: (q: string) => void;
+};
+
+export default function useSearch(orgId: number): UseSearchReturn {
+  const apiClient = useApiClient();
+  const [isTyping, setIsTyping] = useState(false);
+  const [queryString, setQueryString] = useState('');
+  const dispatch = useAppDispatch();
+  const list = useAppSelector(
+    (state) => state.search.matchesByQuery[queryString]
+  );
+
+  const debouncedFinishedTyping = useDebounce(async () => {
+    setIsTyping(false);
+  }, 600);
+
+  const setQuery = (q: string) => {
+    setQueryString(q);
+    setIsTyping(true);
+    debouncedFinishedTyping();
+  };
+
+  if (!isTyping && queryString.length > 2) {
+    const future = loadListIfNecessary(list, dispatch, {
+      actionOnLoad: () => resultsLoad(queryString),
+      actionOnSuccess: (results) => resultsLoaded([queryString, results]),
+      loader: () =>
+        apiClient
+          .post<SearchResult[], { q: string }>(`/api/search?orgId=${orgId}`, {
+            q: queryString,
+          })
+          .then((results) =>
+            results.map((result) => ({
+              id: `${result.type}-${result.match.id}`,
+              result,
+            }))
+          ),
+    });
+
+    return {
+      error: future.error,
+      isLoading: future.isLoading,
+      results: future.data || [],
+      setQuery,
+    };
+  } else {
+    return {
+      error: null,
+      isLoading: false,
+      results: [],
+      setQuery,
+    };
+  }
+}

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -2,7 +2,12 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { SearchResult } from '../components/types';
 import useDebounce from 'utils/hooks/useDebounce';
 import { useState } from 'react';
-import { resultsLoad, resultsLoaded, SearchResultItem } from '../store';
+import {
+  resultsError,
+  resultsLoad,
+  resultsLoaded,
+  SearchResultItem,
+} from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 type UseSearchReturn = {
@@ -33,6 +38,7 @@ export default function useSearch(orgId: number): UseSearchReturn {
 
   if (!isTyping && queryString.length > 2) {
     const future = loadListIfNecessary(list, dispatch, {
+      actionOnError: (err) => resultsError([queryString, err]),
       actionOnLoad: () => resultsLoad(queryString),
       actionOnSuccess: (results) => resultsLoaded([queryString, results]),
       loader: () =>

--- a/src/features/search/store.ts
+++ b/src/features/search/store.ts
@@ -20,9 +20,15 @@ const searchSlice = createSlice({
   initialState,
   name: 'search',
   reducers: {
+    resultsError: (state, action: PayloadAction<[string, unknown]>) => {
+      const [query, error] = action.payload;
+      state.matchesByQuery[query] = remoteList();
+      state.matchesByQuery[query].error = error;
+      state.matchesByQuery[query].loaded = new Date().toISOString();
+    },
     resultsLoad: (state, action: PayloadAction<string>) => {
       const query = action.payload;
-      state.matchesByQuery[query] = remoteList<SearchResultItem>();
+      state.matchesByQuery[query] = remoteList();
       state.matchesByQuery[query].isLoading = true;
     },
     resultsLoaded: (
@@ -37,4 +43,4 @@ const searchSlice = createSlice({
 });
 
 export default searchSlice;
-export const { resultsLoad, resultsLoaded } = searchSlice.actions;
+export const { resultsError, resultsLoad, resultsLoaded } = searchSlice.actions;

--- a/src/features/search/store.ts
+++ b/src/features/search/store.ts
@@ -1,0 +1,40 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { SearchResult } from './components/types';
+import { remoteList, RemoteList } from 'utils/storeUtils';
+
+export type SearchResultItem = {
+  id: string;
+  result: SearchResult;
+};
+
+export interface SearchStoreSlice {
+  matchesByQuery: Record<string, RemoteList<SearchResultItem>>;
+}
+
+const initialState: SearchStoreSlice = {
+  matchesByQuery: {},
+};
+
+const searchSlice = createSlice({
+  initialState,
+  name: 'search',
+  reducers: {
+    resultsLoad: (state, action: PayloadAction<string>) => {
+      const query = action.payload;
+      state.matchesByQuery[query] = remoteList<SearchResultItem>();
+      state.matchesByQuery[query].isLoading = true;
+    },
+    resultsLoaded: (
+      state,
+      action: PayloadAction<[string, SearchResultItem[]]>
+    ) => {
+      const [query, results] = action.payload;
+      state.matchesByQuery[query] = remoteList(results);
+      state.matchesByQuery[query].loaded = new Date().toISOString();
+    },
+  },
+});
+
+export default searchSlice;
+export const { resultsLoad, resultsLoaded } = searchSlice.actions;


### PR DESCRIPTION
## Description
This PR refactors the search feature to use redux instead of react-query.

## Screenshots
None

## Changes
* Adds a store for the `search` feature
* Adds a `useSearch()` hook
* Replaces react-query logic with `useSearch()` in `SearchDialog`

## Notes to reviewer
None

## Related issues
Related to #1542 