### PR TITLE
Survey Form - Privacy Policy Title

### DIFF
--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -170,14 +170,17 @@ export default makeMessages('feat.surveys', {
       text: m('Click to read the full Zetkin Privacy Policy'),
     },
     sign: {
-      anonymous: m('Submit anonymously'),
+      anonymous: m('Sign anonymously'),
       nameAndEmail: m('Sign with name and e-mail'),
     },
     signOptions: m('Choose 1 of these signing options below'),
     submit: m('Submit'),
-    termsDescription: m<{ organization: string }>(
-      'When you submit this survey, the information you provide will be stored and processed in Zetkin by {organization} in order to organize activism and in accordance with the Zetkin privacy policy.'
-    ),
+    terms: {
+      description: m<{ organization: string }>(
+        'When you submit this survey, the information you provide will be stored and processed in Zetkin by {organization} in order to organize activism and in accordance with the Zetkin privacy policy.'
+      ),
+      title: m('Privacy Policy'),
+    },
   },
   tabs: {
     overview: m('Overview'),

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -1217,10 +1217,12 @@ feat:
         link: https://zetkin.org/sv/sekretess
         text: Klicka här för att läsa Zetkins sekretesspolicy
       sign:
-        anonymous: Skicka anonymt
-        nameAndEmail: Skicka med namn och e-mail
+        anonymous: Signera anonymt
+        nameAndEmail: Signera med namn och e-mail
       submit: Skicka
-      termsDescription: När du skickar in enkäten kommer informationen att lagras i Zetkin och hanteras av {organization} i deras verksamhet, i enlighet med Zetkins sekretesspolicy.
+      terms:
+        description: När du skickar in enkäten kommer informationen att lagras i Zetkin och hanteras av {organization} i deras verksamhet, i enlighet med Zetkins sekretesspolicy.
+        title: Sekretesspolicy
     tabs:
       overview: Översikt
       questions: Frågor

--- a/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
@@ -142,6 +142,8 @@ type PageProps = {
   surveyId: string;
 };
 
+type SignatureOption = 'authenticated' | 'email' | 'anonymous';
+
 const Page: FC<PageProps> = ({ orgId, surveyId }) => {
   const elements = useSurveyElements(
     parseInt(orgId, 10),
@@ -150,25 +152,12 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
   const messages = useMessages(messageIds);
   const survey = useSurvey(parseInt(orgId, 10), parseInt(surveyId, 10));
 
-  const [selectedOption, setSelectedOption] = useState<
-    null | 'authenticated' | 'name+email' | 'anonymous'
-  >(null);
-  const [customInput, setCustomInput] = useState({
-    email: '',
-    name: '',
-  });
+  const [selectedOption, setSelectedOption] = useState<null | SignatureOption>(
+    null
+  );
 
-  const handleRadioChange = (
-    value: 'authenticated' | 'name+email' | 'anonymous'
-  ) => {
+  const handleRadioChange = (value: SignatureOption) => {
     setSelectedOption(value);
-  };
-
-  const handleCustomInputChange = (field: 'name' | 'email', value: string) => {
-    setCustomInput((prevInput) => ({
-      ...prevInput,
-      [field]: value,
-    }));
   };
 
   const currentUser = useCurrentUser();
@@ -211,11 +200,8 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
         </Typography>
 
         <RadioGroup
-          onChange={(e) =>
-            handleRadioChange(
-              e.target.value as 'authenticated' | 'name+email' | 'anonymous'
-            )
-          }
+          name="sig"
+          onChange={(e) => handleRadioChange(e.target.value as SignatureOption)}
           value={selectedOption}
         >
           <FormControlLabel
@@ -241,27 +227,16 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
                 <Typography>
                   <Msg id={messageIds.surveyForm.nameEmailOption} />
                 </Typography>
-                {selectedOption === 'name+email' && (
-                  <>
-                    <TextField
-                      label="Name"
-                      onChange={(e) =>
-                        handleCustomInputChange('name', e.target.value)
-                      }
-                      value={customInput.name}
-                    />
-                    <TextField
-                      label="Email"
-                      onChange={(e) =>
-                        handleCustomInputChange('email', e.target.value)
-                      }
-                      value={customInput.email}
-                    />
-                  </>
+                {selectedOption === 'email' && (
+                  <Box display="flex" flexDirection="column">
+                    <TextField label="First Name" name="sig.first_name" />
+                    <TextField label="Last Name" name="sig.last_name" />
+                    <TextField label="Email" name="sig.email" />
+                  </Box>
                 )}
               </div>
             }
-            value="name+email"
+            value="email"
           />
           {survey.data?.signature === 'allow_anonymous' && (
             <FormControlLabel
@@ -280,6 +255,7 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
           control={<Checkbox required />}
           data-testid="Survey-acceptTerms"
           label={<Msg id={messageIds.surveyForm.accept} />}
+          name="privacy.approval"
         />
         <Typography>
           <Msg

--- a/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
@@ -1,27 +1,19 @@
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import Box from '@mui/system/Box';
-import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
 import { IncomingMessage } from 'http';
 import messageIds from 'features/surveys/l10n/messageIds';
+import OptionsQuestion from 'features/surveys/components/surveyForm/OptionsQuestion';
 import { parse } from 'querystring';
 import { scaffold } from 'utils/next';
-import useCurrentUser from 'features/user/hooks/useCurrentUser';
-import {
-  ZetkinSurveyOptionsQuestionElement,
-  ZetkinSurveyTextElement,
-  ZetkinSurveyTextQuestionElement,
-} from 'utils/types/zetkin';
-
-import OptionsQuestion from 'features/surveys/components/surveyForm/OptionsQuestion';
 import TextBlock from 'features/surveys/components/surveyForm/TextBlock';
 import TextQuestion from 'features/surveys/components/surveyForm/TextQuestion';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
 import useSurvey from 'features/surveys/hooks/useSurvey';
 import useSurveyElements from 'features/surveys/hooks/useSurveyElements';
 import ZUIAvatar from 'zui/ZUIAvatar';
-import { FC, useState } from 'react';
-
 import {
+  Box,
+  Button,
+  Checkbox,
   FormControlLabel,
   Link,
   Radio,
@@ -29,8 +21,13 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-
+import { FC, useState } from 'react';
 import { Msg, useMessages } from 'core/i18n';
+import {
+  ZetkinSurveyOptionsQuestionElement,
+  ZetkinSurveyTextElement,
+  ZetkinSurveyTextQuestionElement,
+} from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -164,14 +161,14 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
 
   return (
     <>
-      <h1>{survey.data?.title}</h1>
-
-      {survey.data?.info_text && <p>{survey.data?.info_text}</p>}
-
       <Box alignItems="center" columnGap={1} display="flex" flexDirection="row">
         <ZUIAvatar size="md" url={`/api/orgs/${orgId}/avatar`} />
         {survey.data?.organization.title}
       </Box>
+
+      <h1>{survey.data?.title}</h1>
+
+      {survey.data?.info_text && <p>{survey.data?.info_text}</p>}
 
       <form method="post">
         {(elements.data || []).map((element) => (
@@ -205,7 +202,7 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
           value={selectedOption}
         >
           <FormControlLabel
-            control={<Radio />}
+            control={<Radio required />}
             label={
               <Typography>
                 <Msg
@@ -221,7 +218,7 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
           />
 
           <FormControlLabel
-            control={<Radio />}
+            control={<Radio required />}
             label={
               <div>
                 <Typography>
@@ -229,9 +226,17 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
                 </Typography>
                 {selectedOption === 'email' && (
                   <Box display="flex" flexDirection="column">
-                    <TextField label="First Name" name="sig.first_name" />
-                    <TextField label="Last Name" name="sig.last_name" />
-                    <TextField label="Email" name="sig.email" />
+                    <TextField
+                      label="First Name"
+                      name="sig.first_name"
+                      required
+                    />
+                    <TextField
+                      label="Last Name"
+                      name="sig.last_name"
+                      required
+                    />
+                    <TextField label="Email" name="sig.email" required />
                   </Box>
                 )}
               </div>
@@ -240,7 +245,7 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
           />
           {survey.data?.signature === 'allow_anonymous' && (
             <FormControlLabel
-              control={<Radio />}
+              control={<Radio required />}
               label={
                 <Typography>
                   <Msg id={messageIds.surveyForm.anonymousOption} />
@@ -251,27 +256,32 @@ const Page: FC<PageProps> = ({ orgId, surveyId }) => {
           )}
         </RadioGroup>
 
-        <FormControlLabel
-          control={<Checkbox required />}
-          data-testid="Survey-acceptTerms"
-          label={<Msg id={messageIds.surveyForm.accept} />}
-          name="privacy.approval"
-        />
-        <Typography>
-          <Msg
-            id={messageIds.surveyForm.termsDescription}
-            values={{ organization: survey.data?.organization.title ?? '' }}
+        <Box alignItems="center" component="section" sx={{ py: 2 }}>
+          <Typography fontWeight={'bold'}>
+            <Msg id={messageIds.surveyForm.terms.title} />
+          </Typography>
+          <FormControlLabel
+            control={<Checkbox required />}
+            data-testid="Survey-acceptTerms"
+            label={<Msg id={messageIds.surveyForm.accept} />}
+            name="privacy.approval"
           />
-        </Typography>
-        <Typography>
-          <Link
-            href={messages.surveyForm.policy.link()}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <Msg id={messageIds.surveyForm.policy.text} />
-          </Link>
-        </Typography>
+          <Typography>
+            <Msg
+              id={messageIds.surveyForm.terms.description}
+              values={{ organization: survey.data?.organization.title ?? '' }}
+            />
+          </Typography>
+          <Typography>
+            <Link
+              href={messages.surveyForm.policy.link()}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <Msg id={messageIds.surveyForm.policy.text} />
+            </Link>
+          </Typography>
+        </Box>
 
         <Button
           color="primary"


### PR DESCRIPTION
## Description
This PR adds a title and padding to privacy policy and makes radio buttons and underlying text fields required

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/824010a0-2fda-412f-aec9-e8a9ee642ab3)

## Changes
* Adds title to privacy policy
* Makes radio buttons required, text fields for name and email are required
* Changes imports
* Changes Swedish localization


## Notes to reviewer
"Sign with" radio buttons should be required
If Sign With Name and Email is selected, filling out fields is required

## Related issues
Related to #1620 
