### PR TITLE
Adjust right margin on content in Edit Person dialog

### DIFF
--- a/src/features/profile/components/EditPersonDialog/index.tsx
+++ b/src/features/profile/components/EditPersonDialog/index.tsx
@@ -86,7 +86,7 @@ const EditPersonDialog: FC<EditPersonDialogProps> = ({
             <Close />
           </IconButton>
         </Box>
-        <Box overflow="auto" paddingRight={2} width="100%">
+        <Box overflow="auto" width="100%">
           <EditPersonFields
             fieldsToUpdate={fieldsToUpdate}
             fieldValues={fieldValues}


### PR DESCRIPTION
## Description
This PR adjusts the outer right margin on content in Edit Person dialog, making the outer margins equal on all sides.

## Changes
Remove excessive outer right margin.

## Notes to reviewer
None

## Related issues
Resolves #2035 
