### PR TITLE
Issue 1880/titles truncate on middle

### DIFF
--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -1,5 +1,5 @@
 import { FormEvent } from 'react';
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 
 import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
@@ -141,7 +141,12 @@ const CallHistory = ({
                 )}
                 {assignmentsFuture.data?.map((a) => (
                   <MenuItem key={a.id} value={a.id}>
-                    {a.title}
+                    <Tooltip
+                      placement="right-start"
+                      title={a.title.length >= 40 ? a.title : ''}
+                    >
+                      <Box>{truncateOnMiddle(a.title, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -6,6 +6,7 @@ import { Msg } from 'core/i18n';
 import StyledNumberInput from '../../inputs/StyledNumberInput';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCallAssignments from 'features/callAssignments/hooks/useCallAssignments';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
@@ -116,9 +117,11 @@ const CallHistory = ({
                       <Msg
                         id={localMessageIds.assignmentSelect.assignment}
                         values={{
-                          assignmentTitle:
+                          assignmentTitle: truncateOnMiddle(
                             assignmentsFuture.data?.find((a) => a.id === value)
                               ?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );

--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -1,5 +1,5 @@
 import { FormEvent } from 'react';
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 
 import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
@@ -161,7 +161,12 @@ const CampaignParticipation = ({
                 </MenuItem>
                 {activities.map((a) => (
                   <MenuItem key={a.id} value={a.id}>
-                    {a.title}
+                    <Tooltip
+                      placement="right-start"
+                      title={a.title.length >= 40 ? a.title : ''}
+                    >
+                      <Box>{a.title}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -213,10 +213,8 @@ const CampaignParticipation = ({
                       <Msg
                         id={localMessageIds.campaignSelect.campaign}
                         values={{
-                          campaign: truncateOnMiddle(
+                          campaign:
                             campaigns.find((c) => c.id === value)?.title ?? '',
-                            40
-                          ),
                         }}
                       />
                     );

--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -5,6 +5,7 @@ import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import useEventLocations from 'features/events/hooks/useEventLocations';
 import useEventTypes from 'features/events/hooks/useEventTypes';
@@ -144,8 +145,10 @@ const CampaignParticipation = ({
                       <Msg
                         id={localMessageIds.activitySelect.activity}
                         values={{
-                          activity:
+                          activity: truncateOnMiddle(
                             activities.find((l) => l.id === value)?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );
@@ -210,8 +213,10 @@ const CampaignParticipation = ({
                       <Msg
                         id={localMessageIds.campaignSelect.campaign}
                         values={{
-                          campaign:
+                          campaign: truncateOnMiddle(
                             campaigns.find((c) => c.id === value)?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );
@@ -258,8 +263,10 @@ const CampaignParticipation = ({
                       <Msg
                         id={localMessageIds.locationSelect.location}
                         values={{
-                          location:
+                          location: truncateOnMiddle(
                             locations.find((l) => l.id === value)?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );

--- a/src/features/smartSearch/components/filters/EmailClick/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/index.tsx
@@ -7,6 +7,7 @@ import { Msg } from 'core/i18n';
 import StyledItemSelect from '../../inputs/StyledItemSelect';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import useEmailLinks from 'features/emails/hooks/useLinks';
 import useEmails from 'features/emails/hooks/useEmails';
@@ -145,7 +146,7 @@ const EmailClick = ({
                 >
                   {emailsFuture?.map((email) => (
                     <MenuItem key={`email-${email.id}`} value={email.id}>
-                      {`"${email.title}"`}
+                      {`"${truncateOnMiddle(email.title || '', 40)}"`}
                     </MenuItem>
                   ))}
                 </StyledSelect>

--- a/src/features/smartSearch/components/filters/EmailClick/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/index.tsx
@@ -52,7 +52,7 @@ const EmailClick = ({
   onSubmit,
 }: EmailClickProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();
-  const emailsFuture = useEmails(orgId).data || [];
+  const emails = useEmails(orgId).data || [];
   const projectsFuture = useCampaigns(orgId).data || [];
 
   const { filter, setConfig, setOp } =
@@ -142,22 +142,23 @@ const EmailClick = ({
                   onChange={(e) =>
                     setValueToKey('email', parseInt(e.target.value))
                   }
-                  SelectProps={{
-                    renderValue: function getLabel(value) {
-                      return truncateOnMiddle(
-                        `"${
-                          emailsFuture.find((email) => email.id === value)
-                            ?.title
-                        }"` ?? '',
-                        40
-                      );
-                    },
-                  }}
                   value={filter.config.email || ''}
                 >
-                  {emailsFuture?.map((email) => (
-                    <MenuItem key={`email-${email.id}`} value={email.id}>
-                      {`"${email.title}"`}
+                  {emails.map((email) => (
+                    <MenuItem key={email.id} value={email.id}>
+                      <Tooltip
+                        placement="right-start"
+                        title={
+                          !email.title || email.title.length < 40
+                            ? ''
+                            : email.title
+                        }
+                      >
+                        <Box>{`"${truncateOnMiddle(
+                          email.title ?? '',
+                          40
+                        )}"`}</Box>
+                      </Tooltip>
                     </MenuItem>
                   ))}
                 </StyledSelect>

--- a/src/features/smartSearch/components/filters/EmailClick/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/index.tsx
@@ -142,11 +142,22 @@ const EmailClick = ({
                   onChange={(e) =>
                     setValueToKey('email', parseInt(e.target.value))
                   }
+                  SelectProps={{
+                    renderValue: function getLabel(value) {
+                      return truncateOnMiddle(
+                        `"${
+                          emailsFuture.find((email) => email.id === value)
+                            ?.title
+                        }"` ?? '',
+                        40
+                      );
+                    },
+                  }}
                   value={filter.config.email || ''}
                 >
                   {emailsFuture?.map((email) => (
                     <MenuItem key={`email-${email.id}`} value={email.id}>
-                      {`"${truncateOnMiddle(email.title || '', 40)}"`}
+                      {`"${email.title}"`}
                     </MenuItem>
                   ))}
                 </StyledSelect>

--- a/src/features/smartSearch/components/filters/EmailHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailHistory/index.tsx
@@ -6,6 +6,7 @@ import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import useEmails from 'features/emails/hooks/useEmails';
 import { useNumericRouteParams } from 'core/hooks';
@@ -146,6 +147,17 @@ const EmailHistory = ({
                   onChange={(e) =>
                     setValueToKey('email', parseInt(e.target.value))
                   }
+                  SelectProps={{
+                    renderValue: function getLabel(value) {
+                      return truncateOnMiddle(
+                        `"${
+                          emailsFuture.find((email) => email.id === value)
+                            ?.title
+                        }"` ?? '',
+                        40
+                      );
+                    },
+                  }}
                   value={filter.config.email || ''}
                 >
                   {emailsFuture?.map((email) => (

--- a/src/features/smartSearch/components/filters/EmailHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailHistory/index.tsx
@@ -1,5 +1,5 @@
-import { MenuItem } from '@mui/material';
 import { useState } from 'react';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 
 import FilterForm from '../../FilterForm';
 import messageIds from 'features/smartSearch/l10n/messageIds';
@@ -147,22 +147,23 @@ const EmailHistory = ({
                   onChange={(e) =>
                     setValueToKey('email', parseInt(e.target.value))
                   }
-                  SelectProps={{
-                    renderValue: function getLabel(value) {
-                      return truncateOnMiddle(
-                        `"${
-                          emailsFuture.find((email) => email.id === value)
-                            ?.title
-                        }"` ?? '',
-                        40
-                      );
-                    },
-                  }}
                   value={filter.config.email || ''}
                 >
                   {emailsFuture?.map((email) => (
                     <MenuItem key={`email-${email.id}`} value={email.id}>
-                      {`"${email.title}"`}
+                      <Tooltip
+                        placement="right-start"
+                        title={
+                          !email.title || email.title.length < 40
+                            ? ''
+                            : email.title
+                        }
+                      >
+                        <Box>{`"${truncateOnMiddle(
+                          email.title ?? '',
+                          40
+                        )}"`}</Box>
+                      </Tooltip>
                     </MenuItem>
                   ))}
                 </StyledSelect>

--- a/src/features/smartSearch/components/filters/PersonView/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonView/index.tsx
@@ -1,9 +1,10 @@
 import { FormEvent } from 'react';
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 
 import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
 import StyledSelect from '../../inputs/StyledSelect';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import { useNumericRouteParams } from 'core/hooks';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import useViewTree from 'features/views/hooks/useViewTree';
@@ -124,7 +125,12 @@ const PersonView = ({
                 >
                   {personViews.map((v) => (
                     <MenuItem key={v.id} value={v.id}>
-                      {v.title}
+                      <Tooltip
+                        placement="right-start"
+                        title={v.title.length >= 40 ? v.title : ''}
+                      >
+                        <Box>{truncateOnMiddle(v.title, 40)}</Box>
+                      </Tooltip>
                     </MenuItem>
                   ))}
                 </StyledSelect>

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -1,9 +1,10 @@
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 import { FormEvent, useEffect, useState } from 'react';
 
 import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
 import StyledSelect from '../../inputs/StyledSelect';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCallAssignments from 'features/callAssignments/hooks/useCallAssignments';
 import { useNumericRouteParams } from 'core/hooks';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
@@ -262,7 +263,14 @@ const SubQuery = ({
                       >
                         {renderedOptions.map((o) => (
                           <MenuItem key={o.id} value={o.id}>
-                            {o.title}
+                            <Tooltip
+                              placement="right-start"
+                              title={
+                                !o.title || o.title.length < 40 ? '' : o.title
+                              }
+                            >
+                              <Box>{truncateOnMiddle(o.title ?? '', 40)}</Box>
+                            </Tooltip>
                           </MenuItem>
                         ))}
                       </StyledSelect>

--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -6,6 +6,7 @@ import FilterForm from '../../FilterForm';
 import { Msg } from 'core/i18n';
 import StyledItemSelect from '../../inputs/StyledItemSelect';
 import StyledSelect from '../../inputs/StyledSelect';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
   CONDITION_OPERATOR,
@@ -262,9 +263,11 @@ const SurveyOption = ({
                       <Msg
                         id={localMessageIds.questionSelect.question}
                         values={{
-                          question:
+                          question: truncateOnMiddle(
                             validQuestions.find((q) => q.id === value)?.question
                               .question ?? '',
+                            40
+                          ),
                         }}
                       />
                     );
@@ -295,8 +298,10 @@ const SurveyOption = ({
                       <Msg
                         id={localMessageIds.surveySelect.survey}
                         values={{
-                          surveyTitle:
+                          surveyTitle: truncateOnMiddle(
                             surveys.find((s) => s.id === value)?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );

--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -282,7 +282,16 @@ const SurveyOption = ({
                 )}
                 {validQuestions.map((q) => (
                   <MenuItem key={q.id} value={q.id}>
-                    {q.question.question}
+                    <Tooltip
+                      placement="right-start"
+                      title={
+                        q.question.question.length >= 40
+                          ? q.question.question
+                          : ''
+                      }
+                    >
+                      <Box>{truncateOnMiddle(q.question.question, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>
@@ -316,7 +325,12 @@ const SurveyOption = ({
                 )}
                 {surveys.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
-                    {s.title}
+                    <Tooltip
+                      placement="right-start"
+                      title={s.title.length >= 40 ? s.title : ''}
+                    >
+                      <Box>{truncateOnMiddle(s.title, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -1,9 +1,10 @@
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 import { FormEvent, useEffect, useState } from 'react';
 
 import FilterForm from '../../FilterForm';
 import StyledSelect from '../../inputs/StyledSelect';
 import StyledTextInput from '../../inputs/StyledTextInput';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
   ELEMENT_TYPE,
@@ -22,7 +23,6 @@ import {
 
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { truncateOnMiddle } from 'utils/stringUtils';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveysWithElements from 'features/surveys/hooks/useSurveysWithElements';
 const localMessageIds = messageIds.filters.surveyResponse;
@@ -245,7 +245,16 @@ const SurveyResponse = ({
                 )}
                 {validQuestions.map((q) => (
                   <MenuItem key={q.id} value={q.id}>
-                    {truncateOnMiddle(q.question.question, 50)}
+                    <Tooltip
+                      placement="right-start"
+                      title={
+                        q.question.question.length >= 40
+                          ? q.question.question
+                          : ''
+                      }
+                    >
+                      <Box>{truncateOnMiddle(q.question.question, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>
@@ -279,7 +288,12 @@ const SurveyResponse = ({
                 )}
                 {surveys.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
-                    {s.title}
+                    <Tooltip
+                      placement="right-start"
+                      title={s.title.length >= 40 ? s.title : ''}
+                    >
+                      <Box>{truncateOnMiddle(s.title, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -1,4 +1,4 @@
-import { MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 import { FormEvent, useEffect, useState } from 'react';
 
 import FilterForm from '../../FilterForm';
@@ -145,7 +145,12 @@ const SurveySubmission = ({
                 )}
                 {surveys.map((s) => (
                   <MenuItem key={s.id} value={s.id}>
-                    {s.title}
+                    <Tooltip
+                      placement="right-start"
+                      title={s.title.length >= 40 ? s.title : ''}
+                    >
+                      <Box>{truncateOnMiddle(s.title, 40)}</Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useState } from 'react';
 import FilterForm from '../../FilterForm';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
   NewSmartSearchFilter,
@@ -126,8 +127,10 @@ const SurveySubmission = ({
                       <Msg
                         id={localMessageIds.surveySelect.survey}
                         values={{
-                          surveyTitle:
+                          surveyTitle: truncateOnMiddle(
                             surveys.find((s) => s.id === value)?.title ?? '',
+                            40
+                          ),
                         }}
                       />
                     );

--- a/src/features/smartSearch/components/filters/Task/index.tsx
+++ b/src/features/smartSearch/components/filters/Task/index.tsx
@@ -6,6 +6,7 @@ import Matching from '../Matching';
 import { Msg } from 'core/i18n';
 import StyledSelect from '../../inputs/StyledSelect';
 import TimeFrame from '../TimeFrame';
+import { truncateOnMiddle } from 'utils/stringUtils';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import { useNumericRouteParams } from 'core/hooks';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
@@ -185,6 +186,23 @@ const Task = ({
             taskSelect: (
               <StyledSelect
                 onChange={(e) => handleTaskSelectChange(e.target.value)}
+                SelectProps={{
+                  renderValue: function getLabel(value) {
+                    return value === ANY_TASK ? (
+                      <Msg id={localMessageIds.taskSelect.any} />
+                    ) : (
+                      <Msg
+                        id={localMessageIds.taskSelect.task}
+                        values={{
+                          task: truncateOnMiddle(
+                            tasks.find((t) => t.id === value)?.title ?? '',
+                            40
+                          ),
+                        }}
+                      />
+                    );
+                  },
+                }}
                 value={filter.config.task || ANY_TASK}
               >
                 <MenuItem key={ANY_TASK} value={ANY_TASK}>

--- a/src/features/smartSearch/components/filters/Task/index.tsx
+++ b/src/features/smartSearch/components/filters/Task/index.tsx
@@ -1,5 +1,5 @@
 import { FormEvent } from 'react';
-import { Box, MenuItem } from '@mui/material';
+import { Box, MenuItem, Tooltip } from '@mui/material';
 
 import FilterForm from '../../FilterForm';
 import Matching from '../Matching';
@@ -210,10 +210,17 @@ const Task = ({
                 </MenuItem>
                 {tasks.map((t) => (
                   <MenuItem key={t.id} value={t.id}>
-                    <Msg
-                      id={localMessageIds.taskSelect.task}
-                      values={{ task: t.title }}
-                    />
+                    <Tooltip
+                      placement="right-start"
+                      title={t.title.length >= 40 ? t.title : ''}
+                    >
+                      <Box>
+                        <Msg
+                          id={localMessageIds.taskSelect.task}
+                          values={{ task: truncateOnMiddle(t.title, 40) }}
+                        />
+                      </Box>
+                    </Tooltip>
                   </MenuItem>
                 ))}
               </StyledSelect>

--- a/src/features/smartSearch/components/filters/Task/index.tsx
+++ b/src/features/smartSearch/components/filters/Task/index.tsx
@@ -214,12 +214,7 @@ const Task = ({
                       placement="right-start"
                       title={t.title.length >= 40 ? t.title : ''}
                     >
-                      <Box>
-                        <Msg
-                          id={localMessageIds.taskSelect.task}
-                          values={{ task: truncateOnMiddle(t.title, 40) }}
-                        />
-                      </Box>
+                      <Box>{truncateOnMiddle(t.title, 40)}</Box>
                     </Tooltip>
                   </MenuItem>
                 ))}


### PR DESCRIPTION
## Description
This PR fixes a bug where the long title of a survey/email/callassignment overexpanded, hindering users from seeing the entire smart search filters.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/e1a60ebf-4e90-4b35-b1f5-ccedb908466b)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/9877fdaa-c4f3-4cb2-b49a-010a715e897a)
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/e913537f-a54c-4198-8d75-2e8661e5b7f7)



## Changes

* Adds `truncateOnMiddle` for truncate titles.
* Adds `Tooltip`


## Notes to reviewer
I think `ellipsis` would look better in the popper! Let me know what you think!
I did not truncate campaign titles. Should I truncate that as well?


## Related issues
Resolves #1877 
