### PR TITLE
Fix bug where newly created tags were not added to store

### DIFF
--- a/src/features/tags/hooks/useCreateTag.ts
+++ b/src/features/tags/hooks/useCreateTag.ts
@@ -31,13 +31,14 @@ export default function useCreateTag(
         });
       return tagFuture;
     } else {
+      dispatch(tagCreate());
       const tagFuture = await apiClient
         .post<ZetkinTag, ZetkinTagPostBody>(
           `/api/orgs/${orgId}/people/tags`,
           tag
         )
         .then((data: ZetkinTag) => {
-          //   dispatch(tagGroupCreated);
+          dispatch(tagCreated(data));
           return data;
         });
       return tagFuture;


### PR DESCRIPTION
## Description
This PR fixes an undocumented bug introduced by the hook refactor, which caused new tags to not be added to the store, which in turn meant that they would not show up in tag lists until the user refreshes the page (or the cache is invalidated after five minutes). This only happened to ungrouped tags, due to a forgotten comment. Grouped tags still worked as expected.

## Screenshots
None

## Changes
* Adds dispatching of actions when creating ungrouped tags

## Notes to reviewer
None

## Related issues
Undocumented