### PR TITLE
Fix incorrect link to public project page

### DIFF
--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -170,7 +170,7 @@ const CampaignActionButtons: React.FunctionComponent<
                   <Link
                     color="inherit"
                     display="flex"
-                    href={`/o/${orgId}/campaigns/${campId}`}
+                    href={`/o/${orgId}/projects/${campId}`}
                     sx={{ alignItems: 'center', gap: 1 }}
                     target="_blank"
                     underline="none"


### PR DESCRIPTION
## Description
This PR fixes an undocumented problem reported by several users in the last release. The public project page still only exists in Gen2, but there is a way to find the URL from Gen3. However, it turns out the URL for the link to the public project in Gen3 still includes the word "campaigns" (despite the general rename to "projects") but the redirect in the NEXT config only works for "projects". So users who try to access the public sign-up page via the project page ellipsis menu get a 404 instead of a redirect to Gen2.

## Screenshots
None

## Changes
* Changes "campaigns" to "projects" in public sign-up link

## Notes to reviewer
None

## Related issues
Undocumented