### PR TITLE
Wrap some interactions with act in jest

### DIFF
--- a/src/zui/ZUIEditTextInPlace/index.spec.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.spec.tsx
@@ -36,8 +36,10 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...props} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
-    await userEvent.hover(inputEl);
+    await act(async () => {
+      await userEvent.click(inputEl);
+      await userEvent.hover(inputEl);
+    });
     const tooltip = queryByRole('tooltip');
     expect(tooltip).toBeNull();
   });
@@ -47,9 +49,13 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...props} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
-    await userEvent.clear(inputEl);
-    await userEvent.hover(inputEl);
+    await act(async () => {
+      await userEvent.click(inputEl);
+    });
+    await act(async () => {
+      await userEvent.clear(inputEl);
+      await userEvent.hover(inputEl);
+    });
     const tooltip = await findByMessageId(
       messageIds.editTextInPlace.tooltip.noEmpty
     );
@@ -62,14 +68,20 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...{ ...props, onChange }} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
+    await act(async () => {
+      await userEvent.click(inputEl);
+    });
     // If user tries to save no text
-    await userEvent.clear(inputEl);
-    await userEvent.keyboard('{enter}');
+    await act(async () => {
+      await userEvent.clear(inputEl);
+      await userEvent.keyboard('{enter}');
+    });
     expect(onChange).toHaveBeenCalledTimes(0);
     // If user saves the previous value, it doesn't need to save
-    await userEvent.paste(props.value);
-    await userEvent.keyboard('{enter}');
+    await act(async () => {
+      await userEvent.paste(props.value);
+      await userEvent.keyboard('{enter}');
+    });
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
@@ -79,11 +91,15 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace allowEmpty={true} {...{ ...props, onChange }} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
+    await act(async () => {
+      await userEvent.click(inputEl);
+    });
 
     // If user tries to save no text
-    await userEvent.clear(inputEl);
-    await userEvent.keyboard('{enter}');
+    await act(async () => {
+      await userEvent.clear(inputEl);
+      await userEvent.keyboard('{enter}');
+    });
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
@@ -93,9 +109,11 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...{ ...props, onChange }} />
     );
     const inputEl = getByDisplayValue(props.value) as HTMLInputElement;
-    await userEvent.click(inputEl);
-    await userEvent.paste('New Text');
-    await userEvent.keyboard('{escape}');
+    await act(async () => {
+      await userEvent.click(inputEl);
+      await userEvent.paste('New Text');
+      await userEvent.keyboard('{escape}');
+    });
     expect(onChange).toHaveBeenCalledTimes(0);
     expect(inputEl.value).toBe(props.value);
   });
@@ -106,9 +124,11 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...{ ...props, onChange }} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
-    await userEvent.paste('New Text');
     await act(async () => {
+      await userEvent.click(inputEl);
+    });
+    await act(async () => {
+      await userEvent.paste('New Text');
       await userEvent.keyboard('{enter}');
     });
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -120,11 +140,15 @@ describe('ZUIEditTextInPlace', () => {
       <ZUIEditTextinPlace {...{ ...props, onChange }} />
     );
     const inputEl = getByDisplayValue(props.value);
-    await userEvent.click(inputEl);
-    await userEvent.clear(inputEl);
-    await userEvent.paste('New Text');
+    await act(async () => {
+      await userEvent.click(inputEl);
+    });
+    await act(async () => {
+      await userEvent.clear(inputEl);
+      await userEvent.paste('New Text');
 
-    fireEvent.blur(inputEl);
+      fireEvent.blur(inputEl);
+    });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith('New Text');


### PR DESCRIPTION
## Description
This PR fixes a lot of warnings that are printed when I run yarn test.

For example:

	Warning: An update to ZUIEditTextinPlace inside a test was not
	wrapped in act(...).

	When testing, code that causes React state updates should be
	wrapped into act(...):

	act(() => {
	  /* fire events that update state */
	});
	/* assert on the output */

	This ensures that you're testing the behavior the user would see
	in the browser. Learn more at
	https://reactjs.org/link/wrap-tests-with-act
	    at ZUIEditTextinPlace zui/ZUIEditTextInPlace/index.tsx:67:3
	    at EnvProvider core/env/EnvContext.tsx:12:46
	    ...
	    at ZetkinAppProviders utils/testing/index.tsx:33:60

	  199 |           inputRef={inputRef}
	  200 |           onBlur={handleBlur}
	> 201 |           onChange={(e) => setText(e.target.value)}
	      |                            ^
	  202 |           onFocus={startEditing}
	  203 |           onKeyDown={onKeyDown}
	  204 |           placeholder={placeholder}

	  ...
	  at onChange zui/ZUIEditTextInPlace/index.tsx:201:28
	  ...

Some tests did not work when I wrapped all interactions in a single act. That's why I ended up with multiple act calls in some tests. For example, the test was complaining that it couldn't clear the input and I think that was because the click to focus it hadn't resolved yet. Moving the click to its own act fixed that problem. Maybe the act blocks should be split differently but at least now this test doesn't fill my whole terminal buffer with red error messages. =)

## Notes to reviewer
This is a fix for a test file. The test can be run with `yarn run jest ZUIEditTextInPlace`