### PR TITLE
Fix the playwright test for the new survey page

### DIFF
--- a/integrationTesting/mockData/orgs/KPD/surveys/MembershipSurvey/index.ts
+++ b/integrationTesting/mockData/orgs/KPD/surveys/MembershipSurvey/index.ts
@@ -21,7 +21,7 @@ const KPDMembershipSurvey: ZetkinSurveyExtended = {
             text: 'Yes',
           },
           {
-            id: 1,
+            id: 2,
             text: 'No',
           },
         ],

--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -44,11 +44,12 @@ test.describe('User submitting a survey', () => {
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
     );
 
+    await page.click('input[name="1.options"]');
     await page.fill('input[name="2.text"]', 'Topple capitalism');
     await page.click('data-testid=Survey-acceptTerms');
     await Promise.all([
-      await page.click('data-testid=Survey-submit'),
       page.waitForResponse((res) => res.request().method() == 'POST'),
+      await page.click('data-testid=Survey-submit'),
     ]);
 
     const reqLog = moxy.log(`/v1${apiPostPath}`);


### PR DESCRIPTION
There were three problems here.

## 1. Duplicate IDs in mock data.

Both options in `KPDMembershipSurvey` had an ID of `1`. So if we fixed the other two issues, the test would pass no matter which option was clicked.

## 2. Missing a click for the first question

We had an expectation at the end that checked for a particular answer to question one, but no corresponding `page.click()` to actually set that answer.

## 3. Promise.all race condition

The `page.waitForResponse` was always timing out so I went looking around the repo for other examples. Everywhere else, this is being queued ahead of the submit click in the list of promises passed to `Promise.all`. Changing this one to match that convention fixed the timeout.