### PR TITLE
Show full event start + end time on multi-day events in month calendar

### DIFF
--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -151,6 +151,8 @@ export const getActivitiesByDay = (
                       .second(0)
                       .millisecond(0)
                       .toISOString(),
+                    originalEndTime: event.data.end_time,
+                    originalStartTime: event.data.start_time,
                   },
                 };
 
@@ -171,6 +173,8 @@ export const getActivitiesByDay = (
                       .second(0)
                       .millisecond(0)
                       .toISOString(),
+                    originalEndTime: event.data.end_time,
+                    originalStartTime: event.data.start_time,
                     start_time: dayOfEvent
                       .hour(0)
                       .minute(0)
@@ -191,6 +195,8 @@ export const getActivitiesByDay = (
                   ...event,
                   data: {
                     ...event.data,
+                    originalEndTime: event.data.end_time,
+                    originalStartTime: event.data.start_time,
                     start_time: dayOfEvent
                       .hour(0)
                       .minute(0)

--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import { NonEventActivity } from 'features/campaigns/hooks/useClusteredActivities';
 import range from 'utils/range';
 import { removeOffset } from 'utils/dateUtils';
+import { ZetkinEvent } from 'utils/types/zetkin';
 import {
   ACTIVITIES,
   CampaignActivity,
@@ -105,9 +106,18 @@ const applyToHashmap = (
     };
   }
 };
+export type MultiDayEvent = ZetkinEvent & {
+  originalEndTime: string;
+  originalStartTime: string;
+};
+
+export type MultiDayEventActivity = {
+  data: MultiDayEvent;
+  kind: ACTIVITIES.EVENT;
+};
 
 export const getActivitiesByDay = (
-  activities: CampaignActivity[]
+  activities: (CampaignActivity | MultiDayEventActivity)[]
 ): Record<string, DaySummary> => {
   const dateHashmap: Record<string, DaySummary> = {};
 

--- a/src/features/campaigns/types.ts
+++ b/src/features/campaigns/types.ts
@@ -32,13 +32,8 @@ export type TaskActivity = CampaignActivityBase & {
   kind: ACTIVITIES.TASK;
 };
 
-export type MultiDayEvent = ZetkinEvent & {
-  originalEndTime: string;
-  originalStartTime: string;
-};
-
 export type EventActivity = CampaignActivityBase & {
-  data: ZetkinEvent | MultiDayEvent;
+  data: ZetkinEvent;
   kind: ACTIVITIES.EVENT;
 };
 

--- a/src/features/campaigns/types.ts
+++ b/src/features/campaigns/types.ts
@@ -32,8 +32,13 @@ export type TaskActivity = CampaignActivityBase & {
   kind: ACTIVITIES.TASK;
 };
 
+export type MultiDayEvent = ZetkinEvent & {
+  originalEndTime: string;
+  originalStartTime: string;
+};
+
 export type EventActivity = CampaignActivityBase & {
-  data: ZetkinEvent;
+  data: ZetkinEvent | MultiDayEvent;
   kind: ACTIVITIES.EVENT;
 };
 

--- a/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
@@ -8,7 +8,7 @@ import EventSelectionCheckBox from '../../EventSelectionCheckBox';
 import EventWarningIcons from '../../EventWarningIcons';
 import LocationLabel from '../../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
-import { MultiDayEvent } from 'features/campaigns/types';
+import { MultiDayEvent } from 'features/calendar/components/utils';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from '../StatusDot';
 import useEventState from 'features/events/hooks/useEventState';

--- a/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
@@ -8,6 +8,7 @@ import EventSelectionCheckBox from '../../EventSelectionCheckBox';
 import EventWarningIcons from '../../EventWarningIcons';
 import LocationLabel from '../../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
+import { MultiDayEvent } from 'features/campaigns/types';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from '../StatusDot';
 import useEventState from 'features/events/hooks/useEventState';
@@ -17,7 +18,7 @@ import ZUIIconLabel from 'zui/ZUIIconLabel';
 
 interface MultiEventListItemProps {
   clusterType: CLUSTER_TYPE;
-  event: ZetkinEvent;
+  event: ZetkinEvent | MultiDayEvent;
   onEventClick: (id: number) => void;
 }
 
@@ -30,8 +31,14 @@ const MultiEventListItem: FC<MultiEventListItemProps> = ({
   const messages = useMessages(messageIds);
   const state = useEventState(event.organization.id, event.id);
   const timeSpan = `${intl.formatTime(
-    removeOffset(event.start_time)
-  )}-${intl.formatTime(removeOffset(event.end_time))}`;
+    removeOffset(
+      'originalStartTime' in event ? event.originalStartTime : event.start_time
+    )
+  )}-${intl.formatTime(
+    removeOffset(
+      'originalEndTime' in event ? event.originalEndTime : event.end_time
+    )
+  )}`;
 
   return (
     <Box display="flex" flexDirection="column" paddingBottom={1} width="100%">

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -18,6 +18,7 @@ import EventSelectionCheckBox from '../EventSelectionCheckBox';
 import getEventUrl from 'features/events/utils/getEventUrl';
 import LocationLabel from '../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
+import { MultiDayEvent } from 'features/campaigns/types';
 import Quota from './Quota';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from './StatusDot';
@@ -47,7 +48,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 interface SingleEventProps {
-  event: ZetkinEvent;
+  event: ZetkinEvent | MultiDayEvent;
   onClickAway: () => void;
 }
 
@@ -197,8 +198,24 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         </Box>
         <Typography color="secondary" variant="body2">
           <ZUITimeSpan
-            end={new Date(removeOffset(event.end_time))}
-            start={new Date(removeOffset(event.start_time))}
+            end={
+              new Date(
+                removeOffset(
+                  'originalEndTime' in event
+                    ? event.originalEndTime
+                    : event.end_time
+                )
+              )
+            }
+            start={
+              new Date(
+                removeOffset(
+                  'originalStartTime' in event
+                    ? event.originalStartTime
+                    : event.start_time
+                )
+              )
+            }
           />
         </Typography>
       </Box>

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -18,7 +18,7 @@ import EventSelectionCheckBox from '../EventSelectionCheckBox';
 import getEventUrl from 'features/events/utils/getEventUrl';
 import LocationLabel from '../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
-import { MultiDayEvent } from 'features/campaigns/types';
+import { MultiDayEvent } from 'features/calendar/components/utils';
 import Quota from './Quota';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from './StatusDot';

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -73,8 +73,7 @@ const EventWarningIconsSansModel: FC<{
     if (!hasContact) {
       icons[0] = (
         <WarningSlot
-          key="contact"
-          icon={<FaceRetouchingOff color="error" />}
+          icon={<FaceRetouchingOff key="contact" color="error" />}
           tooltip={messages.activityList.eventItem.contact()}
         />
       );
@@ -84,8 +83,7 @@ const EventWarningIconsSansModel: FC<{
     if (numSignups > 0) {
       icons[1] = (
         <WarningSlot
-          key="signups"
-          icon={<EmojiPeople color="error" />}
+          icon={<EmojiPeople key="signups" color="error" />}
           tooltip={messages.activityList.eventItem.signups()}
         />
       );
@@ -94,8 +92,7 @@ const EventWarningIconsSansModel: FC<{
     if (numRemindersSent < numBooked) {
       icons[2] = (
         <WarningSlot
-          key="reminders"
-          icon={<MailOutline color="error" />}
+          icon={<MailOutline key="reminders" color="error" />}
           tooltip={messages.activityList.eventItem.reminders({
             numMissing: numParticipants - numRemindersSent,
           })}


### PR DESCRIPTION
## Description
This PR changes the EventPopper in the month calendar to display the full event's start and end times, when the event spans over multiple days. Before this, the time displayed showed as 00.00-00.00, since it technically spans over that whole day. This was, for obvious reasons, confusing. 

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/4b0ea10e-5df1-445a-9ef3-0063bc9a4aee)

## Changes
* Adds the properties originalEndTime and originalStartTime to multi day events
* uses these properties where appropriate to display the correct time information

## Related issues
Resolves #1878 
