### PR TITLE
Minor layout fixes for org-switcher in side-bar

### DIFF
--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -229,6 +229,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                             }}
                             onChange={(e) => setSearchString(e.target.value)}
                             placeholder={messages.organizeSidebar.filter()}
+                            size="small"
                             value={searchString}
                           />
                         )}

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -179,6 +179,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                             <Box
                               sx={{
                                 display: 'flex',
+                                flexShrink: 0,
                                 justifyContent: 'center',
                                 width: '48px',
                               }}

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -171,6 +171,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                         sx={{
                           alignItems: 'center',
                           display: 'flex',
+                          overflow: 'hidden',
                         }}
                       >
                         {!showOrgSwitcher && (
@@ -193,7 +194,15 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                                 />
                               )}
                             </Box>
-                            <Typography variant="h6">{data.title}</Typography>
+                            <Typography
+                              sx={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                              }}
+                              variant="h6"
+                            >
+                              {data.title}
+                            </Typography>
                           </>
                         )}
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the org-switcher chevron could disappear for long organization names, as well as the size of the filter in the org-switcher. The chevron is now always visible by truncating the organization name with an ellipsis if they are too long.


## Screenshots
Before the fix:
![Screenshot 2024-03-16 at 11 59 33](https://github.com/zetkin/app.zetkin.org/assets/5444360/6cbdf5aa-82ad-4c26-b455-c55b9ddc6369)

Fixed:
![Screenshot 2024-03-16 at 11 59 55](https://github.com/zetkin/app.zetkin.org/assets/5444360/98b35a75-95d9-44e3-97e6-62c66c85624e)

and it still works the same for short organization names
![Screenshot 2024-03-16 at 12 06 41](https://github.com/zetkin/app.zetkin.org/assets/5444360/e54f561d-97ef-4c0c-b416-526144d36bff)

The chevron now aligns whether expanded or not, since the filter input has the correct size:
![Screenshot 2024-03-16 at 12 23 57](https://github.com/zetkin/app.zetkin.org/assets/5444360/7e9d035a-0eb9-44d0-b9dd-421a5d95d710)

## Changes

* Update CSS in organization sidebar to add overflow behaviour for long organization names.
* Change size of organization switcher filter to match with unexpanded switcher.


## Notes to reviewer
In order to test the longer org name, you can do as follows (quoted from #1797):
> Change the name of the organization using a `PATCH /api/orgs/1` with `{ "title": "Organization With A Long Name" }` 



## Related issues
Resolves #1797
Resolves #1799 
