### PR TITLE
issue-2030/trim value

### DIFF
--- a/src/features/profile/components/EditPersonDialog/index.tsx
+++ b/src/features/profile/components/EditPersonDialog/index.tsx
@@ -92,7 +92,7 @@ const EditPersonDialog: FC<EditPersonDialogProps> = ({
             fieldValues={fieldValues}
             invalidFields={invalidFields}
             onChange={(field, newValue) => {
-              onFieldValueChange(field, newValue);
+              onFieldValueChange(field, newValue.trim());
               setFieldValues({ ...fieldValues, [field]: newValue });
             }}
             onReset={(field) => {

--- a/src/zui/ZUICreatePerson/PersonFieldInput.tsx
+++ b/src/zui/ZUICreatePerson/PersonFieldInput.tsx
@@ -50,10 +50,8 @@ const PersonFieldInput: FC<PersonFieldInputProps> = ({
               field as keyof ZetkinPersonNativeFields
             ]()
       }
-      onChange={(e) => {
-        const trimmedValue = e.target.value.trim();
-        onChange(field, trimmedValue);
-      }}
+      onBlur={(e) => onChange(field, e.target.value.trim())}
+      onChange={(e) => onChange(field, e.target.value)}
       required={required}
       sx={style}
       value={value}


### PR DESCRIPTION
## Description
This PR fixes a bug where user can't type space on textfield in person edit.


## Screenshots

https://github.com/zetkin/app.zetkin.org/assets/77925373/26be4bfb-5db3-42e2-b169-25d07c470845


## Changes

* Adds `onBlur` to `TextField` and trim the string
* Adds `trim()` at the end of new value before sending string to `onFieldValueChange`


## Notes to reviewer
I'm not sure if this is the best solution. If user save value without blurring, then `fieldValues` in `EditPersonDialog` will still contain spaces. But data wouldn't contain spaces..

## Related issues
Resolves #2030 
