### PR TITLE
issue-1783/router-replace-calendar

### DIFF
--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -66,7 +66,7 @@ const Calendar = () => {
 
   useEffect(() => {
     const focusedDate = dayjs.utc(focusDate).format('YYYY-MM-DD');
-    router.push(
+    router.replace(
       {
         pathname: undefined,
         query: {


### PR DESCRIPTION
## Description
This PR fixes a bug where you can't go back in the calendar

## Changes

* Changes
  * Router to use replace instead of push 


## Related issues
Resolves #1783
