### PR TITLE
Create <SurveyOption /> component to unify radio & checkbox styling

### DIFF
--- a/src/features/surveys/components/surveyForm/SurveyOption.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyOption.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+import { FormControlLabel, FormControlLabelProps } from '@mui/material';
+
+export type SurveyOptionProps = FormControlLabelProps;
+
+const SurveyOption: FC<SurveyOptionProps> = ({ ...formControlLabelProps }) => {
+  return (
+    <FormControlLabel
+      {...formControlLabelProps}
+      sx={{
+        '&:has(.Mui-checked)': {
+          '&, & + .MuiFormControlLabel-label': {
+            backgroundColor: '#fbcbd8',
+            borderRadius: '50px',
+          },
+        },
+      }}
+    />
+  );
+};
+
+export default SurveyOption;

--- a/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
@@ -1,8 +1,9 @@
 import { FC } from 'react';
+import SurveyOption from './SurveyOption';
 import {
+  Box,
   Checkbox,
   FormControl,
-  FormControlLabel,
   FormGroup,
   FormLabel,
   MenuItem,
@@ -46,19 +47,21 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element, formData }) => {
           >
             {element.question.question}
           </FormLabel>
-          {element.question.options!.map((option: ZetkinSurveyOption) => (
-            <FormControlLabel
-              key={option.id}
-              control={
-                <Checkbox
-                  defaultChecked={selectedOptions.includes(`${option.id}`)}
-                  name={`${element.id}.options`}
-                />
-              }
-              label={option.text}
-              value={option.id}
-            />
-          ))}
+          <Box display="flex" flexDirection="column" rowGap={1}>
+            {element.question.options!.map((option: ZetkinSurveyOption) => (
+              <SurveyOption
+                key={option.id}
+                control={
+                  <Checkbox
+                    defaultChecked={selectedOptions.includes(`${option.id}`)}
+                    name={`${element.id}.options`}
+                  />
+                }
+                label={option.text}
+                value={option.id}
+              />
+            ))}
+          </Box>
         </FormGroup>
       )}
       {element.question.response_config.widget_type === 'radio' && (
@@ -79,14 +82,16 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element, formData }) => {
           >
             {element.question.question}
           </FormLabel>
-          {element.question.options!.map((option: ZetkinSurveyOption) => (
-            <FormControlLabel
-              key={option.id}
-              control={<Radio />}
-              label={option.text}
-              value={option.id}
-            />
-          ))}
+          <Box display="flex" flexDirection="column" rowGap={1}>
+            {element.question.options!.map((option: ZetkinSurveyOption) => (
+              <SurveyOption
+                key={option.id}
+                control={<Radio />}
+                label={option.text}
+                value={option.id}
+              />
+            ))}
+          </Box>
         </RadioGroup>
       )}
       {element.question.response_config.widget_type === 'select' && (

--- a/src/features/surveys/components/surveyForm/SurveySignature.tsx
+++ b/src/features/surveys/components/surveyForm/SurveySignature.tsx
@@ -1,10 +1,10 @@
 import messageIds from 'features/surveys/l10n/messageIds';
 import { Msg } from 'core/i18n';
+import SurveyOption from './SurveyOption';
 import useCurrentUser from 'features/user/hooks/useCurrentUser';
 import {
   Box,
   FormControl,
-  FormControlLabel,
   FormLabel,
   Radio,
   RadioGroup,
@@ -38,11 +38,6 @@ const SurveySignature: FC<SurveySignatureProps> = ({ formData, survey }) => {
     [setSignatureType]
   );
 
-  const selectedStyle = {
-    backgroundColor: '#fbcbd8',
-    borderRadius: '50px',
-  };
-
   return (
     <FormControl>
       <RadioGroup
@@ -67,74 +62,73 @@ const SurveySignature: FC<SurveySignatureProps> = ({ formData, survey }) => {
           </Typography>
         </FormLabel>
 
-        <FormControlLabel
-          control={<Radio required />}
-          label={
-            <Typography>
-              <Msg
-                id={messageIds.surveySignature.type.user}
-                values={{
-                  email: currentUser?.email ?? '',
-                  person: currentUser?.first_name ?? '',
-                }}
-              />
-            </Typography>
-          }
-          sx={signatureType === 'user' ? selectedStyle : {}}
-          value="user"
-        />
-
-        <FormControlLabel
-          control={<Radio required />}
-          label={
-            <Typography>
-              <Msg id={messageIds.surveySignature.type.email} />
-            </Typography>
-          }
-          sx={signatureType === 'email' ? selectedStyle : {}}
-          value="email"
-        />
-
-        {signatureType === 'email' && (
-          <Box
-            display="flex"
-            flexDirection="column"
-            pt={1}
-            style={{ rowGap: theme.spacing(1) }}
-          >
-            <TextField
-              defaultValue={formData['sig.first_name']}
-              label={<Msg id={messageIds.surveySignature.email.firstName} />}
-              name="sig.first_name"
-              required
-            />
-            <TextField
-              defaultValue={formData['sig.last_name']}
-              label={<Msg id={messageIds.surveySignature.email.lastName} />}
-              name="sig.last_name"
-              required
-            />
-            <TextField
-              defaultValue={formData['sig.email']}
-              label={<Msg id={messageIds.surveySignature.email.email} />}
-              name="sig.email"
-              required
-            />
-          </Box>
-        )}
-
-        {survey.signature === 'allow_anonymous' && (
-          <FormControlLabel
+        <Box display="flex" flexDirection="column" rowGap={1}>
+          <SurveyOption
             control={<Radio required />}
             label={
               <Typography>
-                <Msg id={messageIds.surveySignature.type.anonymous} />
+                <Msg
+                  id={messageIds.surveySignature.type.user}
+                  values={{
+                    email: currentUser?.email ?? '',
+                    person: currentUser?.first_name ?? '',
+                  }}
+                />
               </Typography>
             }
-            sx={signatureType === 'anonymous' ? selectedStyle : {}}
-            value="anonymous"
+            value="user"
           />
-        )}
+
+          <SurveyOption
+            control={<Radio required />}
+            label={
+              <Typography>
+                <Msg id={messageIds.surveySignature.type.email} />
+              </Typography>
+            }
+            value="email"
+          />
+
+          {signatureType === 'email' && (
+            <Box
+              display="flex"
+              flexDirection="column"
+              pt={1}
+              style={{ rowGap: theme.spacing(1) }}
+            >
+              <TextField
+                defaultValue={formData['sig.first_name']}
+                label={<Msg id={messageIds.surveySignature.email.firstName} />}
+                name="sig.first_name"
+                required
+              />
+              <TextField
+                defaultValue={formData['sig.last_name']}
+                label={<Msg id={messageIds.surveySignature.email.lastName} />}
+                name="sig.last_name"
+                required
+              />
+              <TextField
+                defaultValue={formData['sig.email']}
+                label={<Msg id={messageIds.surveySignature.email.email} />}
+                name="sig.email"
+                required
+              />
+            </Box>
+          )}
+
+          {survey.signature === 'allow_anonymous' && (
+            <SurveyOption
+              control={<Radio required />}
+              label={
+                <Typography>
+                  <Msg id={messageIds.surveySignature.type.anonymous} />
+                </Typography>
+              }
+              value="anonymous"
+            />
+          )}
+        </Box>
       </RadioGroup>
     </FormControl>
   );


### PR DESCRIPTION
Just tackling another of the little outstanding structural issues with the new survey! I'm aware that the specifics of the design itself may not have been finalised yet but this should make it much easier to implement once ready.

| Before | After |
|-|-|
| <img width="387" alt="Screenshot 2023-12-17 at 09 56 06" src="https://github.com/zetkin/app.zetkin.org/assets/566159/77a7ba68-7dd3-4250-a1e6-7076e8403103"> | <img width="387" alt="Screenshot 2023-12-17 at 09 55 46" src="https://github.com/zetkin/app.zetkin.org/assets/566159/02432728-5c6e-43a9-95ca-804c75351e4d"> |

There's a slight increase in vertical spacing in this too. That's because without it, the red backgrounds bleed into each other when two adjacent checkboxes are checked. Unfortunately, wrapping them in the `<Box></Box>` necessary to introduce that extra spacing has reindented a lot of the code, so I recommend [hiding the whitespace changes](https://github.com/zetkin/app.zetkin.org/pull/1717/files?w=1) to review this diff.