### PR TITLE
issue-1896/import-message-error-on-eight-rows

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
@@ -18,7 +18,7 @@ const ProblemRowsText: FC<Props> = ({ breakpoint = 8, rows }) => {
         values={{ row: rows[0] }}
       />
     );
-  } else if (rows.length < breakpoint) {
+  } else if (rows.length <= breakpoint) {
     const commaStr = rows.slice(0, -1).join(', ');
     const lastRow = rows[rows.length - 1];
     return (

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -242,7 +242,7 @@ export default makeMessages('feat.import', {
           'This problem exists on rows {commaRows} and {lastRow}.'
         ),
         manyRows: m<{ additionalRows: number; commaRows: string }>(
-          'This problem exists on rows {commaRows} and {additionalRows} additional rows.'
+          'This problem exists on rows {commaRows} and {additionalRows, plural, =1 {1 additional row} other {# additional rows}}.'
         ),
         singleRow: m<{ row: number }>('This problem exists on row {row}.'),
       },


### PR DESCRIPTION
## Description
This PR fixes a bug where an error message displays 'and 0 additional rows' at the end of the sentence if there are more than eight errored rows


## Screenshots
- 7 errored rows
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/f1d146d8-8a09-404f-ba7f-8d7a817856f8)
- 8 errored rows
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/b09e78b0-9fe7-43ba-94a3-17e2c7bcc9e9)
- 9 errored rows
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/b1aa46c3-844c-4c4f-b1e2-6f3be41eca6f)
- 10 errored rows
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/8fdde48e-e12f-44a2-8fad-2f974edbc9e2)



## Changes

* Changes `<` to `<=` in `ProblemRowsText`
* Changes messages for singular/plural case


## Notes to reviewer


## Related issues
Resolves #1896 
