### PR TITLE
Adjust margins of resolve potential duplicates dialog

### DIFF
--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -101,7 +101,7 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
           </Alert>
         </Box>
       </Box>
-      <DialogActions>
+      <DialogActions sx={{ p: 2 }}>
         <Button onClick={() => onClose()} variant="text">
           {messages.modal.cancelButton()}
         </Button>


### PR DESCRIPTION
## Description
This PR adjusts the padding on the DialogActions element in the resolve potential duplicates dialog. 

## Changes
* Makes the outer margin of the dialog content equal all along the right hand side
* Adjusts the outer bottom margin of the content of the dialog
* Adjusts the spacing between the buttons section ("Cancel" and "Merge") and the "Data to merge" section.

## Notes to reviewer
None

## Related issues
Resolves #2033  
