### PR TITLE
Proof of concept: Dynamic translations from Lyra

### DIFF
--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -9,12 +9,12 @@ import {
 } from 'next';
 
 import { AppSession } from './types';
-import { getBrowserLanguage } from './locale';
 import { getMessages } from './locale';
 import getUserMemberships from './getUserMemberships';
 import { stringToBool } from './stringUtils';
 import { ZetkinZ } from './types/sdk';
 import { ApiFetch, createApiFetch } from './apiFetch';
+import { getBrowserLanguage, MessageList } from './locale';
 import { ZetkinSession, ZetkinUser } from './types/zetkin';
 
 //TODO: Create module definition and revert to import.
@@ -189,7 +189,16 @@ export const scaffold =
     // TODO: Respect scope from options again
     //const localeScope = (options?.localeScope ?? []).concat(['misc', 'zui']);
     const localeScope: string[] = [];
-    const messages = await getMessages(lang, localeScope);
+    let messages: MessageList = {};
+    if (process.env.LYRA_URL) {
+      const lyraRes = await fetch(
+        `${process.env.LYRA_URL}/api/translations/${lang}`
+      );
+      const lyraPayload = await lyraRes.json();
+      messages = lyraPayload.translations;
+    } else {
+      messages = await getMessages(lang, localeScope);
+    }
 
     if (hasProps(result)) {
       result.props = {

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -191,11 +191,16 @@ export const scaffold =
     const localeScope: string[] = [];
     let messages: MessageList = {};
     if (process.env.LYRA_URL) {
-      const lyraRes = await fetch(
-        `${process.env.LYRA_URL}/api/translations/${lang}`
-      );
-      const lyraPayload = await lyraRes.json();
-      messages = lyraPayload.translations;
+      try {
+        const lyraRes = await fetch(
+          `${process.env.LYRA_URL}/api/translations/${lang}`
+        );
+        const lyraPayload = await lyraRes.json();
+        messages = lyraPayload.translations;
+      } catch (e: unknown) {
+        // Fall back to stored messages when Lyra is not accessible
+        messages = await getMessages(lang, localeScope);
+      }
     } else {
       messages = await getMessages(lang, localeScope);
     }


### PR DESCRIPTION
## Description
This PR adds a capability to load translations from [Lyra](https://github.com/zetkin/lyra). This is only allowed when the `LYRA_URL` environment variable is set, and it should not be set in production.

## Screenshots
https://github.com/zetkin/app.zetkin.org/assets/550212/07300078-37fd-4ded-ac4c-9a65647279b9

## Changes
* Changes `scaffold()` to conditionally load translations from Lyra instead of the server file system, when the `LYRA_URL` environment variable is set

## Notes to reviewer
This is mostly a proof of concept, but because it only affects environments that enable it, we could still merge it and start using it on Dev as soon as a Lyra instance is up and running somewhere.

## Related issues
Undocumented