### PR TITLE
Only add campId property to query if you are in a project.

### DIFF
--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -70,7 +70,7 @@ const Calendar = () => {
       {
         pathname: undefined,
         query: {
-          campId: campId,
+          ...(campId && { campId: campId }),
           focusDate: focusedDate,
           orgId: orgId,
           timeScale: selectedTimeScale,


### PR DESCRIPTION
## Description
This PR attempts to fix a small bug where `campId` was added to the url without needing to be, when you visited the calendar for all projects.


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/57d0c2e3-33b0-4801-a8a0-2332b14dff91)

## Changes
* Adds condition to test if you are in a project, and if so adds `campId` property to the query


## Related issues
Resolves #1416
