### PR TITLE
Issue 1974/Removes lines from Projects page to speed up loading

### DIFF
--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -1,19 +1,19 @@
-import { GetServerSideProps } from 'next';
-import Head from 'next/head';
-import { Suspense } from 'react';
 import { Box, Grid, Typography } from '@mui/material';
+import { Msg, useMessages } from 'core/i18n';
 
 import ActivitiesOverview from 'features/campaigns/components/ActivitiesOverview';
 import AllCampaignsLayout from 'features/campaigns/layout/AllCampaignsLayout';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import CampaignCard from 'features/campaigns/components/CampaignCard';
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
+import { Suspense } from 'react';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
-import { Msg, useMessages } from 'core/i18n';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -29,15 +29,9 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
 
   const apiClient = new BackendApiClient(ctx.req.headers);
-  const campaignsState = await apiClient.get(`/api/orgs/${orgId}/campaigns`);
-  const eventsState = await apiClient.get(`/api/orgs/${orgId}/actions`);
-  const today = new Date(Date.now()).toISOString();
-  const upcomingEventsState = await apiClient.get(
-    `/api/orgs/${orgId}/actions?filter=start_time>${today}`
-  );
   const orgState = await apiClient.get(`/api/orgs/${orgId}`);
 
-  if (orgState && campaignsState && eventsState && upcomingEventsState) {
+  if (orgState) {
     return {
       props: {},
     };

--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -1,19 +1,19 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { Suspense } from 'react';
 import { Box, Grid, Typography } from '@mui/material';
-import { Msg, useMessages } from 'core/i18n';
 
 import ActivitiesOverview from 'features/campaigns/components/ActivitiesOverview';
 import AllCampaignsLayout from 'features/campaigns/layout/AllCampaignsLayout';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import CampaignCard from 'features/campaigns/components/CampaignCard';
-import { GetServerSideProps } from 'next';
-import Head from 'next/head';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
-import { Suspense } from 'react';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
+import { Msg, useMessages } from 'core/i18n';
 
 const scaffoldOptions = {
   authLevelRequired: 2,


### PR DESCRIPTION
## Description
This PR probably speeds up loading times by removing unnecessary checks before loading the projects page. Page should look identical to before.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/5f1fbc92-a747-4c99-8b6d-ee2c2e2dbdd1)


## Changes
Removes campaignsState, eventsState, and upcomingEventsState, and associated lines. Reordered imports.


## Notes to reviewer
Compare the loading times for a page with many events before and after changes.


## Related issues
Resolves #1974 
