### PR TITLE
Sorting of booked participants in events

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -145,7 +145,6 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       field: 'name',
       flex: 1,
       headerName: messages.eventParticipantsList.columnName(),
-      hideSortIcons: true,
       minWidth: 250,
       renderCell: (params) => {
         if (params.row.person) {
@@ -188,16 +187,18 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
         }
       },
       resizable: false,
-      sortable: false,
+      sortingOrder: ['asc', 'desc', null],
+      valueGetter: (params) => {
+        return `${params.row.first_name || ''} ${params.row.last_name || ''}`;
+      },
     },
     {
       disableColumnMenu: true,
       field: 'phone',
       flex: 1,
       headerName: messages.eventParticipantsList.columnPhone(),
-      hideSortIcons: true,
       resizable: false,
-      sortable: false,
+      sortingOrder: ['asc', 'desc', null],
       valueGetter: (params) => {
         if (params.row.person) {
           return params.row.person.phone;
@@ -211,9 +212,8 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       field: 'email',
       flex: 1,
       headerName: messages.eventParticipantsList.columnEmail(),
-      hideSortIcons: true,
       resizable: false,
-      sortable: false,
+      sortingOrder: ['asc', 'desc', null],
       valueGetter: (params) => {
         if (params.row.person) {
           return params.row.person.email;
@@ -227,7 +227,6 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       field: 'notified',
       flex: 1,
       headerName: messages.eventParticipantsList.columnNotified(),
-      hideSortIcons: true,
       renderCell: (params) => {
         if (params.row.person) {
           return <ZUIRelativeTime datetime={params.row.response_date} />;
@@ -236,7 +235,15 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
         }
       },
       resizable: false,
-      sortable: false,
+      sortingOrder: ['asc', 'desc', null],
+      type: 'date',
+      valueGetter: (params) => {
+        if (params.row.person) {
+          return new Date(params.row.response_date);
+        } else {
+          return new Date(params.row.reminder_sent);
+        }
+      },
     },
     {
       align: 'right',

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -250,8 +250,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       disableColumnMenu: true,
       field: 'cancel',
       flex: 1,
-      headerName: '',
-      hideSortIcons: true,
+      headerName: messages.eventParticipantsList.attendance(),
       minWidth: 300,
       renderCell: (params) => {
         if (type == 'signups') {
@@ -365,7 +364,16 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
         }
       },
       resizable: false,
-      sortable: false,
+      sortingOrder: ['asc', 'desc', null],
+      valueGetter: (params) => {
+        if (params.row.attended) {
+          return 1;
+        } else if (params.row.noshow) {
+          return 2;
+        } else {
+          return 0;
+        }
+      },
     },
   ];
 


### PR DESCRIPTION
## Description
This PR adds sorting of name, phone number, email, and notified date to the booked participants table.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/bc420b37-2ec2-4778-8c08-98cf5c7b08ae)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/38d7969a-e781-4d39-b251-c2932a1f9bf3)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/aa29ac3c-280b-4925-96e3-834e75ec5b76)


## Changes
Adds ascending, descending, and deselection of sorting to Name, Phone, Email, Notified, and Attending fields in the Booked Participants table in Events.
Added header title to Attending column.


## Notes to reviewer
Add participants to event. Notify participants. Add additional participants. Notify again. Click the different columns to sort.


## Related issues
Resolves #1751 
