### PR TITLE
Remove events from calender on event deletion

### DIFF
--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -57,7 +57,7 @@ export default function useEventsFromDateRange(
   const events = dateRange.flatMap((date) => {
     const dateStr = date.slice(0, 10);
     return eventsState.eventsByDate[dateStr].items
-      .filter((item) => !!item.data)
+      .filter((item) => !!item.data && !item.deleted)
       .map((item) => item.data) as ZetkinEvent[];
   });
 

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -120,7 +120,6 @@ const eventsSlice = createSlice({
 
       if (eventListItem) {
         eventListItem.deleted = true;
-        state.eventList.isStale = true;
       }
 
       for (const date in state.eventsByDate) {
@@ -130,7 +129,6 @@ const eventsSlice = createSlice({
 
         if (item) {
           item.deleted = true;
-          state.eventsByDate[date].isStale = true;
         }
       }
 
@@ -141,7 +139,6 @@ const eventsSlice = createSlice({
 
         if (item) {
           item.deleted = true;
-          state.eventsByCampaignId[campaignId].isStale = true;
         }
       }
     },


### PR DESCRIPTION
## Description
This PR removes an event from the calendar when the event is deleted.


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/143598480/4afe456c-3551-41ce-a7d8-f33f640477df


## Changes
* Filter out deleted events from calendar
* Remove all isStale from eventDeleted


## Notes to reviewer
None


## Related issues
Resolves #1950 
