### PR TITLE
Issue 1777/sort import as dropdown

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -22,7 +22,7 @@ import { Msg, useMessages } from 'core/i18n';
 interface MappingRowProps {
   clearConfiguration: () => void;
   column: UIDataColumn<Column>;
-  columnOptions: Option[];
+  columnOptions: Option[][];
   isBeingConfigured: boolean;
   onChange: (newColumn: Column) => void;
   onConfigureStart: () => void;

--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -6,6 +6,7 @@ import {
   Checkbox,
   FormControl,
   InputLabel,
+  ListSubheader,
   MenuItem,
   Select,
   Typography,
@@ -141,12 +142,54 @@ const MappingRow: FC<MappingRowProps> = ({
               sx={{ opacity: column.originalColumn.selected ? '' : '50%' }}
               value={getValue()}
             >
-              {columnOptions.map((option) => {
+              <ListSubheader>
+                <Msg
+                  id={messageIds.configuration.mapping.zetkinFieldGroups.id}
+                />
+              </ListSubheader>
+              {columnOptions[0].map((option) => {
                 const alreadySelected = optionAlreadySelected(option.value);
                 return (
                   <MenuItem
                     key={option.value}
                     disabled={alreadySelected}
+                    sx={{ paddingLeft: 4 }}
+                    value={option.value}
+                  >
+                    {option.label}
+                  </MenuItem>
+                );
+              })}
+              <ListSubheader>
+                <Msg
+                  id={messageIds.configuration.mapping.zetkinFieldGroups.fields}
+                />
+              </ListSubheader>
+              {columnOptions[1].map((option) => {
+                const alreadySelected = optionAlreadySelected(option.value);
+                return (
+                  <MenuItem
+                    key={option.value}
+                    disabled={alreadySelected}
+                    sx={{ paddingLeft: 4 }}
+                    value={option.value}
+                  >
+                    {option.label}
+                  </MenuItem>
+                );
+              })}
+              <ListSubheader>
+                <Msg
+                  id={messageIds.configuration.mapping.zetkinFieldGroups.other}
+                />
+              </ListSubheader>
+              {columnOptions[2].map((option) => {
+                const alreadySelected = optionAlreadySelected(option.value);
+                return (
+                  <MenuItem
+                    key={option.value}
+                    disabled={alreadySelected}
+                    sx={{ paddingLeft: 4 }}
                     value={option.value}
                   >
                     {option.label}

--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -22,7 +22,7 @@ import { Msg, useMessages } from 'core/i18n';
 interface MappingRowProps {
   clearConfiguration: () => void;
   column: UIDataColumn<Column>;
-  columnOptions: Option[][];
+  fieldOptions: Option[];
   isBeingConfigured: boolean;
   onChange: (newColumn: Column) => void;
   onConfigureStart: () => void;
@@ -32,7 +32,7 @@ interface MappingRowProps {
 const MappingRow: FC<MappingRowProps> = ({
   clearConfiguration,
   column,
-  columnOptions,
+  fieldOptions,
   isBeingConfigured,
   onChange,
   onConfigureStart,
@@ -52,6 +52,22 @@ const MappingRow: FC<MappingRowProps> = ({
 
     //Column kind is UNKNOWN, so we want no selected value
     return '';
+  };
+
+  // This has to be a function, not a component with PascalCase. If it is used
+  // as a component, the `Select` below won't recognise it as a valid option.
+  const listOption = ({ value, label, key }: Option & { key?: string }) => {
+    const alreadySelected = optionAlreadySelected(value);
+    return (
+      <MenuItem
+        key={key}
+        disabled={alreadySelected}
+        sx={{ paddingLeft: 4 }}
+        value={value}
+      >
+        {label}
+      </MenuItem>
+    );
   };
 
   return (
@@ -147,54 +163,34 @@ const MappingRow: FC<MappingRowProps> = ({
                   id={messageIds.configuration.mapping.zetkinFieldGroups.id}
                 />
               </ListSubheader>
-              {columnOptions[0].map((option) => {
-                const alreadySelected = optionAlreadySelected(option.value);
-                return (
-                  <MenuItem
-                    key={option.value}
-                    disabled={alreadySelected}
-                    sx={{ paddingLeft: 4 }}
-                    value={option.value}
-                  >
-                    {option.label}
-                  </MenuItem>
-                );
+              {listOption({
+                label: messages.configuration.mapping.id(),
+                value: 'id',
               })}
-              <ListSubheader>
-                <Msg
-                  id={messageIds.configuration.mapping.zetkinFieldGroups.fields}
-                />
-              </ListSubheader>
-              {columnOptions[1].map((option) => {
-                const alreadySelected = optionAlreadySelected(option.value);
-                return (
-                  <MenuItem
-                    key={option.value}
-                    disabled={alreadySelected}
-                    sx={{ paddingLeft: 4 }}
-                    value={option.value}
-                  >
-                    {option.label}
-                  </MenuItem>
-                );
-              })}
+
+              {fieldOptions.length > 0 && (
+                <ListSubheader>
+                  <Msg
+                    id={
+                      messageIds.configuration.mapping.zetkinFieldGroups.fields
+                    }
+                  />
+                </ListSubheader>
+              )}
+              {fieldOptions.map((option) => listOption(option))}
+
               <ListSubheader>
                 <Msg
                   id={messageIds.configuration.mapping.zetkinFieldGroups.other}
                 />
               </ListSubheader>
-              {columnOptions[2].map((option) => {
-                const alreadySelected = optionAlreadySelected(option.value);
-                return (
-                  <MenuItem
-                    key={option.value}
-                    disabled={alreadySelected}
-                    sx={{ paddingLeft: 4 }}
-                    value={option.value}
-                  >
-                    {option.label}
-                  </MenuItem>
-                );
+              {listOption({
+                label: messages.configuration.mapping.organization(),
+                value: 'org',
+              })}
+              {listOption({
+                label: messages.configuration.mapping.tags(),
+                value: 'tag',
               })}
             </Select>
           </FormControl>

--- a/src/features/import/components/ImportDialog/Configure/Mapping/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/index.tsx
@@ -25,7 +25,7 @@ const Mapping: FC<MappingProps> = ({
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
-  const { columnOptions, optionAlreadySelected, updateColumn } =
+  const { fieldOptions, optionAlreadySelected, updateColumn } =
     useColumn(orgId);
 
   return (
@@ -64,7 +64,7 @@ const Mapping: FC<MappingProps> = ({
               <MappingRow
                 clearConfiguration={clearConfiguration}
                 column={column}
-                columnOptions={columnOptions}
+                fieldOptions={fieldOptions}
                 isBeingConfigured={columnIndexBeingConfigured == index}
                 onChange={(column) => updateColumn(index, column)}
                 onConfigureStart={() => onConfigureStart(index)}

--- a/src/features/import/components/ImportDialog/Configure/Preview/FieldsPreview.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Preview/FieldsPreview.tsx
@@ -29,7 +29,7 @@ const FieldsPreview = ({ fieldKey, fields, kind }: FieldsPreviewProps) => {
   }
 
   let fieldColumnHeader = '';
-  columnOptions.forEach((columnOp) => {
+  columnOptions.flat().forEach((columnOp) => {
     if (columnOp.value === `field:${fieldKey}`) {
       fieldColumnHeader = columnOp.label;
     }

--- a/src/features/import/components/ImportDialog/Configure/Preview/FieldsPreview.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Preview/FieldsPreview.tsx
@@ -13,7 +13,7 @@ interface FieldsPreviewProps {
 }
 const FieldsPreview = ({ fieldKey, fields, kind }: FieldsPreviewProps) => {
   const { orgId } = useNumericRouteParams();
-  const { columnOptions } = useColumn(orgId);
+  const { fieldOptions: columnOptions } = useColumn(orgId);
   const globalMessages = useMessages(globalMessageIds);
   const messages = useMessages(messageIds);
 

--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -56,16 +56,18 @@ export default function useColumn(orgId: number) {
     return !!exists;
   };
 
-  const columnOptions: Option[] = [];
+  const columnOptionsIDPartition: Option[] = [];
+  const columnOptionsFieldsPartition: Option[] = [];
+  const columnOptionsOtherPartition: Option[] = [];
 
-  columnOptions.push({
+  columnOptionsIDPartition.push({
     label: messages.configuration.mapping.id(),
     value: 'id',
   });
 
   Object.values(NATIVE_PERSON_FIELDS).forEach((fieldSlug) => {
     if (fieldSlug != 'id' && fieldSlug != 'ext_id') {
-      columnOptions.push({
+      columnOptionsFieldsPartition.push({
         label: globalMessages.personFields[fieldSlug](),
         value: `field:${fieldSlug}`,
       });
@@ -73,20 +75,25 @@ export default function useColumn(orgId: number) {
   });
 
   customFields.forEach((field) =>
-    columnOptions.push({
+    columnOptionsFieldsPartition.push({
       label: field.title,
       value: `field:${field.slug}`,
     })
   );
 
-  columnOptions.push({
+  columnOptionsOtherPartition.push({
     label: messages.configuration.mapping.tags(),
     value: 'tag',
   });
-  columnOptions.push({
+  columnOptionsOtherPartition.push({
     label: messages.configuration.mapping.organization(),
     value: 'org',
   });
+
+  const labelSort = (a: Option, b: Option) => (a.label > b.label ? 1 : 0);
+  const columnOptions: Option[] = columnOptionsIDPartition
+    .concat(columnOptionsFieldsPartition.sort(labelSort))
+    .concat(columnOptionsOtherPartition.sort(labelSort));
 
   return { columnOptions, optionAlreadySelected, updateColumn };
 }

--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -91,9 +91,11 @@ export default function useColumn(orgId: number) {
   });
 
   const labelSort = (a: Option, b: Option) => (a.label > b.label ? 1 : 0);
-  const columnOptions: Option[] = columnOptionsIDPartition
-    .concat(columnOptionsFieldsPartition.sort(labelSort))
-    .concat(columnOptionsOtherPartition.sort(labelSort));
+  const columnOptions: Option[][] = [
+    columnOptionsIDPartition,
+    columnOptionsFieldsPartition.sort(labelSort),
+    columnOptionsOtherPartition.sort(labelSort),
+  ];
 
   return { columnOptions, optionAlreadySelected, updateColumn };
 }

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -128,6 +128,11 @@ export default makeMessages('feat.import', {
       organization: m('Organization'),
       selectZetkinField: m('Import as...'),
       tags: m('Tags'),
+      zetkinFieldGroups: {
+        fields: m('Fields'),
+        id: m('ID'),
+        other: m('Other'),
+      },
       zetkinHeader: m('Zetkin'),
     },
     preview: {

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -583,6 +583,10 @@ feat:
         organization: Organization
         selectZetkinField: Import as...
         tags: Tags
+        zetkinFieldGroups:
+          fields: Fields
+          id: ID
+          other: Other
         zetkinHeader: Zetkin
       preview:
         columnHeader:


### PR DESCRIPTION
## Description
This PR sorts and groups the items in the "import as..." drop-down from the import feature.


## Screenshots
![zetkin ListSubheader dropdown](https://github.com/zetkin/app.zetkin.org/assets/61919302/cfd21a27-b9f9-4bd8-87f8-5254391b13e4)


## Changes
* Adds group names in messageIds
* Updates changes from yarn make-yaml
* Updates useColumn() clients minimally for compatibility
* Changes useColumn() return type minimally
* Adds groups
* Sorts options by their translated label
* Adds ListSubheader to MappingRow's Select
* Adds paddingLeft: 4 to MenuItems


## Notes to reviewer
Go to /people and select "import people" from the top right corner button
Select a file and load it, e.g. this as a csv:
```
ID,forename,surname,phone
00000,Alice,Smith,0123456789
00001,Bob,Smith,0987654321
```
When you are in the Configure stage - open the "import as" dropdown



## Related issues
Resolves #1777 
