### PR TITLE
Issue-1610/ Fix pane when url changes

### DIFF
--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -1,10 +1,12 @@
 import { makeStyles } from '@mui/styles';
+import { useRouter } from 'next/router';
 import { Box, Paper, Slide } from '@mui/material';
 import {
   createContext,
   FC,
   ReactNode,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -57,9 +59,14 @@ export const PaneProvider: FC<PaneProviderProps> = ({
   const [open, setOpen] = useState(false);
   const styles = useStyles();
   const [key, setKey] = useState(0);
+  const { pathname } = useRouter();
 
   const { paneContainerRef, slideRef, updatePaneHeight } =
     useResizablePane(fixedHeight);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   return (
     <PaneContext.Provider


### PR DESCRIPTION
## Description
This PR fixes a bug and closes the pane when the user navigates to another url instead of leave the pane open.


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/36491300/0c99560c-6767-44f1-a2e7-c40a04c37b06


https://github.com/zetkin/app.zetkin.org/assets/36491300/8c436386-9680-46b9-bff1-ace855d0be32




## Changes
* Adds a `useEffect ` in `PaneProvider ` component to set `open ` variable to false when `pathname `changes.

## Notes to reviewer
I'm using pathname from useRouter() instead of router.events because it looks like will be deprecated in [Next 13](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-5-migrating-routing-hooks) and it also requires more code and I think this solution is cleaner and will work with the next versions. 

## Related issues
Resolves #1610 
