### PR TITLE
Issue 1992/emails in upcoming activities

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/items/CallAssignmentOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/CallAssignmentOverviewListItem.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { HeadsetMic, PhoneOutlined } from '@mui/icons-material';
 
 import { CallAssignmentActivity } from 'features/campaigns/types';
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 import OverviewListItem from './OverviewListItem';
 import useCallAssignmentStats from 'features/callAssignments/hooks/useCallAssignmentStats';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
@@ -23,6 +24,7 @@ const CallAssignmentOverviewListItem: FC<
 
   return (
     <OverviewListItem
+      color={getStatusColor(activity.visibleFrom, activity.visibleUntil)}
       endDate={activity.visibleUntil}
       endNumber={callsMade}
       focusDate={focusDate}

--- a/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
@@ -1,13 +1,13 @@
-import { FC } from 'react';
-
 import dayjs from 'dayjs';
+import { FC } from 'react';
+import { EmailOutlined, Person } from '@mui/icons-material';
+
 import { EmailActivity } from 'features/campaigns/types';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { Msg } from 'core/i18n';
-import OverviewListItem from './OverviewListItem';
 import useEmailStats from 'features/emails/hooks/useEmailStats';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
-import { EmailOutlined, Person } from '@mui/icons-material';
+import OverviewListItem, { STATUS_COLORS } from './OverviewListItem';
 
 interface EmailOverviewListItemProps {
   activity: EmailActivity;
@@ -43,8 +43,27 @@ const EmailOverviewListItem: FC<EmailOverviewListItemProps> = ({
     );
   }
 
+  function getColor() {
+    const now = new Date();
+
+    const sendTime = activity.visibleFrom;
+
+    if (sendTime) {
+      if (sendTime > now) {
+        return STATUS_COLORS.BLUE;
+      } else if (sendTime < now) {
+        return STATUS_COLORS.GREEN;
+      }
+    }
+
+    // Should never happen, because it should not be in the
+    // overview if it's not yet scheduled/published.
+    return STATUS_COLORS.GRAY;
+  }
+
   return (
     <OverviewListItem
+      color={getColor()}
       endDate={activity.visibleUntil}
       endNumber={email.locked ? lockedReadyTargets ?? 0 : numTargetMatches}
       focusDate={focusDate}

--- a/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
@@ -28,19 +28,19 @@ const EmailOverviewListItem: FC<EmailOverviewListItemProps> = ({
     if (published === null) {
       return undefined;
     }
-    const now = new Date()
+    const now = new Date();
     const publishedDate = dayjs(published);
-    const id = publishedDate.isBefore(now) ?
-      messageIds.activitiesOverview.subtitles.sentEarlier :
-      messageIds.activitiesOverview.subtitles.sentLater;
-    return (<Msg
-      id={id}
-      values={{
-        relative: <ZUIRelativeTime datetime={publishedDate.toISOString()} />,
-      }}
-    />
+    const id = publishedDate.isBefore(now)
+      ? messageIds.activitiesOverview.subtitles.sentEarlier
+      : messageIds.activitiesOverview.subtitles.sentLater;
+    return (
+      <Msg
+        id={id}
+        values={{
+          relative: <ZUIRelativeTime datetime={publishedDate.toISOString()} />,
+        }}
+      />
     );
-
   }
 
   return (

--- a/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EmailOverviewListItem.tsx
@@ -1,8 +1,12 @@
 import { FC } from 'react';
 
+import dayjs from 'dayjs';
 import { EmailActivity } from 'features/campaigns/types';
+import messageIds from 'features/campaigns/l10n/messageIds';
+import { Msg } from 'core/i18n';
 import OverviewListItem from './OverviewListItem';
 import useEmailStats from 'features/emails/hooks/useEmailStats';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import { EmailOutlined, Person } from '@mui/icons-material';
 
 interface EmailOverviewListItemProps {
@@ -20,6 +24,25 @@ const EmailOverviewListItem: FC<EmailOverviewListItemProps> = ({
     email.id
   );
 
+  function getSubtitle(published: string | null) {
+    if (published === null) {
+      return undefined;
+    }
+    const now = new Date()
+    const publishedDate = dayjs(published);
+    const id = publishedDate.isBefore(now) ?
+      messageIds.activitiesOverview.subtitles.sentEarlier :
+      messageIds.activitiesOverview.subtitles.sentLater;
+    return (<Msg
+      id={id}
+      values={{
+        relative: <ZUIRelativeTime datetime={publishedDate.toISOString()} />,
+      }}
+    />
+    );
+
+  }
+
   return (
     <OverviewListItem
       endDate={activity.visibleUntil}
@@ -31,6 +54,7 @@ const EmailOverviewListItem: FC<EmailOverviewListItemProps> = ({
       PrimaryIcon={EmailOutlined}
       SecondaryIcon={Person}
       startDate={activity.visibleFrom}
+      subtitle={getSubtitle(activity.data.published)}
       title={email.title || ''}
     />
   );

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventClusterOverviewListItem.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mui/icons-material';
 
 import { EventWarningIconsSansModel } from 'features/events/components/EventWarningIcons';
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 import LocationLabel from 'features/events/components/LocationLabel';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { Msg } from 'core/i18n';
@@ -48,8 +49,12 @@ const EventClusterOverviewListItem: FC<EventClusterOverviewListItemProps> = ({
     title,
   } = useEventClusterData(cluster);
 
+  const startDate = cluster.events[0].published
+    ? new Date(cluster.events[0].published)
+    : null;
   return (
     <OverviewListItem
+      color={getStatusColor(startDate, null)}
       endDate={null}
       endNumber={`${numBooked} / ${numParticipantsRequired}`}
       endNumberColor={numBooked < numParticipantsRequired ? 'error' : undefined}
@@ -74,11 +79,7 @@ const EventClusterOverviewListItem: FC<EventClusterOverviewListItemProps> = ({
           : SplitscreenOutlined
       }
       SecondaryIcon={Group}
-      startDate={
-        cluster.events[0].published
-          ? new Date(cluster.events[0].published)
-          : null
-      }
+      startDate={startDate}
       subtitle={
         <ZUIIconLabelRow
           color="secondary"

--- a/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/EventOverviewListItem.tsx
@@ -9,6 +9,7 @@ import {
 import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
 import EventWarningIcons from 'features/events/components/EventWarningIcons';
 import getEventUrl from 'features/events/utils/getEventUrl';
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 import messageIds from 'features/events/l10n/messageIds';
 import OverviewListItem from './OverviewListItem';
 import { removeOffset } from 'utils/dateUtils';
@@ -30,9 +31,13 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
   const { openEventPopper } = useEventPopper();
   const messages = useMessages(messageIds);
 
+  const startDate = event.published ? new Date(event.published) : null;
+  const endDate = event.cancelled ? new Date(event.cancelled) : null;
+
   return (
     <OverviewListItem
-      endDate={event.cancelled ? new Date(event.cancelled) : null}
+      color={getStatusColor(startDate, endDate)}
+      endDate={endDate}
       endNumber={`${event.num_participants_available} / ${event.num_participants_required}`}
       endNumberColor={
         event.num_participants_available < event.num_participants_required
@@ -56,7 +61,7 @@ const EventOverviewListItem: FC<EventOverviewListItemProps> = ({
       }}
       PrimaryIcon={EventOutlined}
       SecondaryIcon={People}
-      startDate={event.published ? new Date(event.published) : null}
+      startDate={startDate}
       statusBar={null}
       subtitle={
         <ZUIIconLabelRow

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -69,6 +69,7 @@ interface OverviewListItemProps {
   SecondaryIcon: OverridableComponent<
     SvgIconTypeMap<Record<string, unknown>, 'svg'>
   >;
+  color: STATUS_COLORS;
   endDate: CampaignActivity['visibleUntil'];
   startDate: CampaignActivity['visibleFrom'];
   focusDate: Date | null;
@@ -85,6 +86,7 @@ interface OverviewListItemProps {
 const OverviewListItem = ({
   PrimaryIcon,
   SecondaryIcon,
+  color,
   endDate,
   startDate,
   focusDate,
@@ -97,7 +99,7 @@ const OverviewListItem = ({
   statusBar,
   subtitle,
 }: OverviewListItemProps) => {
-  const color = getStatusColor(startDate, endDate);
+  //const color = getStatusColor(startDate, endDate);
   const classes = useStyles({ color });
 
   const now = new Date();
@@ -227,28 +229,3 @@ const OverviewListItem = ({
 };
 
 export default OverviewListItem;
-
-function getStatusColor(
-  startDate: Date | null,
-  endDate: Date | null
-): STATUS_COLORS {
-  const now = new Date();
-
-  if (startDate) {
-    if (startDate > now) {
-      return STATUS_COLORS.BLUE;
-    } else if (startDate < now) {
-      if (!endDate || endDate > now) {
-        return STATUS_COLORS.GREEN;
-      } else if (endDate && endDate < now) {
-        // Should never happen, because it should not be
-        // in the overview after it's closed.
-        return STATUS_COLORS.RED;
-      }
-    }
-  }
-
-  // Should never happen, because it should not be in the
-  // overview if it's not yet scheduled/published.
-  return STATUS_COLORS.GRAY;
-}

--- a/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/SurveyOverviewListItem.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { AssignmentOutlined, ChatBubbleOutline } from '@mui/icons-material';
 
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 import getSurveyUrl from 'features/surveys/utils/getSurveyUrl';
 import OverviewListItem from './OverviewListItem';
 import { SurveyActivity } from 'features/campaigns/types';
@@ -23,6 +24,7 @@ const SurveyOverviewListItem: FC<SurveyOverviewListItemProps> = ({
   const { orgId } = useNumericRouteParams();
   return (
     <OverviewListItem
+      color={getStatusColor(activity.visibleFrom, activity.visibleUntil)}
       endDate={activity.visibleUntil}
       endNumber={submissionCount}
       focusDate={focusDate}

--- a/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/TaskOverviewListItem.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react';
 import { CheckBoxOutlined, People } from '@mui/icons-material';
 
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 import OverviewListItem from './OverviewListItem';
 import { TaskActivity } from 'features/campaigns/types';
 import useTaskStats from 'features/tasks/hooks/useTaskStats';
@@ -20,6 +21,7 @@ const TaskOverviewListItem: FC<TasksOverviewListItemProps> = ({
 
   return (
     <OverviewListItem
+      color={getStatusColor(activity.visibleFrom, activity.visibleUntil)}
       endDate={activity.visibleUntil}
       endNumber={stats?.individuals || 0}
       focusDate={focusDate}

--- a/src/features/campaigns/hooks/useActivityOverview.ts
+++ b/src/features/campaigns/hooks/useActivityOverview.ts
@@ -42,7 +42,7 @@ export default function useActivitiyOverview(
     taskActivitiesFuture.error ||
     emailActivitiesFuture.error
   ) {
-    return new ErrorFuture('Error loading acitvities');
+    return new ErrorFuture('Error loading activities');
   }
 
   const activities: CampaignActivity[] = [];
@@ -54,7 +54,7 @@ export default function useActivitiyOverview(
     ...(emailActivitiesFuture.data || [])
   );
 
-  const sortedAcitvities = activities.sort((first, second) => {
+  const sortedActivities = activities.sort((first, second) => {
     if (first.visibleFrom === null) {
       return -1;
     } else if (second.visibleFrom === null) {
@@ -74,7 +74,7 @@ export default function useActivitiyOverview(
   const tomorrowDate = new Date();
   tomorrowDate.setDate(tomorrowDate.getDate() + 1);
 
-  overview.today = sortedAcitvities.filter((activity) => {
+  overview.today = sortedActivities.filter((activity) => {
     if (activity.kind == ACTIVITIES.EVENT) {
       const startDate = new Date(activity.data.start_time);
       return isSameDate(startDate, todayDate);
@@ -86,7 +86,7 @@ export default function useActivitiyOverview(
     }
   });
 
-  overview.tomorrow = sortedAcitvities.filter((activity) => {
+  overview.tomorrow = sortedActivities.filter((activity) => {
     if (activity.kind == ACTIVITIES.EVENT) {
       const startDate = new Date(activity.data.start_time);
       return isSameDate(startDate, tomorrowDate);
@@ -100,7 +100,7 @@ export default function useActivitiyOverview(
     }
   });
 
-  overview.alsoThisWeek = sortedAcitvities.filter((activity) => {
+  overview.alsoThisWeek = sortedActivities.filter((activity) => {
     if (
       overview.today.includes(activity) ||
       overview.tomorrow.includes(activity)

--- a/src/features/campaigns/hooks/useActivityOverview.ts
+++ b/src/features/campaigns/hooks/useActivityOverview.ts
@@ -1,5 +1,6 @@
 import { isSameDate } from 'utils/dateUtils';
 import useCallAssignmentActivities from './useCallAssignmentActivities';
+import useEmailActivities from './useEmailActivities';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useSurveyActivities from './useSurveyActivities';
 import useTaskActivities from './useTaskActivities';
@@ -26,17 +27,20 @@ export default function useActivitiyOverview(
     orgId,
     campId
   );
+  const emailActivitiesFuture = useEmailActivities(orgId, campId);
 
   if (
     callAssignmentActivitiesFuture.isLoading ||
     surveyActivitiesFuture.isLoading ||
-    taskActivitiesFuture.isLoading
+    taskActivitiesFuture.isLoading ||
+    emailActivitiesFuture.isLoading
   ) {
     return new LoadingFuture();
   } else if (
     callAssignmentActivitiesFuture.error ||
     surveyActivitiesFuture.error ||
-    taskActivitiesFuture.error
+    taskActivitiesFuture.error ||
+    emailActivitiesFuture.error
   ) {
     return new ErrorFuture('Error loading acitvities');
   }
@@ -46,7 +50,8 @@ export default function useActivitiyOverview(
     ...eventActivites,
     ...(taskActivitiesFuture.data || []),
     ...(surveyActivitiesFuture.data || []),
-    ...(callAssignmentActivitiesFuture.data || [])
+    ...(callAssignmentActivitiesFuture.data || []),
+    ...(emailActivitiesFuture.data || [])
   );
 
   const sortedAcitvities = activities.sort((first, second) => {

--- a/src/features/campaigns/hooks/useEmailActivities.ts
+++ b/src/features/campaigns/hooks/useEmailActivities.ts
@@ -26,7 +26,6 @@ const visibleUntil = (published: string | null): Date | null => {
   return visibleUntil.toDate();
 };
 
-
 export default function useEmailActivities(
   orgId: number,
   campId?: number
@@ -56,7 +55,6 @@ export default function useEmailActivities(
       const campaignEmails = allEmails.filter(
         (email) => email.campaign?.id === campId
       );
-
 
       campaignEmails.forEach((email) => {
         activities.push({

--- a/src/features/campaigns/hooks/useEmailActivities.ts
+++ b/src/features/campaigns/hooks/useEmailActivities.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ACTIVITIES, CampaignActivity } from '../types';
 import { emailsLoad, emailsLoaded } from 'features/emails/store';
@@ -9,22 +8,6 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-
-const visibleFrom = (published: string | null): Date | null => {
-  if (!published) {
-    return null;
-  }
-  const visibleUntil = dayjs(new Date(published)).startOf('day');
-  return visibleUntil.toDate();
-};
-
-const visibleUntil = (published: string | null): Date | null => {
-  if (!published) {
-    return null;
-  }
-  const visibleUntil = dayjs(new Date(published)).endOf('day');
-  return visibleUntil.toDate();
-};
 
 export default function useEmailActivities(
   orgId: number,
@@ -60,8 +43,8 @@ export default function useEmailActivities(
         activities.push({
           data: email,
           kind: ACTIVITIES.EMAIL,
-          visibleFrom: visibleFrom(email.published || null),
-          visibleUntil: visibleUntil(email.published),
+          visibleFrom: email.published ? new Date(email.published) : null,
+          visibleUntil: email.published ? new Date(email.published) : null,
         });
       });
     } else {
@@ -69,8 +52,8 @@ export default function useEmailActivities(
         activities.push({
           data: email,
           kind: ACTIVITIES.EMAIL,
-          visibleFrom: visibleFrom(email.published || null),
-          visibleUntil: visibleUntil(email.published),
+          visibleFrom: email.published ? new Date(email.published) : null,
+          visibleUntil: email.published ? new Date(email.published) : null,
         });
       });
     }

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -15,6 +15,8 @@ export default makeMessages('feat.campaigns', {
     subtitles: {
       endsLater: m<{ relative: ReactElement }>('Ends {relative}'),
       endsToday: m('Ends today'),
+      sentEarlier: m<{ relative: ReactElement }>('Was sent {relative}'),
+      sentLater: m<{ relative: ReactElement }>('To be sent {relative}'),
       startsLater: m<{ relative: ReactElement }>('Starts {relative}'),
       startsToday: m('Starts today'),
     },

--- a/src/features/campaigns/utils/getStatusColor.ts
+++ b/src/features/campaigns/utils/getStatusColor.ts
@@ -1,0 +1,26 @@
+import { STATUS_COLORS } from '../components/ActivityList/items/ActivityListItem';
+
+export default function getStatusColor(
+  startDate: Date | null,
+  endDate: Date | null
+): STATUS_COLORS {
+  const now = new Date();
+
+  if (startDate) {
+    if (startDate > now) {
+      return STATUS_COLORS.BLUE;
+    } else if (startDate < now) {
+      if (!endDate || endDate > now) {
+        return STATUS_COLORS.GREEN;
+      } else if (endDate && endDate < now) {
+        // Should never happen, because it should not be
+        // in the overview after it's closed.
+        return STATUS_COLORS.RED;
+      }
+    }
+  }
+
+  // Should never happen, because it should not be in the
+  // overview if it's not yet scheduled/published.
+  return STATUS_COLORS.GRAY;
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -86,7 +86,7 @@ export function isInFuture(datestring: string): boolean {
 }
 
 export function isSameDate(first: Date, second: Date): boolean {
-  return first.toISOString().slice(0, 10) == second.toISOString().slice(0, 10);
+  return dayjs(first).isSame(dayjs(second), 'day')
 }
 
 export function isValidDate(date: Date): boolean {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -86,7 +86,7 @@ export function isInFuture(datestring: string): boolean {
 }
 
 export function isSameDate(first: Date, second: Date): boolean {
-  return dayjs(first).isSame(dayjs(second), 'day')
+  return dayjs(first).isSame(dayjs(second), 'day');
 }
 
 export function isValidDate(date: Date): boolean {


### PR DESCRIPTION
## Description
This PR adds email activities to upcoming activities in the overview


## Screenshots
![upcomingemails](https://github.com/zetkin/app.zetkin.org/assets/1464855/a8557e1d-10fc-45da-9bda-d959567a7a36)


## Changes
* Adds emailActivities to the useActivityOverview hook


## Notes to reviewer
Also fixed a typo


## Related issues
Resolves #1992 
