### PR TITLE
Load survey in getServerSideProps and add API downtime + 404 handling

### DIFF
--- a/src/features/surveys/components/surveyForm/ErrorMessage.tsx
+++ b/src/features/surveys/components/surveyForm/ErrorMessage.tsx
@@ -1,0 +1,14 @@
+import Box from '@mui/material/Box';
+import { FC } from 'react';
+import messageIds from 'features/surveys/l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+const ErrorMessage: FC = () => {
+  return (
+    <Box bgcolor="#ee878a" mx={4} my={4} p={2} sx={{ borderRadius: '5px' }}>
+      <Msg id={messageIds.surveyForm.error} />
+    </Box>
+  );
+};
+
+export default ErrorMessage;

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -164,6 +164,9 @@ export default makeMessages('feat.surveys', {
     authenticatedOption: m<{ email: string; person: string }>(
       'Sign as {person} with email {email}'
     ),
+    error: m(
+      'Something went wrong when submitting your answers. Please try again later.'
+    ),
     nameEmailOption: m('Sign with name and email'),
     policy: {
       link: m('https://zetkin.org/privacy'),


### PR DESCRIPTION
## 404 handling

| Before | After |
|-|-|
| ![localhost_3000_o_1_surveys_200(iPhone SE) (1)](https://github.com/zetkin/app.zetkin.org/assets/566159/6f78c15e-0b3d-42c1-99b9-edd42ebb1ba4) | ![localhost_3000_o_1_surveys_200(iPhone SE)](https://github.com/zetkin/app.zetkin.org/assets/566159/7495b555-6a1f-4710-acfc-c97e2590f5ab) |

## Downtime handling

Added a `throw new Error('BLARG IM DED');` before the POST request to test in both cases.

| Before | After |
|-|-|
|  ![localhost_3000_o_1_surveys_20_submitted(iPhone SE)](https://github.com/zetkin/app.zetkin.org/assets/566159/8fca358e-3503-49b2-ac0c-c6f3c31c2a9d) | ![localhost_3000_o_1_surveys_20(iPhone SE) (3)](https://github.com/zetkin/app.zetkin.org/assets/566159/94aed3d1-b967-41c8-a798-cdbb93d860c0) |
