### PR TITLE
Reinstate .first() calls in playwright tests

### DIFF
--- a/integrationTesting/tests/organize/tags/add.spec.ts
+++ b/integrationTesting/tests/organize/tags/add.spec.ts
@@ -47,17 +47,17 @@ test.describe('Tag manager', () => {
 
     await page.locator('text=Add tag').click();
 
-    await playsGuitar.waitFor({ state: 'visible' });
+    await playsGuitar.first().waitFor({ state: 'visible' });
 
     // Select tag
-    await playsGuitar.click();
+    await playsGuitar.first().click();
 
     moxy.setZetkinApiMock(`/orgs/1/people/${ClaraZetkin.id}/tags`, 'get', [
       PlaysGuitarTag,
     ]);
 
     // Wait for the tag to appear on the page
-    await playsGuitar.waitFor({ state: 'visible' });
+    await playsGuitar.first().waitFor({ state: 'visible' });
 
     // Expect to have made request to put tag
     expect(putTagLog().length).toEqual(1);


### PR DESCRIPTION
Made the wrong call at the last minute in https://github.com/zetkin/app.zetkin.org/pull/1807 and removed some `.first()` calls that should have stayed. It's a little flaky there as a result as we saw with the `main` build immediately failing post-merge.
