### PR TITLE
Event feature testing

### DIFF
--- a/src/features/calendar/hooks/useDayCalendarEvents.ts
+++ b/src/features/calendar/hooks/useDayCalendarEvents.ts
@@ -68,7 +68,12 @@ export default function useDayCalendarEvents(
   // and the useEffect() above will soon update the lastDate.
   const lastDateToLoad = lastDate > focusDate ? lastDate : focusDate;
 
-  const activities = useEventsFromDateRange(focusDate, lastDateToLoad);
+  const activities = useEventsFromDateRange(
+    focusDate,
+    lastDateToLoad,
+    orgId,
+    campId
+  );
   const filtered = useFilteredEventActivities(activities);
   const activitiesByDay = getActivitiesByDay(filtered);
 

--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -2,6 +2,7 @@ import { AnyClusteredEvent } from '../utils/clusterEventsForWeekCalender';
 import { getActivitiesByDay } from '../components/utils';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
+import { useNumericRouteParams } from 'core/hooks';
 import {
   CLUSTER_TYPE,
   clusterEvents,
@@ -25,7 +26,13 @@ export default function useMonthCalendarEvents({
   maxPerDay,
   startDate,
 }: UseMonthCalendarEventsParams): UseMonthCalendarEventsReturn {
-  const eventActivities = useEventsFromDateRange(startDate, endDate);
+  const { campId, orgId } = useNumericRouteParams();
+  const eventActivities = useEventsFromDateRange(
+    startDate,
+    endDate,
+    orgId,
+    campId
+  );
 
   // Filter events based on user filters
   const filteredActivities = useFilteredEventActivities(eventActivities);

--- a/src/features/calendar/hooks/useWeekCalendarEvents.ts
+++ b/src/features/calendar/hooks/useWeekCalendarEvents.ts
@@ -1,6 +1,7 @@
 import { isSameDate } from 'utils/dateUtils';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
+import { useNumericRouteParams } from 'core/hooks';
 import clusterEventsForWeekCalender, {
   AnyClusteredEvent,
 } from '../utils/clusterEventsForWeekCalender';
@@ -19,9 +20,12 @@ type UseWeekCalendarEventsReturn = {
 export default function useWeekCalendarEvents({
   dates,
 }: UseWeekCalendarEventsParams): UseWeekCalendarEventsReturn {
+  const { campId, orgId } = useNumericRouteParams();
   const eventActivities = useEventsFromDateRange(
     dates[0],
-    dates[dates.length - 1]
+    dates[dates.length - 1],
+    orgId,
+    campId
   );
   const filteredActivities = useFilteredEventActivities(eventActivities);
 

--- a/src/features/campaigns/hooks/useActivityOverview.ts
+++ b/src/features/campaigns/hooks/useActivityOverview.ts
@@ -19,7 +19,12 @@ export default function useActivitiyOverview(
   const weekFromNow = new Date(startOfToday);
   weekFromNow.setDate(startOfToday.getDate() + 8);
 
-  const eventActivites = useEventsFromDateRange(startOfToday, weekFromNow);
+  const eventActivites = useEventsFromDateRange(
+    startOfToday,
+    weekFromNow,
+    orgId,
+    campId
+  );
   const taskActivitiesFuture = useTaskActivities(orgId, campId);
   const surveyActivitiesFuture = useSurveyActivities(orgId, campId);
   const callAssignmentActivitiesFuture = useCallAssignmentActivities(

--- a/src/features/events/components/EventContactCard.tsx
+++ b/src/features/events/components/EventContactCard.tsx
@@ -103,14 +103,18 @@ const ContactSelect: FC<ContactSelectProps> = ({ orgId, eventId }) => {
 
 const EventContactCard: FC<EventContactCardProps> = ({ data, orgId }) => {
   const messages = useMessages(messageIds);
-  const eventFuture = useEvent(orgId, data.id);
+  const event = useEvent(orgId, data.id)?.data;
+
+  if (!event) {
+    return null;
+  }
 
   return (
     <Box mb={2}>
       <ZUICard
         header={
           <Box>
-            {eventFuture.data?.contact?.id ? (
+            {event.contact?.id ? (
               <Box>
                 <FaceOutlined sx={{ margin: 1, verticalAlign: 'middle' }} />
                 {messages.eventContactCard.header()}

--- a/src/features/events/components/EventParticipantsCard.tsx
+++ b/src/features/events/components/EventParticipantsCard.tsx
@@ -34,7 +34,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
   eventId,
   orgId,
 }) => {
-  const eventData = useEvent(orgId, eventId).data;
+  const event = useEvent(orgId, eventId)?.data;
   const { pendingSignUps, participantsFuture } = useEventParticipants(
     orgId,
     eventId
@@ -48,8 +48,8 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
     participants.filter((p) => p.reminder_sent != null && !p.cancelled)
       .length ?? 0;
 
-  const availParticipants = eventData?.num_participants_available ?? 0;
-  const reqParticipants = eventData?.num_participants_required ?? 0;
+  const availParticipants = event?.num_participants_available ?? 0;
+  const reqParticipants = event?.num_participants_required ?? 0;
 
   const [newReqParticipants, setNewReqParticipants] = useState<number | null>(
     reqParticipants
@@ -58,7 +58,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
     null | (EventTarget & SVGSVGElement)
   >(null);
 
-  if (!eventData) {
+  if (!event) {
     return null;
   }
 
@@ -176,18 +176,18 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
             <Typography color={'secondary'} component="h6" variant="subtitle1">
               {messages.eventParticipantsCard.contact()}
             </Typography>
-            {eventData.contact && (
+            {event.contact && (
               <Box alignItems="center" display="flex">
-                <ZUIPersonHoverCard personId={eventData.contact.id}>
+                <ZUIPersonHoverCard personId={event.contact.id}>
                   <Avatar
-                    src={`/api/orgs/${eventData.organization.id}/people/${eventData.contact.id}/avatar`}
+                    src={`/api/orgs/${event.organization.id}/people/${event.contact.id}/avatar`}
                     style={{ height: 30, marginRight: 10, width: 30 }}
                   />
-                  {eventData.contact.name}
+                  {event.contact.name}
                 </ZUIPersonHoverCard>
               </Box>
             )}
-            {!eventData.contact && (
+            {!event.contact && (
               <Typography>
                 {messages.eventParticipantsCard.noContact()}
               </Typography>
@@ -197,7 +197,7 @@ const EventParticipantsCard: FC<EventParticipantsCardProps> = ({
         <Divider />
         <Box display="flex" justifyContent="center" marginTop={2}>
           <NextLink
-            href={`${getEventUrl(eventData)}/participants`}
+            href={`${getEventUrl(event)}/participants`}
             legacyBehavior
             passHref
           >

--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -22,7 +22,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
   eventId,
   orgId,
 }) => {
-  const eventData = useEvent(orgId, eventId).data;
+  const event = useEvent(orgId, eventId)?.data;
   const { participantsFuture, pendingSignUps } = useEventParticipants(
     orgId,
     eventId
@@ -30,14 +30,14 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
 
   const numSignups = pendingSignUps.length;
 
-  if (!eventData) {
+  if (!event) {
     return null;
   }
 
   return (
     <EventWarningIconsSansModel
       compact={compact}
-      hasContact={!!eventData.contact}
+      hasContact={!!event.contact}
       numParticipants={participantsFuture.data?.length ?? 0}
       numRemindersSent={
         participantsFuture.data?.filter((p) => !!p.reminder_sent).length ?? 0

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -119,7 +119,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
   type,
 }) => {
   const messages = useMessages(messageIds);
-  const eventFuture = useEvent(orgId, eventId);
+  const event = useEvent(orgId, eventId)?.data;
   const { setContact } = useEventContact(orgId, eventId);
   const { deleteParticipant, setParticipantStatus } =
     useEventParticipantsMutations(orgId, eventId);
@@ -150,7 +150,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
         if (params.row.person) {
           return <Typography>{params.row.person.name}</Typography>;
         } else {
-          return eventFuture.data?.contact?.id === params.row.id ? (
+          return event?.contact?.id === params.row.id ? (
             <Typography>
               {params.row.first_name + ' ' + params.row.last_name}
               <Tooltip title={messages.eventParticipantsList.contactTooltip()}>
@@ -284,10 +284,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
             />
           );
         } else if (type == 'booked') {
-          if (
-            eventFuture.data &&
-            new Date(removeOffset(eventFuture.data.start_time)) < new Date()
-          ) {
+          if (event && new Date(removeOffset(event.start_time)) < new Date()) {
             const options: ButtonOption[] = [
               {
                 callback: () => {

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -34,7 +34,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   onClickRecord,
   orgId,
 }) => {
-  const eventData = useEvent(orgId, eventId).data;
+  const event = useEvent(orgId, eventId)?.data;
   const participantStatus = useParticipantStatus(orgId, eventId);
   const {
     respondentsFuture,
@@ -51,8 +51,8 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   const respondents = respondentsFuture.data;
   const messages = useMessages(messageIds);
 
-  const reqParticipants = eventData?.num_participants_required ?? 0;
-  const contactPerson = eventData?.contact;
+  const reqParticipants = event?.num_participants_required ?? 0;
+  const contactPerson = event?.contact;
 
   const hasRecordedAttendance =
     numCancelledParticipants +
@@ -71,7 +71,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
     (state) => state.events.remindingByEventId[eventId]
   );
 
-  if (!eventData) {
+  if (!event) {
     return null;
   }
 
@@ -179,7 +179,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               )}
             </Box>
           </Box>
-          {new Date(removeOffset(eventData.start_time)) > new Date() ? (
+          {new Date(removeOffset(event.start_time)) > new Date() ? (
             <Box display="flex" flexDirection="column">
               <Typography color={'secondary'}>
                 {messages.participantSummaryCard.booked()}

--- a/src/features/events/hooks/useDuplicateEvent.ts
+++ b/src/features/events/hooks/useDuplicateEvent.ts
@@ -4,22 +4,22 @@ import { ZetkinEventPostBody } from './useEventMutations';
 
 export default function useDuplicateEvent(orgId: number, eventId: number) {
   const createEvent = useCreateEvent(orgId);
-  const event = useEvent(orgId, eventId);
+  const event = useEvent(orgId, eventId)?.data;
 
   return () => {
     const duplicateEventPostBody: ZetkinEventPostBody = {
-      activity_id: event.data?.activity?.id,
-      end_time: event.data?.end_time,
-      info_text: event.data?.info_text,
-      location_id: event.data?.location?.id,
-      num_participants_required: event.data?.num_participants_required,
-      organization_id: event.data?.organization.id,
-      start_time: event.data?.start_time,
-      title: event.data?.title,
-      url: event.data?.url,
+      activity_id: event?.activity?.id,
+      end_time: event?.end_time,
+      info_text: event?.info_text,
+      location_id: event?.location?.id,
+      num_participants_required: event?.num_participants_required,
+      organization_id: event?.organization.id,
+      start_time: event?.start_time,
+      title: event?.title,
+      url: event?.url,
     };
-    if (event.data?.campaign) {
-      duplicateEventPostBody.campaign_id = event.data?.campaign.id;
+    if (event?.campaign) {
+      duplicateEventPostBody.campaign_id = event?.campaign.id;
     }
     return createEvent(duplicateEventPostBody);
   };

--- a/src/features/events/hooks/useEvent.ts
+++ b/src/features/events/hooks/useEvent.ts
@@ -7,12 +7,16 @@ import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 export default function useEvent(
   orgId: number,
   id: number
-): IFuture<ZetkinEvent> {
+): IFuture<ZetkinEvent> | null {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const eventList = useAppSelector((state) => state.events.eventList);
 
   const item = eventList.items.find((item) => item.id == id);
+
+  if (item && item.deleted) {
+    return null;
+  }
 
   const eventFuture = loadItemIfNecessary(item, dispatch, {
     actionOnLoad: () => eventLoad(id),

--- a/src/features/events/hooks/useEventState.ts
+++ b/src/features/events/hooks/useEventState.ts
@@ -14,11 +14,11 @@ export default function useEventState(
   orgId: number,
   eventId: number
 ): EventState {
-  const event = useEvent(orgId, eventId);
+  const event = useEvent(orgId, eventId)?.data;
 
-  if (!event.data) {
+  if (!event) {
     return EventState.UNKNOWN;
   }
 
-  return getEventState(event.data);
+  return getEventState(event);
 }

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -46,7 +46,7 @@ export default function useEventsFromDateRange(
           .slice(0, 10)}`
       )
       .then((events) => {
-        dispatch(eventRangeLoaded(events));
+        dispatch(eventRangeLoaded([events, dateRange]));
       });
 
     // This will suspend React from rendering this branch

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -5,23 +5,19 @@ import shouldLoad from 'core/caching/shouldLoad';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ACTIVITIES, EventActivity } from 'features/campaigns/types';
 import { eventRangeLoad, eventRangeLoaded } from '../store';
-import {
-  useApiClient,
-  useAppDispatch,
-  useAppSelector,
-  useNumericRouteParams,
-} from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 export default function useEventsFromDateRange(
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  orgId: number,
+  campId?: number
 ): EventActivity[] {
-  const { campId, orgId } = useNumericRouteParams();
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const eventsState = useAppSelector((state) => state.events);
 
-  const dateRange = range(dayjs(endDate).diff(startDate, 'day') + 2).map(
+  const dateRange = range(dayjs(endDate).diff(startDate, 'day') + 1).map(
     (diff) => {
       const curDate = new Date(startDate);
       curDate.setDate(curDate.getDate() + diff);

--- a/src/features/events/hooks/useParallelEvents.ts
+++ b/src/features/events/hooks/useParallelEvents.ts
@@ -1,4 +1,5 @@
 import useEventsFromDateRange from './useEventsFromDateRange';
+import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { dateIsAfter, dateIsBefore, isSameDate } from 'utils/dateUtils';
 
@@ -10,7 +11,8 @@ export default function useParallelEvents(
   const start = new Date(startString);
   const end = new Date(endString);
 
-  const allEvents = useEventsFromDateRange(start, end);
+  const { campId } = useNumericRouteParams();
+  const allEvents = useEventsFromDateRange(start, end, orgId, campId);
 
   const filteredEvents = allEvents
     .filter((event) => {

--- a/src/features/events/hooks/useParticipantsStatus.ts
+++ b/src/features/events/hooks/useParticipantsStatus.ts
@@ -7,8 +7,8 @@ export default function useParticipantStatus(
   eventId: number
 ): string {
   const { numAvailParticipants } = useEventParticipants(orgId, eventId);
-  const event = useEvent(orgId, eventId);
-  const reqParticipants = event.data?.num_participants_required ?? 0;
+  const event = useEvent(orgId, eventId)?.data;
+  const reqParticipants = event?.num_participants_required ?? 0;
   const diff = reqParticipants - numAvailParticipants;
 
   if (diff <= 0) {

--- a/src/features/events/hooks/useRelatedEvents.ts
+++ b/src/features/events/hooks/useRelatedEvents.ts
@@ -1,4 +1,5 @@
 import useEventsFromDateRange from './useEventsFromDateRange';
+import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { IFuture, ResolvedFuture } from 'core/caching/futures';
 
@@ -9,7 +10,13 @@ export default function useRelatedEvents(
   const relatedEvents: ZetkinEvent[] = [];
   const start = new Date(currentEvent.start_time);
   const end = new Date(currentEvent.end_time);
-  const allEventsInActivities = useEventsFromDateRange(start, end);
+  const { campId } = useNumericRouteParams();
+  const allEventsInActivities = useEventsFromDateRange(
+    start,
+    end,
+    orgId,
+    campId
+  );
 
   const allEvents = allEventsInActivities
     .map((event) => event.data)

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -44,6 +44,10 @@ const EventLayout: React.FC<EventLayoutProps> = ({
 
   const eventTypes = useEventTypes(parseInt(orgId));
 
+  if (!eventFuture) {
+    return null;
+  }
+
   return (
     <TabbedLayout
       actionButtons={

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -523,9 +523,6 @@ const eventsSlice = createSlice({
   },
 });
 
-//skriva tester för storen
-//hur testar man en store? Redux-manualen
-
 function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
   events.forEach((event) => {
     const eventListItem = state.eventList.items.find(
@@ -535,7 +532,9 @@ function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
     if (eventListItem) {
       eventListItem.data = { ...eventListItem.data, ...event };
     } else {
-      state.eventList.items.push(remoteItem(event.id, { data: event }));
+      state.eventList.items.push(
+        remoteItem(event.id, { data: event, loaded: new Date().toISOString() })
+      );
     }
 
     const dateStr = event.start_time.slice(0, 10);

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -171,9 +171,22 @@ const eventsSlice = createSlice({
         state.eventsByDate[dateStr].isLoading = true;
       });
     },
-    eventRangeLoaded: (state, action: PayloadAction<ZetkinEvent[]>) => {
-      const events = action.payload;
+    eventRangeLoaded: (
+      state,
+      action: PayloadAction<[ZetkinEvent[], string[]]>
+    ) => {
+      const [events, isoDateRange] = action.payload;
       addEventToState(state, events);
+
+      isoDateRange.forEach((isoDate) => {
+        const dateStr = isoDate.slice(0, 10);
+        if (!state.eventsByDate[dateStr]) {
+          state.eventsByDate[dateStr] = remoteList();
+        }
+
+        state.eventsByDate[dateStr].isLoading = false;
+        state.eventsByDate[dateStr].loaded = new Date().toISOString();
+      });
     },
     eventUpdate: (state, action: PayloadAction<[number, string[]]>) => {
       const [eventId, mutating] = action.payload;
@@ -510,11 +523,15 @@ const eventsSlice = createSlice({
   },
 });
 
+//skriva tester för storen
+//hur testar man en store? Redux-manualen
+
 function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
   events.forEach((event) => {
     const eventListItem = state.eventList.items.find(
       (item) => item.id == event.id
     );
+
     if (eventListItem) {
       eventListItem.data = { ...eventListItem.data, ...event };
     } else {
@@ -557,6 +574,7 @@ function addEventToState(state: EventsStoreSlice, events: ZetkinEvent[]) {
         );
       }
     }
+
     state.eventsByDate[dateStr].isLoading = false;
     state.eventsByDate[dateStr].isStale = false;
     state.eventsByDate[dateStr].loaded = new Date().toISOString();

--- a/src/features/events/tests/createEvent.spec.tsx
+++ b/src/features/events/tests/createEvent.spec.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+
+import createStore from 'core/store';
+import { makeWrapper } from '../utils/testUtils';
+import mockEvent from 'utils/testing/mocks/mockEvent';
+import mockState from 'utils/testing/mocks/mockState';
+import useEvent from '../hooks/useEvent';
+import useEventsFromDateRange from '../hooks/useEventsFromDateRange';
+import { eventCreate, eventCreated } from '../store';
+
+describe('The event feature', () => {
+  it('creates an event', () => {
+    const event = mockEvent();
+
+    const initialState = mockState();
+
+    const store = createStore(initialState);
+    store.dispatch(eventCreate());
+    store.dispatch(eventCreated(event));
+
+    const { result } = renderHook(
+      () => useEvent(event.organization.id, event.id),
+      { wrapper: makeWrapper(store) }
+    );
+
+    expect(result.current?.data).toEqual(event);
+    expect(result.current?.isLoading).toEqual(false);
+  });
+
+  it('puts a created event on the right day', () => {
+    const startTime = new Date();
+    const endTime = new Date();
+    endTime.setHours(endTime.getHours() + 2);
+
+    const event = mockEvent({
+      end_time: endTime.toISOString(),
+      id: 1,
+      start_time: startTime.toISOString(),
+    });
+
+    const emptyState = mockState();
+    const store = createStore(emptyState);
+
+    store.dispatch(eventCreate());
+    store.dispatch(eventCreated(event));
+
+    const today = new Date();
+    const { result } = renderHook(
+      () => useEventsFromDateRange(today, today, 1, 1),
+      {
+        wrapper: makeWrapper(store),
+      }
+    );
+
+    expect(result.current[0].data.id).toEqual(1);
+  });
+});

--- a/src/features/events/tests/createEvent.spec.tsx
+++ b/src/features/events/tests/createEvent.spec.tsx
@@ -8,8 +8,8 @@ import useEvent from '../hooks/useEvent';
 import useEventsFromDateRange from '../hooks/useEventsFromDateRange';
 import { eventCreate, eventCreated } from '../store';
 
-describe('The event feature', () => {
-  it('creates an event', () => {
+describe('When creating an event', () => {
+  it('the event is created and retrieved from cache', () => {
     const event = mockEvent();
 
     const initialState = mockState();
@@ -27,7 +27,7 @@ describe('The event feature', () => {
     expect(result.current?.isLoading).toEqual(false);
   });
 
-  it('puts a created event on the right day', () => {
+  it('the created event is saved on the right date', () => {
     const startTime = new Date();
     const endTime = new Date();
     endTime.setHours(endTime.getHours() + 2);

--- a/src/features/events/tests/createEvent.spec.tsx
+++ b/src/features/events/tests/createEvent.spec.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';
-import { makeWrapper } from '../utils/testUtils';
+import { makeWrapper } from 'utils/testing';
 import mockEvent from 'utils/testing/mocks/mockEvent';
 import mockState from 'utils/testing/mocks/mockState';
 import useEvent from '../hooks/useEvent';

--- a/src/features/events/tests/deleteEvent.spec.tsx
+++ b/src/features/events/tests/deleteEvent.spec.tsx
@@ -1,0 +1,165 @@
+import { renderHook } from '@testing-library/react';
+
+import createStore from 'core/store';
+import { eventDeleted } from '../store';
+import mockEvent from 'utils/testing/mocks/mockEvent';
+import mockState from 'utils/testing/mocks/mockState';
+import { remoteItem } from 'utils/storeUtils';
+import useCampaignEvents from 'features/campaigns/hooks/useCampaignEvents';
+import useEvent from '../hooks/useEvent';
+import useEventsFromDateRange from '../hooks/useEventsFromDateRange';
+import { makeWrapper, remoteListWithEventItems } from '../utils/testUtils';
+
+describe('Deleting an event', () => {
+  it('does not return the event when trying to get it', () => {
+    const event = mockEvent();
+    const emptyState = mockState();
+
+    const anHourAgo = new Date();
+    anHourAgo.setHours(anHourAgo.getHours() - 1);
+
+    const remoteListWithEventItem = remoteListWithEventItems(
+      [
+        remoteItem(event.id, {
+          data: event,
+          loaded: anHourAgo.toISOString(),
+        }),
+      ],
+      anHourAgo.toISOString()
+    );
+
+    const initialState = mockState({
+      ...emptyState,
+      events: {
+        ...emptyState.events,
+        eventList: remoteListWithEventItem,
+        eventsByCampaignId: {
+          1: remoteListWithEventItem,
+        },
+        eventsByDate: {
+          [event.start_time.slice(0, 10)]: remoteListWithEventItem,
+        },
+      },
+    });
+
+    const store = createStore(initialState);
+    store.dispatch(eventDeleted(event.id));
+
+    const { result } = renderHook(() => useEvent(event.organization.id, 1), {
+      wrapper: makeWrapper(store),
+    });
+
+    expect(result.current).toBe(null);
+  });
+
+  it('does not return deleted events when getting events by campaign date', () => {
+    const endTime = new Date();
+    endTime.setDate(endTime.getDate() + 1);
+    const firstEvent = mockEvent();
+    const secondEvent = mockEvent({ end_time: endTime.toISOString(), id: 2 });
+    const emptyState = mockState();
+
+    const eventItemsList = remoteListWithEventItems(
+      [
+        remoteItem(firstEvent.id, {
+          data: firstEvent,
+          loaded: new Date().toISOString(),
+        }),
+        remoteItem(secondEvent.id, {
+          data: secondEvent,
+          loaded: new Date().toISOString(),
+        }),
+      ],
+      new Date().toISOString()
+    );
+
+    const initialState = mockState({
+      ...emptyState,
+      events: {
+        ...emptyState.events,
+        eventList: eventItemsList,
+        eventsByCampaignId: {
+          1: eventItemsList,
+        },
+        eventsByDate: {
+          [firstEvent.start_time.slice(0, 10)]: eventItemsList,
+        },
+      },
+    });
+
+    const store = createStore(initialState);
+    store.dispatch(eventDeleted(firstEvent.id));
+
+    const { result } = renderHook(
+      () => useCampaignEvents(firstEvent.organization.id, 1),
+      { wrapper: makeWrapper(store) }
+    );
+
+    expect(result.current.numberOfUpcomingEvents).toBe(1);
+  });
+
+  it('does not return deleted events when getting events from a date range', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    const today = new Date();
+
+    const firstEvent = mockEvent({
+      end_time: tomorrow.toISOString(),
+      start_time: yesterday.toISOString(),
+    });
+    const secondEvent = mockEvent({
+      end_time: tomorrow.toISOString(),
+      id: 2,
+      start_time: yesterday.toISOString(),
+    });
+    const emptyState = mockState();
+
+    const eventItemsList = remoteListWithEventItems(
+      [
+        remoteItem(firstEvent.id, {
+          data: firstEvent,
+          loaded: new Date().toISOString(),
+        }),
+        remoteItem(secondEvent.id, {
+          data: secondEvent,
+          loaded: new Date().toISOString(),
+        }),
+      ],
+      new Date().toISOString()
+    );
+
+    const initialState = mockState({
+      ...emptyState,
+      events: {
+        ...emptyState.events,
+        eventList: eventItemsList,
+        eventsByCampaignId: {
+          1: eventItemsList,
+        },
+        eventsByDate: {
+          [yesterday.toISOString().slice(0, 10)]: eventItemsList,
+          [today.toISOString().slice(0, 10)]: eventItemsList,
+          [tomorrow.toISOString().slice(0, 10)]: eventItemsList,
+        },
+      },
+    });
+
+    const store = createStore(initialState);
+    store.dispatch(eventDeleted(firstEvent.id));
+
+    const { result } = renderHook(
+      () => useEventsFromDateRange(today, tomorrow, 1, 1),
+      {
+        wrapper: makeWrapper(store),
+      }
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].data.id).toBe(2);
+    expect(result.current[1].data.id).toBe(2);
+  });
+});

--- a/src/features/events/tests/deleteEvent.spec.tsx
+++ b/src/features/events/tests/deleteEvent.spec.tsx
@@ -2,13 +2,14 @@ import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';
 import { eventDeleted } from '../store';
+import { makeWrapper } from 'utils/testing';
 import mockEvent from 'utils/testing/mocks/mockEvent';
 import mockState from 'utils/testing/mocks/mockState';
 import { remoteItem } from 'utils/storeUtils';
+import { remoteListWithEventItems } from '../utils/testUtils';
 import useCampaignEvents from 'features/campaigns/hooks/useCampaignEvents';
 import useEvent from '../hooks/useEvent';
 import useEventsFromDateRange from '../hooks/useEventsFromDateRange';
-import { makeWrapper, remoteListWithEventItems } from '../utils/testUtils';
 
 describe('Deleting an event', () => {
   it('does not return the event when trying to get it', () => {

--- a/src/features/events/tests/updateEvent.spec.tsx
+++ b/src/features/events/tests/updateEvent.spec.tsx
@@ -1,0 +1,104 @@
+import { renderHook } from '@testing-library/react';
+
+import createStore from 'core/store';
+import mockEvent from 'utils/testing/mocks/mockEvent';
+import mockState from 'utils/testing/mocks/mockState';
+import { remoteItem } from 'utils/storeUtils';
+import useEvent from '../hooks/useEvent';
+import { eventUpdate, eventUpdated } from '../store';
+import { makeWrapper, remoteListWithEventItems } from '../utils/testUtils';
+
+describe('Updating an event', () => {
+  it('updates the title of an event', () => {
+    const emptyState = mockState();
+    const event = mockEvent();
+
+    const now = new Date();
+
+    const eventItemsList = remoteListWithEventItems(
+      [
+        remoteItem(event.id, {
+          data: event,
+          loaded: now.toISOString(),
+        }),
+      ],
+      now.toISOString()
+    );
+
+    const initialState = mockState({
+      ...emptyState,
+      events: {
+        ...emptyState.events,
+        eventList: eventItemsList,
+        eventsByCampaignId: {
+          1: eventItemsList,
+        },
+        eventsByDate: {
+          [now.toISOString().slice(0, 10)]: eventItemsList,
+        },
+      },
+    });
+
+    const updatedEvent = mockEvent({ title: 'Coolest dance party ever' });
+
+    const store = createStore(initialState);
+    store.dispatch(eventUpdate([updatedEvent.id, ['title']]));
+    store.dispatch(eventUpdated(updatedEvent));
+
+    const { result } = renderHook(
+      () => useEvent(event.organization.id, event.id),
+      { wrapper: makeWrapper(store) }
+    );
+
+    expect(result.current?.data).toEqual(updatedEvent);
+    expect(result.current?.isLoading).toEqual(false);
+  });
+
+  it('updates the date of an event', () => {
+    const emptyState = mockState();
+    const event = mockEvent();
+
+    const now = new Date();
+
+    const eventItemsList = remoteListWithEventItems(
+      [
+        remoteItem(event.id, {
+          data: event,
+          loaded: now.toISOString(),
+        }),
+      ],
+      now.toISOString()
+    );
+
+    const initialState = mockState({
+      ...emptyState,
+      events: {
+        ...emptyState.events,
+        eventList: eventItemsList,
+        eventsByCampaignId: {
+          1: eventItemsList,
+        },
+        eventsByDate: {
+          [event.start_time.slice(0, 10)]: eventItemsList,
+        },
+      },
+    });
+
+    const updatedEvent = mockEvent({
+      end_time: '2024-06-16T09:00:00+00:00',
+      start_time: '2024-06-16T07:00:00+00:00',
+    });
+
+    const store = createStore(initialState);
+    store.dispatch(eventUpdate([updatedEvent.id, ['start_time', 'end_time']]));
+    store.dispatch(eventUpdated(updatedEvent));
+
+    const { result } = renderHook(
+      () => useEvent(event.organization.id, event.id),
+      { wrapper: makeWrapper(store) }
+    );
+
+    expect(result.current?.data).toEqual(updatedEvent);
+    expect(result.current?.isLoading).toEqual(false);
+  });
+});

--- a/src/features/events/tests/updateEvent.spec.tsx
+++ b/src/features/events/tests/updateEvent.spec.tsx
@@ -1,12 +1,13 @@
 import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';
+import { makeWrapper } from 'utils/testing';
 import mockEvent from 'utils/testing/mocks/mockEvent';
 import mockState from 'utils/testing/mocks/mockState';
 import { remoteItem } from 'utils/storeUtils';
+import { remoteListWithEventItems } from '../utils/testUtils';
 import useEvent from '../hooks/useEvent';
 import { eventUpdate, eventUpdated } from '../store';
-import { makeWrapper, remoteListWithEventItems } from '../utils/testUtils';
 
 describe('Updating an event', () => {
   it('updates the title of an event', () => {

--- a/src/features/events/utils/testUtils.tsx
+++ b/src/features/events/utils/testUtils.tsx
@@ -1,37 +1,5 @@
-import { ReactNode } from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
-
-import Environment from 'core/env/Environment';
-import { EnvProvider } from 'core/env/EnvContext';
-import IApiClient from 'core/api/client/IApiClient';
 import { RemoteItem } from 'utils/storeUtils';
-import RosaLuxemburgUser from '../../../../integrationTesting/mockData/users/RosaLuxemburgUser';
-import { Store } from 'core/store';
-import { UserContext } from 'core/env/UserContext';
 import { ZetkinEvent } from 'utils/types/zetkin';
-
-export const makeWrapper = (store: Store) =>
-  function Wrapper({ children }: { children: ReactNode }) {
-    const apiClient: jest.Mocked<IApiClient> = {
-      delete: jest.fn(),
-      get: jest.fn(),
-      patch: jest.fn(),
-      post: jest.fn(),
-      put: jest.fn(),
-      rpc: jest.fn(),
-    };
-
-    const env = new Environment(store, apiClient);
-    return (
-      <ReduxProvider store={store}>
-        <EnvProvider env={env}>
-          <UserContext.Provider value={RosaLuxemburgUser}>
-            {children}
-          </UserContext.Provider>
-        </EnvProvider>
-      </ReduxProvider>
-    );
-  };
 
 export const remoteListWithEventItems = (
   items: RemoteItem<ZetkinEvent>[],

--- a/src/features/events/utils/testUtils.tsx
+++ b/src/features/events/utils/testUtils.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+
+import Environment from 'core/env/Environment';
+import { EnvProvider } from 'core/env/EnvContext';
+import IApiClient from 'core/api/client/IApiClient';
+import { RemoteItem } from 'utils/storeUtils';
+import RosaLuxemburgUser from '../../../../integrationTesting/mockData/users/RosaLuxemburgUser';
+import { Store } from 'core/store';
+import { UserContext } from 'core/env/UserContext';
+import { ZetkinEvent } from 'utils/types/zetkin';
+
+export const makeWrapper = (store: Store) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    const apiClient: jest.Mocked<IApiClient> = {
+      delete: jest.fn(),
+      get: jest.fn(),
+      patch: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      rpc: jest.fn(),
+    };
+
+    const env = new Environment(store, apiClient);
+    return (
+      <ReduxProvider store={store}>
+        <EnvProvider env={env}>
+          <UserContext.Provider value={RosaLuxemburgUser}>
+            {children}
+          </UserContext.Provider>
+        </EnvProvider>
+      </ReduxProvider>
+    );
+  };
+
+export const remoteListWithEventItems = (
+  items: RemoteItem<ZetkinEvent>[],
+  loaded: string
+) => {
+  return {
+    error: false,
+    isLoading: false,
+    isStale: false,
+    items,
+    loaded,
+  };
+};

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -50,7 +50,7 @@ interface EventPageProps {
 const EventPage: PageWithLayout<EventPageProps> = ({ orgId, eventId }) => {
   const eventFuture = useEvent(parseInt(orgId), parseInt(eventId));
 
-  if (!eventFuture.data) {
+  if (!eventFuture || !eventFuture.data) {
     return null;
   }
 

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/participants.tsx
@@ -46,6 +46,10 @@ const ParticipantsPage: PageWithLayout<ParticipantsProps> = ({
   const listRef = useRef<HTMLDivElement>();
   const eventFuture = useEvent(parseInt(orgId), parseInt(eventId));
 
+  if (!eventFuture) {
+    return null;
+  }
+
   return (
     <ZUIFuture future={eventFuture}>
       {(data) => {

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -2,7 +2,8 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { CssBaseline } from '@mui/material';
 import { IntlProvider } from 'react-intl';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { FC, ReactElement } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { FC, ReactElement, ReactNode } from 'react';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
 import {
   StyledEngineProvider,
@@ -12,11 +13,13 @@ import {
 
 import { AnyMessage } from 'core/i18n/messages';
 import BrowserApiClient from 'core/api/client/BrowserApiClient';
-import createStore from 'core/store';
 import Environment from 'core/env/Environment';
 import { EnvProvider } from 'core/env/EnvContext';
+import IApiClient from 'core/api/client/IApiClient';
+import RosaLuxemburgUser from '../../../integrationTesting/mockData/users/RosaLuxemburgUser';
 import theme from 'theme';
 import { UserContext } from 'utils/hooks/useFocusDate';
+import createStore, { Store } from 'core/store';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -91,3 +94,26 @@ const customRender = (
 export * from '@testing-library/react';
 
 export { customRender as render };
+
+export const makeWrapper = (store: Store) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    const apiClient: jest.Mocked<IApiClient> = {
+      delete: jest.fn(),
+      get: jest.fn(),
+      patch: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      rpc: jest.fn(),
+    };
+
+    const env = new Environment(store, apiClient);
+    return (
+      <ReduxProvider store={store}>
+        <EnvProvider env={env}>
+          <UserContext.Provider value={RosaLuxemburgUser}>
+            {children}
+          </UserContext.Provider>
+        </EnvProvider>
+      </ReduxProvider>
+    );
+  };

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -1,0 +1,124 @@
+import { RootState } from 'core/store';
+import { remoteItem, remoteList } from 'utils/storeUtils';
+
+const emptyState: RootState = {
+  breadcrumbs: {
+    crumbsByPath: {},
+  },
+  callAssignments: {
+    assignmentList: remoteList(),
+    callAssignmentIdsByCampaignId: {},
+    callList: remoteList(),
+    callersById: {},
+    statsById: {},
+  },
+  campaigns: {
+    campaignList: remoteList(),
+    recentlyCreatedCampaign: null,
+  },
+  emails: {
+    emailList: remoteList(),
+    linksByEmailId: {},
+    statsById: {},
+    themeList: remoteList(),
+  },
+  events: {
+    eventList: remoteList(),
+    eventsByCampaignId: {},
+    eventsByDate: {},
+    filters: {
+      selectedActions: [],
+      selectedStates: [],
+      selectedTypes: [],
+      text: '',
+    },
+    locationList: remoteList(),
+    participantsByEventId: {},
+    remindingByEventId: {},
+    respondentsByEventId: {},
+    selectedEventIds: [],
+    statsByEventId: {},
+    typeList: remoteList(),
+  },
+  files: {
+    fileList: remoteList(),
+  },
+  import: {
+    importResult: null,
+    pendingFile: {
+      selectedSheetIndex: 0,
+      sheets: [],
+      title: '',
+    },
+    preflightSummary: null,
+  },
+  journeys: {
+    journeyInstanceList: remoteList(),
+    journeyInstancesByJourneyId: {},
+    journeyInstancesBySubjectId: {},
+    journeyList: remoteList(),
+    milestonesByInstanceId: {},
+    timelineUpdatesByInstanceId: {},
+  },
+  organizations: {
+    orgData: remoteItem(0),
+    subOrgsByOrgId: {},
+    treeDataList: remoteList(),
+    userMembershipList: remoteList(),
+  },
+  profiles: {
+    fieldsList: remoteList(),
+    orgsByPersonId: {},
+    personById: {},
+  },
+  search: {
+    matchesByQuery: {},
+  },
+  settings: {
+    officialMembershipsList: remoteList(),
+  },
+  smartSearch: {
+    queryList: remoteList(),
+    statsByFilterSpec: {},
+  },
+  surveys: {
+    elementsBySurveyId: {},
+    statsBySurveyId: {},
+    submissionList: remoteList(),
+    submissionsBySurveyId: {},
+    surveyIdsByCampaignId: {},
+    surveyList: remoteList(),
+    surveysWithElementsList: remoteList(),
+  },
+  tags: {
+    tagGroupList: remoteList(),
+    tagList: remoteList(),
+    tagsByPersonId: {},
+  },
+  tasks: {
+    assignedTasksByTaskId: {},
+    statsById: {},
+    taskIdsByCampaignId: {},
+    tasksList: remoteList(),
+  },
+  user: {
+    membershipList: remoteList(),
+    userItem: remoteItem('me'),
+  },
+  views: {
+    accessByViewId: {},
+    columnsByViewId: {},
+    folderList: remoteList(),
+    officialList: remoteList(),
+    recentlyCreatedFolder: null,
+    rowsByViewId: {},
+    viewList: remoteList(),
+  },
+};
+
+export default function mockState(overrides?: RootState) {
+  return {
+    ...emptyState,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Description
This PR started out as working on #1994 but evolved into the start of a way to test whole features. This is not a complete test suite that covers all states and situations an event goes through, but it is a beginning to figuring out ways to make hour hooks and stores testable together. 

## Screenshots
Behold the glorious absence of spinner 😅 
![bild](https://github.com/zetkin/app.zetkin.org/assets/58265097/39b9ebbc-419c-483b-a5b6-7f47e96bf786)

## Changes
* Adds tests for creating, updating and deleting an event
* Adds a file of test utils
* Adds timestamps for when an event item and list were loaded 
* Changes the return type of the useEvent hook to return null when the requested event is deleted
* Changes the useEventsFromDateRange hook to become testable by taking in orgId and campId instead of using useNumericRouteParams (no router to get params from inside the test heh)

## Notes to reviewer
none

## Related issues
Resolves #1994 (once and for all, hopefully)
