### PR TITLE
added week nr in calendar week view

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
+++ b/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
@@ -1,27 +1,24 @@
+import { Msg } from 'core/i18n';
 import theme from 'theme';
 import { Box, Typography } from '@mui/material';
-import { Msg } from 'core/i18n';
+
 import messageIds from '../../l10n/messageIds';
 
 type CalendarWeekNumberProps = {
   weekNr: number;
 };
 
-const HeaderWeekNumber = ({weekNr }: CalendarWeekNumberProps) => {
+const HeaderWeekNumber = ({ weekNr }: CalendarWeekNumberProps) => {
   return (
-
-    <Box
-      marginTop="2px"
-      display="flex"
-      alignItems="center"
-    >
+    <Box alignItems="center" display="flex" marginTop="2px">
       <Typography
         color={theme.palette.secondary.light}
         fontStyle="bold"
         sx={{ fontWeight: 800 }}
         variant="subtitle2"
       >
-       <Msg id={messageIds.ranges.shortWeek} />{weekNr}
+        <Msg id={messageIds.ranges.shortWeek} />
+        {weekNr}
       </Typography>
     </Box>
   );

--- a/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
+++ b/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
@@ -1,0 +1,30 @@
+import theme from 'theme';
+import { Box, Typography } from '@mui/material';
+import { Msg } from 'core/i18n';
+import messageIds from '../../l10n/messageIds';
+
+type CalendarWeekNumberProps = {
+  weekNr: number;
+};
+
+const HeaderWeekNumber = ({weekNr }: CalendarWeekNumberProps) => {
+  return (
+
+    <Box
+      marginTop="2px"
+      display="flex"
+      alignItems="center"
+    >
+      <Typography
+        color={theme.palette.secondary.light}
+        fontStyle="bold"
+        sx={{ fontWeight: 800 }}
+        variant="subtitle2"
+      >
+       <Msg id={messageIds.ranges.shortWeek} />{weekNr}
+      </Typography>
+    </Box>
+  );
+};
+
+export default HeaderWeekNumber;

--- a/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
+++ b/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
@@ -1,6 +1,5 @@
 import { Msg } from 'core/i18n';
-import theme from 'theme';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 
 import messageIds from '../../l10n/messageIds';
 
@@ -9,16 +8,11 @@ type CalendarWeekNumberProps = {
 };
 
 const HeaderWeekNumber = ({ weekNr }: CalendarWeekNumberProps) => {
+  const theme = useTheme();
   return (
     <Box alignItems="center" display="flex" marginTop="2px">
-      <Typography
-        color={theme.palette.secondary.light}
-        fontStyle="bold"
-        sx={{ fontWeight: 800 }}
-        variant="subtitle2"
-      >
-        <Msg id={messageIds.ranges.shortWeek} />
-        {weekNr}
+      <Typography color={theme.palette.secondary.light} variant="subtitle2">
+        <Msg id={messageIds.shortWeek} values={{ weekNumber: weekNr }} />
       </Typography>
     </Box>
   );

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -17,6 +17,7 @@ import EventCluster from '../EventCluster';
 import { eventCreated } from 'features/events/store';
 import EventDayLane from './EventDayLane';
 import EventGhost from './EventGhost';
+import HeaderWeekNumber from './HeaderWeekNumber';
 import { isSameDate } from 'utils/dateUtils';
 import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
@@ -27,9 +28,6 @@ import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from 'features/events/hooks/useEventMutations';
 import { useAppDispatch, useEnv, useNumericRouteParams } from 'core/hooks';
-import WeekNumber from '../CalendarMonthView/WeekNumber';
-import { getWeekNumber } from '../CalendarMonthView/utils';
-import HeaderWeekNumber from './HeaderWeekNumber';
 
 dayjs.extend(isoWeek);
 
@@ -84,9 +82,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         gridTemplateRows={'1fr'}
       >
         {/* Empty */}
-        <HeaderWeekNumber
-                  weekNr={dayjs(dayDates[0]).isoWeek()}
-                />
+        <HeaderWeekNumber weekNr={dayjs(dayDates[0]).isoWeek()} />
         {dayDates.map((weekdayDate: Date, weekday: number) => {
           return (
             <DayHeader

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -27,6 +27,9 @@ import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from 'features/events/hooks/useEventMutations';
 import { useAppDispatch, useEnv, useNumericRouteParams } from 'core/hooks';
+import WeekNumber from '../CalendarMonthView/WeekNumber';
+import { getWeekNumber } from '../CalendarMonthView/utils';
+import HeaderWeekNumber from './HeaderWeekNumber';
 
 dayjs.extend(isoWeek);
 
@@ -81,7 +84,9 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         gridTemplateRows={'1fr'}
       >
         {/* Empty */}
-        <Box />
+        <HeaderWeekNumber
+                  weekNr={dayjs(dayDates[0]).isoWeek()}
+                />
         {dayDates.map((weekdayDate: Date, weekday: number) => {
           return (
             <DayHeader

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -72,6 +72,7 @@ export default makeMessages('feat.calendar', {
     day: m('Day'),
     month: m('Month'),
     week: m('Week'),
+    shortWeek: m('w')
   },
   selectionBar: {
     deselect: m('Deselect'),

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -71,7 +71,6 @@ export default makeMessages('feat.calendar', {
   ranges: {
     day: m('Day'),
     month: m('Month'),
-    shortWeek: m('w'),
     week: m('Week'),
   },
   selectionBar: {
@@ -107,6 +106,7 @@ export default makeMessages('feat.calendar', {
       nextWeek: m<{ dates: ReactElement }>('Next week {dates}'),
     },
   },
+  shortWeek: m<{ weekNumber: number }>('w {weekNumber}'),
   showMore: m('Show'),
   today: m('Today'),
 });

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -71,8 +71,8 @@ export default makeMessages('feat.calendar', {
   ranges: {
     day: m('Day'),
     month: m('Month'),
+    shortWeek: m('w'),
     week: m('Week'),
-    shortWeek: m('w')
   },
   selectionBar: {
     deselect: m('Deselect'),


### PR DESCRIPTION
## Description
This PR adds week numbers in the week view in the calendar header. 

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/20040536/5b1e5f25-0dac-4e4c-99aa-f5a017c4fe60)

## Changes
Added component HeaderWeekNumber.

## Related issues
Resolves #1305
