### PR TITLE
Revert changes introduced by #1888

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/index.tsx
@@ -23,13 +23,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const client = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
-        //We don't want to load the call assignment if its project does not exist
-        //If this GET of the project fails, we end up in the catch block
-        //and return a 404 to the client
-        await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);
-      }
-
       const data = await client.get<ZetkinCallAssignment>(
         `/api/orgs/${orgId}/call_assignments/${callAssId}`
       );

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -18,13 +18,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const backendApiClient = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
-        //We don't want to load the event if its project does not exist
-        //If this GET of the project fails, we end up in the catch block
-        //and return a 404 to the client
-        await backendApiClient.get(`/api/orgs/${orgId}/campaigns/${campId}`);
-      }
-
       const event = await backendApiClient.get<ZetkinEvent>(
         `/api/orgs/${orgId}/actions/${eventId}`
       );

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -25,13 +25,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     try {
       const client = new BackendApiClient(ctx.req.headers);
 
-      if (campId) {
-        //We don't want to load the survey if its project does not exist
-        //If this GET of the project fails, we end up in the catch block
-        //and return a 404 to the client
-        await client.get(`/api/orgs/${orgId}/campaigns/${campId}`);
-      }
-
       const data = await client.get<ZetkinSurvey>(
         `/api/orgs/${orgId}/surveys/${surveyId}`
       );


### PR DESCRIPTION
## Description
This PR undoes the changes that was introduced by #1888 , because we will instead handle this on the backend. 

## Changes
* Removes the check for `campId` and subsequent fetching of project

## Related issues
none
