### PR TITLE
If the endTime is >=24, then set endTime to 23:59 

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -173,8 +173,8 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                       date.getFullYear(),
                       date.getMonth(),
                       date.getDate(),
-                      endTime[0] >= 24 && endTime[1] >= 0 ? '23' : endTime[0],
-                      endTime[0] >= 24 && endTime[1] >= 0 ? '59' : endTime[0]
+                      endTime[0] >= 24 && endTime[1] >= 0 ? 23 : endTime[0],
+                      endTime[0] >= 24 && endTime[1] >= 0 ? 59 : endTime[0]
                     )
                   );
 

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -154,6 +154,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
               sx={{
                 backgroundImage: `repeating-linear-gradient(180deg, ${theme.palette.grey[400]}, ${theme.palette.grey[400]} 1px, ${theme.palette.grey[200]} 1px, ${theme.palette.grey[200]} ${HOUR_HEIGHT}px)`,
                 marginTop: '0.6em', // Aligns the hour marker on each day to the hour on the hour column
+                overflow: 'hidden', // Will prevent the ghostElement to expand the size of the calender, showing vertical scrollbar and whitespace underneath calender #issue-#1614
               }}
             >
               <EventDayLane

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -173,8 +173,8 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                       date.getFullYear(),
                       date.getMonth(),
                       date.getDate(),
-                      endTime[0],
-                      endTime[1]
+                      endTime[0] >= 24 && endTime[1] >= 0 ? '23' : endTime[0],
+                      endTime[0] >= 24 && endTime[1] >= 0 ? '59' : endTime[0]
                     )
                   );
 

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -173,8 +173,8 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                       date.getFullYear(),
                       date.getMonth(),
                       date.getDate(),
-                      endTime[0] >= 24 && endTime[1] >= 0 ? 23 : endTime[0],
-                      endTime[0] >= 24 && endTime[1] >= 0 ? 59 : endTime[0]
+                      endTime[0] >= 24 ? 23 : endTime[0],
+                      endTime[0] >= 24 ? 59 : endTime[0]
                     )
                   );
 

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -175,7 +175,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                       date.getMonth(),
                       date.getDate(),
                       endTime[0] >= 24 ? 23 : endTime[0],
-                      endTime[0] >= 24 ? 59 : endTime[0]
+                      endTime[0] >= 24 ? 59 : endTime[1]
                     )
                   );
 


### PR DESCRIPTION
## Description
This prevents 0-length events to be created, and solves the bug in the most lazy and minimal way. Essentially, it validates if endTime is more than the allowed 23:59 maximum. 

This also prevent the user in dragging a chostElement out of bounds, thus expanding the calender Box element and create a vertical scrollbar. 

## Screenshots
Before: 
<img width="465" alt="Screenshot 2023-11-14 at 17 24 17" src="https://github.com/zetkin/app.zetkin.org/assets/9819978/ca5ae15b-750e-431f-8327-f1f153fef9ce">

After: 
<img width="364" alt="Screenshot 2023-11-14 at 20 23 27" src="https://github.com/zetkin/app.zetkin.org/assets/9819978/e73f2787-b74b-4af9-beac-6b99092d0e0e">


## Notes to reviewer
How to reproduce: 
- Go to calender view, 
- make the screen tall and slim,
- drag to create a new event and drag it out of the bottom view. 

## Related issues
Resolves #1614 
