### PR TITLE
Build docker image in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 Dockerfile
 node_modules
 .git
+.github
 .next
 env

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -41,6 +43,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -29,6 +29,9 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix={{date 'YYMMDD'}}-
+            type=raw,value={{date 'YYMMDD'}}
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
+          file: ./env/frontend/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,0 +1,45 @@
+name: Build docker image
+
+on:
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -42,6 +42,7 @@ jobs:
           tags: |
             type=sha,prefix={{date 'YYMMDD'}}-
             type=raw,value={{date 'YYMMDD'}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -1,7 +1,9 @@
 name: Build docker image
 
 on:
-  pull_request:
+  push:
+    branches:
+      - "release"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,25 +18,32 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Buildx is necessary for GitHub Actions caching to work
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # The image will be tagged YYMMDD and YYMMDD-abcdef,
+          # where abcdef is the shortform hash of the last commit
           tags: |
             type=sha,prefix={{date 'YYMMDD'}}-
             type=raw,value={{date 'YYMMDD'}}
+
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./env/frontend/Dockerfile
@@ -45,6 +52,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/env/frontend/Dockerfile
+++ b/env/frontend/Dockerfile
@@ -7,5 +7,6 @@ COPY yarn.lock /var/app/yarn.lock
 RUN yarn install --no-cache --frozen-lockfile
 
 COPY . /var/app
+RUN yarn build
 
 CMD ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,6 @@
 
 if [[ "$NODE_ENV" == "production" ]];
 then
-    yarn build
     yarn start
 else
     yarn dev


### PR DESCRIPTION
## Description
This PR sets up a CI workflow to build a docker image and push it to the GitHub container registry.

## Screenshots
None

## Changes
* Adds a GitHub Actions workflow to build Docker images, that is executed when something is merged into the `release` branch
* Changes the Dockerfile so that NEXT.js is built into the image
* Adds `.github` to the `.dockerignore` so that github workflows do not affect the image itself

## Notes to reviewer
I appreciate that this might be difficult for anyone except myself to review, but any feedback (even questions) would be useful for me to really think this through.

## Related issues
Undocumented