### PR TITLE
Add playwright test for submitting a survey

### DIFF
--- a/integrationTesting/mockData/orgs/KPD/surveys/MembershipSurvey/index.ts
+++ b/integrationTesting/mockData/orgs/KPD/surveys/MembershipSurvey/index.ts
@@ -1,0 +1,65 @@
+import KPD from '../..';
+import {
+  ELEMENT_TYPE,
+  RESPONSE_TYPE,
+  ZetkinSurveyExtended,
+} from 'utils/types/zetkin';
+
+const KPDMembershipSurvey: ZetkinSurveyExtended = {
+  access: 'open',
+  callers_only: false,
+  campaign: null,
+  elements: [
+    {
+      hidden: false,
+      id: 1,
+      question: {
+        description: '',
+        options: [
+          {
+            id: 1,
+            text: 'Yes',
+          },
+          {
+            id: 1,
+            text: 'No',
+          },
+        ],
+        question: 'Do you want to be active?',
+        required: false,
+        response_config: {
+          widget_type: 'radio',
+        },
+        response_type: RESPONSE_TYPE.OPTIONS,
+      },
+      type: ELEMENT_TYPE.QUESTION,
+    },
+    {
+      hidden: false,
+      id: 2,
+      question: {
+        description: '',
+        question: 'What would you like to do?',
+        required: false,
+        response_config: {
+          multiline: true,
+        },
+        response_type: RESPONSE_TYPE.TEXT,
+      },
+      type: ELEMENT_TYPE.QUESTION,
+    },
+  ],
+  expires: null,
+  id: 1,
+  info_text: '',
+  org_access: 'sameorg',
+  organization: {
+    id: KPD.id,
+    title: KPD.title,
+  },
+  published: '1857-05-07T13:37:00.000Z',
+  signature: 'require_signature',
+  title: 'Membership survey',
+};
+
+export default KPDMembershipSurvey;

--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from '@playwright/test';
+
+import KPD from '../../../mockData/orgs/KPD';
+import KPDMembershipSurvey from '../../../mockData/orgs/KPD/surveys/MembershipSurvey';
+import RosaLuxemburg from '../../../mockData/orgs/KPD/people/RosaLuxemburg';
+import RosaLuxemburgUser from '../../../mockData/users/RosaLuxemburgUser';
+import test from '../../../fixtures/next';
+
+test.describe.only('User submitting a survey', () => {
+  test.afterEach(({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test('submits data successfully', async ({ appUri, login, moxy, page }) => {
+    const apiPostPath = `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`;
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      KPDMembershipSurvey
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
+    const memberships = [
+      {
+        organization: KPD,
+        profile: {
+          id: RosaLuxemburg.id,
+          name: RosaLuxemburg.first_name + ' ' + RosaLuxemburg.last_name,
+        },
+        role: null,
+      },
+    ];
+
+    login(RosaLuxemburgUser, memberships);
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    await page.fill('input', 'Topple capitalism');
+    await Promise.all([
+      page.click('text=Submit'),
+      page.waitForResponse((res) => res.request().method() == 'POST'),
+    ]);
+
+    const reqLog = moxy.log(`/v1${apiPostPath}`);
+    expect(reqLog.length).toBe(1);
+    expect(reqLog[0].data).toMatchObject({
+      responses: [
+        {
+          options: [1],
+          question_id: KPDMembershipSurvey.elements[0].id,
+        },
+        {
+          question_id: KPDMembershipSurvey.elements[1].id,
+          response: 'Topple capitalism',
+        },
+      ],
+    });
+  });
+});

--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -6,7 +6,7 @@ import RosaLuxemburg from '../../../mockData/orgs/KPD/people/RosaLuxemburg';
 import RosaLuxemburgUser from '../../../mockData/users/RosaLuxemburgUser';
 import test from '../../../fixtures/next';
 
-test.describe.only('User submitting a survey', () => {
+test.describe('User submitting a survey', () => {
   test.afterEach(({ moxy }) => {
     moxy.teardown();
   });


### PR DESCRIPTION
## Description
This PR adds a playwright test for submitting a survey in the activist portal.

## Screenshots
None

## Changes
* Adds a mock survey
* Adds a test that visits the Activist Portal survey page, fills the survey out and submits it

## Notes to reviewer
None

## Related issues
Related to #1620
