### PR TITLE
Issue 1721/inherited survey

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
@@ -1,8 +1,10 @@
 import { FC } from 'react';
 import { AssignmentOutlined, ChatBubbleOutline } from '@mui/icons-material';
 
+import getSurveyUrl from 'features/surveys/utils/getSurveyUrl';
 import OverviewListItem from './OverviewListItem';
 import { SurveyActivity } from 'features/campaigns/types';
+import { useNumericRouteParams } from 'core/hooks';
 import useSurveyStats from 'features/surveys/hooks/useSurveyStats';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
 
@@ -18,15 +20,13 @@ const SurveyOverviewListItem: FC<SurveyOverviewListItemProps> = ({
   const survey = activity.data;
   const stats = useSurveyStats(survey.organization.id, survey.id).data;
   const submissionCount = stats?.submissionCount || 0;
-
+  const { orgId } = useNumericRouteParams();
   return (
     <OverviewListItem
       endDate={activity.visibleUntil}
       endNumber={submissionCount}
       focusDate={focusDate}
-      href={`/organize/${survey.organization.id}/projects/${
-        survey.campaign?.id ?? 'standalone'
-      }/surveys/${survey.id}`}
+      href={getSurveyUrl(survey, orgId)}
       PrimaryIcon={AssignmentOutlined}
       SecondaryIcon={ChatBubbleOutline}
       startDate={activity.visibleFrom}

--- a/src/features/campaigns/components/ActivityList/items/SurveyListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/SurveyListItem.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { AssignmentOutlined, ChatBubbleOutline } from '@mui/icons-material';
 
 import ActivityListItemWithStats from './ActivityListItemWithStats';
+import getSurveyUrl from 'features/surveys/utils/getSurveyUrl';
 import { STATUS_COLORS } from './ActivityListItem';
 import useSurvey from 'features/surveys/hooks/useSurvey';
 import useSurveyStats from 'features/surveys/hooks/useSurveyStats';
@@ -52,9 +53,7 @@ const SurveyListItem: FC<SurveyListItemProps> = ({ orgId, surveyId }) => {
       color={color}
       endNumber={submissionCount.toString()}
       greenChipValue={linkedSubmissionCount}
-      href={`/organize/${orgId}/projects/${
-        data.campaign?.id ?? 'standalone'
-      }/surveys/${surveyId}`}
+      href={getSurveyUrl(data, orgId)}
       orangeChipValue={unlinkedSubmissionCount}
       PrimaryIcon={AssignmentOutlined}
       SecondaryIcon={ChatBubbleOutline}

--- a/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
+import getSurveyUrl from 'features/surveys/utils/getSurveyUrl';
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinSurvey } from 'utils/types/zetkin';
 
@@ -15,13 +16,7 @@ const SurveyListItem: React.FunctionComponent<{
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
   return (
-    <Link
-      key={survey.id}
-      href={`/organize/${orgId}/projects/${
-        survey.campaign?.id ?? 'standalone'
-      }/surveys/${survey.id}`}
-      passHref
-    >
+    <Link key={survey.id} href={getSurveyUrl(survey, parseInt(orgId))} passHref>
       <ListItem button component="a" data-testid="SearchDialog-resultsListItem">
         <ListItemAvatar>
           <Avatar>

--- a/src/features/surveys/components/SubmissionWarningAlert.tsx
+++ b/src/features/surveys/components/SubmissionWarningAlert.tsx
@@ -6,7 +6,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { Alert, AlertTitle, Box, Link } from '@mui/material';
 
 type SubmissionWarningAlertProps = {
-  campId: number | 'standalone' | 'inherited';
+  campId: number | 'standalone' | 'shared';
   orgId: number;
   showUnlinkedOnly: boolean;
   surveyId: number;

--- a/src/features/surveys/components/SubmissionWarningAlert.tsx
+++ b/src/features/surveys/components/SubmissionWarningAlert.tsx
@@ -6,7 +6,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { Alert, AlertTitle, Box, Link } from '@mui/material';
 
 type SubmissionWarningAlertProps = {
-  campId: number | 'standalone';
+  campId: number | 'standalone' | 'inherited';
   orgId: number;
   showUnlinkedOnly: boolean;
   surveyId: number;

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -8,7 +8,7 @@ import ZUINumberChip from 'zui/ZUINumberChip';
 import { Box, Link, useTheme } from '@mui/material';
 
 type SurveyUnlinkedCardProps = {
-  campId: number | 'standalone';
+  campId: number | 'standalone' | 'inherited';
   orgId: number;
   surveyId: number;
 };

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -8,7 +8,7 @@ import ZUINumberChip from 'zui/ZUINumberChip';
 import { Box, Link, useTheme } from '@mui/material';
 
 type SurveyUnlinkedCardProps = {
-  campId: number | 'standalone' | 'inherited';
+  campId: number | 'standalone' | 'shared';
   orgId: number;
   surveyId: number;
 };

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -29,18 +29,19 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
   orgId,
   surveyId,
 }) => {
+  const parsedOrg = parseInt(orgId);
   const messages = useMessages(messageIds);
-  const statsFuture = useSurveyStats(parseInt(orgId), parseInt(surveyId));
-  const surveyFuture = useSurvey(parseInt(orgId), parseInt(surveyId));
+  const statsFuture = useSurveyStats(parsedOrg, parseInt(surveyId));
+  const surveyFuture = useSurvey(parsedOrg, parseInt(surveyId));
   const { publish, unpublish, updateSurvey } = useSurveyMutations(
-    parseInt(orgId),
+    parsedOrg,
     parseInt(surveyId)
   );
   const { surveyIsEmpty, ...elementsFuture } = useSurveyElements(
-    parseInt(orgId),
+    parsedOrg,
     parseInt(surveyId)
   );
-  const state = useSurveyState(parseInt(orgId), parseInt(surveyId));
+  const state = useSurveyState(parsedOrg, parseInt(surveyId));
 
   return (
     <TabbedLayout
@@ -59,7 +60,7 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
           </Button>
         )
       }
-      baseHref={getSurveyUrl(surveyFuture.data)}
+      baseHref={getSurveyUrl(surveyFuture.data, parsedOrg)}
       belowActionButtons={
         <ZUIDateRangePicker
           endDate={surveyFuture.data?.expires || null}

--- a/src/features/surveys/utils/getSurveyUrl.ts
+++ b/src/features/surveys/utils/getSurveyUrl.ts
@@ -5,16 +5,16 @@ export default function getSurveyUrl(
   orgId: number
 ) {
   if (survey) {
-    const campId = getSurveyCampId(survey);
+    const campId = getSurveyCampId(survey, orgId);
     return `/organize/${orgId}/projects/${campId}/surveys/${survey.id}`;
   } else {
     return '';
   }
 }
 
-export function getSurveyCampId(survey: ZetkinSurvey | null) {
+export function getSurveyCampId(survey: ZetkinSurvey | null, orgId: number) {
   if (survey) {
-    return survey.org_access === 'suborgs'
+    return survey.organization.id !== orgId
       ? 'inherited'
       : survey.campaign
       ? survey.campaign.id

--- a/src/features/surveys/utils/getSurveyUrl.ts
+++ b/src/features/surveys/utils/getSurveyUrl.ts
@@ -1,10 +1,24 @@
 import { ZetkinSurvey } from 'utils/types/zetkin';
 
-export default function getSurveyUrl(survey: ZetkinSurvey | null) {
+export default function getSurveyUrl(
+  survey: ZetkinSurvey | null,
+  orgId: number
+) {
   if (survey) {
-    return `/organize/${survey.organization.id}/projects/${
-      survey.campaign ? `${survey.campaign.id}` : 'standalone'
-    }/surveys/${survey.id}`;
+    const campId = getSurveyCampId(survey);
+    return `/organize/${orgId}/projects/${campId}/surveys/${survey.id}`;
+  } else {
+    return '';
+  }
+}
+
+export function getSurveyCampId(survey: ZetkinSurvey | null) {
+  if (survey) {
+    return survey.org_access === 'suborgs'
+      ? 'inherited'
+      : survey.campaign
+      ? survey.campaign.id
+      : 'standalone';
   } else {
     return '';
   }

--- a/src/features/surveys/utils/getSurveyUrl.ts
+++ b/src/features/surveys/utils/getSurveyUrl.ts
@@ -14,11 +14,10 @@ export default function getSurveyUrl(
 
 export function getSurveyCampId(survey: ZetkinSurvey | null, orgId: number) {
   if (survey) {
-    return survey.organization.id !== orgId
-      ? 'inherited'
-      : survey.campaign
-      ? survey.campaign.id
-      : 'standalone';
+    if (survey.organization.id !== orgId) {
+      return 'shared';
+    }
+    return survey.campaign?.id ?? 'standalone';
   } else {
     return '';
   }

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -95,7 +95,7 @@ async function fetchElements(
       },
     ];
   } else if (fieldName === 'campId') {
-    if (fieldValue !== 'standalone' && fieldValue !== 'inherited') {
+    if (typeof fieldValue == 'number') {
       const campaign = await apiFetch(
         `/orgs/${orgId}/campaigns/${fieldValue}`
       ).then((res) => res.json());

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -95,7 +95,7 @@ async function fetchElements(
       },
     ];
   } else if (fieldName === 'campId') {
-    if (fieldValue !== 'standalone') {
+    if (fieldValue !== 'standalone' && fieldValue !== 'inherited') {
       const campaign = await apiFetch(
         `/orgs/${orgId}/campaigns/${fieldValue}`
       ).then((res) => res.json());

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -27,7 +27,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       const data = await client.get<ZetkinSurvey>(
         `/api/orgs/${orgId}/surveys/${surveyId}`
       );
-      const actualCampaign = getSurveyCampId(data);
+      const actualCampaign = getSurveyCampId(data).toString();
 
       if (actualCampaign !== campId) {
         return { notFound: true };

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -27,7 +27,10 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       const data = await client.get<ZetkinSurvey>(
         `/api/orgs/${orgId}/surveys/${surveyId}`
       );
-      const actualCampaign = getSurveyCampId(data).toString();
+      const actualCampaign = getSurveyCampId(
+        data,
+        parseInt(orgId as string)
+      ).toString();
 
       if (actualCampaign !== campId) {
         return { notFound: true };

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { Box, Grid } from '@mui/material';
 
 import EmptyOverview from 'features/surveys/components/EmptyOverview';
+import { getSurveyCampId } from 'features/surveys/utils/getSurveyUrl';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SubmissionChartCard from 'features/surveys/components/SubmissionChartCard';
@@ -26,7 +27,8 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       const data = await client.get<ZetkinSurvey>(
         `/api/orgs/${orgId}/surveys/${surveyId}`
       );
-      const actualCampaign = data.campaign?.id.toString() ?? 'standalone';
+      const actualCampaign = getSurveyCampId(data);
+
       if (actualCampaign !== campId) {
         return { notFound: true };
       }
@@ -36,6 +38,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 
     return {
       props: {
+        campId,
         orgId,
         surveyId,
       },
@@ -65,7 +68,6 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
     parseInt(orgId),
     parseInt(surveyId)
   );
-  const campaignId = isNaN(parseInt(campId)) ? 'standalone' : parseInt(campId);
 
   if (onServer) {
     return null;
@@ -100,7 +102,11 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
                 surveyId={surveyId}
               />
               <SurveyUnlinkedCard
-                campId={campaignId}
+                campId={
+                  campId !== 'inherited' && campId !== 'standalone'
+                    ? parseInt(campId)
+                    : campId
+                }
                 orgId={parseInt(orgId)}
                 surveyId={parseInt(surveyId)}
               />

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -106,7 +106,7 @@ const SurveyPage: PageWithLayout<SurveyPageProps> = ({
               />
               <SurveyUnlinkedCard
                 campId={
-                  campId !== 'inherited' && campId !== 'standalone'
+                  campId !== 'shared' && campId !== 'standalone'
                     ? parseInt(campId)
                     : campId
                 }

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
@@ -50,7 +50,8 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
   const surveyFuture = useSurvey(parsedOrg, parseInt(surveyId));
   const submissionsFuture = useSurveySubmissions(parsedOrg, parseInt(surveyId));
 
-  const campaignId = getSurveyCampId(surveyFuture?.data) || 'standalone';
+  const campaignId =
+    getSurveyCampId(surveyFuture?.data, parsedOrg) || 'standalone';
 
   const router = useRouter();
 

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
@@ -3,6 +3,7 @@ import { Grid } from '@mui/material';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 
+import { getSurveyCampId } from 'features/surveys/utils/getSurveyUrl';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SubmissionWarningAlert from 'features/surveys/components/SubmissionWarningAlert';
@@ -45,13 +46,12 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
   orgId,
   surveyId,
 }) => {
-  const surveyFuture = useSurvey(parseInt(orgId), parseInt(surveyId));
-  const submissionsFuture = useSurveySubmissions(
-    parseInt(orgId),
-    parseInt(surveyId)
-  );
+  const parsedOrg = parseInt(orgId);
+  const surveyFuture = useSurvey(parsedOrg, parseInt(surveyId));
+  const submissionsFuture = useSurveySubmissions(parsedOrg, parseInt(surveyId));
 
-  const campaignId = isNaN(parseInt(campId)) ? 'standalone' : parseInt(campId);
+  const campaignId = getSurveyCampId(surveyFuture?.data) || 'standalone';
+
   const router = useRouter();
 
   return (


### PR DESCRIPTION
## Description
This PR fixes a bug where shared submissions in child organizations navigate to the parent organization's submission, which is an original survey.

## Screenshots
- Survey in same organization which has project ID
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/0d23edb9-7b6e-4bd9-96e8-c788980eaa11)

- Survey in same organization which doesn't have project ID
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/044c5f53-c7ed-4f8c-b8c2-6528f09a3cb8)

- Shared survey in sub organization
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/ccfe264c-282f-43a2-8ce8-2a3ecb62657a)


## Changes

* Create `getSurveyCampId` function that returns `campId`(number) / 'standalone' / 'inherited'
* Changes `href` in `Link`
* Add `orgId` parameter in `getSurveyUrl`


## Notes to reviewer


## Related issues
Resolves #1721 
