### PR TITLE
Email editor header tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@date-io/date-fns": "1.x",
     "@date-io/dayjs": "1.x",
     "@editorjs/editorjs": "^2.28.2",
+    "@editorjs/header": "^2.8.1",
     "@editorjs/paragraph": "^2.11.3",
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 //@ts-ignore
+import Header from '@editorjs/header';
+//@ts-ignore
 import Paragraph from '@editorjs/paragraph';
+
 import EditorJS, {
   EditorConfig,
   OutputData,
@@ -66,6 +69,14 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       tools: {
         button: {
           class: Button as unknown as ToolConstructable,
+        },
+        header: {
+          class: Header,
+          config: {
+            defaultLevel: 1,
+            levels: [1, 2, 3],
+          },
+          inlineToolbar: ['variable'],
         },
         libraryImage: {
           class: LibraryImage as unknown as ToolConstructable,

--- a/src/features/emails/components/EmailEditor/EmailSettings/BlockListItem.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/BlockListItem.tsx
@@ -4,6 +4,7 @@ import { OutputBlockData } from '@editorjs/editorjs';
 import { BLOCK_TYPES } from 'features/emails/types';
 import blockHasErrors from './utils/blockHasErrors';
 import ButtonBlockListItem from './ButtonBlockListItem';
+import HeaderBlockListItem from './HeaderBlockListItem';
 import ImageBlockListItem from './ImageBlockListItem';
 import TextBlockListItem from './TextBlockListItem';
 
@@ -28,6 +29,8 @@ const BlockListItem: FC<BlockListItemProps> = ({
         selected={selected}
       />
     );
+  } else if (block.type === BLOCK_TYPES.HEADER) {
+    return <HeaderBlockListItem data={block.data} selected={selected} />;
   } else if (block.type === BLOCK_TYPES.BUTTON) {
     return (
       <ButtonBlockListItem

--- a/src/features/emails/components/EmailEditor/EmailSettings/HeaderBlockListItem.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/HeaderBlockListItem.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+
+import BlockListItemBase from './BlockListItemBase';
+import messageIds from 'features/emails/l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+export interface HeaderBlockData {
+  text: string;
+}
+
+interface HeaderBlockListItemProps {
+  data: HeaderBlockData;
+  selected: boolean;
+}
+
+const HeaderBlockListItem: FC<HeaderBlockListItemProps> = ({
+  data,
+  selected,
+}) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <BlockListItemBase
+      excerpt={data.text}
+      hasErrors={false}
+      selected={selected}
+      title={messages.editor.tools.header.title()}
+    />
+  );
+};
+
+export default HeaderBlockListItem;

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -19,6 +19,9 @@ export default makeMessages('feat.emails', {
         },
         title: m('Button'),
       },
+      header: {
+        title: m('Header'),
+      },
       libraryImage: {
         changeImage: m('Change image'),
         title: m('Image'),

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -5,6 +5,7 @@ export interface EmailTargets {
 
 export enum BLOCK_TYPES {
   BUTTON = 'button',
+  HEADER = 'header',
   LIBRARY_IMAGE = 'libraryImage',
   PARAGRAPH = 'paragraph',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1456,6 +1456,11 @@
   resolved "https://registry.yarnpkg.com/@codexteam/icons/-/icons-0.0.4.tgz#8b72dcd3f3a1b0d880bdceb2abebd74b46d3ae13"
   integrity sha512-V8N/TY2TGyas4wLrPIFq7bcow68b3gu8DfDt1+rrHPtXxcexadKauRJL6eQgfG7Z0LCrN4boLRawR4S9gjIh/Q==
 
+"@codexteam/icons@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@codexteam/icons/-/icons-0.0.5.tgz#d17f39b6a0497c6439f57dd42711817a3dd3679c"
+  integrity sha512-s6H2KXhLz2rgbMZSkRm8dsMJvyUNZsEjxobBEg9ztdrb1B2H3pEzY6iTwI4XUPJWJ3c3qRKwV4TrO3J5jUdoQA==
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -1554,6 +1559,13 @@
   version "2.28.2"
   resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.28.2.tgz#a265c7d10e83adef81813e4dc0f01fe3464dff50"
   integrity sha512-g6V0Nd3W9IIWMpvxDNTssQ6e4kxBp1Y0W4GIf8cXRlmcBp3TUjrgCYJQmNy3l2a6ZzhyBAoVSe8krJEq4g7PQw==
+
+"@editorjs/header@^2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@editorjs/header/-/header-2.8.1.tgz#ba16f43aaf461aa920c3594bdf0d854c4b5119b9"
+  integrity sha512-y0HVXRP7m2W617CWo3fsb5HhXmSLaRpb9GzFx0Vkp/HEm9Dz5YO1s8tC7R8JD3MskwoYh7V0hRFQt39io/r6hA==
+  dependencies:
+    "@codexteam/icons" "^0.0.5"
 
 "@editorjs/paragraph@^2.11.3":
   version "2.11.3"


### PR DESCRIPTION
## Description
This PR adds the prebuilt official editor.js header tool to the email editor, along with support for variables introduced in #1764.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/349b7697-4b02-49d7-8980-7cb0437bdfbd)

## Changes
* Adds the official `@editorjs/header` tool
* Configures header tool to support the inline variable tool introduced in #1764 
* Adds `HeaderBlockListItem` component for the sidebar

## Notes to reviewer
Review after #1764 

## Related issues
Undocumented