### PR TITLE
Stop loading events in campaign cards

### DIFF
--- a/src/features/campaigns/components/CampaignCard.tsx
+++ b/src/features/campaigns/components/CampaignCard.tsx
@@ -1,4 +1,3 @@
-import { FormattedDate } from 'react-intl';
 import NextLink from 'next/link';
 import {
   Card,
@@ -10,8 +9,6 @@ import {
 
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { removeOffset } from 'utils/dateUtils';
-import useCampaignEvents from '../hooks/useCampaignEvents';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinCampaign } from 'utils/types/zetkin';
 
@@ -22,41 +19,12 @@ interface CampaignCardProps {
 const CampaignCard = ({ campaign }: CampaignCardProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();
   const { id, title } = campaign;
-  const { firstEvent, lastEvent, numberOfUpcomingEvents } = useCampaignEvents(
-    orgId,
-    id
-  );
 
   return (
     <Card data-testid="campaign-card">
       <CardContent>
         <Typography gutterBottom noWrap variant="h6">
           {title}
-        </Typography>
-        <Typography gutterBottom variant="body2">
-          {firstEvent && lastEvent ? (
-            <>
-              <FormattedDate
-                day="numeric"
-                month="long"
-                value={removeOffset(firstEvent.start_time)}
-              />{' '}
-              {' - '}
-              <FormattedDate
-                day="numeric"
-                month="long"
-                value={removeOffset(lastEvent.end_time)}
-              />
-            </>
-          ) : (
-            <Msg id={messageIds.indefinite} />
-          )}
-        </Typography>
-        <Typography color="secondary" gutterBottom variant="body2">
-          <Msg
-            id={messageIds.all.upcoming}
-            values={{ numEvents: numberOfUpcomingEvents }}
-          />
         </Typography>
         {/*TODO: labels for calls and surveys*/}
       </CardContent>


### PR DESCRIPTION
## Description
This PR simply remove calls for activities/events in the campaign cards on the projects page, to improve loading performance.

## Changes
- Removes call for events.
- Removes start and end dates from campaign cards.
- Removes number of events from campaign cards.

## Related issues
Resolves #1787 
