### PR TITLE
Undocumented/email editor button tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "nprogress": "^0.2.0",
     "random-seed": "^0.3.0",
     "react": "^18.2.0",
+    "react-contenteditable": "^3.3.7",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -26,6 +26,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
 }) => {
   const { orgId } = useNumericRouteParams();
   const editorInstance = useRef<EditorJS | null>(null);
+  const blockIndexRef = useRef<number | null>(null);
 
   const saved = async () => {
     try {
@@ -89,7 +90,12 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
 
       const currentBlockIndex =
         editorInstance.current?.blocks.getCurrentBlockIndex();
-      if (typeof currentBlockIndex == 'number' && currentBlockIndex >= 0) {
+      if (
+        typeof currentBlockIndex == 'number' &&
+        currentBlockIndex >= 0 &&
+        currentBlockIndex !== blockIndexRef.current
+      ) {
+        blockIndexRef.current = currentBlockIndex;
         onSelectBlock(currentBlockIndex);
       }
     }, 200);

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,5 +1,4 @@
 import EditorJS, {
-  BlockAPI,
   EditorConfig,
   OutputData,
   ToolConstructable,
@@ -13,9 +12,9 @@ import { useNumericRouteParams } from 'core/hooks';
 export type EmailEditorFrontendProps = {
   apiRef: MutableRefObject<EditorJS | null>;
   initialContent: OutputData;
-  onChange: () => void;
+  onChange: (data: OutputData) => void;
   onSave: (data: OutputData) => void;
-  onSelectBlock: (selectedBlock: BlockAPI) => void;
+  onSelectBlock: (selectedBlockIndex: number) => void;
 };
 
 const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
@@ -32,6 +31,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
     try {
       const savedData = await editorInstance.current?.save();
       if (savedData && onSave) {
+        onChange(savedData);
         onSave(savedData);
       }
     } catch (error) {
@@ -46,7 +46,6 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       holder: 'ClientOnlyEditor-container',
       inlineToolbar: ['bold', 'link', 'italic'],
       onChange: () => {
-        onChange();
         saved();
       },
       tools: {
@@ -90,14 +89,8 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
 
       const currentBlockIndex =
         editorInstance.current?.blocks.getCurrentBlockIndex();
-
       if (typeof currentBlockIndex == 'number' && currentBlockIndex >= 0) {
-        const currentBlock =
-          apiRef.current?.blocks.getBlockByIndex(currentBlockIndex);
-
-        if (currentBlock) {
-          onSelectBlock(currentBlock);
-        }
+        onSelectBlock(currentBlockIndex);
       }
     }, 200);
     return () => {

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,11 +1,13 @@
-import LibraryImage from './tools/LibraryImage';
-import { useNumericRouteParams } from 'core/hooks';
 import EditorJS, {
   EditorConfig,
   OutputData,
   ToolConstructable,
 } from '@editorjs/editorjs';
 import { FC, useEffect, useRef } from 'react';
+
+import Button from './tools/Button';
+import LibraryImage from './tools/LibraryImage';
+import { useNumericRouteParams } from 'core/hooks';
 
 export type EditorProps = {
   initialContent: OutputData;
@@ -37,6 +39,9 @@ const EmailEditorFrontend: FC<EditorProps> = ({ initialContent, onSave }) => {
         saved();
       },
       tools: {
+        button: {
+          class: Button as unknown as ToolConstructable,
+        },
         libraryImage: {
           class: LibraryImage as unknown as ToolConstructable,
           config: {

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -50,7 +50,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
                 });
               }
             }}
-            url={currentBlock.data.url}
+            url={currentBlock.data.url || ''}
           />
         )}
       </Box>

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -1,15 +1,43 @@
 import dynamic from 'next/dynamic';
-import { FC } from 'react';
-
-import { EditorProps } from './EmailEditorFrontend';
+import { Box, Typography } from '@mui/material';
+import EditorJS, { BlockAPI, OutputData } from '@editorjs/editorjs';
+import { FC, useRef, useState } from 'react';
 
 const EmailEditorFrontend = dynamic(import('./EmailEditorFrontend'), {
   ssr: false,
 });
 
-const EmailEditor: FC<EditorProps> = ({ initialContent, onSave }) => {
+interface EmailEditorProps {
+  initialContent: OutputData;
+  onSave: (data: OutputData) => void;
+}
+
+const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
+  const apiRef = useRef<EditorJS | null>(null);
+  const [currentBlock, setCurrentBlock] = useState<BlockAPI | null>(null);
+
   return (
-    <EmailEditorFrontend initialContent={initialContent} onSave={onSave} />
+    <Box display="flex">
+      <Box flex={1}>
+        <EmailEditorFrontend
+          apiRef={apiRef}
+          initialContent={initialContent}
+          onChange={() => {
+            //TODO: logic here
+          }}
+          onSave={onSave}
+          onSelectBlock={(selectedBlock: BlockAPI) => {
+            if (!currentBlock || currentBlock.id !== selectedBlock.id) {
+              setCurrentBlock(selectedBlock);
+            }
+          }}
+        />
+      </Box>
+      <Box padding={2} width="25%">
+        <Typography>Settings</Typography>
+        {currentBlock && <Typography>{currentBlock.name}</Typography>}
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -41,6 +41,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
         <Typography>Settings</Typography>
         {currentBlock && currentBlock.type === 'button' && (
           <ButtonSettings
+            key={currentBlock.id}
             onChange={(newUrl: ButtonData['url']) => {
               if (currentBlock.id) {
                 apiRef.current?.blocks.update(currentBlock.id, {

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -1,7 +1,13 @@
 import { FC } from 'react';
 import { Box, useTheme } from '@mui/material';
 
-const ButtonEditableBlock: FC = () => {
+import { ButtonData } from '.';
+
+interface ButtonEditableBlockProps {
+  data: ButtonData;
+}
+
+const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({ data }) => {
   const theme = useTheme();
   return (
     <Box display="flex" justifyContent="center" padding={2}>
@@ -15,7 +21,7 @@ const ButtonEditableBlock: FC = () => {
         sx={{ cursor: 'pointer' }}
         width="5rem"
       >
-        Button
+        {data.buttonText || 'Button'}
       </Box>
     </Box>
   );

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -1,10 +1,22 @@
 import { FC } from 'react';
-import { Box, Button } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 
 const ButtonEditableBlock: FC = () => {
+  const theme = useTheme();
   return (
     <Box display="flex" justifyContent="center" padding={2}>
-      <Button variant="contained">Button</Button>
+      <Box
+        alignItems="center"
+        bgcolor={theme.palette.primary.main}
+        color="white"
+        display="flex"
+        height="2rem"
+        justifyContent="center"
+        sx={{ cursor: 'pointer' }}
+        width="5rem"
+      >
+        Button
+      </Box>
     </Box>
   );
 };

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -1,14 +1,22 @@
-import { FC } from 'react';
 import { Box, useTheme } from '@mui/material';
+import { FC, useState } from 'react';
 
 import { ButtonData } from '.';
+import ContentEditable from 'react-contenteditable';
+import DOMPurify from 'dompurify';
 
 interface ButtonEditableBlockProps {
   data: ButtonData;
+  onChange: (newButtonText: string) => void;
 }
 
-const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({ data }) => {
+const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({
+  data,
+  onChange,
+}) => {
   const theme = useTheme();
+  const [test, setTest] = useState(data.buttonText || 'Add text');
+
   return (
     <Box display="flex" justifyContent="center" padding={2}>
       <Box
@@ -16,12 +24,19 @@ const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({ data }) => {
         bgcolor={theme.palette.primary.main}
         color="white"
         display="flex"
-        height="2rem"
         justifyContent="center"
-        sx={{ cursor: 'pointer' }}
-        width="5rem"
+        padding={2}
       >
-        {data.buttonText || 'Button'}
+        <ContentEditable
+          html={test}
+          onChange={(ev) => {
+            const cleanHtml = DOMPurify.sanitize(ev.currentTarget.innerHTML, {
+              ALLOWED_TAGS: [],
+            });
+            setTest(cleanHtml);
+            onChange(cleanHtml);
+          }}
+        />
       </Box>
     </Box>
   );

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { Box, Button } from '@mui/material';
+
+const ButtonEditableBlock: FC = () => {
+  return (
+    <Box display="flex" justifyContent="center" padding={2}>
+      <Button variant="contained">Button</Button>
+    </Box>
+  );
+};
+
+export default ButtonEditableBlock;

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -4,6 +4,8 @@ import { FC, useState } from 'react';
 import { ButtonData } from '.';
 import ContentEditable from 'react-contenteditable';
 import DOMPurify from 'dompurify';
+import messageIds from 'features/emails/l10n/messageIds';
+import { useMessages } from 'core/i18n';
 
 interface ButtonEditableBlockProps {
   data: ButtonData;
@@ -15,7 +17,10 @@ const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({
   onChange,
 }) => {
   const theme = useTheme();
-  const [test, setTest] = useState(data.buttonText || 'Add text');
+  const messages = useMessages(messageIds);
+  const [buttonText, setButtonText] = useState(
+    data.buttonText || messages.tools.button.block.noButtonText()
+  );
 
   return (
     <Box display="flex" justifyContent="center" padding={2}>
@@ -28,14 +33,15 @@ const ButtonEditableBlock: FC<ButtonEditableBlockProps> = ({
         padding={2}
       >
         <ContentEditable
-          html={test}
+          html={buttonText}
           onChange={(ev) => {
             const cleanHtml = DOMPurify.sanitize(ev.currentTarget.innerHTML, {
               ALLOWED_TAGS: [],
             });
-            setTest(cleanHtml);
+            setButtonText(cleanHtml);
             onChange(cleanHtml);
           }}
+          style={{ outline: 'none' }}
         />
       </Box>
     </Box>

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
@@ -1,9 +1,12 @@
-import { FC } from 'react';
-import { Box, TextField } from '@mui/material';
+import NextLink from 'next/link';
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Link, TextField, Typography } from '@mui/material';
+import { FC, useState } from 'react';
 
 import { ButtonData } from '.';
+import formatUrl from './utils/formatUrl';
 import messageIds from 'features/emails/l10n/messageIds';
-import { useMessages } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
 
 interface ButtonSettingsProps {
   url: ButtonData['url'];
@@ -12,16 +15,45 @@ interface ButtonSettingsProps {
 
 const ButtonSettings: FC<ButtonSettingsProps> = ({ url, onChange }) => {
   const messages = useMessages(messageIds);
+  const [inputValue, setInputValue] = useState(url || '');
+
+  const formattedUrl = formatUrl(inputValue);
+  const error = inputValue.length > 0 && formattedUrl.length == 0;
 
   return (
-    <Box>
+    <Box display="flex" flexDirection="column" gap={1}>
+      <Typography textTransform="uppercase" variant="body2">
+        <Msg id={messageIds.tools.button.settings.linkHeader} />
+      </Typography>
       <TextField
-        defaultValue={url || ''}
         label={messages.tools.button.settings.urlLabel()}
         onChange={(ev) => {
-          onChange(ev.target.value);
+          setInputValue(ev.target.value);
+          if (!error) {
+            onChange(formatUrl(ev.target.value));
+          }
         }}
+        value={inputValue}
       />
+      {error && (
+        <Typography color="error" variant="body2">
+          <Msg id={messageIds.tools.button.settings.invalidUrl} />
+        </Typography>
+      )}
+      {inputValue.length > 0 && !error && (
+        <NextLink href={formattedUrl} passHref rel="">
+          <Link display="flex" rel="noopener" target="_blank" underline="none">
+            <OpenInNew
+              color="secondary"
+              fontSize="small"
+              sx={{ marginRight: 1 }}
+            />
+            <Typography variant="body2">
+              <Msg id={messageIds.tools.button.settings.testLink} />
+            </Typography>
+          </Link>
+        </NextLink>
+      )}
     </Box>
   );
 };

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { Box, TextField } from '@mui/material';
+
+import { ButtonData } from '.';
+import messageIds from 'features/emails/l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+interface ButtonSettingsProps {
+  url: ButtonData['url'];
+  onChange: (newUrl: ButtonData['url']) => void;
+}
+
+const ButtonSettings: FC<ButtonSettingsProps> = ({ url, onChange }) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <Box>
+      <TextField
+        label={messages.tools.button.settings.urlLabel()}
+        onChange={(ev) => {
+          onChange(ev.target.value);
+        }}
+        value={url || ''}
+      />
+    </Box>
+  );
+};
+
+export default ButtonSettings;

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
@@ -16,11 +16,11 @@ const ButtonSettings: FC<ButtonSettingsProps> = ({ url, onChange }) => {
   return (
     <Box>
       <TextField
+        defaultValue={url || ''}
         label={messages.tools.button.settings.urlLabel()}
         onChange={(ev) => {
           onChange(ev.target.value);
         }}
-        value={url || ''}
       />
     </Box>
   );

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonSettings.tsx
@@ -1,6 +1,6 @@
 import NextLink from 'next/link';
-import { OpenInNew } from '@mui/icons-material';
-import { Box, Link, TextField, Typography } from '@mui/material';
+import { Box, IconButton, Link, TextField, Typography } from '@mui/material';
+import { Close, OpenInNew } from '@mui/icons-material';
 import { FC, useState } from 'react';
 
 import { ButtonData } from '.';
@@ -26,6 +26,20 @@ const ButtonSettings: FC<ButtonSettingsProps> = ({ url, onChange }) => {
         <Msg id={messageIds.tools.button.settings.linkHeader} />
       </Typography>
       <TextField
+        InputProps={{
+          endAdornment:
+            inputValue.length > 0 ? (
+              <IconButton
+                onClick={() => {
+                  setInputValue('');
+                }}
+              >
+                <Close />
+              </IconButton>
+            ) : (
+              ''
+            ),
+        }}
         label={messages.tools.button.settings.urlLabel()}
         onChange={(ev) => {
           setInputValue(ev.target.value);

--- a/src/features/emails/components/EmailEditor/tools/Button/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/index.tsx
@@ -1,0 +1,47 @@
+import { BlockToolConstructorOptions } from '@editorjs/editorjs';
+import { createRoot } from 'react-dom/client';
+
+import ButtonEditableBlock from './ButtonEditableBlock';
+import Providers from 'core/Providers';
+
+export interface ButtonData {
+  url: string;
+  buttonText: string;
+}
+
+export default class Button {
+  private _data: ButtonData;
+
+  constructor({ data }: BlockToolConstructorOptions<ButtonData>) {
+    this._data = data;
+  }
+
+  static get isReadOnlySupported() {
+    return false;
+  }
+
+  render() {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    root.render(
+      <Providers {...window.providerData}>
+        <ButtonEditableBlock />
+      </Providers>
+    );
+
+    return container;
+  }
+
+  save() {
+    // TODO: Return updated state
+    return this._data;
+  }
+
+  static get toolbox() {
+    return {
+      icon: '<svg height="100%" stroke-miterlimit="10" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" version="1.1" viewBox="0 0 24 24" width="100%" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs/><g id="Untitled"><path d="M10 12.5L7.5 12.5C5.567 12.5 4 10.933 4 9L4 9C4 7.067 5.567 5.5 7.5 5.5L16 5.5C17.6569 5.5 19 6.84315 19 8.5L19 8.5" fill="none" opacity="1" stroke="#000000" stroke-linecap="round" stroke-linejoin="miter" stroke-width="2"/><path d="M20 14.886L16.623 11.8546L14 9.5L14 17.8333L15.7143 16.4298L17 18.5L19 17.5L18 15.307L20 14.886Z" fill="none" opacity="1" stroke="#000000" stroke-linecap="butt" stroke-linejoin="round" stroke-width="2"/></g></svg>',
+      // TODO: Internationalize this
+      title: 'Button',
+    };
+  }
+}

--- a/src/features/emails/components/EmailEditor/tools/Button/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/index.tsx
@@ -25,7 +25,7 @@ export default class Button {
     const root = createRoot(container);
     root.render(
       <Providers {...window.providerData}>
-        <ButtonEditableBlock />
+        <ButtonEditableBlock data={this._data} />
       </Providers>
     );
 

--- a/src/features/emails/components/EmailEditor/tools/Button/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/index.tsx
@@ -25,7 +25,15 @@ export default class Button {
     const root = createRoot(container);
     root.render(
       <Providers {...window.providerData}>
-        <ButtonEditableBlock data={this._data} />
+        <ButtonEditableBlock
+          data={this._data}
+          onChange={(newButtonText: string) => {
+            this._data = {
+              ...this._data,
+              buttonText: newButtonText,
+            };
+          }}
+        />
       </Providers>
     );
 

--- a/src/features/emails/components/EmailEditor/tools/Button/utils/formatUrl.spec.ts
+++ b/src/features/emails/components/EmailEditor/tools/Button/utils/formatUrl.spec.ts
@@ -1,0 +1,18 @@
+import formatUrl from './formatUrl';
+
+describe('formatUrl()', () => {
+  it('does nothing if value is a correctly formatted url', () => {
+    const url = formatUrl('http://www.google.com');
+    expect(url).toEqual('http://www.google.com');
+  });
+
+  it('adds http:// to a correct url without http://', () => {
+    const url = formatUrl('www.google.com');
+    expect(url).toEqual('http://www.google.com');
+  });
+
+  it('returns empty string if the input value is not a valid url', () => {
+    const url = formatUrl('Angela');
+    expect(url).toEqual('');
+  });
+});

--- a/src/features/emails/components/EmailEditor/tools/Button/utils/formatUrl.ts
+++ b/src/features/emails/components/EmailEditor/tools/Button/utils/formatUrl.ts
@@ -1,0 +1,15 @@
+import isURL from 'validator/lib/isURL';
+
+export default function formatUrl(url: string) {
+  if (isURL(url, { require_protocol: true })) {
+    return url;
+  }
+
+  const withHttp = `http://${url}`;
+
+  if (isURL(withHttp, { require_protocol: true })) {
+    return withHttp;
+  }
+
+  return '';
+}

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -55,6 +55,14 @@ export default makeMessages('feat.emails', {
     title: m('Targets'),
     viewButton: m('View target group'),
   },
+  tools: {
+    button: {
+      settings: {
+        buttonTextLabel: m('Button text'),
+        urlLabel: m('Link url'),
+      },
+    },
+  },
   wasSent: m<{ time: string }>('Was sent at {time}'),
   willSend: m<{ time: string }>('Will send at {time}'),
 });

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -57,6 +57,9 @@ export default makeMessages('feat.emails', {
   },
   tools: {
     button: {
+      block: {
+        noButtonText: m('Add text'),
+      },
       settings: {
         buttonTextLabel: m('Button text'),
         urlLabel: m('Link url'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -61,7 +61,9 @@ export default makeMessages('feat.emails', {
         noButtonText: m('Add text'),
       },
       settings: {
-        buttonTextLabel: m('Button text'),
+        invalidUrl: m('This is not a valid url'),
+        linkHeader: m('Button link'),
+        testLink: m('Click to test link'),
         urlLabel: m('Link url'),
       },
     },

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -58,7 +58,7 @@ export default makeMessages('feat.emails', {
   tools: {
     button: {
       block: {
-        noButtonText: m('Add text'),
+        noButtonText: m('Click to change this text!'),
       },
       settings: {
         invalidUrl: m('This is not a valid url'),

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -1,7 +1,8 @@
 import { Box } from '@mui/material';
+import { GetServerSideProps } from 'next';
+
 import EmailEditor from 'features/emails/components/EmailEditor';
 import EmailLayout from 'features/emails/layout/EmailLayout';
-import { GetServerSideProps } from 'next';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useEmail from 'features/emails/hooks/useEmail';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13263,7 +13263,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.7.1, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -13459,6 +13459,14 @@ react-colorful@^5.1.2:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==
+
+react-contenteditable@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/react-contenteditable/-/react-contenteditable-3.3.7.tgz#18dd1f281841ba2c2b306e2d28278bc31b7929ed"
+  integrity sha512-GA9NbC0DkDdpN3iGvib/OMHWTJzDX2cfkgy5Tt98JJAbA3kLnyrNbBIpsSpPpq7T8d3scD39DHP+j8mAM7BIfQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    prop-types "^15.7.1"
 
 react-dnd-html5-backend@^16.0.1:
   version "16.0.1"


### PR DESCRIPTION
## Description
This PR adds the Button tool to the email editor. 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/aa8b2e47-bb3b-4109-8222-05e949011b3a)

## Changes
- `ButtonEditableBlock` component
- `Button` tool class
- `ButtonSettings` component
- adding the `react-contenteditable` package to help handling `contentEditable` on the button in the WYSIWYG

## Related issues
none