### PR TITLE
Fix sort by assignees in Journeys by assuming data is readonly

### DIFF
--- a/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -100,16 +100,15 @@ function makeEmptyFilterOperator(
   };
 }
 
-const sortByName = (value0: ZetkinPersonType[], value1: ZetkinPersonType[]) => {
-  const names0 = value0.sort((p0, p1) =>
-    fullName(p0).localeCompare(fullName(p1))
-  );
-  const names1 = value1.sort((p0, p1) =>
-    fullName(p0).localeCompare(fullName(p1))
-  );
+const sortByName = (
+  value0: readonly ZetkinPersonType[],
+  value1: readonly ZetkinPersonType[]
+) => {
+  const names0 = value0.map(fullName).sort((p0, p1) => p0.localeCompare(p1));
+  const names1 = value1.map(fullName).sort((p0, p1) => p0.localeCompare(p1));
 
-  const name0 = names0[0] ? fullName(names0[0]) : '';
-  const name1 = names1[0] ? fullName(names1[0]) : '';
+  const name0 = names0[0] ?? '';
+  const name1 = names1[0] ?? '';
 
   if (!name0 && !name1) {
     return 0;


### PR DESCRIPTION
## Description
This PR fixes an issue where exceptions were thrown if you tried to sort the Cases table under Journeys by assignee _when there were more than 1 assignee_ for at least one case.


## Screenshots
![Screenshot 2024-03-16 at 18 55 27](https://github.com/zetkin/app.zetkin.org/assets/5444360/65dd3aa1-4ad1-460a-98f4-8f9fba9f1c06)


## Changes
* Handles the assignee-list as readonly (since it actually was passed as readonly) by creating a copy of the list before sorting.


## Notes to reviewer
Should be able to test at `/organize/1/journeys/1`. Make sure at least one case has 2 or more assignees!

## Related issues
Resolves #1804 
