### PR TITLE
Email editor extra tabs

### DIFF
--- a/integrationTesting/mockData/users/RosaLuxemburgUser.ts
+++ b/integrationTesting/mockData/users/RosaLuxemburgUser.ts
@@ -1,6 +1,7 @@
 import { ZetkinUser } from 'utils/types/zetkin';
 
 const RosaLuxemburgUser: ZetkinUser = {
+  email: 'rosa@zetkin.org',
   first_name: 'Rosa',
   id: 1,
   lang: null,

--- a/src/features/emails/components/EmailEditor/EmailSettings/BlockListItemBase.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/BlockListItemBase.tsx
@@ -45,8 +45,8 @@ const BlockListItemBase: FC<BlockListItemBaseProps> = ({
         paddingY={1.5}
         sx={{
           borderLeft: selected
-            ? `4px solid ${theme.palette.primary.main}`
-            : '4px solid transparent',
+            ? `3px solid ${theme.palette.primary.main}`
+            : '3px solid transparent',
           cursor: expandable ? 'pointer' : 'default',
         }}
       >
@@ -84,8 +84,8 @@ const BlockListItemBase: FC<BlockListItemBaseProps> = ({
             paddingX={2}
             sx={{
               borderLeft: selected
-                ? `4px solid ${theme.palette.primary.main}`
-                : '4px solid transparent',
+                ? `3px solid ${theme.palette.primary.main}`
+                : '3px solid transparent',
             }}
           >
             {children}

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -1,12 +1,14 @@
 import { FC } from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, CircularProgress, Typography } from '@mui/material';
 
 import messageIds from 'features/emails/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import useCurrentUser from 'features/user/hooks/useCurrentUser';
+import useSendTestEmail from 'features/emails/hooks/useSendTestEmail';
 
 const PreviewTab: FC = () => {
   const user = useCurrentUser();
+  const { isLoading, sendTestEmail } = useSendTestEmail();
 
   if (!user) {
     return null;
@@ -22,12 +24,16 @@ const PreviewTab: FC = () => {
       </Typography>
       <Typography>{user.email}</Typography>
       <Button
-        onClick={() => {
-          //send email
+        onClick={async () => {
+          await sendTestEmail();
         }}
         variant="contained"
       >
-        <Msg id={messageIds.editor.settings.tabs.preview.sendButton} />
+        {isLoading ? (
+          <CircularProgress color="inherit" size="1.5rem" />
+        ) : (
+          <Msg id={messageIds.editor.settings.tabs.preview.sendButton} />
+        )}
       </Button>
     </Box>
   );

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -1,0 +1,36 @@
+import { FC } from 'react';
+import { Box, Button, Typography } from '@mui/material';
+
+import messageIds from 'features/emails/l10n/messageIds';
+import { Msg } from 'core/i18n';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
+
+const PreviewTab: FC = () => {
+  const user = useCurrentUser();
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2} padding={2}>
+      <Typography>
+        <Msg id={messageIds.editor.settings.tabs.preview.instructions} />
+      </Typography>
+      <Typography>
+        <Msg id={messageIds.editor.settings.tabs.preview.sendTo} />
+      </Typography>
+      <Typography>{user.email}</Typography>
+      <Button
+        onClick={() => {
+          //send email
+        }}
+        variant="contained"
+      >
+        <Msg id={messageIds.editor.settings.tabs.preview.sendButton} />
+      </Button>
+    </Box>
+  );
+};
+
+export default PreviewTab;

--- a/src/features/emails/components/EmailEditor/EmailSettings/SettingsTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/SettingsTab.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react';
+import { Box, FormControl, TextField } from '@mui/material';
+
+import messageIds from 'features/emails/l10n/messageIds';
+import useEmailSettings from 'features/emails/hooks/useEmailSettings';
+import { useMessages } from 'core/i18n';
+import { ZetkinEmail } from 'utils/types/zetkin';
+
+interface SettingsTabProps {
+  subject: string;
+  onChange: (email: Partial<ZetkinEmail>) => void;
+}
+
+const SettingsTab: FC<SettingsTabProps> = ({
+  subject: initialSubject,
+  onChange,
+}) => {
+  const messages = useMessages(messageIds);
+  const { subject, emailAddress, setSubject, orgTitle } =
+    useEmailSettings(initialSubject);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2} padding={2}>
+      <FormControl fullWidth>
+        <TextField
+          disabled
+          fullWidth
+          label={messages.editor.settings.tabs.settings.senderNameInputLabel()}
+          value={orgTitle}
+        />
+      </FormControl>
+      <FormControl fullWidth>
+        <TextField
+          disabled
+          fullWidth
+          label={messages.editor.settings.tabs.settings.senderAddressInputLabel()}
+          value={emailAddress}
+        />
+      </FormControl>
+      <TextField
+        fullWidth
+        label={messages.editor.settings.tabs.settings.subjectInputLabel()}
+        onChange={(event) => {
+          setSubject(event.target.value);
+          onChange({ subject: event.target.value });
+        }}
+        value={subject}
+      />
+    </Box>
+  );
+};
+
+export default SettingsTab;

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -6,6 +6,7 @@ import { TabContext, TabList, TabPanel } from '@mui/lab';
 
 import BlockListItem from './BlockListItem';
 import messageIds from 'features/emails/l10n/messageIds';
+import PreviewTab from './PreviewTab';
 import { useMessages } from 'core/i18n';
 
 interface EmailSettingsProps {
@@ -54,7 +55,7 @@ const EmailSettings: FC<EmailSettingsProps> = ({
             value="settings"
           />
           <Tab
-            label={messages.editor.settings.tabs.preview()}
+            label={messages.editor.settings.tabs.preview.title()}
             value="preview"
           />
         </TabList>
@@ -85,7 +86,7 @@ const EmailSettings: FC<EmailSettingsProps> = ({
           Foo
         </TabPanel>
         <TabPanel sx={{ padding: 0 }} value="preview">
-          Bar
+          <PreviewTab />
         </TabPanel>
       </TabContext>
     </Box>

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -1,6 +1,6 @@
 import EditorJS from '@editorjs/editorjs';
 import { OutputBlockData } from '@editorjs/editorjs';
-import { Divider, Stack, Tab } from '@mui/material';
+import { Box, Divider, Stack, Tab, useTheme } from '@mui/material';
 import { FC, MutableRefObject, useEffect, useRef, useState } from 'react';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 
@@ -22,6 +22,7 @@ const EmailSettings: FC<EmailSettingsProps> = ({
   const messages = useMessages(messageIds);
   const [activeTab, setActiveTab] = useState<'Content'>('Content');
   const boxRef = useRef<HTMLElement>();
+  const theme = useTheme();
 
   useEffect(() => {
     boxRef.current?.children[selectedBlockIndex]?.scrollIntoView({
@@ -30,30 +31,50 @@ const EmailSettings: FC<EmailSettingsProps> = ({
   }, [selectedBlockIndex]);
 
   return (
-    <TabContext value={activeTab}>
-      <TabList
-        onChange={(ev, newValue) => setActiveTab(newValue)}
-        sx={{ border: 'none' }}
-      >
-        <Tab label={messages.editor.settings.tabs.content()} value="Content" />
-      </TabList>
-      <TabPanel sx={{ padding: 0 }} value="Content">
-        <Stack ref={boxRef} divider={<Divider />} sx={{ paddingTop: 1 }}>
-          {blocks.map((block, index) => (
-            <BlockListItem
-              key={block.id}
-              block={block}
-              onChange={(newData: OutputBlockData['data']) => {
-                if (block.id) {
-                  apiRef.current?.blocks.update(block.id, newData);
-                }
-              }}
-              selected={index === selectedBlockIndex}
-            />
-          ))}
-        </Stack>
-      </TabPanel>
-    </TabContext>
+    <Box
+      sx={{
+        borderLeft: `1px solid ${theme.palette.grey[300]}`,
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: '100%',
+        overflowY: 'auto',
+      }}
+    >
+      <TabContext value={activeTab}>
+        <TabList
+          onChange={(ev, newValue) => setActiveTab(newValue)}
+          sx={{ border: 'none' }}
+        >
+          <Tab
+            label={messages.editor.settings.tabs.content()}
+            value="content"
+          />
+        </TabList>
+        <TabPanel
+          sx={{
+            flexGrow: 0,
+            overflowY: 'auto',
+            padding: 0,
+          }}
+          value="content"
+        >
+          <Stack ref={boxRef} divider={<Divider />} sx={{ paddingTop: 1 }}>
+            {blocks.map((block, index) => (
+              <BlockListItem
+                key={block.id}
+                block={block}
+                onChange={(newData: OutputBlockData['data']) => {
+                  if (block.id) {
+                    apiRef.current?.blocks.update(block.id, newData);
+                  }
+                }}
+                selected={index === selectedBlockIndex}
+              />
+            ))}
+          </Stack>
+        </TabPanel>
+      </TabContext>
+    </Box>
   );
 };
 

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -7,18 +7,24 @@ import { TabContext, TabList, TabPanel } from '@mui/lab';
 import BlockListItem from './BlockListItem';
 import messageIds from 'features/emails/l10n/messageIds';
 import PreviewTab from './PreviewTab';
+import SettingsTab from './SettingsTab';
 import { useMessages } from 'core/i18n';
+import { ZetkinEmail } from 'utils/types/zetkin';
 
 interface EmailSettingsProps {
   apiRef: MutableRefObject<EditorJS | null>;
   blocks: OutputBlockData[];
+  onSave: (email: Partial<ZetkinEmail>) => void;
   selectedBlockIndex: number;
+  subject: string;
 }
 
 const EmailSettings: FC<EmailSettingsProps> = ({
   apiRef,
   blocks,
+  onSave,
   selectedBlockIndex,
+  subject,
 }) => {
   const messages = useMessages(messageIds);
   const [activeTab, setActiveTab] = useState<
@@ -51,7 +57,7 @@ const EmailSettings: FC<EmailSettingsProps> = ({
             value="content"
           />
           <Tab
-            label={messages.editor.settings.tabs.settings()}
+            label={messages.editor.settings.tabs.settings.title()}
             value="settings"
           />
           <Tab
@@ -83,7 +89,7 @@ const EmailSettings: FC<EmailSettingsProps> = ({
           </Stack>
         </TabPanel>
         <TabPanel sx={{ padding: 0 }} value="settings">
-          Foo
+          <SettingsTab onChange={onSave} subject={subject} />
         </TabPanel>
         <TabPanel sx={{ padding: 0 }} value="preview">
           <PreviewTab />

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -21,7 +21,9 @@ const EmailSettings: FC<EmailSettingsProps> = ({
   selectedBlockIndex,
 }) => {
   const messages = useMessages(messageIds);
-  const [activeTab, setActiveTab] = useState<'Content'>('Content');
+  const [activeTab, setActiveTab] = useState<
+    'content' | 'preview' | 'settings'
+  >('content');
   const boxRef = useRef<HTMLElement>();
   const theme = useTheme();
 

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -44,12 +44,10 @@ const EmailSettings: FC<EmailSettingsProps> = ({
       }}
     >
       <TabContext value={activeTab}>
-        <TabList
-          onChange={(ev, newValue) => setActiveTab(newValue)}
-          sx={{ border: 'none' }}
-        >
+        <TabList onChange={(ev, newValue) => setActiveTab(newValue)}>
           <Tab
             label={messages.editor.settings.tabs.content()}
+            sx={{ marginLeft: 2 }}
             value="content"
           />
           <Tab

--- a/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/index.tsx
@@ -49,6 +49,14 @@ const EmailSettings: FC<EmailSettingsProps> = ({
             label={messages.editor.settings.tabs.content()}
             value="content"
           />
+          <Tab
+            label={messages.editor.settings.tabs.settings()}
+            value="settings"
+          />
+          <Tab
+            label={messages.editor.settings.tabs.preview()}
+            value="preview"
+          />
         </TabList>
         <TabPanel
           sx={{
@@ -72,6 +80,12 @@ const EmailSettings: FC<EmailSettingsProps> = ({
               />
             ))}
           </Stack>
+        </TabPanel>
+        <TabPanel sx={{ padding: 0 }} value="settings">
+          Foo
+        </TabPanel>
+        <TabPanel sx={{ padding: 0 }} value="preview">
+          Bar
         </TabPanel>
       </TabContext>
     </Box>

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -4,20 +4,25 @@ import EditorJS, { OutputBlockData, OutputData } from '@editorjs/editorjs';
 import { FC, useEffect, useRef, useState } from 'react';
 
 import EmailSettings from './EmailSettings';
+import { ZetkinEmail } from 'utils/types/zetkin';
 
 const EmailEditorFrontend = dynamic(import('./EmailEditorFrontend'), {
   ssr: false,
 });
 
 interface EmailEditorProps {
-  initialContent: OutputData;
-  onSave: (data: OutputData) => void;
+  email: ZetkinEmail;
+  onSave: (email: Partial<ZetkinEmail>) => void;
 }
 
-const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
+const EmailEditor: FC<EmailEditorProps> = ({ email, onSave }) => {
   const theme = useTheme();
   const apiRef = useRef<EditorJS | null>(null);
   const [selectedBlockIndex, setSelectedBlockIndex] = useState(0);
+
+  const initialContent = email.content
+    ? JSON.parse(email.content)
+    : { blocks: [] };
   const [content, setContent] = useState<OutputData>(initialContent);
 
   const blocksRef = useRef<OutputBlockData[]>();
@@ -46,7 +51,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
           initialContent={initialContent}
           onSave={(newContent: OutputData) => {
             setContent(newContent);
-            onSave(newContent);
+            onSave({ content: JSON.stringify(newContent) });
           }}
           onSelectBlock={(selectedBlockIndex: number) => {
             setSelectedBlockIndex(selectedBlockIndex);
@@ -63,7 +68,9 @@ const EmailEditor: FC<EmailEditorProps> = ({ initialContent, onSave }) => {
         <EmailSettings
           apiRef={apiRef}
           blocks={content.blocks}
+          onSave={onSave}
           selectedBlockIndex={selectedBlockIndex}
+          subject={email.subject || ''}
         />
       </Box>
     </Box>

--- a/src/features/emails/hooks/useEmailSettings.ts
+++ b/src/features/emails/hooks/useEmailSettings.ts
@@ -1,0 +1,24 @@
+import { useNumericRouteParams } from 'core/hooks';
+import useOrganization from 'features/organizations/hooks/useOrganization';
+import { useState } from 'react';
+
+export default function useEmailSettings(initialSubject: string) {
+  const { orgId } = useNumericRouteParams();
+  const organization = useOrganization(orgId).data;
+  const [subject, setSubject] = useState(initialSubject);
+
+  if (!organization) {
+    throw new Error('Error loading organization');
+  }
+
+  if (!organization.email) {
+    throw new Error('Organization does not have an email address');
+  }
+
+  return {
+    emailAddress: organization.email,
+    orgTitle: organization.title,
+    setSubject,
+    subject,
+  };
+}

--- a/src/features/emails/hooks/useSendTestEmail.ts
+++ b/src/features/emails/hooks/useSendTestEmail.ts
@@ -1,0 +1,19 @@
+import { useState } from 'react';
+
+export default function useSendTestEmail() {
+  const [isLoading, setIsLoading] = useState(false);
+
+  return {
+    isLoading,
+    sendTestEmail: () => {
+      //TODO: real logic to send email here
+      return new Promise<void>((resolve) => {
+        setIsLoading(true);
+        setTimeout(() => {
+          resolve();
+          setIsLoading(false);
+        }, 4000);
+      });
+    },
+  };
+}

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -5,6 +5,8 @@ export default makeMessages('feat.emails', {
     settings: {
       tabs: {
         content: m('Content'),
+        preview: m('Preview'),
+        settings: m('Settings'),
       },
     },
     tools: {

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -15,7 +15,12 @@ export default makeMessages('feat.emails', {
           sendTo: m('The email will be sent to this address:'),
           title: m('Preview'),
         },
-        settings: m('Settings'),
+        settings: {
+          senderAddressInputLabel: m('Sender address'),
+          senderNameInputLabel: m('Sender name'),
+          subjectInputLabel: m('Subject'),
+          title: m('Settings'),
+        },
       },
     },
     tools: {

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -5,7 +5,16 @@ export default makeMessages('feat.emails', {
     settings: {
       tabs: {
         content: m('Content'),
-        preview: m('Preview'),
+        preview: {
+          emailInputError: m('This is not a valid email'),
+          emailLabel: m('Input your own email'),
+          instructions: m(
+            'Here you can this email to yourself to preview what it will look like for the recipients. '
+          ),
+          sendButton: m('Send'),
+          sendTo: m('The email will be sent to this address:'),
+          title: m('Preview'),
+        },
         settings: m('Settings'),
       },
     },

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -9,7 +9,7 @@ export default makeMessages('feat.emails', {
           emailInputError: m('This is not a valid email'),
           emailLabel: m('Input your own email'),
           instructions: m(
-            'Here you can this email to yourself to preview what it will look like for the recipients. '
+            'Here you can send this email to yourself to preview what it will look like for the recipients. '
           ),
           sendButton: m('Send'),
           sendTo: m('The email will be sent to this address:'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -6,8 +6,6 @@ export default makeMessages('feat.emails', {
       tabs: {
         content: m('Content'),
         preview: {
-          emailInputError: m('This is not a valid email'),
-          emailLabel: m('Input your own email'),
           instructions: m(
             'Here you can send this email to yourself to preview what it will look like for the recipients. '
           ),

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -32,25 +32,21 @@ type Props = {
 };
 
 const EmailPage: PageWithLayout<Props> = ({ emailId, orgId }) => {
-  const { data, updateEmail } = useEmail(parseInt(orgId), parseInt(emailId));
+  const { data: email, updateEmail } = useEmail(
+    parseInt(orgId),
+    parseInt(emailId)
+  );
   const onServer = useServerSide();
 
   if (onServer) {
     return null;
   }
 
-  if (!data) {
+  if (!email) {
     return null;
   }
 
-  return (
-    <EmailEditor
-      initialContent={data.content ? JSON.parse(data.content) : { blocks: [] }}
-      onSave={(data) => {
-        updateEmail({ content: JSON.stringify(data) });
-      }}
-    />
-  );
+  return <EmailEditor email={email} onSave={(email) => updateEmail(email)} />;
 };
 
 EmailPage.getLayout = function getLayout(page) {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -129,6 +129,7 @@ export interface ZetkinOrganizerAction {
 }
 
 export interface ZetkinUser {
+  email: string;
   first_name: string;
   id: number;
   is_superuser?: boolean;


### PR DESCRIPTION

## Description
This PR adds the Settings and Preview tabs. 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/46516134-5553-45e6-958e-d1b7e7189852)
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/fb978980-abc4-4282-a4fc-d4c4f622ab97)

## Changes
* Adds `Settings` and `Preview` tabs
* Adds fields to display (static) email address of org and name of org as sender, and an input for email subject line
* Adds UI for a button to send a test email to the current user


## Notes to reviewer
The button to send a test email does not do anything yet, it is only UI. Needs API to be finished to work fully.

## Related issues
none
