### PR TITLE
Visual changes to Remind All button for events

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -67,12 +67,8 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
     null | (EventTarget & SVGSVGElement)
   >(null);
 
-  const participantsReminding = useAppSelector(
-    (state) => state.events.remindingByEventId
-  );
-
-  const isRemindingParticipants = Object.values(participantsReminding).some(
-    (participant) => participant
+  const isRemindingParticipants = useAppSelector(
+    (state) => state.events.remindingByEventId[eventId]
   );
 
   if (!eventData) {

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  CircularProgress,
   ClickAwayListener,
   Paper,
   Popper,
@@ -8,7 +9,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { Check, Settings } from '@mui/icons-material';
+import { Check, PriorityHighRounded, Settings } from '@mui/icons-material';
 import { FC, useState } from 'react';
 
 import messageIds from 'features/events/l10n/messageIds';
@@ -20,6 +21,7 @@ import useParticipantStatus from '../hooks/useParticipantsStatus';
 import ZUICard from 'zui/ZUICard';
 import ZUINumberChip from 'zui/ZUINumberChip';
 import { Msg, useMessages } from 'core/i18n';
+import { useAppSelector } from 'core/hooks';
 
 type ParticipantSummaryCardProps = {
   eventId: number;
@@ -68,6 +70,14 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   if (!eventData) {
     return null;
   }
+
+  const participantsReminding = useAppSelector(
+    (state) => state.events.remindingByParticipantId
+  );
+
+  const isRemindingParticipants = Object.values(participantsReminding).some(
+    (participant) => participant
+  );
 
   return (
     <Box>
@@ -180,36 +190,52 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               </Typography>
               <Box alignItems="center" display="flex">
                 <Typography variant="h4">{`${numRemindedParticipants}/${numAvailParticipants}`}</Typography>
-                {numRemindedParticipants < numAvailParticipants && (
-                  <Tooltip
-                    arrow
-                    placement="top-start"
-                    title={
-                      contactPerson == null
-                        ? messages.participantSummaryCard.remindButtondisabledTooltip()
-                        : ''
-                    }
-                  >
-                    <Box>
-                      <Button
-                        disabled={contactPerson == null}
-                        onClick={() => {
-                          sendReminders(eventId);
-                        }}
-                        size="small"
-                        startIcon={<Check />}
-                        sx={{
-                          marginLeft: 2,
-                        }}
-                        variant="outlined"
-                      >
-                        <Msg
-                          id={messageIds.participantSummaryCard.remindButton}
-                        />
-                      </Button>
-                    </Box>
-                  </Tooltip>
-                )}
+                <Tooltip
+                  arrow
+                  placement="top-start"
+                  title={
+                    contactPerson == null
+                      ? messages.participantSummaryCard.remindButtondisabledTooltip()
+                      : ''
+                  }
+                >
+                  <Box>
+                    <Button
+                      disabled={
+                        contactPerson == null ||
+                        numRemindedParticipants >= numAvailParticipants
+                      }
+                      onClick={() => {
+                        sendReminders(
+                          eventId,
+                          bookedParticipants.map(
+                            (participant) => participant.id
+                          )
+                        );
+                      }}
+                      size="small"
+                      startIcon={
+                        contactPerson ? (
+                          isRemindingParticipants ? (
+                            <CircularProgress size={20} />
+                          ) : (
+                            <Check />
+                          )
+                        ) : (
+                          <PriorityHighRounded />
+                        )
+                      }
+                      sx={{
+                        marginLeft: 2,
+                      }}
+                      variant="outlined"
+                    >
+                      <Msg
+                        id={messageIds.participantSummaryCard.remindButton}
+                      />
+                    </Button>
+                  </Box>
+                </Tooltip>
               </Box>
             </Box>
           ) : (

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -68,7 +68,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   >(null);
 
   const participantsReminding = useAppSelector(
-    (state) => state.events.remindingByParticipantId
+    (state) => state.events.remindingByEventId
   );
 
   const isRemindingParticipants = Object.values(participantsReminding).some(

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -203,12 +203,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                         numRemindedParticipants >= numAvailParticipants
                       }
                       onClick={() => {
-                        sendReminders(
-                          eventId,
-                          bookedParticipants.map(
-                            (participant) => participant.id
-                          )
-                        );
+                        sendReminders(eventId);
                       }}
                       size="small"
                       startIcon={

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -9,11 +9,12 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { Check, PriorityHighRounded, Settings } from '@mui/icons-material';
+import { Check, PriorityHigh, Settings } from '@mui/icons-material';
 import { FC, useState } from 'react';
 
 import messageIds from 'features/events/l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
+import { useAppSelector } from 'core/hooks';
 import useEvent from '../hooks/useEvent';
 import useEventParticipants from '../hooks/useEventParticipants';
 import useEventParticipantsMutations from '../hooks/useEventParticipantsMutations';
@@ -21,7 +22,6 @@ import useParticipantStatus from '../hooks/useParticipantsStatus';
 import ZUICard from 'zui/ZUICard';
 import ZUINumberChip from 'zui/ZUINumberChip';
 import { Msg, useMessages } from 'core/i18n';
-import { useAppSelector } from 'core/hooks';
 
 type ParticipantSummaryCardProps = {
   eventId: number;
@@ -67,10 +67,6 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
     null | (EventTarget & SVGSVGElement)
   >(null);
 
-  if (!eventData) {
-    return null;
-  }
-
   const participantsReminding = useAppSelector(
     (state) => state.events.remindingByParticipantId
   );
@@ -78,6 +74,10 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   const isRemindingParticipants = Object.values(participantsReminding).some(
     (participant) => participant
   );
+
+  if (!eventData) {
+    return null;
+  }
 
   return (
     <Box>
@@ -203,6 +203,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                     <Button
                       disabled={
                         contactPerson == null ||
+                        isRemindingParticipants ||
                         numRemindedParticipants >= numAvailParticipants
                       }
                       onClick={() => {
@@ -222,7 +223,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                             <Check />
                           )
                         ) : (
-                          <PriorityHighRounded />
+                          <PriorityHigh />
                         )
                       }
                       sx={{

--- a/src/features/events/hooks/useEventParticipantsMutations.ts
+++ b/src/features/events/hooks/useEventParticipantsMutations.ts
@@ -60,10 +60,10 @@ export default function useEventParticipantsMutations(
       });
   };
 
-  const sendReminders = async (eventId: number, participantIds: number[]) => {
-    dispatch(participantsRemind(participantIds));
+  const sendReminders = async (eventId: number) => {
+    dispatch(participantsRemind(eventId));
     await apiClient.post(`/api/orgs/${orgId}/actions/${eventId}/reminders`, {});
-    dispatch(participantsReminded([eventId, participantIds]));
+    dispatch(participantsReminded(eventId));
   };
 
   const setReqParticipants = (reqParticipants: number) => {

--- a/src/features/events/hooks/useEventParticipantsMutations.ts
+++ b/src/features/events/hooks/useEventParticipantsMutations.ts
@@ -16,7 +16,7 @@ export enum participantStatus {
 
 type useEventParticipantsMutationsMutationsReturn = {
   addParticipant: (personId: number) => void;
-  sendReminders: (eventId: number, participantIds: number[]) => void;
+  sendReminders: (eventId: number) => void;
   setParticipantStatus: (
     personId: number,
     status: participantStatus | null

--- a/src/features/events/hooks/useEventParticipantsMutations.ts
+++ b/src/features/events/hooks/useEventParticipantsMutations.ts
@@ -2,6 +2,7 @@ import useEventMutations from './useEventMutations';
 import { ZetkinEventParticipant } from 'utils/types/zetkin';
 import {
   participantAdded,
+  participantsRemind,
   participantsReminded,
   participantUpdated,
 } from '../store';
@@ -15,7 +16,7 @@ export enum participantStatus {
 
 type useEventParticipantsMutationsMutationsReturn = {
   addParticipant: (personId: number) => void;
-  sendReminders: (eventId: number) => void;
+  sendReminders: (eventId: number, participantIds: number[]) => void;
   setParticipantStatus: (
     personId: number,
     status: participantStatus | null
@@ -59,9 +60,10 @@ export default function useEventParticipantsMutations(
       });
   };
 
-  const sendReminders = async (eventId: number) => {
+  const sendReminders = async (eventId: number, participantIds: number[]) => {
+    dispatch(participantsRemind(participantIds));
     await apiClient.post(`/api/orgs/${orgId}/actions/${eventId}/reminders`, {});
-    dispatch(participantsReminded(eventId));
+    dispatch(participantsReminded([eventId, participantIds]));
   };
 
   const setReqParticipants = (reqParticipants: number) => {

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -60,6 +60,7 @@ export interface EventsStoreSlice {
   };
   locationList: RemoteList<ZetkinLocation>;
   participantsByEventId: Record<number, RemoteList<ZetkinEventParticipant>>;
+  remindingByParticipantId: Record<number, boolean>;
   respondentsByEventId: Record<number, RemoteList<ZetkinEventResponse>>;
   selectedEventIds: number[];
   statsByEventId: Record<number, RemoteItem<EventStats>>;
@@ -78,6 +79,7 @@ const initialState: EventsStoreSlice = {
   },
   locationList: remoteList(),
   participantsByEventId: {},
+  remindingByParticipantId: {},
   respondentsByEventId: {},
   selectedEventIds: [],
   statsByEventId: {},
@@ -488,8 +490,20 @@ const eventsSlice = createSlice({
       state.participantsByEventId[eventId] = remoteList(participants);
       state.participantsByEventId[eventId].loaded = new Date().toISOString();
     },
-    participantsReminded: (state, action: PayloadAction<number>) => {
-      const eventId = action.payload;
+    participantsRemind: (state, action: PayloadAction<number[]>) => {
+      const participantIds = action.payload;
+      participantIds.forEach((participantId) => {
+        state.remindingByParticipantId[participantId] = true;
+      });
+    },
+    participantsReminded: (
+      state,
+      action: PayloadAction<[number, number[]]>
+    ) => {
+      const [eventId, participantIds] = action.payload;
+      participantIds.forEach((participantId) => {
+        state.remindingByParticipantId[participantId] = false;
+      });
       state.participantsByEventId[eventId].items.map((item) => {
         if (item.data && item.data?.reminder_sent == null) {
           item.data = { ...item.data, reminder_sent: new Date().toISOString() };
@@ -605,6 +619,7 @@ export const {
   participantUpdated,
   participantsLoad,
   participantsLoaded,
+  participantsRemind,
   participantsReminded,
   resetSelection,
   respondentsLoad,

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -60,7 +60,7 @@ export interface EventsStoreSlice {
   };
   locationList: RemoteList<ZetkinLocation>;
   participantsByEventId: Record<number, RemoteList<ZetkinEventParticipant>>;
-  remindingByParticipantId: Record<number, boolean>;
+  remindingByEventId: Record<number, boolean>;
   respondentsByEventId: Record<number, RemoteList<ZetkinEventResponse>>;
   selectedEventIds: number[];
   statsByEventId: Record<number, RemoteItem<EventStats>>;
@@ -79,7 +79,7 @@ const initialState: EventsStoreSlice = {
   },
   locationList: remoteList(),
   participantsByEventId: {},
-  remindingByParticipantId: {},
+  remindingByEventId: {},
   respondentsByEventId: {},
   selectedEventIds: [],
   statsByEventId: {},
@@ -490,20 +490,13 @@ const eventsSlice = createSlice({
       state.participantsByEventId[eventId] = remoteList(participants);
       state.participantsByEventId[eventId].loaded = new Date().toISOString();
     },
-    participantsRemind: (state, action: PayloadAction<number[]>) => {
-      const participantIds = action.payload;
-      participantIds.forEach((participantId) => {
-        state.remindingByParticipantId[participantId] = true;
-      });
+    participantsRemind: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      state.remindingByEventId[eventId] = true;
     },
-    participantsReminded: (
-      state,
-      action: PayloadAction<[number, number[]]>
-    ) => {
-      const [eventId, participantIds] = action.payload;
-      participantIds.forEach((participantId) => {
-        state.remindingByParticipantId[participantId] = false;
-      });
+    participantsReminded: (state, action: PayloadAction<number>) => {
+      const eventId = action.payload;
+      state.remindingByEventId[eventId] = false;
       state.participantsByEventId[eventId].items.map((item) => {
         if (item.data && item.data?.reminder_sent == null) {
           item.data = { ...item.data, reminder_sent: new Date().toISOString() };


### PR DESCRIPTION
## Description
This PR adds a Loading Spinner to the Remind All button while the server is sending reminder e-mails. The button remains displayed after the e-mails have been sent and is disabled. If no contact person is assigned the icon is now an exclamation mark instead of a tick.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/78eeabea-ea99-4857-b286-58f514467970)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/fd32a9a2-efef-4480-9b17-ee7373b8f70b)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/86189782-4a2f-4fe4-b236-3e454e533492)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/4c99795e-241c-4051-b96c-dce26d554958)



## Changes
* Adds Loading Spinner while waiting for response that participants have been notified.
* Adds Reminding events to the store to use for when to display the spinner.
* Changes the button to be disabled when sending reminders.
* Changes the icon for no contact person having been assigned
* Changes the button to remain visible after participants having been reminded


## Notes to reviewer
Create or view an Event. Note the icon when no contact person is assigned.
Assign (many) participants to the event. Note the button being clickable and having the icon changed.
Click Remind All. Note the spinner appearing inside the button. Note the button being disabled.
Wait until response. Not icon being changed back to a check mark when done.

## Related issues
Resolves #1482 
