### PR TITLE
Saving email content

### DIFF
--- a/src/features/breadcrumbs/store.ts
+++ b/src/features/breadcrumbs/store.ts
@@ -34,7 +34,10 @@ const breadcrumbsSlice = createSlice({
   reducers: {
     crumbsLoad: (state, action: PayloadAction<string>) => {
       const path = action.payload;
-      state.crumbsByPath[path] = remoteItem(path, { isLoading: true });
+      state.crumbsByPath[path] = remoteItem(path, {
+        data: state.crumbsByPath[path]?.data ?? null,
+        isLoading: true,
+      });
     },
     crumbsLoaded: (state, action: PayloadAction<[string, BreadcrumbItem]>) => {
       const [path, loadedItem] = action.payload;

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -8,10 +8,11 @@ import EditorJS, {
 import { FC, useEffect, useRef } from 'react';
 
 export type EditorProps = {
+  initialContent: OutputData;
   onSave?: (data: OutputData) => void;
 };
 
-const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
+const EmailEditorFrontend: FC<EditorProps> = ({ initialContent, onSave }) => {
   const { orgId } = useNumericRouteParams();
   const editorInstance = useRef<EditorJS | null>(null);
 
@@ -28,6 +29,7 @@ const EmailEditorFrontend: FC<EditorProps> = ({ onSave }) => {
 
   useEffect(() => {
     const editorConfig: EditorConfig = {
+      data: initialContent,
       // TODO: Find way to make unique IDs
       holder: 'ClientOnlyEditor-container',
       inlineToolbar: ['bold', 'link', 'italic'],

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -6,8 +6,10 @@ const EmailEditorFrontend = dynamic(import('./EmailEditorFrontend'), {
   ssr: false,
 });
 
-const EmailEditor: FC<EditorProps> = ({ onSave }) => {
-  return <EmailEditorFrontend onSave={onSave} />;
+const EmailEditor: FC<EditorProps> = ({ initialContent, onSave }) => {
+  return (
+    <EmailEditorFrontend initialContent={initialContent} onSave={onSave} />
+  );
 };
 
 export default EmailEditor;

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -4,6 +4,7 @@ import EmailLayout from 'features/emails/layout/EmailLayout';
 import { GetServerSideProps } from 'next';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
+import useEmail from 'features/emails/hooks/useEmail';
 import useServerSide from 'core/useServerSide';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
@@ -24,15 +25,32 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-const EmailPage: PageWithLayout = () => {
+type Props = {
+  campId: string;
+  emailId: string;
+  orgId: string;
+};
+
+const EmailPage: PageWithLayout<Props> = ({ emailId, orgId }) => {
+  const { data, updateEmail } = useEmail(parseInt(orgId), parseInt(emailId));
   const onServer = useServerSide();
+
   if (onServer) {
+    return null;
+  }
+
+  if (!data) {
     return null;
   }
 
   return (
     <Box>
-      <EmailEditor />
+      <EmailEditor
+        initialContent={JSON.parse(data.content)}
+        onSave={(data) => {
+          updateEmail({ content: JSON.stringify(data) });
+        }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR adds logic for saving (and restoring) the content created using the `EmailEditor`. The data is saved using the API whenver the editor saves (which happens periodically) and restored whenever the page is revisited.

The PR also fixes a shortcoming in how caching of breadcrumbs was previously achieved, causing the breadcrumbs to flicker everytime they refresh.

## Screenshots
None

## Changes
* Adds `initialContent` property to `EmailEditor`
* Sends data to API when `EmailEditor` saves
* Fixes a bug in breadcrumbs causing them to flicker

## Notes to reviewer
None

## Related issues
Undocumented