### PR TITLE
Prevent line breaks in sub-organization dropdown list

### DIFF
--- a/src/zui/ZUIOrgScopeSelect/index.tsx
+++ b/src/zui/ZUIOrgScopeSelect/index.tsx
@@ -91,7 +91,12 @@ const ZUIOrgScopeSelect: FC<Props> = ({
           }}
           renderOption={(props, option, { selected }) => {
             return (
-              <ListItem {...props} key={option.id} value={option.id}>
+              <ListItem
+                {...props}
+                key={option.id}
+                sx={{ whiteSpace: 'nowrap' }}
+                value={option.id}
+              >
                 <Checkbox checked={selected} />
                 <ListItemText primary={option.title} />
               </ListItem>


### PR DESCRIPTION
## Description
This PR prevents line breaks in the sub-organization dropdown menu when editing a smart search query in Lists.


## Screenshots
![sub-org-list](https://github.com/zetkin/app.zetkin.org/assets/143598480/c99904f7-48fa-4135-97ec-f106f283b107)


## Changes
* Adds a whiteSpace property to each ListItem, in order to display the name of each sub-organization on a single line.


## Notes to reviewer
This could preferably be tested by creating a sub-organization with a longer name than the existing ones.


## Related issues
Resolves #2036 
