### PR TITLE
Email editor variable tool UI

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -15,6 +15,7 @@ import messageIds from 'features/emails/l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import { useTheme } from '@mui/material';
+import variableToolFactory from './tools/inlineVariable';
 
 export type EmailEditorFrontendProps = {
   apiRef: MutableRefObject<EditorJS | null>;
@@ -60,7 +61,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       data: initialContent,
       // TODO: Find way to make unique IDs
       holder: 'ClientOnlyEditor-container',
-      inlineToolbar: ['bold', 'italic', 'link'],
+      inlineToolbar: ['bold', 'italic', 'link', 'variable'],
       onChange: () => saveData(),
       tools: {
         button: {
@@ -93,6 +94,9 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
           config: {
             preserveBlank: true,
           },
+        },
+        variable: {
+          class: variableToolFactory('Variable'),
         },
       },
     };

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -49,6 +49,13 @@ export function linkToolFactory(title: string) {
       this._focused = false;
     }
 
+    deactivate(): void {
+      this.updateButton(false);
+      if (this._container) {
+        this._container.style.display = 'none';
+      }
+    }
+
     onToolClose(): void {
       //If the input is empty, remove anchor tag
       if (this._input && this._input.value.length === 0) {
@@ -177,6 +184,7 @@ export function linkToolFactory(title: string) {
     }
 
     surround(range: Range) {
+      this.activate();
       const anchors = getAnchorTags(range);
       if (anchors.length) {
         anchors.forEach((anchor) => {
@@ -251,10 +259,15 @@ export function linkToolFactory(title: string) {
         }
 
         //switch between icons for adding and removing this._link
-        this._button.innerHTML =
-          !this._selectedAnchor && anchors.length == 0
-            ? '<svg width="24" height="24" viewBox="0 0 24 24"><path stroke-width="0" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1M8 13h8v-2H8zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5"/></svg>'
-            : '<svg width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" stroke-width="0" class="ce-inline-tool--active" d="M17 7h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1 0 1.43-.98 2.63-2.31 2.98l1.46 1.46C20.88 15.61 22 13.95 22 12c0-2.76-2.24-5-5-5m-1 4h-2.19l2 2H16zM2 4.27l3.11 3.11C3.29 8.12 2 9.91 2 12c0 2.76 2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1 0-1.59 1.21-2.9 2.76-3.07L8.73 11H8v2h2.73L13 15.27V17h1.73l4.01 4L20 19.74 3.27 3z"/></svg>';
+        this.updateButton(!!this._selectedAnchor && anchors.length == 0);
+      }
+    }
+
+    private updateButton(active: boolean): void {
+      if (this._button) {
+        this._button.innerHTML = !active
+          ? '<svg width="24" height="24" viewBox="0 0 24 24"><path stroke-width="0" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1M8 13h8v-2H8zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5"/></svg>'
+          : '<svg width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" stroke-width="0" class="ce-inline-tool--active" d="M17 7h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1 0 1.43-.98 2.63-2.31 2.98l1.46 1.46C20.88 15.61 22 13.95 22 12c0-2.76-2.24-5-5-5m-1 4h-2.19l2 2H16zM2 4.27l3.11 3.11C3.29 8.12 2 9.91 2 12c0 2.76 2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1 0-1.59 1.21-2.9 2.76-3.07L8.73 11H8v2h2.73L13 15.27V17h1.73l4.01 4L20 19.74 3.27 3z"/></svg>';
       }
     }
   }

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -111,6 +111,7 @@ export default function variableToolFactory(title: string) {
     static get sanitize() {
       return {
         span: {
+          contenteditable: true,
           'data-slug': true,
           style: true,
         },

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -81,6 +81,10 @@ export default function variableToolFactory(title: string) {
       });
     }
 
+    deactivate(): void {
+      this._list.style.display = 'none';
+    }
+
     insertVariable(range: Range, slug: string): void {
       const elem = document.createElement('span');
       elem.contentEditable = 'false';
@@ -119,6 +123,7 @@ export default function variableToolFactory(title: string) {
     }
 
     surround(range: Range): void {
+      this.activate();
       this._pendingRange = range;
       this._list.style.display = 'block';
     }

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -33,10 +33,22 @@ export default function variableToolFactory(title: string) {
       this._list = document.createElement('ul');
       this._list.style.display = 'none';
       this._list.style.listStyleType = 'none';
+      this._list.style.minWidth = '150px';
       this._list.style.padding = '0px';
+      this._list.style.margin = '0px';
 
       Object.entries(this._availableVars).forEach(([slug, title]) => {
         const item = document.createElement('li');
+        item.style.cursor = 'pointer';
+        item.style.padding = '8px';
+        item.style.borderTop = '1px solid rgba(0,0,0,0.1)';
+        item.addEventListener('mouseenter', () => {
+          item.style.backgroundColor = 'rgba(0,0,0,0.05)';
+        });
+        item.addEventListener('mouseleave', () => {
+          item.style.backgroundColor = 'transparent';
+        });
+
         item.dataset.slug = slug;
         item.innerText = title;
         item.addEventListener(

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -27,7 +27,22 @@ export default function variableToolFactory(title: string) {
 
       this._button = document.createElement('button');
       this._button.type = 'button';
-      this._button.innerHTML = 'VAR';
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
+      svg.style.display = 'block';
+      svg.style.padding = '2px';
+      const path = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'path'
+      );
+      path.setAttributeNS(
+        null,
+        'd',
+        'M4 7v2c0 .55-.45 1-1 1H2v4h1c.55 0 1 .45 1 1v2c0 1.65 1.35 3 3 3h3v-2H7c-.55 0-1-.45-1-1v-2c0-1.3-.84-2.42-2-2.83v-.34C5.16 11.42 6 10.3 6 9V7c0-.55.45-1 1-1h3V4H7C5.35 4 4 5.35 4 7m17 3c-.55 0-1-.45-1-1V7c0-1.65-1.35-3-3-3h-3v2h3c.55 0 1 .45 1 1v2c0 1.3.84 2.42 2 2.83v.34c-1.16.41-2 1.52-2 2.83v2c0 .55-.45 1-1 1h-3v2h3c1.65 0 3-1.35 3-3v-2c0-.55.45-1 1-1h1v-4z'
+      );
+      path.setAttributeNS(null, 'stroke-width', '0');
+      svg.appendChild(path);
+      this._button.appendChild(svg);
       this._button.classList.add(this._api.styles.inlineToolButton);
 
       this._list = document.createElement('ul');

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -65,6 +65,9 @@ export default function variableToolFactory(title: string) {
       range.deleteContents();
       range.insertNode(elem);
 
+      // Store slug in dataset
+      elem.dataset.slug = slug;
+
       // Reset editor
       this._api.toolbar.close();
       window.getSelection()?.empty();
@@ -76,6 +79,15 @@ export default function variableToolFactory(title: string) {
 
     protected renderButton() {
       return this._button;
+    }
+
+    static get sanitize() {
+      return {
+        span: {
+          'data-slug': true,
+          style: true,
+        },
+      };
     }
 
     surround(range: Range): void {

--- a/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
+++ b/src/features/emails/components/EmailEditor/tools/inlineVariable/index.ts
@@ -1,0 +1,92 @@
+import {
+  API,
+  InlineTool,
+  InlineToolConstructorOptions,
+} from '@editorjs/editorjs';
+
+import InlineToolBase from '../../utils/InlineToolBase';
+
+export default function variableToolFactory(title: string) {
+  class VariableTool extends InlineToolBase implements InlineTool {
+    private _api: API;
+    private _availableVars: { [slug: string]: string };
+    private _button: HTMLButtonElement;
+    private _list: HTMLUListElement;
+    private _pendingRange: Range | null = null;
+
+    constructor({ api }: InlineToolConstructorOptions) {
+      super();
+
+      this._api = api;
+
+      this._availableVars = {
+        first_name: 'First name',
+        full_name: 'Full name',
+        last_name: 'Last name',
+      };
+
+      this._button = document.createElement('button');
+      this._button.type = 'button';
+      this._button.innerHTML = 'VAR';
+      this._button.classList.add(this._api.styles.inlineToolButton);
+
+      this._list = document.createElement('ul');
+      this._list.style.display = 'none';
+      this._list.style.listStyleType = 'none';
+      this._list.style.padding = '0px';
+
+      Object.entries(this._availableVars).forEach(([slug, title]) => {
+        const item = document.createElement('li');
+        item.dataset.slug = slug;
+        item.innerText = title;
+        item.addEventListener(
+          'click',
+          (ev) => {
+            ev.stopImmediatePropagation();
+            if (this._pendingRange) {
+              this.insertVariable(this._pendingRange, slug);
+            }
+          },
+          { capture: true }
+        );
+
+        this._list.append(item);
+      });
+    }
+
+    insertVariable(range: Range, slug: string): void {
+      const elem = document.createElement('span');
+      elem.contentEditable = 'false';
+      elem.style.backgroundColor = 'rgba(0,0,0,0.1)';
+      elem.style.padding = '0.1em 0.5em';
+      elem.style.borderRadius = '1em';
+      elem.style.display = 'inline-block';
+      elem.textContent = this._availableVars[slug];
+      range.deleteContents();
+      range.insertNode(elem);
+
+      // Reset editor
+      this._api.toolbar.close();
+      window.getSelection()?.empty();
+    }
+
+    renderActions(): HTMLElement {
+      return this._list;
+    }
+
+    protected renderButton() {
+      return this._button;
+    }
+
+    surround(range: Range): void {
+      this._pendingRange = range;
+      this._list.style.display = 'block';
+    }
+
+    static get title(): string {
+      return title;
+    }
+  }
+
+  return VariableTool;
+}

--- a/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
+++ b/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
@@ -49,7 +49,8 @@ export default class InlineToolBase {
     throw new Error('Method must be overridden');
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected update(range: Range): void {
-    throw new Error('Method must be overridden' + range.toString());
+    // Does nothing by default
   }
 }

--- a/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
+++ b/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
@@ -1,5 +1,14 @@
 export default class InlineToolBase {
+  private static _activeInstance: InlineToolBase | null = null;
+
   private _handleSelectionChangeBound: () => void = () => undefined;
+
+  activate() {
+    if (InlineToolBase._activeInstance) {
+      InlineToolBase._activeInstance.deactivate();
+    }
+    InlineToolBase._activeInstance = this;
+  }
 
   checkState() {
     return true;
@@ -8,6 +17,10 @@ export default class InlineToolBase {
   clear() {
     this.onToolClose();
     this.destroy();
+  }
+
+  deactivate() {
+    // Called by activate()
   }
 
   destroy() {


### PR DESCRIPTION
## Description
This PR introduces "variables" as an inline tool in the email composer. Selecting some text and using the new tool replaces the text with a variable of the user's choosing (only three options so far).

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/51127bbf-40da-400f-8fc1-9478a583f9e4)

## Changes
* Adds a new inline tool for variables
* Modifies the inline tool framework introduced by #1763 to allow `deactivate()`, `activate()`

## Notes to reviewer
Review #1763 first.

## Related issues
Undocumented