### PR TITLE
render empty state on no filtering results

### DIFF
--- a/src/pages/organize/[orgId]/people/incoming/index.tsx
+++ b/src/pages/organize/[orgId]/people/incoming/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useState } from 'react';
 import { Box, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
@@ -11,6 +12,7 @@ import { scaffold } from 'utils/next';
 import useJoinSubmissions from 'features/joinForms/hooks/useJoinSubmissions';
 import { useMessages } from 'core/i18n';
 import { usePanes } from 'utils/panes';
+import ZUIEmptyState from 'zui/ZUIEmptyState';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
@@ -69,7 +71,20 @@ const IncomingPage: PageWithLayout<Props> = ({ orgId }) => {
         />
       );
     } else {
-      return <Box m={2}>{messages.submissionList.noFilteringResults()}</Box>;
+      return (
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="column"
+          height="100%"
+          justifyContent="center"
+        >
+          <ZUIEmptyState
+            message={messages.submissionList.noFilteringResults()}
+            renderIcon={(props) => <InfoOutlinedIcon {...props} />}
+          />
+        </Box>
+      );
     }
   };
 


### PR DESCRIPTION
## Description
This PR renders an empty state that is more in line with the overall Zetkin Gen3 UI.


## Screenshots
<img width="1440" alt="Skärmavbild 2024-06-18 kl  13 59 55" src="https://github.com/zetkin/app.zetkin.org/assets/143598480/c58ab622-0485-4d27-87dc-95dacb3f1ffd">


## Changes
* Adds info icon to message when filtering with no results in the Incoming table.


## Notes to reviewer
None