### PR TITLE
Remove invalid characters for phone import validation.

### DIFF
--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -981,4 +981,105 @@ describe('prepareImportOperations()', () => {
       },
     ]);
   });
+
+  it('correctly parses and converts phone numbers with obvious formatting errors', () => {
+    const configData: Sheet = {
+      columns: [
+        {
+          dateFormat: 'se',
+          field: 'phone',
+          kind: ColumnKind.FIELD,
+          selected: true,
+        },
+        { idField: 'id', kind: ColumnKind.ID_FIELD, selected: true },
+      ],
+      firstRowIsHeaders: false,
+      rows: [
+        {
+          data: ['+46732789887', 1],
+        },
+        {
+          data: ['46732789887', 2],
+        },
+        {
+          data: ['0046732789887', 3],
+        },
+        {
+          data: ['-460732789887', 4],
+        },
+        {
+          data: ['46732-78-98-87', 5],
+        },
+        {
+          data: ['460732789887', 6],
+        },
+        {
+          data: ['0732789887', 7],
+        },
+        {
+          data: ['+46 73278 98 87‬', 8],
+        },
+      ],
+      title: 'My sheet',
+    };
+    const result = prepareImportOperations(configData, countryCode);
+    expect(result).toEqual([
+      {
+        data: {
+          phone: '+46732789887',
+          id: 1,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 2,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 3,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 4,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 5,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 6,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 7,
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          phone: '+46732789887',
+          id: 8,
+        },
+        op: 'person.import',
+      },
+    ]);
+  });
 });

--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -986,7 +986,6 @@ describe('prepareImportOperations()', () => {
     const configData: Sheet = {
       columns: [
         {
-          dateFormat: 'se',
           field: 'phone',
           kind: ColumnKind.FIELD,
           selected: true,
@@ -1026,57 +1025,57 @@ describe('prepareImportOperations()', () => {
     expect(result).toEqual([
       {
         data: {
-          phone: '+46732789887',
           id: 1,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 2,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 3,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 4,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 5,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 6,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 7,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },
       {
         data: {
-          phone: '+46732789887',
           id: 8,
+          phone: '+46732789887',
         },
         op: 'person.import',
       },

--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -1016,6 +1016,7 @@ describe('prepareImportOperations()', () => {
           data: ['0732789887', 7],
         },
         {
+          // Phone number contains U202C, a Unicode control character, to validate that it is stripped.
           data: ['+46 73278 98 87‬', 8],
         },
       ],

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -541,5 +541,4 @@ describe('predictProblem()', () => {
     const result = predictProblems(sheet, 'SE', customFields);
     expect(result).toEqual([]);
   });
-
 });

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -534,6 +534,7 @@ describe('predictProblem()', () => {
       firstRowIsHeaders: false,
       rows: [
         {
+          // Phone number contains U202C, a Unicode control character, to check that it is stripped before validating.
           data: ['+46 30777 88 68‬', 10],
         },
       ],

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -520,4 +520,26 @@ describe('predictProblem()', () => {
       },
     ]);
   });
+
+  it('Removes weird characters from phone fields', () => {
+    const sheet = makeFullSheet({
+      columns: [
+        {
+          field: 'phone',
+          kind: ColumnKind.FIELD,
+          selected: true,
+        },
+        { idField: 'id', kind: ColumnKind.ID_FIELD, selected: true },
+      ],
+      firstRowIsHeaders: false,
+      rows: [
+        {
+          data: ['+46 30777 88 68‬', 10],
+        },
+      ],
+    });
+    const result = predictProblems(sheet, 'SE', customFields);
+    expect(result).toEqual([]);
+  });
+
 });

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -111,7 +111,7 @@ export function predictProblems(
             ) {
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
-              const phoneValue = value.replaceAll(/[^\d\+]/g, '');
+              const phoneValue = value.toString().replaceAll(/[^+\d]/g, '');
               if (!isValidPhoneNumber(phoneValue.toString(), country)) {
                 accumulateFieldProblem(column.field, rowIndex);
               }

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -111,7 +111,8 @@ export function predictProblems(
             ) {
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
-              if (!isValidPhoneNumber(value.toString(), country)) {
+              const phoneValue = value.replaceAll(/[^\d\+]/g, '');
+              if (!isValidPhoneNumber(phoneValue.toString(), country)) {
                 accumulateFieldProblem(column.field, rowIndex);
               }
             } else if (column.field == 'gender') {


### PR DESCRIPTION
## Description
This PR fixes a problem where perfectly valid phone numbers would be considered invalid because some random weird characters were included in the import file.

## Changes
* Changes `predictProblems`.ts to filter out any characters other than digits and + before asking `libphonenumber-js` if it's a valid phone number.
* Verifies that these don't follow along when formatting the phone number for inclusion with the import sent to the server in `prepareImportOperations.ts`

## Notes to reviewer
The weird characters are not visible on Github, in vim they are represented as <202c> or "POP DIRECTIONAL FORMATTING".
