### PR TITLE
Issue 2006/public url card

### DIFF
--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -42,7 +42,9 @@ export default makeMessages('feat.settings', {
     },
     urlCard: {
       linkToPub: m('Link to public organization'),
-      subTitle: m('Connect to the organization before assigning'),
+      subTitle: m(
+        'Users must connect to the organization before they can access Zetkin as officials.'
+      ),
     },
     you: m('You'),
   },

--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -40,6 +40,10 @@ export default makeMessages('feat.settings', {
       promote: m('Promote'),
       remove: m('Remove'),
     },
+    urlCard: {
+      linkToPub: m('Link to public organization'),
+      subTitle: m('Connect to the organization before assigning'),
+    },
     you: m('You'),
   },
 });

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -8,6 +8,7 @@ import OfficialList from 'features/settings/components/OfficialList';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SettingsLayout from 'features/settings/layout/SettingsLayout';
+import { useEnv } from 'core/hooks';
 import useNumericRouteParams from 'core/hooks/useNumericRouteParams';
 import useOfficialMemberships from 'features/settings/hooks/useOfficialMemberships';
 import useServerSide from 'core/useServerSide';
@@ -31,7 +32,8 @@ const SettingsPage: PageWithLayout = () => {
   const { orgId } = useNumericRouteParams();
   const listFuture = useOfficialMemberships(orgId).data || [];
   const messages = useMessages(messageIds);
-  const publicOrgUrl = `https://app.zetkin.org/o/${orgId}`;
+  const env = useEnv();
+  const publicOrgUrl = `${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}`;
 
   const adminList = listFuture.filter((user) => user.role === 'admin');
   const organizerList = listFuture.filter((user) => user.role === 'organizer');

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -4,7 +4,6 @@ import { Box, Grid, Link, Typography } from '@mui/material';
 
 import AddOfficialButton from 'features/settings/components/AddOfficialButton';
 import messageIds from 'features/settings/l10n/messageIds';
-import { Msg } from 'core/i18n';
 import OfficialList from 'features/settings/components/OfficialList';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
@@ -14,6 +13,7 @@ import useOfficialMemberships from 'features/settings/hooks/useOfficialMembershi
 import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
+import { Msg, useMessages } from 'core/i18n';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -30,7 +30,8 @@ const SettingsPage: PageWithLayout = () => {
   const onServer = useServerSide();
   const { orgId } = useNumericRouteParams();
   const listFuture = useOfficialMemberships(orgId).data || [];
-  const publicUrl = `https://app.zetkin.org/o/${orgId}`;
+  const messages = useMessages(messageIds);
+  const publicOrgUrl = `https://app.zetkin.org/o/${orgId}`;
 
   const adminList = listFuture.filter((user) => user.role === 'admin');
   const organizerList = listFuture.filter((user) => user.role === 'organizer');
@@ -89,22 +90,22 @@ const SettingsPage: PageWithLayout = () => {
       </Grid>
       <Grid item md={4}>
         <ZUICard
-          header={'Link to public organization'}
-          subheader="Connect to the organization before assigning"
+          header={messages.officials.urlCard.linkToPub()}
+          subheader={messages.officials.urlCard.subTitle()}
         >
           <Box display="flex" paddingBottom={2}>
-            <ZUITextfieldToClipboard copyText={publicUrl}>
-              {publicUrl}
+            <ZUITextfieldToClipboard copyText={publicOrgUrl}>
+              {publicOrgUrl}
             </ZUITextfieldToClipboard>
           </Box>
           <Link
             display="flex"
-            href={`/o/${orgId}`}
+            href={publicOrgUrl}
             sx={{ alignItems: 'center', gap: 1 }}
             target="_blank"
           >
             <OpenInNew fontSize="inherit" />
-            Link to public organization
+            {messages.officials.urlCard.linkToPub()}
           </Link>
         </ZUICard>
       </Grid>

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
-import { Box, Typography } from '@mui/material';
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Grid, Link, Typography } from '@mui/material';
 
 import AddOfficialButton from 'features/settings/components/AddOfficialButton';
 import messageIds from 'features/settings/l10n/messageIds';
@@ -11,6 +12,8 @@ import SettingsLayout from 'features/settings/layout/SettingsLayout';
 import useNumericRouteParams from 'core/hooks/useNumericRouteParams';
 import useOfficialMemberships from 'features/settings/hooks/useOfficialMemberships';
 import useServerSide from 'core/useServerSide';
+import ZUICard from 'zui/ZUICard';
+import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -27,6 +30,7 @@ const SettingsPage: PageWithLayout = () => {
   const onServer = useServerSide();
   const { orgId } = useNumericRouteParams();
   const listFuture = useOfficialMemberships(orgId).data || [];
+  const publicUrl = `https://app.zetkin.org/o/${orgId}`;
 
   const adminList = listFuture.filter((user) => user.role === 'admin');
   const organizerList = listFuture.filter((user) => user.role === 'organizer');
@@ -36,52 +40,75 @@ const SettingsPage: PageWithLayout = () => {
   }
 
   return (
-    <Box>
-      <Box
-        alignItems="center"
-        display="flex"
-        justifyContent="space-between"
-        sx={{
-          marginBottom: '15px',
-          marginTop: '15px',
-        }}
-      >
-        <Typography variant="h4">
-          <Msg id={messageIds.officials.administrators.title} />
+    <Grid container spacing={2}>
+      <Grid item md={8}>
+        <Box
+          alignItems="center"
+          display="flex"
+          justifyContent="space-between"
+          sx={{
+            marginBottom: '15px',
+            marginTop: '15px',
+          }}
+        >
+          <Typography variant="h4">
+            <Msg id={messageIds.officials.administrators.title} />
+          </Typography>
+          <AddOfficialButton
+            disabledList={adminList}
+            orgId={orgId}
+            roleType="admin"
+          />
+        </Box>
+        <Typography mb={2} variant="body2">
+          <Msg id={messageIds.officials.administrators.description} />
         </Typography>
-        <AddOfficialButton
-          disabledList={adminList}
-          orgId={orgId}
-          roleType="admin"
-        />
-      </Box>
-      <Typography mb={2} variant="body2">
-        <Msg id={messageIds.officials.administrators.description} />
-      </Typography>
-      <OfficialList officialList={adminList} orgId={orgId} />
-      <Box
-        alignItems="center"
-        display="flex"
-        justifyContent="space-between"
-        sx={{
-          marginBottom: '15px',
-          marginTop: '40px',
-        }}
-      >
-        <Typography variant="h4">
-          <Msg id={messageIds.officials.organizers.title} />
+        <OfficialList officialList={adminList} orgId={orgId} />
+        <Box
+          alignItems="center"
+          display="flex"
+          justifyContent="space-between"
+          sx={{
+            marginBottom: '15px',
+            marginTop: '40px',
+          }}
+        >
+          <Typography variant="h4">
+            <Msg id={messageIds.officials.organizers.title} />
+          </Typography>
+          <AddOfficialButton
+            disabledList={organizerList}
+            orgId={orgId}
+            roleType="organizer"
+          />
+        </Box>
+        <Typography mb={2} variant="body2">
+          <Msg id={messageIds.officials.organizers.description} />
         </Typography>
-        <AddOfficialButton
-          disabledList={organizerList}
-          orgId={orgId}
-          roleType="organizer"
-        />
-      </Box>
-      <Typography mb={2} variant="body2">
-        <Msg id={messageIds.officials.organizers.description} />
-      </Typography>
-      <OfficialList officialList={organizerList} orgId={orgId} />
-    </Box>
+        <OfficialList officialList={organizerList} orgId={orgId} />
+      </Grid>
+      <Grid item md={4}>
+        <ZUICard
+          header={'Link to public organization'}
+          subheader="Connect to the organization before assigning"
+        >
+          <Box display="flex" paddingBottom={2}>
+            <ZUITextfieldToClipboard copyText={publicUrl}>
+              {publicUrl}
+            </ZUITextfieldToClipboard>
+          </Box>
+          <Link
+            display="flex"
+            href={`/o/${orgId}`}
+            sx={{ alignItems: 'center', gap: 1 }}
+            target="_blank"
+          >
+            <OpenInNew fontSize="inherit" />
+            Link to public organization
+          </Link>
+        </ZUICard>
+      </Grid>
+    </Grid>
   );
 };
 


### PR DESCRIPTION
## Description
This PR implements url card that user can visit public organization page before adding organizers to organizer list in access settings.


## Screenshots
![image](https://github.com/zetkin/app.zetkin.org/assets/77925373/d277b781-8d97-4b9c-a406-8988023ca00f)



## Changes

* Adds `ZUICard` and `ZUITextFieldToClipboard`
* Adds messages
* Changes `<Box/>` to `<Grid/>`


## Notes to reviewer

## Related issues
Resolves #2006 
