### PR TITLE
Add ellipsis menu with copy token option to Join Forms table

### DIFF
--- a/src/features/joinForms/components/JoinFormList.tsx
+++ b/src/features/joinForms/components/JoinFormList.tsx
@@ -2,7 +2,11 @@ import { FC } from 'react';
 import { Box, Card, Divider } from '@mui/material';
 
 import JoinFormListItem from './JoinFormListItem';
+import messageIds from '../l10n/messageIds';
+import { useMessages } from 'core/i18n';
 import { ZetkinJoinForm } from '../types';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import ZUIInlineCopyToClipboard from 'zui/ZUIInlineCopyToClipBoard';
 
 type Props = {
   forms: ZetkinJoinForm[];
@@ -10,13 +14,32 @@ type Props = {
 };
 
 const JoinFormList: FC<Props> = ({ forms, onItemClick }) => {
+  const messages = useMessages(messageIds);
+
   return (
     <Box m={2}>
       <Card>
         {forms.map((form, index) => (
           <Box key={form.id}>
             {index > 0 && <Divider />}
-            <JoinFormListItem form={form} onClick={() => onItemClick(form)} />
+            <Box display="flex" justifyContent="space-between">
+              <JoinFormListItem form={form} onClick={() => onItemClick(form)} />
+              <ZUIEllipsisMenu
+                items={[
+                  {
+                    label: (
+                      <ZUIInlineCopyToClipboard
+                        alwaysShowIcon
+                        clickableChildren
+                        copyText={form.submit_token}
+                      >
+                        {messages.formList.copyToken()}
+                      </ZUIInlineCopyToClipboard>
+                    ),
+                  },
+                ]}
+              />
+            </Box>
           </Box>
         ))}
       </Card>

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -2,6 +2,9 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.joinForms', {
   defaultTitle: m('Untitled form'),
+  formList: {
+    copyToken: m('Copy security token'),
+  },
   formPane: {
     labels: {
       addField: m('Add field'),

--- a/src/zui/ZUIInlineCopyToClipBoard.tsx
+++ b/src/zui/ZUIInlineCopyToClipBoard.tsx
@@ -39,8 +39,14 @@ export const CopyIcon = ({
 const ZUIInlineCopyToClipboard: React.FunctionComponent<{
   alwaysShowIcon?: boolean;
   children: React.ReactNode;
+  clickableChildren?: boolean;
   copyText: string | number | boolean;
-}> = ({ alwaysShowIcon = false, children, copyText }) => {
+}> = ({
+  alwaysShowIcon = false,
+  children,
+  clickableChildren = false,
+  copyText,
+}) => {
   const messages = useMessages(messageIds);
   const [hover, setHover] = useState<boolean>(false);
 
@@ -64,7 +70,9 @@ const ZUIInlineCopyToClipboard: React.FunctionComponent<{
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <Box>{children}</Box>
+      <Box onClick={clickableChildren ? handleClick : undefined}>
+        {children}
+      </Box>
       <Fade in={hover || alwaysShowIcon}>
         <Box
           alignItems="center"
@@ -73,7 +81,7 @@ const ZUIInlineCopyToClipboard: React.FunctionComponent<{
           height={40}
           position="relative"
         >
-          <IconButton onClick={() => handleClick()}>
+          <IconButton onClick={handleClick}>
             <CopyIcon />
           </IconButton>
         </Box>


### PR DESCRIPTION
## Description
This PR adds an ellipsis menu to each row in the Join Forms table. In the ellipsis menu, there is an option of copying the form submit token to the clipboard.


## Screenshots
![ellipsis-menu-with-copy-token](https://github.com/zetkin/app.zetkin.org/assets/143598480/86c97adc-7fcf-44da-a12b-442fc08b068a)


## Changes
* Adds an ellipsis menu to each row in the Join Forms table
* Adds the option of "Copy …" to the ellipsis menu, this user action copies the individual form submit token to the clipboard

