### PR TITLE
Send email preview

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -23,7 +23,7 @@ import variableToolFactory from './tools/inlineVariable';
 
 export type EmailEditorFrontendProps = {
   apiRef: MutableRefObject<EditorJS | null>;
-  frame: EmailFrame;
+  frame: EmailFrame | null;
   initialContent: OutputData;
   onSave: (data: OutputData) => void;
   onSelectBlock: (selectedBlockIndex: number) => void;
@@ -75,7 +75,9 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       tools: {
         button: {
           class: Button as unknown as ToolConstructable,
-          config: frame.blockAttributes ? frame.blockAttributes['button'] : {},
+          config: {
+            attributes: frame?.block_attributes?.['button'] ?? {},
+          },
         },
         header: {
           class: Header,
@@ -88,9 +90,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
         libraryImage: {
           class: LibraryImage as unknown as ToolConstructable,
           config: {
-            attributes: frame.blockAttributes
-              ? frame.blockAttributes['image']
-              : {},
+            attributes: frame?.block_attributes?.['image'] ?? {},
             orgId,
           },
         },
@@ -164,7 +164,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
   const styleSheet: CSSStyleSheet = new CSSStyleSheet();
   styleSheet.deleteRule;
 
-  styleSheet.replaceSync(frame.css || '');
+  styleSheet.replaceSync(frame?.css || '');
   const frameStyles = Array.from(styleSheet.cssRules)
     .map((rule) => `#ClientOnlyEditor-container ${rule.cssText}`)
     .join('\n');

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -1,5 +1,11 @@
 import { FC } from 'react';
-import { Box, Button, CircularProgress, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
 
 import messageIds from 'features/emails/l10n/messageIds';
 import { Msg } from 'core/i18n';
@@ -8,7 +14,7 @@ import useSendTestEmail from 'features/emails/hooks/useSendTestEmail';
 
 const PreviewTab: FC = () => {
   const user = useCurrentUser();
-  const { isLoading, sendTestEmail } = useSendTestEmail();
+  const { isLoading, isPostSend, reset, sendTestEmail } = useSendTestEmail();
 
   if (!user) {
     return null;
@@ -23,18 +29,35 @@ const PreviewTab: FC = () => {
         <Msg id={messageIds.editor.settings.tabs.preview.sendTo} />
       </Typography>
       <Typography>{user.email}</Typography>
-      <Button
-        onClick={async () => {
-          await sendTestEmail();
-        }}
-        variant="contained"
-      >
-        {isLoading ? (
-          <CircularProgress color="inherit" size="1.5rem" />
-        ) : (
-          <Msg id={messageIds.editor.settings.tabs.preview.sendButton} />
-        )}
-      </Button>
+      {isPostSend && (
+        <Alert color="success">
+          <Typography mb={2}>
+            <Msg id={messageIds.editor.settings.tabs.preview.confirmation} />
+          </Typography>
+          <Button
+            color="success"
+            onClick={() => reset()}
+            size="small"
+            variant="outlined"
+          >
+            <Msg id={messageIds.editor.settings.tabs.preview.okButton} />
+          </Button>
+        </Alert>
+      )}
+      {!isPostSend && (
+        <Button
+          onClick={() => {
+            sendTestEmail();
+          }}
+          variant="contained"
+        >
+          {isLoading ? (
+            <CircularProgress color="inherit" size="1.5rem" />
+          ) : (
+            <Msg id={messageIds.editor.settings.tabs.preview.sendButton} />
+          )}
+        </Button>
+      )}
     </Box>
   );
 };

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -14,7 +14,7 @@ import useSendTestEmail from 'features/emails/hooks/useSendTestEmail';
 
 const PreviewTab: FC = () => {
   const user = useCurrentUser();
-  const { isLoading, isPostSend, reset, sendTestEmail } = useSendTestEmail();
+  const { emailWasSent, isLoading, reset, sendTestEmail } = useSendTestEmail();
 
   if (!user) {
     return null;
@@ -29,7 +29,7 @@ const PreviewTab: FC = () => {
         <Msg id={messageIds.editor.settings.tabs.preview.sendTo} />
       </Typography>
       <Typography>{user.email}</Typography>
-      {isPostSend && (
+      {emailWasSent && (
         <Alert color="success">
           <Typography mb={2}>
             <Msg id={messageIds.editor.settings.tabs.preview.confirmation} />
@@ -44,7 +44,7 @@ const PreviewTab: FC = () => {
           </Button>
         </Alert>
       )}
-      {!isPostSend && (
+      {!emailWasSent && (
         <Button
           onClick={() => {
             sendTestEmail();

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -58,10 +58,6 @@ const EmailEditor: FC<EmailEditorProps> = ({ email, onSave }) => {
     blocksRef.current = content.blocks;
   }, [content.blocks.length]);
 
-  if (!email.frame) {
-    return null;
-  }
-
   return (
     <Box display="flex" flexDirection="column" height="100%">
       {readOnly && (

--- a/src/features/emails/hooks/useSendTestEmail.ts
+++ b/src/features/emails/hooks/useSendTestEmail.ts
@@ -6,7 +6,7 @@ import { useApiClient, useNumericRouteParams } from 'core/hooks';
 export default function useSendTestEmail() {
   const apiClient = useApiClient();
   const [isLoading, setIsLoading] = useState(false);
-  const [isPostSend, setIsPostSend] = useState(false);
+  const [emailWasSent, setEmailWasSent] = useState(false);
 
   // TODO: Get these as props instead
   const user = useUser();
@@ -18,10 +18,10 @@ export default function useSendTestEmail() {
   const { emailId, orgId } = useNumericRouteParams();
 
   return {
+    emailWasSent: emailWasSent,
     isLoading,
-    isPostSend,
     reset: () => {
-      setIsPostSend(false);
+      setEmailWasSent(false);
     },
     sendTestEmail: async () => {
       setIsLoading(true);
@@ -36,7 +36,7 @@ export default function useSendTestEmail() {
       });
 
       setIsLoading(false);
-      setIsPostSend(true);
+      setEmailWasSent(true);
     },
   };
 }

--- a/src/features/emails/hooks/useSendTestEmail.ts
+++ b/src/features/emails/hooks/useSendTestEmail.ts
@@ -1,19 +1,42 @@
 import { useState } from 'react';
 
+import { useUser } from 'utils/hooks/useFocusDate';
+import { useApiClient, useNumericRouteParams } from 'core/hooks';
+
 export default function useSendTestEmail() {
+  const apiClient = useApiClient();
   const [isLoading, setIsLoading] = useState(false);
+  const [isPostSend, setIsPostSend] = useState(false);
+
+  // TODO: Get these as props instead
+  const user = useUser();
+  if (!user) {
+    // This should never happen on pages where this hook is used
+    throw new Error('Sending test email only works for signed in users');
+  }
+
+  const { emailId, orgId } = useNumericRouteParams();
 
   return {
     isLoading,
-    sendTestEmail: () => {
-      //TODO: real logic to send email here
-      return new Promise<void>((resolve) => {
-        setIsLoading(true);
-        setTimeout(() => {
-          resolve();
-          setIsLoading(false);
-        }, 4000);
+    isPostSend,
+    reset: () => {
+      setIsPostSend(false);
+    },
+    sendTestEmail: async () => {
+      setIsLoading(true);
+      await apiClient.post(`/api/orgs/${orgId}/emails/${emailId}/preview`, {
+        recipients: [
+          {
+            email: user.email,
+            first_name: user.first_name,
+            last_name: user.last_name,
+          },
+        ],
       });
+
+      setIsLoading(false);
+      setIsPostSend(true);
     },
   };
 }

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -39,9 +39,11 @@ export default makeMessages('feat.emails', {
       tabs: {
         content: m('Content'),
         preview: {
+          confirmation: m('A preview has been sent to your email address.'),
           instructions: m(
             'Here you can send this email to yourself to preview what it will look like for the recipients. '
           ),
+          okButton: m('OK!'),
           sendButton: m('Send'),
           sendTo: m('The email will be sent to this address:'),
           title: m('Preview'),

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -164,7 +164,7 @@ export type BlockAttributes = {
 };
 
 export type EmailFrame = {
-  blockAttributes?: BlockAttributes;
+  block_attributes?: BlockAttributes;
   css?: string;
   id: number;
 };


### PR DESCRIPTION
## Description
This PR implements UI to interact with the new preview API (still not deployed on the backend), which the user can use to send an email to themselves to preview it.

## Screenshots
None

## Changes
* Fixes some mistakes with types of existing features
* Implement real sending in the `useSendTestEmail()` hook
* Tweak preview UI to display a message when the email has been sent
* Use styling from frame in editor and implement logic to rewrite CSS for this to work

## Notes to reviewer
The API for this has not yet been deployed on the dev server, so trying to send will likely result in an error response (404) from the API.

## Related issues
Undocumented