### PR TITLE
Set exported booleans to either 'Yes' or blank

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -22,7 +22,7 @@ import messageIds from 'features/views/l10n/messageIds';
 
 export default class LocalBoolColumnType implements IColumnType {
   cellToString(cell: boolean | null): string {    
-    if (cell == true) {
+    if (cell === true) {
       return messageIds.shareDialog.download.local_bool._defaultMessage;
     } else {
       return '';

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -21,9 +21,9 @@ import useViewGrid, {
 import messageIds from 'features/views/l10n/messageIds';
 
 export default class LocalBoolColumnType implements IColumnType {
-  cellToString(cell: boolean | null): string {    
+  cellToString(cell: boolean | null): string {
     if (cell === true) {
-      return messageIds.shareDialog.download.local_bool._defaultMessage;
+      return messageIds.shareDialog.download.true_bool._defaultMessage;
     } else {
       return '';
     }

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -18,9 +18,15 @@ import useViewGrid, {
   UseViewGridReturn,
 } from 'features/views/hooks/useViewGrid';
 
+import messageIds from 'features/views/l10n/messageIds';
+
 export default class LocalBoolColumnType implements IColumnType {
-  cellToString(cell: boolean | null): string {
-    return String(!!cell);
+  cellToString(cell: boolean | null): string {    
+    if (cell == true) {
+      return messageIds.shareDialog.download.local_bool._defaultMessage;
+    } else {
+      return '';
+    }
   }
 
   getColDef(column: LocalBoolViewColumn): Omit<GridColDef, 'field'> {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
@@ -14,7 +14,11 @@ export default class LocalQueryColumnType
   implements IColumnType<ZetkinViewColumn, LocalQueryViewCell>
 {
   cellToString(cell: LocalQueryViewCell): string {
-    return cell ? cell.toString() : '';
+    if (cell === true) {
+      return messageIds.shareDialog.download.true_bool._defaultMessage;
+    } else {
+      return '';
+    }
   }
 
   getColDef(): Omit<GridColDef, 'field'> {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalQueryColumnType.tsx
@@ -8,6 +8,8 @@ import SmartSearchDialog from 'features/smartSearch/components/SmartSearchDialog
 import theme from '../../../../../theme';
 import { LocalQueryViewColumn, ZetkinViewColumn } from '../../types';
 
+import messageIds from 'features/views/l10n/messageIds';
+
 type LocalQueryViewCell = boolean | null;
 
 export default class LocalQueryColumnType

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -27,7 +27,9 @@ export default class SurveyOptionColumnType
 {
   cellToString(cell: SurveyOptionViewCell): string {
     const pickedThisOption = cell?.filter((submission) => submission.selected);
-    return pickedThisOption?.length ? pickedThisOption[0].submitted : '';
+    return pickedThisOption?.length
+      ? messageIds.shareDialog.download.local_bool._defaultMessage
+      : '';
   }
 
   getColDef(): Omit<GridColDef<SurveyOptionViewColumn>, 'field'> {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -28,7 +28,7 @@ export default class SurveyOptionColumnType
   cellToString(cell: SurveyOptionViewCell): string {
     const pickedThisOption = cell?.filter((submission) => submission.selected);
     return pickedThisOption?.length
-      ? messageIds.shareDialog.download.local_bool._defaultMessage
+      ? messageIds.shareDialog.download.true_bool._defaultMessage
       : '';
   }
 

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -342,7 +342,7 @@ export default makeMessages('feat.views', {
         csv: m('Download CSV file'),
         xlsx: m('Download Excel file'),
       },
-      local_bool: m('Yes'),
+      true_bool: m('Yes'),
       shareLink: m('share data securely'),
       tabLabel: m('Download'),
       warning1: m(

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -342,9 +342,9 @@ export default makeMessages('feat.views', {
         csv: m('Download CSV file'),
         xlsx: m('Download Excel file'),
       },
-      true_bool: m('Yes'),
       shareLink: m('share data securely'),
       tabLabel: m('Download'),
+      true_bool: m('Yes'),
       warning1: m(
         'Avoid exporting data from Zetkin when you can, to ensure that all data is kept in order.'
       ),

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -350,6 +350,7 @@ export default makeMessages('feat.views', {
       warning2: m<{ shareLink: ReactElement }>(
         'You can {shareLink} within Zetkin. Exporting makes sense when you want to copy data to another system.'
       ),
+      local_bool: m('Yes'),
     },
     share: {
       addPlaceholder: m('Add collaborator'),

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -342,6 +342,7 @@ export default makeMessages('feat.views', {
         csv: m('Download CSV file'),
         xlsx: m('Download Excel file'),
       },
+      local_bool: m('Yes'),
       shareLink: m('share data securely'),
       tabLabel: m('Download'),
       warning1: m(
@@ -350,7 +351,6 @@ export default makeMessages('feat.views', {
       warning2: m<{ shareLink: ReactElement }>(
         'You can {shareLink} within Zetkin. Exporting makes sense when you want to copy data to another system.'
       ),
-      local_bool: m('Yes'),
     },
     share: {
       addPlaceholder: m('Add collaborator'),


### PR DESCRIPTION
## Description
This PR changes the 'true / false' values in exported Excel or CSV files to 'yes' or blank. 


## Screenshots
<img width="399" alt="Screenshot 2023-12-10 at 12 21 00" src="https://github.com/zetkin/app.zetkin.org/assets/9819978/8be14492-b787-40a5-a464-6eec9c1b9475">


## Changes
- [X] if 'true' then 'local_bool', else '<blank>'
- [ ] Fix bad localization implementation. Currently hardcoded to `_defaultMessage`. 
- [x] Fix for 'Is In SmartSearch' column; currently it's still true / false. 
![Screenshot 2023-12-10 at 12 12 01](https://github.com/zetkin/app.zetkin.org/assets/9819978/18c5f876-0ac5-4c11-a0fb-94259f713b8f)
<img width="463" alt="Screenshot 2023-12-10 at 12 12 05" src="https://github.com/zetkin/app.zetkin.org/assets/9819978/500fb91d-f5c7-4762-93d0-011ca402d4f1">


## Notes to reviewer


## Related issues
Resolves #1663 
