### PR TITLE
Undocumented survey select widget bug

### DIFF
--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -13,7 +13,7 @@ import {
 test.describe('User submitting a survey', () => {
   const apiPostPath = `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`;
 
-  test.beforeEach(async ({ appUri, login, moxy, page }) => {
+  test.beforeEach(async ({ login, moxy }) => {
     moxy.setZetkinApiMock(
       `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
       'get',
@@ -30,17 +30,17 @@ test.describe('User submitting a survey', () => {
         role: null,
       },
     ]);
-
-    await page.goto(
-      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
   });
 
   test.afterEach(({ moxy }) => {
     moxy.teardown();
   });
 
-  test('submits responses', async ({ moxy, page }) => {
+  test('submits responses', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
     moxy.setZetkinApiMock(
       `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
       'post',
@@ -77,7 +77,11 @@ test.describe('User submitting a survey', () => {
     ]);
   });
 
-  test('submits email signature', async ({ moxy, page }) => {
+  test('submits email signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
     moxy.setZetkinApiMock(
       `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
       'post',
@@ -111,7 +115,11 @@ test.describe('User submitting a survey', () => {
     });
   });
 
-  test('submits user signature', async ({ moxy, page }) => {
+  test('submits user signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
     moxy.setZetkinApiMock(
       `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
       'post',
@@ -138,7 +146,11 @@ test.describe('User submitting a survey', () => {
     expect(data.signature).toBe('user');
   });
 
-  test('submits anonymous signature', async ({ moxy, page }) => {
+  test('submits anonymous signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
     moxy.setZetkinApiMock(
       `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
       'post',
@@ -165,7 +177,11 @@ test.describe('User submitting a survey', () => {
     expect(data.signature).toBe(null);
   });
 
-  test('preserves inputs on error', async ({ page }) => {
+  test('preserves inputs on error', async ({ appUri, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
     await page.click('input[name="1.options"][value="1"]');
     await page.fill('[name="2.text"]', 'Topple capitalism');
     await page.click('input[name="sig"][value="anonymous"]');

--- a/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
+++ b/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
@@ -40,6 +40,28 @@ describe('prepareSurveyApiSubmission()', () => {
     ]);
   });
 
+  it('formats a select widget response', () => {
+    formData['123.options'] = '234';
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.responses).toMatchObject([
+      {
+        options: [234],
+        question_id: 123,
+      },
+    ]);
+  });
+
+  it('formats empty select response', () => {
+    formData['123.options'] = '';
+    const submission = prepareSurveyApiSubmission(formData);
+    expect(submission.responses).toMatchObject([
+      {
+        options: [],
+        question_id: 123,
+      },
+    ]);
+  });
+
   it('signs as the logged-in account when a logged-in user requests to sign as themself', () => {
     formData['sig'] = 'user';
     const submission = prepareSurveyApiSubmission(formData, true);

--- a/src/features/surveys/utils/prepareSurveyApiSubmission.ts
+++ b/src/features/surveys/utils/prepareSurveyApiSubmission.ts
@@ -29,7 +29,7 @@ export default function prepareSurveyApiSubmission(
 
     if (type === 'options' && typeof value === 'string') {
       responses.push({
-        options: [parseInt(value, 10)],
+        options: value == '' ? [] : [parseInt(value, 10)],
         question_id: parseInt(id, 10),
       });
     }


### PR DESCRIPTION
## Description
This PR fixes an undocumented bug in the new survey page. This bug recently surfaced in the production Gen2 version of Zetkin, and since the code in #1756 was based on the logic from there, I guessed (correctly) that the bug would exist here as well.

The bug basically means that if a `<select>` is not interacted with, it will still be submitted (at least on Chrome) with an empty value, and that empty value will not be handled correctly on the server. Instead of removing it, or submitting it with empty options (`options: []`) it gets submitted with a `null` option (`options: [null]`).

## Screenshots
None

## Changes
* Changes integration tests to not navigate (`page.goto`) until within the test cases, to allow for test cases to make additional mocks before navigating
* Adds integration test that reproduces the bug
* Adds unit tests for `prepareSurveyApiSubmission()` that reproduces the bug
* Fixes the bug in `prepareSurveyApiSubmission()`

## Notes to reviewer
None

## Related issues
Undocumented