### PR TITLE
issue-1892/remove-dummy-title

### DIFF
--- a/src/features/calendar/components/EventShiftModal/EventShiftDetails.tsx
+++ b/src/features/calendar/components/EventShiftModal/EventShiftDetails.tsx
@@ -104,9 +104,13 @@ const EventShiftDetails: FC<EventShiftDetailsProps> = ({
       </ZUIFuture>
       <TextField
         fullWidth
+        InputLabelProps={{ shrink: true }}
         label={messages.eventShiftModal.customTitle()}
         maxRows={1}
         onChange={(ev) => onEventTitleChange(ev.target.value)}
+        placeholder={
+          eventTitle || type?.title || messages.eventShiftModal.noTitle()
+        }
         value={eventTitle}
       />
       <DatePicker

--- a/src/features/calendar/components/EventShiftModal/index.tsx
+++ b/src/features/calendar/components/EventShiftModal/index.tsx
@@ -84,7 +84,7 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
           num_participants_required: eventParticipants ? eventParticipants : 0,
           published: publish ? published.toISOString() : null,
           start_time: startDate.toISOString(),
-          title: eventTitle,
+          title: eventTitle || null,
           url: eventLink,
         },
         false

--- a/src/features/calendar/components/EventShiftModal/index.tsx
+++ b/src/features/calendar/components/EventShiftModal/index.tsx
@@ -26,9 +26,7 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
   const { orgId, campId } = useNumericRouteParams();
 
   const [type, setType] = useState<ZetkinEvent['activity']>(null);
-  const [eventTitle, setEventTitle] = useState<string>(
-    messages.eventShiftModal.noTitle()
-  );
+  const [eventTitle, setEventTitle] = useState<string>('');
   const [eventDate, setEventDate] = useState<Dayjs>(startDate);
   const [invalidDate, setInvalidDate] = useState(false);
   const [locationId, setLocationId] = useState<number | null>(null);
@@ -150,10 +148,8 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
               onTypeChange={(newType) => {
                 if (newType) {
                   setType(newType);
-                  setEventTitle(newType.title);
                 } else {
                   setType(null);
-                  setEventTitle(messages.eventShiftModal.noTitle());
                 }
               }}
               orgId={orgId}

--- a/src/features/calendar/components/EventShiftModal/index.tsx
+++ b/src/features/calendar/components/EventShiftModal/index.tsx
@@ -150,8 +150,10 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
               onTypeChange={(newType) => {
                 if (newType) {
                   setType(newType);
+                  setEventTitle(newType.title);
                 } else {
                   setType(null);
+                  setEventTitle(messages.eventShiftModal.noTitle());
                 }
               }}
               orgId={orgId}


### PR DESCRIPTION
## Description
This PR updates the title of multi-shift events when the event type changes. If there is no specified event type, it will display the default title.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/23bb38e6-450d-4b64-8a16-294855e1fbe9)

![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/15c21785-d441-4ffd-9a72-ea7c678482b8)



## Changes

* Adds `placeholder` and `InputLabelProps={{ shrink: true }}` in `TextField`


## Notes to reviewer


## Related issues
Resolves #1892 
