### PR TITLE
Issue 1660/redirection person card 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ module.exports = {
       },
       {
         source: '/organize/:orgId(\\d{1,})/areas',
-        destination: '/legacy?path=/maps&orgId=:orgId',
+        destination: `https://organize.${process.env.ZETKIN_API_DOMAIN}/maps&orgId=:orgId`,
         permanent: false,
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -32,8 +32,7 @@ module.exports = {
       // redirects to Gen2 for MVP August 2021
       {
         source: '/organize/:orgId/people/:personId/edit',
-        destination:
-          'https://organize.zetk.in/people/person%3A:personId/?org=:orgId',
+        destination: `https://organize.${process.env.ZETKIN_API_DOMAIN}/people/person%3A:personId/?org=:orgId`,
         permanent: false,
       },
       {

--- a/src/features/profile/components/PersonDetailsCard.tsx
+++ b/src/features/profile/components/PersonDetailsCard.tsx
@@ -98,11 +98,11 @@ const PersonDetailsCard: React.FunctionComponent<{
   return (
     <ZUISection
       action={
-        <NextLink href={`${router.asPath}/edit`} passHref>
+        <Link href={`${router.asPath}/edit`} target="_blank">
           <Button color="primary" startIcon={<OpenInNew />}>
             <Msg id={messageIds.editButtonLabel} />
           </Button>
-        </NextLink>
+        </Link>
       }
       title={messages.details.title()}
     >


### PR DESCRIPTION
## Description
This PR fixes the redirection in `Areas `(menu) and in `PersonDetailsCard `component to let the redirection go to the correct instance. 


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/36491300/450d64a3-eddd-48b8-90ed-ec2fcb2e8545




## Changes
* Adds the environment variable `ZETKIN_API_DOMAIN` to the `areas ` and ` person edit` redirection in `next.config.js` file
* Changes the NextLink component for a Link to add a target property "_blank" and open the redirected link in a new tab.


## Notes to reviewer
None


## Related issues
Resolves #1660 
