### PR TITLE
Write submission updates to both copies in the store

### DIFF
--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -298,6 +298,16 @@ const surveysSlice = createSlice({
         item.mutating = [];
         state.statsBySurveyId[submission.survey.id].isStale = true;
       }
+      const submissions = state.submissionsBySurveyId[submission.survey.id];
+      if (submissions) {
+        const itemCopy = submissions.items.find(
+          (item) => item.id == submission.id
+        );
+        if (itemCopy) {
+          itemCopy.data = { ...itemCopy.data, ...submission };
+          itemCopy.mutating = [];
+        }
+      }
     },
     surveysLoad: (state) => {
       state.surveyList.isLoading = true;


### PR DESCRIPTION
This is a fix for https://github.com/zetkin/app.zetkin.org/issues/1979, which I'm fairly sure was introduced by me in https://github.com/zetkin/app.zetkin.org/pull/1971. The root cause here is that https://github.com/zetkin/app.zetkin.org/pull/1971 introduced duplication into the submissions data structure in the store without duplicating all the write operations. This was a case where writing only to the old `submissionList` data structure caused stale data to be displayed, because the UI is rendered using the new `submissionsBySurveyId` object.

In the before & after below, the difference is that in the before GIF I have to reload the page in order to get the updated data to show up. In the after GIF, the updated data is immediately rendered once the write operation completes successfully.

| Before | After |
|-|-|
| ![2024-06-19 20 15 16](https://github.com/zetkin/app.zetkin.org/assets/566159/e64acb17-0987-483f-ba78-4c51ddc2f5af) |  ![2024-06-19 20 10 43](https://github.com/zetkin/app.zetkin.org/assets/566159/d9231668-80fa-4a80-9ce9-9a0e7039aaa3) |