### PR TITLE
Fix sizing of images in mass email

### DIFF
--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -6,7 +6,7 @@ import { FC, useEffect, useRef, useState } from 'react';
 import EmailSettings from './EmailSettings';
 import { ZetkinEmail } from 'utils/types/zetkin';
 
-const EmailEditorFrontend = dynamic(import('./EmailEditorFrontend'), {
+const EmailEditorFrontend = dynamic(() => import('./EmailEditorFrontend'), {
   ssr: false,
 });
 

--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -26,9 +26,14 @@ const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
         >
           <Image
             alt={file.original_name}
-            layout="fill"
-            objectFit="contain"
+            height="800"
             src={file.url}
+            style={{
+              height: '100%',
+              objectFit: 'contain',
+              width: '100%',
+            }}
+            width="800"
           />
         </TransparentGridBackground>
         <Typography color="secondary" mt={1} textAlign="center" variant="body2">

--- a/src/features/files/components/FileUploadCard.tsx
+++ b/src/features/files/components/FileUploadCard.tsx
@@ -22,12 +22,14 @@ const FileUploadCard: FC<FileUploadCardProps> = ({ onFileBrowserOpen }) => {
       borderRadius={1}
       display="flex"
       flexDirection="column"
-      height="100%"
       justifyContent="center"
       onClick={onFileBrowserOpen}
       sx={{
+        aspectRatio: '1 / 1',
         borderStyle: 'dashed',
+        boxSizing: 'border-box',
         cursor: 'pointer',
+        width: '100%',
       }}
     >
       <IconButton

--- a/src/features/files/components/FileUploadCard.tsx
+++ b/src/features/files/components/FileUploadCard.tsx
@@ -27,7 +27,6 @@ const FileUploadCard: FC<FileUploadCardProps> = ({ onFileBrowserOpen }) => {
       sx={{
         aspectRatio: '1 / 1',
         borderStyle: 'dashed',
-        boxSizing: 'border-box',
         cursor: 'pointer',
         width: '100%',
       }}

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -19,11 +19,18 @@ const LibraryImage: FC<LibraryImageProps> = ({
     <TransparentGridBackground>
       <Image
         alt={imageFile.original_name}
-        layout="responsive"
-        objectFit="contain"
+        height="400"
         onLoad={() => onLoad && onLoad()}
         onLoadingComplete={() => onLoadingComplete && onLoadingComplete()}
         src={imageFile.url}
+        style={{
+          aspectRatio: '1 / 1',
+          display: 'block',
+          height: 'auto',
+          objectFit: 'contain',
+          width: '100%',
+        }}
+        width="400"
       />
     </TransparentGridBackground>
   );


### PR DESCRIPTION
## Description
This PR fixes the code responsible for sizing the images correctly in the `FileLibraryBrowser` after merging `main` which contained the Next 14 upgrade that introduces new rules for the `next/image` component.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/e25376bc-cddb-40ba-a995-7d6aff5979fd)

## Changes
* Fixes sizing of `FilePreview`
  * Sets `width` and `height` to static values that roughly indicate what size image will need to be loaded
  * Sets actual `width` and `height` (style properties) to 100% so that the `img` element will fill the space
  * Sets `objectFit` to `contain` so that the rendered image will be displayed with correct proportions within the `img` element
* Fixes sizing of `LibraryImage` in the grid
  * Sets `width` and `height` to static values that roughly indicate what size image will need to be loaded
  * Sets actual `width` to 100% to fill the grid square
  * Sets height to `auto` and `aspectRatio: 1 / 1` so that the height will become the same as the width, i.e. `img` element will be square
  * Sets `objectFit` to `contain` so that the rendered image will be displayed with correct proportions within the `img` element
  * Sets `display: block` so that line padding will not affect the final size
* Tweaks sizing of `FileUploadCard` so that it aligns nicely with grid
  * Sets `width` to 100% to fill entire width
  * Sets `aspectRatio: 1 / 1` so that height becomes same pixel value as width
  * Sets `borderBox` so that padding and border does not affect the size
* Fixes (unrelated) bug in SSR of email editor, so that deployment will work properly

## Notes to reviewer
None

## Related issues
Undocumented