### PR TITLE
ISSUE #1256 - Add keyboard input to local_person cell

### DIFF
--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -150,7 +150,7 @@ const ZUIPersonGridEditCell: FC<{
 
               setActiveIndex(Infinity);
               setAnchorEl(null);
-              ev.preventDefault(); // Vad betyder detta :O
+              ev.preventDefault();
             }
           }}
           placeholder={messages.personSelect.search()}

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -60,13 +60,6 @@ const ZUIPersonGridEditCell: FC<{
       let selectedBounds = selectedElement.getBoundingClientRect();
       let scrollableBounds = scrollableElement.getBoundingClientRect();
 
-      console.log(
-        'Selected bottom: ' +
-          selectedBounds.bottom +
-          ', scrollable offset: ' +
-          scrollableElement.scrollTop
-      );
-
       if (selectedBounds.top < scrollableBounds.top) {
         selectedElement.scrollIntoView(true);
       }

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -51,27 +51,13 @@ const ZUIPersonGridEditCell: FC<{
   const [activeIndex, setActiveIndex] = useState<number>(Infinity);
   const scrollableRef = useRef<HTMLUListElement>(null);
 
-  // Scroll (if necessary) when navigating using keyboard
+  // Scroll when navigating using keyboard
   useEffect(() => {
     const scrollableElement = scrollableRef.current;
     const selectedElement = scrollableElement?.querySelector('.Mui-selected');
 
-    if (selectedElement && scrollableElement) {
-      let selectedBounds = selectedElement.getBoundingClientRect();
-      let scrollableBounds = scrollableElement.getBoundingClientRect();
-
-      if (selectedBounds.top < scrollableBounds.top) {
-        selectedElement.scrollIntoView(true);
-      }
-
-      if (
-        selectedBounds.bottom >
-        scrollableBounds.bottom +
-          scrollableElement.offsetHeight -
-          scrollableBounds.top
-      ) {
-        selectedElement.scrollIntoView(false);
-      }
+    if (selectedElement) {
+      selectedElement.scrollIntoView();
     }
   }, [scrollableRef, activeIndex]);
 
@@ -245,8 +231,8 @@ const ZUIPersonGridEditCell: FC<{
                     </Box>
                   )}
                   <List
-                    className={styles.searchingList}
                     ref={scrollableRef}
+                    className={styles.searchingList}
                     sx={{
                       display:
                         showSuggestedPeople || searching ? 'block' : 'none',


### PR DESCRIPTION
## Description
This PR adds keyboard input (arrow down, up and enter) to editing local_person cell. Also scrolls into view when navigating by arrow keys.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/21238654/13cd51f3-5896-4d71-bbc8-c7dd7e734429)


## Changes
* Adds keyboard input 
* Adds scroll into view


## Notes to reviewer
N/A


## Related issues
Resolves #1256 
