### PR TITLE
Show if person has zetkin account or not

### DIFF
--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -37,7 +37,7 @@ export default makeMessages('feat.profile', {
     timeline: m('Timeline'),
   },
   user: {
-    hasAccount: m('Has Zetkin account'),
-    noAccount: m('No Zetkin account'),
+    hasAccount: m('Connected to a Zetkin account'),
+    noAccount: m('Not connected to a Zetkin account'),
   },
 });

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -36,4 +36,8 @@ export default makeMessages('feat.profile', {
     profile: m('Profile'),
     timeline: m('Timeline'),
   },
+  user: {
+    hasAccount: m('Has Zetkin account'),
+    noAccount: m('No Zetkin account'),
+  },
 });

--- a/src/features/profile/layout/SinglePersonLayout.tsx
+++ b/src/features/profile/layout/SinglePersonLayout.tsx
@@ -30,6 +30,15 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
       baseHref={`/organize/${orgId}/people/${personId}`}
       defaultTab="/"
       fixedHeight={fixedHeight}
+      subtitle={
+        <Msg
+          id={
+            person?.is_user
+              ? messageIds.user.hasAccount
+              : messageIds.user.noAccount
+          }
+        />
+      }
       tabs={[
         { href: `/`, label: messages.tabs.profile() },
         {
@@ -43,27 +52,14 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
         },
       ]}
       title={
-        <Box display="flex" flexDirection="column" justifyContent="center">
-          <Box>
-            <Typography variant="h3">
-              {`${person?.first_name} ${person?.last_name}`}
-            </Typography>
-            {person?.ext_id && (
-              <Typography
-                color="secondary"
-                variant="h3"
-              >{`\u00A0#${person?.ext_id}`}</Typography>
-            )}
-          </Box>
-          <Typography color="secondary" variant="body2">
-            <Msg
-              id={
-                person?.is_user
-                  ? messageIds.user.hasAccount
-                  : messageIds.user.noAccount
-              }
-            />
-          </Typography>
+        <Box alignContent="center" display="flex">
+          {`${person?.first_name} ${person?.last_name}`}
+          {person?.ext_id && (
+            <Typography
+              color="secondary"
+              variant="h3"
+            >{`\u00A0#${person?.ext_id}`}</Typography>
+          )}
         </Box>
       }
     >

--- a/src/features/profile/layout/SinglePersonLayout.tsx
+++ b/src/features/profile/layout/SinglePersonLayout.tsx
@@ -1,12 +1,11 @@
 import { FunctionComponent } from 'react';
 import { Box, Typography } from '@mui/material';
 
+import messageIds from '../l10n/messageIds';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
-import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from '../hooks/usePerson';
-
-import messageIds from '../l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
 
 interface SinglePersonLayoutProps {
   children: React.ReactNode;
@@ -44,19 +43,27 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
         },
       ]}
       title={
-        <Box
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-          }}
-        >
-          {`${person?.first_name} ${person?.last_name}`}
-          {person?.ext_id && (
-            <Typography
-              color="secondary"
-              variant="h3"
-            >{`\u00A0#${person?.ext_id}`}</Typography>
-          )}
+        <Box display="flex" flexDirection="column" justifyContent="center">
+          <Box>
+            <Typography variant="h3">
+              {`${person?.first_name} ${person?.last_name}`}
+            </Typography>
+            {person?.ext_id && (
+              <Typography
+                color="secondary"
+                variant="h3"
+              >{`\u00A0#${person?.ext_id}`}</Typography>
+            )}
+          </Box>
+          <Typography color="secondary" variant="body2">
+            <Msg
+              id={
+                person?.is_user
+                  ? messageIds.user.hasAccount
+                  : messageIds.user.noAccount
+              }
+            />
+          </Typography>
         </Box>
       }
     >

--- a/src/zui/ZUIPerson/index.tsx
+++ b/src/zui/ZUIPerson/index.tsx
@@ -18,7 +18,8 @@ const PersonLink: React.FunctionComponent<{
   id: number;
   link?: boolean;
   orgId: string | number;
-}> = ({ children, link, id, orgId }) => {
+  underline: boolean;
+}> = ({ children, link, id, orgId, underline }) => {
   if (link) {
     return (
       <NextLink
@@ -26,7 +27,10 @@ const PersonLink: React.FunctionComponent<{
         legacyBehavior
         passHref
       >
-        <Link style={{ cursor: 'pointer' }} underline="hover">
+        <Link
+          style={{ cursor: 'pointer' }}
+          underline={underline ? 'hover' : 'none'}
+        >
           {children}
         </Link>
       </NextLink>
@@ -57,7 +61,7 @@ const ZUIPerson: React.FunctionComponent<{
   const { orgId } = useRouter().query as { orgId: string };
 
   return (
-    <PersonLink id={id} link={link} orgId={orgId}>
+    <PersonLink id={id} link={link} orgId={orgId} underline={!showText}>
       <Box display="flex" {...containerProps}>
         <Tooltip title={tooltip ? name : ''}>
           <Avatar

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -12,6 +12,8 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 
+import messageIds from 'features/profile/l10n/messageIds';
+import { Msg } from 'core/i18n';
 import TagsList from 'features/tags/components/TagManager/components/TagsList';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from 'features/profile/hooks/usePerson';
@@ -92,6 +94,17 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
                     id={person?.id}
                     link
                     name={`${person?.first_name} ${person?.last_name}`}
+                    subtitle={
+                      <Typography color="secondary" variant="body2">
+                        <Msg
+                          id={
+                            person?.is_user
+                              ? messageIds.user.hasAccount
+                              : messageIds.user.noAccount
+                          }
+                        />
+                      </Typography>
+                    }
                     tooltip={false}
                   />
                 </Grid>


### PR DESCRIPTION
## Description
This PR adds subtitle under a person's name on the profile page and in the `ZUIPersonHoverCard` to indicate if the person has a Zetkin account or not.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/2e70200f-0691-4039-a849-de9f7c4aa3cd)

![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/c63be65a-370b-42b8-85d4-cc217404349e)

## Changes
* Adds message under profile title and under person's name on person hover card

## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #1886 
