### PR TITLE
Issue 1830/fuzzy match tags

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
@@ -5,6 +5,8 @@ import messageIds from 'features/import/l10n/messageIds';
 import { TagColumn } from 'features/import/utils/types';
 import TagConfigRow from './TagConfigRow';
 import { UIDataColumn } from 'features/import/hooks/useUIDataColumns';
+import useGuessTags from 'features/import/hooks/useGuessTags';
+import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { Msg, useMessages } from 'core/i18n';
 
@@ -13,7 +15,9 @@ interface TagConfigProps {
 }
 
 const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
+  const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
+  const guessTags = useGuessTags(orgId, uiDataColumn);
   return (
     <Box
       display="flex"
@@ -28,7 +32,7 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
         </Typography>
         <Button
           onClick={() => {
-            console.log('hi');
+            guessTags();
           }}
         >
           {messages.configuration.configure.tags.guess()}

--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Box, Divider, Typography } from '@mui/material';
+import { Box, Button, Divider, Typography } from '@mui/material';
 
 import messageIds from 'features/import/l10n/messageIds';
 import { TagColumn } from 'features/import/utils/types';
@@ -22,9 +22,18 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
       padding={2}
       sx={{ overflowY: 'auto' }}
     >
-      <Typography sx={{ paddingBottom: 2 }} variant="h5">
-        <Msg id={messageIds.configuration.configure.tags.header} />
-      </Typography>
+      <Box alignItems="baseline" display="flex" justifyContent="space-between">
+        <Typography sx={{ paddingBottom: 2 }} variant="h5">
+          <Msg id={messageIds.configuration.configure.tags.header} />
+        </Typography>
+        <Button
+          onClick={() => {
+            console.log('hi');
+          }}
+        >
+          {messages.configuration.configure.tags.guess()}
+        </Button>
+      </Box>
       <Box alignItems="center" display="flex" paddingY={2}>
         <Box width="50%">
           <Typography variant="body2">

--- a/src/features/import/hooks/useGuessTags.ts
+++ b/src/features/import/hooks/useGuessTags.ts
@@ -4,7 +4,10 @@ import { UIDataColumn } from './useUIDataColumns';
 import useTags from 'features/tags/hooks/useTags';
 import { CellData, TagColumn } from '../utils/types';
 
-type TagMap = { id: number; value: CellData };
+type TagMap = {
+  tags: { id: number }[];
+  value: CellData;
+};
 
 const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
   const tags = useTags(orgId);
