### PR TITLE
Issue 1962/Resolves Unsent Notification filter error

### DIFF
--- a/src/features/events/hooks/useFilteredEventActivities.ts
+++ b/src/features/events/hooks/useFilteredEventActivities.ts
@@ -100,7 +100,7 @@ export default function useFilteredEventActivities(
         (filterState.selectedActions.includes(
           ACTION_FILTER_OPTIONS.UNSENT_NOTIFICATIONS
         ) &&
-          stats.numReminded != stats.numBooked)
+          stats.numReminded >= stats.numBooked)
       ) {
         return false;
       }


### PR DESCRIPTION
## Description
This PR fixes the Unsent Notification Filter bug which filtered away the wrong events from the calendar.
The filter previously displayed events that had matching amounts of notified participants to booked participants. It now sorts out events where the booked participants are greater than the amount of notified participants.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/be650c5e-c4d0-4532-aaba-f6af721054b4)
![image](https://github.com/zetkin/app.zetkin.org/assets/14234034/7cf2b40c-4097-4586-a6b0-b25e9f87d654)


## Changes

* Changes the Unsent Notifications filter to filter away events that have greater or equal amounts of reminded participants to booked participants.


## Notes to reviewer
Create events with different amount of notified to booked participants. I used 0/0, 0/3, 2/3 and 3/3 for my testing. Enable the Unsent Notifications filter. Only 0/3 and 2/3 should be visible.


## Related issues
Resolves #1962 
