### PR TITLE
Create component to display library image.

### DIFF
--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -1,27 +1,27 @@
-import { Box } from '@mui/material';
 import { FC } from 'react';
 import Image from 'next/image';
+import { Box, useTheme } from '@mui/material';
 
 import { ZetkinFile } from 'utils/types/zetkin';
 
 interface LibraryImageProps {
-  onSelectImage: () => void;
   imageFile: ZetkinFile;
 }
 
-const LibraryImage: FC<LibraryImageProps> = ({ imageFile, onSelectImage }) => {
+const LibraryImage: FC<LibraryImageProps> = ({ imageFile }) => {
+  const theme = useTheme();
+
   return (
     <Box
-      height={200}
-      onClick={onSelectImage}
+      border={1}
+      borderColor={theme.palette.grey[400]}
+      borderRadius={1}
       sx={{
         backgroundImage:
           'linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%);',
         backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0px',
         backgroundSize: '30px 30px',
-        cursor: 'pointer',
       }}
-      width={200}
     >
       <Image
         alt={imageFile.original_name}

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -1,0 +1,38 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import Image from 'next/image';
+
+import { ZetkinFile } from 'utils/types/zetkin';
+
+interface LibraryImageProps {
+  onSelectImage: () => void;
+  imageFile: ZetkinFile;
+}
+
+const LibraryImage: FC<LibraryImageProps> = ({ imageFile, onSelectImage }) => {
+  return (
+    <Box
+      height={200}
+      onClick={onSelectImage}
+      sx={{
+        backgroundImage:
+          'linear-gradient(45deg, #808080 25%, transparent 25%), linear-gradient(-45deg, #808080 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #808080 75%), linear-gradient(-45deg, transparent 75%, #808080 75%);',
+        backgroundPosition: '0 0, 0 15px, 15px -15px, -15px 0px',
+        backgroundSize: '30px 30px',
+        cursor: 'pointer',
+      }}
+      width={200}
+    >
+      <Image
+        alt={imageFile.original_name}
+        height="100%"
+        layout="responsive"
+        objectFit="contain"
+        src={imageFile.url}
+        width="100%"
+      />
+    </Box>
+  );
+};
+
+export default LibraryImage;

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import LibraryImage from './LibraryImage';
+import { truncateOnMiddle } from 'utils/stringUtils';
+import { ZetkinFile } from 'utils/types/zetkin';
+
+interface LibraryImageCardProps {
+  imageFile: ZetkinFile;
+  onSelectImage: () => void;
+}
+
+const LibraryImageCard: FC<LibraryImageCardProps> = ({
+  imageFile,
+  onSelectImage,
+}) => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      onClick={onSelectImage}
+      sx={{ cursor: 'pointer' }}
+    >
+      <LibraryImage imageFile={imageFile} />
+      <Typography alignSelf="center">
+        {truncateOnMiddle(imageFile.original_name, 30)}
+      </Typography>
+    </Box>
+  );
+};
+
+export default LibraryImageCard;


### PR DESCRIPTION
## Description
This PR adds a component that displays a library image against a checked gray background.


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/e71333c1-79e9-4e00-b91d-a8da37ef5634)

## Changes
* Adds LibraryImage component.

## Related issues
none
