### PR TITLE
Issue 1941 / Importer: Adjust warning messages to better suit small imports

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
@@ -41,6 +41,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
         onClickBack={onClickBack}
         status="warning"
         title={messages.preflight.messages.majorChange.title({
+          amount: problem.amount,
           field: getFieldTitle(problem.field),
         })}
       />

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -51,7 +51,12 @@ export default function usePreflight(orgId: number) {
   );
 
   if (problems.length == 0) {
-    problems.push(...problemsFromPreview(previewData));
+    problems.push(
+      ...problemsFromPreview(
+        sheet.firstRowIsHeaders ? sheet.rows.length - 1 : sheet.rows.length,
+        previewData
+      )
+    );
   }
 
   const hasError = problems.some(

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -250,9 +250,11 @@ export default makeMessages('feat.import', {
         title: m<{ field: string }>('Wrong format for field: {field}'),
       },
       majorChange: {
-        description: m('Make sure you have configured the columns correctly'),
-        title: m<{ field: string }>(
-          "This import will overwrite lots of people's {field}"
+        description: m(
+          'This warning is shown when more than 30% of imported people are affected. Make sure you have configured the columns correctly'
+        ),
+        title: m<{ amount: number; field: string }>(
+          'This import will overwrite "{field}" for {amount} people'
         ),
       },
       missingIdAndName: {

--- a/src/features/import/utils/problems/problemsFromPreview.spec.ts
+++ b/src/features/import/utils/problems/problemsFromPreview.spec.ts
@@ -74,13 +74,13 @@ describe('problemsFromPreview()', () => {
       },
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(0, preview);
     expect(problems).toHaveLength(0);
   });
 
   it('returns NO_IMPACT for empty preview', () => {
     const preview = makeFullPreview({});
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(0, preview);
     expect(problems).toEqual([
       {
         kind: ImportProblemKind.NO_IMPACT,
@@ -106,7 +106,7 @@ describe('problemsFromPreview()', () => {
       ],
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(10, preview);
     expect(problems).toEqual([
       {
         indices: [0, 1],
@@ -131,7 +131,7 @@ describe('problemsFromPreview()', () => {
       ],
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(0, preview);
     expect(problems).toEqual([
       {
         indices: [0, 2],
@@ -151,7 +151,7 @@ describe('problemsFromPreview()', () => {
       ],
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(0, preview);
     expect(problems).toEqual([
       {
         indices: [1],
@@ -174,7 +174,7 @@ describe('problemsFromPreview()', () => {
       },
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(0, preview);
     expect(problems).toEqual([]);
   });
 
@@ -195,7 +195,7 @@ describe('problemsFromPreview()', () => {
       },
     });
 
-    const problems = problemsFromPreview(preview);
+    const problems = problemsFromPreview(100, preview);
     expect(problems).toEqual([
       {
         field: 'first_name',

--- a/src/features/import/utils/problems/problemsFromPreview.spec.ts
+++ b/src/features/import/utils/problems/problemsFromPreview.spec.ts
@@ -198,10 +198,12 @@ describe('problemsFromPreview()', () => {
     const problems = problemsFromPreview(100, preview);
     expect(problems).toEqual([
       {
+        amount: 40,
         field: 'first_name',
         kind: ImportProblemKind.MAJOR_CHANGE,
       },
       {
+        amount: 40,
         field: 'last_name',
         kind: ImportProblemKind.MAJOR_CHANGE,
       },

--- a/src/features/import/utils/problems/problemsFromPreview.ts
+++ b/src/features/import/utils/problems/problemsFromPreview.ts
@@ -2,6 +2,7 @@ import { ImportPreview, ImportPreviewProblemCode } from '../types';
 import { ImportProblem, ImportProblemKind, ImportRowProblem } from './types';
 
 export default function problemsFromPreview(
+  opCount: number,
   preview: ImportPreview
 ): ImportProblem[] {
   const problems: ImportProblem[] = [];
@@ -46,10 +47,11 @@ export default function problemsFromPreview(
   // Check for major changes to fields
   Object.keys(summary.updated.byChangedField).forEach((fieldSlug) => {
     const fieldChanges = summary.updated.byChangedField[fieldSlug] || 0;
-    const percentage = fieldChanges / summary.updated.total;
+    const percentage = fieldChanges / opCount;
 
-    if (percentage > 0.3) {
+    if (fieldChanges > 1 && percentage >= 0.3) {
       problems.push({
+        amount: fieldChanges,
         field: fieldSlug,
         kind: ImportProblemKind.MAJOR_CHANGE,
       });

--- a/src/features/import/utils/problems/types.ts
+++ b/src/features/import/utils/problems/types.ts
@@ -16,6 +16,7 @@ export type ImportFieldProblem = {
 };
 
 export type ImportFieldMetaProblem = {
+  amount: number;
   field: string;
   kind: ImportProblemKind.MAJOR_CHANGE;
 };

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -839,8 +839,9 @@ feat:
         invalidFormat:
           title: "Wrong format for field: {field}"
         majorChange:
-          description: Make sure you have configured the columns correctly
-          title: This import will overwrite lots of people's {field}
+          description: This warning is shown when more than 30% of imported people are
+            affected. Make sure you have configured the columns correctly
+          title: This import will overwrite "{field}" for {amount} people
         missingIdAndName:
           description: Every row needs to contain at least a full name, or an ID of a
             person that already exists in Zetkin.


### PR DESCRIPTION
## Description
This PR changes the wording and triggering of warning messages in the importer related to major changes. 


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/21238654/8efd93c4-bde7-4c9e-935b-0586bf0cb4a9)


## Changes
* Changes messageIDs so that the warning explains why the message is shown
* Changes messageIDs so that the amount of people affected is shown
* Changes the triggering of the warning so that it is shown when 


## Notes to reviewer
To test, import a file where less than 30% of peoples first names are changed, and one with 30% or more. 


## Related issues
Resolves #1780