@@ -16,9 +19,9 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
   const guessTags = () => {
     // Loop through each possible cell value
     const matchedRows = uiDataColumn.uniqueValues.reduce(
-      (acc: TagMap[], cellValue: string | number) => {
+      (acc: TagMap[], cellValue: CellData) => {
         if (typeof cellValue === 'string') {
-          // Find orgs with most similar name
+          // Find tags with most similar name
           const results = fuse.search(cellValue);
           // Filter out items with a bad match
           const goodResults = results.filter(
@@ -29,7 +32,7 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
             return [
               ...acc,
               {
-                id: goodResults[0].item.id,
+                tags: [{ id: goodResults[0].item.id }],
                 value: cellValue,
               },
             ];
@@ -40,9 +43,7 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
       []
     );
 
-    console.log(matchedRows);
-
-    // uiDataColumn.selectOrgs(matchedRows);
+    uiDataColumn.assignTags(matchedRows);
   };
 
   return guessTags;

--- a/src/features/import/hooks/useGuessTags.ts
+++ b/src/features/import/hooks/useGuessTags.ts
@@ -1,0 +1,51 @@
+import Fuse from 'fuse.js';
+
+import { UIDataColumn } from './useUIDataColumns';
+import useTags from 'features/tags/hooks/useTags';
+import { CellData, TagColumn } from '../utils/types';
+
+type TagMap = { id: number; value: CellData };
+
+const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
+  const tags = useTags(orgId);
+  const fuse = new Fuse(tags.data || [], {
+    includeScore: true,
+    keys: ['title'],
+  });
+
+  const guessTags = () => {
+    // Loop through each possible cell value
+    const matchedRows = uiDataColumn.uniqueValues.reduce(
+      (acc: TagMap[], cellValue: string | number) => {
+        if (typeof cellValue === 'string') {
+          // Find orgs with most similar name
+          const results = fuse.search(cellValue);
+          // Filter out items with a bad match
+          const goodResults = results.filter(
+            (result) => result.score && result.score < 0.25
+          );
+          // If there is a match, guess it
+          if (goodResults.length > 0) {
+            return [
+              ...acc,
+              {
+                id: goodResults[0].item.id,
+                value: cellValue,
+              },
+            ];
+          }
+        }
+        return acc;
+      },
+      []
+    );
+
+    console.log(matchedRows);
+
+    // uiDataColumn.selectOrgs(matchedRows);
+  };
+
+  return guessTags;
+};
+
+export default useGuessTags;

--- a/src/features/import/hooks/useGuessTags.ts
+++ b/src/features/import/hooks/useGuessTags.ts
@@ -4,11 +4,6 @@ import { UIDataColumn } from './useUIDataColumns';
 import useTags from 'features/tags/hooks/useTags';
 import { CellData, TagColumn } from '../utils/types';
 
-type TagMap = {
-  tags: { id: number }[];
-  value: CellData;
-};
-
 const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
   const tags = useTags(orgId);
   const fuse = new Fuse(tags.data || [], {
@@ -19,7 +14,7 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
   const guessTags = () => {
     // Loop through each possible cell value
     const matchedRows = uiDataColumn.uniqueValues.reduce(
-      (acc: TagMap[], cellValue: CellData) => {
+      (acc: TagColumn['mapping'], cellValue: CellData) => {
         if (typeof cellValue === 'string') {
           // Find tags with most similar name
           const results = fuse.search(cellValue);

--- a/src/features/import/hooks/useUIDataColumns.ts
+++ b/src/features/import/hooks/useUIDataColumns.ts
@@ -241,13 +241,15 @@ export default function useUIDataColumns(
 
     const assignTags = (mapping: TagColumn['mapping']) => {
       if (originalColumn.kind == ColumnKind.TAG) {
-        columnUpdate([
-          index,
-          {
-            ...originalColumn,
-            mapping,
-          },
-        ]);
+        dispatch(
+          columnUpdate([
+            index,
+            {
+              ...originalColumn,
+              mapping,
+            },
+          ])
+        );
       }
     };
 

--- a/src/features/import/hooks/useUIDataColumns.ts
+++ b/src/features/import/hooks/useUIDataColumns.ts
@@ -4,17 +4,12 @@ import notEmpty from 'utils/notEmpty';
 import { useMessages } from 'core/i18n';
 import useTags from 'features/tags/hooks/useTags';
 import { ZetkinTag } from 'utils/types/zetkin';
-import { CellData, Column, ColumnKind } from '../utils/types';
+import { CellData, Column, ColumnKind, TagColumn } from '../utils/types';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 export type UIDataColumn<CType extends Column> = {
   assignTag: (tag: { id: number }, value: CellData) => void;
-  assignTags: (
-    mapping: {
-      tags: { id: number }[];
-      value: CellData;
-    }[]
-  ) => void;
+  assignTags: (mapping: TagColumn['mapping']) => void;
   columnValuesMessage: string;
   deselectOrg: (value: CellData) => void;
   getAssignedTags: (value: CellData) => ZetkinTag[];
@@ -244,12 +239,7 @@ export default function useUIDataColumns(
       }
     };
 
-    const assignTags = (
-      mapping: {
-        tags: { id: number }[];
-        value: CellData;
-      }[]
-    ) => {
+    const assignTags = (mapping: TagColumn['mapping']) => {
       if (originalColumn.kind == ColumnKind.TAG) {
         columnUpdate([
           index,

--- a/src/features/import/hooks/useUIDataColumns.ts
+++ b/src/features/import/hooks/useUIDataColumns.ts
@@ -9,6 +9,12 @@ import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 export type UIDataColumn<CType extends Column> = {
   assignTag: (tag: { id: number }, value: CellData) => void;
+  assignTags: (
+    mapping: {
+      tags: { id: number }[];
+      value: CellData;
+    }[]
+  ) => void;
   columnValuesMessage: string;
   deselectOrg: (value: CellData) => void;
   getAssignedTags: (value: CellData) => ZetkinTag[];
@@ -238,6 +244,23 @@ export default function useUIDataColumns(
       }
     };
 
+    const assignTags = (
+      mapping: {
+        tags: { id: number }[];
+        value: CellData;
+      }[]
+    ) => {
+      if (originalColumn.kind == ColumnKind.TAG) {
+        columnUpdate([
+          index,
+          {
+            ...originalColumn,
+            mapping,
+          },
+        ]);
+      }
+    };
+
     const unAssignTag = (tagId: number, value: CellData) => {
       if (originalColumn.kind == ColumnKind.TAG) {
         const map = originalColumn.mapping.find((map) => map.value == value);
@@ -425,6 +448,7 @@ export default function useUIDataColumns(
 
     return {
       assignTag,
+      assignTags,
       columnValuesMessage,
       deselectOrg,
       getAssignedTags,

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -39,6 +39,7 @@ export default makeMessages('feat.import', {
       },
       tags: {
         empty: m('Empty'),
+        guess: m('Guess tags'),
         header: m('Map values to tags'),
         numberOfRows: m<{ numRows: number }>(
           '{numRows, plural, =1 {1 row} other {# rows}}'


### PR DESCRIPTION
## Description
This PR implements fuzzy matching for tag values in cells in the importer, similar to the way it's done with Orgs


## Screenshots
<img width="603" alt="Screenshot 2024-03-19 at 17 07 34" src="https://github.com/zetkin/app.zetkin.org/assets/110108245/0cf95fab-de1b-4289-8b26-734a1ca22131">


## Changes

* Adds
  * Button to Tag configuration which says "Guess tags"
  * Hook that automatically guesses tags and applies them


## Notes to reviewer
* Add some tags to the example file, or use this one: 
[Example.file.xlsx](https://github.com/zetkin/app.zetkin.org/files/14654042/Example.file.xlsx)

Then import the file, select the column to map to tags, and press "guess tags"


## Related issues
Resolves #1830 
