### PR TITLE
evaluate booked participant list before adding

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -42,6 +42,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
     numNoshowParticipants,
     numRemindedParticipants,
     numSignedParticipants,
+    bookedParticipants,
   } = useEventParticipants(orgId, eventId);
   const { addParticipant, setReqParticipants, sendReminders } =
     useEventParticipantsMutations(orgId, eventId);
@@ -153,7 +154,11 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                 <Button
                   onClick={() => {
                     respondents?.map((r) => {
-                      addParticipant(r.person.id);
+                      if (
+                        !bookedParticipants.some((p) => p.id === r.person.id)
+                      ) {
+                        addParticipant(r.person.id);
+                      }
                     });
                   }}
                   size="small"


### PR DESCRIPTION
## Description
This PR fixes an error where clicking the Book all button will add all signed up participants to the booked participant list, without checking if they are already in it, making the list contain duplicates. 


## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Checks if added participant is already in the booked list, only adds the people who are not

## Notes to reviewer
My first ever pr in Zetkin. And type script too! yay 

## Related issues
Resolves #1591 
