### PR TITLE
ISSUE-1731/breadcrumbs-caching

### DIFF
--- a/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
+++ b/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
@@ -8,7 +8,7 @@ export default function useBreadcrumbElements() {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const router = useRouter();
-  const path = router.pathname;
+  const { pathname, asPath: path } = router;
   const crumbsItem = useAppSelector(
     (state) => state.breadcrumbs.crumbsByPath[path]
   );
@@ -20,7 +20,7 @@ export default function useBreadcrumbElements() {
     actionOnSuccess: (item) => crumbsLoaded([path, item]),
     loader: async () => {
       const elements = await apiClient.get<BreadcrumbElement[]>(
-        `/api/breadcrumbs?pathname=${path}&${query}`
+        `/api/breadcrumbs?pathname=${pathname}&${query}`
       );
 
       return { elements, id: path };

--- a/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
+++ b/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
@@ -9,20 +9,20 @@ export default function useBreadcrumbElements() {
   const dispatch = useAppDispatch();
   const router = useRouter();
   const path = router.pathname;
+  const query = getPathParameters(router);
   const crumbsItem = useAppSelector(
-    (state) => state.breadcrumbs.crumbsByPath[path]
+    (state) =>
+      state.breadcrumbs.crumbsByPath[path] &&
+      state.breadcrumbs.crumbsByPath[path][query]
   );
 
-  const query = getPathParameters(router);
-
   const future = loadItemIfNecessary(crumbsItem, dispatch, {
-    actionOnLoad: () => crumbsLoad(path),
-    actionOnSuccess: (item) => crumbsLoaded([path, item]),
+    actionOnLoad: () => crumbsLoad({ path, query }),
+    actionOnSuccess: (item) => crumbsLoaded([{ path, query }, item]),
     loader: async () => {
       const elements = await apiClient.get<BreadcrumbElement[]>(
         `/api/breadcrumbs?pathname=${path}&${query}`
       );
-
       return { elements, id: path };
     },
   });

--- a/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
+++ b/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
@@ -9,20 +9,20 @@ export default function useBreadcrumbElements() {
   const dispatch = useAppDispatch();
   const router = useRouter();
   const path = router.pathname;
-  const query = getPathParameters(router);
   const crumbsItem = useAppSelector(
-    (state) =>
-      state.breadcrumbs.crumbsByPath[path] &&
-      state.breadcrumbs.crumbsByPath[path][query]
+    (state) => state.breadcrumbs.crumbsByPath[path]
   );
 
+  const query = getPathParameters(router);
+
   const future = loadItemIfNecessary(crumbsItem, dispatch, {
-    actionOnLoad: () => crumbsLoad({ path, query }),
-    actionOnSuccess: (item) => crumbsLoaded([{ path, query }, item]),
+    actionOnLoad: () => crumbsLoad(path),
+    actionOnSuccess: (item) => crumbsLoaded([path, item]),
     loader: async () => {
       const elements = await apiClient.get<BreadcrumbElement[]>(
         `/api/breadcrumbs?pathname=${path}&${query}`
       );
+
       return { elements, id: path };
     },
   });

--- a/src/features/breadcrumbs/store.ts
+++ b/src/features/breadcrumbs/store.ts
@@ -8,7 +8,7 @@ type BreadcrumbItem = {
 };
 
 export interface BreadcrumbsStoreSlice {
-  crumbsByPath: Record<string, Record<string, RemoteItem<BreadcrumbItem>>>;
+  crumbsByPath: Record<string, RemoteItem<BreadcrumbItem>>;
 }
 
 const initialState: BreadcrumbsStoreSlice = {
@@ -25,36 +25,20 @@ const breadcrumbsSlice = createSlice({
       // In lieu of a general-purpose way of identifying what changed, when
       // anything is updated, we invalidate all breadcrumbs.
       Object.keys(state.crumbsByPath).forEach((path) => {
-        Object.keys(state.crumbsByPath[path]).forEach((query) => {
-          state.crumbsByPath[path][query].isStale = true;
-        });
+        state.crumbsByPath[path].isStale = true;
       });
     });
   },
   initialState,
   name: 'breadcrumbs',
   reducers: {
-    crumbsLoad: (
-      state,
-      action: PayloadAction<{ path: string; query: string }>
-    ) => {
-      const { path, query } = action.payload;
-      if (!state.crumbsByPath[path]) {
-        state.crumbsByPath[path] = {};
-      }
-      state.crumbsByPath[path][query] = remoteItem(path, {
-        isLoading: true,
-      });
+    crumbsLoad: (state, action: PayloadAction<string>) => {
+      const path = action.payload;
+      state.crumbsByPath[path] = remoteItem(path, { isLoading: true });
     },
-    crumbsLoaded: (
-      state,
-      action: PayloadAction<[{ path: string; query: string }, BreadcrumbItem]>
-    ) => {
-      const [{ path, query }, loadedItem] = action.payload;
-      if (!state.crumbsByPath[path]) {
-        state.crumbsByPath[path] = {};
-      }
-      state.crumbsByPath[path][query] = remoteItem<BreadcrumbItem>(path, {
+    crumbsLoaded: (state, action: PayloadAction<[string, BreadcrumbItem]>) => {
+      const [path, loadedItem] = action.payload;
+      state.crumbsByPath[path] = remoteItem<BreadcrumbItem>(path, {
         data: loadedItem,
         loaded: new Date().toISOString(),
       });


### PR DESCRIPTION
## Description
This PR fixes an issue where breadcrumbs were not updating when clicking multiple surveys, only showing the first suvery in the breadcrumbs even when navigating to a new one. This had to do with the caching not updating the breadcrumbs for the route for 5 min, because changing the query parameters didn't make the cached item stale.

This does not fix the flashing issue which is fixed here: https://github.com/zetkin/app.zetkin.org/pull/1735/files#diff-11f03a79b05fa9c9284cbceb9b0418dce3aa12accc517783930d46dd70ffe527R38

## Changes

Changes the key used in the store for cached responses to use the `router.asPath` value instead of the `router.pathname` value. This includes ids in the path and is unique per each route.

## Notes to reviewer

* Go to surveys
* Click on a survey
* Click "back"
* Click on a different survey
* The breadcrumb should be correct

Also try:
* Changing the title of an editable title item and checking the breadcrumbs change when it saves

## Related issues
Resolves #1731
