### PR TITLE
Fix breadcrumbs for projects, which were omitted by an incorrect check

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -1,6 +1,7 @@
 import { ApiFetch, createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { isInteger } from 'utils/stringUtils';
 import { ZetkinViewFolder } from 'features/views/components/types';
 
 interface LabeledBreadcrumbElement {
@@ -100,7 +101,8 @@ async function fetchElements(
       },
     ];
   } else if (fieldName === 'campId') {
-    if (typeof fieldValue == 'number') {
+    // check if the value is a numeric ID, as `fieldValue` could also be passed as 'standalone' or 'shared'
+    if (isInteger(fieldValue)) {
       const campaign = await apiFetch(
         `/orgs/${orgId}/campaigns/${fieldValue}`
       ).then((res) => res.json());

--- a/src/utils/stringUtils.spec.ts
+++ b/src/utils/stringUtils.spec.ts
@@ -1,5 +1,4 @@
-import { stringToBool } from './stringUtils';
-import { truncateOnMiddle } from './stringUtils';
+import { isInteger, stringToBool, truncateOnMiddle } from './stringUtils';
 
 describe('stringToBool()', () => {
   // Returns false
@@ -54,5 +53,26 @@ describe('truncateOnMiddle()', () => {
     expect(truncateOnMiddle('Supercalifragilisticexpialidocious', 20)).toEqual(
       'Supercal...idocious'
     );
+  });
+});
+
+describe('isInteger()', () => {
+  it.each(['0', '2', '20000', '  0', '1  '])(
+    'should return true for integer string %p',
+    (numberString) => {
+      expect(isInteger(numberString)).toBe(true);
+    }
+  );
+  it.each([
+    '',
+    '    ',
+    '3.14',
+    'other',
+
+    // TypeScript should catch these, but test that we do not throw in case TS does not
+    null as unknown as string,
+    undefined as unknown as string,
+  ])('should return false for non-integer string %p', (numberString) => {
+    expect(isInteger(numberString)).toBe(false);
   });
 });

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -43,4 +43,7 @@ const truncateOnMiddle = (str: string, maxLength: number) => {
   return `${firstPart}...${lastPart}`;
 };
 
+export const isInteger = (str: string): boolean =>
+  Number.isInteger(parseFloat(str));
+
 export { getEllipsedString, stringToBool, truncateOnMiddle };


### PR DESCRIPTION
## Description
This PR fixes breadcrumbs for projects, which was caused by an incorrect check. The old if-check always evaluated to `false`, since the `fieldValue` is always a string. Instead, we check whether the string is an integer ID or not.

This bug seems to have been introduced in PR #1729.

## Screenshots

![Screenshot 2024-03-16 at 16 31 42](https://github.com/zetkin/app.zetkin.org/assets/5444360/7b898c55-5bd4-439d-b972-6549f25b7347)


## Changes
* Change if-clause checking whether an integer ID is passed or not, using an `isInteger`-function.
* Added tests for the `isInteger`-function


## Notes to reviewer
Visit a project, e.g. `/organize/1/projects/1`.


## Related issues
Resolves #1771 
