### PR TITLE
Correct misspelled function name

### DIFF
--- a/src/features/campaigns/hooks/useActivityList.ts
+++ b/src/features/campaigns/hooks/useActivityList.ts
@@ -11,7 +11,7 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 
-export default function useAcitvityList(
+export default function useActivityList(
   orgId: number,
   campId?: number
 ): IFuture<CampaignActivity[]> {

--- a/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/activities/index.tsx
@@ -9,7 +9,7 @@ import messageIds from 'features/campaigns/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SingleCampaignLayout from 'features/campaigns/layout/SingleCampaignLayout';
-import useAcitvityList from 'features/campaigns/hooks/useActivityList';
+import useActivityList from 'features/campaigns/hooks/useActivityList';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
@@ -44,7 +44,7 @@ const CampaignActivitiesPage: PageWithLayout<
   const messages = useMessages(messageIds);
   const onServer = useServerSide();
   const { orgId, campId } = useNumericRouteParams();
-  const campaignActivitiesFuture = useAcitvityList(orgId, campId);
+  const campaignActivitiesFuture = useActivityList(orgId, campId);
 
   const [searchString, setSearchString] = useState('');
   const [filters, setFilters] = useState<ACTIVITIES[]>([

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -7,7 +7,7 @@ import FilterActivities from 'features/campaigns/components/ActivityList/FilterA
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
-import useAcitvityList from 'features/campaigns/hooks/useActivityList';
+import useActivityList from 'features/campaigns/hooks/useActivityList';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
@@ -32,7 +32,7 @@ const CampaignActivitiesPage: PageWithLayout = () => {
   const messages = useMessages(messageIds);
   const onServer = useServerSide();
   const { orgId, campId } = useNumericRouteParams();
-  const activitiesFuture = useAcitvityList(orgId, campId);
+  const activitiesFuture = useActivityList(orgId, campId);
   const [searchString, setSearchString] = useState('');
   const [filters, setFilters] = useState<ACTIVITIES[]>([
     ACTIVITIES.CALL_ASSIGNMENT,


### PR DESCRIPTION
## Description
This PR changes the function name useAcitvityList to useActivityList.

## Changes
* Changes the function name useAcitvityList to useActivityList in the useActivityList hook and in the files that import it.

## Notes to reviewer
none
