### PR TITLE
Add dropdown of genders to smart search person data filter.

### DIFF
--- a/src/features/smartSearch/components/filters/PersonData/DisplayPersonData.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/DisplayPersonData.tsx
@@ -1,10 +1,11 @@
-import { Msg } from 'core/i18n';
 import {
   DATA_FIELD,
+  Gender,
   OPERATION,
   PersonDataFilterConfig,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
+import { Msg, useMessages } from 'core/i18n';
 
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
@@ -16,6 +17,7 @@ interface DisplayPersonDataProps {
 }
 
 const DisplayPersonData = ({ filter }: DisplayPersonDataProps): JSX.Element => {
+  const messages = useMessages(localMessageIds);
   const {
     config: { fields },
   } = filter;
@@ -27,12 +29,24 @@ const DisplayPersonData = ({ filter }: DisplayPersonDataProps): JSX.Element => {
     let existing;
     let criteriaString: JSX.Element | null = null;
     criteria.forEach((c) => {
+      let text: string;
+      const field = fields[c];
+
+      if (!field) {
+        text = '';
+      } else if (c !== DATA_FIELD.GENDER) {
+        text = field;
+      } else {
+        const gender = field as Gender;
+        text = messages.genders[gender]();
+      }
+
       existing = (
         <Msg
           id={localMessageIds.fieldMatches}
           values={{
             field: <UnderlinedMsg id={localMessageIds.fieldSelect[c]} />,
-            value: <UnderlinedText text={fields[c] || ''} />,
+            value: <UnderlinedText text={text} />,
           }}
         />
       );

--- a/src/features/smartSearch/components/filters/PersonData/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/index.tsx
@@ -7,6 +7,8 @@ import StyledTextInput from '../../inputs/StyledTextInput';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
   DATA_FIELD,
+  Gender,
+  genders,
   NewSmartSearchFilter,
   OPERATION,
   PersonDataFilterConfig,
@@ -56,6 +58,7 @@ const PersonData = ({
   ).map((f) => ({ field: f, value: filter.config.fields[f] || '' }));
 
   const [criteria, setCriteria] = useState<Criterion[]>(initialCriteria);
+  const [gender, setGender] = useState<Gender>('f');
 
   // check that there are no blank fields before submitting
   const submittable = criteria.every((c) => c.value.length);
@@ -153,13 +156,28 @@ const PersonData = ({
                 ))}
               </StyledSelect>
             ),
-            value: (
-              <StyledTextInput
-                inputString={c.value} // for dynamic width
-                onChange={(e) => handleValueChange(e.target.value, c)}
-                value={c.value}
-              />
-            ),
+            value:
+              c.field === DATA_FIELD.GENDER ? (
+                <StyledSelect
+                  onChange={(e) => {
+                    setGender(e.target.value as Gender);
+                    handleValueChange(e.target.value, c);
+                  }}
+                  value={gender}
+                >
+                  {genders.map((gender) => (
+                    <MenuItem key={gender} value={gender}>
+                      <Msg id={localMessageIds.genders[gender]} />
+                    </MenuItem>
+                  ))}
+                </StyledSelect>
+              ) : (
+                <StyledTextInput
+                  inputString={c.value} // for dynamic width
+                  onChange={(e) => handleValueChange(e.target.value, c)}
+                  value={c.value}
+                />
+              ),
           }}
         />
       );

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -134,6 +134,9 @@ export interface PersonDataFilterConfig {
   };
 }
 
+export type Gender = 'f' | 'm' | 'o' | 'unknown';
+export const genders: Gender[] = ['f', 'm', 'o', 'unknown'];
+
 export interface PersonFieldFilterConfig {
   after?: string;
   before?: string;

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -186,6 +186,12 @@ export default makeMessages('feat.smartSearch', {
       fieldTuple: m<{ first: ReactElement; second: ReactElement }>(
         '{first} and {second}'
       ),
+      genders: {
+        f: m('female'),
+        m: m('male'),
+        o: m('other'),
+        unknown: m('unknown'),
+      },
       inputString: m<{
         addRemoveSelect: ReactElement;
         criteria: ReactElement | string | null;


### PR DESCRIPTION
## Description
This PR adds a dropdown with selections when you want to find people by gender in the person data filter.


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/a24e8569-2091-435a-9f8e-fd873238872a)


## Changes
* Adds a dropdown box to select gender, to replace the free text 


## Related issues
Resolves #1060

