### PR TITLE
Email layout conditional fixed height

### DIFF
--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -19,9 +19,13 @@ import { Msg, useMessages } from 'core/i18n';
 
 interface EmailLayoutProps {
   children: React.ReactNode;
+  fixedHeight?: boolean;
 }
 
-const EmailLayout: FC<EmailLayoutProps> = ({ children }) => {
+const EmailLayout: FC<EmailLayoutProps> = ({
+  children,
+  fixedHeight = false,
+}) => {
   const { orgId, campId, emailId } = useNumericRouteParams();
   const router = useRouter();
   const messages = useMessages(messageIds);
@@ -47,6 +51,7 @@ const EmailLayout: FC<EmailLayoutProps> = ({ children }) => {
         baseHref={`/organize/${orgId}/projects/${campId}/emails/${emailId}`}
         belowActionButtons={<DeliveryStatusMessage email={email} />}
         defaultTab="/"
+        fixedHeight={fixedHeight}
         subtitle={
           <Box alignItems="center" display="flex">
             <Box marginRight={1}>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -50,7 +50,7 @@ const EmailPage: PageWithLayout<Props> = ({ emailId, orgId }) => {
 };
 
 EmailPage.getLayout = function getLayout(page) {
-  return <EmailLayout>{page}</EmailLayout>;
+  return <EmailLayout fixedHeight>{page}</EmailLayout>;
 };
 
 export default EmailPage;


### PR DESCRIPTION
## Description
This PR gives the `EmailLayout` a property to set `fixedHeight `, and adds this to the compose tab

## Related issues
none
