### PR TITLE
Fix survey sorting

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -14,12 +14,17 @@ import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import {
   DataGridPro,
   GridCellParams,
+  GridComparatorFn,
   GridRenderCellParams,
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
 import { FC, useEffect, useMemo } from 'react';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
+
+const alphabeticalComparator: GridComparatorFn<string> = (v1, v2) =>
+  //compares strings alphabetically, locale aware
+  v1.localeCompare(v2);
 
 const SurveySubmissionsList = ({
   submissions,
@@ -68,7 +73,17 @@ const SurveySubmissionsList = ({
           </Box>
         );
       },
+      sortComparator: alphabeticalComparator,
       sortable: true,
+      valueGetter: (
+        params: GridRenderCellParams<ZetkinSurveySubmission, string>
+      ) => {
+        if (params.row.respondent !== null) {
+          return params.row.respondent[field];
+        } else {
+          return 'anonymous';
+        }
+      },
     };
   };
 

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -14,17 +14,12 @@ import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import {
   DataGridPro,
   GridCellParams,
-  GridComparatorFn,
   GridRenderCellParams,
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
 import { FC, useEffect, useMemo } from 'react';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
-
-const alphabeticalComparator: GridComparatorFn<string> = (v1, v2) =>
-  //compares strings alphabetically, locale aware
-  v1.localeCompare(v2);
 
 const SurveySubmissionsList = ({
   submissions,
@@ -73,15 +68,15 @@ const SurveySubmissionsList = ({
           </Box>
         );
       },
-      sortComparator: alphabeticalComparator,
+      sortComparator: (v1: string, v2: string) => v1.localeCompare(v2),
       sortable: true,
       valueGetter: (
         params: GridRenderCellParams<ZetkinSurveySubmission, string>
       ) => {
         if (params.row.respondent !== null) {
-          return params.row.respondent[field];
+          return params.row.respondent[field] || '';
         } else {
-          return 'anonymous';
+          return messages.submissions.anonymous();
         }
       },
     };


### PR DESCRIPTION
## Description
This PR adds sorting for all survey submission fields using a `sortComparator` in the `makeSimpleColumn` function

## Changes
* Adds a `GridComparatorFn`, `alphabeticalComparator`, to `SurveySubmissionsList.tsx` to compare values alphabetically
* Adds a `sortComparator` (`alphabeticalComparator`) and `valueGetter` to the `makeSimpleColumn` function to enable alphabetical sorting for those columns

## Related issues
Resolves #1703 
