### PR TITLE
remove redundant padding top above event title

### DIFF
--- a/src/features/calendar/components/EventCluster/Event.tsx
+++ b/src/features/calendar/components/EventCluster/Event.tsx
@@ -207,7 +207,7 @@ const Event = ({
       {!collapsed && (
         <Box height="100%">
           <Box className={classes.titleContainer}>
-            <Box alignItems="center" display="flex" sx={{ pl: 1, pt: 0.8 }}>
+            <Box alignItems="center" display="flex" sx={{ pl: 1 }}>
               {(isHovered || selectedEvents.length > 0) && (
                 <EventSelectionCheckBox events={events} />
               )}


### PR DESCRIPTION
## Description
This PR fixes a bug where event hour lines in weekly view don't align with calendar's hour lines.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/aeb45b4a-d7cf-461e-b62b-5696fad498b2)



## Changes

* Removes `pt:0.8`


## Notes to reviewer


## Related issues
Resolves #1891 
