### PR TITLE
Remove space from email when importing

### DIFF
--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -821,6 +821,45 @@ describe('prepareImportOperations()', () => {
         },
       ]);
     });
+
+    it('removes leading/trailing spaces from email addresses', () => {
+      const configData: Sheet = {
+        columns: [
+          {
+            field: 'email',
+            kind: ColumnKind.FIELD,
+            selected: true,
+          },
+        ],
+        firstRowIsHeaders: false,
+        rows: [
+          {
+            data: [' clara@example.com '],
+          },
+          {
+            data: ['zetkin@example.com'],
+          },
+        ],
+        title: '',
+      };
+
+      const result = prepareImportOperations(configData, countryCode);
+      expect(result).toEqual([
+        {
+          data: {
+            email: 'clara@example.com',
+          },
+          op: 'person.import',
+        },
+        {
+          data: {
+            email: 'zetkin@example.com',
+          },
+          op: 'person.import',
+        },
+      ]);
+    });
+
     it('remove duplicated tagIds', () => {
       const configData: Sheet = {
         columns: [

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -68,6 +68,10 @@ export default function prepareImportOperations(
               value = parsedPhoneNumber.format('E.164');
             }
 
+            if (fieldKey == 'email') {
+              value = value.toString().trim();
+            }
+
             //If they have uppecase letters we parse to lower
             if (fieldKey == 'gender') {
               value = value.toString().toLowerCase();

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -104,6 +104,31 @@ describe('predictProblem()', () => {
     expect(problems).toEqual([]);
   });
 
+  it('ignores leading/trailing space in email', () => {
+    const sheet = makeFullSheet({
+      columns: [
+        {
+          idField: 'id',
+          kind: ColumnKind.ID_FIELD,
+          selected: true,
+        },
+        {
+          field: 'email',
+          kind: ColumnKind.FIELD,
+          selected: true,
+        },
+      ],
+      rows: [
+        {
+          data: [1, ' clara@example.com '],
+        },
+      ],
+    });
+
+    const problems = predictProblems(sheet, 'SE', []);
+    expect(problems).toEqual([]);
+  });
+
   it('ignores first row when header', () => {
     const sheet = makeFullSheet({
       columns: [

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -104,7 +104,10 @@ export function predictProblems(
               rowHasFirstName = true;
             } else if (column.field == 'last_name') {
               rowHasLastName = true;
-            } else if (column.field == 'email' && !isEmail(value.toString())) {
+            } else if (
+              column.field == 'email' &&
+              !isEmail(value.toString().trim())
+            ) {
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
               if (!isValidPhoneNumber(value.toString(), country)) {


### PR DESCRIPTION
## Description
This PR changes validation logic and preparation of import bulk ops so that leading/trailing spaces in an email address are removed before validating or sending to the server.

## Screenshots
N/A

## Changes
* Changes `predictProblems()` to ignore leading/trailing whitespace before checking email addresses
* Changes `prepareImportOperations()` to remove leading/trailing whitespace before ops are sent to the server

## Notes to reviewer
None

## Related issues
Resolves #1897 