### PR TITLE
Mock GET /api/orgs/1/people/fields in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,20 +27,31 @@ const I18nProvider = (props) => {
   );
 };
 
-function mockFetch(path, init) {
+async function mockFetch(path, init) {
   if (path === '/api/orgs/1/people/1' && init === undefined) {
-    return Promise.resolve(
-      new Response(
-        JSON.stringify({
-          data: mockPerson(),
-        })
-      )
+    return new Response(
+      JSON.stringify({
+        data: mockPerson(),
+      })
     );
-  } else if (path === '/api/orgs/1/people/1/tags' && init === undefined) {
-    return Promise.resolve(new Response('[]'));
-  } else {
-    return Promise.reject({ error: 'unmocked request', path, init });
   }
+
+  if (path === '/api/orgs/1/people/1/tags' && init === undefined) {
+    return new Response('[]');
+  }
+
+  if (path === '/api/orgs/1/people/fields' && init === undefined) {
+    return new Response(
+      JSON.stringify({
+        data: [],
+      })
+    );
+  }
+
+  throw new Error(
+    `unmocked request to path: '${path}'
+    with init: ${JSON.stringify(init)}`
+  );
 }
 
 class MockApiClient extends FetchApiClient {


### PR DESCRIPTION
## Description
This PR adds mocking for GET `/api/orgs/1/people/fields` in Storybook. The story `PersonDetailsCard` sends those so mocking them seems prudent.

With this is a refactoring to async instead of explicit promises and an addition of stack traces to for unmocked requests.

## Notes to reviewer
This is a fix for Storybook and it can be tested with `yarn storybook`. Open your browser's developer tools console and open the story `PersonDetailsCard`. Without the fix, you will find a warning about an unmocked request. With the fix, you will find no warning about that... unless you interact with the person editor.