### PR TITLE
issue-1889 and 1890 /wrong-times-in-calendar

### DIFF
--- a/src/features/calendar/components/EventCluster/MultiShift.tsx
+++ b/src/features/calendar/components/EventCluster/MultiShift.tsx
@@ -40,19 +40,9 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime
-                hour="numeric"
-                hour12={false}
-                minute="numeric"
-                value={removeOffset(event.start_time)}
-              />
+              <FormattedTime value={removeOffset(event.start_time)} />
               {'-'}
-              <FormattedTime
-                hour="numeric"
-                hour12={false}
-                minute="numeric"
-                value={removeOffset(event.end_time)}
-              />
+              <FormattedTime value={removeOffset(event.end_time)} />
             </>
           ),
           requiresAction: false,
@@ -101,19 +91,9 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime
-                hour="numeric"
-                hour12={false}
-                minute="numeric"
-                value={removeOffset(event.start_time)}
-              />
+              <FormattedTime value={removeOffset(event.start_time)} />
               {'-'}
-              <FormattedTime
-                hour="numeric"
-                hour12={false}
-                minute="numeric"
-                value={removeOffset(event.end_time)}
-              />
+              <FormattedTime value={removeOffset(event.end_time)} />
             </>
           ),
           requiresAction: false,

--- a/src/features/calendar/components/EventCluster/MultiShift.tsx
+++ b/src/features/calendar/components/EventCluster/MultiShift.tsx
@@ -40,9 +40,19 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime value={removeOffset(event.start_time)} />
+              <FormattedTime
+                hour="numeric"
+                hour12={false}
+                minute="numeric"
+                value={removeOffset(event.start_time)}
+              />
               {'-'}
-              <FormattedTime value={removeOffset(event.end_time)} />
+              <FormattedTime
+                hour="numeric"
+                hour12={false}
+                minute="numeric"
+                value={removeOffset(event.end_time)}
+              />
             </>
           ),
           requiresAction: false,
@@ -91,9 +101,19 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime value={removeOffset(event.start_time)} />
+              <FormattedTime
+                hour="numeric"
+                hour12={false}
+                minute="numeric"
+                value={removeOffset(event.start_time)}
+              />
               {'-'}
-              <FormattedTime value={removeOffset(event.end_time)} />
+              <FormattedTime
+                hour="numeric"
+                hour12={false}
+                minute="numeric"
+                value={removeOffset(event.end_time)}
+              />
             </>
           ),
           requiresAction: false,

--- a/src/features/calendar/components/EventCluster/MultiShift.tsx
+++ b/src/features/calendar/components/EventCluster/MultiShift.tsx
@@ -91,9 +91,9 @@ function createMultiShiftFieldGroups({
           kind: 'ScheduledTime',
           message: (
             <>
-              <FormattedTime value={event.start_time} />
+              <FormattedTime value={removeOffset(event.start_time)} />
               {'-'}
-              <FormattedTime value={event.end_time} />
+              <FormattedTime value={removeOffset(event.end_time)} />
             </>
           ),
           requiresAction: false,


### PR DESCRIPTION
## Description
This PR fixes a bug where event weekly view in calendar displays wrong event time in a multi-shift event.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/543e1cae-b312-4108-8e1c-db2fc42ccfa1)



## Changes

* Adds `removeOffset` to event times


## Notes to reviewer

## Related issues
Resolves #1889 
