### PR TITLE
Undocumented/small fixes on email editor

### DIFF
--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -20,6 +20,7 @@ import useCreateCampaignActivity from '../hooks/useCreateCampaignActivity';
 import useCreateEmail from 'features/emails/hooks/useCreateEmail';
 import useCreateEvent from 'features/events/hooks/useCreateEvent';
 import { useNumericRouteParams } from 'core/hooks';
+import useOrganization from 'features/organizations/hooks/useOrganization';
 import { ZetkinCampaign } from 'utils/types/zetkin';
 import ZUIButtonMenu from 'zui/ZUIButtonMenu';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
@@ -42,6 +43,7 @@ const CampaignActionButtons: React.FunctionComponent<
 > = ({ campaign }) => {
   const messages = useMessages(messageIds);
   const { orgId, campId } = useNumericRouteParams();
+  const organization = useOrganization(orgId).data;
 
   // Dialogs
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -55,6 +57,10 @@ const CampaignActionButtons: React.FunctionComponent<
   );
   const { deleteCampaign, updateCampaign } = useCampaign(orgId, campaign.id);
   const { createEmail } = useCreateEmail(orgId);
+
+  if (!organization) {
+    return null;
+  }
 
   const handleCreateEvent = () => {
     const defaultStart = new Date();
@@ -107,6 +113,7 @@ const CampaignActionButtons: React.FunctionComponent<
               onClick: () => setCreateTaskDialogOpen(true),
             },
             {
+              disabled: !organization.email,
               icon: <EmailOutlined />,
               label: messages.linkGroup.createEmail(),
               onClick: () =>

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -180,7 +180,7 @@ export function linkToolFactory(title: string) {
     }
 
     get shortcut() {
-      return 'CMD+Q';
+      return 'CMD+K';
     }
 
     surround(range: Range) {

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -259,13 +259,13 @@ export function linkToolFactory(title: string) {
         }
 
         //switch between icons for adding and removing this._link
-        this.updateButton(!!this._selectedAnchor && anchors.length == 0);
+        this.updateButton(!this._selectedAnchor && anchors.length == 0);
       }
     }
 
