### PR TITLE
Apply WAI-ARIA group role to privacy policy

### DIFF
--- a/src/features/surveys/components/surveyForm/SurveyPrivacyPolicy.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyPrivacyPolicy.tsx
@@ -1,8 +1,15 @@
-import Box from '@mui/material/Box';
 import { FC } from 'react';
 import messageIds from 'features/surveys/l10n/messageIds';
 import { ZetkinSurveyExtended } from 'utils/types/zetkin';
-import { Checkbox, FormControlLabel, Link, Typography } from '@mui/material';
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel,
+  Link,
+  Typography,
+} from '@mui/material';
 import { Msg, useMessages } from 'core/i18n';
 
 export type SurveyPrivacyPolicyProps = {
@@ -16,38 +23,48 @@ const SurveyPrivacyPolicy: FC<SurveyPrivacyPolicyProps> = ({
 }) => {
   const messages = useMessages(messageIds);
   return (
-    <Box alignItems="center" component="section" sx={{ py: 2 }}>
-      <Typography fontWeight={'bold'}>
-        <Msg id={messageIds.surveyForm.terms.title} />
-      </Typography>
-
-      <FormControlLabel
-        control={
-          <Checkbox
-            defaultChecked={formData['privacy.approval'] === 'on'}
-            required
-          />
-        }
-        data-testid="Survey-acceptTerms"
-        label={<Msg id={messageIds.surveyForm.accept} />}
-        name="privacy.approval"
-      />
-      <Typography style={{ fontSize: '0.8em' }}>
-        <Msg
-          id={messageIds.surveyForm.terms.description}
-          values={{ organization: survey.organization.title }}
-        />
-      </Typography>
-      <Typography style={{ fontSize: '0.8em', marginBottom: '0.5em' }}>
-        <Link
-          href={messages.surveyForm.policy.link()}
-          rel="noreferrer"
-          target="_blank"
+    <FormControl>
+      <FormGroup aria-labelledby="privacy-policy-label">
+        <FormLabel
+          id="privacy-policy-label"
+          style={{
+            color: 'black',
+            fontSize: '1.5em',
+            fontWeight: '500',
+            marginBottom: '0.5em',
+            marginTop: '0.5em',
+          }}
         >
-          <Msg id={messageIds.surveyForm.policy.text} />
-        </Link>
-      </Typography>
-    </Box>
+          <Msg id={messageIds.surveyForm.terms.title} />
+        </FormLabel>
+        <FormControlLabel
+          control={
+            <Checkbox
+              defaultChecked={formData['privacy.approval'] === 'on'}
+              required
+            />
+          }
+          data-testid="Survey-acceptTerms"
+          label={<Msg id={messageIds.surveyForm.accept} />}
+          name="privacy.approval"
+        />
+        <Typography style={{ fontSize: '0.8em' }}>
+          <Msg
+            id={messageIds.surveyForm.terms.description}
+            values={{ organization: survey.organization.title }}
+          />
+        </Typography>
+        <Typography style={{ fontSize: '0.8em', marginBottom: '0.5em' }}>
+          <Link
+            href={messages.surveyForm.policy.link()}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Msg id={messageIds.surveyForm.policy.text} />
+          </Link>
+        </Typography>
+      </FormGroup>
+    </FormControl>
   );
 };
 


### PR DESCRIPTION
While putting https://github.com/zetkin/app.zetkin.org/pull/1720 together I noticed that `<SurveyPrivacyPolicy />` was still in the fairly rough first draft form from the code camp as I hadn't gotten around to applying the [WAI-ARIA group role](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria) to it. This PR aligns the markup for this component with what you'd get out of `<SurveyOptionsQuestion />` for a question with a single checkbox option.

Always nice to include a before/after demoing the screen reader UX impact so here's that! The difference to look out for here is that in the "after" GIF, the group role on the privacy policy causes the beginning and end of the group to be announced when entering and leaving. In the "before" GIF, you can see that happen when leaving the `<SurveySignature />` group above, but not on the privacy policy.

| Before | After |
|-|-|
| ![2023-12-18 07 18 30](https://github.com/zetkin/app.zetkin.org/assets/566159/259b8712-a805-4b2a-8341-3f3f77fa5c9d) | ![2023-12-18 07 17 46](https://github.com/zetkin/app.zetkin.org/assets/566159/e51e505d-b34e-43e0-9f27-4479008a0843) |

Appreciate your patience with all these little tweaks. Have been more perfectionist than usual with this feature as it's nice for it to be a bit of a reference implementation for what a maximally accessible form can look like within Zetkin!