### PR TITLE
Do not show, "No results" on search when opening the dialog

### DIFF
--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -19,61 +19,52 @@ import messages from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 
 interface ResultsListProps {
-  isLoading: boolean;
-  queryString: string;
   results: SearchResult[];
 }
 
 const ResultsList: FunctionComponent<ResultsListProps> = ({
-  isLoading,
-  queryString,
   results,
 }): JSX.Element => {
-  if (queryString.length > 2 && !isLoading) {
-    return (
-      <List>
-        {/* If results empty */}
-        {results.length === 0 && queryString.length > 2 && (
-          <ListItem>
-            <ListItemText>
-              <Msg id={messages.noResults} />
-            </ListItemText>
-          </ListItem>
-        )}
-        {/* If results */}
-        {results.length > 0 && (
-          <>
-            {results.slice(0, 6).map((result) => {
-              if (result.type === SEARCH_DATA_TYPE.PERSON) {
-                return <PersonListItem person={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.CAMPAIGN) {
-                return <CampaignListItem campaign={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.TASK) {
-                return <TaskListItem task={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.CALL_ASSIGNMENT) {
-                return <CallAssignmentListItem callAssignment={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.SURVEY) {
-                return <SurveyListItem survey={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.VIEW) {
-                return <ViewListItem view={result.match} />;
-              }
-              if (result.type === SEARCH_DATA_TYPE.JOURNEY_INSTANCE) {
-                return (
-                  <JourneyInstanceListItem journeyInstance={result.match} />
-                );
-              }
-            })}
-          </>
-        )}
-      </List>
-    );
-  }
-  return null;
+  return (
+    <List>
+      {/* If results empty */}
+      {results.length === 0 && (
+        <ListItem>
+          <ListItemText>
+            <Msg id={messages.noResults} />
+          </ListItemText>
+        </ListItem>
+      )}
+      {/* If results */}
+      {results.length > 0 && (
+        <>
+          {results.slice(0, 6).map((result) => {
+            if (result.type === SEARCH_DATA_TYPE.PERSON) {
+              return <PersonListItem person={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.CAMPAIGN) {
+              return <CampaignListItem campaign={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.TASK) {
+              return <TaskListItem task={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.CALL_ASSIGNMENT) {
+              return <CallAssignmentListItem callAssignment={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.SURVEY) {
+              return <SurveyListItem survey={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.VIEW) {
+              return <ViewListItem view={result.match} />;
+            }
+            if (result.type === SEARCH_DATA_TYPE.JOURNEY_INSTANCE) {
+              return <JourneyInstanceListItem journeyInstance={result.match} />;
+            }
+          })}
+        </>
+      )}
+    </List>
+  );
 };
 
 export default ResultsList;

--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -84,12 +84,8 @@ const SearchDialog: React.FunctionComponent<{
               }
             }}
           />
-          {results && (
-            <ResultsList
-              isLoading={isLoading}
-              queryString={queryString}
-              results={results.map((item) => item.result)}
-            />
+          {results && queryString.length > 2 && !isLoading && (
+            <ResultsList results={results.map((item) => item.result)} />
           )}
         </Box>
       </Dialog>

--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -28,7 +28,7 @@ const SearchDialog: React.FunctionComponent<{
   const router = useRouter();
   const { orgId } = useNumericRouteParams();
 
-  const { error, results, isLoading, setQuery } = useSearch(orgId);
+  const { error, results, isLoading, setQuery, queryString } = useSearch(orgId);
 
   const handleRouteChange = () => {
     // Close dialog when clicking an item
@@ -84,7 +84,7 @@ const SearchDialog: React.FunctionComponent<{
               }
             }}
           />
-          {results && (
+          {results.length > 0 && queryString.length > 2 && (
             <ResultsList results={results.map((item) => item.result)} />
           )}
         </Box>

--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -84,7 +84,7 @@ const SearchDialog: React.FunctionComponent<{
               }
             }}
           />
-          {results && queryString.length > 2 && !isLoading && (
+          {Array.isArray(results) && queryString.length > 2 && !isLoading && (
             <ResultsList results={results.map((item) => item.result)} />
           )}
         </Box>

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -13,6 +13,7 @@ import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 type UseSearchReturn = {
   error: unknown;
   isLoading: boolean;
+  queryString: string;
   results: SearchResultItem[];
   setQuery: (q: string) => void;
 };
@@ -57,6 +58,7 @@ export default function useSearch(orgId: number): UseSearchReturn {
     return {
       error: future.error,
       isLoading: future.isLoading,
+      queryString,
       results: future.data || [],
       setQuery,
     };
@@ -64,6 +66,7 @@ export default function useSearch(orgId: number): UseSearchReturn {
     return {
       error: null,
       isLoading: false,
+      queryString,
       results: [],
       setQuery,
     };


### PR DESCRIPTION
## Description
This PR fixes something I noticed which changed in the search bar: When you open the search bar it instantly shows "No results".

This changes is to that it only shows. "No results" if a search has taken place and there actually are no results. 

## Changes

* Changes
  * useSearch returns `null` instead of an empty array if there is no response yet
  * The SearchDialog only renders the results list if there is a value for results. Therefore it does not render, "no results" unless the server actually returns no results.

## Notes to reviewer
* Open the search dialog, you should only see the search bar
* Type in a name
* Add on to that name with some nonsense, you should see, "no results"
* Delete the text and you should only see the search bar.

