### PR TITLE
css fix to truncate all instances of StyledSelect when needed

### DIFF
--- a/src/features/smartSearch/components/inputs/StyledSelect.tsx
+++ b/src/features/smartSearch/components/inputs/StyledSelect.tsx
@@ -10,6 +10,8 @@ const useStyles = makeStyles((theme) => ({
   MuiSelect: {
     fontSize: theme.typography.h4.fontSize,
     padding: 0,
+    maxWidth: '700px',
+    textOverflow: 'ellipsis'
   },
   MuiTextField: {
     display: 'inline',


### PR DESCRIPTION
## Description
This PR solves the issue #1877 by using CSS ellipsis.

## Changes
Setting maxWidth of 700px and using css ellipsis.


## Related issues
Resolves #1877 
