### PR TITLE
Issue #1795 - Sort and filter survey columns

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -1,4 +1,3 @@
-import { GridColDef } from '@mui/x-data-grid-pro';
 import { IColumnType } from '.';
 import { makeStyles } from '@mui/styles';
 import { usePanes } from 'utils/panes';
@@ -7,6 +6,11 @@ import { ZetkinSurveyOption } from 'utils/types/zetkin';
 import { ZetkinViewColumn } from '../../types';
 import { Box, Chip } from '@mui/material';
 import { FC, useState } from 'react';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridValueGetterParams,
+} from '@mui/x-data-grid-pro';
 
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
@@ -28,26 +32,13 @@ export default class SurveyOptionsColumnType
 
   getColDef(): Omit<GridColDef, 'field'> {
     return {
-      filterable: false,
-      renderCell: (params) => {
-        return <Cell cell={params.value} />;
+      filterable: true,
+      renderCell: (params: GridRenderCellParams) => {
+        return <Cell cell={params.row[params.field]} />;
       },
-      sortComparator: (
-        val0: SurveyOptionsViewCell | undefined,
-        val1: SurveyOptionsViewCell | undefined
-      ) => {
-        if (!val0 && !val1) {
-          return 0;
-        } else if (!val0) {
-          return -1;
-        } else if (!val1) {
-          return 1;
-        }
-
-        // Sort total number of options selected
-        const count0 = val0.reduce((sum, sub) => sum + sub.selected.length, 0);
-        const count1 = val1.reduce((sum, sub) => sum + sub.selected.length, 0);
-        return count0 - count1;
+      valueGetter: (params: GridValueGetterParams) => {
+        const cell: SurveyOptionsViewCell = params.row[params.field];
+        return this.cellToString(cell);
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { GridColDef } from '@mui/x-data-grid-pro';
+
 import { makeStyles } from '@mui/styles';
 import { useRouter } from 'next/router';
 import { FC, useState } from 'react';
@@ -10,6 +10,12 @@ import { SurveyResponseViewColumn } from '../../types';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import { usePanes } from 'utils/panes';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
+
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridValueGetterParams,
+} from '@mui/x-data-grid-pro';
 
 export type SurveyResponseViewCell = {
   submission_id: number;
@@ -26,29 +32,13 @@ export default class SurveyResponseColumnType
 
   getColDef(): Omit<GridColDef<SurveyResponseViewCell>, 'field'> {
     return {
-      filterable: false,
-      renderCell: (params) => {
-        return <Cell cell={params.value} />;
+      filterable: true,
+      renderCell: (params: GridRenderCellParams) => {
+        return <Cell cell={params.row[params.field]} />;
       },
-      sortComparator: (
-        v1: SurveyResponseViewCell,
-        v2: SurveyResponseViewCell
-      ) => {
-        const getConcatenatedText = (arr: SurveyResponseViewCell) => {
-          if (!arr || arr.length === 0) {
-            return '';
-          }
-
-          return arr
-            .filter((obj) => obj && obj.text) // Filter out null or undefined elements
-            .map((obj) => obj.text)
-            .join('');
-        };
-
-        const text1 = getConcatenatedText(v1);
-        const text2 = getConcatenatedText(v2);
-
-        return text1.localeCompare(text2);
+      valueGetter: (params: GridValueGetterParams) => {
+        const cell: SurveyResponseViewCell = params.row[params.field];
+        return this.cellToString(cell);
       },
       width: 250,
     };


### PR DESCRIPTION
## Description
This PR adds filtering and sorting of two types of survey columns in views - free text questions and questions with different options as answers.

Be aware that there are some issue related to the `cellToString `method that I'm reusing for this code - see: #1815.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/21238654/6609039e-a6c3-4ece-91dd-f5b290a8e283)


## Changes
* Adds filtering and sorting of `surveyResponseColumnType` and `surveyOptionsColumnType`.
* Removes old sorting functionality (that didn't work)

## Notes to reviewer
Be aware of the issue i mentioned above.


## Related issues
Resolves #1795
