### PR TITLE
Misc email fixes

### DIFF
--- a/src/features/emails/components/EmailDelivery.tsx
+++ b/src/features/emails/components/EmailDelivery.tsx
@@ -48,8 +48,7 @@ const EmailDelivery = ({ email, onClose, orgId }: EmailDeliveryProps) => {
   );
   const naiveSending = `${sendingDate}T${sendingTime}`;
 
-  //change time string to 'email.published' when API is fixed
-  const scheduledTime = getOffset('2023-12-25T12:25:00+09:00');
+  const scheduledTime = email.published ? getOffset(email.published) : null;
   const currentTzValue = findCurrentTZ().utc;
   const [tzValue, setTzValue] = useState(scheduledTime || currentTzValue);
 

--- a/src/features/emails/hooks/useEmail.ts
+++ b/src/features/emails/hooks/useEmail.ts
@@ -10,7 +10,9 @@ import { futureToObject, IFuture, PromiseFuture } from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinEmail, ZetkinQuery } from 'utils/types/zetkin';
 
-type ZetkinEmailPatchBody = Partial<ZetkinEmail> & { lock?: boolean };
+type ZetkinEmailPatchBody = Partial<Omit<ZetkinEmail, 'locked'>> & {
+  locked?: boolean;
+};
 
 interface UseEmailReturn {
   data: ZetkinEmail | null;
@@ -52,7 +54,10 @@ export default function useEmail(
     const mutating = Object.keys(data);
     dispatch(emailUpdate([emailId, mutating]));
     const promise = apiClient
-      .patch<ZetkinEmail>(`/api/orgs/${orgId}/emails/${emailId}`, data)
+      .patch<ZetkinEmail, ZetkinEmailPatchBody>(
+        `/api/orgs/${orgId}/emails/${emailId}`,
+        data
+      )
       .then((email: ZetkinEmail) => {
         dispatch(emailUpdated([email, mutating]));
         return email;

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/design/index.tsx
@@ -46,7 +46,17 @@ const EmailPage: PageWithLayout<Props> = ({ emailId, orgId }) => {
     return null;
   }
 
-  return <EmailEditor email={email} onSave={(email) => updateEmail(email)} />;
+  return (
+    <EmailEditor
+      email={email}
+      onSave={(email) => {
+        updateEmail({
+          ...email,
+          locked: undefined,
+        });
+      }}
+    />
+  );
 };
 
 EmailPage.getLayout = function getLayout(page) {

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -80,7 +80,7 @@ const EmailPage: PageWithLayout = () => {
                 isScheduled={!!email.published}
                 isTargeted={isTargeted}
                 lockedTargets={lockedTargets}
-                onToggleLocked={() => updateEmail({ lock: !email.locked })}
+                onToggleLocked={() => updateEmail({ locked: !email.locked })}
                 readyTargets={readyTargets}
               />
             </Box>


### PR DESCRIPTION
## Description
This PR makes some minor changes to the UI logic based on recent changes to the API (not deployed yet).

## Screenshots
None

## Changes
* Uses `email.published` instead of hardcoded date in `EmailDelivery`, because the API now supports timezones
* Renames `lock` to `locked` when patching an email, as per recent changes to naming in the API

## Notes to reviewer
The API changes have not been deployed yet, so it's not possible to test these. Please just look at the code.

One question I have is whether the changes in 1f6b63a6fe8bd0efd3e4df7da18baea42a9a8a88 even make sense, seeing as how this UI should never be reachable when the email is published (the button will be "Cancel" instead of "Delivery" then). Maybe it's still good to have this code here, but I believe `email.published` will always be `null` whenever this UI is visible.

## Related issues
Undocumented