### PR TITLE
Issue 1818/filter assignee for view

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -1,6 +1,12 @@
 import { FC } from 'react';
 import { useRouter } from 'next/router';
-import { GridCellParams, GridColDef, GridFilterOperator, GridRenderCellParams, GridRenderEditCellParams, GridValueGetterParams, useGridApiContext, } from '@mui/x-data-grid-pro';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridRenderEditCellParams,
+  GridValueGetterParams,
+  useGridApiContext,
+} from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
 import { IFuture } from 'core/caching/futures';
@@ -20,21 +26,6 @@ import { useMessages } from 'core/i18n';
 
 type LocalPersonViewCell = null | ZetkinPerson;
 
-function makeEmptyFilterOperator(
-/*   messages: UseMessagesMap<typeof messageIds>
- */): GridFilterOperator {
-  return {
-    getApplyFilterFn: () => {
-      return (params: GridCellParams) => {
-        const people = params.value as ZetkinPerson[];
-        return people.length === 0;
-      };
-    },
-    label: "Is empty",
-    value: 'isEmpty',
-  };
-}
-
 export default class LocalPersonColumnType
   implements IColumnType<LocalPersonViewColumn, LocalPersonViewCell>
 {
@@ -47,45 +38,25 @@ export default class LocalPersonColumnType
     return {
       align: 'center',
       editable: true,
-      filterOperators: [
-        makeEmptyFilterOperator(
-
-
-        )
-      ],
       filterable: true,
       headerAlign: 'center',
 
-      renderCell: (params:GridRenderCellParams) => {
+      renderCell: (params: GridRenderCellParams) => {
         return <ZUIPersonGridCell person={params.row[params.field]} />;
       },
-      renderEditCell: (params:GridRenderEditCellParams) => {
-        return <EditCell cell={params.row[params.field]} column={col} row={params.row} />;
+      renderEditCell: (params: GridRenderEditCellParams) => {
+        return (
+          <EditCell
+            cell={params.row[params.field]}
+            column={col}
+            row={params.row}
+          />
+        );
       },
-       /* sortComparator: (
-        val0: LocalPersonViewCell,
-        val1: LocalPersonViewCell
-      ) => {
-
-        if (!val0 && !val1) {
-          return 0;
-        }
-        if (!val0) {
-          return 1;
-        }
-        if (!val1) {
-          return -1;
-        }
-
-        const name0 = `${val0.first_name}  ${val0.last_name}`;
-        const name1 = `${val1.first_name}  ${val1.last_name}`;
-        return name0.localeCompare(name1);
-      },  */
-
       valueGetter: (params: GridValueGetterParams) => {
         const cell = params.row[params.field];
         return this.cellToString(cell);
-      }
+      },
     };
   }
   getSearchableStrings(cell: LocalPersonViewCell): string[] {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { useRouter } from 'next/router';
-import { GridColDef, useGridApiContext } from '@mui/x-data-grid-pro';
+import { GridCellParams, GridColDef, GridFilterOperator, GridRenderCellParams, GridRenderEditCellParams, GridValueGetterParams, useGridApiContext, } from '@mui/x-data-grid-pro';
 
 import { IColumnType } from '.';
 import { IFuture } from 'core/caching/futures';
@@ -20,6 +20,21 @@ import { useMessages } from 'core/i18n';
 
 type LocalPersonViewCell = null | ZetkinPerson;
 
+function makeEmptyFilterOperator(
+/*   messages: UseMessagesMap<typeof messageIds>
+ */): GridFilterOperator {
+  return {
+    getApplyFilterFn: () => {
+      return (params: GridCellParams) => {
+        const people = params.value as ZetkinPerson[];
+        return people.length === 0;
+      };
+    },
+    label: "Is empty",
+    value: 'isEmpty',
+  };
+}
+
 export default class LocalPersonColumnType
   implements IColumnType<LocalPersonViewColumn, LocalPersonViewCell>
 {
@@ -32,19 +47,26 @@ export default class LocalPersonColumnType
     return {
       align: 'center',
       editable: true,
-      filterable: false,
+      filterOperators: [
+        makeEmptyFilterOperator(
+
+
+        )
+      ],
+      filterable: true,
       headerAlign: 'center',
 
-      renderCell: (params) => {
-        return <ZUIPersonGridCell person={params.value} />;
+      renderCell: (params:GridRenderCellParams) => {
+        return <ZUIPersonGridCell person={params.row[params.field]} />;
       },
-      renderEditCell: (params) => {
-        return <EditCell cell={params.value} column={col} row={params.row} />;
+      renderEditCell: (params:GridRenderEditCellParams) => {
+        return <EditCell cell={params.row[params.field]} column={col} row={params.row} />;
       },
-      sortComparator: (
+       /* sortComparator: (
         val0: LocalPersonViewCell,
         val1: LocalPersonViewCell
       ) => {
+
         if (!val0 && !val1) {
           return 0;
         }
@@ -55,10 +77,15 @@ export default class LocalPersonColumnType
           return -1;
         }
 
-        const name0 = val0.first_name + val1.last_name;
-        const name1 = val1.first_name + val1.last_name;
+        const name0 = `${val0.first_name}  ${val0.last_name}`;
+        const name1 = `${val1.first_name}  ${val1.last_name}`;
         return name0.localeCompare(name1);
-      },
+      },  */
+
+      valueGetter: (params: GridValueGetterParams) => {
+        const cell = params.row[params.field];
+        return this.cellToString(cell);
+      }
     };
   }
   getSearchableStrings(cell: LocalPersonViewCell): string[] {


### PR DESCRIPTION
## Description
This PR adds filtering for assigned column for views.


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/21238654/029e3a7d-602f-40e9-bc6f-6e0fd461a0e2)


## Changes
* Added filtering for assigned person on views (`localPersonColumnType`)
* Inadvertedly changes ordering so that empty values are sorted first :(


## Notes to reviewer
Note that this PR does not mimic the functionality from Journeys, but it does enable filtering :)


## Related issues
Resolves #1818 
