### PR TITLE
Fix breadcrumbs url when there is a standalone Event

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
@@ -3,12 +3,22 @@ import { scaffold } from 'utils/next';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, campId } = ctx.params!;
-  return {
-    redirect: {
-      destination: `/organize/${orgId}/projects/${campId}/calendar`,
-      permanent: false,
-    },
-  };
+
+  if (campId === 'standalone') {
+    return {
+      redirect: {
+        destination: `/organize/${orgId}/projects/calendar`,
+        permanent: false,
+      },
+    };
+  } else {
+    return {
+      redirect: {
+        destination: `/organize/${orgId}/projects/${campId}/calendar`,
+        permanent: false,
+      },
+    };
+  }
 });
 
 export default function NotUsed(): null {


### PR DESCRIPTION
## Description
This PR fixes the broken url in the breadcrumbs of standalone Events page.


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/36491300/4b4e4674-bf7e-4d7f-9d1e-64176d597f12



## Changes
* Adds a `if/else` case to redirect to` /organize/${orgId}/projects/calendar` in the cases that the Event doesn't belong to a project, so it's a standalone event. 


## Notes to reviewer
None


## Related issues
Resolves #1910 
