### PR TITLE
Build survey URLs in a way that avoids unwanted trailing slashes

### DIFF
--- a/src/features/surveys/components/SurveyURLCard.tsx
+++ b/src/features/surveys/components/SurveyURLCard.tsx
@@ -5,6 +5,7 @@ import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
 
+import { buildUrl } from 'utils/stringUtils';
 import messageIds from '../l10n/messageIds';
 
 interface SurveyURLCardProps {
@@ -37,9 +38,15 @@ const SurveyURLCard = ({ isOpen, orgId, surveyId }: SurveyURLCardProps) => {
     >
       <Box display="flex" paddingBottom={2}>
         <ZUITextfieldToClipboard
-          copyText={`${process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
+          copyText={buildUrl(
+            process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN || '',
+            `/o/${orgId}/surveys/${surveyId}`
+          )}
         >
-          {`${process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
+          {buildUrl(
+            process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN || '',
+            `/o/${orgId}/surveys/${surveyId}`
+          )}
         </ZUITextfieldToClipboard>
       </Box>
       <Link

--- a/src/utils/stringUtils.spec.ts
+++ b/src/utils/stringUtils.spec.ts
@@ -1,4 +1,9 @@
-import { isInteger, stringToBool, truncateOnMiddle } from './stringUtils';
+import {
+  buildUrl,
+  isInteger,
+  stringToBool,
+  truncateOnMiddle,
+} from './stringUtils';
 
 describe('stringToBool()', () => {
   // Returns false
@@ -74,5 +79,19 @@ describe('isInteger()', () => {
     undefined as unknown as string,
   ])('should return false for non-integer string %p', (numberString) => {
     expect(isInteger(numberString)).toBe(false);
+  });
+});
+
+describe('buildUrl()', () => {
+  it('combines a hostname and path into a URL', () => {
+    expect(buildUrl('https://example.com', '/path/to/resource')).toEqual(
+      'https://example.com/path/to/resource'
+    );
+  });
+
+  it('strips trailing slashes from the hostname', () => {
+    expect(buildUrl('https://example.com/', '/path/to/resource')).toEqual(
+      'https://example.com/path/to/resource'
+    );
   });
 });

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -46,4 +46,8 @@ const truncateOnMiddle = (str: string, maxLength: number) => {
 export const isInteger = (str: string): boolean =>
   Number.isInteger(parseFloat(str));
 
-export { getEllipsedString, stringToBool, truncateOnMiddle };
+const buildUrl = (hostname: string, path: string): string => {
+  return `${hostname.replace(/\/$/, '')}${path}`;
+};
+
+export { getEllipsedString, stringToBool, truncateOnMiddle, buildUrl };


### PR DESCRIPTION
This is a possible implementation of the code change described in https://github.com/zetkin/app.zetkin.org/issues/1772. Seems like we might want to tweak some details here, like maybe the function name might want the word “instance” in it for example, but I think it's in the right ballpark in general!