### PR TITLE
Issue 1999 / Add responsive top margin

### DIFF
--- a/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
+++ b/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip } from '@mui/material';
+import { Box, Chip, useMediaQuery } from '@mui/material';
 
 import { Msg } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
@@ -26,6 +26,7 @@ const DisplayPersonTags = ({ filter }: DisplayPersonTagProps): JSX.Element => {
   const { condition, tags: tagIds, min_matching } = config;
   const { data } = useTags(orgId);
   const tags = data || [];
+  const isDesktop = useMediaQuery('(min-width:600px');
 
   // preserve the order of the tag array
   const selectedTags = tagIds.reduce((acc: ZetkinTag[], id) => {
@@ -52,7 +53,7 @@ const DisplayPersonTags = ({ filter }: DisplayPersonTagProps): JSX.Element => {
           <UnderlinedMsg id={localMessageIds.condition.preview[condition]} />
         ),
         tags: (
-          <Box alignItems="start" display="inline-flex">
+          <Box alignItems="start" display="inline-flex" sx={{ marginTop:  isDesktop ? '10px' : null }}>
             {selectedTags.map((t) => (
               <Chip
                 key={t.id}

--- a/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
+++ b/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
@@ -53,7 +53,11 @@ const DisplayPersonTags = ({ filter }: DisplayPersonTagProps): JSX.Element => {
           <UnderlinedMsg id={localMessageIds.condition.preview[condition]} />
         ),
         tags: (
-          <Box alignItems="start" display="inline-flex" sx={{ marginTop:  isDesktop ? '10px' : null }}>
+          <Box
+            alignItems="start"
+            display="inline-flex"
+            sx={{ marginTop: isDesktop ? '10px' : null }}
+          >
             {selectedTags.map((t) => (
               <Chip
                 key={t.id}


### PR DESCRIPTION
## Description
This PR adds a top margin of 10 px to DisplayPersonTags on devices with screen width larger than 600 pixels.

The reason I made it responsive was that on mobile screens the tags wrapped nicer without margin.

## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/97404672/57efacc4-cdc7-46a0-af87-7ded2d778d71)

## Changes

* Adds a useMediaQuery hook in DisplayPersonTags
* Adds styling to the container element in DisplayPersonTags


## Notes to reviewer
1. Go to smart search
2. Click add/remove people
3. Click Tags
4. Add some tags
5. Click save selection
6. Displayed tags should now look better


## Related issues
Resolves #1999
