### PR TITLE
Add email:string to ZetkinUser

### DIFF
--- a/integrationTesting/mockData/users/RosaLuxemburgUser.ts
+++ b/integrationTesting/mockData/users/RosaLuxemburgUser.ts
@@ -1,6 +1,7 @@
 import { ZetkinUser } from 'utils/types/zetkin';
 
 const RosaLuxemburgUser: ZetkinUser = {
+  email: 'rosa@example.org',
   first_name: 'Rosa',
   id: 1,
   lang: null,

--- a/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
@@ -225,7 +225,7 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
                 <Msg
                   id={messageIds.surveyForm.authenticatedOption}
                   values={{
-                    email: '', // currentUser?.email,
+                    email: currentUser?.email ?? '',
                     person: currentUser?.first_name ?? '',
                   }}
                 />

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -135,6 +135,7 @@ export interface ZetkinUser {
   lang: string | null;
   last_name: string;
   username: string;
+  email: string;
 }
 
 export interface ZetkinOrganization {


### PR DESCRIPTION
The `ZetkinUser` type has no `email` property.

<img width="382" alt="Screenshot 2023-11-12 at 10 06 38" src="https://github.com/zetkin/app.zetkin.org/assets/566159/a265d6f4-c030-4175-8b21-2ada7f8f866a">

We have some code in the new survey page that accesses that nonexistent property. This generates a `Property 'email' does not exist on type 'ZetkinUser'.` error.

<img width="868" alt="Screenshot 2023-11-12 at 10 07 19" src="https://github.com/zetkin/app.zetkin.org/assets/566159/f224aeff-b7c6-49c7-8c39-9971d5abca7f">

But the property does seem to exist. See `testuser@example.com` in the screenshot below showing how the above code snippet actually renders.

<img width="401" alt="Screenshot 2023-11-12 at 10 08 40" src="https://github.com/zetkin/app.zetkin.org/assets/566159/e18cdec7-783d-4c24-9375-5ba428f0e2e7">

So maybe this type is simply incorrect and we can add this property.