### PR TITLE
Merge settings

### DIFF
--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react';
 import theme from 'theme';
 import {
   Box,
@@ -8,9 +7,11 @@ import {
   DialogTitle,
   useMediaQuery,
 } from '@mui/material';
+import { FC, useState } from 'react';
 
 import FieldSettings from './FieldSettings';
 import messageIds from '../l10n/messageIds';
+import useFieldSettings from '../hooks/useFieldSettings';
 import { useMessages } from 'core/i18n';
 import { ZetkinDuplicate } from '../store';
 
@@ -27,6 +28,10 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
 }) => {
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const messages = useMessages(messageIds);
+  const { fieldValues, initialOverrides } = useFieldSettings(
+    duplicate.duplicatePersons
+  );
+  const [overrides, setOverrides] = useState(initialOverrides);
 
   return (
     <Dialog
@@ -41,7 +46,12 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
         <DialogTitle variant="h5">{messages.modal.title()}</DialogTitle>
       </Box>
       <Box display="flex" flexDirection="column">
-        <FieldSettings duplicatePersons={duplicate.duplicatePersons} />
+        <FieldSettings
+          fieldValues={fieldValues}
+          onChange={(field, value) => {
+            setOverrides({ ...overrides, [`${field}`]: value });
+          }}
+        />
       </Box>
       <DialogActions>
         <Button variant="text">{messages.modal.cancelButton()}</Button>

--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -9,6 +9,7 @@ import {
   useMediaQuery,
 } from '@mui/material';
 
+import FieldSettings from './FieldSettings';
 import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import { ZetkinDuplicate } from '../store';
@@ -38,6 +39,9 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
     >
       <Box display="flex" flexDirection="column" overflow="hidden" padding={2}>
         <DialogTitle variant="h5">{messages.modal.title()}</DialogTitle>
+      </Box>
+      <Box display="flex" flexDirection="column">
+        <FieldSettings duplicatePersons={duplicate.duplicatePersons} />
       </Box>
       <DialogActions>
         <Button variant="text">{messages.modal.cancelButton()}</Button>

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -17,28 +17,28 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
 
   const sortedValues = sortValuesByFrequency(field, values);
 
-  const getGender = (value: string) => {
+  const getLabel = (value: string) => {
+    if (field === NATIVE_PERSON_FIELDS.GENDER) {
+      if (value === 'f') {
+        return messages.modal.fieldSettings.gender.f();
+      } else if (value === 'm') {
+        return messages.modal.fieldSettings.gender.m();
+      } else {
+        return messages.modal.fieldSettings.gender.o();
+      }
+    }
+
     if (!value) {
       return messages.modal.fieldSettings.noData();
     }
 
-    if (value === 'f') {
-      return messages.modal.fieldSettings.gender.f();
-    } else if (value === 'm') {
-      return messages.modal.fieldSettings.gender.m();
-    } else {
-      return messages.modal.fieldSettings.gender.o();
-    }
+    return value;
   };
 
   return (
     <>
       {sortedValues.length === 1 && (
-        <Typography color="secondary">
-          {field === NATIVE_PERSON_FIELDS.GENDER
-            ? getGender(sortedValues[0])
-            : sortedValues[0]}
-        </Typography>
+        <Typography color="secondary">{getLabel(sortedValues[0])}</Typography>
       )}
       {sortedValues.length > 1 && (
         <Select
@@ -47,7 +47,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
         >
           {sortedValues.map((value, index) => (
             <MenuItem key={index} value={value}>
-              {field === NATIVE_PERSON_FIELDS.GENDER ? getGender(value) : value}
+              {getLabel(value)}
             </MenuItem>
           ))}
         </Select>

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -1,7 +1,9 @@
 import { FC, useState } from 'react';
 
+import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import sortValuesByFrequency from 'features/duplicates/utils/sortValuesByFrequency';
+import { useMessages } from 'core/i18n';
 import { MenuItem, Select, Typography } from '@mui/material';
 
 interface FieldSettingsRowProps {
@@ -10,23 +12,42 @@ interface FieldSettingsRowProps {
 }
 
 const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
+  const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
 
   const sortedValues = sortValuesByFrequency(field, values);
 
+  const getGender = (value: string) => {
+    if (!value) {
+      return messages.modal.fieldSettings.noData();
+    }
+
+    if (value === 'f') {
+      return messages.modal.fieldSettings.gender.f();
+    } else if (value === 'm') {
+      return messages.modal.fieldSettings.gender.m();
+    } else {
+      return messages.modal.fieldSettings.gender.o();
+    }
+  };
+
   return (
     <>
       {sortedValues.length === 1 && (
-        <Typography color="secondary">{sortedValues[0]}</Typography>
+        <Typography color="secondary">
+          {field === NATIVE_PERSON_FIELDS.GENDER
+            ? getGender(sortedValues[0])
+            : sortedValues[0]}
+        </Typography>
       )}
       {sortedValues.length > 1 && (
         <Select
           onChange={(event) => setSelectedValue(event.target.value)}
           value={selectedValue}
         >
-          {sortedValues.map((value) => (
-            <MenuItem key={value} value={value}>
-              {value}
+          {sortedValues.map((value, index) => (
+            <MenuItem key={index} value={value}>
+              {field === NATIVE_PERSON_FIELDS.GENDER ? getGender(value) : value}
             </MenuItem>
           ))}
         </Select>

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -18,7 +18,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
   const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
 
-  const sortedValues = sortValuesByFrequency(field, values);
+  const sortedValues = sortValuesByFrequency(values);
 
   const getLabel = (value: string) => {
     if (field === NATIVE_PERSON_FIELDS.GENDER) {

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -1,10 +1,12 @@
+import { ArrowForward } from '@mui/icons-material';
+import { Box, MenuItem, Select, Typography, useTheme } from '@mui/material';
 import { FC, useState } from 'react';
 
+import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import sortValuesByFrequency from 'features/duplicates/utils/sortValuesByFrequency';
-import { useMessages } from 'core/i18n';
-import { MenuItem, Select, Typography } from '@mui/material';
+import { Msg, useMessages } from 'core/i18n';
 
 interface FieldSettingsRowProps {
   field: NATIVE_PERSON_FIELDS;
@@ -12,6 +14,7 @@ interface FieldSettingsRowProps {
 }
 
 const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
+  const theme = useTheme();
   const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
 
@@ -36,23 +39,53 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
   };
 
   return (
-    <>
-      {sortedValues.length === 1 && (
-        <Typography color="secondary">{getLabel(sortedValues[0])}</Typography>
-      )}
-      {sortedValues.length > 1 && (
-        <Select
-          onChange={(event) => setSelectedValue(event.target.value)}
-          value={selectedValue}
+    <Box
+      alignItems="center"
+      display="flex"
+      justifyContent="space-between"
+      padding={1}
+    >
+      <Box
+        alignItems="center"
+        display="flex"
+        justifyContent="space-between"
+        width="50%"
+      >
+        <Box
+          bgcolor={theme.palette.grey[200]}
+          padding={1}
+          sx={{ borderRadius: 2 }}
         >
-          {sortedValues.map((value, index) => (
-            <MenuItem key={index} value={value}>
-              {getLabel(value)}
-            </MenuItem>
-          ))}
-        </Select>
-      )}
-    </>
+          <Typography>
+            <Msg id={globalMessageIds.personFields[field]} />
+          </Typography>
+        </Box>
+        <ArrowForward color="secondary" />
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="flex-start"
+        paddingLeft={1}
+        width="50%"
+      >
+        {sortedValues.length === 1 && (
+          <Typography color="secondary">{getLabel(sortedValues[0])}</Typography>
+        )}
+        {sortedValues.length > 1 && (
+          <Select
+            fullWidth
+            onChange={(event) => setSelectedValue(event.target.value)}
+            value={selectedValue}
+          >
+            {sortedValues.map((value, index) => (
+              <MenuItem key={index} value={value}>
+                {getLabel(value)}
+              </MenuItem>
+            ))}
+          </Select>
+        )}
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -32,7 +32,11 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
     }
 
     if (!value) {
-      return messages.modal.fieldSettings.noData();
+      return (
+        <span style={{ fontStyle: 'italic' }}>
+          {messages.modal.fieldSettings.noValue()}
+        </span>
+      );
     }
 
     return value;

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -5,20 +5,22 @@ import { FC, useState } from 'react';
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
-import sortValuesByFrequency from 'features/duplicates/utils/sortValuesByFrequency';
 import { Msg, useMessages } from 'core/i18n';
 
 interface FieldSettingsRowProps {
   field: NATIVE_PERSON_FIELDS;
+  onChange: (selectedValue: string) => void;
   values: string[];
 }
 
-const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
+const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
+  field,
+  onChange,
+  values,
+}) => {
   const theme = useTheme();
   const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
-
-  const sortedValues = sortValuesByFrequency(values);
 
   const getLabel = (value: string) => {
     if (field === NATIVE_PERSON_FIELDS.GENDER) {
@@ -72,16 +74,19 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
         paddingLeft={1}
         width="50%"
       >
-        {sortedValues.length === 1 && (
-          <Typography color="secondary">{getLabel(sortedValues[0])}</Typography>
+        {values.length === 1 && (
+          <Typography color="secondary">{getLabel(values[0])}</Typography>
         )}
-        {sortedValues.length > 1 && (
+        {values.length > 1 && (
           <Select
             fullWidth
-            onChange={(event) => setSelectedValue(event.target.value)}
+            onChange={(event) => {
+              setSelectedValue(event.target.value);
+              onChange(event.target.value);
+            }}
             value={selectedValue}
           >
-            {sortedValues.map((value, index) => (
+            {values.map((value, index) => (
               <MenuItem key={index} value={value}>
                 {getLabel(value)}
               </MenuItem>

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -1,0 +1,38 @@
+import { FC, useState } from 'react';
+
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+import sortValuesByFrequency from 'features/duplicates/utils/sortValuesByFrequency';
+import { MenuItem, Select, Typography } from '@mui/material';
+
+interface FieldSettingsRowProps {
+  field: NATIVE_PERSON_FIELDS;
+  values: string[];
+}
+
+const FieldSettingsRow: FC<FieldSettingsRowProps> = ({ field, values }) => {
+  const [selectedValue, setSelectedValue] = useState(values[0]);
+
+  const sortedValues = sortValuesByFrequency(field, values);
+
+  return (
+    <>
+      {sortedValues.length === 1 && (
+        <Typography color="secondary">{sortedValues[0]}</Typography>
+      )}
+      {sortedValues.length > 1 && (
+        <Select
+          onChange={(event) => setSelectedValue(event.target.value)}
+          value={selectedValue}
+        >
+          {sortedValues.map((value) => (
+            <MenuItem key={value} value={value}>
+              {value}
+            </MenuItem>
+          ))}
+        </Select>
+      )}
+    </>
+  );
+};
+
+export default FieldSettingsRow;

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Box, Divider, useTheme } from '@mui/material';
 
 import FieldSettingsRow from './FieldSettingsRow';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
@@ -9,17 +10,29 @@ interface FieldSettingsProps {
 }
 
 const FieldSettings: FC<FieldSettingsProps> = ({ duplicatePersons }) => {
+  const theme = useTheme();
+
+  const nativePersonFields = Object.values(NATIVE_PERSON_FIELDS);
+
   return (
-    <>
-      {Object.values(NATIVE_PERSON_FIELDS).map((field) => {
+    <Box
+      border={1}
+      sx={{ borderColor: theme.palette.grey[300], borderRadius: 2 }}
+    >
+      {nativePersonFields.map((field, index) => {
         const values = duplicatePersons.map((person) => {
           const value = person[field];
           return value ? value.toString() : '';
         });
 
-        return <FieldSettingsRow key={field} field={field} values={values} />;
+        return (
+          <>
+            {index !== 0 && <Divider />}
+            <FieldSettingsRow key={field} field={field} values={values} />
+          </>
+        );
       })}
-    </>
+    </Box>
   );
 };
 

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -3,52 +3,33 @@ import { Box, Divider, useTheme } from '@mui/material';
 
 import FieldSettingsRow from './FieldSettingsRow';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
-import { ZetkinPerson } from 'utils/types/zetkin';
 
 interface FieldSettingsProps {
-  duplicatePersons: ZetkinPerson[];
+  fieldValues: Record<string, string[]>;
+  onChange: (field: NATIVE_PERSON_FIELDS, selectedValue: string) => void;
 }
 
-const FieldSettings: FC<FieldSettingsProps> = ({ duplicatePersons }) => {
+const FieldSettings: FC<FieldSettingsProps> = ({ fieldValues, onChange }) => {
   const theme = useTheme();
-
-  const nativePersonFields = Object.values(NATIVE_PERSON_FIELDS).filter(
-    (field) => field !== NATIVE_PERSON_FIELDS.ID
-  );
-
-  const sortedNativePersonFields = nativePersonFields.filter(
-    (field) =>
-      field === NATIVE_PERSON_FIELDS.FIRST_NAME ||
-      field === NATIVE_PERSON_FIELDS.LAST_NAME ||
-      field === NATIVE_PERSON_FIELDS.EMAIL ||
-      field === NATIVE_PERSON_FIELDS.PHONE
-  );
-
-  const otherFields = nativePersonFields.filter(
-    (field) =>
-      field !== NATIVE_PERSON_FIELDS.FIRST_NAME &&
-      field !== NATIVE_PERSON_FIELDS.LAST_NAME &&
-      field !== NATIVE_PERSON_FIELDS.EMAIL &&
-      field !== NATIVE_PERSON_FIELDS.PHONE
-  );
-
-  sortedNativePersonFields.push(...otherFields);
 
   return (
     <Box
       border={1}
       sx={{ borderColor: theme.palette.grey[300], borderRadius: 2 }}
     >
-      {sortedNativePersonFields.map((field, index) => {
-        const values = duplicatePersons.map((person) => {
-          const value = person[field];
-          return value ? value.toString() : '';
-        });
-
+      {Object.entries(fieldValues).map((entry, index) => {
+        const [field, values] = entry;
         return (
           <>
             {index !== 0 && <Divider />}
-            <FieldSettingsRow key={field} field={field} values={values} />
+            <FieldSettingsRow
+              key={index}
+              field={field as NATIVE_PERSON_FIELDS}
+              onChange={(selectedValue: string) =>
+                onChange(field as NATIVE_PERSON_FIELDS, selectedValue)
+              }
+              values={values}
+            />
           </>
         );
       })}

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -16,12 +16,30 @@ const FieldSettings: FC<FieldSettingsProps> = ({ duplicatePersons }) => {
     (field) => field !== NATIVE_PERSON_FIELDS.ID
   );
 
+  const sortedNativePersonFields = nativePersonFields.filter(
+    (field) =>
+      field === NATIVE_PERSON_FIELDS.FIRST_NAME ||
+      field === NATIVE_PERSON_FIELDS.LAST_NAME ||
+      field === NATIVE_PERSON_FIELDS.EMAIL ||
+      field === NATIVE_PERSON_FIELDS.PHONE
+  );
+
+  const otherFields = nativePersonFields.filter(
+    (field) =>
+      field !== NATIVE_PERSON_FIELDS.FIRST_NAME &&
+      field !== NATIVE_PERSON_FIELDS.LAST_NAME &&
+      field !== NATIVE_PERSON_FIELDS.EMAIL &&
+      field !== NATIVE_PERSON_FIELDS.PHONE
+  );
+
+  sortedNativePersonFields.push(...otherFields);
+
   return (
     <Box
       border={1}
       sx={{ borderColor: theme.palette.grey[300], borderRadius: 2 }}
     >
-      {nativePersonFields.map((field, index) => {
+      {sortedNativePersonFields.map((field, index) => {
         const values = duplicatePersons.map((person) => {
           const value = person[field];
           return value ? value.toString() : '';

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -12,7 +12,9 @@ interface FieldSettingsProps {
 const FieldSettings: FC<FieldSettingsProps> = ({ duplicatePersons }) => {
   const theme = useTheme();
 
-  const nativePersonFields = Object.values(NATIVE_PERSON_FIELDS);
+  const nativePersonFields = Object.values(NATIVE_PERSON_FIELDS).filter(
+    (field) => field !== NATIVE_PERSON_FIELDS.ID
+  );
 
   return (
     <Box

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+
+import FieldSettingsRow from './FieldSettingsRow';
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+interface FieldSettingsProps {
+  duplicatePersons: ZetkinPerson[];
+}
+
+const FieldSettings: FC<FieldSettingsProps> = ({ duplicatePersons }) => {
+  return (
+    <>
+      {Object.values(NATIVE_PERSON_FIELDS).map((field) => {
+        const values = duplicatePersons.map((person) => {
+          const value = person[field];
+          return value ? value.toString() : '';
+        });
+
+        return <FieldSettingsRow key={field} field={field} values={values} />;
+      })}
+    </>
+  );
+};
+
+export default FieldSettings;

--- a/src/features/duplicates/hooks/useDuplicates.tsx
+++ b/src/features/duplicates/hooks/useDuplicates.tsx
@@ -2,7 +2,7 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { duplicatesLoad, duplicatesLoaded, ZetkinDuplicate } from '../store';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 
-export default function useDuplicates(orgId: number) {
+export default function useDuplicates() {
   const dispatch = useAppDispatch();
   const duplicatesList = useAppSelector(
     (state) => state.duplicates.duplicatesList

--- a/src/features/duplicates/hooks/useFieldSettings.ts
+++ b/src/features/duplicates/hooks/useFieldSettings.ts
@@ -1,0 +1,50 @@
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+import sortValuesByFrequency from '../utils/sortValuesByFrequency';
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+export default function useFieldSettings(duplicates: ZetkinPerson[]) {
+  const nativePersonFields = Object.values(NATIVE_PERSON_FIELDS).filter(
+    (field) => field !== NATIVE_PERSON_FIELDS.ID
+  );
+
+  const sortedNativePersonFields = nativePersonFields.filter(
+    (field) =>
+      field === NATIVE_PERSON_FIELDS.FIRST_NAME ||
+      field === NATIVE_PERSON_FIELDS.LAST_NAME ||
+      field === NATIVE_PERSON_FIELDS.EMAIL ||
+      field === NATIVE_PERSON_FIELDS.PHONE
+  );
+
+  const otherFields = nativePersonFields.filter(
+    (field) =>
+      field !== NATIVE_PERSON_FIELDS.FIRST_NAME &&
+      field !== NATIVE_PERSON_FIELDS.LAST_NAME &&
+      field !== NATIVE_PERSON_FIELDS.EMAIL &&
+      field !== NATIVE_PERSON_FIELDS.PHONE
+  );
+
+  sortedNativePersonFields.push(...otherFields);
+
+  const fieldValues: Record<string, string[]> = {};
+
+  sortedNativePersonFields.forEach((field) => {
+    const values = duplicates.map((person) => {
+      const value = person[field];
+      return value ? value.toString() : '';
+    });
+
+    fieldValues[field] = sortValuesByFrequency(values);
+  });
+
+  const initialOverrides: Partial<ZetkinPerson> = {};
+
+  Object.entries(fieldValues).forEach((entry) => {
+    const [field, values] = entry;
+
+    if (values.length > 1) {
+      initialOverrides[field] = values[0];
+    }
+  });
+
+  return { fieldValues, initialOverrides };
+}

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -9,7 +9,7 @@ export default makeMessages('feat.duplicates', {
         m: m('Male'),
         o: m('Other'),
       },
-      noData: m('No data'),
+      noValue: m('No value'),
     },
     mergeButton: m('Merge'),
     title: m('Merge duplicates'),

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -3,6 +3,14 @@ import { m, makeMessages } from 'core/i18n';
 export default makeMessages('feat.duplicates', {
   modal: {
     cancelButton: m('Cancel'),
+    fieldSettings: {
+      gender: {
+        f: m('Female'),
+        m: m('Male'),
+        o: m('Other'),
+      },
+      noData: m('No data'),
+    },
     mergeButton: m('Merge'),
     title: m('Merge duplicates'),
   },

--- a/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
@@ -1,20 +1,20 @@
-import mostSharedValue from './sortValuesByFrequency';
+import sortValuesByFrequency from './sortValuesByFrequency';
 
 describe('sortValuesByFrequency()', () => {
   it('returns a string value if field is the same on each person', () => {
-    const values = mostSharedValue(['Clara', 'Clara', 'Clara']);
+    const values = sortValuesByFrequency(['Clara', 'Clara', 'Clara']);
 
     expect(values[0]).toBe('Clara');
   });
 
   it('returns a list of every value if the value on each persons field is different', () => {
-    const values = mostSharedValue(['Angela', 'Huey', 'Clara']);
+    const values = sortValuesByFrequency(['Angela', 'Huey', 'Clara']);
 
     expect(values).toHaveLength(3);
   });
 
   it('returns a list sorted in order of frequency when some values appear more than once', () => {
-    const values = mostSharedValue([
+    const values = sortValuesByFrequency([
       'Angela',
       'Angela',
       'Huey',
@@ -29,11 +29,11 @@ describe('sortValuesByFrequency()', () => {
     expect(values[2]).toBe('Huey');
   });
 
-  it('handles when fields have null as value', () => {
-    const values = mostSharedValue(['', '', 'Kleine Alexanderstraße 28']);
+  it('sorts empty values to the end of the array, even if they are frequent', () => {
+    const values = sortValuesByFrequency(['', '', 'Kleine Alexanderstraße 28']);
 
     expect(values).toHaveLength(2);
-    expect(values[0]).toBe('');
-    expect(values[1]).toBe('Kleine Alexanderstraße 28');
+    expect(values[0]).toBe('Kleine Alexanderstraße 28');
+    expect(values[1]).toBe('');
   });
 });

--- a/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
@@ -1,29 +1,20 @@
 import mostSharedValue from './sortValuesByFrequency';
-import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 
 describe('sortValuesByFrequency()', () => {
   it('returns a string value if field is the same on each person', () => {
-    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
-      'Clara',
-      'Clara',
-      'Clara',
-    ]);
+    const values = mostSharedValue(['Clara', 'Clara', 'Clara']);
 
     expect(values[0]).toBe('Clara');
   });
 
   it('returns a list of every value if the value on each persons field is different', () => {
-    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
-      'Angela',
-      'Huey',
-      'Clara',
-    ]);
+    const values = mostSharedValue(['Angela', 'Huey', 'Clara']);
 
     expect(values).toHaveLength(3);
   });
 
   it('returns a list sorted in order of frequency when some values appear more than once', () => {
-    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
+    const values = mostSharedValue([
       'Angela',
       'Angela',
       'Huey',
@@ -39,11 +30,7 @@ describe('sortValuesByFrequency()', () => {
   });
 
   it('handles when fields have null as value', () => {
-    const values = mostSharedValue(NATIVE_PERSON_FIELDS.STREET_ADDRESS, [
-      '',
-      '',
-      'Kleine Alexanderstraße 28',
-    ]);
+    const values = mostSharedValue(['', '', 'Kleine Alexanderstraße 28']);
 
     expect(values).toHaveLength(2);
     expect(values[0]).toBe('');

--- a/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
@@ -1,0 +1,52 @@
+import mostSharedValue from './sortValuesByFrequency';
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+
+describe('sortValuesByFrequency()', () => {
+  it('returns a string value if field is the same on each person', () => {
+    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
+      'Clara',
+      'Clara',
+      'Clara',
+    ]);
+
+    expect(values[0]).toBe('Clara');
+  });
+
+  it('returns a list of every value if the value on each persons field is different', () => {
+    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
+      'Angela',
+      'Huey',
+      'Clara',
+    ]);
+
+    expect(values).toHaveLength(3);
+  });
+
+  it('returns a list sorted in order of frequency when some values appear more than once', () => {
+    const values = mostSharedValue(NATIVE_PERSON_FIELDS.FIRST_NAME, [
+      'Angela',
+      'Angela',
+      'Huey',
+      'Clara',
+      'Clara',
+      'Clara',
+    ]);
+
+    expect(values).toHaveLength(3);
+    expect(values[0]).toBe('Clara');
+    expect(values[1]).toBe('Angela');
+    expect(values[2]).toBe('Huey');
+  });
+
+  it('handles when fields have null as value', () => {
+    const values = mostSharedValue(NATIVE_PERSON_FIELDS.STREET_ADDRESS, [
+      '',
+      '',
+      'Kleine Alexanderstraße 28',
+    ]);
+
+    expect(values).toHaveLength(2);
+    expect(values[0]).toBe('');
+    expect(values[1]).toBe('Kleine Alexanderstraße 28');
+  });
+});

--- a/src/features/duplicates/utils/sortValuesByFrequency.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.ts
@@ -1,9 +1,4 @@
-import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
-
-export default function sortValuesByFrequency(
-  field: NATIVE_PERSON_FIELDS,
-  values: string[]
-) {
+export default function sortValuesByFrequency(values: string[]) {
   const frequency: Record<string | number, number> = {};
 
   values.forEach((value) => {

--- a/src/features/duplicates/utils/sortValuesByFrequency.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.ts
@@ -1,0 +1,30 @@
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+
+export default function sortValuesByFrequency(
+  field: NATIVE_PERSON_FIELDS,
+  values: string[]
+) {
+  const frequency: Record<string | number, number> = {};
+
+  values.forEach((value) => {
+    if (!frequency[value]) {
+      frequency[value] = 0;
+    }
+    frequency[value] = frequency[value] + 1;
+  });
+
+  const uniqueValues = [...new Set(values)];
+
+  return uniqueValues.sort((value1, value2) => {
+    const a = value1 || '';
+    const b = value2 || '';
+
+    if (frequency[a] > frequency[b]) {
+      return -1;
+    } else if (frequency[b] > frequency[a]) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+}

--- a/src/features/duplicates/utils/sortValuesByFrequency.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.ts
@@ -10,7 +10,7 @@ export default function sortValuesByFrequency(values: string[]) {
 
   const uniqueValues = [...new Set(values)];
 
-  return uniqueValues.sort((value1, value2) => {
+  const sortedByFrequency = uniqueValues.sort((value1, value2) => {
     const a = value1 || '';
     const b = value2 || '';
 
@@ -22,4 +22,13 @@ export default function sortValuesByFrequency(values: string[]) {
       return 0;
     }
   });
+
+  const emptyValues = sortedByFrequency.filter((value) => !value);
+
+  const sortedWithEmptyValuesAtEnd = sortedByFrequency.filter(
+    (value) => !!value
+  );
+  sortedWithEmptyValuesAtEnd.push(...emptyValues);
+
+  return sortedWithEmptyValuesAtEnd;
 }

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -8,7 +8,6 @@ import PeopleLayout from 'features/views/layout/PeopleLayout';
 import { scaffold } from 'utils/next';
 import useDuplicates from 'features/duplicates/hooks/useDuplicates';
 import { useMessages } from 'core/i18n';
-import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async () => {
@@ -19,8 +18,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(async () => {
 
 const DuplicatesPage: PageWithLayout = () => {
   const onServer = useServerSide();
-  const { orgId } = useNumericRouteParams();
-  const list = useDuplicates(orgId).data ?? [];
+  const list = useDuplicates().data ?? [];
   const messages = useMessages(messageIds);
 
   if (onServer) {

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -6,9 +6,10 @@ import messageIds from 'features/duplicates/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import PeopleLayout from 'features/views/layout/PeopleLayout';
 import { scaffold } from 'utils/next';
-import useDuplicates from 'features/duplicates/hooks/useDuplicates';
+//import useDuplicates from 'features/duplicates/hooks/useDuplicates';
 import { useMessages } from 'core/i18n';
 import useServerSide from 'core/useServerSide';
+import { ZetkinDuplicate } from 'features/duplicates/store';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async () => {
   return {
@@ -18,7 +19,69 @@ export const getServerSideProps: GetServerSideProps = scaffold(async () => {
 
 const DuplicatesPage: PageWithLayout = () => {
   const onServer = useServerSide();
-  const list = useDuplicates().data ?? [];
+  //const list = useDuplicates().data ?? [];
+  const list: ZetkinDuplicate[] = [
+    {
+      dismissed: null,
+      duplicatePersons: [
+        {
+          alt_phone: '',
+          city: 'Oakland',
+          co_address: '',
+          country: 'USA',
+          email: 'angela@blackpanthers.org',
+          ext_id: '74',
+          first_name: 'Angel',
+          gender: 'f',
+          id: 2,
+          is_user: false,
+          last_name: 'Davidsson',
+          phone: '0018493298448',
+          street_address: '45 Main Street',
+          zip_code: '34910',
+        },
+        {
+          alt_phone: '',
+          city: 'Linköping',
+          co_address: '',
+          country: 'USA',
+          email: 'haeju@blackpanthers.org',
+          ext_id: '74',
+          first_name: 'Haeju',
+          gender: 'f',
+          id: 2,
+          is_user: false,
+          last_name: 'Eom',
+          phone: '0018493298448',
+          street_address: '45 Main Street',
+          zip_code: '34910',
+        },
+        {
+          alt_phone: '',
+          city: 'Oakland',
+          co_address: '',
+          country: 'USA',
+          email: 'angela@blackpanthers.org',
+          ext_id: '74',
+          first_name: 'Angela',
+          gender: 'f',
+          id: 2,
+          is_user: false,
+          last_name: 'Davis',
+          phone: '0018493298449',
+          street_address: '45 Main Street',
+          zip_code: '34910',
+        },
+      ],
+      id: 100,
+      merged: null,
+      organization: {
+        id: 1,
+        title: 'My Organization',
+      },
+      status: 'pending',
+    },
+  ];
   const messages = useMessages(messageIds);
 
   if (onServer) {


### PR DESCRIPTION
## Description
This PR creates the right side of the merge modal, where the user decides which values will be on the merged person.

## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/203edc29-6244-4f8b-881c-4cfa304c636b)

## Changes
* Adds `FieldSettings` and `FieldSettingsRow` components
* Adds hook `useFieldSettings` to collect the data that will be displayed
* Saves the choices the user makes in a state called `overrides`
* Adds a function with tests that merges and sorts values by how frequent they are


## Related issues
none
