### PR TITLE
Move object from story template this to args

### DIFF
--- a/src/zui/ZUISuffixedNumber/index.stories.tsx
+++ b/src/zui/ZUISuffixedNumber/index.stories.tsx
@@ -10,4 +10,5 @@ const Template: ComponentStory<typeof ZUISuffixedNumber> = (args) => {
   return <ZUISuffixedNumber number={args.number} />;
 };
 
-export const basic = Template.bind({ number: 54321 });
+export const basic = Template.bind({});
+basic.args = { number: 54321 };


### PR DESCRIPTION
## Description
This PR moves story arguments for `ZUISuffixedNumber` from the `this`-parameter of bind to the `args` property. With arguments directly on `this`, Storybook finds no arguments and for this Story, that leads to nothing being rendered.

## Screenshots

### main
![main](https://github.com/zetkin/app.zetkin.org/assets/7813515/3625c352-b3be-4848-8c3a-618511afd4c3)

### fixed
![fixed](https://github.com/zetkin/app.zetkin.org/assets/7813515/9c2d5b4c-e242-4da2-8ede-a06021ca4752)

## Notes to reviewer
This is a fix for a story in Storybook. Use `yarn storybook` to test it.
