### PR TITLE
undocumented/create-person-endless-loading

### DIFF
--- a/src/zui/ZUICreatePerson/index.tsx
+++ b/src/zui/ZUICreatePerson/index.tsx
@@ -37,7 +37,7 @@ const ZUICreatePerson: FC<ZUICreatePersonProps> = ({
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const customFields = useCustomFields(orgId).data ?? [];
+  const customFields = useCustomFields(orgId).data;
   const createPerson = useCreatePerson(orgId);
 
   const [tags, setTags] = useState<number[]>([]);
@@ -61,14 +61,13 @@ const ZUICreatePerson: FC<ZUICreatePersonProps> = ({
             {title}
           </Typography>
         </Box>
-        {customFields.length === 0 && (
+        {!customFields ? (
           <Box
             sx={{ display: 'flex', justifyContent: 'center', m: 8, pr: '40px' }}
           >
             <CircularProgress />
           </Box>
-        )}
-        {customFields.length > 0 && (
+        ) : (
           <PersonalInfoForm
             onChange={(field, value) => {
               if (value === '') {
@@ -117,7 +116,8 @@ const ZUICreatePerson: FC<ZUICreatePersonProps> = ({
                 disabled={
                   personalInfo.first_name === undefined ||
                   personalInfo.last_name === undefined ||
-                  checkInvalidFields(customFields, personalInfo).length !== 0
+                  checkInvalidFields(customFields || [], personalInfo)
+                    .length !== 0
                 }
                 onClick={async (e) => {
                   const person = await createPerson(personalInfo, tags);


### PR DESCRIPTION
## Description
This PR fixes a bug where the 'Create' panel would only show the loading indicator when there are no custom fields


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/144b0303-14e5-4058-96ef-8128311aee97)


## Changes

* Changes to ternary operator and render circular progress when `customFields` is `null`


## Notes to reviewer


## Related issues
Undocumented. This bug was reported by Patrik
