### PR TITLE
Scroll to survey error automatically

### DIFF
--- a/src/features/surveys/components/surveyForm/SurveyContainer.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyContainer.tsx
@@ -1,16 +1,17 @@
 import { Box, BoxProps } from '@mui/material';
-import { FC, ReactNode } from 'react';
+import { forwardRef, ForwardRefRenderFunction, ReactNode } from 'react';
 
 export type SurveyContainerProps = BoxProps & {
   children: ReactNode;
 };
 
-const SurveyContainer: FC<SurveyContainerProps> = ({
-  children,
-  ...boxProps
-}) => {
+const SurveyContainer: ForwardRefRenderFunction<
+  unknown,
+  SurveyContainerProps
+> = ({ children, ...boxProps }, ref) => {
   return (
     <Box
+      ref={ref}
       alignItems="center"
       display="flex"
       flexDirection="column"
@@ -23,4 +24,4 @@ const SurveyContainer: FC<SurveyContainerProps> = ({
   );
 };
 
-export default SurveyContainer;
+export default forwardRef(SurveyContainer);

--- a/src/features/surveys/components/surveyForm/SurveyErrorMessage.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyErrorMessage.tsx
@@ -1,14 +1,20 @@
 import Box from '@mui/material/Box';
-import { FC } from 'react';
 import messageIds from 'features/surveys/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import SurveyContainer from './SurveyContainer';
 import { useTheme } from '@mui/material';
+import { FC, useEffect, useRef } from 'react';
 
 const SurveyErrorMessage: FC = () => {
+  const element = useRef<HTMLDivElement>(null);
   const theme = useTheme();
+  useEffect(() => {
+    if (element.current) {
+      element.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, []);
   return (
-    <SurveyContainer pt={4}>
+    <SurveyContainer ref={element} pt={4} px={2}>
       <Box
         bgcolor={theme.palette.error.light}
         data-testid="Survey-error"


### PR DESCRIPTION
Currently the error pops in at the top and you don't get much notice of it. This just adds a quick `scrollIntoView()` call to address that. Doing this as a separate PR to give the PR itself more chance to stabilize and get merged.

| Before | After |
|-|-|
| ![2024-03-17 12 26 04](https://github.com/zetkin/app.zetkin.org/assets/566159/3599fc61-5a6d-4a45-8740-b3466938fd90) | ![2024-03-17 12 23 42](https://github.com/zetkin/app.zetkin.org/assets/566159/bce0ca09-01f1-4120-b59d-ae5e6491e1d1) |