### PR TITLE
issue-1687/sorted orgs in menu

### DIFF
--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -1,11 +1,12 @@
 import NextLink from 'next/link';
-import ProceduralColorIcon from './ProceduralColorIcon';
-import React from 'react';
 import TreeItem from '@mui/lab/TreeItem';
-import { TreeItemData } from '../types';
 import TreeView from '@mui/lab/TreeView';
 import { Box, Typography, useTheme } from '@mui/material';
 import { ChevronRight, ExpandMore } from '@mui/icons-material';
+import React, { useMemo } from 'react';
+
+import ProceduralColorIcon from './ProceduralColorIcon';
+import { TreeItemData } from '../types';
 
 interface OrganizationTreeProps {
   treeItemData: TreeItemData[];
@@ -53,6 +54,10 @@ function OrganizationTree({
   orgId,
 }: OrganizationTreeProps): JSX.Element {
   const theme = useTheme();
+  const sortedTreeItems = useMemo(() => {
+    const sorted = treeItemData.sort((a, b) => a.title.localeCompare(b.title));
+    return sorted;
+  }, [treeItemData.length]);
 
   return (
     <div>
@@ -76,7 +81,7 @@ function OrganizationTree({
           },
         }}
       >
-        {renderTree({ onSwitchOrg, orgId, treeItemData })}
+        {renderTree({ onSwitchOrg, orgId, treeItemData: sortedTreeItems })}
       </TreeView>
     </div>
   );

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -1,9 +1,9 @@
 import NextLink from 'next/link';
+import React from 'react';
 import TreeItem from '@mui/lab/TreeItem';
 import TreeView from '@mui/lab/TreeView';
 import { Box, Typography, useTheme } from '@mui/material';
 import { ChevronRight, ExpandMore } from '@mui/icons-material';
-import React, { useMemo } from 'react';
 
 import ProceduralColorIcon from './ProceduralColorIcon';
 import { TreeItemData } from '../types';
@@ -16,7 +16,11 @@ interface OrganizationTreeProps {
 
 function renderTree(props: OrganizationTreeProps): React.ReactNode {
   const { treeItemData, orgId, onSwitchOrg } = props;
-  return treeItemData.map((item) => (
+  const sortedTreeItem = [...treeItemData].sort((a, b) =>
+    a.title.localeCompare(b.title)
+  );
+
+  return sortedTreeItem.map((item) => (
     <TreeItem
       key={item.id}
       label={
@@ -54,10 +58,6 @@ function OrganizationTree({
   orgId,
 }: OrganizationTreeProps): JSX.Element {
   const theme = useTheme();
-  const sortedTreeItems = useMemo(() => {
-    const sorted = treeItemData.sort((a, b) => a.title.localeCompare(b.title));
-    return sorted;
-  }, [treeItemData.length]);
 
   return (
     <div>
@@ -81,7 +81,7 @@ function OrganizationTree({
           },
         }}
       >
-        {renderTree({ onSwitchOrg, orgId, treeItemData: sortedTreeItems })}
+        {renderTree({ onSwitchOrg, orgId, treeItemData })}
       </TreeView>
     </div>
   );

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -16,11 +16,11 @@ interface OrganizationTreeProps {
 
 function renderTree(props: OrganizationTreeProps): React.ReactNode {
   const { treeItemData, orgId, onSwitchOrg } = props;
-  const sortedTreeItem = [...treeItemData].sort((a, b) =>
+  const sortedTreeItems = [...treeItemData].sort((a, b) =>
     a.title.localeCompare(b.title)
   );
 
-  return sortedTreeItem.map((item) => (
+  return sortedTreeItems.map((item) => (
     <TreeItem
       key={item.id}
       label={


### PR DESCRIPTION
## Description
This PR sorts organizations alphabetically in menu 


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/a5ec21a9-237c-4b0c-a3bc-a05b2730c905)



## Changes

* Adds `useMemo` and sort list


## Notes to reviewer
used `useMemo` to prevent the sorting from being triggered every time user moves a cursor to the sidebar.


## Related issues
Resolves #1687 
