### PR TITLE
Add missing property to mock store state

### DIFF
--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -16,6 +16,9 @@ const emptyState: RootState = {
     campaignList: remoteList(),
     recentlyCreatedCampaign: null,
   },
+  duplicates: {
+    potentialDuplicatesList: remoteList(),
+  },
   emails: {
     emailList: remoteList(),
     linksByEmailId: {},


### PR DESCRIPTION
## Description
This PR fixes a merge conflict introduced by merging #1995 and #2021 in parallel, because the mock state introduced in #2021 did not adhere to the changes to the store type introduced in #1995.

## Screenshots
None

## Changes
* Adds missing `duplicates` store slice to `mockState()`

## Notes to reviewer
None

## Related issues
Undocumented