### PR TITLE
Lazy loading data for person hover card

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -299,7 +299,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     renderCell: (params) => {
       const url = `/api/orgs/${orgId}/people/${params.value}/avatar`;
       return (
-        // eslint-disable-next-line @next/next/no-img-element
         <ZUIPersonHoverCard personId={params.value as number}>
           <NextLink
             href={`/organize/${orgId}/people/${params.value}`}

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -67,9 +67,7 @@ const ZUIPersonHoverCard: FC<{
             name: 'preventOverflow',
             options: {
               altAxis: true,
-              altBoundary: true,
               padding: 8,
-              rootBoundary: 'document',
               tether: true,
             },
           },

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -10,7 +10,7 @@ import {
   PopperProps,
   Typography,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 import MailIcon from '@mui/icons-material/Mail';
@@ -24,7 +24,7 @@ import usePersonTags from 'features/tags/hooks/usePersonTags';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIPerson from 'zui/ZUIPerson';
 
-const ZUIPersonHoverCard: React.FunctionComponent<{
+const ZUIPersonHoverCard: FC<{
   BoxProps?: BoxProps;
   children: React.ReactNode;
   personId: number;
@@ -49,10 +49,6 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
     setAnchorEl(null);
     setOpen(false);
   };
-
-  const { orgId } = useNumericRouteParams();
-  const person = usePerson(orgId, personId).data;
-  const tags = usePersonTags(orgId, personId).data;
 
   return (
     <Box
@@ -82,86 +78,93 @@ const ZUIPersonHoverCard: React.FunctionComponent<{
         style={{ zIndex: 1300 }}
         {...popperProps}
       >
-        {person && (
-          <Fade in={open} timeout={200}>
-            <Card elevation={5} style={{ padding: 24 }} variant="elevation">
-              <Grid
-                container
-                direction="column"
-                spacing={2}
-                style={{ width: '25rem' }}
-              >
-                <Grid item>
-                  <ZUIPerson
-                    id={person?.id}
-                    link
-                    name={`${person?.first_name} ${person?.last_name}`}
-                    subtitle={
-                      <Typography color="secondary" variant="body2">
-                        <Msg
-                          id={
-                            person?.is_user
-                              ? messageIds.user.hasAccount
-                              : messageIds.user.noAccount
-                          }
-                        />
-                      </Typography>
-                    }
-                    tooltip={false}
-                  />
-                </Grid>
-                {tags && (
-                  <Grid item>
-                    <TagsList
-                      cap={10}
-                      capOverflowHref={`/organize/${orgId}/people/${person?.id}`}
-                      isGrouped={false}
-                      tags={tags}
-                    />
-                  </Grid>
-                )}
-                {(['phone', 'alt_phone', 'email'] as Array<keyof ZetkinPerson>)
-                  .filter((field) => !!person[field])
-                  .map((field) => {
-                    const value = person[field];
-                    const linkType = field.includes('mail')
-                      ? 'mailto:'
-                      : field.includes('phone')
-                      ? 'tel:'
-                      : '';
-
-                    if (typeof value === 'object') {
-                      return null;
-                    }
-                    return (
-                      <Grid key={field} container item>
-                        <Box display="flex" flexDirection="row">
-                          {field.includes('mail') ? (
-                            <MailIcon color="secondary" />
-                          ) : (
-                            <PhoneIcon color="secondary" />
-                          )}
-                          <Typography style={{ marginLeft: '1.5rem' }}>
-                            <Link href={linkType + value}> {value} </Link>
-                          </Typography>
-                          <Button
-                            onClick={() =>
-                              navigator.clipboard.writeText(value as string)
-                            }
-                            style={{ marginTop: '-0.3rem' }}
-                          >
-                            <CopyIcon color="secondary" />
-                          </Button>
-                        </Box>
-                      </Grid>
-                    );
-                  })}
-              </Grid>
-            </Card>
-          </Fade>
-        )}
+        <Fade in={open} timeout={200}>
+          <Box>{open && <HoverCardContent personId={personId} />}</Box>
+        </Fade>
       </Popper>
     </Box>
+  );
+};
+
+const HoverCardContent: FC<{ personId: number }> = ({ personId }) => {
+  const { orgId } = useNumericRouteParams();
+  const person = usePerson(orgId, personId).data;
+  const tags = usePersonTags(orgId, personId).data;
+
+  if (!person) {
+    return null;
+  }
+
+  return (
+    <Card elevation={5} style={{ padding: 24 }} variant="elevation">
+      <Grid container direction="column" spacing={2} style={{ width: '25rem' }}>
+        <Grid item>
+          <ZUIPerson
+            id={person?.id}
+            link
+            name={`${person?.first_name} ${person?.last_name}`}
+            subtitle={
+              <Typography color="secondary" variant="body2">
+                <Msg
+                  id={
+                    person?.is_user
+                      ? messageIds.user.hasAccount
+                      : messageIds.user.noAccount
+                  }
+                />
+              </Typography>
+            }
+            tooltip={false}
+          />
+        </Grid>
+        {tags && (
+          <Grid item>
+            <TagsList
+              cap={10}
+              capOverflowHref={`/organize/${orgId}/people/${person?.id}`}
+              isGrouped={false}
+              tags={tags}
+            />
+          </Grid>
+        )}
+        {(['phone', 'alt_phone', 'email'] as Array<keyof ZetkinPerson>)
+          .filter((field) => !!person[field])
+          .map((field) => {
+            const value = person[field];
+            const linkType = field.includes('mail')
+              ? 'mailto:'
+              : field.includes('phone')
+              ? 'tel:'
+              : '';
+
+            if (typeof value === 'object') {
+              return null;
+            }
+            return (
+              <Grid key={field} container item>
+                <Box display="flex" flexDirection="row">
+                  {field.includes('mail') ? (
+                    <MailIcon color="secondary" />
+                  ) : (
+                    <PhoneIcon color="secondary" />
+                  )}
+                  <Typography style={{ marginLeft: '1.5rem' }}>
+                    <Link href={linkType + value}> {value} </Link>
+                  </Typography>
+                  <Button
+                    onClick={() =>
+                      navigator.clipboard.writeText(value as string)
+                    }
+                    style={{ marginTop: '-0.3rem' }}
+                  >
+                    <CopyIcon color="secondary" />
+                  </Button>
+                </Box>
+              </Grid>
+            );
+          })}
+      </Grid>
+    </Card>
   );
 };
 


### PR DESCRIPTION
## Description
This PR fixes a performance issue in lists (and potentially other places) that can even trigger a browser error. The bug was caused by every avatar in a list loading the relevant person object and it's tags, in case it needs to display the hover card. This happened because the hover card always loads it's data, even before it's displayed, and this PR changes the hover card to only load data once it's opened.

It also fixes an unrelated issue that I came across while testing this, which was that the popper was allowed to open outside of the browser viewport.

## Screenshots
None

## Changes
* Modify `ZUIPersonHoverCard` so that it loads data lazily, i.e. only once the popper actually shows
* Fix an issue causing the `ZUIPersonHoverCard` to display the popper outside of the viewport bounds sometimes
* Removes an obsolete `eslint-disable` comment

## Notes to reviewer
Please play around with hover cards all over the place, as this affects all hover cards, not just the ones in lists.

## Related issues
Resolves #1984