### PR TITLE
Delete tags

### DIFF
--- a/src/features/tags/components/TagManager/TagManagerController.spec.tsx
+++ b/src/features/tags/components/TagManager/TagManagerController.spec.tsx
@@ -1,12 +1,11 @@
-import { render } from 'utils/testing';
 import singletonRouter from 'next/router';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 
 import messageIds from 'features/tags/l10n/messageIds';
-import { TagManagerController } from './TagManagerController';
-
 import mockTag from 'utils/testing/mocks/mockTag';
+import { render } from 'utils/testing';
+import { TagManagerController } from './TagManagerController';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { EditTag, NewTag } from './types';
 
@@ -22,6 +21,7 @@ const createTagCallback = jest.fn<Promise<ZetkinTag>, [NewTag]>((tag) =>
 );
 const unassignTagCallback = jest.fn((tag: ZetkinTag) => tag);
 const editTagCallback = jest.fn((tag: EditTag) => tag);
+const deleteTagCallback = jest.fn((tagId: number) => tagId);
 
 describe('<TagManagerController />', () => {
   describe('Renders list of tags passed in', () => {
@@ -35,6 +35,7 @@ describe('<TagManagerController />', () => {
           availableTags={[tag1, tag2]}
           onAssignTag={assignTagCallback}
           onCreateTag={createTagCallback}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
@@ -86,6 +87,7 @@ describe('<TagManagerController />', () => {
         groupTags
         onAssignTag={assignTagCallback}
         onCreateTag={createTagCallback}
+        onDeleteTag={deleteTagCallback}
         onEditTag={editTagCallback}
         onUnassignTag={unassignTagCallback}
       />
@@ -118,6 +120,7 @@ describe('<TagManagerController />', () => {
         availableTags={[tag1]}
         onAssignTag={onAssignTag}
         onCreateTag={createTagCallback}
+        onDeleteTag={deleteTagCallback}
         onEditTag={editTagCallback}
         onUnassignTag={unassignTagCallback}
       />
@@ -152,6 +155,7 @@ describe('<TagManagerController />', () => {
         availableTags={[tag]}
         onAssignTag={onAssignTag}
         onCreateTag={createTagCallback}
+        onDeleteTag={deleteTagCallback}
         onEditTag={editTagCallback}
         onUnassignTag={unassignTagCallback}
       />
@@ -201,6 +205,7 @@ describe('<TagManagerController />', () => {
         availableTags={[tag1]}
         onAssignTag={assignTagCallback}
         onCreateTag={createTagCallback}
+        onDeleteTag={deleteTagCallback}
         onEditTag={editTagCallback}
         onUnassignTag={onUnassignTag}
       />
@@ -244,6 +249,7 @@ describe('<TagManagerController />', () => {
           availableTags={[]}
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
@@ -273,6 +279,7 @@ describe('<TagManagerController />', () => {
           availableTags={[]}
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
@@ -310,6 +317,7 @@ describe('<TagManagerController />', () => {
           availableTags={[]}
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
@@ -379,6 +387,7 @@ describe('<TagManagerController />', () => {
           disableEditTags
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />
@@ -403,6 +412,7 @@ describe('<TagManagerController />', () => {
           availableTags={[tagToEdit]}
           onAssignTag={assignTagCallback}
           onCreateTag={onCreateTag}
+          onDeleteTag={deleteTagCallback}
           onEditTag={editTagCallback}
           onUnassignTag={unassignTagCallback}
         />

--- a/src/features/tags/components/TagManager/TagManagerController.tsx
+++ b/src/features/tags/components/TagManager/TagManagerController.tsx
@@ -1,14 +1,13 @@
 import { Add } from '@mui/icons-material';
-import { useState } from 'react';
 import { Box, Button, Popover } from '@mui/material';
+import { FC, useState } from 'react';
 
+import messageIds from '../../l10n/messageIds';
+import { Msg } from 'core/i18n';
 import TagSelect from 'features/tags/components/TagManager/components/TagSelect';
 import TagsList from './components/TagsList';
 import { EditTag, NewTag } from './types';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';
-
-import messageIds from '../../l10n/messageIds';
-import { Msg } from 'core/i18n';
 
 export interface TagManagerControllerProps {
   assignedTags: ZetkinTag[];
@@ -20,13 +19,12 @@ export interface TagManagerControllerProps {
   ignoreValues?: boolean;
   onAssignTag: (tag: ZetkinTag) => void;
   onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
+  onDeleteTag: (tagId: number) => void;
   onEditTag: (tag: EditTag) => void;
   onUnassignTag: (tag: ZetkinTag) => void;
 }
 
-export const TagManagerController: React.FunctionComponent<
-  TagManagerControllerProps
-> = ({
+export const TagManagerController: FC<TagManagerControllerProps> = ({
   assignedTags,
   availableGroups,
   availableTags,
@@ -36,6 +34,7 @@ export const TagManagerController: React.FunctionComponent<
   ignoreValues = false,
   onAssignTag,
   onCreateTag,
+  onDeleteTag,
   onEditTag,
   onUnassignTag,
 }) => {
@@ -76,6 +75,7 @@ export const TagManagerController: React.FunctionComponent<
               // New tag is accessible in TagSelect
               return newTag;
             }}
+            onDeleteTag={onDeleteTag}
             onEditTag={onEditTag}
             onSelect={onAssignTag}
             tags={availableTags}

--- a/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
@@ -12,6 +12,7 @@ jest.mock('next/dist/client/router', () => require('next-router-mock'));
 
 describe('<TagDialog />', () => {
   let onSubmit: jest.Mock<NewTag | EditTag, [tag: NewTag | EditTag]>;
+  const deleteTagCallback = jest.fn((tagId: number) => tagId);
 
   beforeEach(() => {
     onSubmit = jest.fn((tag: NewTag | EditTag) => tag);
@@ -25,6 +26,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
+        onDelete={deleteTagCallback}
         onSubmit={onSubmit}
         open={true}
       />
@@ -54,6 +56,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
+        onDelete={deleteTagCallback}
         onSubmit={onSubmit}
         open={true}
       />
@@ -86,6 +89,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
+        onDelete={deleteTagCallback}
         onSubmit={onSubmit}
         open={true}
       />
@@ -125,6 +129,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
+        onDelete={deleteTagCallback}
         onSubmit={onSubmit}
         open={true}
         tag={mockTag({ id: 1000, title })}
@@ -153,6 +158,7 @@ describe('<TagDialog />', () => {
       <TagDialog
         groups={[]}
         onClose={() => undefined}
+        onDelete={deleteTagCallback}
         onSubmit={onSubmit}
         open={true}
         tag={mockTag({ id: 1000, title: 'Value tag', value_type: 'text' })}

--- a/src/features/tags/components/TagManager/components/TagDialog/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/index.tsx
@@ -1,22 +1,22 @@
 /* eslint-disable jsx-a11y/no-autofocus */
-import { TextField } from '@mui/material';
+import { Box, Button, TextField } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import ColorPicker from './ColorPicker';
+import messageIds from '../../../../l10n/messageIds';
 import TagGroupSelect from './TagGroupSelect';
 import TypeSelect from './TypeSelect';
 import ZUIDialog from 'zui/ZUIDialog';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import { EditTag, NewTag, NewTagGroup } from '../../types';
+import { Msg, useMessages } from 'core/i18n';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';
-
-import messageIds from '../../../../l10n/messageIds';
-import { useMessages } from 'core/i18n';
 
 interface TagDialogProps {
   groups: ZetkinTagGroup[];
   open: boolean;
   onClose: () => void;
+  onDelete: (tagId: number) => void;
   onSubmit: (tag: NewTag | EditTag) => void;
   tag?: ZetkinTag | Pick<ZetkinTag, 'title'>;
 }
@@ -25,6 +25,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
   groups,
   open,
   onClose,
+  onDelete,
   onSubmit,
   tag,
 }) => {
@@ -132,13 +133,30 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           onChange={(value) => setType(value)}
           value={type}
         />
-        <ZUISubmitCancelButtons
-          onCancel={closeAndClear}
-          submitDisabled={!title || !color.valid}
-          submitText={
-            editingTag ? undefined : messages.dialog.submitCreateTagButton()
-          }
-        />
+        <Box
+          alignItems="flex-end"
+          display="flex"
+          justifyContent="space-between"
+        >
+          {tag && 'id' in tag && (
+            <Button
+              onClick={() => {
+                onDelete(tag.id);
+                closeAndClear();
+              }}
+              sx={{ margin: 1 }}
+            >
+              <Msg id={messageIds.dialog.deleteButtonLabel} />
+            </Button>
+          )}
+          <ZUISubmitCancelButtons
+            onCancel={closeAndClear}
+            submitDisabled={!title || !color.valid}
+            submitText={
+              editingTag ? undefined : messages.dialog.submitCreateTagButton()
+            }
+          />
+        </Box>
       </form>
     </ZUIDialog>
   );

--- a/src/features/tags/components/TagManager/components/TagSelect/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/index.tsx
@@ -1,39 +1,44 @@
 import useAutocomplete from '@mui/material/useAutocomplete';
-import { useState } from 'react';
 import { Box, TextField } from '@mui/material';
+import { FC, useContext, useState } from 'react';
 
+import messageIds from '../../../../l10n/messageIds';
 import TagDialog from 'features/tags/components/TagManager/components/TagDialog';
 import TagSelectList from './TagSelectList';
+import { useMessages } from 'core/i18n';
 import ValueTagForm from './ValueTagForm';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import { EditTag, NewTag } from '../../types';
 import { filterTags, groupTags } from '../../utils';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';
 
-import messageIds from '../../../../l10n/messageIds';
-import { useMessages } from 'core/i18n';
-
-const TagSelect: React.FunctionComponent<{
+interface TagSelectProps {
   disableEditTags?: boolean;
   disabledTags: ZetkinTag[];
   groups: ZetkinTagGroup[];
   ignoreValues?: boolean;
   onClose: () => void;
   onCreateTag: (tag: NewTag) => Promise<ZetkinTag>;
+  onDeleteTag: (tagId: number) => void;
   onEditTag: (tag: EditTag) => void;
   onSelect: (tag: ZetkinTag) => void;
   tags: ZetkinTag[];
-}> = ({
+}
+
+const TagSelect: FC<TagSelectProps> = ({
   disableEditTags,
   disabledTags,
   groups,
   ignoreValues = false,
   onClose,
   onCreateTag,
+  onDeleteTag,
   onEditTag,
   onSelect,
   tags,
 }) => {
   const messages = useMessages(messageIds);
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
 
   const [inputValue, setInputValue] = useState('');
   const [selectedValueTag, setSelectedValueTag] = useState<ZetkinTag | null>(
@@ -135,6 +140,14 @@ const TagSelect: React.FunctionComponent<{
       <TagDialog
         groups={groups}
         onClose={() => setTagToEdit(undefined)}
+        onDelete={(tagId) => {
+          showConfirmDialog({
+            onSubmit: () => {
+              onDeleteTag(tagId);
+            },
+            warningText: messages.dialog.deleteWarning(),
+          });
+        }}
         onSubmit={async (tag) => {
           if ('id' in tag) {
             // If existing tag

--- a/src/features/tags/hooks/useDeleteTag.ts
+++ b/src/features/tags/hooks/useDeleteTag.ts
@@ -1,0 +1,12 @@
+import { tagDeleted } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+
+export default function useDeleteTag(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  return async (tagId: number) => {
+    await apiClient.delete(`/api/orgs/${orgId}/people/tags/${tagId}`);
+    dispatch(tagDeleted(tagId));
+  };
+}

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -7,6 +7,10 @@ export default makeMessages('feat.tags', {
     colorErrorText: m('Please enter a valid hex code'),
     colorLabel: m('Color'),
     createTitle: m('Create tag'),
+    deleteButtonLabel: m('Delete'),
+    deleteWarning: m(
+      'Are you sure you want to delete this tag? Deleting a tag cannot be undone.'
+    ),
     editTitle: m('Edit tag'),
     groupCreatePrompt: m<{ groupName: string }>('Add "{groupName}"'),
     groupLabel: m('Group'),

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -37,7 +37,7 @@ const tagsSlice = createSlice({
         state.tagsByPersonId[personId] = remoteList();
       }
       state.tagsByPersonId[personId].items.push(
-        remoteItem(personId, { data: tag })
+        remoteItem(tag.id, { data: tag })
       );
     },
     tagCreate: (state) => {
@@ -47,6 +47,24 @@ const tagsSlice = createSlice({
       const tag = action.payload;
       state.tagList.isLoading = false;
       state.tagList.items.push(remoteItem(tag.id, { data: tag }));
+    },
+    tagDeleted: (state, action: PayloadAction<number>) => {
+      const tagId = action.payload;
+      const tagListItem = state.tagList.items.find((item) => item.id === tagId);
+
+      if (tagListItem) {
+        tagListItem.deleted = true;
+      }
+
+      for (const personId in state.tagsByPersonId) {
+        const item = state.tagsByPersonId[personId].items.find((item) => {
+          return item.id === tagId;
+        });
+
+        if (item) {
+          item.deleted = true;
+        }
+      }
     },
     tagGroupCreate: (state) => {
       state.tagGroupList.isLoading;
@@ -139,6 +157,7 @@ export const {
   tagAssigned,
   tagCreate,
   tagCreated,
+  tagDeleted,
   tagGroupCreate,
   tagGroupCreated,
   tagGroupsLoad,

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -57,13 +57,9 @@ const tagsSlice = createSlice({
       }
 
       for (const personId in state.tagsByPersonId) {
-        const item = state.tagsByPersonId[personId].items.find((item) => {
-          return item.id === tagId;
-        });
-
-        if (item) {
-          item.deleted = true;
-        }
+        state.tagsByPersonId[personId].items = state.tagsByPersonId[
+          personId
+        ].items.filter((item) => item.id != tagId);
       }
     },
     tagGroupCreate: (state) => {


### PR DESCRIPTION
## Description
This PR adds a delete button to the dialog where you edit a tag. 


## Screenshots
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/d3490eae-31dc-4439-80ca-305c9b99b3ab)
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/4d6ca23d-8e86-4a7e-894d-673deedebc31)


## Changes
* Adds `useDeleteTag` hook
* Makes some refactors to components in the `TagManager`-family for easier reading of types
* Adds the UI to delete a tag
* Fixes an error in the tag store where remote items were indexed by person id instead of tag id 


## Related issues
none
