### PR TITLE
Fix bug that caused state to be reset in sub-query configuration

### DIFF
--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -71,7 +71,7 @@ const SubQuery = ({
   const [operator, setOperator] = useState<IN_OPERATOR>(IN_OPERATOR.IN);
 
   useEffect(() => {
-    if (queries.length) {
+    if (!selectedQuery && queries.length) {
       setSelectedQuery(
         queries.find((q) => q.id === filter.config.query_id) || queries[0]
       );


### PR DESCRIPTION
## Description
This PR fixes a bug that caused state to be reset after selecting anything in the `sub_query` ("Based on another Smart Search query") filter in Smart Search.

## Screenshots
None

## Changes
* Change logic so that the value only resets after load if user didn't yet select a query

## Notes to reviewer
The underlying problem is that the `useEffect()` hook executes everytime, because the `assignments` and `standaloneQueries` are always a new array (beacuse of how `loadListIfNecessary` works, i.e. it always maps to a new array).

## Related issues
Resolves #1708 