### PR TITLE
Remove a tags inside next links in 404 page.

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -16,9 +16,7 @@ export default function Custom404(): JSX.Element {
       <AppBar color="transparent" elevation={0} position="static">
         <Toolbar>
           <Link href="/" passHref>
-            <a>
-              <ZUILogo htmlColor="#EE323E" />
-            </a>
+            <ZUILogo htmlColor="#EE323E" />
           </Link>
         </Toolbar>
       </AppBar>
@@ -33,9 +31,7 @@ export default function Custom404(): JSX.Element {
           <Box mt={2}>
             <Typography align="center" variant="h6">
               <Link data-testid="back-home-link" href="/" passHref>
-                <a>
-                  <Msg id={messageIds.err404.backToHomePage} />
-                </a>
+                <Msg id={messageIds.err404.backToHomePage} />
               </Link>
             </Typography>
           </Box>


### PR DESCRIPTION
## Description
This PR solves a small bug I came across when deliberately attempting to access the 404 page. The `a` tags inside the `Link` components were causing Next to return 204 and not access the page, so I removed them, and everythings seems to work as intended.
