### PR TITLE
solved issue where special characters are not caught in email import

### DIFF
--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -10,6 +10,10 @@ import {
   ImportRowProblem,
 } from './types';
 
+const hasUnknownChars = (value: string) => {
+  return [...value].some((char) => char.charCodeAt(0) > 127);
+};
+
 const VALIDATORS: Record<CUSTOM_FIELD_TYPE, (value: string) => boolean> = {
   date: (value) => {
     try {
@@ -104,7 +108,10 @@ export function predictProblems(
               rowHasFirstName = true;
             } else if (column.field == 'last_name') {
               rowHasLastName = true;
-            } else if (column.field == 'email' && !isEmail(value.toString())) {
+            } else if (
+              column.field == 'email' &&
+              (hasUnknownChars(value.toString()) || !isEmail(value.toString()))
+            ) {
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
               if (!isValidPhoneNumber(value.toString(), country)) {


### PR DESCRIPTION
## Description
This PR resolves issue where special characters are not caught in email import


## Screenshots
![Skärmavbild 2024-04-07 kl  12 23 32](https://github.com/zetkin/app.zetkin.org/assets/143996815/3355d85a-8e67-4fb0-97ad-f5c4586aa394)


## Changes

* Changes predictProblems.ts to also find non ASCII characters for email field.


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #1873
