### PR TITLE
issue 1609/covered tooltip

### DIFF
--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -75,7 +75,7 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
           },
         ]}
         open={open}
-        style={{ zIndex: 9999 }}
+        style={{ zIndex: 1300 }}
         {...popperProps}
       >
         {person && (


### PR DESCRIPTION
## Description
This PR fixes a bug that tooltip of tags are blocked by event popper.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/bfbbb56d-aaf0-4705-9744-f1069c63bcd9)



## Changes

* Changes `zIndex` in `Popper`


## Notes to reviewer


## Related issues
Resolves #1609 
