### PR TITLE
Issue 1781 / Format phone to E.164

### DIFF
--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -65,7 +65,7 @@ export default function prepareImportOperations(
                 typeof value == 'string' ? value : value.toString(),
                 countryCode
               );
-              value = parsedPhoneNumber.formatInternational();
+              value = parsedPhoneNumber.format('E.164');
             }
 
             //If they have uppecase letters we parse to lower


### PR DESCRIPTION
## Description
This PR uses E.164 formatting for phone numbers instead of the international format.

## Changes
Changing the format function to use E.164


## Notes to reviewer
Import same number with spaces or different country code formats, it should recognize that the phone number exists already instead of updating the phone number.

## Related issues
Resolves #1781 
