### PR TITLE
remove config to prevent error when adding assigned person column

### DIFF
--- a/src/features/views/components/ViewColumnDialog/choices/misc.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices/misc.tsx
@@ -73,9 +73,6 @@ export const localPerson: ColumnChoice = {
   color: blue,
   defaultColumns: (messages, columns) => [
     {
-      config: {
-        field: COLUMN_TYPE.LOCAL_PERSON,
-      },
       title: getUniqueColumnName(
         messages.columnDialog.choices.localPerson.columnTitle(),
         columns


### PR DESCRIPTION
## Description
This PR…


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/6b21d039-40c9-47d1-b2e5-8027a1d20669



## Changes

* Removes key `config` in default columns


## Notes to reviewer


## Related issues
Resolves #1583 
