### PR TITLE
Issue 1973/ Clickable phone numbers in participant list

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -1,10 +1,9 @@
-import FaceOutlinedIcon from '@mui/icons-material/FaceOutlined';
-import { FC } from 'react';
 import {
   Box,
   Button,
   FormControl,
   InputLabel,
+  Link,
   MenuItem,
   Select,
   Tooltip,
@@ -12,6 +11,8 @@ import {
 } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 
+import FaceOutlinedIcon from '@mui/icons-material/FaceOutlined';
+import { FC } from 'react';
 import filterParticipants from '../utils/filterParticipants';
 import messageIds from 'features/events/l10n/messageIds';
 import noPropagate from 'utils/noPropagate';
@@ -193,12 +194,14 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       renderCell: (params) => {
         if (params.row.person) {
           return (
-            <a href={'tel:' + params.row.person.phone}>
+            <Link href={'tel:' + params.row.person.phone}>
               {params.row.person.phone}
-            </a>
+            </Link>
           );
         } else {
-          return <a href={'tel:' + params.row.phone}>{params.row.phone}</a>;
+          return (
+            <Link href={'tel:' + params.row.phone}>{params.row.phone}</Link>
+          );
         }
       },
       resizable: false,
@@ -212,12 +215,14 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       renderCell: (params) => {
         if (params.row.person) {
           return (
-            <a href={'mailto:' + params.row.person.email}>
+            <Link href={'mailto:' + params.row.person.email}>
               {params.row.person.email}
-            </a>
+            </Link>
           );
         } else {
-          return <a href={'mailto:' + params.row.email}>{params.row.email}</a>;
+          return (
+            <Link href={'mailto:' + params.row.email}>{params.row.email}</Link>
+          );
         }
       },
       resizable: false,

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -192,11 +192,15 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       headerName: messages.eventParticipantsList.columnPhone(),
       resizable: false,
       sortingOrder: ['asc', 'desc', null],
-      valueGetter: (params) => {
+      renderCell: (params) => {
         if (params.row.person) {
-          return params.row.person.phone;
+          return (
+            <a href={'tel:' + params.row.person.phone}>
+              {params.row.person.phone}
+            </a>
+          );
         } else {
-          return params.row.phone;
+          return <a href={'tel:' + params.row.phone}>{params.row.phone}</a>;
         }
       },
     },
@@ -207,11 +211,15 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       headerName: messages.eventParticipantsList.columnEmail(),
       resizable: false,
       sortingOrder: ['asc', 'desc', null],
-      valueGetter: (params) => {
+      renderCell: (params) => {
         if (params.row.person) {
-          return params.row.person.email;
+          return (
+            <a href={'mailto:' + params.row.person.email}>
+              {params.row.person.email}
+            </a>
+          );
         } else {
-          return params.row.email;
+          return <a href={'mailto:' + params.row.email}>{params.row.email}</a>;
         }
       },
     },

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -190,8 +190,6 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       field: 'phone',
       flex: 1,
       headerName: messages.eventParticipantsList.columnPhone(),
-      resizable: false,
-      sortingOrder: ['asc', 'desc', null],
       renderCell: (params) => {
         if (params.row.person) {
           return (
@@ -203,14 +201,14 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           return <a href={'tel:' + params.row.phone}>{params.row.phone}</a>;
         }
       },
+      resizable: false,
+      sortingOrder: ['asc', 'desc', null],
     },
     {
       disableColumnMenu: true,
       field: 'email',
       flex: 1,
       headerName: messages.eventParticipantsList.columnEmail(),
-      resizable: false,
-      sortingOrder: ['asc', 'desc', null],
       renderCell: (params) => {
         if (params.row.person) {
           return (
@@ -222,6 +220,8 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           return <a href={'mailto:' + params.row.email}>{params.row.email}</a>;
         }
       },
+      resizable: false,
+      sortingOrder: ['asc', 'desc', null],
     },
     {
       disableColumnMenu: true,

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -3,9 +3,11 @@ import PhoneIcon from '@mui/icons-material/Phone';
 import {
   Box,
   BoxProps,
+  Button,
   Card,
   Fade,
   Grid,
+  Link,
   Popper,
   PopperProps,
   Typography,
@@ -21,6 +23,7 @@ import usePersonTags from 'features/tags/hooks/usePersonTags';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUICopyToClipboard from 'zui/ZUICopyToClipboard';
 import ZUIPerson from 'zui/ZUIPerson';
+import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 
 const ZUIPersonHoverCard: React.FunctionComponent<{
   BoxProps?: BoxProps;
@@ -122,23 +125,35 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
                   .filter((field) => !!person[field])
                   .map((field) => {
                     const value = person[field];
+                    const linkType = field.includes('mail')
+                      ? 'mailto:'
+                      : field.includes('phone')
+                      ? 'tel:'
+                      : '';
+
                     if (typeof value === 'object') {
                       return null;
                     }
                     return (
                       <Grid key={field} container item>
-                        <ZUICopyToClipboard copyText={value as string}>
-                          <Box display="flex" flexDirection="row">
-                            {field.includes('mail') ? (
-                              <MailIcon color="secondary" />
-                            ) : (
-                              <PhoneIcon color="secondary" />
-                            )}
-                            <Typography style={{ marginLeft: '1.5rem' }}>
-                              {value}
-                            </Typography>
-                          </Box>
-                        </ZUICopyToClipboard>
+                        <Box display="flex" flexDirection="row">
+                          {field.includes('mail') ? (
+                            <MailIcon color="secondary" />
+                          ) : (
+                            <PhoneIcon color="secondary" />
+                          )}
+                          <Typography style={{ marginLeft: '1.5rem' }}>
+                            <a href={linkType + value}> {value} </a>
+                          </Typography>
+                          <Button
+                            onClick={() =>
+                              navigator.clipboard.writeText(value as string)
+                            }
+                            style={{ marginTop: '-0.3rem' }}
+                          >
+                            <CopyIcon color="secondary" />
+                          </Button>
+                        </Box>
                       </Grid>
                     );
                   })}

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Fade,
   Grid,
+  Link,
   Popper,
   PopperProps,
   Typography,
@@ -141,7 +142,7 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
                             <PhoneIcon color="secondary" />
                           )}
                           <Typography style={{ marginLeft: '1.5rem' }}>
-                            <a href={linkType + value}> {value} </a>
+                            <Link href={linkType + value}> {value} </Link>
                           </Typography>
                           <Button
                             onClick={() =>

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -1,5 +1,3 @@
-import MailIcon from '@mui/icons-material/Mail';
-import PhoneIcon from '@mui/icons-material/Phone';
 import {
   Box,
   BoxProps,
@@ -13,15 +11,17 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 
+import { CopyIcon } from './ZUIInlineCopyToClipBoard';
+import MailIcon from '@mui/icons-material/Mail';
 import messageIds from 'features/profile/l10n/messageIds';
 import { Msg } from 'core/i18n';
+import PhoneIcon from '@mui/icons-material/Phone';
 import TagsList from 'features/tags/components/TagManager/components/TagsList';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from 'features/profile/hooks/usePerson';
 import usePersonTags from 'features/tags/hooks/usePersonTags';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIPerson from 'zui/ZUIPerson';
-import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 
 const ZUIPersonHoverCard: React.FunctionComponent<{
   BoxProps?: BoxProps;

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   Fade,
   Grid,
-  Link,
   Popper,
   PopperProps,
   Typography,
@@ -21,7 +20,6 @@ import { useNumericRouteParams } from 'core/hooks';
 import usePerson from 'features/profile/hooks/usePerson';
 import usePersonTags from 'features/tags/hooks/usePersonTags';
 import { ZetkinPerson } from 'utils/types/zetkin';
-import ZUICopyToClipboard from 'zui/ZUICopyToClipboard';
 import ZUIPerson from 'zui/ZUIPerson';
 import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 


### PR DESCRIPTION
## Description
This PR adds tel: and mailto: links to a participants hover card, and adds a button to copy the field.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/f3d36dcf-3c41-446a-bd98-b61103f0e8ca)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/e3d140f3-ac99-4dbf-acab-c544900004da)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/ebd9832a-de1b-4182-97e8-0850f931316f)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/d2c8be92-f9cf-4b10-a3de-7694eded2b80)



## Changes

* Adds tel: and mailto: links to the field (or neither if the mail and phone field are not found).
* Adds tel: and mailto: links to the data cells in the participant list.
* Changes the existing feature of using ZUICopyToClipboard in the hover card, to using a Button with similar functionality.


## Notes to reviewer
Go to an event with participants, or add participants with both phone numbers and email to an event. Hover their profile picture in the participant list. Try the links and copy buttons in the hover card. Try the links in the data table.


## Related issues
Resolves #1973 
