### PR TITLE
Issue 1760/delete button in cancelled

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -48,6 +48,7 @@ const Buttons: FC<{ options: ButtonOption[] }> = ({ options }) => {
         display: 'flex',
         flexDirection: 'row',
         gap: 0.5,
+        justifyContent: 'flex-end',
       }}
     >
       {options.map((option) => (

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -119,10 +119,8 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
   const messages = useMessages(messageIds);
   const eventFuture = useEvent(orgId, eventId);
   const { setContact } = useEventContact(orgId, eventId);
-  const { setParticipantStatus } = useEventParticipantsMutations(
-    orgId,
-    eventId
-  );
+  const { deleteParticipant, setParticipantStatus } =
+    useEventParticipantsMutations(orgId, eventId);
 
   const columns: GridColDef[] = [
     {
@@ -345,6 +343,11 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           return (
             <Buttons
               options={[
+                {
+                  callback: () => deleteParticipant(params.row.id),
+                  title: messages.eventParticipantsList.buttonDelete(),
+                  variant: 'text',
+                },
                 {
                   callback: () => {
                     setParticipantStatus(params.row.id, null);

--- a/src/features/events/hooks/useEventParticipantsMutations.ts
+++ b/src/features/events/hooks/useEventParticipantsMutations.ts
@@ -2,6 +2,7 @@ import useEventMutations from './useEventMutations';
 import { ZetkinEventParticipant } from 'utils/types/zetkin';
 import {
   participantAdded,
+  participantDeleted,
   participantsRemind,
   participantsReminded,
   participantUpdated,
@@ -16,6 +17,7 @@ export enum participantStatus {
 
 type useEventParticipantsMutationsMutationsReturn = {
   addParticipant: (personId: number) => void;
+  deleteParticipant: (participantId: number) => void;
   sendReminders: (eventId: number) => void;
   setParticipantStatus: (
     personId: number,
@@ -42,6 +44,13 @@ export default function useEventParticipantsMutations(
       {}
     );
     dispatch(participantAdded([eventId, participant]));
+  };
+
+  const deleteParticipant = async (participantId: number) => {
+    await apiClient.delete(
+      `/api/orgs/${orgId}/actions/${eventId}/participants/${participantId}`
+    );
+    dispatch(participantDeleted([eventId, participantId]));
   };
 
   const updateParticipant = (
@@ -83,6 +92,7 @@ export default function useEventParticipantsMutations(
 
   return {
     addParticipant,
+    deleteParticipant,
     sendReminders,
     setParticipantStatus,
     setReqParticipants,

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -70,6 +70,7 @@ export default makeMessages('feat.events', {
     buttonBook: m('Book'),
     buttonCancel: m('Cancel'),
     buttonCancelled: m('Cancelled'),
+    buttonDelete: m('Delete'),
     buttonNoshow: m('No-show'),
     cancelledParticipants: m('Cancelled Participants'),
     columnEmail: m('Email'),

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -351,6 +351,12 @@ const eventsSlice = createSlice({
         remoteItem(participant.id, { data: participant })
       );
     },
+    participantDeleted: (state, action: PayloadAction<[number, number]>) => {
+      const [eventId, participantId] = action.payload;
+      state.participantsByEventId[eventId].items = state.participantsByEventId[
+        eventId
+      ].items.filter((participant) => participant.id !== participantId);
+    },
     participantUpdated: (
       state,
       action: PayloadAction<[number, ZetkinEventParticipant]>
@@ -566,6 +572,7 @@ export const {
   locationsLoad,
   locationsLoaded,
   participantAdded,
+  participantDeleted,
   participantUpdated,
   participantsLoad,
   participantsLoaded,


### PR DESCRIPTION
## Description
This PR adds "Delete" button in table under "Cancelled" to remove participants who were added accidentally or to remove them as necessary


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/8b6eabff-1ce2-46b9-8580-a88caa1eb2cb



## Changes

* Adds `deleteParticipant` in hook.
* Adds `participantDeleted` in store
* Adds message
* Adds `justifyContent:flex-end` to align the buttons to the right side


## Notes to reviewer
Aligned the buttons to the right side

![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/cfbda539-d52c-4751-989d-a77cc99e4753)


## Related issues
Resolves #1760 
