### PR TITLE
stop sidebar animation flicker when reloading page

### DIFF
--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -6,6 +6,7 @@ import useLocalStorage from '../hooks/useLocalStorage';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import ZUIEllipsisMenu from '../ZUIEllipsisMenu';
 import {
   Architecture,
@@ -32,7 +33,6 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
 
 import OrganizationSwitcher from 'features/organizations/components/OrganizationSwitcher';
 import SearchDialog from 'features/search/components/SearchDialog';
@@ -88,19 +88,13 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
 
   const [checked, setChecked] = useState(false);
   const [lastOpen, setLastOpen] = useLocalStorage('orgSidebarOpen', true);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(lastOpen);
   const [searchString, setSearchString] = useState('');
   const organizationFuture = useOrganization(orgId);
 
   const handleExpansion = () => {
     setChecked(!checked);
   };
-
-  useEffect(() => {
-    if (lastOpen != open) {
-      setOpen(lastOpen);
-    }
-  }, []);
 
   const handleClick = () => {
     //remove checked state if menu is collapsed
@@ -141,7 +135,6 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
         onMouseOver={() => {
           setHover(true);
         }}
-        open={open}
         variant="permanent"
       >
         <Box display="flex" flexDirection="column" height="100%">


### PR DESCRIPTION
remove open attribute didn't have an affect

## Description
stop sidebar animation flicker when reloading page



## Changes
Change defaultstate on Open from false to LastOpen
Removed the open attribute from Drawer since I didn't see it having an effect.

## Notes to reviewer
open drawer, reload page 
close drawer reload page

## Related issues
Resolves #1685
