### PR TITLE
Improve UX of selecting file to upload in Importer, by ignoring new API

### DIFF
--- a/src/features/import/components/ImportDialog/ParseFile.tsx
+++ b/src/features/import/components/ImportDialog/ParseFile.tsx
@@ -106,6 +106,10 @@ const ParseFile: FC<ParseFileProps> = ({ onClose, onSuccess }) => {
     onError: () => {
       setError(true);
     },
+    // We do not want to use the FS Access API as it is bad UX where a user has
+    // to manually change what file type they want to upload.
+    // See discussion here: https://github.com/react-dropzone/react-dropzone/issues/1191
+    useFsAccessApi: false,
   });
 
   return (


### PR DESCRIPTION
## Description
This PR makes it easier to upload any of the accepted file-types (.xls, .xlsx, .csv) in the importer without drag-and-drop, especially in Chrome on MacOS and Ubuntu. Previously, the behaviour was counterintuitive to the point of being unusable, as indicated by issue #1776. However, it was working as designed according to [this issue in the `react-dropzone` repository](https://github.com/react-dropzone/react-dropzone/issues/1191), where others have had the same experience as we do.


## Screenshots
It now works without having to change the file-type in the Options-menu!
![Screenshot 2024-03-17 at 11 26 18](https://github.com/zetkin/app.zetkin.org/assets/5444360/a9fac1d6-9d19-4acc-80de-f59bbdd6dd3e)


## Changes
* Disabled the usage of the new File System Access API in the file-selector for the importer


## Notes to reviewer
I have only been able to test this in Chrome on MacOS. It would be great if people that have access to other OS:es and browsers could verify that this doesn't break anything in other OS/browser-combinations.


## Related issues
Resolves #1776 
