### PR TITLE
Email editor image tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@date-io/date-fns": "1.x",
     "@date-io/dayjs": "1.x",
+    "@editorjs/editorjs": "^2.28.2",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@messageformat/parser": "^5.1.0",

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -18,6 +18,7 @@ import campaignsSlice, {
   CampaignsStoreSlice,
 } from 'features/campaigns/store';
 import eventsSlice, { EventsStoreSlice } from 'features/events/store';
+import filesSlice, { FilesStoreSlice } from 'features/files/store';
 import journeysSlice, {
   journeyInstanceCreated,
   JourneysStoreSlice,
@@ -44,6 +45,7 @@ export interface RootState {
   callAssignments: CallAssignmentSlice;
   campaigns: CampaignsStoreSlice;
   events: EventsStoreSlice;
+  files: FilesStoreSlice;
   journeys: JourneysStoreSlice;
   organizations: OrganizationsStoreSlice;
   profiles: ProfilesStoreSlice;
@@ -61,6 +63,7 @@ const reducer = {
   callAssignments: callAssignmentsSlice.reducer,
   campaigns: campaignsSlice.reducer,
   events: eventsSlice.reducer,
+  files: filesSlice.reducer,
   journeys: journeysSlice.reducer,
   organizations: organizationsSlice.reducer,
   profiles: profilesSlice.reducer,

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,3 +1,4 @@
+import LibraryImage from './tools/LibraryImage';
 import EditorJS, { EditorConfig, OutputData } from '@editorjs/editorjs';
 import { FC, useEffect, useRef } from 'react';
 
@@ -27,7 +28,9 @@ const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
       onChange: () => {
         saved();
       },
-      tools: {},
+      tools: {
+        image: LibraryImage,
+      },
     };
 
     // Create the EditorJS instance

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,5 +1,10 @@
 import LibraryImage from './tools/LibraryImage';
-import EditorJS, { EditorConfig, OutputData } from '@editorjs/editorjs';
+import { useNumericRouteParams } from 'core/hooks';
+import EditorJS, {
+  EditorConfig,
+  OutputData,
+  ToolConstructable,
+} from '@editorjs/editorjs';
 import { FC, useEffect, useRef } from 'react';
 
 export type EditorProps = {
@@ -7,6 +12,7 @@ export type EditorProps = {
 };
 
 const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
+  const { orgId } = useNumericRouteParams();
   const editorInstance = useRef<EditorJS | null>(null);
 
   const saved = async () => {
@@ -29,7 +35,12 @@ const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
         saved();
       },
       tools: {
-        image: LibraryImage,
+        libraryImage: {
+          class: LibraryImage as unknown as ToolConstructable,
+          config: {
+            orgId,
+          },
+        },
       },
     };
 

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,0 +1,52 @@
+import EditorJS, { EditorConfig, OutputData } from '@editorjs/editorjs';
+import { FC, useEffect, useRef } from 'react';
+
+export type EditorProps = {
+  onSave?: (data: OutputData) => void;
+};
+
+const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
+  const editorInstance = useRef<EditorJS | null>(null);
+
+  const saved = async () => {
+    try {
+      const savedData = await editorInstance.current?.save();
+      if (savedData && onSave) {
+        onSave(savedData);
+      }
+    } catch (error) {
+      //TODO: handle error
+    }
+  };
+
+  useEffect(() => {
+    const editorConfig: EditorConfig = {
+      // TODO: Find way to make unique IDs
+      holder: 'ClientOnlyEditor-container',
+      inlineToolbar: ['bold', 'link', 'italic'],
+      onChange: () => {
+        saved();
+      },
+      tools: {},
+    };
+
+    // Create the EditorJS instance
+    editorInstance.current = new EditorJS(editorConfig);
+
+    return () => {
+      // Cleanup when the component is unmounted
+      if (editorInstance.current) {
+        editorInstance.current.destroy();
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      id="ClientOnlyEditor-container"
+      style={{ backgroundColor: 'white', border: '1px solid black' }}
+    />
+  );
+};
+
+export default EmailEditorFrontend;

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+import { EditorProps } from './EmailEditorFrontend';
+import { FC } from 'react';
+
+const EmailEditorFrontend = dynamic(import('./EmailEditorFrontend'), {
+  ssr: false,
+});
+
+const EmailEditor: FC<EditorProps> = ({ onSave }) => {
+  return <EmailEditorFrontend onSave={onSave} />;
+};
+
+export default EmailEditor;

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
@@ -1,12 +1,54 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
+
 import { LibraryImageData } from './types';
+import ZUIImageSelectDialog from 'zui/ZUIImageSelectDialog';
 
 type Props = {
   data: LibraryImageData;
+  onChange: (data: LibraryImageData) => void;
+  orgId: number;
 };
 
-const LibraryImageEditableBlock: FC<Props> = ({ data }) => {
-  return <h1>IMAGE PLACEHOLDER {JSON.stringify(data)}</h1>;
+const LibraryImageEditableBlock: FC<Props> = ({
+  data: initialData,
+  onChange,
+  orgId,
+}) => {
+  // Start in "selecting" state if the block was just added
+  const [selecting, setSelecting] = useState(!initialData.fileId);
+  const [data, setData] = useState(initialData);
+
+  // TODO: Add way of handling alt text
+  return (
+    <>
+      {data.url && (
+        <img
+          alt=""
+          src={data.url}
+          style={{
+            maxWidth: '100%',
+          }}
+        />
+      )}
+      <ZUIImageSelectDialog
+        onClose={() => setSelecting(false)}
+        onSelectFile={(file) => {
+          setData({
+            fileId: file.id,
+            url: file.url,
+          });
+
+          onChange({
+            fileId: file.id,
+            url: file.url,
+          });
+          setSelecting(false);
+        }}
+        open={selecting}
+        orgId={orgId}
+      />
+    </>
+  );
 };
 
 export default LibraryImageEditableBlock;

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react';
 
+import FileLibraryDialog from 'features/files/components/FileLibraryDialog';
 import { LibraryImageData } from './types';
-import ZUIImageSelectDialog from 'zui/ZUIImageSelectDialog';
 
 type Props = {
   data: LibraryImageData;
@@ -30,7 +30,7 @@ const LibraryImageEditableBlock: FC<Props> = ({
           }}
         />
       )}
-      <ZUIImageSelectDialog
+      <FileLibraryDialog
         onClose={() => setSelecting(false)}
         onSelectFile={(file) => {
           setData({

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { LibraryImageData } from './types';
+
+type Props = {
+  data: LibraryImageData;
+};
+
+const LibraryImageEditableBlock: FC<Props> = ({ data }) => {
+  return <h1>IMAGE PLACEHOLDER {JSON.stringify(data)}</h1>;
+};
+
+export default LibraryImageEditableBlock;

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/LibraryImageEditableBlock.tsx
@@ -46,6 +46,7 @@ const LibraryImageEditableBlock: FC<Props> = ({
         }}
         open={selecting}
         orgId={orgId}
+        type="image"
       />
     </>
   );

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/index.tsx
@@ -1,12 +1,22 @@
 import { BlockToolConstructorOptions } from '@editorjs/editorjs';
 import { createRoot } from 'react-dom/client';
-import { LibraryImageData } from './types';
 import LibraryImageEditableBlock from './LibraryImageEditableBlock';
+import Providers from 'core/Providers';
+import { LibraryImageConfig, LibraryImageData } from './types';
 
 export default class LibraryImage {
+  private _config: LibraryImageConfig;
   private _data: LibraryImageData;
 
-  constructor({ data }: BlockToolConstructorOptions<LibraryImageData>) {
+  constructor({
+    config,
+    data,
+  }: BlockToolConstructorOptions<LibraryImageData, LibraryImageConfig>) {
+    if (!config) {
+      throw new Error('Config must be defined');
+    }
+
+    this._config = config;
     this._data = data;
   }
 
@@ -17,7 +27,17 @@ export default class LibraryImage {
   render() {
     const container = document.createElement('div');
     const root = createRoot(container);
-    root.render(<LibraryImageEditableBlock data={this._data} />);
+    root.render(
+      <Providers {...window.providerData}>
+        <LibraryImageEditableBlock
+          data={this._data}
+          onChange={(newData) => {
+            this._data = { ...newData };
+          }}
+          orgId={this._config.orgId}
+        />
+      </Providers>
+    );
 
     return container;
   }

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/index.tsx
@@ -1,0 +1,38 @@
+import { BlockToolConstructorOptions } from '@editorjs/editorjs';
+import { createRoot } from 'react-dom/client';
+import { LibraryImageData } from './types';
+import LibraryImageEditableBlock from './LibraryImageEditableBlock';
+
+export default class LibraryImage {
+  private _data: LibraryImageData;
+
+  constructor({ data }: BlockToolConstructorOptions<LibraryImageData>) {
+    this._data = data;
+  }
+
+  static get isReadOnlySupported() {
+    return false;
+  }
+
+  render() {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    root.render(<LibraryImageEditableBlock data={this._data} />);
+
+    return container;
+  }
+
+  save() {
+    // TODO: Return updated state
+    return this._data;
+  }
+
+  static get toolbox() {
+    return {
+      // SVG icon from MUI
+      icon: '<svg><path d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86-3 3.87L9 13.14 6 17h12l-3.86-5.14z"/></svg>',
+      // TODO: Internationalize this
+      title: 'Image',
+    };
+  }
+}

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/types.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/types.tsx
@@ -1,3 +1,7 @@
+export type LibraryImageConfig = {
+  orgId: number;
+};
+
 export type LibraryImageData = {
   fileId: number;
   url: string;

--- a/src/features/emails/components/EmailEditor/tools/LibraryImage/types.tsx
+++ b/src/features/emails/components/EmailEditor/tools/LibraryImage/types.tsx
@@ -1,0 +1,4 @@
+export type LibraryImageData = {
+  fileId: number;
+  url: string;
+};

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -13,13 +13,11 @@ interface EmailLayoutProps {
 
 const EmailLayout: FC<EmailLayoutProps> = ({ children }) => {
   const messages = useMessages(messageIds);
-  //   const emailFuture = useEmail()
 
   return (
     <TabbedLayout
       actionButtons={<EmailActionButtons />}
-      baseHref={`/}`}
-      //   belowActionButtons={}
+      baseHref={`/`}
       defaultTab="/"
       subtitle={<Box alignItems="center" display="flex" />}
       tabs={[
@@ -34,7 +32,9 @@ const EmailLayout: FC<EmailLayoutProps> = ({ children }) => {
       ]}
       title={
         <ZUIEditTextinPlace
-          onChange={() => console.log('hey')}
+          onChange={() => {
+            // Do nothing for now
+          }}
           value={'default'}
         />
       }

--- a/src/features/files/components/DropZoneContainer.tsx
+++ b/src/features/files/components/DropZoneContainer.tsx
@@ -1,0 +1,38 @@
+import { Box, lighten, useTheme } from '@mui/material';
+import { FC, ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+  state: 'accepting' | 'loading';
+};
+
+const DropZoneContainer: FC<Props> = ({ children, state }) => {
+  const theme = useTheme();
+
+  const stateColors: Record<Props['state'], string> = {
+    accepting: theme.palette.primary.main,
+    loading: theme.palette.primary.main,
+  };
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        backgroundColor: lighten(stateColors[state], 0.9),
+        borderColor: stateColors[state],
+        borderStyle: state == 'accepting' ? 'dashed' : 'solid',
+        borderWidth: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        justifyContent: 'center',
+        padding: 1,
+        width: '100%',
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default DropZoneContainer;

--- a/src/features/files/components/FileDropZone.tsx
+++ b/src/features/files/components/FileDropZone.tsx
@@ -1,0 +1,60 @@
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { FC, ReactNode } from 'react';
+
+import DropZoneContainer from './DropZoneContainer';
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { UploadFileOutlined } from '@mui/icons-material';
+import useFileUploads, { FileUploadState } from '../hooks/useFileUploads';
+
+type Props = {
+  children: (props: { openFilePicker: () => void }) => ReactNode;
+  orgId: number;
+};
+
+const FileDropZone: FC<Props> = ({ children, orgId }) => {
+  const {
+    fileUploads,
+    getDropZoneProps,
+    getInputProps,
+    isDraggingOver,
+    openFilePicker,
+  } = useFileUploads(orgId, {
+    multiple: false,
+  });
+
+  const activeFileUploads = fileUploads.filter(
+    (upload) => upload.state == FileUploadState.UPLOADING
+  );
+  const isUploading = activeFileUploads.length > 0;
+
+  return (
+    <Box height="100%">
+      {isUploading && (
+        <DropZoneContainer state="loading">
+          <CircularProgress sx={{ mb: 2 }} />
+          <Typography variant="body1">{activeFileUploads[0].name}</Typography>
+        </DropZoneContainer>
+      )}
+      {!isUploading && (
+        <Box height="100%" {...getDropZoneProps()}>
+          <input {...getInputProps()} />
+          {isDraggingOver && (
+            <DropZoneContainer state="accepting">
+              <UploadFileOutlined
+                color="primary"
+                sx={{ fontSize: 40, mb: 1 }}
+              />
+              <Typography variant="body1">
+                <Msg id={messageIds.fileUpload.dropToUpload} />
+              </Typography>
+            </DropZoneContainer>
+          )}
+          {!isDraggingOver && children({ openFilePicker })}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default FileDropZone;

--- a/src/features/files/components/FileDropZone.tsx
+++ b/src/features/files/components/FileDropZone.tsx
@@ -5,14 +5,16 @@ import DropZoneContainer from './DropZoneContainer';
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
 import { UploadFileOutlined } from '@mui/icons-material';
+import { ZetkinFile } from 'utils/types/zetkin';
 import useFileUploads, { FileUploadState } from '../hooks/useFileUploads';
 
 type Props = {
   children: (props: { openFilePicker: () => void }) => ReactNode;
+  onUploadComplete?: (file: ZetkinFile) => void;
   orgId: number;
 };
 
-const FileDropZone: FC<Props> = ({ children, orgId }) => {
+const FileDropZone: FC<Props> = ({ children, onUploadComplete, orgId }) => {
   const {
     fileUploads,
     getDropZoneProps,
@@ -21,6 +23,7 @@ const FileDropZone: FC<Props> = ({ children, orgId }) => {
     openFilePicker,
   } = useFileUploads(orgId, {
     multiple: false,
+    onUploadComplete: onUploadComplete,
   });
 
   const activeFileUploads = fileUploads.filter(

--- a/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
+++ b/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import { FC, useState } from 'react';
 
+import FileUploadCard from '../FileUploadCard';
 import LibraryImageCard from '../LibraryImageCard';
 import messageIds from 'features/files/l10n/messageIds';
 import useFiles from 'features/files/hooks/useFiles';
@@ -18,12 +19,18 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { TYPE_OPTIONS, TypeOption } from 'features/files/types';
 
 type Props = {
+  onFileBrowserOpen: () => void;
   onSelectFile: (file: ZetkinFile) => void;
   orgId: number;
   type?: TypeOption;
 };
 
-const FileLibraryBrowser: FC<Props> = ({ onSelectFile, orgId, type }) => {
+const FileLibraryBrowser: FC<Props> = ({
+  onFileBrowserOpen,
+  onSelectFile,
+  orgId,
+  type,
+}) => {
   const [sorting, setSorting] = useState('date');
   const [filterText, setFilterText] = useState('');
   const [filterType, setFilterType] = useState<TypeOption | 'any'>(
@@ -112,6 +119,9 @@ const FileLibraryBrowser: FC<Props> = ({ onSelectFile, orgId, type }) => {
 
             return (
               <Grid container>
+                <Grid md={3} p={1} pb={5} xs={12}>
+                  <FileUploadCard onFileBrowserOpen={onFileBrowserOpen} />
+                </Grid>
                 {sortedFiles.map((file) => (
                   <Grid key={file.id} md={3} p={1} xs={12}>
                     <LibraryImageCard

--- a/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
+++ b/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
@@ -40,8 +40,8 @@ const FileLibraryBrowser: FC<Props> = ({
   const messages = useMessages(messageIds);
 
   return (
-    <Box>
-      <Box display="flex" gap={1} mt={1}>
+    <Box display="flex" flexDirection="column" height="100%">
+      <Box display="flex" gap={1} py={1}>
         <TextField
           fullWidth
           label={messages.searching.label()}
@@ -93,7 +93,7 @@ const FileLibraryBrowser: FC<Props> = ({
           </Select>
         </FormControl>
       </Box>
-      <Box>
+      <Box overflow="auto">
         <ZUIFuture future={filesFuture}>
           {(allFiles) => {
             const filteredFiles = allFiles.filter((file) => {

--- a/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
+++ b/src/features/files/components/FileLibraryDialog/FileLibraryBrowser.tsx
@@ -1,0 +1,132 @@
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from '@mui/material';
+import { FC, useState } from 'react';
+
+import LibraryImageCard from '../LibraryImageCard';
+import messageIds from 'features/files/l10n/messageIds';
+import useFiles from 'features/files/hooks/useFiles';
+import { useMessages } from 'core/i18n';
+import { ZetkinFile } from 'utils/types/zetkin';
+import ZUIFuture from 'zui/ZUIFuture';
+import { TYPE_OPTIONS, TypeOption } from 'features/files/types';
+
+type Props = {
+  onSelectFile: (file: ZetkinFile) => void;
+  orgId: number;
+  type?: TypeOption;
+};
+
+const FileLibraryBrowser: FC<Props> = ({ onSelectFile, orgId, type }) => {
+  const [sorting, setSorting] = useState('date');
+  const [filterText, setFilterText] = useState('');
+  const [filterType, setFilterType] = useState<TypeOption | 'any'>(
+    type || 'any'
+  );
+  const filesFuture = useFiles(orgId);
+  const messages = useMessages(messageIds);
+
+  return (
+    <Box>
+      <Box display="flex" gap={1} mt={1}>
+        <TextField
+          fullWidth
+          label={messages.searching.label()}
+          onChange={(ev) => setFilterText(ev.currentTarget.value)}
+          value={filterText}
+        />
+        <FormControl fullWidth>
+          <InputLabel>{messages.sorting.label()}</InputLabel>
+          <Select
+            label={messages.sorting.label()}
+            onChange={(ev) => setSorting(ev.target.value)}
+            value={sorting}
+          >
+            <MenuItem value="date">{messages.sorting.options.date()}</MenuItem>
+            <MenuItem value="originalName">
+              {messages.sorting.options.originalName()}
+            </MenuItem>
+          </Select>
+        </FormControl>
+        <FormControl disabled={!!type} fullWidth>
+          <InputLabel>{messages.typeFilter.label()}</InputLabel>
+          <Select
+            label={messages.typeFilter.label()}
+            onChange={(ev) =>
+              setFilterType(
+                ev.target.value == 'any'
+                  ? 'any'
+                  : (ev.target.value as TypeOption)
+              )
+            }
+            value={filterType}
+          >
+            <MenuItem value="any">{messages.typeFilter.anyOption()}</MenuItem>
+            {Object.keys(TYPE_OPTIONS).map((typeStr) => {
+              if (!(typeStr in TYPE_OPTIONS)) {
+                throw new Error('Unknown format');
+              }
+
+              // This cast is safe because the error above would have been
+              // thrown if typeStr is not one of the allowed strings.
+              const typeKey = typeStr as TypeOption;
+
+              return (
+                <MenuItem key={typeKey} value={typeKey}>
+                  {messages.typeFilter.options[typeKey]()}
+                </MenuItem>
+              );
+            })}
+          </Select>
+        </FormControl>
+      </Box>
+      <Box>
+        <ZUIFuture future={filesFuture}>
+          {(allFiles) => {
+            const filteredFiles = allFiles.filter((file) => {
+              const matchesText =
+                !filterText ||
+                file.original_name.toLowerCase().includes(filterText);
+
+              const matchesType =
+                filterType == 'any' ||
+                TYPE_OPTIONS[filterType].includes(file.mime_type);
+
+              return matchesText && matchesType;
+            });
+            const sortedFiles = filteredFiles.sort((f0, f1) => {
+              if (sorting == 'originalName') {
+                return f0.original_name.localeCompare(f1.original_name);
+              } else {
+                const d0 = new Date(f0.uploaded);
+                const d1 = new Date(f1.uploaded);
+                return d1.getTime() - d0.getTime();
+              }
+            });
+
+            return (
+              <Grid container>
+                {sortedFiles.map((file) => (
+                  <Grid key={file.id} md={3} p={1} xs={12}>
+                    <LibraryImageCard
+                      imageFile={file}
+                      onSelectImage={() => onSelectFile(file)}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            );
+          }}
+        </ZUIFuture>
+      </Box>
+    </Box>
+  );
+};
+
+export default FileLibraryBrowser;

--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+import LibraryImage from '../LibraryImage';
+import messageIds from 'features/files/l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { ZetkinFile } from 'utils/types/zetkin';
+
+type Props = {
+  file: ZetkinFile;
+  onBack: () => void;
+  onSelect: () => void;
+};
+
+const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
+  return (
+    <Box>
+      <Box my={2}>
+        <LibraryImage imageFile={file} interactive={false} />
+        <Typography color="secondary" mt={1} textAlign="center" variant="body2">
+          {file.original_name}
+        </Typography>
+      </Box>
+      <Box display="flex" gap={1} justifyContent="flex-end">
+        <Button onClick={() => onBack()} variant="outlined">
+          <Msg id={messageIds.libraryDialog.preview.backButton} />
+        </Button>
+        <Button onClick={() => onSelect()} variant="contained">
+          <Msg id={messageIds.libraryDialog.preview.useButton} />
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default FilePreview;

--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -14,8 +14,8 @@ type Props = {
 
 const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
   return (
-    <Box>
-      <Box my={2}>
+    <Box display="flex" flexDirection="column" height="100%">
+      <Box my={2} overflow="auto">
         <LibraryImage imageFile={file} interactive={false} />
         <Typography color="secondary" mt={1} textAlign="center" variant="body2">
           {file.original_name}

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -20,6 +20,7 @@ type Props = {
   onSelectFile: (file: ZetkinFile) => void;
   open: boolean;
   orgId: number;
+  type?: TypeOption;
 };
 
 type TypeOption = keyof typeof messageIds.typeFilter.options;
@@ -33,10 +34,13 @@ const FileLibraryDialog: FC<Props> = ({
   onSelectFile,
   open,
   orgId,
+  type,
 }) => {
   const [sorting, setSorting] = useState('date');
   const [filterText, setFilterText] = useState('');
-  const [filterType, setFilterType] = useState<TypeOption | 'any'>('any');
+  const [filterType, setFilterType] = useState<TypeOption | 'any'>(
+    type || 'any'
+  );
   const filesFuture = useFiles(orgId);
   const messages = useMessages(messageIds);
 
@@ -66,7 +70,7 @@ const FileLibraryDialog: FC<Props> = ({
             </MenuItem>
           </Select>
         </FormControl>
-        <FormControl fullWidth>
+        <FormControl disabled={!!type} fullWidth>
           <InputLabel>{messages.typeFilter.label()}</InputLabel>
           <Select
             label={messages.typeFilter.label()}

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,4 +1,11 @@
-import { Box, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import {
+  Box,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from '@mui/material';
 import { FC, useState } from 'react';
 
 import messageIds from 'features/files/l10n/messageIds';
@@ -22,6 +29,7 @@ const FileLibraryDialog: FC<Props> = ({
   orgId,
 }) => {
   const [sorting, setSorting] = useState('date');
+  const [filterText, setFilterText] = useState('');
   const filesFuture = useFiles(orgId);
   const messages = useMessages(messageIds);
 
@@ -31,7 +39,13 @@ const FileLibraryDialog: FC<Props> = ({
       open={open}
       title={messages.libraryDialog.title()}
     >
-      <Box display="flex" mt={1}>
+      <Box display="flex" gap={1} mt={1}>
+        <TextField
+          fullWidth
+          label={messages.searching.label()}
+          onChange={(ev) => setFilterText(ev.currentTarget.value)}
+          value={filterText}
+        />
         <FormControl fullWidth>
           <InputLabel>{messages.sorting.label()}</InputLabel>
           <Select
@@ -49,7 +63,13 @@ const FileLibraryDialog: FC<Props> = ({
       <Box>
         <ZUIFuture future={filesFuture}>
           {(allFiles) => {
-            const sortedFiles = allFiles.sort((f0, f1) => {
+            const filteredFiles = allFiles.filter((file) => {
+              return (
+                !filterText ||
+                file.original_name.toLowerCase().includes(filterText)
+              );
+            });
+            const sortedFiles = filteredFiles.sort((f0, f1) => {
               if (sorting == 'originalName') {
                 return f0.original_name.localeCompare(f1.original_name);
               } else {

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -28,7 +28,9 @@ const FileLibraryDialog: FC<Props> = ({
   const [selectedFile, setSelectedFile] = useState<ZetkinFile | null>(null);
   const messages = useMessages(messageIds);
 
-  const { getDropZoneProps } = useFileUploads(orgId, { multiple: false });
+  const { getDropZoneProps, openFilePicker } = useFileUploads(orgId, {
+    multiple: false,
+  });
 
   return (
     <ZUIDialog
@@ -47,6 +49,7 @@ const FileLibraryDialog: FC<Props> = ({
         )}
         {!selectedFile && (
           <FileLibraryBrowser
+            onFileBrowserOpen={() => openFilePicker()}
             onSelectFile={(file) => {
               setSelectedFile(file);
             }}

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,8 +1,11 @@
+import { Box } from '@mui/material';
 import { FC } from 'react';
-import { Box, Dialog } from '@mui/material';
 
+import messageIds from 'features/files/l10n/messageIds';
 import useFiles from 'features/files/hooks/useFiles';
+import { useMessages } from 'core/i18n';
 import { ZetkinFile } from 'utils/types/zetkin';
+import ZUIDialog from 'zui/ZUIDialog';
 import ZUIFuture from 'zui/ZUIFuture';
 
 type Props = {
@@ -19,9 +22,14 @@ const FileLibraryDialog: FC<Props> = ({
   orgId,
 }) => {
   const filesFuture = useFiles(orgId);
+  const messages = useMessages(messageIds);
 
   return (
-    <Dialog onClose={onClose} open={open}>
+    <ZUIDialog
+      onClose={onClose}
+      open={open}
+      title={messages.libraryDialog.title()}
+    >
       <ZUIFuture future={filesFuture}>
         {(data) => (
           <>
@@ -33,7 +41,7 @@ const FileLibraryDialog: FC<Props> = ({
           </>
         )}
       </ZUIFuture>
-    </Dialog>
+    </ZUIDialog>
   );
 };
 

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,0 +1,40 @@
+import { FC } from 'react';
+import { Box, Dialog } from '@mui/material';
+
+import useFiles from 'features/files/hooks/useFiles';
+import { ZetkinFile } from 'utils/types/zetkin';
+import ZUIFuture from 'zui/ZUIFuture';
+
+type Props = {
+  onClose: () => void;
+  onSelectFile: (file: ZetkinFile) => void;
+  open: boolean;
+  orgId: number;
+};
+
+const FileLibraryDialog: FC<Props> = ({
+  onClose,
+  onSelectFile,
+  open,
+  orgId,
+}) => {
+  const filesFuture = useFiles(orgId);
+
+  return (
+    <Dialog onClose={onClose} open={open}>
+      <ZUIFuture future={filesFuture}>
+        {(data) => (
+          <>
+            {data.map((file) => (
+              <Box key={file.id} onClick={() => onSelectFile(file)}>
+                {file.original_name}
+              </Box>
+            ))}
+          </>
+        )}
+      </ZUIFuture>
+    </Dialog>
+  );
+};
+
+export default FileLibraryDialog;

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -12,6 +12,7 @@ import { FC, useState } from 'react';
 import LibraryImageCard from '../LibraryImageCard';
 import messageIds from 'features/files/l10n/messageIds';
 import useFiles from 'features/files/hooks/useFiles';
+import useFileUploads from 'features/files/hooks/useFileUploads';
 import { useMessages } from 'core/i18n';
 import { ZetkinFile } from 'utils/types/zetkin';
 import ZUIDialog from 'zui/ZUIDialog';
@@ -46,6 +47,8 @@ const FileLibraryDialog: FC<Props> = ({
   const filesFuture = useFiles(orgId);
   const messages = useMessages(messageIds);
 
+  const { getDropZoneProps } = useFileUploads(orgId, { multiple: false });
+
   return (
     <ZUIDialog
       maxWidth="lg"
@@ -53,96 +56,100 @@ const FileLibraryDialog: FC<Props> = ({
       open={open}
       title={messages.libraryDialog.title()}
     >
-      <Box display="flex" gap={1} mt={1}>
-        <TextField
-          fullWidth
-          label={messages.searching.label()}
-          onChange={(ev) => setFilterText(ev.currentTarget.value)}
-          value={filterText}
-        />
-        <FormControl fullWidth>
-          <InputLabel>{messages.sorting.label()}</InputLabel>
-          <Select
-            label={messages.sorting.label()}
-            onChange={(ev) => setSorting(ev.target.value)}
-            value={sorting}
-          >
-            <MenuItem value="date">{messages.sorting.options.date()}</MenuItem>
-            <MenuItem value="originalName">
-              {messages.sorting.options.originalName()}
-            </MenuItem>
-          </Select>
-        </FormControl>
-        <FormControl disabled={!!type} fullWidth>
-          <InputLabel>{messages.typeFilter.label()}</InputLabel>
-          <Select
-            label={messages.typeFilter.label()}
-            onChange={(ev) =>
-              setFilterType(
-                ev.target.value == 'any'
-                  ? 'any'
-                  : (ev.target.value as TypeOption)
-              )
-            }
-            value={filterType}
-          >
-            <MenuItem value="any">{messages.typeFilter.anyOption()}</MenuItem>
-            {Object.keys(TYPE_OPTIONS).map((typeStr) => {
-              if (!(typeStr in TYPE_OPTIONS)) {
-                throw new Error('Unknown format');
+      <Box {...getDropZoneProps()}>
+        <Box display="flex" gap={1} mt={1}>
+          <TextField
+            fullWidth
+            label={messages.searching.label()}
+            onChange={(ev) => setFilterText(ev.currentTarget.value)}
+            value={filterText}
+          />
+          <FormControl fullWidth>
+            <InputLabel>{messages.sorting.label()}</InputLabel>
+            <Select
+              label={messages.sorting.label()}
+              onChange={(ev) => setSorting(ev.target.value)}
+              value={sorting}
+            >
+              <MenuItem value="date">
+                {messages.sorting.options.date()}
+              </MenuItem>
+              <MenuItem value="originalName">
+                {messages.sorting.options.originalName()}
+              </MenuItem>
+            </Select>
+          </FormControl>
+          <FormControl disabled={!!type} fullWidth>
+            <InputLabel>{messages.typeFilter.label()}</InputLabel>
+            <Select
+              label={messages.typeFilter.label()}
+              onChange={(ev) =>
+                setFilterType(
+                  ev.target.value == 'any'
+                    ? 'any'
+                    : (ev.target.value as TypeOption)
+                )
               }
+              value={filterType}
+            >
+              <MenuItem value="any">{messages.typeFilter.anyOption()}</MenuItem>
+              {Object.keys(TYPE_OPTIONS).map((typeStr) => {
+                if (!(typeStr in TYPE_OPTIONS)) {
+                  throw new Error('Unknown format');
+                }
 
-              // This cast is safe because the error above would have been
-              // thrown if typeStr is not one of the allowed strings.
-              const typeKey = typeStr as TypeOption;
+                // This cast is safe because the error above would have been
+                // thrown if typeStr is not one of the allowed strings.
+                const typeKey = typeStr as TypeOption;
+
+                return (
+                  <MenuItem key={typeKey} value={typeKey}>
+                    {messages.typeFilter.options[typeKey]()}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        </Box>
+        <Box>
+          <ZUIFuture future={filesFuture}>
+            {(allFiles) => {
+              const filteredFiles = allFiles.filter((file) => {
+                const matchesText =
+                  !filterText ||
+                  file.original_name.toLowerCase().includes(filterText);
+
+                const matchesType =
+                  filterType == 'any' ||
+                  TYPE_OPTIONS[filterType].includes(file.mime_type);
+
+                return matchesText && matchesType;
+              });
+              const sortedFiles = filteredFiles.sort((f0, f1) => {
+                if (sorting == 'originalName') {
+                  return f0.original_name.localeCompare(f1.original_name);
+                } else {
+                  const d0 = new Date(f0.uploaded);
+                  const d1 = new Date(f1.uploaded);
+                  return d1.getTime() - d0.getTime();
+                }
+              });
 
               return (
-                <MenuItem key={typeKey} value={typeKey}>
-                  {messages.typeFilter.options[typeKey]()}
-                </MenuItem>
+                <Grid container>
+                  {sortedFiles.map((file) => (
+                    <Grid key={file.id} md={3} p={1} xs={12}>
+                      <LibraryImageCard
+                        imageFile={file}
+                        onSelectImage={() => onSelectFile(file)}
+                      />
+                    </Grid>
+                  ))}
+                </Grid>
               );
-            })}
-          </Select>
-        </FormControl>
-      </Box>
-      <Box>
-        <ZUIFuture future={filesFuture}>
-          {(allFiles) => {
-            const filteredFiles = allFiles.filter((file) => {
-              const matchesText =
-                !filterText ||
-                file.original_name.toLowerCase().includes(filterText);
-
-              const matchesType =
-                filterType == 'any' ||
-                TYPE_OPTIONS[filterType].includes(file.mime_type);
-
-              return matchesText && matchesType;
-            });
-            const sortedFiles = filteredFiles.sort((f0, f1) => {
-              if (sorting == 'originalName') {
-                return f0.original_name.localeCompare(f1.original_name);
-              } else {
-                const d0 = new Date(f0.uploaded);
-                const d1 = new Date(f1.uploaded);
-                return d1.getTime() - d0.getTime();
-              }
-            });
-
-            return (
-              <Grid container>
-                {sortedFiles.map((file) => (
-                  <Grid key={file.id} md={3} p={1} xs={12}>
-                    <LibraryImageCard
-                      imageFile={file}
-                      onSelectImage={() => onSelectFile(file)}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
-            );
-          }}
-        </ZUIFuture>
+            }}
+          </ZUIFuture>
+        </Box>
       </Box>
     </ZUIDialog>
   );

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,5 +1,5 @@
-import { Box } from '@mui/material';
-import { FC } from 'react';
+import { Box, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import { FC, useState } from 'react';
 
 import messageIds from 'features/files/l10n/messageIds';
 import useFiles from 'features/files/hooks/useFiles';
@@ -21,6 +21,7 @@ const FileLibraryDialog: FC<Props> = ({
   open,
   orgId,
 }) => {
+  const [sorting, setSorting] = useState('date');
   const filesFuture = useFiles(orgId);
   const messages = useMessages(messageIds);
 
@@ -30,17 +31,46 @@ const FileLibraryDialog: FC<Props> = ({
       open={open}
       title={messages.libraryDialog.title()}
     >
-      <ZUIFuture future={filesFuture}>
-        {(data) => (
-          <>
-            {data.map((file) => (
-              <Box key={file.id} onClick={() => onSelectFile(file)}>
-                {file.original_name}
-              </Box>
-            ))}
-          </>
-        )}
-      </ZUIFuture>
+      <Box display="flex" mt={1}>
+        <FormControl fullWidth>
+          <InputLabel>{messages.sorting.label()}</InputLabel>
+          <Select
+            label={messages.sorting.label()}
+            onChange={(ev) => setSorting(ev.target.value)}
+            value={sorting}
+          >
+            <MenuItem value="date">{messages.sorting.options.date()}</MenuItem>
+            <MenuItem value="originalName">
+              {messages.sorting.options.originalName()}
+            </MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+      <Box>
+        <ZUIFuture future={filesFuture}>
+          {(allFiles) => {
+            const sortedFiles = allFiles.sort((f0, f1) => {
+              if (sorting == 'originalName') {
+                return f0.original_name.localeCompare(f1.original_name);
+              } else {
+                const d0 = new Date(f0.uploaded);
+                const d1 = new Date(f1.uploaded);
+                return d1.getTime() - d0.getTime();
+              }
+            });
+
+            return (
+              <>
+                {sortedFiles.map((file) => (
+                  <Box key={file.id} onClick={() => onSelectFile(file)}>
+                    {file.original_name}
+                  </Box>
+                ))}
+              </>
+            );
+          }}
+        </ZUIFuture>
+      </Box>
     </ZUIDialog>
   );
 };

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -45,7 +45,10 @@ const FileLibraryDialog: FC<Props> = ({
           />
         )}
         {!selectedFile && (
-          <FileDropZone orgId={orgId}>
+          <FileDropZone
+            onUploadComplete={(file) => setSelectedFile(file)}
+            orgId={orgId}
+          >
             {({ openFilePicker }) => (
               <FileLibraryBrowser
                 onFileBrowserOpen={() => openFilePicker()}

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -34,6 +34,7 @@ const FileLibraryDialog: FC<Props> = ({
 
   return (
     <ZUIDialog
+      contentHeight="80vh"
       maxWidth="lg"
       onClose={onClose}
       open={open}

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
 import { FC, useState } from 'react';
 
+import FileDropZone from '../FileDropZone';
 import FileLibraryBrowser from './FileLibraryBrowser';
 import FilePreview from './FilePreview';
 import messageIds from 'features/files/l10n/messageIds';
 import { TypeOption } from 'features/files/types';
-import useFileUploads from 'features/files/hooks/useFileUploads';
 import { useMessages } from 'core/i18n';
 import { ZetkinFile } from 'utils/types/zetkin';
 import ZUIDialog from 'zui/ZUIDialog';
@@ -28,10 +28,6 @@ const FileLibraryDialog: FC<Props> = ({
   const [selectedFile, setSelectedFile] = useState<ZetkinFile | null>(null);
   const messages = useMessages(messageIds);
 
-  const { getDropZoneProps, openFilePicker } = useFileUploads(orgId, {
-    multiple: false,
-  });
-
   return (
     <ZUIDialog
       contentHeight="80vh"
@@ -40,7 +36,7 @@ const FileLibraryDialog: FC<Props> = ({
       open={open}
       title={messages.libraryDialog.title()}
     >
-      <Box {...getDropZoneProps()}>
+      <Box height="100%">
         {selectedFile && (
           <FilePreview
             file={selectedFile}
@@ -49,14 +45,18 @@ const FileLibraryDialog: FC<Props> = ({
           />
         )}
         {!selectedFile && (
-          <FileLibraryBrowser
-            onFileBrowserOpen={() => openFilePicker()}
-            onSelectFile={(file) => {
-              setSelectedFile(file);
-            }}
-            orgId={orgId}
-            type={type}
-          />
+          <FileDropZone orgId={orgId}>
+            {({ openFilePicker }) => (
+              <FileLibraryBrowser
+                onFileBrowserOpen={() => openFilePicker()}
+                onSelectFile={(file) => {
+                  setSelectedFile(file);
+                }}
+                orgId={orgId}
+                type={type}
+              />
+            )}
+          </FileDropZone>
         )}
       </Box>
     </ZUIDialog>

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,7 +1,8 @@
 import { Box } from '@mui/material';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import FileLibraryBrowser from './FileLibraryBrowser';
+import FilePreview from './FilePreview';
 import messageIds from 'features/files/l10n/messageIds';
 import { TypeOption } from 'features/files/types';
 import useFileUploads from 'features/files/hooks/useFileUploads';
@@ -24,6 +25,7 @@ const FileLibraryDialog: FC<Props> = ({
   orgId,
   type,
 }) => {
+  const [selectedFile, setSelectedFile] = useState<ZetkinFile | null>(null);
   const messages = useMessages(messageIds);
 
   const { getDropZoneProps } = useFileUploads(orgId, { multiple: false });
@@ -36,11 +38,22 @@ const FileLibraryDialog: FC<Props> = ({
       title={messages.libraryDialog.title()}
     >
       <Box {...getDropZoneProps()}>
-        <FileLibraryBrowser
-          onSelectFile={onSelectFile}
-          orgId={orgId}
-          type={type}
-        />
+        {selectedFile && (
+          <FilePreview
+            file={selectedFile}
+            onBack={() => setSelectedFile(null)}
+            onSelect={() => onSelectFile && onSelectFile(selectedFile)}
+          />
+        )}
+        {!selectedFile && (
+          <FileLibraryBrowser
+            onSelectFile={(file) => {
+              setSelectedFile(file);
+            }}
+            orgId={orgId}
+            type={type}
+          />
+        )}
       </Box>
     </ZUIDialog>
   );

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   FormControl,
+  Grid,
   InputLabel,
   MenuItem,
   Select,
@@ -8,6 +9,7 @@ import {
 } from '@mui/material';
 import { FC, useState } from 'react';
 
+import LibraryImageCard from '../LibraryImageCard';
 import messageIds from 'features/files/l10n/messageIds';
 import useFiles from 'features/files/hooks/useFiles';
 import { useMessages } from 'core/i18n';
@@ -46,6 +48,7 @@ const FileLibraryDialog: FC<Props> = ({
 
   return (
     <ZUIDialog
+      maxWidth="lg"
       onClose={onClose}
       open={open}
       title={messages.libraryDialog.title()}
@@ -127,13 +130,16 @@ const FileLibraryDialog: FC<Props> = ({
             });
 
             return (
-              <>
+              <Grid container>
                 {sortedFiles.map((file) => (
-                  <Box key={file.id} onClick={() => onSelectFile(file)}>
-                    {file.original_name}
-                  </Box>
+                  <Grid key={file.id} md={3} p={1} xs={12}>
+                    <LibraryImageCard
+                      imageFile={file}
+                      onSelectImage={() => onSelectFile(file)}
+                    />
+                  </Grid>
                 ))}
-              </>
+              </Grid>
             );
           }}
         </ZUIFuture>

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -1,22 +1,13 @@
-import {
-  Box,
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
-} from '@mui/material';
-import { FC, useState } from 'react';
+import { Box } from '@mui/material';
+import { FC } from 'react';
 
-import LibraryImageCard from '../LibraryImageCard';
+import FileLibraryBrowser from './FileLibraryBrowser';
 import messageIds from 'features/files/l10n/messageIds';
-import useFiles from 'features/files/hooks/useFiles';
+import { TypeOption } from 'features/files/types';
 import useFileUploads from 'features/files/hooks/useFileUploads';
 import { useMessages } from 'core/i18n';
 import { ZetkinFile } from 'utils/types/zetkin';
 import ZUIDialog from 'zui/ZUIDialog';
-import ZUIFuture from 'zui/ZUIFuture';
 
 type Props = {
   onClose: () => void;
@@ -26,12 +17,6 @@ type Props = {
   type?: TypeOption;
 };
 
-type TypeOption = keyof typeof messageIds.typeFilter.options;
-
-const TYPE_OPTIONS: Record<TypeOption, string[]> = {
-  image: ['image/png', 'image/jpeg'],
-};
-
 const FileLibraryDialog: FC<Props> = ({
   onClose,
   onSelectFile,
@@ -39,12 +24,6 @@ const FileLibraryDialog: FC<Props> = ({
   orgId,
   type,
 }) => {
-  const [sorting, setSorting] = useState('date');
-  const [filterText, setFilterText] = useState('');
-  const [filterType, setFilterType] = useState<TypeOption | 'any'>(
-    type || 'any'
-  );
-  const filesFuture = useFiles(orgId);
   const messages = useMessages(messageIds);
 
   const { getDropZoneProps } = useFileUploads(orgId, { multiple: false });
@@ -57,99 +36,11 @@ const FileLibraryDialog: FC<Props> = ({
       title={messages.libraryDialog.title()}
     >
       <Box {...getDropZoneProps()}>
-        <Box display="flex" gap={1} mt={1}>
-          <TextField
-            fullWidth
-            label={messages.searching.label()}
-            onChange={(ev) => setFilterText(ev.currentTarget.value)}
-            value={filterText}
-          />
-          <FormControl fullWidth>
-            <InputLabel>{messages.sorting.label()}</InputLabel>
-            <Select
-              label={messages.sorting.label()}
-              onChange={(ev) => setSorting(ev.target.value)}
-              value={sorting}
-            >
-              <MenuItem value="date">
-                {messages.sorting.options.date()}
-              </MenuItem>
-              <MenuItem value="originalName">
-                {messages.sorting.options.originalName()}
-              </MenuItem>
-            </Select>
-          </FormControl>
-          <FormControl disabled={!!type} fullWidth>
-            <InputLabel>{messages.typeFilter.label()}</InputLabel>
-            <Select
-              label={messages.typeFilter.label()}
-              onChange={(ev) =>
-                setFilterType(
-                  ev.target.value == 'any'
-                    ? 'any'
-                    : (ev.target.value as TypeOption)
-                )
-              }
-              value={filterType}
-            >
-              <MenuItem value="any">{messages.typeFilter.anyOption()}</MenuItem>
-              {Object.keys(TYPE_OPTIONS).map((typeStr) => {
-                if (!(typeStr in TYPE_OPTIONS)) {
-                  throw new Error('Unknown format');
-                }
-
-                // This cast is safe because the error above would have been
-                // thrown if typeStr is not one of the allowed strings.
-                const typeKey = typeStr as TypeOption;
-
-                return (
-                  <MenuItem key={typeKey} value={typeKey}>
-                    {messages.typeFilter.options[typeKey]()}
-                  </MenuItem>
-                );
-              })}
-            </Select>
-          </FormControl>
-        </Box>
-        <Box>
-          <ZUIFuture future={filesFuture}>
-            {(allFiles) => {
-              const filteredFiles = allFiles.filter((file) => {
-                const matchesText =
-                  !filterText ||
-                  file.original_name.toLowerCase().includes(filterText);
-
-                const matchesType =
-                  filterType == 'any' ||
-                  TYPE_OPTIONS[filterType].includes(file.mime_type);
-
-                return matchesText && matchesType;
-              });
-              const sortedFiles = filteredFiles.sort((f0, f1) => {
-                if (sorting == 'originalName') {
-                  return f0.original_name.localeCompare(f1.original_name);
-                } else {
-                  const d0 = new Date(f0.uploaded);
-                  const d1 = new Date(f1.uploaded);
-                  return d1.getTime() - d0.getTime();
-                }
-              });
-
-              return (
-                <Grid container>
-                  {sortedFiles.map((file) => (
-                    <Grid key={file.id} md={3} p={1} xs={12}>
-                      <LibraryImageCard
-                        imageFile={file}
-                        onSelectImage={() => onSelectFile(file)}
-                      />
-                    </Grid>
-                  ))}
-                </Grid>
-              );
-            }}
-          </ZUIFuture>
-        </Box>
+        <FileLibraryBrowser
+          onSelectFile={onSelectFile}
+          orgId={orgId}
+          type={type}
+        />
       </Box>
     </ZUIDialog>
   );

--- a/src/features/files/components/FileUploadCard.tsx
+++ b/src/features/files/components/FileUploadCard.tsx
@@ -31,7 +31,6 @@ const FileUploadCard: FC<FileUploadCardProps> = ({ onFileBrowserOpen }) => {
       }}
     >
       <IconButton
-        onClick={onFileBrowserOpen}
         sx={{
           backgroundColor: theme.palette.grey[300],
           borderRadius: 100,
@@ -46,7 +45,6 @@ const FileUploadCard: FC<FileUploadCardProps> = ({ onFileBrowserOpen }) => {
         />
       </IconButton>
       <Link
-        onClick={onFileBrowserOpen}
         sx={{
           color: theme.palette.primary.main,
           cursor: 'pointer',

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -1,6 +1,6 @@
-import { FC } from 'react';
 import Image from 'next/image';
 import { Box, useTheme } from '@mui/material';
+import { FC, useState } from 'react';
 
 import { ZetkinFile } from 'utils/types/zetkin';
 
@@ -8,19 +8,29 @@ interface LibraryImageProps {
   imageFile: ZetkinFile;
 }
 
+const DEFAULT_GRID_INTENSITY = 0.02;
+
 const LibraryImage: FC<LibraryImageProps> = ({ imageFile }) => {
   const theme = useTheme();
+  const [gridIntensity, setGridIntensity] = useState(DEFAULT_GRID_INTENSITY);
 
   return (
     <Box
       border={1}
       borderColor={theme.palette.grey[400]}
       borderRadius={1}
+      onMouseEnter={() => {
+        setGridIntensity(0.15);
+      }}
+      onMouseLeave={() => {
+        setGridIntensity(DEFAULT_GRID_INTENSITY);
+      }}
       sx={{
-        backgroundImage:
-          'linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%);',
+        backgroundColor: '#eee',
+        backgroundImage: `linear-gradient(45deg, rgba(0,0,0,${gridIntensity}) 25%, transparent 25%), linear-gradient(-45deg, rgba(0,0,0,${gridIntensity}) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, rgba(0,0,0,${gridIntensity}) 75%), linear-gradient(-45deg, transparent 75%, rgba(0,0,0,${gridIntensity}) 75%);`,
         backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0px',
         backgroundSize: '30px 30px',
+        transition: 'backgroundImage 0.2s',
       }}
     >
       <Image

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -9,6 +9,8 @@ interface LibraryImageProps {
   imageFile: ZetkinFile;
   interactive?: boolean;
   lowGridIntensity?: number;
+  onLoad?: () => void;
+  onLoadingComplete?: () => void;
 }
 
 const LibraryImage: FC<LibraryImageProps> = ({
@@ -16,6 +18,8 @@ const LibraryImage: FC<LibraryImageProps> = ({
   highGridIntensity: hoverGridIntensity = 0.15,
   imageFile,
   interactive = true,
+  onLoad,
+  onLoadingComplete,
 }) => {
   const theme = useTheme();
   const [gridIntensity, setGridIntensity] = useState(
@@ -48,6 +52,8 @@ const LibraryImage: FC<LibraryImageProps> = ({
         height="100%"
         layout="responsive"
         objectFit="contain"
+        onLoad={() => onLoad && onLoad()}
+        onLoadingComplete={() => onLoadingComplete && onLoadingComplete()}
         src={imageFile.url}
         width="100%"
       />

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -5,14 +5,22 @@ import { FC, useState } from 'react';
 import { ZetkinFile } from 'utils/types/zetkin';
 
 interface LibraryImageProps {
+  highGridIntensity?: number;
   imageFile: ZetkinFile;
+  interactive?: boolean;
+  lowGridIntensity?: number;
 }
 
-const DEFAULT_GRID_INTENSITY = 0.02;
-
-const LibraryImage: FC<LibraryImageProps> = ({ imageFile }) => {
+const LibraryImage: FC<LibraryImageProps> = ({
+  lowGridIntensity: defaultGridIntensity = 0.02,
+  highGridIntensity: hoverGridIntensity = 0.15,
+  imageFile,
+  interactive = true,
+}) => {
   const theme = useTheme();
-  const [gridIntensity, setGridIntensity] = useState(DEFAULT_GRID_INTENSITY);
+  const [gridIntensity, setGridIntensity] = useState(
+    interactive ? defaultGridIntensity : hoverGridIntensity
+  );
 
   return (
     <Box
@@ -20,10 +28,12 @@ const LibraryImage: FC<LibraryImageProps> = ({ imageFile }) => {
       borderColor={theme.palette.grey[400]}
       borderRadius={1}
       onMouseEnter={() => {
-        setGridIntensity(0.15);
+        setGridIntensity(hoverGridIntensity);
       }}
       onMouseLeave={() => {
-        setGridIntensity(DEFAULT_GRID_INTENSITY);
+        if (interactive) {
+          setGridIntensity(defaultGridIntensity);
+        }
       }}
       sx={{
         backgroundColor: '#eee',

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -1,8 +1,7 @@
-import { FC } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { FC, useState } from 'react';
 
 import LibraryImage from './LibraryImage';
-import { truncateOnMiddle } from 'utils/stringUtils';
 import { ZetkinFile } from 'utils/types/zetkin';
 
 interface LibraryImageCardProps {
@@ -14,6 +13,8 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
   imageFile,
   onSelectImage,
 }) => {
+  const [loading, setLoading] = useState(true);
+
   return (
     <Box
       display="flex"
@@ -21,15 +22,28 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
       onClick={onSelectImage}
       sx={{ cursor: 'pointer' }}
     >
-      <LibraryImage imageFile={imageFile} />
-      <Typography
-        alignSelf="center"
-        color="secondary"
-        paddingTop={1}
-        variant="body2"
-      >
-        {truncateOnMiddle(imageFile.original_name, 24)}
-      </Typography>
+      <LibraryImage
+        imageFile={imageFile}
+        onLoad={() => setLoading(true)}
+        onLoadingComplete={() => setLoading(false)}
+      />
+      <Box alignItems="center" display="flex" justifyContent="center" mt={1}>
+        {loading && (
+          <CircularProgress color="primary" size="1em" sx={{ mr: 1 }} />
+        )}
+        <Typography
+          alignSelf="center"
+          color="secondary"
+          component="span"
+          maxWidth="80%"
+          noWrap
+          overflow="hidden"
+          textOverflow="ellipsis"
+          variant="body2"
+        >
+          {imageFile.original_name}
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -22,8 +22,13 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
       sx={{ cursor: 'pointer' }}
     >
       <LibraryImage imageFile={imageFile} />
-      <Typography alignSelf="center" color="secondary" paddingTop={1}>
-        {truncateOnMiddle(imageFile.original_name, 30)}
+      <Typography
+        alignSelf="center"
+        color="secondary"
+        paddingTop={1}
+        variant="body2"
+      >
+        {truncateOnMiddle(imageFile.original_name, 24)}
       </Typography>
     </Box>
   );

--- a/src/features/files/hooks/useFileUploads.ts
+++ b/src/features/files/hooks/useFileUploads.ts
@@ -43,6 +43,7 @@ export default function useFileUploads(
   props?: {
     accept?: Accept;
     multiple?: boolean;
+    onUploadComplete?: (file: ZetkinFile) => void;
   }
 ): UseFileUploads {
   const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
@@ -104,6 +105,10 @@ export default function useFileUploads(
             : file
         )
       );
+
+      if (props?.onUploadComplete) {
+        props.onUploadComplete(payload.data);
+      }
     } catch (err) {
       // TODO: Handle error more gracefully
       setFileUploads(

--- a/src/features/files/hooks/useFileUploads.ts
+++ b/src/features/files/hooks/useFileUploads.ts
@@ -31,7 +31,9 @@ export interface FileUpload {
 interface UseFileUploads {
   cancelFileUpload: (file: FileUpload) => void;
   fileUploads: FileUpload[];
+  getInputProps: DropzoneState['getInputProps'];
   getDropZoneProps: DropzoneState['getRootProps'];
+  isDraggingOver: boolean;
   openFilePicker: () => void;
   reset: () => void;
 }
@@ -122,7 +124,7 @@ export default function useFileUploads(
     addFiles(acceptedFiles);
   }, []);
 
-  const { getRootProps } = useDropzone({
+  const { getInputProps, getRootProps, isDragActive } = useDropzone({
     accept: props?.accept,
     multiple: props?.multiple,
     noClick: true,
@@ -137,6 +139,8 @@ export default function useFileUploads(
     },
     fileUploads,
     getDropZoneProps: getRootProps,
+    getInputProps,
+    isDraggingOver: isDragActive,
     openFilePicker: () => {
       fileInput.current?.click();
     },

--- a/src/features/files/hooks/useFileUploads.ts
+++ b/src/features/files/hooks/useFileUploads.ts
@@ -1,6 +1,8 @@
 import { Accept, DropzoneState, useDropzone } from 'react-dropzone';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { fileUploaded } from '../store';
+import { useAppDispatch } from 'core/hooks';
 import { ZetkinFile } from 'utils/types/zetkin';
 
 export enum FileUploadState {
@@ -42,6 +44,7 @@ export default function useFileUploads(
   }
 ): UseFileUploads {
   const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
+  const dispatch = useAppDispatch();
 
   const fileKeyRef = useRef<number>(1);
   const filesRef = useRef(fileUploads);
@@ -88,11 +91,14 @@ export default function useFileUploads(
         method: 'POST',
       });
 
-      const data = await res.json();
+      const payload = await res.json();
+
+      dispatch(fileUploaded(payload.data));
+
       setFileUploads(
         filesRef.current.map((file) =>
           file.key == upload.key
-            ? { ...file, apiData: data.data, state: FileUploadState.SUCCESS }
+            ? { ...file, apiData: payload.data, state: FileUploadState.SUCCESS }
             : file
         )
       );

--- a/src/features/files/hooks/useFileUploads.ts
+++ b/src/features/files/hooks/useFileUploads.ts
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import { Accept, DropzoneState, useDropzone } from 'react-dropzone';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -35,11 +34,13 @@ interface UseFileUploads {
   reset: () => void;
 }
 
-export default function useFileUploads(props?: {
-  accept?: Accept;
-  multiple?: boolean;
-}): UseFileUploads {
-  const { orgId } = useRouter().query;
+export default function useFileUploads(
+  orgId: number,
+  props?: {
+    accept?: Accept;
+    multiple?: boolean;
+  }
+): UseFileUploads {
   const [fileUploads, setFileUploads] = useState<FileUpload[]>([]);
 
   const fileKeyRef = useRef<number>(1);

--- a/src/features/files/hooks/useFiles.ts
+++ b/src/features/files/hooks/useFiles.ts
@@ -1,0 +1,17 @@
+import { IFuture } from 'core/caching/futures';
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+import { ZetkinFile } from 'utils/types/zetkin';
+import { filesLoad, filesLoaded } from '../store';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+
+export default function useFiles(orgId: number): IFuture<ZetkinFile[]> {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const list = useAppSelector((state) => state.files.fileList);
+
+  return loadListIfNecessary(list, dispatch, {
+    actionOnLoad: () => filesLoad(),
+    actionOnSuccess: (data) => filesLoaded(data),
+    loader: async () => apiClient.get(`/api/orgs/${orgId}/files`),
+  });
+}

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -2,6 +2,7 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.files', {
   fileUpload: {
+    dropToUpload: m('Drop file here to upload it'),
     instructions: m(' or drag and drop'),
     selectClick: m('Click to upload'),
   },

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -14,4 +14,11 @@ export default makeMessages('feat.files', {
       originalName: m('Original filename'),
     },
   },
+  typeFilter: {
+    anyOption: m('Any type'),
+    label: m('Type'),
+    options: {
+      image: m('Images'),
+    },
+  },
 });

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -4,6 +4,9 @@ export default makeMessages('feat.files', {
   libraryDialog: {
     title: m('Library'),
   },
+  searching: {
+    label: m('Search'),
+  },
   sorting: {
     label: m('Sort by'),
     options: {

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -4,4 +4,11 @@ export default makeMessages('feat.files', {
   libraryDialog: {
     title: m('Library'),
   },
+  sorting: {
+    label: m('Sort by'),
+    options: {
+      date: m('Date'),
+      originalName: m('Original filename'),
+    },
+  },
 });

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -2,6 +2,10 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.files', {
   libraryDialog: {
+    preview: {
+      backButton: m('Back to library'),
+      useButton: m('Use'),
+    },
     title: m('Library'),
   },
   searching: {

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -1,0 +1,7 @@
+import { m, makeMessages } from 'core/i18n';
+
+export default makeMessages('feat.files', {
+  libraryDialog: {
+    title: m('Library'),
+  },
+});

--- a/src/features/files/store.ts
+++ b/src/features/files/store.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ZetkinFile } from 'utils/types/zetkin';
+import { remoteList, RemoteList } from 'utils/storeUtils';
+
+export interface FilesStoreSlice {
+  fileList: RemoteList<ZetkinFile>;
+}
+
+const initialState: FilesStoreSlice = {
+  fileList: remoteList(),
+};
+
+const filesSlice = createSlice({
+  initialState: initialState,
+  name: 'tags',
+  reducers: {
+    filesLoad: (state) => {
+      state.fileList.isLoading = true;
+    },
+    filesLoaded: (state, action: PayloadAction<ZetkinFile[]>) => {
+      state.fileList = remoteList(action.payload);
+      state.fileList.loaded = new Date().toISOString();
+    },
+  },
+});
+
+export default filesSlice;
+export const { filesLoad, filesLoaded } = filesSlice.actions;

--- a/src/features/files/store.ts
+++ b/src/features/files/store.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { ZetkinFile } from 'utils/types/zetkin';
-import { remoteList, RemoteList } from 'utils/storeUtils';
+import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 
 export interface FilesStoreSlice {
   fileList: RemoteList<ZetkinFile>;
@@ -15,6 +15,12 @@ const filesSlice = createSlice({
   initialState: initialState,
   name: 'tags',
   reducers: {
+    fileUploaded: (state, action: PayloadAction<ZetkinFile>) => {
+      const file = action.payload;
+      state.fileList.items = state.fileList.items.concat([
+        remoteItem(file.id, { data: file, loaded: new Date().toISOString() }),
+      ]);
+    },
     filesLoad: (state) => {
       state.fileList.isLoading = true;
     },
@@ -26,4 +32,4 @@ const filesSlice = createSlice({
 });
 
 export default filesSlice;
-export const { filesLoad, filesLoaded } = filesSlice.actions;
+export const { fileUploaded, filesLoad, filesLoaded } = filesSlice.actions;

--- a/src/features/files/types.ts
+++ b/src/features/files/types.ts
@@ -1,0 +1,5 @@
+export type TypeOption = 'image';
+
+export const TYPE_OPTIONS: Record<TypeOption, string[]> = {
+  image: ['image/png', 'image/jpeg'],
+};

--- a/src/features/tasks/components/TaskPreviewSection.tsx
+++ b/src/features/tasks/components/TaskPreviewSection.tsx
@@ -11,12 +11,14 @@ import ZUISection from 'zui/ZUISection';
 import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from '../l10n/messageIds';
+import { useNumericRouteParams } from 'core/hooks';
 
 interface TaskPreviewSectionProps {
   task: ZetkinTask;
 }
 
 const TaskPreviewSection: React.FC<TaskPreviewSectionProps> = ({ task }) => {
+  const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const [selecting, setSelecting] = useState(false);
 
@@ -84,6 +86,7 @@ const TaskPreviewSection: React.FC<TaskPreviewSectionProps> = ({ task }) => {
           });
         }}
         open={selecting}
+        orgId={orgId}
       />
     </ZUISection>
   );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,34 +1,19 @@
 import '../styles.css';
 
-import { AdapterDayjs } from '@mui/x-date-pickers-pro/AdapterDayjs';
 import { AppProps } from 'next/app';
 import createStore from 'core/store';
 import CssBaseline from '@mui/material/CssBaseline';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
-import { IntlProvider } from 'react-intl';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
-import { LocalizationProvider } from '@mui/x-date-pickers-pro';
 import { NoSsr } from '@mui/base';
 import NProgress from 'nprogress';
-import { Provider as ReduxProvider } from 'react-redux';
+import { Theme } from '@mui/material/styles';
 import { useEffect } from 'react';
 import Router, { useRouter } from 'next/router';
-import {
-  StyledEngineProvider,
-  Theme,
-  ThemeProvider,
-} from '@mui/material/styles';
 
 import BrowserApiClient from 'core/api/client/BrowserApiClient';
 import Environment from 'core/env/Environment';
-import { EnvProvider } from 'core/env/EnvContext';
-import { EventPopperProvider } from 'features/events/components/EventPopper/EventPopperProvider';
 import { PageWithLayout } from '../utils/types';
-import { themeWithLocale } from '../theme';
-import { UserContext } from 'utils/hooks/useFocusDate';
-import { ZUIConfirmDialogProvider } from 'zui/ZUIConfirmDialogProvider';
-import { ZUISnackbarProvider } from 'zui/ZUISnackbarContext';
+import Providers from 'core/Providers';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -84,36 +69,16 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   }, []);
 
   return (
-    <ReduxProvider store={store}>
-      <EnvProvider env={env}>
-        <UserContext.Provider value={pageProps.user}>
-          <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={themeWithLocale(lang)}>
-              <LocalizationProvider dateAdapter={AdapterDayjs}>
-                <IntlProvider
-                  defaultLocale="en"
-                  locale={lang}
-                  messages={messages}
-                >
-                  <ZUISnackbarProvider>
-                    <ZUIConfirmDialogProvider>
-                      <EventPopperProvider>
-                        <DndProvider backend={HTML5Backend}>
-                          <CssBaseline />
-                          <NoSsr>
-                            {getLayout(<Component {...restProps} />, restProps)}
-                          </NoSsr>
-                        </DndProvider>
-                      </EventPopperProvider>
-                    </ZUIConfirmDialogProvider>
-                  </ZUISnackbarProvider>
-                </IntlProvider>
-              </LocalizationProvider>
-            </ThemeProvider>
-          </StyledEngineProvider>
-        </UserContext.Provider>
-      </EnvProvider>
-    </ReduxProvider>
+    <Providers
+      env={env}
+      lang={lang}
+      messages={messages}
+      store={store}
+      user={pageProps.user}
+    >
+      <CssBaseline />
+      <NoSsr>{getLayout(<Component {...restProps} />, restProps)}</NoSsr>
+    </Providers>
   );
 }
 

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material';
+import EmailEditor from 'features/emails/components/EmailEditor';
+import EmailLayout from 'features/emails/layout/EmailLayout';
+import { GetServerSideProps } from 'next';
+import { PageWithLayout } from 'utils/types';
+import { scaffold } from 'utils/next';
+import useServerSide from 'core/useServerSide';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId, campId, emailId } = ctx.params!;
+
+    return {
+      props: {
+        campId,
+        emailId,
+        orgId,
+      },
+    };
+  },
+  {
+    authLevelRequired: 2,
+    localeScope: ['layout.organize.email', 'pages.organizeEmail'],
+  }
+);
+
+const EmailPage: PageWithLayout = () => {
+  const onServer = useServerSide();
+  if (onServer) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <EmailEditor />
+    </Box>
+  );
+};
+
+EmailPage.getLayout = function getLayout(page) {
+  return <EmailLayout>{page}</EmailLayout>;
+};
+
+export default EmailPage;

--- a/src/zui/ZUIDialog/index.tsx
+++ b/src/zui/ZUIDialog/index.tsx
@@ -10,6 +10,7 @@ import {
 
 interface ZUIDialogProps {
   children: React.ReactNode;
+  contentHeight?: number | string;
   open: boolean;
   onClose: () => void;
   title?: string;
@@ -18,6 +19,7 @@ interface ZUIDialogProps {
 
 const ZUIDialog: FunctionComponent<ZUIDialogProps> = ({
   children,
+  contentHeight,
   maxWidth,
   open,
   onClose,
@@ -36,7 +38,7 @@ const ZUIDialog: FunctionComponent<ZUIDialogProps> = ({
     >
       <Box p={2}>
         {title && <DialogTitle>{title}</DialogTitle>}
-        <DialogContent>{children}</DialogContent>
+        <DialogContent sx={{ height: contentHeight }}>{children}</DialogContent>
       </Box>
     </Dialog>
   );

--- a/src/zui/ZUIImageSelectDialog.tsx
+++ b/src/zui/ZUIImageSelectDialog.tsx
@@ -17,14 +17,16 @@ interface ZUIImageSelectDialogProps {
   onClose: () => void;
   onSelectFile: (file: ZetkinFile) => void;
   open: boolean;
+  orgId: number;
 }
 const ZUIImageSelectDialog: React.FC<ZUIImageSelectDialogProps> = ({
   onClose,
   onSelectFile,
   open,
+  orgId,
 }) => {
   const { fileUploads, getDropZoneProps, openFilePicker, reset } =
-    useFileUploads({ accept: FILECAT_IMAGES, multiple: false });
+    useFileUploads(orgId, { accept: FILECAT_IMAGES, multiple: false });
 
   const selectedFileData = fileUploads[0]?.apiData ?? null;
 

--- a/src/zui/ZUITimeline/TimelineAddNote.tsx
+++ b/src/zui/ZUITimeline/TimelineAddNote.tsx
@@ -10,6 +10,7 @@ import useFileUploads, {
 } from 'features/files/hooks/useFileUploads';
 
 import messageIds from './l10n/messageIds';
+import { useNumericRouteParams } from 'core/hooks';
 
 interface AddNoteProps {
   disabled?: boolean;
@@ -20,6 +21,7 @@ const TimelineAddNote: React.FunctionComponent<AddNoteProps> = ({
   disabled,
   onSubmit,
 }) => {
+  const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const [clear, setClear] = useState<number>(0);
   const [note, setNote] = useState<ZetkinNoteBody | null>(null);
@@ -29,7 +31,7 @@ const TimelineAddNote: React.FunctionComponent<AddNoteProps> = ({
     fileUploads,
     openFilePicker,
     reset: resetFileUploads,
-  } = useFileUploads();
+  } = useFileUploads(orgId);
 
   useEffect(() => {
     if (!disabled) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@editorjs/editorjs@^2.28.2":
+  version "2.28.2"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.28.2.tgz#a265c7d10e83adef81813e4dc0f01fe3464dff50"
+  integrity sha512-g6V0Nd3W9IIWMpvxDNTssQ6e4kxBp1Y0W4GIf8cXRlmcBp3TUjrgCYJQmNy3l2a6ZzhyBAoVSe8krJEq4g7PQw==
+
 "@emotion/babel-plugin@^11.10.0":
   version "11.10.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.10.2.tgz#879db80ba622b3f6076917a1e6f648b1c7d008c7"


### PR DESCRIPTION
## Description
This PR (collaboration between myself and @ziggabyte) introduces the `EmailEditor`, with a single non-standard tool called `LibraryImage` that allows a user to upload images and also browse previously uploaded images. Uploading and browsing is implemented in a separate UI called `FileLibraryDialog` which can also be used elsewhere.

## Screenshots
<img width="1611" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/b28435a4-ba02-4562-b1a5-298f4ec15f40">
<img width="1611" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/7c954e4a-045f-45de-8b4b-625a810f4d23">
<img width="1611" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/2d4272e2-0849-40ca-b37a-7e6560fc0940">
<img width="1611" alt="image" src="https://github.com/zetkin/app.zetkin.org/assets/550212/0a68c323-cfb4-4db0-b076-64c451b5c30d">

## Changes
* Adds Editor.js
* Creates new `Providers` component to group all providers, which also exposes the provided data on the `window` object (see notes to reviewer below)
* Creates `LibraryImage` tool for the editor
* Creates hook and store logic for loading uploaded files from the API
* Creates `FileLibraryDialog` with support for:
  * Browsing previously uploaded files
  * Filtering/sorting files
  * Uploading new files
  * Selecting and previewing a file

## Notes to reviewer
I'm sorry about the size of this PR but it's a whole new feature, and various aspects of it have been broken out into separate PRs that have already been reviewed (#1730, #1733).

There's a bit of a hack going on in the `Providers` component, which exposes the provided data on the `window` object. This is because with the way Editor.js works, we need two separate React trees. The Editor.js library does not use React, but it's possible to build tools using React by rendering them to a DOM element, but that requires a separate tree. For that tree to integrate well with the general react app, it needs to have access to the same store, the same localized messages etc. In short, it needs to have the same providers in it's context.

We solved this by exposing provided data on `window` in the main app, and then passing that data to identical providers in the tool sub-tree.

## Related issues
Undocumented