### PR TITLE
New lint rule for sorting imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,14 +81,15 @@ module.exports = {
             html: true,
           },
         ],
-        'sort-imports': [
-          'error',
-          {
-            ignoreCase: true,
-            allowSeparatedGroups: true,
-            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
-          },
-        ],
+        'local-rules/sort-imports': 'error',
+        // 'sort-imports': [
+        //   'error',
+        //   {
+        //     ignoreCase: true,
+        //     allowSeparatedGroups: true,
+        //     memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
+        //   },
+        // ],
         'sort-keys': 'error',
         'sort-vars': 'error',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,15 +81,15 @@ module.exports = {
             html: true,
           },
         ],
-        'local-rules/sort-imports': 'error',
-        // 'sort-imports': [
-        //   'error',
-        //   {
-        //     ignoreCase: true,
-        //     allowSeparatedGroups: true,
-        //     memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
-        //   },
-        // ],
+        'local-rules/sort-imports': 'off', // When switching this on, remove the built-in `sort-imports` rule below!
+        'sort-imports': [
+          'error',
+          {
+            ignoreCase: true,
+            allowSeparatedGroups: true,
+            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
+          },
+        ],
         'sort-keys': 'error',
         'sort-vars': 'error',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,10 +7,9 @@ module.exports = {
   parserOptions: { ecmaVersion: 8 }, // to enable features such as async/await
   // We don't want to lint generated files nor node_modules, but we want to lint .prettierrc.js (ignored by default by eslint)
   ignorePatterns: ['node_modules/*', '.next/*', '.out/*', '!.prettierrc.js'],
-  extends: [
-    'eslint:recommended',
-    'next',
-    'prettier',
+  extends: ['eslint:recommended', 'next', 'prettier'],
+  plugins: [
+    'eslint-plugin-local-rules', // Registers locally defined eslint rules found in `./eslint-local-rules`
   ],
   settings: { react: { version: 'detect' } },
   overrides: [

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+// Everything exported from here will be available as rules
+// with the name `local-rules/<PROPERTY_NAME>`
+module.exports = {};

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -1,3 +1,7 @@
+const sortImports = require('./sort-imports.rule');
+
 // Everything exported from here will be available as rules
 // with the name `local-rules/<PROPERTY_NAME>`
-module.exports = {};
+module.exports = {
+  'sort-imports': sortImports,
+};

--- a/eslint-local-rules/sort-imports.bdd.js
+++ b/eslint-local-rules/sort-imports.bdd.js
@@ -1,0 +1,182 @@
+const rule = require('./sort-imports.rule');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+ruleTester.run('The sort-imports rule', rule, {
+  valid: [
+    {
+      // OK since only 3rd party imports
+      code: `
+import { useState } from 'react';
+`,
+    },
+    {
+      // OK since only local imports
+      code: `
+    import { someUtil } from 'utils/foo';
+    import x from './bar';
+    `,
+    },
+    {
+      // OK since imports in correct order with blank line
+      code: `
+    import { useState } from 'react';
+
+    import { someUtil } from 'utils/foo';
+    import x from './bar';
+    `,
+    },
+  ],
+  invalid: [
+    // Illegal since mix in code
+    {
+      code: `
+import { useState } from 'react';
+const x = 2
+import { store } from '@reduxjs/toolkit';
+      `,
+      errors: [
+        {
+          message: "Don't mix code between imports",
+        },
+      ],
+    },
+
+    // Illegal since 3rd - local - 3rd
+    {
+      code: `
+// Random comment
+import { useState } from 'react';
+import { someUtil } from 'utils/foo';
+import { store } from '@reduxjs/toolkit';
+
+const y = x.bar;
+      `,
+      output: `
+// Random comment
+import { useState } from 'react';
+import { store } from '@reduxjs/toolkit';
+
+import { someUtil } from 'utils/foo';
+
+const y = x.bar;
+      `,
+      errors: [
+        {
+          message: "Don't do 3rd party imports after local imports",
+        },
+      ],
+    },
+
+    // Illegal since 3rd - local - 3rd (with line)
+    {
+      code: `
+// Random comment
+import { useState } from 'react';
+
+import { someUtil } from 'utils/foo';
+import { store } from '@reduxjs/toolkit';
+
+const y = x.bar;
+      `,
+      output: `
+// Random comment
+import { useState } from 'react';
+import { store } from '@reduxjs/toolkit';
+
+import { someUtil } from 'utils/foo';
+
+const y = x.bar;
+      `,
+      errors: [
+        {
+          message: "Don't do 3rd party imports after local imports",
+        },
+      ],
+    },
+
+    // Illegal since local - 3rd
+    {
+      code: `
+// Random comment
+import { someUtil } from 'utils/foo';
+import { store } from '@reduxjs/toolkit';
+
+const y = x.bar;
+      `,
+      output: `
+// Random comment
+import { store } from '@reduxjs/toolkit';
+
+import { someUtil } from 'utils/foo';
+
+const y = x.bar;
+      `,
+      errors: [
+        {
+          message: "Don't do 3rd party imports after local imports",
+        },
+      ],
+    },
+
+    // Illegal since local - 3rd (but with line)
+    {
+      code: `
+// Random comment
+import { someUtil } from 'utils/foo';
+
+import { store } from '@reduxjs/toolkit';
+
+const y = x.bar;
+      `,
+      output: `
+// Random comment
+import { store } from '@reduxjs/toolkit';
+
+import { someUtil } from 'utils/foo';
+
+const y = x.bar;
+      `,
+      errors: [
+        {
+          message: "Don't do 3rd party imports after local imports",
+        },
+      ],
+    },
+
+    //Illegal since no blank line
+    {
+      code: `
+// Random comment
+import { useState } from 'react';
+import { someUtil } from 'utils/foo';
+import x from './bar';
+
+const y = x.bar;
+      `,
+      output: `
+// Random comment
+import { useState } from 'react';
+
+import { someUtil } from 'utils/foo';
+import x from './bar';
+
+const y = x.bar;
+      `,
+      errors: [
+        {
+          message: 'No blank line between 3rd party imports and local imports',
+        },
+      ],
+    },
+  ],
+});

--- a/eslint-local-rules/sort-imports.bdd.js
+++ b/eslint-local-rules/sort-imports.bdd.js
@@ -1,3 +1,7 @@
+// This test suite is used when developing the rule. Execute by simply running
+// `node ./eslint-local-rules/sort-imports.bdd.js` in the terminal.
+// These tests should not be made part of the regular unit test suite.
+
 const rule = require('./sort-imports.rule');
 const RuleTester = require('eslint').RuleTester;
 
@@ -80,7 +84,7 @@ const y = x.bar;
     // Illegal since 3rd - local - 3rd (with line)
     {
       code: `
-// Random comment
+// Random comment 5
 import { useState } from 'react';
 
 import { someUtil } from 'utils/foo';
@@ -89,7 +93,7 @@ import { store } from '@reduxjs/toolkit';
 const y = x.bar;
       `,
       output: `
-// Random comment
+// Random comment 5
 import { useState } from 'react';
 import { store } from '@reduxjs/toolkit';
 

--- a/eslint-local-rules/sort-imports.rule.js
+++ b/eslint-local-rules/sort-imports.rule.js
@@ -1,0 +1,102 @@
+const packageJson = require('../package.json');
+const deps = [
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.devDependencies),
+].concat('@mui'); // seems we sometimes import other @mui packages that aren't direct deps
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforce importing 3rd party code first',
+      category: 'Possible Errors',
+      recommended: false,
+    },
+    schema: [],
+    fixable: 'code',
+  },
+  create: function (ctx) {
+    return {
+      Program: (node) => {
+        const { body } = node;
+        // ----- First we make sure that we don't mix code between imports ---
+        const firstCodeIdx = body.findIndex(
+          (n) => n.type !== 'ImportDeclaration'
+        );
+        const trailingImport =
+          firstCodeIdx === -1
+            ? null
+            : body
+                .slice(firstCodeIdx)
+                .find((n) => n.type === 'ImportDeclaration');
+        if (trailingImport) {
+          return ctx.report({
+            node: trailingImport,
+            message: "Don't mix code between imports",
+          });
+        }
+
+        // ----- Next we ensure that the 3rd party imports come first ---
+
+        const imports = body.filter((n) => n.type === 'ImportDeclaration');
+        const firstLocalIdx = imports.findIndex(
+          (n) => !is3rdParty(n.source.value)
+        );
+        const trailing3rd =
+          firstLocalIdx === -1
+            ? null
+            : imports
+                .slice(firstLocalIdx)
+                .find((n) => is3rdParty(n.source.value));
+
+        if (trailing3rd) {
+          return ctx.report({
+            node: trailing3rd,
+            message: "Don't do 3rd party imports after local imports",
+            fix: (fixer) => {
+              const code = ctx.getSourceCode().getText(trailing3rd);
+              const priorNode = imports[imports.indexOf(trailing3rd) - 1];
+              const blankLineBefore =
+                trailing3rd.range[0] - priorNode.range[1] > 1;
+              const firstLocal = imports[firstLocalIdx];
+              const lastLegal3rd = imports[firstLocalIdx - 1];
+              const firstLocalHasPreceedingBlank =
+                lastLegal3rd && firstLocal.range[0] - lastLegal3rd.range[1] > 1;
+              const fixes = [
+                fixer.removeRange([
+                  trailing3rd.range[0] - (blankLineBefore ? 1 : 0),
+                  trailing3rd.range[1] + 1, // assume there's a linebreak here
+                ]),
+                firstLocalIdx === 0
+                  ? fixer.insertTextBefore(firstLocal, code + '\n\n')
+                  : fixer.insertTextAfter(
+                      lastLegal3rd,
+                      '\n' + code + (firstLocalHasPreceedingBlank ? '' : '\n')
+                    ),
+              ];
+              return fixes;
+            },
+          });
+        }
+
+        // ----- Now we check that there is a blank line between 3rd party and local imports ---
+        if (firstLocalIdx > 0) {
+          const lastThirdParty = imports[firstLocalIdx - 1];
+          const firstLocal = imports[firstLocalIdx];
+          if (firstLocal.range[0] - lastThirdParty.range[1] === 1) {
+            ctx.report({
+              node: firstLocal,
+              message:
+                'No blank line between 3rd party imports and local imports',
+              fix: (fixer) => fixer.insertTextAfter(lastThirdParty, '\n'),
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+const is3rdParty = (str) => deps.some((d) => str.startsWith(d));

--- a/eslint-local-rules/sort-imports.rule.js
+++ b/eslint-local-rules/sort-imports.rule.js
@@ -1,8 +1,4 @@
-const packageJson = require('../package.json');
-const deps = [
-  ...Object.keys(packageJson.dependencies),
-  ...Object.keys(packageJson.devDependencies),
-].concat('@mui'); // seems we sometimes import other @mui packages that aren't direct deps
+const is3rdParty = require('./utils/is-3rd-party');
 
 /**
  * @type {import('eslint').Rule.RuleModule}
@@ -25,17 +21,16 @@ module.exports = {
         const firstCodeIdx = body.findIndex(
           (n) => n.type !== 'ImportDeclaration'
         );
-        const trailingImport =
-          firstCodeIdx === -1
-            ? null
-            : body
-                .slice(firstCodeIdx)
-                .find((n) => n.type === 'ImportDeclaration');
-        if (trailingImport) {
-          return ctx.report({
-            node: trailingImport,
-            message: "Don't mix code between imports",
-          });
+        if (firstCodeIdx !== -1) {
+          const trailingImport = body
+            .slice(firstCodeIdx)
+            .find((n) => n.type === 'ImportDeclaration');
+          if (trailingImport) {
+            return ctx.report({
+              node: body[firstCodeIdx],
+              message: "Don't mix code between imports",
+            });
+          }
         }
 
         // ----- Next we ensure that the 3rd party imports come first ---
@@ -44,44 +39,44 @@ module.exports = {
         const firstLocalIdx = imports.findIndex(
           (n) => !is3rdParty(n.source.value)
         );
-        const trailing3rd =
-          firstLocalIdx === -1
-            ? null
-            : imports
-                .slice(firstLocalIdx)
-                .find((n) => is3rdParty(n.source.value));
-
-        if (trailing3rd) {
-          return ctx.report({
-            node: trailing3rd,
-            message: "Don't do 3rd party imports after local imports",
-            fix: (fixer) => {
-              const code = ctx.getSourceCode().getText(trailing3rd);
-              const priorNode = imports[imports.indexOf(trailing3rd) - 1];
-              const blankLineBefore =
-                trailing3rd.range[0] - priorNode.range[1] > 1;
-              const firstLocal = imports[firstLocalIdx];
-              const lastLegal3rd = imports[firstLocalIdx - 1];
-              const firstLocalHasPreceedingBlank =
-                lastLegal3rd && firstLocal.range[0] - lastLegal3rd.range[1] > 1;
-              const fixes = [
-                fixer.removeRange([
-                  trailing3rd.range[0] - (blankLineBefore ? 1 : 0),
-                  trailing3rd.range[1] + 1, // assume there's a linebreak here
-                ]),
-                firstLocalIdx === 0
-                  ? fixer.insertTextBefore(firstLocal, code + '\n\n')
-                  : fixer.insertTextAfter(
-                      lastLegal3rd,
-                      '\n' + code + (firstLocalHasPreceedingBlank ? '' : '\n')
-                    ),
-              ];
-              return fixes;
-            },
-          });
+        if (firstLocalIdx !== -1) {
+          const trailing3rd = imports
+            .slice(firstLocalIdx)
+            .find((n) => is3rdParty(n.source.value));
+          if (trailing3rd) {
+            return ctx.report({
+              node: trailing3rd,
+              message: "Don't do 3rd party imports after local imports",
+              fix: (fixer) => {
+                const code = ctx.getSourceCode().getText(trailing3rd);
+                const priorNode = imports[imports.indexOf(trailing3rd) - 1];
+                const blankLineBefore =
+                  trailing3rd.range[0] - priorNode.range[1] > 1;
+                const firstLocal = imports[firstLocalIdx];
+                const lastLegal3rd = imports[firstLocalIdx - 1];
+                const firstLocalHasPreceedingBlank =
+                  lastLegal3rd &&
+                  firstLocal.range[0] - lastLegal3rd.range[1] > 1;
+                const fixes = [
+                  fixer.removeRange([
+                    trailing3rd.range[0] - (blankLineBefore ? 1 : 0),
+                    trailing3rd.range[1] + 1, // assume there's a linebreak here
+                  ]),
+                  firstLocalIdx === 0
+                    ? fixer.insertTextBefore(firstLocal, code + '\n\n')
+                    : fixer.insertTextAfter(
+                        lastLegal3rd,
+                        '\n' + code + (firstLocalHasPreceedingBlank ? '' : '\n')
+                      ),
+                ];
+                return fixes;
+              },
+            });
+          }
         }
 
         // ----- Now we check that there is a blank line between 3rd party and local imports ---
+
         if (firstLocalIdx > 0) {
           const lastThirdParty = imports[firstLocalIdx - 1];
           const firstLocal = imports[firstLocalIdx];
@@ -98,5 +93,3 @@ module.exports = {
     };
   },
 };
-
-const is3rdParty = (str) => deps.some((d) => str.startsWith(d));

--- a/eslint-local-rules/utils/is-3rd-party.js
+++ b/eslint-local-rules/utils/is-3rd-party.js
@@ -1,0 +1,19 @@
+// Util to identify whether an import is 3rd party
+
+const is3rdParty = (str) => deps.some((d) => str.startsWith(d));
+module.exports = is3rdParty;
+
+// The tsconfig is wired to allow referencing `./src/some/code` as `some/code`,
+// which means we can't identify local imports by looking for a leading `.`.
+// Instead we check if the import matches a dependency listed in package.json!
+
+const packageJson = require('../../package.json');
+const deps = [
+  ...Object.keys(packageJson.dependencies),
+  ...Object.keys(packageJson.devDependencies),
+  '@mui', // seems we sometimes import @mui packages that aren't direct deps so we hard-code that here
+];
+
+// NB: Node packages will be identified as "not 3rd party" which is arguably correct, but likely
+// this util is used to identify local imports. Another util might be needed to differentiate
+// between local imports and built-in node packages.

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-loader": "^4.0.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-local-rules": "^2.0.0",
     "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-no-switch-statements": "^1.0.0",
     "eslint-plugin-react": "^7.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7910,6 +7910,11 @@ eslint-plugin-jsx-a11y@^6.4.1, eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
+eslint-plugin-local-rules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.0.tgz#cda95d7616cc0e2609d76c347c187ca2be1e252e"
+  integrity sha512-sWueme0kUcP0JC1+6OBDQ9edBDVFJR92WJHSRbhiRExlenMEuUisdaVBPR+ItFBFXo2Pdw6FD2UfGZWkz8e93g==
+
 eslint-plugin-next@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz#f9ef680e8f68763c716ab44697c4b3cc3e0b2069"


### PR DESCRIPTION
## Description

The current linting of imports is done by the built-in `sort-imports` rule. It enforces alphabetical sorting, split between single and multiple imports. This is rather frustrating in practice since adding a property import to a pre-existing line might mean that you now have to move that line, and it is generally hard to figure out what the correct position for a line is. 

This PR adds a new locally defined alternative to `sort-imports` which instead enforces having 3rd party imports before local imports. The hope is that this means bigger immediate benefit and less frustration. The rule also includes autofix to facilitate both initial adoption and subsequent workflow. The PR does not activate the new rule, so merging it is a `noop`.

## Changes

* Adds the `eslint-plugin-local-rules` package, which is a simple pointer allowing us to define eslint rules locally in `/eslint-local-rules` (non-configurable, this name is hard-coded into the package)
* Adds definition for a `sort-imports` rule which separates 3rd party imports from local imports
* Adds the new rule to the `.eslintrc` file but turned off for now, as we want to do the initial fix run during a less PR-busy time

## Notes to reviewer

* To understand the nuances of the rule, a good starting point is to look at the tests in `./eslint-local-rules/sort-imports.bdd.js`.
* To do a test run of the rule with auto-fixer:
    1. In `.eslintrc`, switch `local-rules/sort-imports` from `off` to `error` (line 84)
    2. Also switch `sort-imports` from `error` to `off` (line 85)
    3. Run `npx eslint . --fix` in the terminal.
    4. Go through the 160+ changed files and check that the fixes are sound 🙈 😅 
* There are some known limitations of the current implementation of the rule:
    1. It marks an error if you have non-import code intermingled inbetween import lines, but these are currently not corrected by the auto-fixer. I didn't deem it worth doing for now since the problem is only pre-existing in two files;
      * `src/features/smartSearch/components/filters/Task/DisplayTask.tsx`
      * `src/zui/ZUITimeline/index.stories.tsx`
    2. If there are several 3rd party imports in a row that need to be moved, the fixer will only move the first. This means that after the fixer has been run, you'll still have errors in the same file, and have to run the fixer again. This is caused by me cheating a bit to handle whitespace in the rule. This can be fixed by a refactor, but as the problem only pre-exists in a single file (`src/pages/_app.tsx`) I hoped I could get away with this cheat for now. When we do the initial adoption of the rule we have to run the fixer twice (thrice?), but after that it won't be an issue since it will correctly flag all errors.
    3. The rule right now treats built-in node packages as non-3rd-party imports, which might or might not be what we want. But right now there are just a couple of node files so I think this is ok:
      * `integrationTesting/globalSetup.ts`
      * `integrationTesting/fixtures/next.ts`
  * The rule doesn't add any special behaviours for the import of CSS files (`import 'some/file.css';`). Politically speaking it might make sense to force all of them together, or at least have them last in their respective group (3rd party and local). But right now the rule just checks that they are in the correct grouping.

