### PR TITLE
issue-1951/endless-spinner

### DIFF
--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -512,24 +512,23 @@ const eventsSlice = createSlice({
 
 function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
   events.forEach((event) => {
-    const dateStr = event.start_time.slice(0, 10);
-
-    if (!state.eventsByDate[dateStr]) {
-      state.eventsByDate[dateStr] = remoteList();
-    }
-
     const eventListItem = state.eventList.items.find(
       (item) => item.id == event.id
     );
-    const eventByDateItem = state.eventsByDate[dateStr].items.find(
-      (item) => item.id == event.id
-    );
-
     if (eventListItem) {
       eventListItem.data = { ...eventListItem.data, ...event };
     } else {
       state.eventList.items.push(remoteItem(event.id, { data: event }));
     }
+
+    const dateStr = event.start_time.slice(0, 10);
+
+    if (!state.eventsByDate[dateStr]) {
+      state.eventsByDate[dateStr] = remoteList();
+    }
+    const eventByDateItem = state.eventsByDate[dateStr].items.find(
+      (item) => item.id == event.id
+    );
 
     if (eventByDateItem) {
       eventByDateItem.data = { ...eventByDateItem.data, ...event };
@@ -539,6 +538,9 @@ function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
         remoteItem(event.id, { data: event })
       );
     }
+    state.eventsByDate[dateStr].isLoading = false;
+    state.eventsByDate[dateStr].isStale = false;
+    state.eventsByDate[dateStr].loaded = new Date().toISOString();
 
     const campaign = event.campaign;
     if (campaign) {


### PR DESCRIPTION
## Description
This PR fixes endless spinner in calendar day view


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/070ecfbe-1cd7-4c7f-8ca5-e234a7b5b3d4



## Changes

* Adds `false` to `isLoading`, `isStale`. And set timestamp to `loaded`


## Notes to reviewer


## Related issues
Resolves #1951 
Resolves #1968 
