### PR TITLE
Issue #1808: Fix loading all surveys for smart search

### DIFF
--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -40,7 +40,7 @@ const SurveySubmission = ({
   filter: initialFilter,
 }: SurveySubmissionProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();
-  const surveys = useSurveys(orgId);
+  const surveys = useSurveys(orgId).data || [];
 
   const [submittable, setSubmittable] = useState(false);
 

--- a/src/features/surveys/hooks/useSurveys.ts
+++ b/src/features/surveys/hooks/useSurveys.ts
@@ -2,8 +2,9 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinSurvey } from 'utils/types/zetkin';
 import { surveysLoad, surveysLoaded } from 'features/surveys/store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { IFuture } from 'core/caching/futures';
 
-export default function useSurveys(orgId: number): ZetkinSurvey[] {
+export default function useSurveys(orgId: number): IFuture<ZetkinSurvey[]> {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const surveyList = useAppSelector((state) => state.surveys.surveyList);
@@ -14,5 +15,5 @@ export default function useSurveys(orgId: number): ZetkinSurvey[] {
     loader: () => apiClient.get<ZetkinSurvey[]>(`/api/orgs/${orgId}/surveys`),
   });
 
-  return surveys.data ?? [];
+  return surveys;
 }

--- a/src/features/surveys/hooks/useSurveys.ts
+++ b/src/features/surveys/hooks/useSurveys.ts
@@ -1,8 +1,8 @@
+import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinSurvey } from 'utils/types/zetkin';
 import { surveysLoad, surveysLoaded } from 'features/surveys/store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-import { IFuture } from 'core/caching/futures';
 
 export default function useSurveys(orgId: number): IFuture<ZetkinSurvey[]> {
   const apiClient = useApiClient();

--- a/src/features/surveys/hooks/useSurveysWithElements.ts
+++ b/src/features/surveys/hooks/useSurveysWithElements.ts
@@ -18,7 +18,9 @@ export default function useSurveysWithElements(
     (state) => state.surveys.surveysWithElementsList
   );
 
-  if (surveys.length === 0) {
+  const surveysData = surveys.data;
+
+  if (surveys.isLoading || !surveysData) {
     return new LoadingFuture();
   }
 
@@ -28,7 +30,7 @@ export default function useSurveysWithElements(
       surveysWithElementsLoaded(surveysAndElements),
     loader: () => {
       return Promise.all(
-        surveys.map((survey) =>
+        surveysData.map((survey) =>
           apiClient.get<ZetkinSurveyExtended>(
             `/api/orgs/${orgId}/surveys/${survey.id}`
           )

--- a/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
@@ -22,7 +22,7 @@ const SurveySubmitDateConfig = ({
 }: SurveySubmitDateConfigProps) => {
   const messages = useMessages(messageIds);
   const { orgId } = useNumericRouteParams();
-  const surveys = useSurveys(orgId);
+  const surveys = useSurveys(orgId).data || [];
 
   return !surveys || surveys.length > 0 ? (
     <FormControl sx={{ width: 300 }}>


### PR DESCRIPTION
## Description
This PR fixes a bug where sometimes all surveys will not show up as selectable in the UI, for smart searches. The bug was present for 2 of 3 different types of smart search filters. 


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/21238654/3caa8b58-59de-4859-a8d7-a0376d534cf6)


## Changes
* Changes survey loading so that it fixes bug #1808


## Notes to reviewer
Think about an old friend and reminisce a bit.


## Related issues
Resolves #1808
