### PR TITLE
Fix bug in inline link tool

### DIFF
--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -155,6 +155,7 @@ export function linkToolFactory(title: string) {
 
       this._container = document.createElement('div');
       this._container.style.padding = '8px';
+      this._container.style.display = 'none';
 
       this._container.appendChild(this._input);
       this._container.appendChild(this._inputStatusContainer);
@@ -166,6 +167,7 @@ export function linkToolFactory(title: string) {
       this._button = document.createElement('button');
       this._button.type = 'button';
       this._button.classList.add(this._api.styles.inlineToolButton);
+      this.updateButton(true);
       return this._button;
     }
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the inline link tool icon did not display correctly, and the field would always be visible. 

I still feel this tool is buggy, but this fixes the most acute problem.

## Changes
* Sets visibility to none when the element is first added
* Adds the svg to the icon button

## Related issues
none
