### PR TITLE
Undocumented/table buttons

### DIFF
--- a/src/features/settings/hooks/useRolesMutations.tsx
+++ b/src/features/settings/hooks/useRolesMutations.tsx
@@ -1,0 +1,45 @@
+import { ZetkinOfficial } from 'utils/types/zetkin';
+import { accessDeleted, adminDemoted, organizerPromoted } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+
+type useRolesMutationsReturn = {
+  demoteAdmin: (personId: number) => void;
+  promoteOrganizer: (personId: number) => void;
+  removeAccess: (personId: number) => void;
+};
+
+export default function useRolesMutations(
+  orgId: number
+): useRolesMutationsReturn {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  const demoteAdmin = async (personId: number) => {
+    return apiClient
+      .put<ZetkinOfficial>(`/api/orgs/${orgId}/officials/${personId}`, {
+        role: 'organizer',
+      })
+      .then((user) => {
+        dispatch(adminDemoted([personId, user]));
+        return user;
+      });
+  };
+
+  const promoteOrganizer = async (personId: number) => {
+    return apiClient
+      .put<ZetkinOfficial>(`/api/orgs/${orgId}/officials/${personId}`, {
+        role: 'admin',
+      })
+      .then((user) => {
+        dispatch(organizerPromoted([personId, user]));
+        return user;
+      });
+  };
+
+  const removeAccess = async (personId: number) => {
+    await apiClient.delete(`/api/orgs/${orgId}/officials/${personId}`);
+    dispatch(accessDeleted(personId));
+  };
+
+  return { demoteAdmin, promoteOrganizer, removeAccess };
+}

--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -26,4 +26,10 @@ export default makeMessages('feat.settings', {
     access: m('Access'),
     title: m('Settings'),
   },
+  tableButtons: {
+    demote: m('Demote'),
+    promote: m('Promote'),
+    remove: m('Remove'),
+  },
+  you: m('You'),
 });

--- a/src/features/settings/store.tsx
+++ b/src/features/settings/store.tsx
@@ -1,6 +1,6 @@
 import { ZetkinOfficial } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { remoteList, RemoteList } from 'utils/storeUtils';
+import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 
 export interface RolesStoreSlice {
   rolesList: RemoteList<ZetkinOfficial>;
@@ -14,6 +14,37 @@ const RolesSlice = createSlice({
   initialState,
   name: 'roles',
   reducers: {
+    accessDeleted: (state, action: PayloadAction<number>) => {
+      const officialId = action.payload;
+      state.rolesList.items = state.rolesList.items.filter(
+        (user) => user.id !== officialId
+      );
+    },
+    adminDemoted: (state, action: PayloadAction<[number, ZetkinOfficial]>) => {
+      const [userId, user] = action.payload;
+      const item = state.rolesList.items.find((item) => item.id === userId);
+
+      if (item) {
+        item.data = { ...item.data, ...user };
+        item.mutating = [];
+      } else {
+        state.rolesList.items.push(remoteItem(userId, { data: user }));
+      }
+    },
+    organizerPromoted: (
+      state,
+      action: PayloadAction<[number, ZetkinOfficial]>
+    ) => {
+      const [userId, user] = action.payload;
+      const item = state.rolesList.items.find((item) => item.id === userId);
+
+      if (item) {
+        item.data = { ...item.data, ...user };
+        item.mutating = [];
+      } else {
+        state.rolesList.items.push(remoteItem(userId, { data: user }));
+      }
+    },
     rolesLoad: (state) => {
       state.rolesList.isLoading = true;
     },
@@ -28,4 +59,10 @@ const RolesSlice = createSlice({
 });
 
 export default RolesSlice;
-export const { rolesLoaded, rolesLoad } = RolesSlice.actions;
+export const {
+  accessDeleted,
+  adminDemoted,
+  organizerPromoted,
+  rolesLoaded,
+  rolesLoad,
+} = RolesSlice.actions;

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -1,13 +1,16 @@
 import { GetServerSideProps } from 'next';
-import { Box, Typography } from '@mui/material';
+import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
+import { Box, Button, FormControl, Typography } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 
 import messageIds from 'features/settings/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SettingsLayout from 'features/settings/layout/SettingsLayout';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
 import useNumericRouteParams from 'core/hooks/useNumericRouteParams';
 import useRoles from 'features/settings/hooks/useRoles';
+import useRolesMutations from 'features/settings/hooks/useRolesMutations';
 import useServerSide from 'core/useServerSide';
 import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
@@ -29,6 +32,9 @@ const SettingsPage: PageWithLayout = () => {
   const { orgId } = useNumericRouteParams();
   const roles = useRoles(orgId).data || [];
   const messages = useMessages(messageIds);
+  const { demoteAdmin, promoteOrganizer, removeAccess } =
+    useRolesMutations(orgId);
+  const user = useCurrentUser();
 
   if (onServer) {
     return null;
@@ -71,6 +77,68 @@ const SettingsPage: PageWithLayout = () => {
       ),
       resizable: false,
       sortingOrder: ['asc', 'desc', null],
+    },
+    {
+      align: 'right',
+      disableColumnMenu: true,
+      field: 'cancel',
+      flex: 1,
+      headerName: '',
+      minWidth: 300,
+      renderCell: (params) => {
+        if (params.row.id === user?.id) {
+          return <Typography>{messages.you()}</Typography>;
+        } else if (params.row.role === 'admin') {
+          return (
+            <FormControl
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 2,
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Button onClick={() => demoteAdmin(params.row.id)} size="small">
+                <ArrowDownward />
+                {messages.tableButtons.demote()}
+              </Button>
+              <Button
+                onClick={() => removeAccess(params.row.id)}
+                size="small"
+                variant="outlined"
+              >
+                {messages.tableButtons.remove()}
+              </Button>
+            </FormControl>
+          );
+        } else {
+          return (
+            <FormControl
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 2,
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Button
+                onClick={() => promoteOrganizer(params.row.id)}
+                size="small"
+              >
+                <ArrowUpward />
+                {messages.tableButtons.promote()}
+              </Button>
+              <Button
+                onClick={() => removeAccess(params.row.id)}
+                size="small"
+                variant="outlined"
+              >
+                {messages.tableButtons.remove()}
+              </Button>
+            </FormControl>
+          );
+        }
+      },
     },
   ];
 


### PR DESCRIPTION
## Description
This PR adds the logic and components to promote, demote and remove access.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/36491300/fb071ca9-069a-425f-86c4-955f878f26f2)


## Changes

* Adds `useRolesMutations ` hook to dispatch the necessary actions
* Adds the `promote`, `demote `and `removeAccess ` actions in the store
* Adds buttons to the tables and logic to implement actions.


## Notes to reviewer
WIP


## Related issues
Related to access management task.
