### PR TITLE
issue-1853/fix-endless-reload

### DIFF
--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -79,7 +79,7 @@ const SurveyOption = ({
         survey: filter.config.survey || surveys[0].id,
       });
     }
-  }, [surveys]);
+  }, [surveys.length]);
 
   // check if there are questions with response type of 'text'
   const validQuestions: ZetkinSurveyQuestionElement[] =


### PR DESCRIPTION
## Description
This PR fixes a bug where the survey option filter component in smart search re-renders endlessly.

## Screenshots


## Changes

* Changes dependency of `useEffect`


## Notes to reviewer


## Related issues
Resolves #1853 
