### PR TITLE
Add test coverage for survey API submission code

### DIFF
--- a/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
+++ b/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
@@ -1,0 +1,61 @@
+import prepareSurveyApiSubmission from './prepareSurveyApiSubmission';
+
+describe('prepareSurveyApiSubmission()', () => {
+  let formData: NodeJS.Dict<string | string[]>;
+
+  beforeEach(() => {
+    formData = {};
+  });
+
+  it('formats a text response', () => {
+    formData['123.text'] = 'Lorem ipsum dolor sit amet';
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.responses).toMatchObject([
+      {
+        question_id: 123,
+        response: 'Lorem ipsum dolor sit amet',
+      },
+    ]);
+  });
+
+  it('formats a radio button response', () => {
+    formData['123.options'] = '456';
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.responses).toMatchObject([
+      {
+        options: [456],
+        question_id: 123,
+      },
+    ]);
+  });
+
+  it('formats a checkbox response', () => {
+    formData['123.options'] = ['456', '789'];
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.responses).toMatchObject([
+      {
+        options: [456, 789],
+        question_id: 123,
+      },
+    ]);
+  });
+
+  it('signs as the logged-in account when a logged-in user requests to sign as themself', () => {
+    formData['sig'] = 'user';
+    const submission = prepareSurveyApiSubmission(formData, true);
+    expect(submission.signature).toEqual('user');
+  });
+
+  it('signs with custom contact details when a name and email are given', () => {
+    formData['sig'] = 'email';
+    formData['sig.email'] = 'testuser@example.org';
+    formData['sig.first_name'] = 'test';
+    formData['sig.last_name'] = 'user';
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.signature).toMatchObject({
+      email: 'testuser@example.org',
+      first_name: 'test',
+      last_name: 'user',
+    });
+  });
+});

--- a/src/features/surveys/utils/prepareSurveyApiSubmission.ts
+++ b/src/features/surveys/utils/prepareSurveyApiSubmission.ts
@@ -1,0 +1,63 @@
+import {
+  ZetkinSurveyApiSubmission,
+  ZetkinSurveyQuestionResponse,
+  ZetkinSurveySignaturePayload,
+} from 'utils/types/zetkin';
+
+export default function prepareSurveyApiSubmission(
+  formData: NodeJS.Dict<string | string[]>,
+  isLoggedIn?: boolean
+): ZetkinSurveyApiSubmission {
+  const responses: ZetkinSurveyQuestionResponse[] = [];
+  const responseEntries = Object.fromEntries(
+    Object.entries(formData).filter(([name]) =>
+      name.match(/^[0-9]+\.(options|text)$/)
+    )
+  );
+
+  for (const name in responseEntries) {
+    const value = responseEntries[name];
+    const fields = name.split('.');
+    const [id, type] = fields;
+
+    if (type == 'text') {
+      responses.push({
+        question_id: parseInt(id),
+        response: value as string,
+      });
+    }
+
+    if (type === 'options' && typeof value === 'string') {
+      responses.push({
+        options: [parseInt(value, 10)],
+        question_id: parseInt(id, 10),
+      });
+    }
+
+    if (type === 'options' && Array.isArray(value)) {
+      responses.push({
+        options: value.map((o) => parseInt(o, 10)),
+        question_id: parseInt(id, 10),
+      });
+    }
+  }
+
+  let signature: ZetkinSurveySignaturePayload = null;
+
+  if (formData.sig === 'user' && isLoggedIn) {
+    signature = 'user';
+  }
+
+  if (formData.sig == 'email') {
+    signature = {
+      email: formData['sig.email'] as string,
+      first_name: formData['sig.first_name'] as string,
+      last_name: formData['sig.last_name'] as string,
+    };
+  }
+
+  return {
+    responses,
+    signature,
+  };
+}

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -284,6 +284,11 @@ export type ZetkinSurveyFormStatus =
   | 'error'
   | 'submitted';
 
+export type ZetkinSurveyApiSubmission = {
+  responses: ZetkinSurveyQuestionResponse[];
+  signature: ZetkinSurveySignaturePayload;
+};
+
 export enum RESPONSE_TYPE {
   OPTIONS = 'options',
   TEXT = 'text',


### PR DESCRIPTION
The survey API submission code in https://github.com/zetkin/app.zetkin.org/pull/1636 that we copied from [`survey.js`](https://github.com/zetkin/www.zetk.in/blob/master/src/server/forms/survey.js) over in zetkin/www.zetk.in seems important, and also a nice easy target for some unit tests. Could also be nice to get another load-bearing part of the survey page outside the blast radius of the app router migration.

<img width="1170" alt="Screenshot 2023-12-10 at 21 33 37" src="https://github.com/zetkin/app.zetkin.org/assets/566159/1dc42c9a-96af-4aaf-889d-d51d8431888f">