### PR TITLE
Enable sorting and filtering of SurveySubmitted columns

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -1,7 +1,11 @@
 import { AssignmentTurnedInOutlined } from '@mui/icons-material';
 import { Box } from '@mui/material';
 import { FC } from 'react';
-import { GridColDef } from '@mui/x-data-grid-pro';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridValueGetterParams,
+} from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
@@ -25,8 +29,17 @@ export default class SurveySubmittedColumnType
   }
   getColDef(): Omit<GridColDef<NonNullable<SurveySubmittedViewCell>>, 'field'> {
     return {
-      renderCell: (params) => {
-        return <Cell cell={params.value} />;
+      renderCell: (params: GridRenderCellParams) => {
+        return <Cell cell={params.row[params.field]} />;
+      },
+      type: 'date',
+      valueGetter: (params: GridValueGetterParams) => {
+        const submissions: SurveySubmittedViewCell = params.row[params.field];
+        if (submissions?.length) {
+          const lastSub = submissions[submissions.length - 1];
+          return new Date(lastSub.submitted);
+        }
+        return null;
       },
       width: 250,
     };


### PR DESCRIPTION
## Description
This PR configures `survey_submitted` columns as `date` type, with a value getter to enable sorting and filtering natively in MUI X DataGrid. For this to work, the _raw_ value must be retrieved using `row[field]` instead of `value`, so the PR also changes how the value is retrieved in `renderCell()`.

## Screenshots
None

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes the DataGrid "column definition" for this type of column
  * Sets `type` to `date` to enable native filtering and sorting
  * Adds `valueGetter()` to get the date value (or `null`)
  * Changes `renderCell()` to use raw value from row, instead of the `value` property (which is henceforth the raw date, because of the `valueGetter()`)

## Notes to reviewer
It's become apparent to me that types need to be improved here. There are actually several occurrences of implicit `any` in this code, but that's a bigger-scope thing than what this fix can cover.

I would like to get this into tonights release.

## Related issues
Resolves #1723 