### PR TITLE
issue-1956/assigned-avatar-resets

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -4,7 +4,6 @@ import {
   GridColDef,
   GridRenderCellParams,
   GridRenderEditCellParams,
-  GridValueGetterParams,
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
 
@@ -42,20 +41,10 @@ export default class LocalPersonColumnType
       headerAlign: 'center',
 
       renderCell: (params: GridRenderCellParams) => {
-        return <ZUIPersonGridCell person={params.row[params.field]} />;
+        return <ZUIPersonGridCell person={params.value} />;
       },
       renderEditCell: (params: GridRenderEditCellParams) => {
-        return (
-          <EditCell
-            cell={params.row[params.field]}
-            column={col}
-            row={params.row}
-          />
-        );
-      },
-      valueGetter: (params: GridValueGetterParams) => {
-        const cell = params.row[params.field];
-        return this.cellToString(cell);
+        return <EditCell cell={params.value} column={col} row={params.row} />;
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -53,7 +53,9 @@ export default class LocalPersonColumnType
         if (!v2) {
           return -1;
         }
-        return v1.first_name.localeCompare(v2.first_name);
+        const name1 = `${v1.first_name} ${v1.last_name}`;
+        const name2 = `${v2.first_name} ${v2.last_name}`;
+        return name1.localeCompare(name2);
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -46,7 +46,15 @@ export default class LocalPersonColumnType
       renderEditCell: (params: GridRenderEditCellParams) => {
         return <EditCell cell={params.value} column={col} row={params.row} />;
       },
-      sortComparator: (v1, v2) => v1?.first_name.localeCompare(v2?.first_name),
+      sortComparator: (v1, v2) => {
+        if (!v1) {
+          return 1;
+        }
+        if (!v2) {
+          return -1;
+        }
+        return v1.first_name.localeCompare(v2.first_name);
+      },
     };
   }
   getSearchableStrings(cell: LocalPersonViewCell): string[] {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -46,6 +46,7 @@ export default class LocalPersonColumnType
       renderEditCell: (params: GridRenderEditCellParams) => {
         return <EditCell cell={params.value} column={col} row={params.row} />;
       },
+      sortComparator: (v1, v2) => v1?.first_name.localeCompare(v2?.first_name),
     };
   }
   getSearchableStrings(cell: LocalPersonViewCell): string[] {


### PR DESCRIPTION
## Description
This PR fixes a bug where assigned avatar resets only in UI after editing the cell.


## Screenshots


https://github.com/zetkin/app.zetkin.org/assets/77925373/e77e5a4a-0e84-4ab9-a6f5-2358ab940f0c



## Changes

* Removes `valueGetter` that converts object to string
* Adds `sortComparator` for sorting assignee


## Notes to reviewer

## Related issues
Resolves #1956 
