### PR TITLE
Add support for the full suite of survey question options in the new survey form

### DIFF
--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -9,9 +9,6 @@ import {
   ELEMENT_TYPE,
   RESPONSE_TYPE,
   ZetkinSurveyApiSubmission,
-  ZetkinSurveyQuestionElement,
-  ZetkinSurveyQuestionResponse,
-  ZetkinSurveySignaturePayload,
 } from 'utils/types/zetkin';
 
 test.describe('User submitting a survey', () => {
@@ -55,16 +52,17 @@ test.describe('User submitting a survey', () => {
 
     const log = moxy.log(`/v1${apiPostPath}`);
     expect(log.length).toBe(1);
-    const [request] = log;
-    const data = request.data as {
-      responses: ZetkinSurveyQuestionResponse[];
-    };
-    expect(data.responses).toMatchObject([
-      {
-        question_id: KPDMembershipSurvey.elements[1].id,
-        response: 'Topple capitalism',
-      },
-    ]);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toEqual({
+      responses: [
+        {
+          question_id: KPDMembershipSurvey.elements[1].id,
+          response: 'Topple capitalism',
+        },
+      ],
+      signature: null,
+    });
   });
 
   test('required text input blocks submission when empty', async ({
@@ -77,18 +75,22 @@ test.describe('User submitting a survey', () => {
       'get',
       {
         ...KPDMembershipSurvey,
-        elements: KPDMembershipSurvey.elements.map((element, i) => {
-          if (i === 1) {
-            return {
-              ...element,
-              question: {
-                ...(element as ZetkinSurveyQuestionElement).question,
-                required: true,
+        elements: [
+          {
+            hidden: false,
+            id: 2,
+            question: {
+              description: '',
+              question: 'What would you like to do?',
+              required: true,
+              response_config: {
+                multiline: true,
               },
-            };
-          }
-          return element;
-        }),
+              response_type: RESPONSE_TYPE.TEXT,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
       }
     );
 
@@ -104,21 +106,54 @@ test.describe('User submitting a survey', () => {
       }
     );
 
-    const requiredTextInput = await page.locator('[name="2.text"][required]');
+    const requiredTextInput = await page.locator('[name="2.text"]');
     await requiredTextInput.waitFor({ state: 'visible' });
 
     await page.click('input[name="sig"][value="anonymous"]');
     await page.click('data-testid=Survey-acceptTerms');
     await page.click('data-testid=Survey-submit');
 
-    const validationMessage = await requiredTextInput.evaluate((element) => {
-      const input = element as HTMLTextAreaElement;
-      return input.validationMessage;
-    });
-    expect(validationMessage).toBe('Please fill in this field.');
+    const valueMissing = await requiredTextInput.evaluate(
+      (element: HTMLTextAreaElement) => element.validity.valueMissing
+    );
+    expect(valueMissing).toBe(true);
   });
 
-  test('submits responses', async ({ appUri, moxy, page }) => {
+  test('submits radio input', async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: [
+          {
+            hidden: false,
+            id: 1,
+            question: {
+              description: '',
+              options: [
+                {
+                  id: 1,
+                  text: 'Yes',
+                },
+                {
+                  id: 2,
+                  text: 'No',
+                },
+              ],
+              question: 'Do you want to be active?',
+              required: false,
+              response_config: {
+                widget_type: 'radio',
+              },
+              response_type: RESPONSE_TYPE.OPTIONS,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
+      }
+    );
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
     );
@@ -132,9 +167,145 @@ test.describe('User submitting a survey', () => {
     );
 
     await page.click('input[name="1.options"]');
-    await page.fill('[name="2.text"]', 'Topple capitalism');
+
+    await page.click('input[name="sig"][value="anonymous"]');
+    await page.click('data-testid=Survey-acceptTerms');
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'POST'),
+      await page.click('data-testid=Survey-submit'),
+    ]);
+
+    const log = moxy.log(`/v1${apiPostPath}`);
+    expect(log.length).toBe(1);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toEqual({
+      responses: [
+        {
+          options: [1],
+          question_id: KPDMembershipSurvey.elements[0].id,
+        },
+      ],
+      signature: null,
+    });
+  });
+
+  test('required radio input blocks submission when empty', async ({
+    appUri,
+    moxy,
+    page,
+  }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: [
+          {
+            hidden: false,
+            id: 1,
+            question: {
+              description: '',
+              options: [
+                {
+                  id: 1,
+                  text: 'Yes',
+                },
+                {
+                  id: 2,
+                  text: 'No',
+                },
+              ],
+              question: 'Do you want to be active?',
+              required: true,
+              response_config: {
+                widget_type: 'radio',
+              },
+              response_type: RESPONSE_TYPE.OPTIONS,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
+      }
+    );
+
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
+    const requiredRadioInput = await page.locator(
+      '[name="1.options"] >> nth=0'
+    );
+    await requiredRadioInput.waitFor({ state: 'visible' });
+
+    await page.click('input[name="sig"][value="anonymous"]');
+    await page.click('data-testid=Survey-acceptTerms');
+    await page.click('data-testid=Survey-submit');
+
+    const valueMissing = await requiredRadioInput.evaluate(
+      (element: HTMLInputElement) => element.validity.valueMissing
+    );
+    expect(valueMissing).toBe(true);
+  });
+
+  test('submits checkbox input', async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: [
+          {
+            hidden: false,
+            id: 3,
+            question: {
+              description: '',
+              options: [
+                {
+                  id: 1,
+                  text: 'Flyers',
+                },
+                {
+                  id: 2,
+                  text: 'Phone banking',
+                },
+              ],
+              question: 'How do you want to help?',
+              required: false,
+              response_config: {
+                widget_type: 'checkbox',
+              },
+              response_type: RESPONSE_TYPE.OPTIONS,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
+      }
+    );
+
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
     await page.click('input[name="3.options"][value="1"]');
     await page.click('input[name="3.options"][value="2"]');
+
     await page.click('input[name="sig"][value="anonymous"]');
     await page.click('data-testid=Survey-acceptTerms');
     await Promise.all([
@@ -144,66 +315,54 @@ test.describe('User submitting a survey', () => {
 
     const log = moxy.log(`/v1${apiPostPath}`);
     expect(log.length).toBe(1);
-    const [request] = log;
-    const data = request.data as {
-      responses: ZetkinSurveyQuestionResponse[];
-    };
-    expect(data.responses.length).toBe(3);
-    expect(data.responses).toMatchObject([
-      {
-        options: [1],
-        question_id: KPDMembershipSurvey.elements[0].id,
-      },
-      {
-        question_id: KPDMembershipSurvey.elements[1].id,
-        response: 'Topple capitalism',
-      },
-      {
-        options: [1, 2],
-        question_id: KPDMembershipSurvey.elements[2].id,
-      },
-    ]);
-  });
 
-  test('submits email signature', async ({ appUri, moxy, page }) => {
-    await page.goto(
-      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
-    );
-
-    await page.click('input[name="1.options"]');
-    await page.fill('[name="2.text"]', 'Topple capitalism');
-    await page.click('input[name="sig"][value="email"]');
-    await page.fill('input[name="sig.email"]', 'testuser@example.org');
-    await page.fill('input[name="sig.first_name"]', 'Test');
-    await page.fill('input[name="sig.last_name"]', 'User');
-    await page.click('data-testid=Survey-acceptTerms');
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      await page.click('data-testid=Survey-submit'),
-    ]);
-
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
-    const [request] = log;
-    const data = request.data as {
-      signature: ZetkinSurveySignaturePayload;
-    };
-    expect(data.signature).toMatchObject({
-      email: 'testuser@example.org',
-      first_name: 'Test',
-      last_name: 'User',
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toEqual({
+      responses: [
+        {
+          options: [1, 2],
+          question_id: KPDMembershipSurvey.elements[2].id,
+        },
+      ],
+      signature: null,
     });
   });
 
-  test('submits user signature', async ({ appUri, moxy, page }) => {
+  test('submits select input', async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: [
+          {
+            hidden: false,
+            id: 3,
+            question: {
+              description: '',
+              options: [
+                {
+                  id: 1,
+                  text: 'Yes',
+                },
+                {
+                  id: 2,
+                  text: 'No',
+                },
+              ],
+              question: 'Is this a select box?',
+              required: false,
+              response_config: {
+                widget_type: 'select',
+              },
+              response_type: RESPONSE_TYPE.OPTIONS,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
+      }
+    );
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
     );
@@ -216,39 +375,16 @@ test.describe('User submitting a survey', () => {
       }
     );
 
-    await page.click('input[name="1.options"][value="1"]');
-    await page.fill('[name="2.text"]', 'Topple capitalism');
-    await page.click('input[name="sig"][value="user"]');
-    await page.click('data-testid=Survey-acceptTerms');
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      await page.click('data-testid=Survey-submit'),
-    ]);
-
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
-    const [request] = log;
-    const data = request.data as {
-      signature: ZetkinSurveySignaturePayload;
-    };
-    expect(data.signature).toBe('user');
-  });
-
-  test('submits anonymous signature', async ({ appUri, moxy, page }) => {
-    await page.goto(
-      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    const selectInput = await page.locator(
+      '[id="mui-component-select-3.options"]'
     );
+    const yes = await page.locator('[role="option"][data-value="1"]');
 
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
-    );
+    await selectInput.waitFor({ state: 'visible' });
+    await selectInput.click();
+    await yes.waitFor({ state: 'visible' });
+    await yes.click();
 
-    await page.click('input[name="1.options"][value="1"]');
-    await page.fill('[name="2.text"]', 'Topple capitalism');
     await page.click('input[name="sig"][value="anonymous"]');
     await page.click('data-testid=Survey-acceptTerms');
     await Promise.all([
@@ -258,11 +394,76 @@ test.describe('User submitting a survey', () => {
 
     const log = moxy.log(`/v1${apiPostPath}`);
     expect(log.length).toBe(1);
-    const [request] = log;
-    const data = request.data as {
-      signature: ZetkinSurveySignaturePayload;
-    };
-    expect(data.signature).toBe(null);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toEqual({
+      responses: [
+        {
+          options: [1],
+          question_id: 3,
+        },
+      ],
+      signature: null,
+    });
+  });
+
+  test('required select input blocks submission when empty', async ({
+    appUri,
+    moxy,
+    page,
+  }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: [
+          {
+            hidden: false,
+            id: 3,
+            question: {
+              description: '',
+              options: [
+                {
+                  id: 1,
+                  text: 'Yes',
+                },
+                {
+                  id: 2,
+                  text: 'No',
+                },
+              ],
+              question: 'Is this a select box?',
+              required: true,
+              response_config: {
+                widget_type: 'select',
+              },
+              response_type: RESPONSE_TYPE.OPTIONS,
+            },
+            type: ELEMENT_TYPE.QUESTION,
+          },
+        ],
+      }
+    );
+
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    const selectInput = await page.locator(
+      '[id="mui-component-select-3.options"]'
+    );
+    const hiddenInput = await page.locator('input[name="3.options"]');
+
+    await selectInput.waitFor({ state: 'visible' });
+    await page.click('input[name="sig"][value="anonymous"]');
+    await page.click('data-testid=Survey-acceptTerms');
+    await page.click('data-testid=Survey-submit');
+
+    const valueMissing = await hiddenInput.evaluate(
+      (element: HTMLSelectElement) => element.validity.valueMissing
+    );
+    expect(valueMissing).toBe(true);
   });
 
   test('submits untouched "select" widget as []', async ({
@@ -277,7 +478,6 @@ test.describe('User submitting a survey', () => {
       {
         ...KPDMembershipSurvey,
         elements: [
-          ...KPDMembershipSurvey.elements,
           {
             hidden: false,
             id: 3,
@@ -333,14 +533,110 @@ test.describe('User submitting a survey', () => {
     expect(data).toEqual({
       responses: [
         {
-          question_id: 2,
-          response: '',
-        },
-        {
           options: [],
           question_id: 3,
         },
       ],
+      signature: null,
+    });
+  });
+
+  test('submits email signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
+    await page.click('input[name="1.options"]');
+    await page.fill('[name="2.text"]', 'Topple capitalism');
+    await page.click('input[name="sig"][value="email"]');
+    await page.fill('input[name="sig.email"]', 'testuser@example.org');
+    await page.fill('input[name="sig.first_name"]', 'Test');
+    await page.fill('input[name="sig.last_name"]', 'User');
+    await page.click('data-testid=Survey-acceptTerms');
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'POST'),
+      await page.click('data-testid=Survey-submit'),
+    ]);
+
+    const log = moxy.log(`/v1${apiPostPath}`);
+    expect(log.length).toBe(1);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toMatchObject({
+      signature: {
+        email: 'testuser@example.org',
+        first_name: 'Test',
+        last_name: 'User',
+      },
+    });
+  });
+
+  test('submits user signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
+    await page.click('input[name="1.options"][value="1"]');
+    await page.fill('[name="2.text"]', 'Topple capitalism');
+    await page.click('input[name="sig"][value="user"]');
+    await page.click('data-testid=Survey-acceptTerms');
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'POST'),
+      await page.click('data-testid=Survey-submit'),
+    ]);
+
+    const log = moxy.log(`/v1${apiPostPath}`);
+    expect(log.length).toBe(1);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toMatchObject({
+      signature: 'user',
+    });
+  });
+
+  test('submits anonymous signature', async ({ appUri, moxy, page }) => {
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
+      'post',
+      {
+        timestamp: '1857-05-07T13:37:00.000Z',
+      }
+    );
+
+    await page.click('input[name="1.options"][value="1"]');
+    await page.fill('[name="2.text"]', 'Topple capitalism');
+    await page.click('input[name="sig"][value="anonymous"]');
+    await page.click('data-testid=Survey-acceptTerms');
+    await Promise.all([
+      page.waitForResponse((res) => res.request().method() == 'POST'),
+      await page.click('data-testid=Survey-submit'),
+    ]);
+
+    const log = moxy.log(`/v1${apiPostPath}`);
+    expect(log.length).toBe(1);
+
+    const data = log[0].data as ZetkinSurveyApiSubmission;
+    expect(data).toMatchObject({
       signature: null,
     });
   });
@@ -371,5 +667,31 @@ test.describe('User submitting a survey', () => {
       page.locator('input[name="sig"][value="anonymous"]')
     ).toBeChecked();
     await expect(page.locator('data-testid=Survey-acceptTerms')).toBeChecked();
+  });
+
+  test("doesn't render hidden elements", async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock(
+      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`,
+      'get',
+      {
+        ...KPDMembershipSurvey,
+        elements: KPDMembershipSurvey.elements.map((element) => ({
+          ...element,
+          hidden: true,
+        })),
+      }
+    );
+
+    await page.goto(
+      `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
+    );
+
+    const radioInput = await page.locator('input[name="1.options"]');
+    const textInput = await page.locator('[name="2.text"]');
+    const checkboxInput = await page.locator('input[name="3.options"]');
+
+    expect(await radioInput.isVisible()).toBeFalsy();
+    expect(await textInput.isVisible()).toBeFalsy();
+    expect(await checkboxInput.isVisible()).toBeFalsy();
   });
 });

--- a/src/features/surveys/components/surveyForm/SurveyElements.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyElements.tsx
@@ -14,14 +14,18 @@ export type SurveyElementsProps = {
 const SurveyElements: FC<SurveyElementsProps> = ({ survey }) => {
   return (
     <Box display="flex" flexDirection="column" gap={4} paddingX={2}>
-      {survey.elements.map((element) => (
-        <Box key={element.id}>
-          {element.type === 'question' && <SurveyQuestion element={element} />}
-          {element.type === 'text' && (
-            <SurveyTextBlock element={element as ZetkinSurveyTextElement} />
-          )}
-        </Box>
-      ))}
+      {survey.elements
+        .filter((element) => element.hidden !== true)
+        .map((element) => (
+          <Box key={element.id}>
+            {element.type === 'question' && (
+              <SurveyQuestion element={element} />
+            )}
+            {element.type === 'text' && (
+              <SurveyTextBlock element={element as ZetkinSurveyTextElement} />
+            )}
+          </Box>
+        ))}
     </Box>
   );
 };

--- a/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
@@ -1,7 +1,9 @@
+import messageIds from 'features/surveys/l10n/messageIds';
 import SurveyContainer from './SurveyContainer';
 import SurveyOption from './SurveyOption';
 import SurveyQuestionDescription from './SurveyQuestionDescription';
 import SurveySubheading from './SurveySubheading';
+import { useMessages } from 'core/i18n';
 import {
   Box,
   Checkbox,
@@ -25,6 +27,7 @@ export type OptionsQuestionProps = {
 };
 
 const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
+  const messages = useMessages(messageIds);
   const [dropdownValue, setDropdownValue] = useState('');
   const handleDropdownChange = useCallback((event: SelectChangeEvent) => {
     setDropdownValue(event.target.value);
@@ -91,7 +94,11 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 <Box>
                   <FormLabel id={`label-${element.id}`}>
                     <SurveySubheading>
-                      {element.question.question}
+                      <>
+                        {element.question.question}
+                        {element.question.required &&
+                          ` (${messages.surveyForm.required()})`}
+                      </>
                     </SurveySubheading>
                   </FormLabel>
                   {element.question.description && (
@@ -105,7 +112,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 {element.question.options!.map((option: ZetkinSurveyOption) => (
                   <SurveyOption
                     key={option.id}
-                    control={<Radio />}
+                    control={<Radio required={element.question.required} />}
                     label={option.text}
                     value={option.id}
                   />
@@ -123,7 +130,11 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
               <Box display="flex" flexDirection="column">
                 <FormLabel id={`label-${element.id}`}>
                   <SurveySubheading>
-                    {element.question.question}
+                    <>
+                      {element.question.question}
+                      {element.question.required &&
+                        ` (${messages.surveyForm.required()})`}
+                    </>
                   </SurveySubheading>
                 </FormLabel>
                 {element.question.description && (
@@ -136,6 +147,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 aria-labelledby={`label-${element.id}`}
                 name={`${element.id}.options`}
                 onChange={handleDropdownChange}
+                required={element.question.required}
                 value={dropdownValue}
               >
                 {element.question.options!.map((option: ZetkinSurveyOption) => (

--- a/src/features/surveys/components/surveyForm/SurveyTextQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyTextQuestion.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react';
+import messageIds from 'features/surveys/l10n/messageIds';
 import SurveyContainer from './SurveyContainer';
 import SurveyQuestionDescription from './SurveyQuestionDescription';
 import SurveySubheading from './SurveySubheading';
+import { useMessages } from 'core/i18n';
 import { ZetkinSurveyTextQuestionElement } from 'utils/types/zetkin';
 import { Box, FormControl, FormLabel, TextField } from '@mui/material';
 
@@ -10,13 +12,20 @@ export type SurveyOptionsQuestionProps = {
 };
 
 const SurveyOptionsQuestion: FC<SurveyOptionsQuestionProps> = ({ element }) => {
+  const messages = useMessages(messageIds);
   return (
     <FormControl fullWidth>
       <SurveyContainer>
         <Box display="flex" flexDirection="column" rowGap={2}>
           <Box>
             <FormLabel htmlFor={`input-${element.id}`}>
-              <SurveySubheading>{element.question.question}</SurveySubheading>
+              <SurveySubheading>
+                <>
+                  {element.question.question}
+                  {element.question.required &&
+                    ` (${messages.surveyForm.required()})`}
+                </>
+              </SurveySubheading>
             </FormLabel>
             {element.question.description && (
               <SurveyQuestionDescription id={`description-${element.id}`}>

--- a/src/features/surveys/components/surveyForm/SurveyTextQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyTextQuestion.tsx
@@ -30,6 +30,7 @@ const SurveyOptionsQuestion: FC<SurveyOptionsQuestionProps> = ({ element }) => {
             inputProps={{ 'aria-describedby': `description-${element.id}` }}
             multiline={element.question.response_config.multiline}
             name={`${element.id}.text`}
+            required={element.question.required}
             rows={element.question.response_config.multiline ? 4 : 1}
             type="text"
           />

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -167,6 +167,7 @@ export default makeMessages('feat.surveys', {
       link: m('https://zetkin.org/privacy'),
       text: m('Click to read the full Zetkin Privacy Policy'),
     },
+    required: m('required'),
     sign: {
       anonymous: m('Sign anonymously'),
       nameAndEmail: m('Sign with name and e-mail'),


### PR DESCRIPTION
Creating another side branch off of https://github.com/zetkin/app.zetkin.org/pull/1756 in order to make a nice clean space for us to nail down these last little details. There's a bunch of stuff like `hidden` and `required` that needs to be handled properly by the new survey form components, and also needs playwright tests to keep an eye on it. To get the ball rolling, I've begun here with the `required` property on the text questions as it's probably the simplest.

It raises a few little questions.

1. How do we want to identify required fields to users? We could e.g. add the string `(required)` on the end of the label. Even just an asterisk on the end is sufficient. (https://www.w3.org/TR/WCAG20-TECHS/H90.html)
2. How does this change how we structure the playwright tests here? I think the `submits responses` test has become long enough that its size is beginning to obscure the intent of the individual assertions. So I've kind of sketched out some possible ways of splitting things up more, but haven't invested a lot of love into the ideas there.

Dropping this here already now in a fairly raw initial state just for the benefit of having the progress so far out of my head and onto a real PR. Whatever ideas come to mind from reading this, throw them my way.