### PR TITLE
issue-1890/hours-in-month-view

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -34,7 +34,7 @@ import { useAppDispatch, useEnv, useNumericRouteParams } from 'core/hooks';
 dayjs.extend(isoWeek);
 
 const HOUR_HEIGHT = 80;
-const HOUR_COLUMN_WIDTH = '50px';
+const HOUR_COLUMN_WIDTH = '60px';
 
 export interface CalendarWeekViewProps {
   focusDate: Date;
@@ -112,10 +112,6 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         <Box>
           {range(24).map((hour: number) => {
             const time = dayjs().set('hour', hour).set('minute', 0).toString();
-            const is12HourClock = Intl.DateTimeFormat(navigator.language, {
-              hour: 'numeric',
-            }).resolvedOptions().hour12;
-
             return (
               <Box
                 key={`hour-${hour}`}
@@ -124,11 +120,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                 justifyContent="flex-end"
               >
                 <Typography color={theme.palette.grey[500]} variant="caption">
-                  <FormattedTime
-                    hour="numeric"
-                    minute={is12HourClock ? undefined : 'numeric'}
-                    value={time}
-                  />
+                  <FormattedTime hour="numeric" minute="numeric" value={time} />
                 </Typography>
               </Box>
             );

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -111,7 +111,11 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         {/* Hours column */}
         <Box>
           {range(24).map((hour: number) => {
-            const time = dayjs().set('hour', hour).set('minute', 0);
+            const time = dayjs().set('hour', hour).set('minute', 0).toString();
+            const is12HourClock = Intl.DateTimeFormat(navigator.language, {
+              hour: 'numeric',
+            }).resolvedOptions().hour12;
+
             return (
               <Box
                 key={`hour-${hour}`}
@@ -122,9 +126,8 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                 <Typography color={theme.palette.grey[500]} variant="caption">
                   <FormattedTime
                     hour="numeric"
-                    hour12={false}
-                    minute="numeric"
-                    value={time.toDate()}
+                    minute={is12HourClock ? undefined : 'numeric'}
+                    value={time}
                   />
                 </Typography>
               </Box>


### PR DESCRIPTION
## Description
This PR fixes a bug where the calendar only displays time in a 24-hour format on the hour lines.


## Screenshots
- 12hrs
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/7acaaf52-71b2-4f78-9cfb-bafa453247cf)

- 24hrs
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/e35d520e-85bb-4d9f-8287-6482eb6a2388)


## Changes

* Adds `.toString()` to time so that `FormattedTime` can show 12/24 hour automatically
* Creates `is12HourClock` to change `minute` prop in `FormattedTime`


## Notes to reviewer
I made `is12HourClock` to remove the minutes (":00") in `FormattedTime` on a 12-hour clock. This was necessary because of styles of text in calendar. When the hour is displayed as a two-digit number, the width for text becomes too narrow.
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/03f37f02-a8cd-486e-af8c-f7edcc823012)

I tried to increase the width of `Box` where texts are in. It would look good on 12 clock time like this
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/708dd328-4e43-4166-bd74-0be6cf8d8527)
But there was too much space between the time and day lane on the 24-hour clock.
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/5a7853d0-01eb-4002-a285-1287e0c491a0)

So I decided to remove minute to make it look nicer.

## Related issues
Resolves #1890 
