### PR TITLE
Add page to be displayed after a user unsubscribes from email

### DIFF
--- a/src/app/o/[orgId]/unsubscribed/page.tsx
+++ b/src/app/o/[orgId]/unsubscribed/page.tsx
@@ -1,0 +1,29 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import UnsubscribedPage from 'features/emails/pages/UnsubscribedPage';
+import { ZetkinOrganization } from 'utils/types/zetkin';
+
+type PageProps = {
+  params: {
+    orgId: string;
+  };
+};
+
+export default async function Page({ params }: PageProps) {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+
+  try {
+    const org = await apiClient.get<ZetkinOrganization>(
+      `/api/orgs/${params.orgId}`
+    );
+
+    return <UnsubscribedPage org={org} />;
+  } catch (err) {
+    return notFound();
+  }
+}

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -175,6 +175,12 @@ export default makeMessages('feat.emails', {
     ),
     unsubButton: m('Unsubscribe me'),
   },
+  unsubscribedPage: {
+    h: m('Unsubscribed!'),
+    info: m<{ org: string }>(
+      'You have been unsubscribed from mass email from {org}.'
+    ),
+  },
   varDefaults: {
     target: m('reader'),
   },

--- a/src/features/emails/pages/UnsubscribedPage.tsx
+++ b/src/features/emails/pages/UnsubscribedPage.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { ZetkinOrganization } from 'utils/types/zetkin';
+
+type Props = {
+  org: ZetkinOrganization;
+};
+
+const UnsubscribedPage: FC<Props> = ({ org }) => {
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        width: '100vw',
+      }}
+    >
+      <Box maxWidth={500}>
+        <Typography mb={1} variant="h4">
+          <Msg id={messageIds.unsubscribedPage.h} />
+        </Typography>
+        <Typography>
+          <Msg
+            id={messageIds.unsubscribedPage.info}
+            values={{ org: org.title }}
+          />
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default UnsubscribedPage;


### PR DESCRIPTION
## Description
This PR adds a page that users will be redirected to after visiting the magic "unsubscribe" URL that they are linked to from the already existing /o/{org_id}/unsubscribe page, added by #1861.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/fd3c1c66-0c92-4ecc-ac14-a64ef843f0f9)

## Changes
* Adds a very simple page

## Notes to reviewer
None

## Related issues
Undocumented