### PR TITLE
bug/fix-marker-position

### DIFF
--- a/src/features/events/components/LocationModal/BasicMarker.tsx
+++ b/src/features/events/components/LocationModal/BasicMarker.tsx
@@ -40,7 +40,7 @@ const BasicMarker: FC<BasicMarkerProps> = ({ color, events }) => {
         fill="none"
         height="40"
         style={{
-          transform: 'translate(-14px, -44px)',
+          transform: 'translate(-7.5px, -34px)',
         }}
         viewBox="0 0 31 40"
         width="27"

--- a/src/features/events/components/LocationModal/BasicMarker.tsx
+++ b/src/features/events/components/LocationModal/BasicMarker.tsx
@@ -36,7 +36,15 @@ const BasicMarker: FC<BasicMarkerProps> = ({ color, events }) => {
           <Typography>{events > 9 ? '9+' : events}</Typography>
         </Box>
       )}
-      <svg fill="none" height="40" viewBox="0 0 31 40" width="27">
+      <svg
+        fill="none"
+        height="40"
+        style={{
+          transform: 'translate(-14px, -44px)',
+        }}
+        viewBox="0 0 31 40"
+        width="27"
+      >
         <path
           d="M14 38.479C13.6358 38.0533 13.1535 37.4795
            12.589 36.7839C11.2893 35.1826 9.55816 32.9411

--- a/src/features/events/components/LocationModal/SelectedMarker.tsx
+++ b/src/features/events/components/LocationModal/SelectedMarker.tsx
@@ -2,7 +2,15 @@ import { FC } from 'react';
 
 const SelectedMarker: FC = () => {
   return (
-    <svg fill="none" height="50" viewBox="0 0 44 63" width="40">
+    <svg
+      fill="none"
+      height="50"
+      style={{
+        transform: 'translate(-14px, -44px)',
+      }}
+      viewBox="0 0 44 63"
+      width="40"
+    >
       <path
         d="M22 61L21.6289 61.3351L22 61.7459L22.3711
          61.3351L22 61ZM22 61C22.3711 61.3351 22.3712


### PR DESCRIPTION
## Description
This PR fixes the bug where the marker pointer on maps is not placed on the exact map location.


## Screenshots
These pictures are of markers places right on the very corner of the waterfront. Both markers appear exactly where they were clicked on the map.
![Screenshot from 2023-11-12 09-46-39](https://github.com/zetkin/app.zetkin.org/assets/41007222/251b9645-3b92-424f-8d16-219013d68d9e)
![Screenshot from 2023-11-12 09-46-54](https://github.com/zetkin/app.zetkin.org/assets/41007222/77271e37-92b6-43e7-b6fc-dc9c222dc63e)

## Changes
* Adds transformer on the svg to offet it relative to where leaflet places the marker.



## Notes to reviewer
Place marker on map and see that it appears exactly where expected. Save the marker and see that the places marker's pointer is in the same location.