### PR TITLE
Check if project exists before loading activity

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       const client = new BackendApiClient(ctx.req.headers);
 
       if (campId) {
-        //We don't want to load the event if its project does not exist
+        //We don't want to load the call assignment if its project does not exist
         //If this GET of the project fails, we end up in the catch block
         //and return a 404 to the client
         await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -22,6 +22,14 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     const { orgId, campId, callAssId } = ctx.params!;
     try {
       const client = new BackendApiClient(ctx.req.headers);
+
+      if (campId) {
+        //We don't want to load the event if its project does not exist
+        //If this GET of the project fails, we end up in the catch block
+        //and return a 404 to the client
+        await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);
+      }
+
       const data = await client.get<ZetkinCallAssignment>(
         `/api/orgs/${orgId}/call_assignments/${callAssId}`
       );

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -16,11 +16,20 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   async (ctx) => {
     const { orgId, campId, eventId } = ctx.params!;
     try {
-      const client = new BackendApiClient(ctx.req.headers);
-      const data = await client.get<ZetkinEvent>(
+      const backendApiClient = new BackendApiClient(ctx.req.headers);
+
+      if (campId) {
+        //We don't want to load the event if its project does not exist
+        //If this GET of the project fails, we end up in the catch block
+        //and return a 404 to the client
+        await backendApiClient.get(`/api/orgs/${orgId}/campaigns/${campId}`);
+      }
+
+      const event = await backendApiClient.get<ZetkinEvent>(
         `/api/orgs/${orgId}/actions/${eventId}`
       );
-      const actualCampaign = data.campaign?.id.toString() ?? 'standalone';
+      const actualCampaign = event.campaign?.id.toString() ?? 'standalone';
+
       if (actualCampaign !== campId) {
         return { notFound: true };
       }

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       const client = new BackendApiClient(ctx.req.headers);
 
       if (campId) {
-        //We don't want to load the event if its project does not exist
+        //We don't want to load the survey if its project does not exist
         //If this GET of the project fails, we end up in the catch block
         //and return a 404 to the client
         await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -24,6 +24,14 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     const { orgId, campId, surveyId } = ctx.params!;
     try {
       const client = new BackendApiClient(ctx.req.headers);
+
+      if (campId) {
+        //We don't want to load the event if its project does not exist
+        //If this GET of the project fails, we end up in the catch block
+        //and return a 404 to the client
+        await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);
+      }
+
       const data = await client.get<ZetkinSurvey>(
         `/api/orgs/${orgId}/surveys/${surveyId}`
       );


### PR DESCRIPTION
## Description
This PR solves a bug where you could still access activities that belonged to deleted projects via its url. 
Now we check if we have a `campId` query parameter and see if the project exists, and only load the activity if the project exists.

## Changes
* Adds a small `GET` of the project if an activity url has a `campId` parameter


## Related issues
Resolves #1576 