-    private updateButton(active: boolean): void {
+    private updateButton(showPlainLinkIcon: boolean): void {
       if (this._button) {
-        this._button.innerHTML = !active
+        this._button.innerHTML = showPlainLinkIcon
           ? '<svg width="24" height="24" viewBox="0 0 24 24"><path stroke-width="0" d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1M8 13h8v-2H8zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5"/></svg>'
           : '<svg width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" stroke-width="0" class="ce-inline-tool--active" d="M17 7h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1 0 1.43-.98 2.63-2.31 2.98l1.46 1.46C20.88 15.61 22 13.95 22 12c0-2.76-2.24-5-5-5m-1 4h-2.19l2 2H16zM2 4.27l3.11 3.11C3.29 8.12 2 9.91 2 12c0 2.76 2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1 0-1.59 1.21-2.9 2.76-3.07L8.73 11H8v2h2.73L13 15.27V17h1.73l4.01 4L20 19.74 3.27 3z"/></svg>';
       }

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -13,7 +13,7 @@ export default makeMessages('feat.emails', {
           noButtonText: m('Click to change this text!'),
         },
         settings: {
-          invalidUrl: m('This is not a valid url'),
+          invalidUrl: m('This is not a valid link'),
           testLink: m('Click to test link'),
           urlLabel: m('Link url'),
         },
@@ -27,14 +27,14 @@ export default makeMessages('feat.emails', {
         title: m('Image'),
       },
       link: {
-        addUrl: m('Add a url'),
-        invalidUrl: m('This is not a valid url'),
+        addUrl: m('Add a link'),
+        invalidUrl: m('This is not a valid link'),
         testLink: m('Click to test link'),
         title: m('Link'),
       },
       paragraph: {
         invalidUrls: m(
-          'There are one or more invalid URLs in this text block.'
+          'There are one or more invalid link in this text block.'
         ),
         title: m('Text'),
       },

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -75,6 +75,12 @@ export default makeMessages('feat.emails', {
       'Are you sure you want to delete this email? This action is permanent and cannot be undone.'
     ),
   },
+  orgHasNoEmail: {
+    errorMessage: m(
+      'Your organization can not use the email feature since it does not have a registered email address.'
+    ),
+    goBackButton: m('Go back'),
+  },
   state: {
     draft: m('Draft'),
     scheduled: m('Scheduled'),

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
-import { Box, Typography } from '@mui/material';
+import { useRouter } from 'next/router';
+import { Box, Button, Dialog, Typography } from '@mui/material';
 
 import EmailActionButtons from '../components/EmailActionButtons';
 import EmailStatusChip from '../components/EmailStatusChip';
@@ -10,6 +11,7 @@ import useEmail from '../hooks/useEmail';
 import useEmailState from '../hooks/useEmailState';
 import useEmailTargets from '../hooks/useEmailTargets';
 import { useNumericRouteParams } from 'core/hooks';
+import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 import { Msg, useMessages } from 'core/i18n';
@@ -20,73 +22,100 @@ interface EmailLayoutProps {
 
 const EmailLayout: FC<EmailLayoutProps> = ({ children }) => {
   const { orgId, campId, emailId } = useNumericRouteParams();
+  const router = useRouter();
   const messages = useMessages(messageIds);
   const { data: email, updateEmail } = useEmail(orgId, emailId);
   const targetsFuture = useEmailTargets(orgId, emailId);
   const emailState = useEmailState(orgId, emailId);
-  if (!email) {
+  const organization = useOrganization(orgId).data;
+
+  if (!email || !organization) {
     return null;
   }
 
   return (
-    <TabbedLayout
-      actionButtons={
-        <EmailActionButtons
-          email={email}
-          emailState={emailState}
-          orgId={orgId}
-        />
-      }
-      baseHref={`/organize/${orgId}/projects/${campId}/emails/${emailId}`}
-      defaultTab="/"
-      fixedHeight
-      subtitle={
-        <Box alignItems="center" display="flex">
-          <Box marginRight={1}>
-            <EmailStatusChip state={emailState} />
+    <>
+      <TabbedLayout
+        actionButtons={
+          <EmailActionButtons
+            email={email}
+            emailState={emailState}
+            orgId={orgId}
+          />
+        }
+        baseHref={`/organize/${orgId}/projects/${campId}/emails/${emailId}`}
+        defaultTab="/"
+        fixedHeight
+        subtitle={
+          <Box alignItems="center" display="flex">
+            <Box marginRight={1}>
+              <EmailStatusChip state={emailState} />
+            </Box>
+            <Box display="flex" marginX={1}>
+              <ZUIFuture
+                future={targetsFuture}
+                ignoreDataWhileLoading
+                skeletonWidth={100}
+              >
+                {(data) => (
+                  <>
+                    <People />
+                    <Typography marginLeft={1}>
+                      <Msg
+                        id={messageIds.stats.targets}
+                        values={{ numTargets: data.allTargets }}
+                      />
+                    </Typography>
+                  </>
+                )}
+              </ZUIFuture>
+            </Box>
           </Box>
-          <Box display="flex" marginX={1}>
-            <ZUIFuture
-              future={targetsFuture}
-              ignoreDataWhileLoading
-              skeletonWidth={100}
-            >
-              {(data) => (
-                <>
-                  <People />
-                  <Typography marginLeft={1}>
-                    <Msg
-                      id={messageIds.stats.targets}
-                      values={{ numTargets: data.allTargets }}
-                    />
-                  </Typography>
-                </>
-              )}
-            </ZUIFuture>
-          </Box>
+        }
+        tabs={[
+          {
+            href: '/',
+            label: messages.tabs.overview(),
+          },
+          {
+            href: '/design',
+            label: messages.tabs.compose(),
+          },
+        ]}
+        title={
+          <ZUIEditTextinPlace
+            onChange={(newTitle) => {
+              updateEmail({ title: newTitle });
+            }}
+            value={email.title || ''}
+          />
+        }
+      >
+        {children}
+      </TabbedLayout>
+      <Dialog open={!organization.email}>
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="column"
+          gap={2}
+          justifyContent="center"
+          padding={2}
+        >
+          <Typography>
+            <Msg id={messageIds.orgHasNoEmail.errorMessage} />
+          </Typography>
+          <Button
+            onClick={() => {
+              router.back();
+            }}
+            variant="contained"
+          >
+            <Msg id={messageIds.orgHasNoEmail.goBackButton} />
+          </Button>
         </Box>
-      }
-      tabs={[
-        {
-          href: '/',
-          label: messages.tabs.overview(),
-        },
-        {
-          href: '/design',
-          label: messages.tabs.compose(),
-        },
-      ]}
-      title={
-        <ZUIEditTextinPlace
-          onChange={(newTitle) => {
-            updateEmail({ title: newTitle });
-          }}
-          value={email.title || ''}
-        />
-      }
-    >
-      {children}
-    </TabbedLayout>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -41,10 +41,8 @@ const EmailPage: PageWithLayout = () => {
       <Head>
         <title>{email?.title}</title>
       </Head>
-      <Box>
-        <Box mb={2}>
-          <EmailTargets emailId={emailId} orgId={orgId} />
-        </Box>
+      <Box mb={2}>
+        <EmailTargets emailId={emailId} orgId={orgId} />
       </Box>
     </>
   );

--- a/src/zui/ZUIButtonMenu.tsx
+++ b/src/zui/ZUIButtonMenu.tsx
@@ -8,6 +8,7 @@ import { FC, MouseEvent, useState } from 'react';
 
 type ZUIButtonMenuProps = {
   items: {
+    disabled?: boolean;
     icon: JSX.Element;
     label: string;
     onClick: () => void;
@@ -67,6 +68,7 @@ const ZUIButtonMenu: FC<ZUIButtonMenuProps> = ({ items, label }) => {
           return (
             <MenuItem
               key={idx}
+              disabled={item.disabled}
               disableRipple
               onClick={() => {
                 handleClose();


### PR DESCRIPTION
## Description
This PR fixes a few smaller things for the email editor and email in general

## Changes
* Change short cut for link tool from Q to K
* Change the wording in some messages from "url" to "link"
* Show correct icon in link tool when selecting a link for unlinking
* Disable creation of new email and accessing email pages when org does not have an email address

## Notes to reviewer
The text for the error message is just made up, can most certainly be better! 


## Related issues
Resolves #[id]
