### PR TITLE
Use overflow: auto rather than overflow: scroll on panes

### DIFF
--- a/src/utils/panes/Pane.tsx
+++ b/src/utils/panes/Pane.tsx
@@ -30,7 +30,7 @@ const Pane: FC<PaneProps> = ({ children, onClose }) => {
       <Box
         sx={{
           flex: 1,
-          overflowY: 'scroll',
+          overflowY: 'auto',
           padding: 2,
         }}
       >


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/1961. This issue is caused by the use of `overflow-y: scroll` in a case where `overflow-y: auto` would have been better. More details at https://kilianvalkhof.com/2021/css-html/you-want-overflow-auto-not-overflow-scroll/.

This is difficult to reproduce on a Mac due to the system default behavior of hiding scroll bars automatically. I temporarily switched my system configuration to match that of a Windows or Linux system like so.

![Show scroll bars: always](https://github.com/zetkin/app.zetkin.org/assets/566159/038e0d6a-46c6-41b6-8aed-c1710f57522a)

By doing this I was able to reproduce the issue locally and confirm that this code fix addresses it.

| Before | After |
|-|-|
| ![Screenshot 2024-05-15 at 21 13 33](https://github.com/zetkin/app.zetkin.org/assets/566159/0bdc745c-7731-4209-b0ff-4dc1e2bf7dd4) | ![Screenshot 2024-05-15 at 21 13 46](https://github.com/zetkin/app.zetkin.org/assets/566159/b3856d05-d898-4c1a-878e-5b685de7d0ec) |