### PR TITLE
issue 1590/remove json type fields

### DIFF
--- a/src/features/views/components/ViewColumnDialog/PersonFieldConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/PersonFieldConfig.tsx
@@ -46,7 +46,7 @@ const PersonFieldConfig = ({
 
   const fields: Field[] = [];
 
-  customFields.map((field) => {
+  customFields.forEach((field) => {
     if (field.type !== 'json') {
       fields.push({
         slug: field.slug,


### PR DESCRIPTION
## Description
This PR fixes a bug where it displays JSON data to cell as "[object object]".


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/15cbb610-f33d-4f7b-b052-91f6c23bc526


## Changes


* Adds if condition for filtering field type "json"

## Notes to reviewer
Extra text of Casey warren is "[object object]" because the its value is literally "[object object]" 
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/0b64a19b-41bb-4d4f-b233-37c23e497fc7)


## Related issues
Resolves #1590 
