### PR TITLE
Redirect /emails to project

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/emails/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/index.tsx
@@ -1,0 +1,16 @@
+import { GetServerSideProps } from 'next';
+import { scaffold } from 'utils/next';
+
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+  const { orgId, campId } = ctx.params!;
+  return {
+    redirect: {
+      destination: `/organize/${orgId}/projects/${campId}`,
+      permanent: false,
+    },
+  };
+});
+
+export default function NotUsed(): null {
+  return null;
+}


### PR DESCRIPTION
## Description
This PR adds a redirect to the project page from `/emails`

## Changes
* Adds `index.tsx` at `.../emails`, that redirects to the project

## Notes to reviewer
Is this where we want to redirect to? I just picked somethign

## Related issues
Resolves #1898 
