### PR TITLE
sub_query Smart Search filter crashes if org has no smart searches yet.

### DIFF
--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -127,143 +127,151 @@ const SubQuery = ({
           <Msg id={localMessageIds.examples.two} />
         </>
       )}
-      renderSentence={() => (
-        <Msg
-          id={localMessageIds.inputString}
-          values={{
-            addRemoveSelect: (
-              <StyledSelect
-                onChange={(e) => setOp(e.target.value as OPERATION)}
-                value={filter.op}
-              >
-                {Object.values(OPERATION).map((o) => (
-                  <MenuItem key={o} value={o}>
-                    <Msg id={messageIds.operators[o]} />
+      renderSentence={() =>
+        queries.length == 0 ? (
+          <Msg id={messageIds.filters.subQuery.noSmartSearches} />
+        ) : (
+          <Msg
+            id={localMessageIds.inputString}
+            values={{
+              addRemoveSelect: (
+                <StyledSelect
+                  onChange={(e) => setOp(e.target.value as OPERATION)}
+                  value={filter.op}
+                >
+                  {Object.values(OPERATION).map((o) => (
+                    <MenuItem key={o} value={o}>
+                      <Msg id={messageIds.operators[o]} />
+                    </MenuItem>
+                  ))}
+                </StyledSelect>
+              ),
+              matchSelect: (
+                <StyledSelect
+                  onChange={(e) =>
+                    handleMatchOperatorChange(e.target.value as IN_OPERATOR)
+                  }
+                  value={operator || IN_OPERATOR.IN}
+                >
+                  <MenuItem key={IN_OPERATOR.IN} value={IN_OPERATOR.IN}>
+                    <Msg id={messageIds.filters.subQuery.matchSelect.in} />
                   </MenuItem>
-                ))}
-              </StyledSelect>
-            ),
-            matchSelect: (
-              <StyledSelect
-                onChange={(e) =>
-                  handleMatchOperatorChange(e.target.value as IN_OPERATOR)
-                }
-                value={operator || IN_OPERATOR.IN}
-              >
-                <MenuItem key={IN_OPERATOR.IN} value={IN_OPERATOR.IN}>
-                  <Msg id={messageIds.filters.subQuery.matchSelect.in} />
-                </MenuItem>
-                <MenuItem key={IN_OPERATOR.NOTIN} value={IN_OPERATOR.NOTIN}>
-                  <Msg id={messageIds.filters.subQuery.matchSelect.notin} />
-                </MenuItem>
-              </StyledSelect>
-            ),
-            query: !selectedQuery ? (
-              <Msg
-                id={localMessageIds.query.edit.none}
-                values={{
-                  querySelect: (
-                    <StyledSelect
-                      SelectProps={{
-                        renderValue: function getLabel() {
-                          return (
-                            <Msg id={localMessageIds.query.selectLabel.none} />
-                          );
-                        },
-                      }}
-                      value={NO_QUERY_SELECTED}
-                    >
-                      <MenuItem
-                        key={NO_QUERY_SELECTED}
+                  <MenuItem key={IN_OPERATOR.NOTIN} value={IN_OPERATOR.NOTIN}>
+                    <Msg id={messageIds.filters.subQuery.matchSelect.notin} />
+                  </MenuItem>
+                </StyledSelect>
+              ),
+              query: !selectedQuery ? (
+                <Msg
+                  id={localMessageIds.query.edit.none}
+                  values={{
+                    querySelect: (
+                      <StyledSelect
+                        SelectProps={{
+                          renderValue: function getLabel() {
+                            return (
+                              <Msg
+                                id={localMessageIds.query.selectLabel.none}
+                              />
+                            );
+                          },
+                        }}
                         value={NO_QUERY_SELECTED}
                       >
-                        <Msg id={localMessageIds.query.selectOptions.none} />
-                      </MenuItem>
-                    </StyledSelect>
-                  ),
-                  titleSelect: <></>, // Not actually used, but required for interface consistency
-                }}
-              />
-            ) : (
-              <Msg
-                id={localMessageIds.query.edit[selectedQuery.type || 'none']}
-                values={{
-                  querySelect: (
-                    <StyledSelect
-                      onChange={(e) =>
-                        handleTypeChange(e.target.value as QUERY_TYPE)
-                      }
-                      SelectProps={{
-                        renderValue: function getLabel(value) {
-                          return (
+                        <MenuItem
+                          key={NO_QUERY_SELECTED}
+                          value={NO_QUERY_SELECTED}
+                        >
+                          <Msg id={localMessageIds.query.selectOptions.none} />
+                        </MenuItem>
+                      </StyledSelect>
+                    ),
+                    titleSelect: <></>, // Not actually used, but required for interface consistency
+                  }}
+                />
+              ) : (
+                <Msg
+                  id={localMessageIds.query.edit[selectedQuery.type || 'none']}
+                  values={{
+                    querySelect: (
+                      <StyledSelect
+                        onChange={(e) =>
+                          handleTypeChange(e.target.value as QUERY_TYPE)
+                        }
+                        SelectProps={{
+                          renderValue: function getLabel(value) {
+                            return (
+                              <Msg
+                                id={
+                                  localMessageIds.query.selectLabel[
+                                    value as QUERY_TYPE
+                                  ]
+                                }
+                              />
+                            );
+                          },
+                        }}
+                        value={selectedQuery.type}
+                      >
+                        {standaloneQueries.length > 0 && (
+                          <MenuItem
+                            key={QUERY_TYPE.STANDALONE}
+                            value={QUERY_TYPE.STANDALONE}
+                          >
                             <Msg
                               id={
-                                localMessageIds.query.selectLabel[
-                                  value as QUERY_TYPE
-                                ]
+                                localMessageIds.query.selectOptions.standalone
                               }
                             />
-                          );
-                        },
-                      }}
-                      value={selectedQuery.type}
-                    >
-                      {standaloneQueries.length && (
-                        <MenuItem
-                          key={QUERY_TYPE.STANDALONE}
-                          value={QUERY_TYPE.STANDALONE}
-                        >
-                          <Msg
-                            id={localMessageIds.query.selectOptions.standalone}
-                          />
-                        </MenuItem>
-                      )}
-                      {targetGroupQueriesWithTitles.length && (
-                        <MenuItem
-                          key={QUERY_TYPE.TARGET}
-                          value={QUERY_TYPE.TARGET}
-                        >
-                          <Msg
-                            id={
-                              localMessageIds.query.selectOptions
-                                .callassignment_target
-                            }
-                          />
-                        </MenuItem>
-                      )}
-                      {purposeGroupQueriesWithTitles.length && (
-                        <MenuItem
-                          key={QUERY_TYPE.PURPOSE}
-                          value={QUERY_TYPE.PURPOSE}
-                        >
-                          <Msg
-                            id={
-                              localMessageIds.query.selectOptions
-                                .callassignment_goal
-                            }
-                          />
-                        </MenuItem>
-                      )}
-                    </StyledSelect>
-                  ),
-                  titleSelect: (
-                    <StyledSelect
-                      onChange={(e) => handleOptionChange(+e.target.value)}
-                      value={selectedQuery.id}
-                    >
-                      {renderedOptions.map((o) => (
-                        <MenuItem key={o.id} value={o.id}>
-                          {o.title}
-                        </MenuItem>
-                      ))}
-                    </StyledSelect>
-                  ),
-                }}
-              />
-            ),
-          }}
-        />
-      )}
+                          </MenuItem>
+                        )}
+                        {targetGroupQueriesWithTitles.length > 0 && (
+                          <MenuItem
+                            key={QUERY_TYPE.TARGET}
+                            value={QUERY_TYPE.TARGET}
+                          >
+                            <Msg
+                              id={
+                                localMessageIds.query.selectOptions
+                                  .callassignment_target
+                              }
+                            />
+                          </MenuItem>
+                        )}
+                        {purposeGroupQueriesWithTitles.length > 0 && (
+                          <MenuItem
+                            key={QUERY_TYPE.PURPOSE}
+                            value={QUERY_TYPE.PURPOSE}
+                          >
+                            <Msg
+                              id={
+                                localMessageIds.query.selectOptions
+                                  .callassignment_goal
+                              }
+                            />
+                          </MenuItem>
+                        )}
+                      </StyledSelect>
+                    ),
+                    titleSelect: (
+                      <StyledSelect
+                        onChange={(e) => handleOptionChange(+e.target.value)}
+                        value={selectedQuery.id}
+                      >
+                        {renderedOptions.map((o) => (
+                          <MenuItem key={o.id} value={o.id}>
+                            {o.title}
+                          </MenuItem>
+                        ))}
+                      </StyledSelect>
+                    ),
+                  }}
+                />
+              ),
+            }}
+          />
+        )
+      }
     />
   );
 };

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -313,6 +313,9 @@ export default makeMessages('feat.smartSearch', {
         in: m('match'),
         notin: m('do not match'),
       },
+      noSmartSearches: m(
+        'There are no Smart Searches in this organisation yet.'
+      ),
       query: {
         edit: {
           callassignment_goal: m<{


### PR DESCRIPTION
## Description
This PR fixes a bug where the UI would crash when rendering the Smart search filter form for `sub_query`, by actually testing if there are queries to select from and if there are none, render a message instead. 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/1d81867e-1a64-45de-8254-45faab86e2af)

## Changes
- Switch out accidentally always truthy conditions with actual condition tests
- Render a message when there are no queries to select from.

## Related issues
Resolves #1690
