### PR TITLE
Preserve TextQuestion input field state on error

### DIFF
--- a/src/features/surveys/components/surveyForm/TextQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/TextQuestion.tsx
@@ -2,9 +2,10 @@ import { FC } from 'react';
 import { ZetkinSurveyTextQuestionElement } from 'utils/types/zetkin';
 import { FormControl, FormLabel, TextField } from '@mui/material';
 
-const OptionsQuestion: FC<{ element: ZetkinSurveyTextQuestionElement }> = ({
-  element,
-}) => {
+const OptionsQuestion: FC<{
+  defaultValue?: string;
+  element: ZetkinSurveyTextQuestionElement;
+}> = ({ element, defaultValue = '' }) => {
   return (
     <FormControl sx={{ width: '100%' }}>
       <FormLabel
@@ -20,6 +21,7 @@ const OptionsQuestion: FC<{ element: ZetkinSurveyTextQuestionElement }> = ({
         {element.question.question}
       </FormLabel>
       <TextField
+        defaultValue={defaultValue}
         fullWidth
         id={`input-${element.id}`}
         name={`${element.id}.text`}


### PR DESCRIPTION
Testing this with a sneaky little `throw new Error()` just before the API call.

<img width="1025" alt="Screenshot 2023-11-15 at 20 26 49" src="https://github.com/zetkin/app.zetkin.org/assets/566159/4c0b1967-26bb-4856-ac3f-630f59378c5d">

Working real nice. The text field value now survives the error. I've gone with `defaultValue` here cos I'm trying to avoid making it controlled and having to do any actual state management in JS if possible. Feels like it's fitting in with the general low-JS web platform-centric approach here which I'm really loving.

| Before | After |
|-|-|
|  ![2023-11-15 20 27 57](https://github.com/zetkin/app.zetkin.org/assets/566159/641b8f14-287c-4b4b-8679-dabf7495fdeb) | ![2023-11-15 20 27 17](https://github.com/zetkin/app.zetkin.org/assets/566159/ec5a5d3e-9f89-4549-adbc-b64d5025765c) |

I think there's lots of style stuff and other things you might want to dig into here which is a big part of why I was so keen to keep this one really really small so there's lots of space for that kind of tweaking. It was fun working in YOLO mode at Code Camp but I'm up for slowing down now and taking the time to work through a bunch of change requests to onboard me a bit more into the ideal style and approach choices you prefer at Zetkin if you have the bandwidth to give that kind of feedback. And like that `typeof` ternary I've written at the bottom of this diff is hideous I think so do please suggest something a bit more elegant if an idea comes to mind.