### PR TITLE
issue-1686/navigate event

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -17,7 +17,10 @@ import campaignsSlice, {
   campaignDeleted,
   CampaignsStoreSlice,
 } from 'features/campaigns/store';
-import eventsSlice, { EventsStoreSlice } from 'features/events/store';
+import eventsSlice, {
+  eventCreated,
+  EventsStoreSlice,
+} from 'features/events/store';
 import journeysSlice, {
   journeyInstanceCreated,
   JourneysStoreSlice,
@@ -99,6 +102,16 @@ listenerMiddleware.startListening({
     const [callAssignment, campId] = action.payload;
     Router.push(
       `/organize/${callAssignment.organization?.id}/projects/${campId}/callassignments/${callAssignment.id}`
+    );
+  },
+});
+
+listenerMiddleware.startListening({
+  actionCreator: eventCreated,
+  effect: (action) => {
+    const event = action.payload;
+    Router.push(
+      `/organize/${event.organization?.id}/projects/${event.campaign?.id}/events/${event.id}`
     );
   },
 });

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -17,10 +17,7 @@ import campaignsSlice, {
   campaignDeleted,
   CampaignsStoreSlice,
 } from 'features/campaigns/store';
-import eventsSlice, {
-  eventCreated,
-  EventsStoreSlice,
-} from 'features/events/store';
+import eventsSlice, { EventsStoreSlice } from 'features/events/store';
 import journeysSlice, {
   journeyInstanceCreated,
   JourneysStoreSlice,
@@ -102,16 +99,6 @@ listenerMiddleware.startListening({
     const [callAssignment, campId] = action.payload;
     Router.push(
       `/organize/${callAssignment.organization?.id}/projects/${campId}/callassignments/${callAssignment.id}`
-    );
-  },
-});
-
-listenerMiddleware.startListening({
-  actionCreator: eventCreated,
-  effect: (action) => {
-    const event = action.payload;
-    Router.push(
-      `/organize/${event.organization?.id}/projects/${event.campaign?.id}/events/${event.id}`
     );
   },
 });

--- a/src/features/events/hooks/useCreateEvent.ts
+++ b/src/features/events/hooks/useCreateEvent.ts
@@ -1,7 +1,7 @@
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from './useEventMutations';
 import { eventCreate, eventCreated } from '../store';
-import { useApiClient, useAppDispatch } from 'core/hooks';
+import { useApiClient, useAppDispatch, useEnv } from 'core/hooks';
 
 type useCreateEventReturn = {
   createEvent: (eventBody: ZetkinEventPostBody) => Promise<ZetkinEvent>;
@@ -10,6 +10,7 @@ type useCreateEventReturn = {
 export default function useCreateEvent(orgId: number): useCreateEventReturn {
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
+  const env = useEnv();
 
   const createEvent = async (eventBody: ZetkinEventPostBody) => {
     dispatch(eventCreate());
@@ -20,6 +21,10 @@ export default function useCreateEvent(orgId: number): useCreateEventReturn {
       eventBody
     );
     dispatch(eventCreated(event));
+    env.router.push(
+      `/organize/${orgId}/projects/${event.campaign?.id}/events/${event.id}`
+    );
+
     return event;
   };
 

--- a/src/features/events/hooks/useCreateEvent.ts
+++ b/src/features/events/hooks/useCreateEvent.ts
@@ -1,3 +1,4 @@
+import getEventUrl from '../utils/getEventUrl';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from './useEventMutations';
 import { eventCreate, eventCreated } from '../store';
@@ -21,9 +22,7 @@ export default function useCreateEvent(orgId: number): useCreateEventReturn {
       eventBody
     );
     dispatch(eventCreated(event));
-    env.router.push(
-      `/organize/${orgId}/projects/${event.campaign?.id}/events/${event.id}`
-    );
+    env.router.push(getEventUrl(event));
 
     return event;
   };


### PR DESCRIPTION
## Description
This PR fixes a bug that page doesn't navigate to newly created event page.


## Screenshots



https://github.com/zetkin/app.zetkin.org/assets/77925373/603133e5-2baf-4131-9584-31cb2f4ab808


## Changes

* Adds `listenerMiddleware`


## Notes to reviewer


## Related issues
Resolves #1686 
