### PR TITLE
Issue/1298 eslint rule no useless fragments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
           },
         ],
         'react/jsx-no-target-blank': 'error',
+        'react/jsx-no-useless-fragment': 'error',
         'react/jsx-sort-props': [
           'error',
           {

--- a/src/core/i18n/Msg.tsx
+++ b/src/core/i18n/Msg.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 
 import { InterpolatedMessage, PlainMessage, ValueRecord } from './messages';
@@ -19,7 +20,7 @@ function Msg<Values extends ValueRecord>({
 function Msg<Values extends ValueRecord>({
   id,
   values,
-}: MsgProps<Values>): JSX.Element {
+}: MsgProps<Values>): ReactNode {
   const intl = useIntl();
 
   const descriptor = {
@@ -31,7 +32,7 @@ function Msg<Values extends ValueRecord>({
     ? intl.formatMessage(descriptor, values)
     : intl.formatMessage(descriptor);
 
-  return <>{str}</>;
+  return str;
 }
 
 export default Msg;

--- a/src/features/calendar/components/CalendarEventFilter/CheckboxFilterList.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/CheckboxFilterList.tsx
@@ -31,69 +31,65 @@ const CheckboxFilterList = ({
 
   const visibleOptions = expand ? options : options.slice(0, maxCollapsed);
   return (
-    <>
-      <FormGroup sx={{ mb: 2 }}>
-        <Box alignItems="center" display="flex" justifyContent="space-between">
-          <Typography color="secondary" variant="body1">
-            {title}
-          </Typography>
-          <AllAndNoneToggle
-            maxLength={options.length}
-            onSelectAll={() =>
-              onFilterChange(options.map((item) => item.value))
+    <FormGroup sx={{ mb: 2 }}>
+      <Box alignItems="center" display="flex" justifyContent="space-between">
+        <Typography color="secondary" variant="body1">
+          {title}
+        </Typography>
+        <AllAndNoneToggle
+          maxLength={options.length}
+          onSelectAll={() => onFilterChange(options.map((item) => item.value))}
+          onSelectNone={() => onFilterChange([])}
+          selectedFilterLength={selectedValues.length}
+        />
+      </Box>
+      {visibleOptions.map((item) => {
+        return (
+          <FormControlLabel
+            key={item.value}
+            control={
+              <Checkbox
+                checked={selectedValues.includes(item.value)}
+                name={item.value}
+                onChange={() => {
+                  const alreadyExists = selectedValues.includes(item.value);
+                  onFilterChange(
+                    alreadyExists
+                      ? selectedValues.filter(
+                          (filterOption) => filterOption !== item.value
+                        )
+                      : [...selectedValues, item.value]
+                  );
+                }}
+              />
             }
-            onSelectNone={() => onFilterChange([])}
-            selectedFilterLength={selectedValues.length}
+            label={item.label}
+            sx={{ pl: 1 }}
           />
-        </Box>
-        {visibleOptions.map((item) => {
-          return (
-            <FormControlLabel
-              key={item.value}
-              control={
-                <Checkbox
-                  checked={selectedValues.includes(item.value)}
-                  name={item.value}
-                  onChange={() => {
-                    const alreadyExists = selectedValues.includes(item.value);
-                    onFilterChange(
-                      alreadyExists
-                        ? selectedValues.filter(
-                            (filterOption) => filterOption !== item.value
-                          )
-                        : [...selectedValues, item.value]
-                    );
-                  }}
-                />
-              }
-              label={item.label}
-              sx={{ pl: 1 }}
-            />
-          );
-        })}
-        {options.length > maxCollapsed && (
-          <Button
-            onClick={() => setExpand(!expand)}
-            sx={{
-              display: 'flex',
-              justifyContent: 'flex-start',
-              width: 'fit-content',
-            }}
-            variant="text"
-          >
-            {expand && <Msg id={messageIds.eventFilter.collapse} />}
-            {!expand && (
-              <Typography sx={{ textDecoration: 'underline' }} variant="body2">
-                <Msg
-                  id={messageIds.eventFilter.expand}
-                  values={{ numOfOptions: options.length - maxCollapsed }}
-                />
-              </Typography>
-            )}
-          </Button>
-        )}
-      </FormGroup>
-    </>
+        );
+      })}
+      {options.length > maxCollapsed && (
+        <Button
+          onClick={() => setExpand(!expand)}
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            width: 'fit-content',
+          }}
+          variant="text"
+        >
+          {expand && <Msg id={messageIds.eventFilter.collapse} />}
+          {!expand && (
+            <Typography sx={{ textDecoration: 'underline' }} variant="body2">
+              <Msg
+                id={messageIds.eventFilter.expand}
+                values={{ numOfOptions: options.length - maxCollapsed }}
+              />
+            </Typography>
+          )}
+        </Button>
+      )}
+    </FormGroup>
   );
 };
 

--- a/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
@@ -31,20 +31,16 @@ const EventInputFilter = ({
     <TextField
       fullWidth
       InputProps={{
-        endAdornment: (
-          <>
-            {userInput && (
-              <IconButton
-                onClick={() => {
-                  setUserInput('');
-                  onChangeFilterText('');
-                }}
-              >
-                <Clear />
-              </IconButton>
-            )}
-          </>
-        ),
+        endAdornment: userInput ? (
+          <IconButton
+            onClick={() => {
+              setUserInput('');
+              onChangeFilterText('');
+            }}
+          >
+            <Clear />
+          </IconButton>
+        ) : null,
         startAdornment: (
           <InputAdornment position="start">
             <FilterList />

--- a/src/features/calendar/components/EventCluster/FieldGroup.tsx
+++ b/src/features/calendar/components/EventCluster/FieldGroup.tsx
@@ -37,18 +37,16 @@ const FieldGroup: FC<FieldGroupProps> = ({ fields, height }) => {
     (f) => f.presentation === FIELD_PRESENTATION.ICON_ONLY
   );
   return (
-    <>
-      <Box className={classes.fields} height={height}>
-        <Box className={classes.fieldsWithIconOnly}>
-          {fieldsWithIconOnly.map((field, index) => (
-            <Field key={`${field.kind}-${index}`} field={field} />
-          ))}
-        </Box>
-        {fieldsWithLabel.map((field, index) => (
+    <Box className={classes.fields} height={height}>
+      <Box className={classes.fieldsWithIconOnly}>
+        {fieldsWithIconOnly.map((field, index) => (
           <Field key={`${field.kind}-${index}`} field={field} />
         ))}
       </Box>
-    </>
+      {fieldsWithLabel.map((field, index) => (
+        <Field key={`${field.kind}-${index}`} field={field} />
+      ))}
+    </Box>
   );
 };
 

--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -87,71 +87,69 @@ const Calendar = () => {
   }
 
   return (
-    <>
-      <Box display="flex" flexDirection="column" height={'100%'} padding={2}>
-        <CalendarNavBar
-          focusDate={focusDate}
-          onChangeFocusDate={(date) => {
-            setFocusDate(date);
-          }}
-          onChangeTimeScale={(timeScale) => {
-            setSelectedTimeScale(timeScale);
-          }}
-          onStepBackward={() => {
-            // Steps back to the last day with an event on day view
-            if (selectedTimeScale === TimeScale.DAY && prevActivityDay) {
-              setFocusDate(prevActivityDay[0]);
-            } else {
-              setFocusDate(
-                dayjs(focusDate).subtract(1, selectedTimeScale).toDate()
-              );
-            }
-          }}
-          onStepForward={() => {
-            // Steps forward to the next day with an event on day view
-            if (selectedTimeScale === TimeScale.DAY && nextActivityDay) {
-              setFocusDate(nextActivityDay[0]);
-            } else {
-              setFocusDate(dayjs(focusDate).add(1, selectedTimeScale).toDate());
-            }
-          }}
-          orgId={parseInt(orgId as string)}
-          timeScale={selectedTimeScale}
-        />
+    <Box display="flex" flexDirection="column" height={'100%'} padding={2}>
+      <CalendarNavBar
+        focusDate={focusDate}
+        onChangeFocusDate={(date) => {
+          setFocusDate(date);
+        }}
+        onChangeTimeScale={(timeScale) => {
+          setSelectedTimeScale(timeScale);
+        }}
+        onStepBackward={() => {
+          // Steps back to the last day with an event on day view
+          if (selectedTimeScale === TimeScale.DAY && prevActivityDay) {
+            setFocusDate(prevActivityDay[0]);
+          } else {
+            setFocusDate(
+              dayjs(focusDate).subtract(1, selectedTimeScale).toDate()
+            );
+          }
+        }}
+        onStepForward={() => {
+          // Steps forward to the next day with an event on day view
+          if (selectedTimeScale === TimeScale.DAY && nextActivityDay) {
+            setFocusDate(nextActivityDay[0]);
+          } else {
+            setFocusDate(dayjs(focusDate).add(1, selectedTimeScale).toDate());
+          }
+        }}
+        orgId={parseInt(orgId as string)}
+        timeScale={selectedTimeScale}
+      />
 
-        <Box
-          display="flex"
-          flexDirection="column"
-          flexGrow={1}
-          marginTop={2}
-          overflow="auto"
-        >
-          <Suspense>
-            {selectedTimeScale === TimeScale.DAY && (
-              <CalendarDayView
-                focusDate={focusDate}
-                onClickPreviousDay={(date) => setFocusDate(date)}
-                previousActivityDay={prevActivityDay}
-              />
-            )}
-            {selectedTimeScale === TimeScale.WEEK && (
-              <CalendarWeekView
-                focusDate={focusDate}
-                onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
-              />
-            )}
-            {selectedTimeScale === TimeScale.MONTH && (
-              <CalendarMonthView
-                focusDate={focusDate}
-                onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
-                onClickWeek={(date) => navigateTo(TimeScale.WEEK, date)}
-              />
-            )}
-          </Suspense>
-        </Box>
-        <SelectionBar />
+      <Box
+        display="flex"
+        flexDirection="column"
+        flexGrow={1}
+        marginTop={2}
+        overflow="auto"
+      >
+        <Suspense>
+          {selectedTimeScale === TimeScale.DAY && (
+            <CalendarDayView
+              focusDate={focusDate}
+              onClickPreviousDay={(date) => setFocusDate(date)}
+              previousActivityDay={prevActivityDay}
+            />
+          )}
+          {selectedTimeScale === TimeScale.WEEK && (
+            <CalendarWeekView
+              focusDate={focusDate}
+              onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
+            />
+          )}
+          {selectedTimeScale === TimeScale.MONTH && (
+            <CalendarMonthView
+              focusDate={focusDate}
+              onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
+              onClickWeek={(date) => navigateTo(TimeScale.WEEK, date)}
+            />
+          )}
+        </Suspense>
       </Box>
-    </>
+      <SelectionBar />
+    </Box>
   );
 };
 

--- a/src/features/events/components/AddPersonButton.tsx
+++ b/src/features/events/components/AddPersonButton.tsx
@@ -106,25 +106,23 @@ const AddPersonButton = ({ orgId, eventId }: AddPersonButtonProps) => {
               };
 
               return (
-                <>
-                  <ZUIPersonSelect
-                    getOptionDisabled={(option) =>
-                      participants.some(
-                        (participant) => participant.id == option.id
-                      )
-                    }
-                    getOptionExtraLabel={(option) => {
-                      return getOptionExtraLabel(option.id);
-                    }}
-                    name="person"
-                    onChange={(person) => {
-                      addParticipant(person.id);
-                    }}
-                    placeholder={messages.addPerson.addPlaceholder()}
-                    selectedPerson={null}
-                    variant="outlined"
-                  />
-                </>
+                <ZUIPersonSelect
+                  getOptionDisabled={(option) =>
+                    participants.some(
+                      (participant) => participant.id == option.id
+                    )
+                  }
+                  getOptionExtraLabel={(option) => {
+                    return getOptionExtraLabel(option.id);
+                  }}
+                  name="person"
+                  onChange={(person) => {
+                    addParticipant(person.id);
+                  }}
+                  placeholder={messages.addPerson.addPlaceholder()}
+                  selectedPerson={null}
+                  variant="outlined"
+                />
               );
             }}
           </ZUIFutures>

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -74,13 +74,9 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
         <ZUIEllipsisMenu
           items={[
             {
-              label: (
-                <>
-                  {event.cancelled
-                    ? messages.eventActionButtons.restore()
-                    : messages.eventActionButtons.cancel()}
-                </>
-              ),
+              label: event.cancelled
+                ? messages.eventActionButtons.restore()
+                : messages.eventActionButtons.cancel(),
               onSelect: () => {
                 showConfirmDialog({
                   onSubmit: handleCancel,

--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -437,9 +437,9 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                     value={link}
                   />
                 )}
-                renderPreview={() => {
-                  if (data.url && data.url !== '') {
-                    return (
+                {...(data.url &&
+                  data.url !== '' && {
+                    renderPreview: () => (
                       <Box marginLeft={4}>
                         <Typography
                           color={theme.palette.text.secondary}
@@ -455,18 +455,19 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                           variant="body1"
                         >
                           {data.url}
-                          <Link href={getWorkingUrl(data.url)} target="_blank">
+                          <Link
+                            //TS won't infer type here for some reason
+                            href={getWorkingUrl(data.url as string)}
+                            target="_blank"
+                          >
                             <Box marginLeft={1}>
                               <OpenInNewIcon color="primary" />
                             </Box>
                           </Link>
                         </Typography>
                       </Box>
-                    );
-                  } else {
-                    return <></>;
-                  }
-                }}
+                    ),
+                  })}
                 value={link || ''}
               />
             </Box>
@@ -485,23 +486,19 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                   value={infoText}
                 />
               )}
-              renderPreview={() => {
-                if (data.info_text !== '') {
-                  return (
-                    <Box>
-                      <Typography
-                        color={theme.palette.text.secondary}
-                        variant="subtitle1"
-                      >
-                        {messages.eventOverviewCard.description().toUpperCase()}
-                      </Typography>
-                      <Typography variant="body1">{data.info_text}</Typography>
-                    </Box>
-                  );
-                } else {
-                  return <></>;
-                }
-              }}
+              {...(data.info_text !== '' && {
+                renderPreview: () => (
+                  <Box>
+                    <Typography
+                      color={theme.palette.text.secondary}
+                      variant="subtitle1"
+                    >
+                      {messages.eventOverviewCard.description().toUpperCase()}
+                    </Typography>
+                    <Typography variant="body1">{data.info_text}</Typography>
+                  </Box>
+                ),
+              })}
               value={infoText}
             />
           </Box>

--- a/src/features/events/components/EventParticipantsFilter.tsx
+++ b/src/features/events/components/EventParticipantsFilter.tsx
@@ -23,20 +23,16 @@ const EventParticipantsFilter = ({
   return (
     <TextField
       InputProps={{
-        endAdornment: (
-          <>
-            {userInput && (
-              <IconButton
-                onClick={() => {
-                  setUserInput('');
-                  onFilterChange('');
-                }}
-              >
-                <ClearIcon />
-              </IconButton>
-            )}
-          </>
-        ),
+        endAdornment: userInput ? (
+          <IconButton
+            onClick={() => {
+              setUserInput('');
+              onFilterChange('');
+            }}
+          >
+            <ClearIcon />
+          </IconButton>
+        ) : null,
         startAdornment: <SearchIcon color="secondary" sx={{ mr: 1 }} />,
       }}
       onChange={(e) => {

--- a/src/features/events/components/EventRelatedCard.tsx
+++ b/src/features/events/components/EventRelatedCard.tsx
@@ -21,28 +21,24 @@ const EventRelatedCard: FC<EventRelatedCardProps> = ({ data, orgId }) => {
   return (
     <ZUIFuture future={relatedEvents}>
       {(events) => {
-        return (
-          <>
-            {events.length > 0 && (
-              <Box mt={2}>
-                <ZUICard header={messages.eventRelatedCard.header()}>
-                  <Box>
-                    {events.map((event, index) => {
-                      return (
-                        <Box key={event.id}>
-                          {index > 0 && (
-                            <Divider sx={{ marginBottom: 1, marginTop: 1 }} />
-                          )}
-                          <RelatedEvent event={event} />
-                        </Box>
-                      );
-                    })}
-                  </Box>
-                </ZUICard>
+        return events.length > 0 ? (
+          <Box mt={2}>
+            <ZUICard header={messages.eventRelatedCard.header()}>
+              <Box>
+                {events.map((event, index) => {
+                  return (
+                    <Box key={event.id}>
+                      {index > 0 && (
+                        <Divider sx={{ marginBottom: 1, marginTop: 1 }} />
+                      )}
+                      <RelatedEvent event={event} />
+                    </Box>
+                  );
+                })}
               </Box>
-            )}
-          </>
-        );
+            </ZUICard>
+          </Box>
+        ) : null;
       }}
     </ZUIFuture>
   );

--- a/src/features/events/components/LocationLabel.tsx
+++ b/src/features/events/components/LocationLabel.tsx
@@ -17,7 +17,7 @@ const LocationLabel: FC<LocationLabelProps> = ({ location }) => {
   if (!location) {
     return <>{messages.common.noLocation()}</>;
   }
-  return <>{location.title}</>;
+  return <span>{location.title}</span>;
 };
 
 export default LocationLabel;

--- a/src/features/events/components/LocationModal/LocationDetailsCard.tsx
+++ b/src/features/events/components/LocationModal/LocationDetailsCard.tsx
@@ -116,13 +116,11 @@ const LocationDetailsCard: FC<LocationDetailsCardProps> = ({
                   value={title}
                 />
               )}
-              renderPreview={() => {
-                if (location.title !== '') {
-                  return <Typography variant="h5">{location.title}</Typography>;
-                } else {
-                  return <></>;
-                }
-              }}
+              {...(location.title !== '' && {
+                renderPreview: () => (
+                  <Typography variant="h5">{location.title}</Typography>
+                ),
+              })}
               value={location.title}
             />
             <Close

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -151,39 +151,33 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
         if (params.row.person) {
           return <Typography>{params.row.person.name}</Typography>;
         } else {
-          return (
-            <>
-              {eventFuture.data?.contact?.id === params.row.id ? (
-                <Typography>
-                  {params.row.first_name + ' ' + params.row.last_name}
-                  <Tooltip
-                    title={messages.eventParticipantsList.contactTooltip()}
-                  >
-                    <FaceOutlinedIcon
-                      sx={{ marginLeft: '8px', verticalAlign: 'bottom' }}
-                    />
-                  </Tooltip>
-                </Typography>
-              ) : (
-                <Typography>
-                  {params.row.first_name + ' ' + params.row.last_name}
+          return eventFuture.data?.contact?.id === params.row.id ? (
+            <Typography>
+              {params.row.first_name + ' ' + params.row.last_name}
+              <Tooltip title={messages.eventParticipantsList.contactTooltip()}>
+                <FaceOutlinedIcon
+                  sx={{ marginLeft: '8px', verticalAlign: 'bottom' }}
+                />
+              </Tooltip>
+            </Typography>
+          ) : (
+            <Typography>
+              {params.row.first_name + ' ' + params.row.last_name}
 
-                  <Tooltip
-                    title={messages.eventParticipantsList.participantTooltip()}
-                  >
-                    <FaceOutlinedIcon
-                      onClick={noPropagate(() => setContact(params.row.id))}
-                      sx={{
-                        display: 'none',
-                        marginLeft: '8px',
-                        opacity: '50%',
-                        verticalAlign: 'bottom',
-                      }}
-                    />
-                  </Tooltip>
-                </Typography>
-              )}
-            </>
+              <Tooltip
+                title={messages.eventParticipantsList.participantTooltip()}
+              >
+                <FaceOutlinedIcon
+                  onClick={noPropagate(() => setContact(params.row.id))}
+                  sx={{
+                    display: 'none',
+                    marginLeft: '8px',
+                    opacity: '50%',
+                    verticalAlign: 'bottom',
+                  }}
+                />
+              </Tooltip>
+            </Typography>
           );
         }
       },

--- a/src/features/journeys/components/JourneyInstanceSummary.tsx
+++ b/src/features/journeys/components/JourneyInstanceSummary.tsx
@@ -88,35 +88,31 @@ const JourneyInstanceSummary = ({
             submitDisabled={isLoading}
           />
         </form>
+      ) : // Not editing
+      journeyInstance.summary.length > 0 ? (
+        <ZUICollapse collapsedSize={90}>
+          <ZUIMarkdown
+            BoxProps={{
+              fontSize: '1rem',
+              style: {
+                overflowWrap: 'anywhere',
+              },
+            }}
+            markdown={journeyInstance.summary}
+          />
+        </ZUICollapse>
       ) : (
-        // Not editing
-        <>
-          {journeyInstance.summary.length > 0 ? (
-            <ZUICollapse collapsedSize={90}>
-              <ZUIMarkdown
-                BoxProps={{
-                  fontSize: '1rem',
-                  style: {
-                    overflowWrap: 'anywhere',
-                  },
-                }}
-                markdown={journeyInstance.summary}
-              />
-            </ZUICollapse>
-          ) : (
-            <Typography
-              color="secondary"
-              onClick={() => setEditingSummary(true)}
-              style={{
-                cursor: 'pointer',
-                padding: '1rem 0 1rem 0',
-              }}
-              variant="body1"
-            >
-              {summaryPlaceholder}
-            </Typography>
-          )}
-        </>
+        <Typography
+          color="secondary"
+          onClick={() => setEditingSummary(true)}
+          style={{
+            cursor: 'pointer',
+            padding: '1rem 0 1rem 0',
+          }}
+          variant="body1"
+        >
+          {summaryPlaceholder}
+        </Typography>
       )}
     </ZUISection>
   );

--- a/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
@@ -50,32 +50,30 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
   });
 
   return (
-    <>
-      <DataGridPro
-        checkboxSelection
-        columns={columnsWithHeaderTitles}
-        disableRowSelectionOnClick={true}
-        initialState={{ pagination: { paginationModel: { pageSize: 50 } } }}
-        onColumnOrderChange={(params) => {
-          setColumnOrder(params.column.field, params.targetIndex - 1);
-        }}
-        onColumnResize={(params) => {
-          setColumnWidth(params.colDef.field, params.width);
-        }}
-        rows={rows}
-        slotProps={{
-          toolbar: {
-            gridColumns: columnsWithHeaderTitles,
-            onQuickSearchChange: setQuickSearch,
-            onSortModelChange: modelGridProps.onSortModelChange,
-            sortModel: modelGridProps.sortModel,
-          },
-        }}
-        slots={{ toolbar: Toolbar }}
-        {...modelGridProps}
-        {...dataGridProps}
-      />
-    </>
+    <DataGridPro
+      checkboxSelection
+      columns={columnsWithHeaderTitles}
+      disableRowSelectionOnClick={true}
+      initialState={{ pagination: { paginationModel: { pageSize: 50 } } }}
+      onColumnOrderChange={(params) => {
+        setColumnOrder(params.column.field, params.targetIndex - 1);
+      }}
+      onColumnResize={(params) => {
+        setColumnWidth(params.colDef.field, params.width);
+      }}
+      rows={rows}
+      slotProps={{
+        toolbar: {
+          gridColumns: columnsWithHeaderTitles,
+          onQuickSearchChange: setQuickSearch,
+          onSortModelChange: modelGridProps.onSortModelChange,
+          sortModel: modelGridProps.sortModel,
+        },
+      }}
+      slots={{ toolbar: Toolbar }}
+      {...modelGridProps}
+      {...dataGridProps}
+    />
   );
 };
 

--- a/src/features/smartSearch/components/filters/CallBlocked/index.tsx
+++ b/src/features/smartSearch/components/filters/CallBlocked/index.tsx
@@ -57,7 +57,6 @@ const CallBlocked = ({
       disableSubmit={!submittable}
       onCancel={onCancel}
       onSubmit={(e) => handleSubmit(e)}
-      renderExamples={() => <></>}
       renderSentence={() => (
         <Msg
           id={localMessageIds.inputString}

--- a/src/features/smartSearch/components/filters/PersonField/DisplayPersonField.tsx
+++ b/src/features/smartSearch/components/filters/PersonField/DisplayPersonField.tsx
@@ -20,7 +20,7 @@ interface DisplayPersonFieldProps {
 
 const DisplayPersonField = ({
   filter,
-}: DisplayPersonFieldProps): JSX.Element => {
+}: DisplayPersonFieldProps): JSX.Element | null => {
   const { orgId } = useNumericRouteParams();
   const fields = useCustomFields(orgId).data ?? [];
   const { config } = filter;
@@ -37,7 +37,7 @@ const DisplayPersonField = ({
   const fieldType = field?.type || '';
   if (fieldType != 'date' && fieldType != 'text' && fieldType != 'url') {
     // TODO:
-    return <></>;
+    return null;
   }
 
   return (

--- a/src/features/smartSearch/components/filters/PersonField/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonField/index.tsx
@@ -115,7 +115,7 @@ const PersonField = ({
     });
   };
 
-  function getFieldInput(type: CUSTOM_FIELD_TYPE | null): JSX.Element {
+  function getFieldInput(type?: CUSTOM_FIELD_TYPE | null): JSX.Element {
     const fieldSelect = selectedField ? (
       <StyledSelect
         onChange={(e) => handleFieldChange(e.target.value)}
@@ -143,7 +143,9 @@ const PersonField = ({
     );
 
     if (!type || type == CUSTOM_FIELD_TYPE.JSON) {
-      // Not relevant
+      // TODO: If this case is not relevant error handle it
+      // Using null here causes a type error for FilterForm
+      // eslint-disable-next-line react/jsx-no-useless-fragment
       return <></>;
     } else {
       if (type == CUSTOM_FIELD_TYPE.DATE) {
@@ -205,7 +207,6 @@ const PersonField = ({
       disableSubmit={!submittable}
       onCancel={onCancel}
       onSubmit={(e) => handleSubmit(e)}
-      renderExamples={() => <></>}
       renderSentence={() => (
         <Msg
           id={localMessageIds.inputString}
@@ -222,7 +223,7 @@ const PersonField = ({
                 ))}
               </StyledSelect>
             ),
-            field: getFieldInput(selectedField?.type ?? null),
+            field: getFieldInput(selectedField?.type),
           }}
         />
       )}

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -181,7 +181,9 @@ const SubQuery = ({
                       </MenuItem>
                     </StyledSelect>
                   ),
-                  titleSelect: <></>, // Not actually used, but required for interface consistency
+                  // Not actually used, but required for interface consistency
+                  // eslint-disable-next-line react/jsx-no-useless-fragment
+                  titleSelect: <></>,
                 }}
               />
             ) : (

--- a/src/features/surveys/components/SubmissionWarningAlert.tsx
+++ b/src/features/surveys/components/SubmissionWarningAlert.tsx
@@ -26,7 +26,7 @@ const SubmissionWarningAlert = ({
         const unlinkedSubs = sub.unlinkedSubmissionCount;
 
         if (unlinkedSubs === 0) {
-          return <></>;
+          return null;
         }
 
         return (

--- a/src/features/surveys/components/SurveyEditor/index.tsx
+++ b/src/features/surveys/components/SurveyEditor/index.tsx
@@ -136,7 +136,7 @@ const SurveyEditor: FC<SurveyEditorProps> = ({ orgId, readOnly, surveyId }) => {
                     }
 
                     // Only required to satisfy typescript. Should never happen.
-                    return <></>;
+                    return null;
                   },
                 }))}
                 onReorder={(ids) => {

--- a/src/features/surveys/components/SurveySuborgsCard.tsx
+++ b/src/features/surveys/components/SurveySuborgsCard.tsx
@@ -32,9 +32,7 @@ const SurveySuborgsCard = ({
           />
         }
         subheader={messages.shareSuborgsCard.caption()}
-      >
-        <></>
-      </ZUICard>
+      />
     </Box>
   );
 };

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -27,35 +27,31 @@ const SurveyUnlinkedCard = ({
       {(sub) => {
         const unlinkedSubmitters = sub.unlinkedSubmissionCount;
 
-        return (
-          <>
-            {unlinkedSubmitters > 0 && (
-              <Box paddingTop={2}>
-                <ZUICard
-                  header={messages.unlinkedCard.header()}
-                  status={
-                    <ZUINumberChip
-                      color={theme.palette.grey[200]}
-                      value={unlinkedSubmitters}
-                    />
-                  }
-                  subheader={messages.unlinkedCard.description()}
-                >
-                  <NextLink
-                    href={`/organize/${orgId}/projects/${campId}/surveys/${surveyId}/submissions?filter=linked`}
-                    passHref
-                  >
-                    <Link>
-                      {messages.unlinkedCard.openLink({
-                        numUnlink: unlinkedSubmitters,
-                      })}
-                    </Link>
-                  </NextLink>
-                </ZUICard>
-              </Box>
-            )}
-          </>
-        );
+        return unlinkedSubmitters > 0 ? (
+          <Box paddingTop={2}>
+            <ZUICard
+              header={messages.unlinkedCard.header()}
+              status={
+                <ZUINumberChip
+                  color={theme.palette.grey[200]}
+                  value={unlinkedSubmitters}
+                />
+              }
+              subheader={messages.unlinkedCard.description()}
+            >
+              <NextLink
+                href={`/organize/${orgId}/projects/${campId}/surveys/${surveyId}/submissions?filter=linked`}
+                passHref
+              >
+                <Link>
+                  {messages.unlinkedCard.openLink({
+                    numUnlink: unlinkedSubmitters,
+                  })}
+                </Link>
+              </NextLink>
+            </ZUICard>
+          </Box>
+        ) : null;
       }}
     </ZUIFuture>
   );

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType.tsx
@@ -102,7 +102,7 @@ const Cell: FC<{
   const [isRestricted] = useAccessLevel();
 
   if (cell?.value_type != null) {
-    return <>{cell.value}</>;
+    return <span>{cell.value}</span>;
   } else if (cell) {
     return (
       <TagChip

--- a/src/features/views/components/ViewJumpMenu.tsx
+++ b/src/features/views/components/ViewJumpMenu.tsx
@@ -131,44 +131,46 @@ const ViewJumpMenu: FunctionComponent = () => {
         }}
       >
         <ZUIFuture future={itemsFuture}>
-          <Box {...getRootProps()} p={1}>
-            <TextField
-              {...tfProps}
-              autoFocus={true}
-              color="primary"
-              fullWidth
-              placeholder={messages.viewLayout.jumpMenu.placeholder()}
-              size="small"
-              variant="outlined"
-            />
-          </Box>
-          <List
-            {...getListboxProps()}
-            ref={listRef}
-            dense
-            style={{ overflowY: 'scroll' }}
-          >
-            {options.map((view, idx) => {
-              return (
-                <Link
-                  key={view.id}
-                  href={{
-                    pathname: `/organize/${orgId}/people/lists/${view.id}`,
-                  }}
-                  passHref
-                >
-                  <ListItem
-                    button
-                    component="a"
-                    selected={idx == activeIndex}
-                    tabIndex={-1}
+          <>
+            <Box {...getRootProps()} p={1}>
+              <TextField
+                {...tfProps}
+                autoFocus={true}
+                color="primary"
+                fullWidth
+                placeholder={messages.viewLayout.jumpMenu.placeholder()}
+                size="small"
+                variant="outlined"
+              />
+            </Box>
+            <List
+              {...getListboxProps()}
+              ref={listRef}
+              dense
+              style={{ overflowY: 'scroll' }}
+            >
+              {options.map((view, idx) => {
+                return (
+                  <Link
+                    key={view.id}
+                    href={{
+                      pathname: `/organize/${orgId}/people/lists/${view.id}`,
+                    }}
+                    passHref
                   >
-                    <ListItemText>{view.title}</ListItemText>
-                  </ListItem>
-                </Link>
-              );
-            })}
-          </List>
+                    <ListItem
+                      button
+                      component="a"
+                      selected={idx == activeIndex}
+                      tabIndex={-1}
+                    >
+                      <ListItemText>{view.title}</ListItemText>
+                    </ListItem>
+                  </Link>
+                );
+              })}
+            </List>
+          </>
         </ZUIFuture>
       </Popover>
     </>

--- a/src/features/views/hooks/useAccessLevel.tsx
+++ b/src/features/views/hooks/useAccessLevel.tsx
@@ -8,7 +8,7 @@ const AccessLevelContext = createContext<UseAccessLevelReturn>([false, null]);
 
 type AccessLevelProviderProps = {
   accessLevel?: ZetkinObjectAccess['level'] | null;
-  children: JSX.Element;
+  children: JSX.Element | null;
   isRestricted?: boolean;
 };
 

--- a/src/features/views/layout/SharedViewLayout.tsx
+++ b/src/features/views/layout/SharedViewLayout.tsx
@@ -49,7 +49,9 @@ const SharedViewLayout: FunctionComponent<SharedViewLayoutProps> = ({
   const viewFuture = useView(orgId, viewId);
 
   const title = (
-    <ZUIFuture future={viewFuture}>{(view) => <>{view.title}</>}</ZUIFuture>
+    <ZUIFuture future={viewFuture}>
+      {(view) => <span>{view.title}</span>}
+    </ZUIFuture>
   );
   const subtitle = (
     // TODO: Replace with model eventually

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -67,32 +67,30 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   }
 
   const title = (
-    <>
-      <ZUIFuture future={viewFuture}>
-        {(view) => {
-          return (
-            <Box>
-              <ZUIEditTextinPlace
-                key={view.id}
-                onChange={(newTitle) => {
-                  try {
-                    updateView(viewId, { title: newTitle });
-                    showSnackbar(
-                      'success',
-                      messages.editViewTitleAlert.success()
-                    );
-                  } catch (err) {
-                    showSnackbar('error', messages.editViewTitleAlert.error());
-                  }
-                }}
-                value={view?.title}
-              />
-              <ViewJumpMenu />
-            </Box>
-          );
-        }}
-      </ZUIFuture>
-    </>
+    <ZUIFuture future={viewFuture}>
+      {(view) => {
+        return (
+          <Box>
+            <ZUIEditTextinPlace
+              key={view.id}
+              onChange={(newTitle) => {
+                try {
+                  updateView(viewId, { title: newTitle });
+                  showSnackbar(
+                    'success',
+                    messages.editViewTitleAlert.success()
+                  );
+                } catch (err) {
+                  showSnackbar('error', messages.editViewTitleAlert.error());
+                }
+              }}
+              value={view?.title}
+            />
+            <ViewJumpMenu />
+          </Box>
+        );
+      }}
+    </ZUIFuture>
   );
 
   const ellipsisMenu: ZUIEllipsisMenuProps['items'] = [];

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -67,7 +67,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   const router = useRouter();
   const { lang, messages, ...restProps } = pageProps;
   const c = Component as PageWithLayout;
-  const getLayout = c.getLayout || ((page) => <>{page}</>);
+  const getLayout = c.getLayout || ((page) => page);
 
   if (typeof window !== 'undefined') {
     window.__reactRendered = true;

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -93,11 +93,9 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
           </Head>
 
           <AccessLevelProvider>
-            <>
-              {(!columnsFuture.isLoading || !!columnsFuture.data?.length) && (
-                <ViewDataTable columns={cols} rows={rows} view={view} />
-              )}
-            </>
+            {!columnsFuture.isLoading || !!columnsFuture.data?.length ? (
+              <ViewDataTable columns={cols} rows={rows} view={view} />
+            ) : null}
           </AccessLevelProvider>
         </>
       )}

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -116,17 +116,15 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
             <title>{view.title}</title>
           </Head>
           <AccessLevelProvider accessLevel={accessLevel} isRestricted={true}>
-            <>
-              {!columnsFuture.isLoading && (
-                <ViewDataTable
-                  columns={cols}
-                  disableBulkActions
-                  disableConfigure={!canConfigure}
-                  rows={rows}
-                  view={view}
-                />
-              )}
-            </>
+            {!columnsFuture.isLoading ? (
+              <ViewDataTable
+                columns={cols}
+                disableBulkActions
+                disableConfigure={!canConfigure}
+                rows={rows}
+                view={view}
+              />
+            ) : null}
           </AccessLevelProvider>
         </>
       )}

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
@@ -75,13 +75,9 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
                   );
                 }
               }
-              return (
-                <>
-                  {(submissions.length !== 0 || !showUnlinkedOnly) && (
-                    <SurveySubmissionsList submissions={submissions} />
-                  )}
-                </>
-              );
+              return submissions.length !== 0 || !showUnlinkedOnly ? (
+                <SurveySubmissionsList submissions={submissions} />
+              ) : null;
             }}
           </ZUIFuture>
         </Grid>

--- a/src/zui/ZUICard/index.tsx
+++ b/src/zui/ZUICard/index.tsx
@@ -2,7 +2,7 @@ import { Box, Card, Typography } from '@mui/material';
 import { FC, ReactNode } from 'react';
 
 type ZUICardProps = {
-  children: ReactNode;
+  children?: ReactNode;
   header: string | JSX.Element;
   status?: ReactNode;
   subheader?: string;

--- a/src/zui/ZUIDate/index.tsx
+++ b/src/zui/ZUIDate/index.tsx
@@ -6,14 +6,7 @@ interface ZUIDateProps {
 
 const ZUIDate: React.FunctionComponent<ZUIDateProps> = ({ datetime }) => {
   return (
-    <>
-      <FormattedDate
-        day="numeric"
-        month="long"
-        value={datetime}
-        year="numeric"
-      />
-    </>
+    <FormattedDate day="numeric" month="long" value={datetime} year="numeric" />
   );
 };
 

--- a/src/zui/ZUIFuture/index.tsx
+++ b/src/zui/ZUIFuture/index.tsx
@@ -1,15 +1,15 @@
+import { FC } from 'react';
 import { Skeleton } from '@mui/material';
-import { FC, ReactNode } from 'react';
 
 import { IFuture } from 'core/caching/futures';
 
 type ZUIFutureBuilderFunc<DataType> = (
   data: DataType,
   isLoading: boolean
-) => JSX.Element;
+) => JSX.Element | null;
 
 interface ZUIFutureProps<DataType> {
-  children: ReactNode | null | ZUIFutureBuilderFunc<DataType>;
+  children: JSX.Element | null | ZUIFutureBuilderFunc<DataType>;
   future: IFuture<DataType>;
   ignoreDataWhileLoading?: boolean;
   skeleton?: JSX.Element;
@@ -37,7 +37,7 @@ function ZUIFuture<DataType>({
     if (typeof children == 'function') {
       return children(future.data, future.isLoading);
     } else {
-      return <>{children}</>;
+      return children;
     }
   } else if (future.isLoading) {
     return skeleton;

--- a/src/zui/ZUIFutures/index.tsx
+++ b/src/zui/ZUIFutures/index.tsx
@@ -9,7 +9,7 @@ import messageIds from 'zui/l10n/messageIds';
 
 interface ZUIFuturesProps<G extends Record<string, unknown>> {
   children?:
-    | React.ReactNode
+    | JSX.Element
     | (({
         data,
       }: {
@@ -65,11 +65,9 @@ function ZUIFutures<G extends Record<string, unknown>>({
   });
 
   // Render children if query resolves successfully
-  return typeof children === 'function' ? (
-    children({ data: dataObjects as { [I in keyof G]: G[I] } }) // Expose the successfully resolved query if children is a function
-  ) : (
-    <>{children || null}</>
-  ); // Otherwise render children
+  return typeof children === 'function'
+    ? children({ data: dataObjects as { [I in keyof G]: G[I] } }) // Expose the successfully resolved query if children is a function
+    : children || null; // Otherwise render children
 }
 
 export default ZUIFutures;

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -164,77 +164,75 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 <Avatar alt="icon" src={`/api/orgs/${orgId}/avatar`} />
               )}
               <ZUIFuture future={organizationFuture}>
-                {(data) => (
-                  <>
-                    {open && (
-                      <>
-                        <Box
-                          sx={{
-                            alignItems: 'center',
-                            display: 'flex',
-                          }}
-                        >
-                          {!showOrgSwitcher && (
-                            <>
-                              <Box
-                                sx={{
-                                  display: 'flex',
-                                  justifyContent: 'center',
-                                  width: '48px',
-                                }}
-                              >
-                                {hover ? (
-                                  <IconButton onClick={handleClick}>
-                                    <KeyboardDoubleArrowLeftOutlined />
-                                  </IconButton>
-                                ) : (
-                                  <Avatar
-                                    alt="icon"
-                                    src={`/api/orgs/${orgId}/avatar`}
-                                  />
-                                )}
-                              </Box>
-                              <Typography variant="h6">{data.title}</Typography>
-                            </>
-                          )}
-
-                          {showOrgSwitcher && (
-                            <TextField
-                              fullWidth
-                              InputProps={{
-                                endAdornment:
-                                  searchString.length > 0 ? (
-                                    <Close
-                                      color="secondary"
-                                      onClick={() => setSearchString('')}
-                                      sx={{ cursor: 'pointer' }}
-                                    />
-                                  ) : (
-                                    ''
-                                  ),
-                                startAdornment: (
-                                  <FilterListOutlined
-                                    color="secondary"
-                                    sx={{ marginRight: '0.5em' }}
-                                  />
-                                ),
+                {(data) =>
+                  open ? (
+                    <>
+                      <Box
+                        sx={{
+                          alignItems: 'center',
+                          display: 'flex',
+                        }}
+                      >
+                        {!showOrgSwitcher && (
+                          <>
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                width: '48px',
                               }}
-                              onChange={(e) => setSearchString(e.target.value)}
-                              placeholder={messages.organizeSidebar.filter()}
-                              value={searchString}
-                            />
-                          )}
-                        </Box>
+                            >
+                              {hover ? (
+                                <IconButton onClick={handleClick}>
+                                  <KeyboardDoubleArrowLeftOutlined />
+                                </IconButton>
+                              ) : (
+                                <Avatar
+                                  alt="icon"
+                                  src={`/api/orgs/${orgId}/avatar`}
+                                />
+                              )}
+                            </Box>
+                            <Typography variant="h6">{data.title}</Typography>
+                          </>
+                        )}
 
-                        <Box sx={{ display: open ? 'flex' : 'none' }}>
-                          <IconButton onClick={handleExpansion}>
-                            {checked ? <ExpandLess /> : <ExpandMore />}
-                          </IconButton>
-                        </Box>
-                      </>
-                    )}
-                  </>
-                )}
+                        {showOrgSwitcher && (
+                          <TextField
+                            fullWidth
+                            InputProps={{
+                              endAdornment:
+                                searchString.length > 0 ? (
+                                  <Close
+                                    color="secondary"
+                                    onClick={() => setSearchString('')}
+                                    sx={{ cursor: 'pointer' }}
+                                  />
+                                ) : (
+                                  ''
+                                ),
+                              startAdornment: (
+                                <FilterListOutlined
+                                  color="secondary"
+                                  sx={{ marginRight: '0.5em' }}
+                                />
+                              ),
+                            }}
+                            onChange={(e) => setSearchString(e.target.value)}
+                            placeholder={messages.organizeSidebar.filter()}
+                            value={searchString}
+                          />
+                        )}
+                      </Box>
+
+                      <Box sx={{ display: open ? 'flex' : 'none' }}>
+                        <IconButton onClick={handleExpansion}>
+                          {checked ? <ExpandLess /> : <ExpandMore />}
+                        </IconButton>
+                      </Box>
+                    </>
+                  ) : null
+                }
               </ZUIFuture>
             </Box>
             {checked && (

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -266,9 +266,7 @@ const ZUIPersonGridEditCell: FC<{
             )}
           </Paper>
         </Popper>
-      ) : (
-        <></>
-      )}
+      ) : null}
     </Box>
   );
 };

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -21,7 +21,7 @@ export type ZUIReorderableRenderProps = {
 type ReorderableItem = {
   hidden?: boolean;
   id: IDType;
-  renderContent: (props: ZUIReorderableRenderProps) => JSX.Element;
+  renderContent: (props: ZUIReorderableRenderProps) => JSX.Element | null;
 };
 
 export enum ZUIReorderableWidget {

--- a/src/zui/ZUISuffixedNumber/index.tsx
+++ b/src/zui/ZUISuffixedNumber/index.tsx
@@ -20,7 +20,7 @@ const ZUISuffixedNumber: FC<ZUISuffixedNumberProps> = ({ number }) => {
     );
   }
 
-  return <>{number}</>;
+  return <span>{number}</span>;
 };
 
 export default ZUISuffixedNumber;

--- a/src/zui/ZUITimeline/TimelineActor.tsx
+++ b/src/zui/ZUITimeline/TimelineActor.tsx
@@ -10,13 +10,11 @@ const TimelineActor: React.FunctionComponent<{
   size: number;
 }> = ({ actor, size }) => {
   return (
-    <>
-      <Grid item>
-        <ZUIPersonHoverCard personId={actor.id}>
-          <ZUIPerson id={actor.id} name={''} showText={false} size={size} />
-        </ZUIPersonHoverCard>
-      </Grid>
-    </>
+    <Grid item>
+      <ZUIPersonHoverCard personId={actor.id}>
+        <ZUIPerson id={actor.id} name={''} showText={false} size={size} />
+      </ZUIPersonHoverCard>
+    </Grid>
   );
 };
 

--- a/src/zui/ZUITimeline/updates/elements/UpdateContainer.tsx
+++ b/src/zui/ZUITimeline/updates/elements/UpdateContainer.tsx
@@ -29,11 +29,9 @@ const UpdateContainer: React.FC<UpdateContainerProps> = ({
       <UpdateHeader timestamp={update.timestamp}>{headerContent}</UpdateHeader>
       {actionButton || null}
       {children && (
-        <>
-          <div style={{ gridColumn: '2 / end', overflowWrap: 'anywhere' }}>
-            {children}
-          </div>
-        </>
+        <div style={{ gridColumn: '2 / end', overflowWrap: 'anywhere' }}>
+          {children}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Description
This PR adds the eslint rule Disallow unnecessary fragments (`react/jsx-no-useless-fragment`)
And refactors any instances where this is the case. 

I chose to render `null` in a lot of cases where we were rendering empty fragments; see philosophy here https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx

In cases where Fragments were essentially serving to change type from a ReactNode to a JSX.Element (strings or numbers), I wrapped these in <span> tags instead. 

⚠️ The integration test `tests/organize/tags/add.spec.ts `seems flaky. It's failing locally but was also failing locally on a clean `main`
Closes #1298 

## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
* Changes…


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #[id]
