### PR TITLE
Issue 1417/wrong numbers in popper

### DIFF
--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -47,8 +47,8 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
   const remindedParticipants =
     participants.filter((p) => p.reminder_sent != null && !p.cancelled)
       .length ?? 0;
-  const availParticipants =
-    participants.filter((p) => !p.cancelled).length ?? 0;
+
+  const availParticipants = eventData?.num_participants_available ?? 0;
   const reqParticipants = eventData?.num_participants_required ?? 0;
 
   const [newReqParticipants, setNewReqParticipants] = useState<number | null>(

--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -35,11 +35,21 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
   orgId,
 }) => {
   const eventData = useEvent(orgId, eventId).data;
-  const { pendingSignUps } = useEventParticipants(orgId, eventId);
+  const { pendingSignUps, participantsFuture } = useEventParticipants(
+    orgId,
+    eventId
+  );
+  const participants = participantsFuture.data || [];
+
   const { setReqParticipants } = useEventParticipantsMutations(orgId, eventId);
   const messages = useMessages(messageIds);
+
+  const remindedParticipants =
+    participants.filter((p) => p.reminder_sent != null && !p.cancelled)
+      .length ?? 0;
+  const availParticipants =
+    participants.filter((p) => !p.cancelled).length ?? 0;
   const reqParticipants = eventData?.num_participants_required ?? 0;
-  const availParticipants = eventData?.num_participants_available ?? 0;
 
   const [newReqParticipants, setNewReqParticipants] = useState<number | null>(
     reqParticipants
@@ -153,9 +163,9 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
             marginBottom={1}
           >
             <Typography color={'secondary'} component="h6" variant="subtitle1">
-              {messages.eventParticipantsCard.booked()}
+              {messages.eventParticipantsCard.notifications()}
             </Typography>
-            <Typography>{`${availParticipants}/${availParticipants}`}</Typography>
+            <Typography>{`${remindedParticipants}/${availParticipants}`}</Typography>
           </Box>
           <Box
             alignItems="center"

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -76,9 +76,10 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
     state == EventState.CANCELLED;
 
   const remindedParticipants =
-    participants.filter((p) => p.reminder_sent != null).length ?? 0;
+    participants.filter((p) => p.reminder_sent != null && !p.cancelled)
+      .length ?? 0;
   const availableParticipants =
-    participants.filter((p) => p.cancelled !== null).length ?? 0;
+    participants.filter((p) => !p.cancelled).length ?? 0;
   const signedParticipants =
     respondents.filter((r) => !participants.some((p) => p.id === r.id))
       .length ?? 0;

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -53,11 +53,11 @@ export default makeMessages('feat.events', {
     url: m('Link'),
   },
   eventParticipantsCard: {
-    booked: m('Notifications'),
     confirmed: m('Confirmed Attendance'),
     contact: m('Contact'),
     header: m('Participants'),
     noContact: m('None assigned'),
+    notifications: m('Notifications'),
     participantList: m('View participants'),
     pending: m('Pending sign-ups'),
     reqParticipantsHelperText: m('The minimum number of participants required'),

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -581,7 +581,9 @@ function updateAvailParticipantToState(
       }
     }
   }
-  state.statsByEventId[eventId].isStale = true;
+  if (state.statsByEventId[eventId]) {
+    state.statsByEventId[eventId].isStale = true;
+  }
 }
 
 export default eventsSlice;

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -581,6 +581,7 @@ function updateAvailParticipantToState(
       }
     }
   }
+  state.statsByEventId[eventId].isStale = true;
 }
 
 export default eventsSlice;


### PR DESCRIPTION
## Description
This PR fixes an error where event in popper, calendar and overview card display incorrect numbers of booked / noticed participants.


## Screenshots
 - Notified participant : 1, Booked participant : 1, Cancelled participant: 1
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/9a6f00c8-3d0f-467e-91a7-f60c75580392)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/0cf47a2f-1722-4857-ad86-f237ce1ab3c8)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/0133d565-34f0-4550-8b45-799941769d16)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/987e599c-4ea4-48be-9caf-eee0b16f6e9a)


## Changes

* Adds `updateAvailParticipantsToState` function
* Changes messageIds key `booked` to `noticifations`


## Notes to reviewer


## Related issues
Resolves #1417 
