### PR TITLE
Trigger configuration on ID column selection

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -125,12 +125,14 @@ const MappingRow: FC<MappingRowProps> = ({
                     mapping: [],
                     selected: true,
                   });
+                  onConfigureStart();
                 } else if (event.target.value == 'tag') {
                   onChange({
                     kind: ColumnKind.TAG,
                     mapping: [],
                     selected: true,
                   });
+                  onConfigureStart();
                 } else if (event.target.value.startsWith('field')) {
                   onChange({
                     field: event.target.value.slice(6),

--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -118,6 +118,7 @@ const MappingRow: FC<MappingRowProps> = ({
                     kind: ColumnKind.ID_FIELD,
                     selected: true,
                   });
+                  onConfigureStart();
                 } else if (event.target.value == 'org') {
                   onChange({
                     kind: ColumnKind.ORGANIZATION,


### PR DESCRIPTION
## Description
When importing people from an excel sheet, the user can map columns of the sheet. The columns ID, Organization and Tag require additional configuration, which is triggered after pressing the relevant button in the UI. This interaction is unnecessary.

This PR triggers the configuration view automatically for columns ID, Organization and Tag, without needing to press the equivalent button.

## Screenshots
<img width="1314" alt="Screenshot 2024-03-16 at 16 27 23" src="https://github.com/zetkin/app.zetkin.org/assets/1938798/7acaf034-4dda-4ac2-a522-fac768647eb4">
<img width="1314" alt="Screenshot 2024-03-16 at 16 27 46" src="https://github.com/zetkin/app.zetkin.org/assets/1938798/908c9b91-832d-4d1c-a3e0-c4ce985b6892">

## Changes
* Add `onConfigureStart()` triggers when the checkboxes for ID, Organization or Tag are checked in the import dialog window

## Related issues
Resolves #1827 
