### PR TITLE
Only try to fetch project if campId param is a number.

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const client = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
+      if (typeof campId === 'string' && !isNaN(parseInt(campId))) {
         //We don't want to load the call assignment if its project does not exist
         //If this GET of the project fails, we end up in the catch block
         //and return a 404 to the client

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -18,7 +18,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const backendApiClient = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
+      if (typeof campId === 'string' && !isNaN(parseInt(campId))) {
         //We don't want to load the event if its project does not exist
         //If this GET of the project fails, we end up in the catch block
         //and return a 404 to the client

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const client = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
+      if (typeof campId === 'string' && !isNaN(parseInt(campId))) {
         //We don't want to load the survey if its project does not exist
         //If this GET of the project fails, we end up in the catch block
         //and return a 404 to the client


### PR DESCRIPTION
## Description
This PR fixes a mistake in #1888 - to check that the `campId` param is a number before attempting to fetch the project.

## Changes
- checks if campId is a number 

## Related issues
none
