### PR TITLE
Privacy Policy Title

### DIFF
--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -46,6 +46,7 @@ test.describe('User submitting a survey', () => {
 
     await page.click('input[name="1.options"]');
     await page.fill('input[name="2.text"]', 'Topple capitalism');
+    await page.click('input[name="sig"][value="authenticated"]');
     await page.click('data-testid=Survey-acceptTerms');
     await Promise.all([
       page.waitForResponse((res) => res.request().method() == 'POST'),

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -173,14 +173,17 @@ export default makeMessages('feat.surveys', {
       text: m('Click to read the full Zetkin Privacy Policy'),
     },
     sign: {
-      anonymous: m('Submit anonymously'),
+      anonymous: m('Sign anonymously'),
       nameAndEmail: m('Sign with name and e-mail'),
     },
     signOptions: m('Choose how to sign'),
     submit: m('Submit'),
-    termsDescription: m<{ organization: string }>(
-      'When you submit this survey, the information you provide will be stored and processed in Zetkin by {organization} in order to organize activism and in accordance with the Zetkin privacy policy.'
-    ),
+    terms: {
+      description: m<{ organization: string }>(
+        'When you submit this survey, the information you provide will be stored and processed in Zetkin by {organization} in order to organize activism and in accordance with the Zetkin privacy policy.'
+      ),
+      title: m('Privacy Policy'),
+    },
   },
   tabs: {
     overview: m('Overview'),

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -1217,10 +1217,12 @@ feat:
         link: https://zetkin.org/sv/sekretess
         text: Klicka här för att läsa Zetkins sekretesspolicy
       sign:
-        anonymous: Skicka anonymt
-        nameAndEmail: Skicka med namn och e-mail
+        anonymous: Signera anonymt
+        nameAndEmail: Signera med namn och e-mail
       submit: Skicka
-      termsDescription: När du skickar in enkäten kommer informationen att lagras i Zetkin och hanteras av {organization} i deras verksamhet, i enlighet med Zetkins sekretesspolicy.
+      terms:
+        description: När du skickar in enkäten kommer informationen att lagras i Zetkin och hanteras av {organization} i deras verksamhet, i enlighet med Zetkins sekretesspolicy.
+        title: Sekretesspolicy
     tabs:
       overview: Översikt
       questions: Frågor

--- a/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/o/[orgId]/surveys/[surveyId]/index.tsx
@@ -1,27 +1,18 @@
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import Box from '@mui/system/Box';
-import Button from '@mui/material/Button';
-import Checkbox from '@mui/material/Checkbox';
+import ErrorMessage from 'features/surveys/components/surveyForm/ErrorMessage';
 import { IncomingMessage } from 'http';
 import messageIds from 'features/surveys/l10n/messageIds';
+import OptionsQuestion from 'features/surveys/components/surveyForm/OptionsQuestion';
 import { parse } from 'querystring';
 import { scaffold } from 'utils/next';
-import useCurrentUser from 'features/user/hooks/useCurrentUser';
-import {
-  ZetkinSurveyExtended,
-  ZetkinSurveyOptionsQuestionElement,
-  ZetkinSurveyTextElement,
-  ZetkinSurveyTextQuestionElement,
-} from 'utils/types/zetkin';
-
-import ErrorMessage from 'features/surveys/components/surveyForm/ErrorMessage';
-import OptionsQuestion from 'features/surveys/components/surveyForm/OptionsQuestion';
 import TextBlock from 'features/surveys/components/surveyForm/TextBlock';
 import TextQuestion from 'features/surveys/components/surveyForm/TextQuestion';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
 import ZUIAvatar from 'zui/ZUIAvatar';
-import { FC, useState } from 'react';
-
 import {
+  Box,
+  Button,
+  Checkbox,
   Container,
   FormControlLabel,
   FormControlLabelProps,
@@ -32,8 +23,14 @@ import {
   Typography,
   useRadioGroup,
 } from '@mui/material';
-
+import { FC, useState } from 'react';
 import { Msg, useMessages } from 'core/i18n';
+import {
+  ZetkinSurveyExtended,
+  ZetkinSurveyOptionsQuestionElement,
+  ZetkinSurveyTextElement,
+  ZetkinSurveyTextQuestionElement,
+} from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -206,16 +203,16 @@ const Page: FC<PageProps> = ({ orgId, status, survey }) => {
 
   return (
     <Container style={{ height: '100vh' }}>
-      <h1>{survey.title}</h1>
-
-      {status === 'error' && <ErrorMessage />}
-
-      {survey.info_text && <p>{survey.info_text}</p>}
-
       <Box alignItems="center" columnGap={1} display="flex" flexDirection="row">
         <ZUIAvatar size="md" url={`/api/orgs/${orgId}/avatar`} />
         {survey.organization.title}
       </Box>
+
+      {status === 'error' && <ErrorMessage />}
+
+      <h1>{survey.title}</h1>
+
+      {survey.info_text && <p>{survey.info_text}</p>}
 
       <form method="post">
         {survey.elements.map((element) => (
@@ -257,7 +254,7 @@ const Page: FC<PageProps> = ({ orgId, status, survey }) => {
           value={selectedOption}
         >
           <RadioFormControlLabel
-            control={<Radio />}
+            control={<Radio required />}
             label={
               <Typography>
                 <Msg
@@ -273,27 +270,28 @@ const Page: FC<PageProps> = ({ orgId, status, survey }) => {
           />
 
           <RadioFormControlLabel
-            control={<Radio />}
+            control={<Radio required />}
             label={
               <div>
                 <Typography>
                   <Msg id={messageIds.surveyForm.nameEmailOption} />
                 </Typography>
-                {selectedOption === 'email' && (
-                  <Box display="flex" flexDirection="column">
-                    <TextField label="First Name" name="sig.first_name" />
-                    <TextField label="Last Name" name="sig.last_name" />
-                    <TextField label="Email" name="sig.email" />
-                  </Box>
-                )}
               </div>
             }
             value="email"
           />
 
+          {selectedOption === 'email' && (
+            <Box display="flex" flexDirection="column">
+              <TextField label="First Name" name="sig.first_name" required />
+              <TextField label="Last Name" name="sig.last_name" required />
+              <TextField label="Email" name="sig.email" required />
+            </Box>
+          )}
+
           {survey.signature === 'allow_anonymous' && (
             <RadioFormControlLabel
-              control={<Radio />}
+              control={<Radio required />}
               label={
                 <Typography>
                   <Msg id={messageIds.surveyForm.anonymousOption} />
@@ -304,27 +302,33 @@ const Page: FC<PageProps> = ({ orgId, status, survey }) => {
           )}
         </RadioGroup>
 
-        <FormControlLabel
-          control={<Checkbox required />}
-          data-testid="Survey-acceptTerms"
-          label={<Msg id={messageIds.surveyForm.accept} />}
-          name="privacy.approval"
-        />
-        <Typography style={{ fontSize: '0.8em' }}>
-          <Msg
-            id={messageIds.surveyForm.termsDescription}
-            values={{ organization: survey.organization.title ?? '' }}
+        <Box alignItems="center" component="section" sx={{ py: 2 }}>
+          <Typography fontWeight={'bold'}>
+            <Msg id={messageIds.surveyForm.terms.title} />
+          </Typography>
+
+          <FormControlLabel
+            control={<Checkbox required />}
+            data-testid="Survey-acceptTerms"
+            label={<Msg id={messageIds.surveyForm.accept} />}
+            name="privacy.approval"
           />
-        </Typography>
-        <Typography style={{ fontSize: '0.8em', marginBottom: '0.5em' }}>
-          <Link
-            href={messages.surveyForm.policy.link()}
-            rel="noreferrer"
-            target="_blank"
-          >
-            <Msg id={messageIds.surveyForm.policy.text} />
-          </Link>
-        </Typography>
+          <Typography style={{ fontSize: '0.8em' }}>
+            <Msg
+              id={messageIds.surveyForm.terms.description}
+              values={{ organization: survey.organization.title }}
+            />
+          </Typography>
+          <Typography style={{ fontSize: '0.8em', marginBottom: '0.5em' }}>
+            <Link
+              href={messages.surveyForm.policy.link()}
+              rel="noreferrer"
+              target="_blank"
+            >
+              <Msg id={messageIds.surveyForm.policy.text} />
+            </Link>
+          </Typography>
+        </Box>
 
         <Button
           color="primary"


### PR DESCRIPTION
## Description
This PR adds a title and padding to privacy policy and makes radio buttons and underlying text fields required

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/824010a0-2fda-412f-aec9-e8a9ee642ab3)

## Changes
* Adds title to privacy policy
* Makes radio buttons required, text fields for name and email are required
* Changes imports
* Changes Swedish localization


## Notes to reviewer
"Sign with" radio buttons should be required
If Sign With Name and Email is selected, filling out fields is required

## Related issues
Related to #1620 