### PR TITLE
Issue 1954 / Add if statement prior setting date

### DIFF
--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -43,7 +43,7 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     setPublished(null);
   };
   const handleChangeDate = (date: string | null) => {
-    if(date) {
+    if (date) {
       setPublished(date);
     }
   };

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -43,7 +43,9 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     setPublished(null);
   };
   const handleChangeDate = (date: string | null) => {
-    if(date) setPublished(date);
+    if(date) {
+      setPublished(date);
+    }
   };
 
   const handleDelete = () => {

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -43,7 +43,7 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     setPublished(null);
   };
   const handleChangeDate = (date: string | null) => {
-    setPublished(date);
+    if(date) setPublished(date);
   };
 
   const handleDelete = () => {

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/icons-material';
 import React, { useContext } from 'react';
 
+import dayjs from 'dayjs';
 import messageIds from '../l10n/messageIds';
 import useDuplicateEvent from '../hooks/useDuplicateEvent';
 import useEventMutations from '../hooks/useEventMutations';
@@ -34,7 +35,6 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
 
   const published =
     !!event.published && new Date(event.published) <= new Date();
-
   const handlePublish = () => {
     setPublished(new Date().toISOString());
   };
@@ -43,7 +43,10 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     setPublished(null);
   };
   const handleChangeDate = (date: string | null) => {
-    if (date) {
+    const newDateIsDifferent =
+      date && date != dayjs(event.published).format('YYYY-MM-DD');
+
+    if (newDateIsDifferent) {
       setPublished(date);
     }
   };


### PR DESCRIPTION
## Description

This PR resolves a bug with regarding Event status when cancelling a drafted event.

Opening and closing the datepicker caused the date value being set to null. And then changing the status because of date value.

As far as my understanding goes, event status is dependent on date. So Im thinking this was working as intended from a point of view since an event without a date is considered a draft? And if the date gets set to the future it should be scheduled and so on... 

I have added an if statement that checks date before setting it so that the 'cancelled' status sticks around.

## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/97404672/b8377b03-d8ec-4d51-ad34-e40e7f1a66ec

## Changes

* If statement validates date before setPublish in handleDateChange.

## Notes to reviewer

1. Go to / create any event
2. Click 'Cancel Event'
3. Click 'Not visible or scheduled'
4. Click outside date picker
5. Event status should not change

## Related issues
Resolves #1954
