### PR TITLE
Add badge to display number of pending submissions in Incoming tab

### DIFF
--- a/src/features/views/layout/PeopleLayout.tsx
+++ b/src/features/views/layout/PeopleLayout.tsx
@@ -7,6 +7,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import messageIds from '../l10n/messageIds';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useItemSummary from '../hooks/useItemSummary';
+import useJoinSubmissions from 'features/joinForms/hooks/useJoinSubmissions';
 import { useNumericRouteParams } from 'core/hooks';
 
 interface PeopleLayoutProps {
@@ -19,6 +20,11 @@ const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
   const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const itemSummaryFuture = useItemSummary(orgId, null);
+
+  const { data: submissions } = useJoinSubmissions(orgId);
+  const pendingSubmissions = submissions?.filter(
+    (submission) => submission.state === 'pending'
+  );
 
   const onServer = useServerSide();
   if (onServer) {
@@ -52,6 +58,7 @@ const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
           label: messages.browserLayout.tabs.joinForms(),
         },
         {
+          badge: pendingSubmissions?.length || 0,
           href: '/incoming',
           label: messages.browserLayout.tabs.incoming(),
         },

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -96,8 +96,8 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
 
   const HorizontallyCenteredBadge = styled(Badge)(() => ({
     '& .MuiBadge-badge': {
-      top: '50%',
       right: -15,
+      top: '50%',
       transform: 'translateY(-50%)',
     },
   }));

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -2,9 +2,11 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
 import {
   Alert,
+  Badge,
   Box,
   Button,
   Collapse,
+  styled,
   Tab,
   TabProps,
   Tabs,
@@ -42,7 +44,12 @@ interface TabbedLayoutProps {
   subtitle?: string | ReactElement;
   defaultTab: string;
   noPad?: boolean;
-  tabs: { href: string; label: string; tabProps?: TabProps }[];
+  tabs: {
+    badge?: number;
+    href: string;
+    label: string;
+    tabProps?: TabProps;
+  }[];
   onClickAlertBtn?: () => void;
 }
 
@@ -87,6 +94,14 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
     ? (value: boolean) => setCollapsed(value)
     : undefined;
 
+  const HorizontallyCenteredBadge = styled(Badge)(() => ({
+    '& .MuiBadge-badge': {
+      top: '50%',
+      right: -15,
+      transform: 'translateY(-50%)',
+    },
+  }));
+
   return (
     <DefaultLayout>
       {alertMsg && (
@@ -130,7 +145,20 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
                 <Tab
                   {...tab.tabProps}
                   key={tab.href}
-                  label={tab.label}
+                  label={
+                    !tab.badge ? (
+                      tab.label
+                    ) : (
+                      <HorizontallyCenteredBadge
+                        badgeContent={tab.badge}
+                        color="primary"
+                      >
+                        <Box component="span" sx={{ mr: 1.5 }}>
+                          {tab.label}
+                        </Box>
+                      </HorizontallyCenteredBadge>
+                    )
+                  }
                   sx={{
                     paddingX: 3,
                   }}


### PR DESCRIPTION
## Description
This PR adds a badge to display the number of pending submissions in the Incoming tab.


## Screenshots
![incoming-badge](https://github.com/zetkin/app.zetkin.org/assets/143598480/0fbb9ce4-ab78-4908-a37b-2910b72dfb2b)


## Changes
* Adds a MUI Badge component to the Incoming (under "People") tab to display the number of submissions waiting to be handled. The component is rendered conditionally depending on whether there are pending submissions. If there are none, a badge is not displayed. 


## Notes to reviewer
When styling the Badge component and its wrapped component to fit our needs (horizontal centering of the badge and preventing the badge from overlapping the tab label), there might be problems with displaying the badge – when playing around with margins, I've encountered situations where the badge is cropped in the top and right corners, seemingly by the tab itself. The underlining of the Incoming tab when active also does not stretch all the way under the badge. Perhaps we might be better off with a custom component? In that case especially, this PR is a WIP.
