### PR TITLE
Fix bug causing error when a single event type loads

### DIFF
--- a/src/features/events/hooks/useEventType.ts
+++ b/src/features/events/hooks/useEventType.ts
@@ -15,8 +15,8 @@ export default function useEventType(
   );
 
   return loadItemIfNecessary(typeItem, dispatch, {
-    actionOnLoad: () => typeLoad(orgId),
-    actionOnSuccess: (data) => typeLoaded([orgId, data]),
+    actionOnLoad: () => typeLoad(typeId),
+    actionOnSuccess: (data) => typeLoaded(data),
     loader: () =>
       apiClient.get<ZetkinActivity>(`/api/orgs/${orgId}/activities/${typeId}`),
   });

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -479,14 +479,14 @@ const eventsSlice = createSlice({
         remoteItem(data.id, { data: data, isLoading: false }),
       ]);
     },
-    typeLoad: (state, action) => {
+    typeLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const item = state.typeList.items.find((item) => item.id == id);
       state.typeList.items = state.typeList.items
         .filter((item) => item.id != id)
         .concat([remoteItem(id, { data: item?.data, isLoading: true })]);
     },
-    typeLoaded: (state, action) => {
+    typeLoaded: (state, action: PayloadAction<ZetkinActivity>) => {
       const activity = action.payload;
       const item = state.typeList.items.find((item) => item.id == activity.id);
 


### PR DESCRIPTION
## Description
This PR fixes an undocumented bug in how the `typeLoad` and `typeLoaded` store actions were implemented, which caused an error to be thrown when loading a single event type ("activity"). This in turn caused a bug when rendering Smart Searches.


## Screenshots
None

## Changes
* Adds types to the `typeLoad` and `typeLoaded` actions
* Changes the use of said actions to more closely resemble how similar actions are used elsewhere (not including `orgId`)

## Notes to reviewer
None

## Related issues
Undocumented