### PR TITLE
Fix error displaying question options in SmartSearch dialog

### DIFF
--- a/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
@@ -49,7 +49,7 @@ const DisplaySurveyOption = ({
   const options =
     question && question.response_type == RESPONSE_TYPE.OPTIONS
       ? (optionIds.map((oId) =>
-          question.options?.find((option) => option.id === oId)
+          question.options?.find((option) => option.id == oId)
         ) as ZetkinSurveyOption[])
       : [];
 

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -160,7 +160,7 @@ export interface RandomFilterConfig {
 export interface SurveyOptionFilterConfig {
   survey: number;
   question: number;
-  options: number[];
+  options: number[] | string[];
   operator: CONDITION_OPERATOR;
 }
 


### PR DESCRIPTION
## Description
Resolves error in dialog when option id is of type string and not number.

## Changes

* Type of option ids to `number[] | string[]`.
* Comparison to use basic equality `==`.


## Related issues
Resolves #1817 