### PR TITLE
When dragging to create event in weekly calender, show pop-up label `Create event` at the bottom of the event

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -238,7 +238,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                         anchorEl={ghostAnchorEl}
                         anchorOrigin={{
                           horizontal: index > 3 ? 'left' : 'right',
-                          vertical: 'top',
+                          vertical: 'bottom',
                         }}
                         onClose={() => {
                           setPendingEvent(null);


### PR DESCRIPTION


## Description
This PR solves https://github.com/zetkin/app.zetkin.org/issues/1574 by changing the position of the pop-up. When you drag down to create a event, the pop-up should appear close to where you release again, so even without the issue, I find this setting better. 

But it also solves the issue, since the position of the pop-up will always be in view. When it was at the top, user would be able to scroll out of view of the position of the pop-up. The pop-up would thus appear outside of the calender. 


## Screenshots
![Screenshot 2023-11-09 at 19 04 46](https://github.com/zetkin/app.zetkin.org/assets/9819978/412db421-f34b-44ef-8eb3-0934ef6759fb)

Before, it would go: 
![Screenshot 2023-11-09 at 19 05 26](https://github.com/zetkin/app.zetkin.org/assets/9819978/e02c383d-b108-44ab-9f15-ca62607f8f1c)

And it is done, to fix this edge case situation: 
![Large GIF (380x672)](https://github.com/zetkin/app.zetkin.org/assets/9819978/40c7e765-ee94-41f7-b924-41bd54dd4c41)



## Notes to reviewer
I have made this assuming the only thing effected by it, would be this "drag down to create" feature in the weekly calender. Maybe consider, if the component is also used elsewhere, maybe make sure it's not ruining something else, somewhere else


## Related issues
Resolves #1574
