### PR TITLE
issue-1582/random assignee on cell when editing

### DIFF
--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -287,14 +287,14 @@ const ZUIPersonGridEditCell: FC<{
                         )}
 
                         {searchResults.map((option, index) => {
-                          const optProps = autoComplete.getOptionProps({
-                            index,
-                            option,
-                          });
                           return (
                             <PersonListItem
                               key={option.id}
-                              itemProps={optProps}
+                              itemProps={{
+                                onClick: () => {
+                                  onUpdate(option);
+                                },
+                              }}
                               orgId={orgId}
                               person={option}
                               selected={


### PR DESCRIPTION
## Description
This PR fixes a bug where editing the assignee in a cell in a list sets a random person when the user types the same input as before


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/564bee8c-6d28-4a1c-97e3-f67bb6c2120d


## Changes

* Changes `itemProps`


## Notes to reviewer

## Related issues
Resolves #1582 
