### PR TITLE
issue-1701/date-error-smart-search

### DIFF
--- a/src/features/smartSearch/components/filters/TimeFrame.tsx
+++ b/src/features/smartSearch/components/filters/TimeFrame.tsx
@@ -62,7 +62,7 @@ const TimeFrame = ({
   const afterDateSelect = (
     <StyledDatePicker
       onChange={(date) => {
-        if (date) {
+        if (date && !isNaN(date.day())) {
           setAfter(date.toDate());
         }
       }}
@@ -72,7 +72,7 @@ const TimeFrame = ({
   const beforeDateSelect = (
     <StyledDatePicker
       onChange={(date) => {
-        if (date) {
+        if (date && !isNaN(date.day())) {
           setBefore(date.toDate());
         }
       }}


### PR DESCRIPTION
## Description
This PR fixes a bug where an error is thrown when deleting values from a date select in a smart search filter.

The current fix is that now if you delete, for example, the month, the user will see, `20/MM/2023` and if the user saves then it will NOT update the value.

But should we:
* Make the save button disabled if the date field isn't valid? (This seems difficult)
* Make the value revert to what it was previously when clicking away? (This seems easier but maybe is still difficult and is it useful)
* Or is this fine? It's a tiny bit confusing because if you save with an invalid value, you don't know what to expect, but it is an improvement and nothing breaks when you save.

## Screenshots
<img width="1164" alt="Screenshot 2023-12-29 at 12 43 56" src="https://github.com/zetkin/app.zetkin.org/assets/110108245/0aa2311e-3cdb-43bd-be10-c6d797f728fa">

## Changes

* Only updates the state for the date if the inputted date is valid

## Notes to reviewer
* Go to smart search
* Pick a filter with a date
* Select a date
* Delete a field
* You should not see an error
* If you enter a new value now, and hit save, the filter should show the correct value 


## Related issues
Resolves #1701
