### PR TITLE
Fix accepted files error using MIME files types

### DIFF
--- a/src/features/import/components/UploadFile.tsx
+++ b/src/features/import/components/UploadFile.tsx
@@ -81,7 +81,11 @@ const UploadFile = () => {
 
   const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
     accept: {
-      types: ['.csv', '.xls', '.xlsx'],
+      'application/vnd.ms-excel': ['.xls'],
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xlsx',
+      ],
+      'text/csv': ['.csv'],
     },
     maxFiles: 1,
     noClick: true,

--- a/src/features/import/hooks/useImportedFile.ts
+++ b/src/features/import/hooks/useImportedFile.ts
@@ -24,11 +24,7 @@ export default function useFileImport() {
 
   async function parseData(file: File) {
     setLoading(true);
-    if (
-      file.type === 'text/comma-separated-values' ||
-      file.type === 'text/csv' ||
-      file.type === 'application/csv'
-    ) {
+    if (file.type === 'text/csv') {
       const res = await parseCSVFile(file);
       const withColumns = fileWithColumns(res);
       saveData(withColumns);
@@ -36,8 +32,7 @@ export default function useFileImport() {
     } else if (
       file.type === 'application/vnd.ms-excel' ||
       file.type ===
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
-      file.type === 'application/xls'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     ) {
       const res = await parseExcelFile(file);
       saveData(res);


### PR DESCRIPTION
## Description
This PR fixes the console error `"Skipped "types" because it is not a valid MIME type."` changing the accepted files in the `DropZone `by MIME types.


## Screenshots
None

## Changes
* Changes `accept `files in `useDropZone `hook by:
      - 'application/vnd.ms-excel': ['.xls'],
      - 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
      - 'text/csv': ['.csv'],
* Changes the file types in `useImportFile ` hook by the types below.

## Notes to reviewer
None

## Related issues
Resolves undocumented/fix-types
