### PR TITLE
Move client-side environment variables to context

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,8 @@
+ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org
 
 # Zetkin API settings
 ZETKIN_API_DOMAIN=dev.zetkin.org
 ZETKIN_API_HOST=api.dev.zetkin.org
-NEXT_PUBLIC_ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org
 ZETKIN_CLIENT_ID=a0db63a12bae45ff83d12de70c8992c0
 ZETKIN_CLIENT_SECRET=MWQyZmE2M2UtMzM3Yi00ODUyLWI2NGMtOWY5YTY5NTY3YjU5
 ZETKIN_APP_HOST=localhost:3000

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,3 @@
-# Client settings
-NEXT_PUBLIC_APP_USE_TLS=0
 
 # Zetkin API settings
 ZETKIN_API_DOMAIN=dev.zetkin.org

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,15 @@ export default async function RootLayout({
     <html lang="en">
       <body>
         <AppRouterCacheProvider>
-          <ClientContext lang={lang} messages={messages} user={user}>
+          <ClientContext
+            envVars={{
+              MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY || null,
+              ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN || null,
+            }}
+            lang={lang}
+            messages={messages}
+            user={user}
+          >
             {children}
           </ClientContext>
         </AppRouterCacheProvider>

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -25,6 +25,10 @@ declare module '@mui/styles/defaultTheme' {
 
 type ClientContextProps = {
   children: ReactNode;
+  envVars: {
+    MUIX_LICENSE_KEY: string | null;
+    ZETKIN_APP_DOMAIN: string | null;
+  };
   lang: string;
   messages: MessageList;
   user: ZetkinUser | null;
@@ -32,11 +36,12 @@ type ClientContextProps = {
 
 const ClientContext: FC<ClientContextProps> = ({
   children,
+  envVars,
   lang,
   messages,
   user,
 }) => {
-  const env = new Environment(store, new BrowserApiClient());
+  const env = new Environment(store, new BrowserApiClient(), envVars);
   return (
     <ReduxProvider store={store}>
       <StyledEngineProvider injectFirst>

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -1,20 +1,34 @@
 import IApiClient from 'core/api/client/IApiClient';
 import { Store } from '../store';
 
+type EnvVars = {
+  MUIX_LICENSE_KEY: string | null;
+  ZETKIN_APP_DOMAIN: string | null;
+};
+
 export default class Environment {
   private _apiClient: IApiClient;
   private _store: Store;
+  private _vars: EnvVars;
 
   get apiClient() {
     return this._apiClient;
   }
 
-  constructor(store: Store, apiClient: IApiClient) {
+  constructor(store: Store, apiClient: IApiClient, envVars?: EnvVars) {
     this._apiClient = apiClient;
     this._store = store;
+    this._vars = envVars || {
+      MUIX_LICENSE_KEY: null,
+      ZETKIN_APP_DOMAIN: null,
+    };
   }
 
   get store() {
     return this._store;
+  }
+
+  get vars() {
+    return this._vars;
   }
 }

--- a/src/features/surveys/components/SurveyURLCard.tsx
+++ b/src/features/surveys/components/SurveyURLCard.tsx
@@ -1,6 +1,7 @@
 import { OpenInNew } from '@mui/icons-material';
 import { Box, Link, useTheme } from '@mui/material';
 
+import { useEnv } from 'core/hooks';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
@@ -16,6 +17,8 @@ interface SurveyURLCardProps {
 const SurveyURLCard = ({ isOpen, orgId, surveyId }: SurveyURLCardProps) => {
   const messages = useMessages(messageIds);
   const theme = useTheme();
+  const env = useEnv();
+
   return (
     <ZUICard
       header={isOpen ? messages.urlCard.open() : messages.urlCard.preview()}
@@ -37,9 +40,9 @@ const SurveyURLCard = ({ isOpen, orgId, surveyId }: SurveyURLCardProps) => {
     >
       <Box display="flex" paddingBottom={2}>
         <ZUITextfieldToClipboard
-          copyText={`${process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
+          copyText={`${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
         >
-          {`${process.env.NEXT_PUBLIC_ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
+          {`${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}/surveys/${surveyId}`}
         </ZUITextfieldToClipboard>
       </Box>
       <Link

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,11 +20,6 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
-// MUI-X license
-if (process.env.NEXT_PUBLIC_MUIX_LICENSE_KEY) {
-  LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUIX_LICENSE_KEY);
-}
-
 // Progress bar
 NProgress.configure({ showSpinner: false });
 Router.events.on(
@@ -47,7 +42,7 @@ declare global {
 }
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
-  const { lang, messages, ...restProps } = pageProps;
+  const { envVars, lang, messages, ...restProps } = pageProps;
   const c = Component as PageWithLayout;
   const getLayout = c.getLayout || ((page) => page);
 
@@ -55,7 +50,12 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     window.__reactRendered = true;
   }
 
-  const env = new Environment(store, new BrowserApiClient());
+  const env = new Environment(store, new BrowserApiClient(), envVars || {});
+
+  // MUI-X license
+  if (env.vars.MUIX_LICENSE_KEY) {
+    LicenseInfo.setLicenseKey(env.vars.MUIX_LICENSE_KEY);
+  }
 
   useEffect(() => {
     // Remove the server-side injected CSS.

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -189,6 +189,10 @@ export const scaffold =
     if (hasProps(result)) {
       result.props = {
         ...result.props,
+        envVars: {
+          MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY || null,
+          ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN || null,
+        },
         lang,
         messages,
         user: ctx.user,

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -29,7 +29,10 @@ interface ZetkinAppProvidersProps {
 
 const ZetkinAppProviders: FC<ZetkinAppProvidersProps> = ({ children }) => {
   const store = createStore();
-  const env = new Environment(store, new BrowserApiClient());
+  const env = new Environment(store, new BrowserApiClient(), {
+    MUIX_LICENSE_KEY: null,
+    ZETKIN_APP_DOMAIN: 'https://app.zetkin.org',
+  });
 
   return (
     <UserContext.Provider value={null}>


### PR DESCRIPTION
## Description
This PR refactors the use of client-side (`NEXT_PUBLIC_*`) environment variables so that instead of building them into the bundle, they are accessed server-side and serialized into the client-side code at runtime.

This change allows for a single build to be deployed to any instance of Zetkin, and for that build to be prebuilt.

## Screenshots
None

## Changes
* Creates an object for environment variables in the `Environment` class, returned by `useEnv()`
* Removes unused `NEXT_PUBLIC_APP_USE_TLS` variable
* Moves client-side accessible `NEXT_PUBLIC_MUIX_LICENSE_KEY` and `NEXT_PUBLIC_ZETKIN_APP_DOMAIN` environment variables to server-side `MUIX_LICENSE_KEY` and `ZETKIN_APP_DOMAIN`
* Changes entry points in the pages router `_app.tsx`, app-router `layout.tsx` and test harness to pass said variables to context
* Changes uses of said variables to retrieve them from context using `useEnv()` instead of global `process.env`


## Notes to reviewer
To verify that this is working:

1. Build a production build using `next build`
2. Copy `.env.development` to `.env.production`
3. Start the local server with `yarn start -p 3000`
4. Browse to a survey and note the shareable URL
5. Modify `.env.production` to change the value of `ZETKIN_APP_DOMAIN`
6. Restart the server (do NOT rebuild it)
7. Browse to the survey again and verify that the shareable URL has changed to reflect the new value of `ZETKIN_APP_DOMAIN`

## Related issues
Resolves #1786 