### PR TITLE
Fix bug regarding wrongly formatted phone numbers 

### DIFF
--- a/src/features/import/hooks/useConfigure.ts
+++ b/src/features/import/hooks/useConfigure.ts
@@ -9,11 +9,7 @@ import {
   ImportPreview,
   ZetkinPersonImportPostBody,
 } from '../utils/types';
-import {
-  importErrorsAdd,
-  importPreviewAdd,
-  importPreviewClear,
-} from '../store';
+import { importErrorsAdd, importPreviewAdd } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 export default function useConfigure(orgId: number) {
@@ -32,7 +28,25 @@ export default function useConfigure(orgId: number) {
     const errors = foreseeErrors(configuredSheet, countryCode, customFields);
 
     if (errors.length > 0 && !errors.includes(IMPORT_ERROR.ID_MISSING)) {
-      dispatch(importPreviewClear());
+      dispatch(
+        importPreviewAdd({
+          addedToOrg: {
+            byOrg: {},
+            total: 0,
+          },
+          created: {
+            total: 0,
+          },
+          tagged: {
+            byTag: {},
+            total: 0,
+          },
+          updated: {
+            byField: {},
+            total: 0,
+          },
+        })
+      );
       dispatch(importErrorsAdd(errors));
     }
 

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -198,13 +198,13 @@ export default function usePreflight(orgId: number) {
     });
   }
 
-  const importOperations = prepareImportOperations(
-    sheet,
-    organization.country as CountryCode
-  );
-
   const importPeople = async () => {
     setLoading(true);
+
+    const importOperations = prepareImportOperations(
+      sheet,
+      organization.country as CountryCode
+    );
 
     const importResult = await apiClient.post<
       PersonImport,

--- a/src/features/import/store.ts
+++ b/src/features/import/store.ts
@@ -44,9 +44,6 @@ const importSlice = createSlice({
     importPreviewAdd: (state, action: PayloadAction<PersonImportSummary>) => {
       state.preflightSummary = action.payload;
     },
-    importPreviewClear: (state) => {
-      state.preflightSummary = null;
-    },
     importResultAdd: (state, action: PayloadAction<PersonImport>) => {
       state.importResult = action.payload;
     },
@@ -66,7 +63,6 @@ export const {
   columnUpdate,
   importErrorsAdd,
   importPreviewAdd,
-  importPreviewClear,
   importResultAdd,
   setFirstRowIsHeaders,
   setSelectedSheetIndex,

--- a/src/features/import/utils/getAddedOrgsSummary.ts
+++ b/src/features/import/utils/getAddedOrgsSummary.ts
@@ -25,15 +25,14 @@ export interface AddedOrgsSummary {
   orgs: string[];
 }
 
-export default function getAddedOrgsSummary(membershipsAdded: {
-  byOrg: { [key: number]: number };
-  total: number;
-}): AddedOrgsSummary {
+export default function getAddedOrgsSummary(
+  addedToOrg: PersonImportSummary['addedToOrg']
+): AddedOrgsSummary {
   const orgs: string[] = [];
 
-  if (!checkEmptyObj(membershipsAdded.byOrg)) {
-    orgs.push(...Object.keys(membershipsAdded.byOrg));
+  if (!checkEmptyObj(addedToOrg.byOrg)) {
+    orgs.push(...Object.keys(addedToOrg.byOrg));
   }
 
-  return { numCreated: membershipsAdded.total, orgs };
+  return { numCreated: addedToOrg.total, orgs };
 }


### PR DESCRIPTION
This PR attempts to fix a bug in the import. When a user tried to use a column containing invalid phone numbers as phone numbers an error was thrown. 

I'm solving this by sending an empty object to the store, saying it's an empty preflight summary. This is not a good solution, but changing it to a better solution would require a long chain of refactoring that did not feel relevant to take on at this point. 

It also updates a type and parameter name in a function, just because it caught my eye and I wanted to change it. 