### PR TITLE
New rule for import order linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,19 @@ module.exports = {
           },
         ],
         curly: 'error',
+        'import/order': [
+          'error',
+          {
+            alphabetize: {
+              order: 'ignore',
+              orderImportKind: 'ignore',
+            },
+            groups: [
+              ['external', 'builtin'],
+            ],
+            'newlines-between': 'always',
+          },
+        ],
         'jsx-a11y/anchor-is-valid': 'off',
         'no-console': 'error',
         'no-switch-statements/no-switch': 'error',
@@ -81,14 +94,6 @@ module.exports = {
           {
             component: true,
             html: true,
-          },
-        ],
-        'sort-imports': [
-          'error',
-          {
-            ignoreCase: true,
-            allowSeparatedGroups: true,
-            memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple'],
           },
         ],
         'sort-keys': 'error',

--- a/integrationTesting/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend.ts
+++ b/integrationTesting/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend.ts
@@ -1,6 +1,5 @@
 import { TASK_TYPE } from 'features/tasks/components/types';
 import { ZetkinTask } from 'utils/types/zetkin';
-
 import KPD from '../../..';
 import ReferendumSignatureCollection from '..';
 

--- a/integrationTesting/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
+++ b/integrationTesting/mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/VisitReferendumWebsite.ts
@@ -1,6 +1,5 @@
 import { ZetkinTask } from 'utils/types/zetkin';
 import { TASK_TYPE, VisitLinkConfig } from 'features/tasks/components/types';
-
 import KPD from '../../..';
 import ReferendumSignatureCollection from '..';
 

--- a/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import KPD from '../../../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 

--- a/integrationTesting/tests/organize/campaigns/detail/edit.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/edit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import KPD from '../../../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import RosaLuxemburg from '../../../../mockData/orgs/KPD/people/RosaLuxemburg';

--- a/integrationTesting/tests/organize/campaigns/list/create.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/list/create.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import KPD from '../../../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import WelcomeNewMembers from '../../../../mockData/orgs/KPD/campaigns/WelcomeNewMembers';

--- a/integrationTesting/tests/organize/campaigns/list/list.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/list/list.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import KPD from '../../../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import WelcomeNewMembers from '../../../../mockData/orgs/KPD/campaigns/WelcomeNewMembers';

--- a/integrationTesting/tests/organize/journeys/instance-detail/close.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/close.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ActivistTag from '../../../../mockData/orgs/KPD/tags/Activist';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import CodingSkillsTag from '../../../../mockData/orgs/KPD/tags/Coding';

--- a/integrationTesting/tests/organize/journeys/instance-detail/display.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/display.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';
 import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';

--- a/integrationTesting/tests/organize/journeys/instance-detail/edit-summary.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/edit-summary.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';
 import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';

--- a/integrationTesting/tests/organize/journeys/instance-detail/edit-type.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/edit-type.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';
 import MarxistTraining from '../../../../mockData/orgs/KPD/journeys/MarxistTraining';

--- a/integrationTesting/tests/organize/journeys/instance-detail/navigate.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/navigate.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';
 import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';

--- a/integrationTesting/tests/organize/journeys/instance-detail/notes.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/notes.spec.ts
@@ -1,8 +1,7 @@
 import { expect } from '@playwright/test';
+
 import test from '../../../../fixtures/next';
-
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
-
 import ClaraZetkin from '../../../../mockData/orgs/KPD/people/ClaraZetkin';
 import KPD from '../../../../mockData/orgs/KPD';
 import MemberOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding';

--- a/integrationTesting/tests/organize/journeys/instance-detail/reopen.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/reopen.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';
 import { ZetkinJourneyInstance } from '../../../../../src/utils/types/zetkin';

--- a/integrationTesting/tests/organize/journeys/instance-detail/sidebar.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ActivistTag from '../../../../mockData/orgs/KPD/tags/Activist';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import CodingSkillsTag from '../../../../mockData/orgs/KPD/tags/Coding';

--- a/integrationTesting/tests/organize/journeys/instance-milestones/milestones.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-milestones/milestones.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import { AttendMeeting } from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import ClarasOnboarding from '../../../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../../../mockData/orgs/KPD';

--- a/integrationTesting/tests/organize/journeys/list.spec.ts
+++ b/integrationTesting/tests/organize/journeys/list.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import KPD from '../../../mockData/orgs/KPD';
 import MarxistTraining from '../../../mockData/orgs/KPD/journeys/MarxistTraining';
 import MemberOnboarding from '../../../mockData/orgs/KPD/journeys/MemberOnboarding';

--- a/integrationTesting/tests/organize/memberships.spec.ts
+++ b/integrationTesting/tests/organize/memberships.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../fixtures/next';
 
+import test from '../../fixtures/next';
 import KPD from '../../mockData/orgs/KPD';
 import RosaLuxemburg from '../../mockData/orgs/KPD/people/RosaLuxemburg';
 import RosaLuxemburgUser from '../../mockData/users/RosaLuxemburgUser';

--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../fixtures/next';
 
+import test from '../../fixtures/next';
 import ClarasOnboarding from '../../mockData/orgs/KPD/journeys/MemberOnboarding/instances/ClarasOnboarding';
 import KPD from '../../mockData/orgs/KPD';
 import ReferendumSignatures from '../../mockData/orgs/KPD/campaigns/ReferendumSignatures';

--- a/integrationTesting/tests/organize/tags/add.spec.ts
+++ b/integrationTesting/tests/organize/tags/add.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../mockData/orgs/KPD/tags/Coding';
 import KPD from '../../../mockData/orgs/KPD';

--- a/integrationTesting/tests/organize/tags/create.spec.ts
+++ b/integrationTesting/tests/organize/tags/create.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import ActivistTag from '../../../mockData/orgs/KPD/tags/Activist';
 import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../mockData/orgs/KPD/tags/Coding';

--- a/integrationTesting/tests/organize/tags/edit.spec.ts
+++ b/integrationTesting/tests/organize/tags/edit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import ActivistTag from '../../../mockData/orgs/KPD/tags/Activist';
 import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../mockData/orgs/KPD/tags/Coding';

--- a/integrationTesting/tests/organize/tags/list.spec.ts
+++ b/integrationTesting/tests/organize/tags/list.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import ActivistTag from '../../../mockData/orgs/KPD/tags/Activist';
 import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../mockData/orgs/KPD/tags/Coding';

--- a/integrationTesting/tests/organize/tags/remove.spec.ts
+++ b/integrationTesting/tests/organize/tags/remove.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
 import CodingSkillsTag from '../../../mockData/orgs/KPD/tags/Coding';
 import KPD from '../../../mockData/orgs/KPD';

--- a/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
@@ -2,7 +2,6 @@ import { expect } from '@playwright/test';
 import fs from 'fs/promises';
 
 import test from '../../../../fixtures/next';
-
 import KPD from '../../../../mockData/orgs/KPD';
 import ReferendumSignatureCollection from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import SpeakToFriend from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';

--- a/integrationTesting/tests/organize/tasks/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/delete.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ReferendumSignatureCollection from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import SpeakToFriend from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
 

--- a/integrationTesting/tests/organize/tasks/detail/edit.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/edit.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ReferendumSignatureCollection from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import SpeakToFriend from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
 

--- a/integrationTesting/tests/organize/tasks/detail/update-target.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/update-target.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import ReferendumSignatureCollection from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures';
 import SpeakToFriend from '../../../../mockData/orgs/KPD/campaigns/ReferendumSignatures/tasks/SpeakToFriend';
 

--- a/integrationTesting/tests/organize/views/detail/add-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/add-row.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete.spec.ts
@@ -1,6 +1,6 @@
-import test from '../../../../fixtures/next';
 import { expect, Page } from '@playwright/test';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/display.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/display.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/jump.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/jump.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/rename.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/detail/smart-search.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/smart-search.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import AllMembersColumns from '../../../../mockData/orgs/KPD/people/views/AllMembers/columns';
 import AllMembersRows from '../../../../mockData/orgs/KPD/people/views/AllMembers/rows';

--- a/integrationTesting/tests/organize/views/list/create.spec.ts
+++ b/integrationTesting/tests/organize/views/list/create.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import KPD from '../../../../mockData/orgs/KPD';
 import NewView from '../../../../mockData/orgs/KPD/people/views/NewView';
 import NewViewColumns from '../../../../mockData/orgs/KPD/people/views/NewView/columns';

--- a/integrationTesting/tests/organize/views/list/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/list/delete.spec.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test';
-import test, { NextWorkerFixtures } from '../../../../fixtures/next';
 
+import test, { NextWorkerFixtures } from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import KPD from '../../../../mockData/orgs/KPD';
 

--- a/integrationTesting/tests/organize/views/list/display.spec.ts
+++ b/integrationTesting/tests/organize/views/list/display.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import KPD from '../../../../mockData/orgs/KPD';
 

--- a/integrationTesting/tests/organize/views/list/navigate.spec.ts
+++ b/integrationTesting/tests/organize/views/list/navigate.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../../fixtures/next';
 
+import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import KPD from '../../../../mockData/orgs/KPD';
 

--- a/integrationTesting/tests/organize/views/redirect.spec.ts
+++ b/integrationTesting/tests/organize/views/redirect.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
-import test from '../../../fixtures/next';
 
+import test from '../../../fixtures/next';
 import KPD from '../../../mockData/orgs/KPD';
 
 test('Navigating to /organize/:orgId/people/views redirects to views page', async ({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
+import { headers } from 'next/headers';
+
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import ClientContext from 'core/env/ClientContext';
-import { headers } from 'next/headers';
 import { ZetkinUser } from 'utils/types/zetkin';
 import { getBrowserLanguage, getMessages } from 'utils/locale';
 

--- a/src/core/caching/cacheUtils.ts
+++ b/src/core/caching/cacheUtils.ts
@@ -1,5 +1,6 @@
-import { AppDispatch } from 'core/store';
 import { PayloadAction } from '@reduxjs/toolkit';
+
+import { AppDispatch } from 'core/store';
 import shouldLoad from './shouldLoad';
 import {
   IFuture,

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -1,22 +1,23 @@
 'use client';
 
-import BrowserApiClient from 'core/api/client/BrowserApiClient';
 import CssBaseline from '@mui/material/CssBaseline';
-import Environment from 'core/env/Environment';
-import { EnvProvider } from 'core/env/EnvContext';
 import { IntlProvider } from 'react-intl';
-import { MessageList } from 'utils/locale';
 import { Provider as ReduxProvider } from 'react-redux';
-import { store } from 'core/store';
-import { themeWithLocale } from '../../theme';
-import { UserProvider } from './UserContext';
-import { ZetkinUser } from 'utils/types/zetkin';
 import { FC, ReactNode } from 'react';
 import {
   StyledEngineProvider,
   Theme,
   ThemeProvider,
 } from '@mui/material/styles';
+
+import BrowserApiClient from 'core/api/client/BrowserApiClient';
+import Environment from 'core/env/Environment';
+import { EnvProvider } from 'core/env/EnvContext';
+import { MessageList } from 'utils/locale';
+import { store } from 'core/store';
+import { themeWithLocale } from '../../theme';
+import { UserProvider } from './UserContext';
+import { ZetkinUser } from 'utils/types/zetkin';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/core/env/UserContext.tsx
+++ b/src/core/env/UserContext.tsx
@@ -1,5 +1,6 @@
-import { ZetkinUser } from 'utils/types/zetkin';
 import { createContext, FC, ReactNode } from 'react';
+
+import { ZetkinUser } from 'utils/types/zetkin';
 
 const UserContext = createContext<ZetkinUser | null>(null);
 

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -1,5 +1,6 @@
-import type { AppDispatch, RootState } from '../store';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+import type { AppDispatch, RootState } from '../store';
 
 export { default as useApiClient } from './useApiClient';
 export { default as useEnv } from './useEnv';

--- a/src/core/hooks/useEnv.ts
+++ b/src/core/hooks/useEnv.ts
@@ -1,5 +1,6 @@
-import { EnvContext } from 'core/env/EnvContext';
 import { useContext } from 'react';
+
+import { EnvContext } from 'core/env/EnvContext';
 
 export default function useEnv() {
   const env = useContext(EnvContext);

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -1,5 +1,4 @@
 import { RPCRouter } from './router';
-
 import { addBulkOptionsDef } from 'features/surveys/rpc/addBulkOptions';
 import { copyEmailDef } from 'features/emails/rpc/copyEmail';
 import { copyEventsDef } from 'features/events/rpc/copyEvents';

--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -7,7 +7,6 @@ import { Breadcrumbs, Link, Typography, useMediaQuery } from '@mui/material';
 
 import { Breadcrumb } from 'utils/types';
 import { Msg } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import useBreadcrumbElements from '../hooks/useBreadcrumbs';
 

--- a/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
+++ b/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
@@ -1,7 +1,8 @@
+import { NextRouter, useRouter } from 'next/router';
+
 import { BreadcrumbElement } from 'pages/api/breadcrumbs';
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
 import { crumbsLoad, crumbsLoaded } from '../store';
-import { NextRouter, useRouter } from 'next/router';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 export default function useBreadcrumbElements() {

--- a/src/features/breadcrumbs/store.ts
+++ b/src/features/breadcrumbs/store.ts
@@ -1,5 +1,6 @@
-import { BreadcrumbElement } from 'pages/api/breadcrumbs';
 import { Action, createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { BreadcrumbElement } from 'pages/api/breadcrumbs';
 import { remoteItem, RemoteItem } from 'utils/storeUtils';
 
 type BreadcrumbItem = {

--- a/src/features/calendar/components/CalendarEventFilter/EventFilterPane.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/EventFilterPane.tsx
@@ -1,3 +1,5 @@
+import { Box, Button } from '@mui/material';
+
 import CheckboxFilterList from './CheckboxFilterList';
 import EventInputFilter from './EventInputFilter';
 import messageIds from 'features/calendar/l10n/messageIds';
@@ -12,7 +14,6 @@ import {
   filterUpdated,
   STATE_FILTER_OPTIONS,
 } from 'features/events/store';
-import { Box, Button } from '@mui/material';
 import { Msg, useMessages } from 'core/i18n';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 

--- a/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
@@ -1,7 +1,8 @@
-import useDebounce from 'utils/hooks/useDebounce';
 import { Clear, FilterList } from '@mui/icons-material';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import { useEffect, useState } from 'react';
+
+import useDebounce from 'utils/hooks/useDebounce';
 
 interface EventInputFilterProps {
   onChangeFilterText: (value: string) => void;

--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import { FormattedDate } from 'react-intl';
-import theme from 'theme';
 import { Box, Typography } from '@mui/material';
 
+import theme from 'theme';
 import { AnyClusteredEvent } from 'features/calendar/utils/clusterEventsForWeekCalender';
 import EventCluster from '../EventCluster';
 

--- a/src/features/calendar/components/CalendarMonthView/WeekNumber.tsx
+++ b/src/features/calendar/components/CalendarMonthView/WeekNumber.tsx
@@ -1,5 +1,6 @@
-import theme from 'theme';
 import { Box, Typography } from '@mui/material';
+
+import theme from 'theme';
 
 type CalendarWeekNumberProps = {
   onClick: () => void;

--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
 import React, { useState } from 'react';
+import dayjs from 'dayjs';
 
 import Day from './Day';
-import dayjs from 'dayjs';
 import range from 'utils/range';
 import useMonthCalendarEvents from 'features/calendar/hooks/useMonthCalendarEvents';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
+++ b/src/features/calendar/components/CalendarWeekView/HeaderWeekNumber.tsx
@@ -1,6 +1,6 @@
-import { Msg } from 'core/i18n';
 import { Box, Typography, useTheme } from '@mui/material';
 
+import { Msg } from 'core/i18n';
 import messageIds from '../../l10n/messageIds';
 
 type CalendarWeekNumberProps = {

--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/system';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { Suspense, useEffect, useState } from 'react';
+import utc from 'dayjs/plugin/utc';
 
 import CalendarDayView from './CalendarDayView';
 import CalendarMonthView from './CalendarMonthView';
@@ -10,7 +11,6 @@ import CalendarWeekView from './CalendarWeekView';
 import SelectionBar from '../../events/components/SelectionBar';
 import useDayCalendarNav from '../hooks/useDayCalendarNav';
 
-import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
 
 export enum TimeScale {

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.calendar', {

--- a/src/features/callAssignments/components/CallAssignmentCallersList.tsx
+++ b/src/features/callAssignments/components/CallAssignmentCallersList.tsx
@@ -2,15 +2,14 @@ import { makeStyles } from '@mui/styles';
 import { useRouter } from 'next/router';
 import { Avatar, Box, Button, Tooltip } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
+import { Delete, Edit } from '@mui/icons-material';
 
 import { CallAssignmentCaller } from '../apiTypes';
 import TagChip from 'features/tags/components/TagManager/components/TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUIResponsiveContainer from 'zui/ZUIResponsiveContainer';
-import { Delete, Edit } from '@mui/icons-material';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
@@ -4,7 +4,6 @@ import { Box, CircularProgress } from '@mui/material';
 
 import { CallAssignmentState } from '../hooks/useCallAssignmentState';
 import { Msg } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface CallAssignmentStatusChipProps {

--- a/src/features/callAssignments/components/CallerConfigDialog.tsx
+++ b/src/features/callAssignments/components/CallerConfigDialog.tsx
@@ -8,7 +8,6 @@ import { useMessages } from 'core/i18n';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUIDialog from 'zui/ZUIDialog';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
-
 import messageIds from '../l10n/messageIds';
 
 interface CallerConfigDialogProps {

--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -12,7 +12,6 @@ import { useContext, useState } from 'react';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUITextEditor from 'zui/ZUITextEditor';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import useCallerInstructions from '../hooks/useCallerInstructions';
 

--- a/src/features/callAssignments/hooks/useCallerInstructions.ts
+++ b/src/features/callAssignments/hooks/useCallerInstructions.ts
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import { CallAssignmentData } from '../apiTypes';
 import { RootState } from 'core/store';
 import useCallAssignment from './useCallAssignment';
-import { useState } from 'react';
 import { callAssignmentUpdate, callAssignmentUpdated } from '../store';
 import { IFuture, PromiseFuture } from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.callAssignments', {

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -1,11 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import {
   remoteItem,
   RemoteItem,
   remoteList,
   RemoteList,
 } from 'utils/storeUtils';
-
 import {
   Call,
   CallAssignmentCaller,

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItemWithStats.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItemWithStats.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress } from '@mui/material';
 import { FC } from 'react';
+
 import ZUIMultiNumberChip from 'zui/ZUIMultiNumberChip';
 import ActivityListItem, { AcitivityListItemProps } from './ActivityListItem';
 

--- a/src/features/campaigns/components/CampaignDetailsForm.tsx
+++ b/src/features/campaigns/components/CampaignDetailsForm.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import ZUISubmitCancelButtons from '../../../zui/ZUISubmitCancelButtons';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinCampaign, ZetkinPerson } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 interface CampaignDetailsFormProps {

--- a/src/features/campaigns/components/CampaignsActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignsActionButtons.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Box, Button } from '@mui/material';
 
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import useCreateCampaign from '../hooks/useCreateCampaign';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/campaigns/components/EditableCampaignTitle.tsx
+++ b/src/features/campaigns/components/EditableCampaignTitle.tsx
@@ -3,7 +3,6 @@ import { FC } from 'react';
 
 import { ZetkinCampaign } from 'utils/types/zetkin';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
-
 import useCampaign from '../hooks/useCampaign';
 import { useNumericRouteParams } from 'core/hooks';
 

--- a/src/features/campaigns/layout/AllCampaignsLayout.tsx
+++ b/src/features/campaigns/layout/AllCampaignsLayout.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import CampaignsActionButtons from '../components/CampaignsActionButtons';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import { useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface AllCampaignsLayoutProps {

--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -1,4 +1,3 @@
-import theme from 'theme';
 import {
   Alert,
   AlertTitle,
@@ -12,6 +11,7 @@ import {
 import { FC, useState } from 'react';
 import React, { useEffect } from 'react';
 
+import theme from 'theme';
 import FieldSettings from './FieldSettings';
 import messageIds from '../l10n/messageIds';
 import { PotentialDuplicate } from '../store';

--- a/src/features/duplicates/components/DuplicateCard.tsx
+++ b/src/features/duplicates/components/DuplicateCard.tsx
@@ -1,7 +1,7 @@
-import theme from 'theme';
 import { Box, Button, Paper, Typography } from '@mui/material';
 import { FC, useContext, useState } from 'react';
 
+import theme from 'theme';
 import ConfigureModal from './ConfigureModal';
 import messageIds from '../l10n/messageIds';
 import { PotentialDuplicate } from '../store';

--- a/src/features/duplicates/store.tsx
+++ b/src/features/duplicates/store.tsx
@@ -1,5 +1,6 @@
-import { ZetkinPerson } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ZetkinPerson } from 'utils/types/zetkin';
 import { RemoteList, remoteList } from 'utils/storeUtils';
 
 export interface PotentialDuplicate {

--- a/src/features/emails/components/CancelButton.tsx
+++ b/src/features/emails/components/CancelButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mui/material';
 import { FC } from 'react';
+
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/emails/components/DeliveryStatusMessage.tsx
+++ b/src/features/emails/components/DeliveryStatusMessage.tsx
@@ -1,9 +1,9 @@
 import { Box } from '@mui/system';
 import { AccessTime, Send } from '@mui/icons-material';
+import { Typography } from '@mui/material';
 
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { Typography } from '@mui/material';
 import { ZetkinEmail } from 'utils/types/zetkin';
 import ZUIDateTime from 'zui/ZUIDateTime';
 

--- a/src/features/emails/components/EmailDelivery.tsx
+++ b/src/features/emails/components/EmailDelivery.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   Tab,
 } from '@mui/material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
 
 import deliveryProblems from '../utils/deliveryProblems';
 import messageIds from '../l10n/messageIds';
@@ -25,7 +26,6 @@ import {
   removeOffset,
 } from 'utils/dateUtils';
 import { Msg, useMessages } from 'core/i18n';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
 import ZUITimezonePicker, { findCurrentTZ } from 'zui/ZUITimezonePicker';
 
 interface EmailDeliveryProps {

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -3,7 +3,6 @@
 import Header from '@editorjs/header';
 //@ts-ignore
 import Paragraph from '@editorjs/paragraph';
-
 import { Box, useTheme } from '@mui/material';
 import EditorJS, {
   EditorConfig,

--- a/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.spec.ts
+++ b/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.spec.ts
@@ -1,6 +1,7 @@
+import { OutputBlockData } from '@editorjs/editorjs';
+
 import blockProblems from './blockProblems';
 import { ButtonData } from '../../tools/Button';
-import { OutputBlockData } from '@editorjs/editorjs';
 import { TextBlockData } from '../TextBlockListItem';
 import { BLOCK_TYPES, BlockProblem } from 'features/emails/types';
 

--- a/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/ButtonEditableBlock.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable sort-keys */
 import { Box } from '@mui/material';
 import { FC, useState } from 'react';
+import ContentEditable from 'react-contenteditable';
+import DOMPurify from 'dompurify';
 
 import { BlockAttributes } from 'features/emails/types';
 import { ButtonData } from '.';
-import ContentEditable from 'react-contenteditable';
 import { defaultButtonAttributes } from '../../utils/defaultBlockAttributes';
-import DOMPurify from 'dompurify';
 import messageIds from 'features/emails/l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/emails/components/EmailStatusChip.tsx
+++ b/src/features/emails/components/EmailStatusChip.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
-import { EmailState } from '../hooks/useEmailState';
 import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
 
+import { EmailState } from '../hooks/useEmailState';
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/emails/hooks/useEmailSettings.ts
+++ b/src/features/emails/hooks/useEmailSettings.ts
@@ -1,6 +1,7 @@
+import { useState } from 'react';
+
 import { useNumericRouteParams } from 'core/hooks';
 import useOrganization from 'features/organizations/hooks/useOrganization';
-import { useState } from 'react';
 
 export default function useEmailSettings(initialSubject: string) {
   const { orgId } = useNumericRouteParams();

--- a/src/features/emails/hooks/useEmailStats.ts
+++ b/src/features/emails/hooks/useEmailStats.ts
@@ -1,5 +1,4 @@
 import { PlaceholderFuture, ResolvedFuture } from 'core/caching/futures';
-
 import { futureToObject } from 'core/caching/futures';
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
 import useEmail from './useEmail';

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react';
 import { useRouter } from 'next/router';
 import { Box, Button, Dialog, Typography } from '@mui/material';
+import { People } from '@mui/icons-material';
 
 import DeliveryStatusMessage from '../components/DeliveryStatusMessage';
 import EmailActionButtons from '../components/EmailActionButtons';
 import EmailStatusChip from '../components/EmailStatusChip';
 import messageIds from '../l10n/messageIds';
-import { People } from '@mui/icons-material';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import useEmail from '../hooks/useEmail';
 import useEmailStats from '../hooks/useEmailStats';

--- a/src/features/emails/utils/deliveryProblems.ts
+++ b/src/features/emails/utils/deliveryProblems.ts
@@ -1,6 +1,7 @@
+import { OutputData } from '@editorjs/editorjs';
+
 import blockProblems from '../components/EmailEditor/EmailSettings/utils/blockProblems';
 import { DeliveryProblem } from '../types';
-import { OutputData } from '@editorjs/editorjs';
 import { ZetkinEmail } from 'utils/types/zetkin';
 
 export default function deliveryProblems(

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -7,8 +7,8 @@ import {
   RestoreOutlined,
 } from '@mui/icons-material';
 import React, { useContext } from 'react';
-
 import dayjs from 'dayjs';
+
 import messageIds from '../l10n/messageIds';
 import useDuplicateEvent from '../hooks/useDuplicateEvent';
 import useEventMutations from '../hooks/useEventMutations';

--- a/src/features/events/components/EventPopper/MultiEventPopper/index.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/index.tsx
@@ -7,6 +7,11 @@ import {
   Typography,
 } from '@mui/material';
 import React, { FC, useState } from 'react';
+import {
+  ArrowBack,
+  EventOutlined,
+  SplitscreenOutlined,
+} from '@mui/icons-material';
 
 import ArbitraryCluster from './ArbitraryCluster';
 import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
@@ -18,11 +23,6 @@ import SingleEvent from '../SingleEvent';
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from '../../../../../utils/types/zetkin';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
-import {
-  ArrowBack,
-  EventOutlined,
-  SplitscreenOutlined,
-} from '@mui/icons-material';
 
 export interface MultiEventPopperProps {
   anchorPosition: { left: number; top: number } | undefined;

--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
-import { useMessages } from 'core/i18n';
 import {
   AccessTime,
   ArrowForward,
@@ -13,6 +12,7 @@ import {
 import { Box, Button, Link, Typography } from '@mui/material';
 import { FC, useContext } from 'react';
 
+import { useMessages } from 'core/i18n';
 import { eventsDeselected } from 'features/events/store';
 import EventSelectionCheckBox from '../EventSelectionCheckBox';
 import getEventUrl from 'features/events/utils/getEventUrl';

--- a/src/features/events/components/EventStatusChip.tsx
+++ b/src/features/events/components/EventStatusChip.tsx
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
 import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
-import { Msg } from 'core/i18n';
 
+import { Msg } from 'core/i18n';
 import { EventState } from '../hooks/useEventState';
 import messageIds from '../l10n/messageIds';
 

--- a/src/features/events/components/LocationModal/LocationSearch.tsx
+++ b/src/features/events/components/LocationModal/LocationSearch.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
 import { Autocomplete, IconButton, TextField } from '@mui/material';
+import { MyLocation } from '@mui/icons-material';
 
 import messageIds from 'features/events/l10n/messageIds';
-import { MyLocation } from '@mui/icons-material';
 import { useMessages } from 'core/i18n';
 import { ZetkinLocation } from 'utils/types/zetkin';
 

--- a/src/features/events/components/LocationModal/Map.tsx
+++ b/src/features/events/components/LocationModal/Map.tsx
@@ -3,9 +3,6 @@ import Fuse from 'fuse.js';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { FC, useRef, useState } from 'react';
 import { MapContainer, Marker, TileLayer, useMap } from 'react-leaflet';
-
-import BasicMarker from './BasicMarker';
-import SelectedMarker from './SelectedMarker';
 import { useTheme } from '@mui/material';
 import {
   divIcon,
@@ -13,6 +10,9 @@ import {
   Map as MapType,
   Marker as MarkerType,
 } from 'leaflet';
+
+import BasicMarker from './BasicMarker';
+import SelectedMarker from './SelectedMarker';
 import { ZetkinEvent, ZetkinLocation } from 'utils/types/zetkin';
 
 interface MapProps {

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -10,9 +10,9 @@ import {
   Typography,
 } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
-
 import FaceOutlinedIcon from '@mui/icons-material/FaceOutlined';
 import { FC } from 'react';
+
 import filterParticipants from '../utils/filterParticipants';
 import messageIds from 'features/events/l10n/messageIds';
 import noPropagate from 'utils/noPropagate';

--- a/src/features/events/components/RelatedEvent.tsx
+++ b/src/features/events/components/RelatedEvent.tsx
@@ -5,7 +5,6 @@ import { Box, Link, Typography } from '@mui/material';
 import { getParticipantsStatusColor } from 'features/events/utils/eventUtils';
 import messageIds from '../l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
-
 import getEventUrl from '../utils/getEventUrl';
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from 'utils/types/zetkin';

--- a/src/features/events/hooks/useCreateEvent.ts
+++ b/src/features/events/hooks/useCreateEvent.ts
@@ -1,5 +1,6 @@
-import getEventUrl from '../utils/getEventUrl';
 import { useRouter } from 'next/router';
+
+import getEventUrl from '../utils/getEventUrl';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventPostBody } from './useEventMutations';
 import { eventCreate, eventCreated } from '../store';

--- a/src/features/events/layout/EventLayout.tsx
+++ b/src/features/events/layout/EventLayout.tsx
@@ -1,9 +1,9 @@
 import { Box } from '@mui/material';
 import EventIcon from '@mui/icons-material/Event';
 import PeopleIcon from '@mui/icons-material/People';
-import TabbedLayout from 'utils/layout/TabbedLayout';
 import { useState } from 'react';
 
+import TabbedLayout from 'utils/layout/TabbedLayout';
 import EventActionButtons from '../components/EventActionButtons';
 import EventStatusChip from '../components/EventStatusChip';
 import EventTypeAutocomplete from '../components/EventTypeAutocomplete';

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -1,5 +1,6 @@
-import { ParticipantOp } from './types';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ParticipantOp } from './types';
 import {
   RemoteItem,
   remoteItem,

--- a/src/features/events/utils/filterParticipants.ts
+++ b/src/features/events/utils/filterParticipants.ts
@@ -1,4 +1,5 @@
 import Fuse from 'fuse.js';
+
 import {
   ZetkinEventParticipant,
   ZetkinEventResponse,

--- a/src/features/files/components/FileDropZone.tsx
+++ b/src/features/files/components/FileDropZone.tsx
@@ -1,10 +1,10 @@
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { FC, ReactNode } from 'react';
+import { UploadFileOutlined } from '@mui/icons-material';
 
 import DropZoneContainer from './DropZoneContainer';
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { UploadFileOutlined } from '@mui/icons-material';
 import { ZetkinFile } from 'utils/types/zetkin';
 import useFileUploads, { FileUploadState } from '../hooks/useFileUploads';
 

--- a/src/features/import/hooks/useFileParsing.ts
+++ b/src/features/import/hooks/useFileParsing.ts
@@ -1,8 +1,9 @@
+import { useState } from 'react';
+
 import { addFile } from '../store';
 import { parseCSVFile } from '../utils/parseFile';
 import { parseExcelFile } from '../utils/parseFile';
 import { useAppDispatch } from 'core/hooks';
-import { useState } from 'react';
 import { ColumnKind, ImportedFile } from '../utils/types';
 
 function fileWithColumns(file: ImportedFile): ImportedFile {

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.import', {

--- a/src/features/import/store.ts
+++ b/src/features/import/store.ts
@@ -1,10 +1,11 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import {
   Column,
   ImportedFile,
   ImportPreview,
   PersonImport,
 } from './utils/types';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface ImportStoreSlice {
   importResult: PersonImport | null;

--- a/src/features/import/utils/createPreviewData.spec.ts
+++ b/src/features/import/utils/createPreviewData.spec.ts
@@ -1,6 +1,7 @@
+import { describe, it } from '@jest/globals';
+
 import createPreviewData from './createPreviewData';
 import { ColumnKind, Sheet } from './types';
-import { describe, it } from '@jest/globals';
 
 describe('createPreviewData()', () => {
   it('converts fields to preview object', () => {

--- a/src/features/import/utils/parseFile.ts
+++ b/src/features/import/utils/parseFile.ts
@@ -1,5 +1,6 @@
 import * as XLSX from 'xlsx';
 import { parse } from 'papaparse';
+
 import { CellData, ImportedFile, Row } from './types';
 
 export async function parseCSVFile(file: File): Promise<ImportedFile> {

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -1,7 +1,8 @@
+import { CountryCode, parsePhoneNumber } from 'libphonenumber-js';
+
 import getUniqueTags from './getUniqueTags';
 import parseDate from './parseDate';
 import { CellData, ColumnKind, Sheet } from './types';
-import { CountryCode, parsePhoneNumber } from 'libphonenumber-js';
 
 export type ZetkinPersonImportOp = {
   data?: Record<string, CellData>;

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -1,8 +1,9 @@
 import isEmail from 'validator/lib/isEmail';
 import isURL from 'validator/lib/isURL';
+import { CountryCode, isValidPhoneNumber } from 'libphonenumber-js';
+
 import parseDate from '../parseDate';
 import { ColumnKind, Sheet } from '../types';
-import { CountryCode, isValidPhoneNumber } from 'libphonenumber-js';
 import { CUSTOM_FIELD_TYPE, ZetkinCustomField } from 'utils/types/zetkin';
 import {
   ImportFieldProblem,

--- a/src/features/journeys/components/JourneyCard.tsx
+++ b/src/features/journeys/components/JourneyCard.tsx
@@ -4,7 +4,6 @@ import { Box, Card, CardActionArea, Link, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
 import { ZetkinJourney } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 interface JourneyCardProps {

--- a/src/features/journeys/components/JourneyInstanceCloseButton.tsx
+++ b/src/features/journeys/components/JourneyInstanceCloseButton.tsx
@@ -8,7 +8,6 @@ import ZUIDialog from 'zui/ZUIDialog';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinJourneyInstance, ZetkinTag } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 import useJourneyInstanceMutations from '../hooks/useJourneyInstanceMutations';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/journeys/components/JourneyInstanceCreateFab.tsx
+++ b/src/features/journeys/components/JourneyInstanceCreateFab.tsx
@@ -2,7 +2,6 @@ import { Add } from '@mui/icons-material';
 import { Fab } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-
 import makeStyles from '@mui/styles/makeStyles';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/journeys/components/JourneyInstanceOutcome.spec.tsx
+++ b/src/features/journeys/components/JourneyInstanceOutcome.spec.tsx
@@ -1,7 +1,6 @@
 import JourneyInstanceOutcome from './JourneyInstanceOutcome';
 import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
 import { render } from 'utils/testing';
-
 import messageIds from '../l10n/messageIds';
 
 describe('<JourneyInstanceOutcome/>', () => {

--- a/src/features/journeys/components/JourneyInstanceOutcome.tsx
+++ b/src/features/journeys/components/JourneyInstanceOutcome.tsx
@@ -2,7 +2,6 @@ import { Box, Card, CardContent, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 const JourneyInstanceOutcome = ({

--- a/src/features/journeys/components/JourneyInstanceSidebar.tsx
+++ b/src/features/journeys/components/JourneyInstanceSidebar.tsx
@@ -13,7 +13,6 @@ import {
   ZetkinPerson as ZetkinPersonType,
   ZetkinTag,
 } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 import zuiMessageIds from 'zui/l10n/messageIds';
 

--- a/src/features/journeys/components/JourneyInstanceSummary.tsx
+++ b/src/features/journeys/components/JourneyInstanceSummary.tsx
@@ -9,7 +9,6 @@ import ZUIMarkdown from 'zui/ZUIMarkdown';
 import ZUISection from 'zui/ZUISection';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import useJourneyInstanceMutations from '../hooks/useJourneyInstanceMutations';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/journeys/components/JourneyInstancesDataTable/getColumns.ts
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getColumns.ts
@@ -5,7 +5,6 @@ import getTagColumns from './getTagColumns';
 import { JourneyTagColumnData } from 'features/journeys/utils/journeyInstanceUtils';
 import { UseMessagesMap } from 'core/i18n';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
-
 import messageIds from 'features/journeys/l10n/messageIds';
 
 const getColumns = (

--- a/src/features/journeys/components/JourneyInstancesDataTable/getRows.ts
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getRows.ts
@@ -1,4 +1,5 @@
 import Fuse from 'fuse.js';
+
 import { ID_SEARCH_CHAR } from 'zui/ZUIDataTableSearch';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 

--- a/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -17,7 +17,6 @@ import {
   ZetkinJourneyInstance,
   ZetkinPerson as ZetkinPersonType,
 } from 'utils/types/zetkin';
-
 import messageIds from 'features/journeys/l10n/messageIds';
 
 function makeSelectFilterOperator(

--- a/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
@@ -1,16 +1,14 @@
 import { DataGridPro, DataGridProProps } from '@mui/x-data-grid-pro';
+import { FunctionComponent, useState } from 'react';
 
 import getColumns from './getColumns';
 import { getRows } from './getRows';
 import Toolbar from './Toolbar';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
-import { FunctionComponent, useState } from 'react';
-
 import { JourneyTagColumnData } from 'features/journeys/utils/journeyInstanceUtils';
 import useConfigurableDataGridColumns from 'zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns';
 import { useMessages } from 'core/i18n';
 import useModelsFromQueryString from 'zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString';
-
 import messageIds from 'features/journeys/l10n/messageIds';
 
 interface JourneysDataTableProps {

--- a/src/features/journeys/components/JourneyMilestoneProgress.tsx
+++ b/src/features/journeys/components/JourneyMilestoneProgress.tsx
@@ -4,7 +4,6 @@ import { Box, LinearProgress, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
 import { ZetkinJourneyMilestoneStatus } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 export const getCompletionPercentage = (

--- a/src/features/journeys/components/JourneyStatusChip.tsx
+++ b/src/features/journeys/components/JourneyStatusChip.tsx
@@ -3,7 +3,6 @@ import makeStyles from '@mui/styles/makeStyles';
 
 import { useMessages } from 'core/i18n';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/journeys/layout/JourneysLayout.tsx
+++ b/src/features/journeys/layout/JourneysLayout.tsx
@@ -1,8 +1,7 @@
-import { useMessages } from 'core/i18n';
 import { useRouter } from 'next/router';
 
+import { useMessages } from 'core/i18n';
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
-
 import messageIds from '../l10n/messageIds';
 
 interface JourneysLayoutProps {

--- a/src/features/organizations/components/SearchResults/Ancestors.stories.tsx
+++ b/src/features/organizations/components/SearchResults/Ancestors.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
+import { Box } from '@mui/material';
 
 import Ancestors from './Ancestors';
-import { Box } from '@mui/material';
 
 export default {
   component: Ancestors,

--- a/src/features/organizations/rpc/getUserOrgTree.ts
+++ b/src/features/organizations/rpc/getUserOrgTree.ts
@@ -1,8 +1,9 @@
+import { z } from 'zod';
+
 import generateTreeData from '../utils/generateTreeData';
 import IApiClient from 'core/api/client/IApiClient';
 import { makeRPCDef } from 'core/rpc/types';
 import { TreeItemData } from '../types';
-import { z } from 'zod';
 import { ZetkinMembership, ZetkinOrganization } from 'utils/types/zetkin';
 
 const paramsSchema = z.object({});

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -1,5 +1,6 @@
-import { TreeItemData } from './types';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { TreeItemData } from './types';
 import {
   remoteItem,
   RemoteItem,

--- a/src/features/organizations/utils/generateTreeData.spec.ts
+++ b/src/features/organizations/utils/generateTreeData.spec.ts
@@ -1,6 +1,7 @@
+import { describe, expect, it } from '@jest/globals';
+
 import generateTreeData from './generateTreeData';
 import { TreeItemData } from '../types';
-import { describe, expect, it } from '@jest/globals';
 import { ZetkinMembership, ZetkinOrganization } from 'utils/types/zetkin';
 
 describe('generateTreeData()', () => {

--- a/src/features/profile/components/PersonCard.tsx
+++ b/src/features/profile/components/PersonCard.tsx
@@ -11,7 +11,6 @@ import { ReactEventHandler, SyntheticEvent, useState } from 'react';
 
 import { useMessages } from 'core/i18n';
 import ZUISection from 'zui/ZUISection';
-
 import messageIds from '../l10n/messageIds';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/profile/components/PersonDeleteCard.tsx
+++ b/src/features/profile/components/PersonDeleteCard.tsx
@@ -9,7 +9,6 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 const PersonDeleteCard: React.FunctionComponent<{

--- a/src/features/profile/components/PersonJourneysCard/index.tsx
+++ b/src/features/profile/components/PersonJourneysCard/index.tsx
@@ -6,7 +6,6 @@ import { Button, List, ListItem, Menu, MenuItem } from '@mui/material';
 import PersonCard from '../PersonCard';
 import ZUIJourneyInstanceItem from 'zui/ZUIJourneyInstanceItem';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/profile/l10n/messageIds';
 import useJourneys from 'features/journeys/hooks/useJourneys';
 import usePersonJourneyInstances from 'features/journeys/hooks/usePersonJourneyInstances';

--- a/src/features/profile/components/PersonOrganizationsCard/OrganizationsTree.tsx
+++ b/src/features/profile/components/PersonOrganizationsCard/OrganizationsTree.tsx
@@ -13,7 +13,6 @@ import {
   ListItemSecondaryAction,
   ListItemText,
 } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 
 import { PersonOrganization } from 'utils/organize/people';

--- a/src/features/profile/components/PersonOrganizationsCard/index.tsx
+++ b/src/features/profile/components/PersonOrganizationsCard/index.tsx
@@ -17,7 +17,6 @@ import { useMessages } from 'core/i18n';
 import usePersonOrgData from 'features/profile/hooks/usePersonOrgData';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
-
 import messageIds from 'features/profile/l10n/messageIds';
 
 interface PersonOrganizationsCardProps {

--- a/src/features/profile/hooks/usePersonSearch.ts
+++ b/src/features/profile/hooks/usePersonSearch.ts
@@ -1,7 +1,8 @@
+import { useEffect, useState } from 'react';
+
 import { useApiClient } from 'core/hooks';
 import useDebounce from 'utils/hooks/useDebounce';
 import { ZetkinPerson } from 'utils/types/zetkin';
-import { useEffect, useState } from 'react';
 
 type UsePersonSearchReturn = {
   isLoading: boolean;

--- a/src/features/profile/store.ts
+++ b/src/features/profile/store.ts
@@ -1,5 +1,6 @@
-import { PersonOrganization } from 'utils/organize/people';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { PersonOrganization } from 'utils/organize/people';
 import {
   RemoteItem,
   remoteItem,

--- a/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
@@ -5,7 +5,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
@@ -5,7 +5,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinCampaign } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
@@ -4,7 +4,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinPerson } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
@@ -6,7 +6,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 import getSurveyUrl from 'features/surveys/utils/getSurveyUrl';
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinSurvey } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
@@ -5,7 +5,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinTask } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
@@ -5,7 +5,6 @@ import { Avatar, ListItem, ListItemAvatar } from '@mui/material';
 
 import ResultsListItemText from './ResultsListItemText';
 import { ZetkinView } from 'utils/types/zetkin';
-
 import messageIds from '../../../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/ResultsList/index.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/index.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-
 import { List, ListItem, ListItemText } from '@mui/material';
 
 import CallAssignmentListItem from './CallAssignmentListItem';
@@ -9,12 +8,10 @@ import PersonListItem from './PersonListItem';
 import SurveyListItem from './SurveyListItem';
 import TaskListItem from './TaskListItem';
 import ViewListItem from './ViewListItem';
-
 import {
   SEARCH_DATA_TYPE,
   SearchResult,
 } from 'features/search/components/types';
-
 import messages from '../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/search/components/SearchDialog/SearchField.tsx
+++ b/src/features/search/components/SearchDialog/SearchField.tsx
@@ -5,10 +5,8 @@ import {
   useEffect,
   useRef,
 } from 'react';
-
 import Error from '@mui/icons-material/Error';
 import Search from '@mui/icons-material/Search';
-
 import {
   CircularProgress,
   InputAdornment,

--- a/src/features/search/hooks/useSearch.ts
+++ b/src/features/search/hooks/useSearch.ts
@@ -1,7 +1,8 @@
+import { useState } from 'react';
+
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { SearchResult } from '../components/types';
 import useDebounce from 'utils/hooks/useDebounce';
-import { useState } from 'react';
 import {
   resultsError,
   resultsLoad,

--- a/src/features/settings/store.tsx
+++ b/src/features/settings/store.tsx
@@ -1,5 +1,6 @@
-import { ZetkinMembership } from 'utils/types/zetkin';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ZetkinMembership } from 'utils/types/zetkin';
 import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 
 export interface SettingsStoreSlice {

--- a/src/features/smartSearch/components/OrgScope.tsx
+++ b/src/features/smartSearch/components/OrgScope.tsx
@@ -1,9 +1,9 @@
 import { FC, ReactElement } from 'react';
+import { Typography } from '@mui/material';
 
 import { FilterConfigOrgOptions } from './types';
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { Typography } from '@mui/material';
 import useCommaPlural from 'zui/hooks/useCommaPlural';
 import useSubOrganizations from 'features/organizations/hooks/useSubOrganizations';
 

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/index.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/index.tsx
@@ -9,12 +9,12 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import { useRef } from 'react';
 
 import FilterGalleryCard from './FilterGalleryCard';
 import { GROUPED_FILTERS } from './groupedFilters';
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
-import { useRef } from 'react';
 import {
   FILTER_CATEGORY,
   FILTER_TYPE,

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
@@ -16,7 +16,6 @@ import {
   FILTER_TYPE,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import QueryOverviewChip from './QueryOverviewChip';
 import QueryOverviewFilterListItem from './QueryOverviewFilterListItem';

--- a/src/features/smartSearch/components/StartsWith/DisplayStartsWith.tsx
+++ b/src/features/smartSearch/components/StartsWith/DisplayStartsWith.tsx
@@ -1,5 +1,4 @@
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 const localMessageIds = messageIds.filters.all;
 

--- a/src/features/smartSearch/components/StartsWith/index.tsx
+++ b/src/features/smartSearch/components/StartsWith/index.tsx
@@ -3,7 +3,6 @@ import { FormEvent, useState } from 'react';
 
 import FilterForm from '../FilterForm';
 import StyledSelect from 'features/smartSearch/components/inputs/StyledSelect';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.all;

--- a/src/features/smartSearch/components/filters/CallBlocked/DisplayCallBlocked.tsx
+++ b/src/features/smartSearch/components/filters/CallBlocked/DisplayCallBlocked.tsx
@@ -4,7 +4,6 @@ import {
   OPERATION,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 

--- a/src/features/smartSearch/components/filters/CallBlocked/index.tsx
+++ b/src/features/smartSearch/components/filters/CallBlocked/index.tsx
@@ -12,7 +12,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import useCallAssignments from 'features/callAssignments/hooks/useCallAssignments';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -18,7 +18,6 @@ import {
   TIME_FRAME,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 const localMessageIds = messageIds.filters.callHistory;

--- a/src/features/smartSearch/components/filters/CampaignParticipation/DisplayCampaignParticipation.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/DisplayCampaignParticipation.tsx
@@ -6,7 +6,6 @@ import {
   OPERATION,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedActivityTitle from './UnderlinedActivityTitle';
 import UnderlinedCampaignTitle from './UnderlinedCampaignTitle';

--- a/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedActivityTitle.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedActivityTitle.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedCampaignTitle.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedCampaignTitle.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedLocationTitle.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedLocationTitle.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -20,7 +20,6 @@ import {
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 
 const localMessageIds = messageIds.filters.campaignParticipation;

--- a/src/features/smartSearch/components/filters/DisplayTimeFrame.tsx
+++ b/src/features/smartSearch/components/filters/DisplayTimeFrame.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react';
 
 import { TIME_FRAME } from '../types';
 import { TimeFrameConfig } from '../utils';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../UnderlinedMsg';
 

--- a/src/features/smartSearch/components/filters/EmailBlacklist/DisplayEmailBlacklist.tsx
+++ b/src/features/smartSearch/components/filters/EmailBlacklist/DisplayEmailBlacklist.tsx
@@ -4,7 +4,6 @@ import {
   OPERATION,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 

--- a/src/features/smartSearch/components/filters/EmailBlacklist/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailBlacklist/index.tsx
@@ -12,7 +12,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 const localMessageIds = messageIds.filters.emailBlacklist;
 

--- a/src/features/smartSearch/components/filters/Matching.tsx
+++ b/src/features/smartSearch/components/filters/Matching.tsx
@@ -2,12 +2,9 @@ import { MenuItem, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 
 import { getMatchingWithConfig } from '../utils';
-
 import { MATCHING } from 'features/smartSearch/components/types';
-
 import StyledNumberInput from '../inputs/StyledNumberInput';
 import StyledSelect from '../inputs/StyledSelect';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/smartSearch/components/filters/MostActive/DisplayMostActive.tsx
+++ b/src/features/smartSearch/components/filters/MostActive/DisplayMostActive.tsx
@@ -4,10 +4,8 @@ import {
   OPERATION,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import DisplayTimeFrame from '../DisplayTimeFrame';
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 const localMessageIds = messageIds.filters.mostActive;

--- a/src/features/smartSearch/components/filters/MostActive/index.tsx
+++ b/src/features/smartSearch/components/filters/MostActive/index.tsx
@@ -13,7 +13,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.mostActive;

--- a/src/features/smartSearch/components/filters/PersonData/DisplayPersonData.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/DisplayPersonData.tsx
@@ -5,7 +5,6 @@ import {
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/PersonData/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/index.tsx
@@ -14,7 +14,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.personData;

--- a/src/features/smartSearch/components/filters/PersonField/DisplayPersonField.tsx
+++ b/src/features/smartSearch/components/filters/PersonField/DisplayPersonField.tsx
@@ -6,7 +6,6 @@ import {
   PersonFieldFilterConfig,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/PersonField/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonField/index.tsx
@@ -15,7 +15,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import useCustomFields from 'features/profile/hooks/useCustomFields';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
+++ b/src/features/smartSearch/components/filters/PersonTags/DisplayPersonTags.tsx
@@ -9,7 +9,6 @@ import {
   PersonTagsFilterConfig,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 

--- a/src/features/smartSearch/components/filters/PersonTags/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonTags/index.tsx
@@ -17,7 +17,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.personTags;

--- a/src/features/smartSearch/components/filters/PersonView/DisplayPersonView.tsx
+++ b/src/features/smartSearch/components/filters/PersonView/DisplayPersonView.tsx
@@ -4,7 +4,6 @@ import {
   PersonViewFilterConfig,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/PersonView/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonView/index.tsx
@@ -16,7 +16,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 const localMessageIds = messageIds.filters.personView;
 

--- a/src/features/smartSearch/components/filters/Random/DisplayRandom.tsx
+++ b/src/features/smartSearch/components/filters/Random/DisplayRandom.tsx
@@ -1,11 +1,9 @@
 import { getQuantityWithConfig } from 'features/smartSearch/components/utils';
-
 import {
   OPERATION,
   RandomFilterConfig,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import UnderlinedMsg from '../../UnderlinedMsg';

--- a/src/features/smartSearch/components/filters/Random/index.tsx
+++ b/src/features/smartSearch/components/filters/Random/index.tsx
@@ -14,7 +14,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.random;

--- a/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
@@ -4,7 +4,6 @@ import {
   SmartSearchFilterWithId,
   SubQueryFilterConfig,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import UnderlinedMsg from '../../UnderlinedMsg';

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -19,7 +19,6 @@ import {
   ZetkinQuery,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 
 const localMessageIds = messageIds.filters.subQuery;

--- a/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
@@ -13,7 +13,6 @@ import {
   SmartSearchFilterWithId,
   SurveyOptionFilterConfig,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -23,7 +23,6 @@ import {
   ZetkinSurveyOption,
   ZetkinSurveyQuestionElement,
 } from 'utils/types/zetkin';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveysWithElements from 'features/surveys/hooks/useSurveysWithElements';

--- a/src/features/smartSearch/components/filters/SurveyResponse/DisplaySurveyResponse.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/DisplaySurveyResponse.tsx
@@ -4,7 +4,6 @@ import {
   SmartSearchFilterWithId,
   SurveyResponseFilterConfig,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import UnderlinedMsg from '../../UnderlinedMsg';

--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -20,7 +20,6 @@ import {
   SurveyResponseFilterConfig,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/smartSearch/components/filters/SurveySubmission/DisplaySurveySubmission.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/DisplaySurveySubmission.tsx
@@ -6,7 +6,6 @@ import {
   SmartSearchFilterWithId,
   SurveySubmissionFilterConfig,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -14,7 +14,6 @@ import {
   TIME_FRAME,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/smartSearch/components/filters/Task/DisplayTask.tsx
+++ b/src/features/smartSearch/components/filters/Task/DisplayTask.tsx
@@ -1,9 +1,6 @@
 import DisplayTimeFrame from '../DisplayTimeFrame';
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
-const localMessageIds = messageIds.filters.task;
-
 import UnderlinedCampaignTitle from '../CampaignParticipation/UnderlinedCampaignTitle';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedTaskTitle from './UnderlinedTaskTitle';
@@ -23,6 +20,8 @@ import {
 interface DisplayTaskProps {
   filter: SmartSearchFilterWithId<TaskFilterConfig>;
 }
+
+const localMessageIds = messageIds.filters.task;
 
 const DisplayTask = ({ filter }: DisplayTaskProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();

--- a/src/features/smartSearch/components/filters/Task/UnderlinedTaskTitle.tsx
+++ b/src/features/smartSearch/components/filters/Task/UnderlinedTaskTitle.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import UnderlinedText from '../../UnderlinedText';

--- a/src/features/smartSearch/components/filters/Task/index.tsx
+++ b/src/features/smartSearch/components/filters/Task/index.tsx
@@ -12,7 +12,6 @@ import { useNumericRouteParams } from 'core/hooks';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import useTasks from 'features/tasks/hooks/useTasks';
 import { getTaskStatus, getTaskTimeFrameWithConfig } from '../../utils';
-
 import {
   NewSmartSearchFilter,
   OPERATION,
@@ -23,7 +22,6 @@ import {
   TIME_FRAME,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 const localMessageIds = messageIds.filters.task;
 

--- a/src/features/smartSearch/components/filters/TimeFrame.tsx
+++ b/src/features/smartSearch/components/filters/TimeFrame.tsx
@@ -8,7 +8,6 @@ import { Msg } from 'core/i18n';
 import StyledNumberInput from '../inputs/StyledNumberInput';
 import StyledSelect from '../inputs/StyledSelect';
 import { TIME_FRAME } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import StyledDatePicker from '../inputs/StyledDatePicker';
 

--- a/src/features/smartSearch/components/filters/User/DisplayUser.tsx
+++ b/src/features/smartSearch/components/filters/User/DisplayUser.tsx
@@ -4,7 +4,6 @@ import {
   SmartSearchFilterWithId,
   UserFilterConfig,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 const localMessageIds = messageIds.filters.user;

--- a/src/features/smartSearch/components/filters/User/index.tsx
+++ b/src/features/smartSearch/components/filters/User/index.tsx
@@ -11,7 +11,6 @@ import {
   UserFilterConfig,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import { Msg } from 'core/i18n';
 const localMessageIds = messageIds.filters.user;

--- a/src/features/smartSearch/components/inputs/StyledGroupedSelect.tsx
+++ b/src/features/smartSearch/components/inputs/StyledGroupedSelect.tsx
@@ -5,7 +5,6 @@ import {
   TextFieldProps,
   Theme,
 } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 import { FC, ReactElement } from 'react';
 interface StyleProps {

--- a/src/features/smartSearch/components/inputs/StyledItemSelect.tsx
+++ b/src/features/smartSearch/components/inputs/StyledItemSelect.tsx
@@ -5,7 +5,6 @@ import { Theme, Tooltip } from '@mui/material';
 
 import { getEllipsedString } from 'utils/stringUtils';
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/smartSearch/l10n/messageIds';
 
 const useStyles = makeStyles<Theme>((theme) => ({

--- a/src/features/smartSearch/components/inputs/StyledNumberInput.tsx
+++ b/src/features/smartSearch/components/inputs/StyledNumberInput.tsx
@@ -1,5 +1,4 @@
 import { TextField, TextFieldProps } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/smartSearch/components/inputs/StyledSelect.tsx
+++ b/src/features/smartSearch/components/inputs/StyledSelect.tsx
@@ -1,5 +1,4 @@
 import { TextField, TextFieldProps, Theme } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 interface StyleProps {
   minWidth?: string;

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyEntrySegment.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyEntrySegment.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { useTheme } from '@mui/material';
+
 import SmartSearchSankeySegment from './SmartSearchSankeySegment';
 import { useSankey } from './SmartSearchSankeyProvider';
-import { useTheme } from '@mui/material';
 
 type SmartSearchSankeyEntrySegmentProps = {
   hovered: boolean;

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyExitSegment.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyExitSegment.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+
 import SmartSearchSankeySegment from './SmartSearchSankeySegment';
 import { useSankey } from './SmartSearchSankeyProvider';
 

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyFilterSegment.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyFilterSegment.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
+import { useTheme } from '@mui/material';
+
 import SmartSearchSankeySegment from './SmartSearchSankeySegment';
 import { useSankey } from './SmartSearchSankeyProvider';
-import { useTheme } from '@mui/material';
 
 type SmartSearchSankeyFilterSegmentProps = {
   filterIndex: number;

--- a/src/features/smartSearch/hooks/useSmartSearch.ts
+++ b/src/features/smartSearch/hooks/useSmartSearch.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import {
   FILTER_TYPE,
   OPERATION,

--- a/src/features/smartSearch/hooks/useSmartSearchFilter.ts
+++ b/src/features/smartSearch/hooks/useSmartSearchFilter.ts
@@ -1,4 +1,6 @@
 import { Dispatch } from 'react';
+import { SetStateAction, useState } from 'react';
+
 import {
   DefaultFilterConfig,
   NewSmartSearchFilter,
@@ -6,7 +8,6 @@ import {
   SmartSearchFilterWithId,
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
-import { SetStateAction, useState } from 'react';
 
 interface UseSmartSearchFilter<T> {
   filter: ZetkinSmartSearchFilter<T> | SmartSearchFilterWithId<T>;

--- a/src/features/surveys/components/EmptyOverview.tsx
+++ b/src/features/surveys/components/EmptyOverview.tsx
@@ -2,7 +2,6 @@ import { QuizOutlined } from '@mui/icons-material';
 import { Box, Button, Link, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface EmptyOverviewProps {

--- a/src/features/surveys/components/SubmissionChartCard.tsx
+++ b/src/features/surveys/components/SubmissionChartCard.tsx
@@ -9,7 +9,6 @@ import ZUICard from 'zui/ZUICard';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUINumberChip from 'zui/ZUINumberChip';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 type SubmissionChartCardProps = {

--- a/src/features/surveys/components/SubmissionWarningAlert.tsx
+++ b/src/features/surveys/components/SubmissionWarningAlert.tsx
@@ -1,9 +1,10 @@
-import messageIds from '../l10n/messageIds';
 import NextLink from 'next/link';
+import { Alert, AlertTitle, Box, Link } from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import useSurveyStats from '../hooks/useSurveyStats';
 import ZUIFuture from 'zui/ZUIFuture';
-import { Alert, AlertTitle, Box, Link } from '@mui/material';
 
 type SubmissionWarningAlertProps = {
   campId: number | 'standalone' | 'shared';

--- a/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
+++ b/src/features/surveys/components/SurveyEditor/AddBlocks.tsx
@@ -10,7 +10,6 @@ import { Msg } from 'core/i18n';
 import theme from 'theme';
 import useSurveyMutations from 'features/surveys/hooks/useSurveyMutations';
 import { ELEMENT_TYPE, RESPONSE_TYPE } from 'utils/types/zetkin';
-
 import messageIds from 'features/surveys/l10n/messageIds';
 
 type AddBlocksProps = {

--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -16,7 +16,6 @@ import useSurveyMutations from 'features/surveys/hooks/useSurveyMutations';
 import { ZetkinSurveyTextQuestionElement } from 'utils/types/zetkin';
 import ZUIPreviewableInput from 'zui/ZUIPreviewableInput';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/surveys/l10n/messageIds';
 
 interface OpenQuestionBlockProps {

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -7,7 +7,6 @@ import useEditPreviewBlock from 'zui/hooks/useEditPreviewBlock';
 import { useMessages } from 'core/i18n';
 import useSurveyMutations from 'features/surveys/hooks/useSurveyMutations';
 import { ZetkinSurveyTextElement } from 'utils/types/zetkin';
-
 import messageIds from 'features/surveys/l10n/messageIds';
 
 interface TextBlockProps {

--- a/src/features/surveys/components/SurveyStatusChip.tsx
+++ b/src/features/surveys/components/SurveyStatusChip.tsx
@@ -1,9 +1,9 @@
 import { Box } from '@mui/material';
 import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
+
 import { Msg } from 'core/i18n';
 import { SurveyState } from '../hooks/useSurveyState';
-
 import messageIds from '../l10n/messageIds';
 
 interface SurveyStatusChipProps {

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -1,16 +1,6 @@
 import { Box } from '@mui/system';
 import { Link } from '@mui/material';
-import messageIds from '../l10n/messageIds';
-import SurveySubmissionPane from '../panes/SurveySubmissionPane';
-import { useNumericRouteParams } from 'core/hooks';
-import { usePanes } from 'utils/panes';
-import usePersonSearch from 'features/profile/hooks/usePersonSearch';
 import { useRouter } from 'next/router';
-import useSurveySubmission from '../hooks/useSurveySubmission';
-import ZUIPersonGridCell from 'zui/ZUIPersonGridCell';
-import ZUIPersonGridEditCell from 'zui/ZUIPersonGridEditCell';
-import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
-import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import {
   DataGridPro,
   GridCellParams,
@@ -18,6 +8,17 @@ import {
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
 import { FC, useEffect, useMemo } from 'react';
+
+import messageIds from '../l10n/messageIds';
+import SurveySubmissionPane from '../panes/SurveySubmissionPane';
+import { useNumericRouteParams } from 'core/hooks';
+import { usePanes } from 'utils/panes';
+import usePersonSearch from 'features/profile/hooks/usePersonSearch';
+import useSurveySubmission from '../hooks/useSurveySubmission';
+import ZUIPersonGridCell from 'zui/ZUIPersonGridCell';
+import ZUIPersonGridEditCell from 'zui/ZUIPersonGridEditCell';
+import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import { Msg, useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
 

--- a/src/features/surveys/components/SurveySuborgsCard.tsx
+++ b/src/features/surveys/components/SurveySuborgsCard.tsx
@@ -1,9 +1,10 @@
+import { Box, Switch } from '@mui/material';
+
 import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import useSurvey from '../hooks/useSurvey';
 import useSurveyMutations from '../hooks/useSurveyMutations';
 import ZUICard from 'zui/ZUICard';
-import { Box, Switch } from '@mui/material';
 
 const SurveySuborgsCard = ({
   orgId,

--- a/src/features/surveys/components/SurveyURLCard.tsx
+++ b/src/features/surveys/components/SurveyURLCard.tsx
@@ -5,7 +5,6 @@ import { useEnv } from 'core/hooks';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface SurveyURLCardProps {

--- a/src/features/surveys/components/SurveyUnlinkedCard.tsx
+++ b/src/features/surveys/components/SurveyUnlinkedCard.tsx
@@ -1,11 +1,12 @@
-import messageIds from '../l10n/messageIds';
 import NextLink from 'next/link';
+import { Box, Link, useTheme } from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import useSurveyStats from '../hooks/useSurveyStats';
 import ZUICard from 'zui/ZUICard';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUINumberChip from 'zui/ZUINumberChip';
-import { Box, Link, useTheme } from '@mui/material';
 
 type SurveyUnlinkedCardProps = {
   campId: number | 'standalone' | 'shared';

--- a/src/features/surveys/hooks/useSurveyMutations.ts
+++ b/src/features/surveys/hooks/useSurveyMutations.ts
@@ -1,5 +1,6 @@
-import addBulkOptions from '../rpc/addBulkOptions';
 import dayjs from 'dayjs';
+
+import addBulkOptions from '../rpc/addBulkOptions';
 import {
   ELEMENT_TYPE,
   ZetkinOptionsQuestion,

--- a/src/features/surveys/layout/SurveyLayout.tsx
+++ b/src/features/surveys/layout/SurveyLayout.tsx
@@ -1,10 +1,13 @@
+import { useRouter } from 'next/router';
+import { Box, Button } from '@mui/material';
+import { ChatBubbleOutline, QuizOutlined } from '@mui/icons-material';
+
 import { ELEMENT_TYPE } from 'utils/types/zetkin';
 import getSurveyUrl from '../utils/getSurveyUrl';
 import messageIds from '../l10n/messageIds';
 import SurveyStatusChip from '../components/SurveyStatusChip';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useMemberships from 'features/organizations/hooks/useMemberships';
-import { useRouter } from 'next/router';
 import useSurvey from '../hooks/useSurvey';
 import useSurveyElements from '../hooks/useSurveyElements';
 import useSurveyMutations from '../hooks/useSurveyMutations';
@@ -15,8 +18,6 @@ import ZUIFuture from 'zui/ZUIFuture';
 import ZUIFutures from 'zui/ZUIFutures';
 import { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
-import { Box, Button } from '@mui/material';
-import { ChatBubbleOutline, QuizOutlined } from '@mui/icons-material';
 import { Msg, useMessages } from 'core/i18n';
 import useSurveyState, { SurveyState } from '../hooks/useSurveyState';
 

--- a/src/features/surveys/panes/SurveySubmissionPane.tsx
+++ b/src/features/surveys/panes/SurveySubmissionPane.tsx
@@ -1,9 +1,9 @@
-import { EyeClosed } from 'zui/icons/EyeClosed';
 import { makeStyles } from '@mui/styles';
 import { Box, Typography } from '@mui/material';
 import { Check, FormatQuote } from '@mui/icons-material';
 import { FC, ReactNode } from 'react';
 
+import { EyeClosed } from 'zui/icons/EyeClosed';
 import { Msg } from 'core/i18n';
 import PaneHeader from 'utils/panes/PaneHeader';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -12,7 +12,6 @@ import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import useHydratedSurveySubmission, {
   ELEM_TYPE,
 } from '../hooks/useHydratedSurveySubmission';
-
 import messageIds from '../l10n/messageIds';
 
 interface SurveySubmissionPaneProps {

--- a/src/features/tags/components/TagManager/components/TagChip.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.spec.tsx
@@ -1,7 +1,7 @@
-import { render } from 'utils/testing';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 
+import { render } from 'utils/testing';
 import mockTag from 'utils/testing/mocks/mockTag';
 import TagChip from './TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';

--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -1,7 +1,6 @@
 import { Clear } from '@mui/icons-material';
 import { useState } from 'react';
 import { Box, IconButton, lighten, Theme, Tooltip } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 
 import { DEFAULT_TAG_COLOR } from '../utils';

--- a/src/features/tags/components/TagManager/components/TagDialog/ColorPicker.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/ColorPicker.tsx
@@ -2,7 +2,6 @@ import ReplayIcon from '@mui/icons-material/Replay';
 import { Box, InputAdornment, TextField } from '@mui/material';
 
 import { DEFAULT_TAG_COLOR, hexRegex, randomColor } from '../../utils';
-
 import messageIds from '../../../../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
@@ -1,10 +1,9 @@
-import { render } from 'utils/testing';
 import singletonRouter from 'next/router';
 import userEvent from '@testing-library/user-event';
 
+import { render } from 'utils/testing';
 import mockTag from 'utils/testing/mocks/mockTag';
 import { EditTag, NewTag } from '../../types';
-
 import messageIds from 'features/tags/l10n/messageIds';
 import TagDialog from 'features/tags/components/TagManager/components/TagDialog';
 

--- a/src/features/tags/components/TagManager/components/TagDialog/TagGroupSelect.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TagGroupSelect.tsx
@@ -4,7 +4,6 @@ import { Box, TextField } from '@mui/material';
 
 import { NewTagGroup } from '../../types';
 import { ZetkinTagGroup } from 'utils/types/zetkin';
-
 import messageIds from '../../../../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/tags/components/TagManager/components/TagDialog/TypeSelect.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TypeSelect.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mui/material';
 
 import { ZetkinTag } from 'utils/types/zetkin';
-
 import messageIds from '../../../../l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
 

--- a/src/features/tags/components/TagManager/components/TagSelect/TagSelectList.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/TagSelectList.tsx
@@ -4,7 +4,6 @@ import { Box, IconButton, List, ListItem, ListSubheader } from '@mui/material';
 
 import TagChip from '../TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';
-
 import messageIds from '../../../../l10n/messageIds';
 import { Msg } from 'core/i18n';
 

--- a/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -4,7 +4,6 @@ import { Box, Typography } from '@mui/material';
 import TagChip from '../TagChip';
 import { ZetkinTag } from 'utils/types/zetkin';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
-
 import messageIds from '../../../../l10n/messageIds';
 import Msg from 'core/i18n/Msg';
 

--- a/src/features/tags/utils/compareTags.spec.ts
+++ b/src/features/tags/utils/compareTags.spec.ts
@@ -1,6 +1,7 @@
+import { describe, expect, it } from '@jest/globals';
+
 import compareTags from './compareTags';
 import { ZetkinTag } from 'utils/types/zetkin';
-import { describe, expect, it } from '@jest/globals';
 
 describe('compareTags()', () => {
   it('puts any tag before null', () => {

--- a/src/features/tasks/components/TaskActionButtons/PublishButton.tsx
+++ b/src/features/tasks/components/TaskActionButtons/PublishButton.tsx
@@ -8,7 +8,6 @@ import { ZetkinTask } from 'utils/types/zetkin';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import getTaskStatus, { TASK_STATUS } from 'features/tasks/utils/getTaskStatus';
 import { Msg, useMessages, UseMessagesMap } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const getTooltipContents = (

--- a/src/features/tasks/components/TaskActionButtons/index.tsx
+++ b/src/features/tasks/components/TaskActionButtons/index.tsx
@@ -11,7 +11,6 @@ import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIDialog from 'zui/ZUIDialog';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 import { ZetkinTaskRequestBody } from '../types';
 

--- a/src/features/tasks/components/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -1,7 +1,8 @@
+import singletonRouter from 'next/router';
+
 import { ASSIGNED_STATUS } from 'features/tasks/components/types';
 import mockAssignedTask from 'utils/testing/mocks/mockAssignedTask';
 import { render } from 'utils/testing';
-import singletonRouter from 'next/router';
 import TaskAssigneesList from 'features/tasks/components/TaskAssigneesList';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));

--- a/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
@@ -1,9 +1,9 @@
+import singletonRouter from 'next/router';
+
 import { ASSIGNED_STATUS } from 'features/tasks/components/types';
 import mockAssignedTask from 'utils/testing/mocks/mockAssignedTask';
 import { render } from 'utils/testing';
-import singletonRouter from 'next/router';
 import TaskStatusSubtitle from './TaskStatusSubtitle';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 jest.mock('next/dist/client/router', () => require('next-router-mock'));

--- a/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { Done, NotInterested } from '@mui/icons-material';
 
 import { Msg } from 'core/i18n';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
@@ -6,8 +7,6 @@ import {
   ASSIGNED_STATUS,
   ZetkinAssignedTask,
 } from 'features/tasks/components/types';
-import { Done, NotInterested } from '@mui/icons-material';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const TaskStatusSubtitle = ({

--- a/src/features/tasks/components/TaskAssigneesList/index.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/index.tsx
@@ -6,7 +6,6 @@ import { useMessages } from 'core/i18n';
 import { ZetkinAssignedTask } from 'features/tasks/components/types';
 import ZUIPerson from 'zui/ZUIPerson';
 import ZUISection from 'zui/ZUISection';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const TaskAssigneesList: React.FunctionComponent<{

--- a/src/features/tasks/components/TaskAssigneesList/utils.ts
+++ b/src/features/tasks/components/TaskAssigneesList/utils.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+
 import {
   ASSIGNED_STATUS,
   ZetkinAssignedTask,

--- a/src/features/tasks/components/TaskDetailsForm/fields/CollectDemographicsFields.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/fields/CollectDemographicsFields.tsx
@@ -4,7 +4,6 @@ import { TextField } from 'mui-rff';
 import { COLLECT_DEMOGRAPHICS_FIELDS } from '../constants';
 import { DEMOGRAPHICS_FIELD } from 'features/tasks/components/types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const CollectDemographicsFields: React.FunctionComponent = (): JSX.Element => {

--- a/src/features/tasks/components/TaskDetailsForm/fields/ReassignFields.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/fields/ReassignFields.tsx
@@ -3,7 +3,6 @@ import { TextField } from 'mui-rff';
 
 import { DEFAULT_REASSIGN_INTERVAL, TASK_DETAILS_FIELDS } from '../constants';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const ReassignFields: React.FunctionComponent = () => {

--- a/src/features/tasks/components/TaskDetailsForm/fields/ShareLinkFields.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/fields/ShareLinkFields.tsx
@@ -2,7 +2,6 @@ import { TextField } from 'mui-rff';
 
 import { SHARE_LINK_FIELDS } from '../constants';
 import { useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const ShareLinkFields = (): JSX.Element => {

--- a/src/features/tasks/components/TaskDetailsForm/fields/TimeEstimateField.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/fields/TimeEstimateField.tsx
@@ -3,7 +3,6 @@ import { TextField } from 'mui-rff';
 
 import { DEFAULT_TIME_ESTIMATE, TASK_DETAILS_FIELDS } from '../constants';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const TimeEstimateField: React.FunctionComponent = () => {

--- a/src/features/tasks/components/TaskDetailsForm/fields/VisitLinkFields.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/fields/VisitLinkFields.tsx
@@ -2,7 +2,6 @@ import { TextField } from 'mui-rff';
 
 import { useMessages } from 'core/i18n';
 import { VISIT_LINK_FIELDS } from '../constants';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 const VisitLinkFields = (): JSX.Element => {

--- a/src/features/tasks/components/TaskDetailsForm/index.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/index.tsx
@@ -15,13 +15,11 @@ import {
 } from 'features/tasks/components/types';
 import getTaskStatus, { TASK_STATUS } from 'features/tasks/utils/getTaskStatus';
 import { Msg, useMessages } from 'core/i18n';
-
 import CollectDemographicsFields from './fields/CollectDemographicsFields';
 import ReassignFields from './fields/ReassignFields';
 import ShareLinkFields from './fields/ShareLinkFields';
 import TimeEstimateField from './fields/TimeEstimateField';
 import VisitLinkFields from './fields/VisitLinkFields';
-
 import ZUISubmitCancelButtons from '../../../../zui/ZUISubmitCancelButtons';
 import {
   configForTaskType,
@@ -34,7 +32,6 @@ import {
   DEFAULT_TIME_ESTIMATE,
   TASK_DETAILS_FIELDS,
 } from './constants';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 import useCampaigns from 'features/campaigns/hooks/useCampaigns';
 import { useNumericRouteParams } from 'core/hooks';

--- a/src/features/tasks/components/TaskDetailsSection.tsx
+++ b/src/features/tasks/components/TaskDetailsSection.tsx
@@ -1,12 +1,11 @@
+import { Card, List } from '@mui/material';
+
 import { ZetkinTask } from 'utils/types/zetkin';
 import ZUIDateTime from 'zui/ZUIDateTime';
-
 import TaskProperty from './TaskProperty';
 import TaskTypeDetailsSection from 'features/tasks/components/TaskTypeDetailsSection';
 import { useMessages } from 'core/i18n';
 import ZUISection from 'zui/ZUISection';
-import { Card, List } from '@mui/material';
-
 import messageIds from '../l10n/messageIds';
 
 interface TaskDetailsCardProps {

--- a/src/features/tasks/components/TaskPreviewSection.tsx
+++ b/src/features/tasks/components/TaskPreviewSection.tsx
@@ -7,7 +7,6 @@ import ZUIEditableImage from 'zui/ZUIEditableImage';
 import ZUIMarkdown from 'zui/ZUIMarkdown';
 import ZUISection from 'zui/ZUISection';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface TaskPreviewSectionProps {

--- a/src/features/tasks/components/TaskProperty.tsx
+++ b/src/features/tasks/components/TaskProperty.tsx
@@ -2,7 +2,6 @@ import NextLink from 'next/link';
 import { Link, ListItem, ListItemText } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface TaskPropertyProps {

--- a/src/features/tasks/components/TaskStatusChip.tsx
+++ b/src/features/tasks/components/TaskStatusChip.tsx
@@ -1,7 +1,7 @@
 import { Chip } from '@mui/material';
+
 import { TASK_STATUS } from 'features/tasks/utils/getTaskStatus';
 import { useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 enum ChipColors {

--- a/src/features/tasks/components/TaskStatusText.tsx
+++ b/src/features/tasks/components/TaskStatusText.tsx
@@ -2,7 +2,6 @@ import { Msg } from 'core/i18n';
 import { ZetkinTask } from 'utils/types/zetkin';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import getTaskStatus, { TASK_STATUS } from 'features/tasks/utils/getTaskStatus';
-
 import messageIds from '../l10n/messageIds';
 
 interface TaskStatusTextProps {

--- a/src/features/tasks/components/TaskTypeDetailsSection/CollectDemographicsDetails.tsx
+++ b/src/features/tasks/components/TaskTypeDetailsSection/CollectDemographicsDetails.tsx
@@ -1,7 +1,6 @@
 import { CollectDemographicsConfig } from 'features/tasks/components/types';
 import TaskProperty from '../TaskProperty';
 import { useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 interface CollectDemographicsDetailsProps {

--- a/src/features/tasks/components/TaskTypeDetailsSection/ShareLinkDetails.tsx
+++ b/src/features/tasks/components/TaskTypeDetailsSection/ShareLinkDetails.tsx
@@ -1,7 +1,6 @@
 import { ShareLinkConfig } from 'features/tasks/components/types';
 import TaskProperty from '../TaskProperty';
 import { useMessages } from 'core/i18n';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 interface ShareLinkDetailsProps {

--- a/src/features/tasks/components/TaskTypeDetailsSection/VisitLinkDetails.tsx
+++ b/src/features/tasks/components/TaskTypeDetailsSection/VisitLinkDetails.tsx
@@ -1,7 +1,6 @@
 import TaskProperty from '../TaskProperty';
 import { useMessages } from 'core/i18n';
 import { VisitLinkConfig } from 'features/tasks/components/types';
-
 import messageIds from 'features/tasks/l10n/messageIds';
 
 interface VisitLinkDetailsProps {

--- a/src/features/tasks/components/TaskTypeDetailsSection/index.tsx
+++ b/src/features/tasks/components/TaskTypeDetailsSection/index.tsx
@@ -5,7 +5,6 @@ import {
   TASK_TYPE,
   VisitLinkConfig,
 } from 'features/tasks/components/types';
-
 import CollectDemographicsDetails from './CollectDemographicsDetails';
 import ShareLinkDetails from './ShareLinkDetails';
 import VisitLinkDetails from './VisitLinkDetails';

--- a/src/features/tasks/components/types.ts
+++ b/src/features/tasks/components/types.ts
@@ -1,4 +1,5 @@
 import { Dayjs } from 'dayjs';
+
 import { ZetkinFile } from 'utils/types/zetkin';
 import {
   ZetkinQuery,

--- a/src/features/tasks/layout/SingleTaskLayout.tsx
+++ b/src/features/tasks/layout/SingleTaskLayout.tsx
@@ -2,7 +2,6 @@ import { Box } from '@mui/material';
 import { FunctionComponent } from 'react';
 
 import TabbedLayout from '../../../utils/layout/TabbedLayout';
-
 import getTaskStatus from 'features/tasks/utils/getTaskStatus';
 import TaskActionButtons from '../components/TaskActionButtons';
 import TaskStatusChip from '../components/TaskStatusChip';
@@ -10,7 +9,6 @@ import TaskStatusText from '../components/TaskStatusText';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useTask from '../hooks/useTask';
-
 import messageIds from '../l10n/messageIds';
 
 interface SingleTaskLayoutProps {

--- a/src/features/tasks/rpc/getTaskStats.ts
+++ b/src/features/tasks/rpc/getTaskStats.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import IApiClient from 'core/api/client/IApiClient';
 import { makeRPCDef } from 'core/rpc/types';
-import { z } from 'zod';
 import { ASSIGNED_STATUS, ZetkinAssignedTask } from '../components/types';
 
 const paramsSchema = z.object({

--- a/src/features/tasks/utils/getTaskStatus.ts
+++ b/src/features/tasks/utils/getTaskStatus.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+
 import { ZetkinTask } from 'utils/types/zetkin';
 
 export enum TASK_STATUS {

--- a/src/features/user/store.ts
+++ b/src/features/user/store.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import {
   RemoteItem,
   remoteItem,

--- a/src/features/views/components/EmptyView.tsx
+++ b/src/features/views/components/EmptyView.tsx
@@ -14,7 +14,6 @@ import UseViewDataTableMutations from '../hooks/useViewDataTableMutations';
 import ViewSmartSearchDialog from './ViewSmartSearchDialog';
 import { ZetkinView } from 'features/views/components/types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import zuiMessageIds from 'zui/l10n/messageIds';
 

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogDownloadTab.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { Box, Button, Link, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ShareViewDialogDownloadTabProps {

--- a/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
+++ b/src/features/views/components/ShareViewDialog/ShareViewDialogShareTab/index.tsx
@@ -12,7 +12,6 @@ import ZUIFutures from 'zui/ZUIFutures';
 import ZUIInlineCopyToClipboard from 'zui/ZUIInlineCopyToClipBoard';
 import ZUIScrollingContainer from 'zui/ZUIScrollingContainer';
 import { Msg, useMessages } from 'core/i18n';
-
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/views/l10n/messageIds';
 

--- a/src/features/views/components/ShareViewDialog/index.tsx
+++ b/src/features/views/components/ShareViewDialog/index.tsx
@@ -8,7 +8,6 @@ import ShareViewDialogShareTab from './ShareViewDialogShareTab';
 import { useMessages } from 'core/i18n';
 import { ZetkinView } from '../types';
 import ZUIDialog from 'zui/ZUIDialog';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ShareViewDialogProps {

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -8,9 +8,7 @@ import { Msg } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useViewBrowserMutations from 'features/views/hooks/useViewBrowserMutations';
 import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
-
 import { BrowserRowContext, BrowserRowDropProps } from './BrowserRow';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface BrowserItemProps {

--- a/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItemIcon.tsx
@@ -1,4 +1,3 @@
-import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
 import {
   ArrowBack,
   Folder,
@@ -7,6 +6,7 @@ import {
 } from '@mui/icons-material';
 import { FC, useContext } from 'react';
 
+import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
 import { BrowserRowContext } from './BrowserRow';
 
 interface BrowserItemIconProps {

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -27,7 +27,6 @@ import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import useViewBrowserItems, {
   ViewBrowserItem,
 } from 'features/views/hooks/useViewBrowserItems';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ViewBrowserProps {

--- a/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnChoiceCard.tsx
@@ -8,7 +8,6 @@ import {
 } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ColumnChoiceCardProps {

--- a/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnEditor.tsx
@@ -5,7 +5,6 @@ import { FunctionComponent, useState } from 'react';
 import { ColumnChoiceWithKey } from './choices';
 import { Msg, useMessages } from 'core/i18n';
 import { SelectedViewColumn, ZetkinViewColumn } from '../types';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ColumnEditorProps {

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Typography, useTheme } from '@mui/material';
-import choices, { ColumnChoiceWithKey } from '../choices';
 
+import choices, { ColumnChoiceWithKey } from '../choices';
 import categories from '../categories';
 import { ColumnChoice } from '../choices';
 import ColumnChoiceCard from '../ColumnChoiceCard';
@@ -8,7 +8,6 @@ import { filterChoicesByMode } from './utils';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import { ZetkinViewColumn } from '../../types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface CategoriesProps {

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
@@ -4,7 +4,6 @@ import ColumnChoiceCard from '../ColumnChoiceCard';
 import { ColumnChoiceWithKey } from '../choices';
 import { useMessages } from 'core/i18n';
 import { ZetkinViewColumn } from '../../types';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface SearchResultsProps {

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
@@ -16,7 +16,6 @@ import choices, {
   ColumnChoiceWithKey,
 } from '../choices';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ColumnGalleryProps {

--- a/src/features/views/components/ViewColumnDialog/LocalQueryConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/LocalQueryConfig.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+
 import { SelectedViewColumn } from '../types';
 import SmartSearch from 'features/smartSearch/components/SmartSearchDialog/SmartSearch';
 

--- a/src/features/views/components/ViewColumnDialog/PersonFieldConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/PersonFieldConfig.tsx
@@ -18,7 +18,6 @@ import {
   ZetkinViewColumn,
 } from '../types';
 import { Msg, useMessages } from 'core/i18n';
-
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/views/l10n/messageIds';
 import useCustomFields from 'features/profile/hooks/useCustomFields';

--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -16,7 +16,6 @@ import {
   ZetkinSurveyTextQuestionElement,
 } from 'utils/types/zetkin';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveysWithElements from 'features/surveys/hooks/useSurveysWithElements';

--- a/src/features/views/components/ViewColumnDialog/SurveyResponsePluralConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponsePluralConfig.tsx
@@ -8,7 +8,6 @@ import {
   RESPONSE_TYPE,
   ZetkinSurveyQuestionElement,
 } from 'utils/types/zetkin';
-
 import messageIds from 'features/views/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveysWithElements from 'features/surveys/hooks/useSurveysWithElements';

--- a/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
@@ -8,7 +8,6 @@ import {
 
 import { COLUMN_TYPE, SelectedViewColumn } from '../types';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveys from 'features/surveys/hooks/useSurveys';

--- a/src/features/views/components/ViewColumnDialog/choices/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/choices/index.tsx
@@ -1,5 +1,4 @@
 import { CHOICES, ColumnChoice, ColumnChoiceWithKey } from './types';
-
 import * as fields from './fields';
 import * as misc from './misc';
 import * as query from './query';

--- a/src/features/views/components/ViewColumnDialog/choices/types.ts
+++ b/src/features/views/components/ViewColumnDialog/choices/types.ts
@@ -4,7 +4,6 @@ import {
   SelectedViewColumn,
   ZetkinViewColumn,
 } from '../../types';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 export enum CHOICES {

--- a/src/features/views/components/ViewColumnDialog/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/index.tsx
@@ -9,7 +9,6 @@ import {
   SelectedViewColumn,
   ZetkinViewColumn,
 } from 'features/views/components/types';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface ViewColumnDialogProps {

--- a/src/features/views/components/ViewDataTable/ViewDataTableColumnMenu.tsx
+++ b/src/features/views/components/ViewDataTable/ViewDataTableColumnMenu.tsx
@@ -9,7 +9,6 @@ import {
 
 import { Msg } from 'core/i18n';
 import noPropagate from 'utils/noPropagate';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 export type ViewDataTableColumnMenuProps = {

--- a/src/features/views/components/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/features/views/components/ViewDataTable/ViewDataTableFooter.tsx
@@ -7,7 +7,6 @@ import useView from 'features/views/hooks/useView';
 import useViewGrid from 'features/views/hooks/useViewGrid';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import { MUIOnlyPersonSelect as ZUIPersonSelect } from 'zui/ZUIPersonSelect';
-
 import messageIds from 'features/views/l10n/messageIds';
 import zuiMessageIds from 'zui/l10n/messageIds';
 

--- a/src/features/views/components/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/features/views/components/ViewDataTable/ViewDataTableToolbar.tsx
@@ -12,7 +12,6 @@ import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIDataTableSearch from 'zui/ZUIDataTableSearch';
 import ZUIDataTableSorting from 'zui/ZUIDataTableSorting';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 export interface ViewDataTableToolbarProps {

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -19,7 +19,6 @@ import {
   ZetkinViewColumn,
 } from '../../types';
 import { ZetkinPerson, ZetkinViewRow } from 'utils/types/zetkin';
-
 import messageIds from 'features/views/l10n/messageIds';
 import { useMessages } from 'core/i18n';
 

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -22,7 +22,6 @@ import { usePanes } from 'utils/panes';
 import { ZetkinOrganizerAction } from 'utils/types/zetkin';
 import { ZetkinViewRow } from '../../types';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -11,7 +11,6 @@ import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import theme from '../../../../../theme';
 import { usePanes } from 'utils/panes';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 type SurveyOptionViewCell =

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -1,9 +1,5 @@
-import { IColumnType } from '.';
 import { makeStyles } from '@mui/styles';
-import { usePanes } from 'utils/panes';
 import { useRouter } from 'next/router';
-import { ZetkinSurveyOption } from 'utils/types/zetkin';
-import { ZetkinViewColumn } from '../../types';
 import { Box, Chip } from '@mui/material';
 import { FC, useState } from 'react';
 import {
@@ -12,6 +8,10 @@ import {
   GridValueGetterParams,
 } from '@mui/x-data-grid-pro';
 
+import { ZetkinViewColumn } from '../../types';
+import { ZetkinSurveyOption } from 'utils/types/zetkin';
+import { usePanes } from 'utils/panes';
+import { IColumnType } from '.';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
 

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -1,8 +1,12 @@
 import { Box } from '@mui/material';
-
 import { makeStyles } from '@mui/styles';
 import { useRouter } from 'next/router';
 import { FC, useState } from 'react';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridValueGetterParams,
+} from '@mui/x-data-grid-pro';
 
 import { getEllipsedString } from 'utils/stringUtils';
 import { IColumnType } from '.';
@@ -10,12 +14,6 @@ import { SurveyResponseViewColumn } from '../../types';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import { usePanes } from 'utils/panes';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
-
-import {
-  GridColDef,
-  GridRenderCellParams,
-  GridValueGetterParams,
-} from '@mui/x-data-grid-pro';
 
 export type SurveyResponseViewCell = {
   submission_id: number;

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -6,12 +6,12 @@ import {
   GridRenderCellParams,
   GridValueGetterParams,
 } from '@mui/x-data-grid-pro';
+import { useRouter } from 'next/router';
 
 import { IColumnType } from '.';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import { SurveySubmittedViewColumn } from '../../types';
 import { usePanes } from 'utils/panes';
-import { useRouter } from 'next/router';
 import ZUIRelativeTime from '../../../../../zui/ZUIRelativeTime';
 
 type SurveySubmittedViewCell =

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -56,7 +56,6 @@ import {
   ZetkinViewColumn,
   ZetkinViewRow,
 } from 'utils/types/zetkin';
-
 import messageIds from 'features/views/l10n/messageIds';
 import useDebounce from 'utils/hooks/useDebounce';
 import useViewMutations from 'features/views/hooks/useViewMutations';

--- a/src/features/views/components/ViewFolderSubtitle.tsx
+++ b/src/features/views/components/ViewFolderSubtitle.tsx
@@ -8,7 +8,6 @@ import {
 import { useMessages } from 'core/i18n';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
-
 import messageIds from '../l10n/messageIds';
 
 interface ViewFolderSubtitleProps {

--- a/src/features/views/components/ViewJumpMenu.tsx
+++ b/src/features/views/components/ViewJumpMenu.tsx
@@ -23,7 +23,6 @@ import useViewBrowserItems, {
   ViewBrowserItem,
   ViewBrowserViewItem,
 } from '../hooks/useViewBrowserItems';
-
 import messageIds from '../l10n/messageIds';
 
 const ViewJumpMenu: FunctionComponent = () => {

--- a/src/features/views/components/ViewRenameColumnDialog.tsx
+++ b/src/features/views/components/ViewRenameColumnDialog.tsx
@@ -1,11 +1,10 @@
 import { FunctionComponent, useState } from 'react';
-
 import { TextField } from '@mui/material';
+
 import { useMessages } from 'core/i18n';
 import { ZetkinViewColumn } from 'features/views/components/types';
 import ZUIDialog from 'zui/ZUIDialog';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
-
 import messageIds from '../l10n/messageIds';
 
 interface ViewRenameColumnDialogProps {

--- a/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
+++ b/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
@@ -13,7 +13,6 @@ import { FC, ReactNode, useMemo } from 'react';
 import { Msg } from 'core/i18n';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 interface PreviewableSubmissionData {

--- a/src/features/views/hooks/useCreateView.ts
+++ b/src/features/views/hooks/useCreateView.ts
@@ -1,5 +1,6 @@
-import createNew from '../rpc/createNew/client';
 import { useRouter } from 'next/router';
+
+import createNew from '../rpc/createNew/client';
 import { ZetkinView } from '../components/types';
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import { viewCreate, viewCreated } from '../store';

--- a/src/features/views/layout/PeopleLayout.tsx
+++ b/src/features/views/layout/PeopleLayout.tsx
@@ -3,7 +3,6 @@ import { useMessages } from 'core/i18n';
 import useServerSide from 'core/useServerSide';
 import ViewFolderSubtitle from '../components/ViewFolderSubtitle';
 import ZUIFuture from 'zui/ZUIFuture';
-
 import messageIds from '../l10n/messageIds';
 import TabbedLayout from 'utils/layout/TabbedLayout';
 import useItemSummary from '../hooks/useItemSummary';

--- a/src/features/views/layout/SharedViewLayout.tsx
+++ b/src/features/views/layout/SharedViewLayout.tsx
@@ -10,7 +10,6 @@ import useViewGrid from '../hooks/useViewGrid';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
-
 import messageIds from '../l10n/messageIds';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -2,8 +2,9 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
 import { Box, Button, Theme } from '@mui/material';
 import { FunctionComponent, useContext, useState } from 'react';
-
 import NProgress from 'nprogress';
+import { Group, Share, ViewColumnOutlined } from '@mui/icons-material';
+
 import ShareViewDialog from '../components/ShareViewDialog';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
@@ -20,9 +21,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
-import { Group, Share, ViewColumnOutlined } from '@mui/icons-material';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 import SimpleLayout from 'utils/layout/SimpleLayout';
 import useView from '../hooks/useView';

--- a/src/features/views/rpc/createNew/server.ts
+++ b/src/features/views/rpc/createNew/server.ts
@@ -11,7 +11,6 @@ import {
   ZetkinViewColumn,
 } from '../../components/types';
 import { Params, paramsSchema, Result } from './client';
-
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/views/l10n/messageIds';
 

--- a/src/features/views/rpc/deleteFolder.ts
+++ b/src/features/views/rpc/deleteFolder.ts
@@ -1,6 +1,7 @@
+import { z } from 'zod';
+
 import IApiClient from 'core/api/client/IApiClient';
 import { makeRPCDef } from 'core/rpc/types';
-import { z } from 'zod';
 import { ZetkinView, ZetkinViewFolder } from '../components/types';
 
 const paramsSchema = z.object({

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -1,3 +1,5 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
 import { Call } from 'features/callAssignments/apiTypes';
 import { callUpdated } from 'features/callAssignments/store';
 import columnTypes from './components/ViewDataTable/columnTypes';
@@ -12,7 +14,6 @@ import {
   ZetkinViewFolder,
   ZetkinViewRow,
 } from './components/types';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
 import { tagAssigned, tagUnassigned } from 'features/tags/store';
 import {

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -4,7 +4,6 @@ import { AppBar, Box, Container, Toolbar, Typography } from '@mui/material';
 
 import { Msg } from 'core/i18n';
 import ZUILogo from 'zui/ZUILogo';
-
 import messageIds from 'core/l10n/messageIds';
 
 export default function Custom404(): JSX.Element {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,10 +6,10 @@ import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { NoSsr } from '@mui/base';
 import NProgress from 'nprogress';
 import Router from 'next/router';
-import { store } from 'core/store';
 import { Theme } from '@mui/material/styles';
 import { useEffect } from 'react';
 
+import { store } from 'core/store';
 import BrowserApiClient from 'core/api/client/BrowserApiClient';
 import Environment from 'core/env/Environment';
 import { PageWithLayout } from '../utils/types';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @next/next/no-sync-scripts */
 import { Children } from 'react';
 import ServerStyleSheets from '@mui/styles/ServerStyleSheets';
-import theme from '../theme';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
+
+import theme from '../theme';
 
 // boilerplate page taken from https://github.com/mui-org/material-ui/tree/master/examples/nextjs
 

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -1,6 +1,6 @@
-import { ApiFetch, createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { ApiFetch, createApiFetch } from 'utils/apiFetch';
 import { isInteger } from 'utils/stringUtils';
 import { ZetkinViewFolder } from 'features/views/components/types';
 

--- a/src/pages/api/journeyInstances/download.ts
+++ b/src/pages/api/journeyInstances/download.ts
@@ -9,7 +9,6 @@ import {
   JourneyTagColumnType,
 } from 'features/journeys/utils/journeyInstanceUtils';
 import { ZetkinJourney, ZetkinJourneyInstance } from 'utils/types/zetkin';
-
 import messageIds from 'features/journeys/l10n/messageIds';
 
 const FORMAT_TYPES = {

--- a/src/pages/api/rpc.ts
+++ b/src/pages/api/rpc.ts
@@ -1,5 +1,6 @@
-import { createRPCRouter } from 'core/rpc';
 import { NextApiRequest, NextApiResponse } from 'next';
+
+import { createRPCRouter } from 'core/rpc';
 
 export default async function handle(
   req: NextApiRequest,

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -1,7 +1,7 @@
-import { createApiFetch } from 'utils/apiFetch';
-import makeSearchRequest from 'utils/api/makeSearchRequest';
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import { createApiFetch } from 'utils/apiFetch';
+import makeSearchRequest from 'utils/api/makeSearchRequest';
 import { SEARCH_DATA_TYPE } from 'features/search/components/types';
 
 /**

--- a/src/pages/api/stats/calls/date.ts
+++ b/src/pages/api/stats/calls/date.ts
@@ -1,5 +1,6 @@
-import { createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
+
+import { createApiFetch } from 'utils/apiFetch';
 
 export interface DateStats {
   date: string;

--- a/src/pages/api/stats/calls/hour.ts
+++ b/src/pages/api/stats/calls/hour.ts
@@ -1,5 +1,6 @@
-import { createApiFetch } from 'utils/apiFetch';
 import { NextApiRequest, NextApiResponse } from 'next';
+
+import { createApiFetch } from 'utils/apiFetch';
 
 export interface DateStats {
   date: string;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
-import { AppSession } from '../utils/types';
 import { getIronSession } from 'iron-session';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Container, Typography } from '@mui/material';
 
+import { AppSession } from '../utils/types';
 import getUserMemberships from 'utils/getUserMemberships';
 import messageIds from 'core/l10n/messageIds';
 import { Msg } from 'core/i18n';

--- a/src/pages/legacy.tsx
+++ b/src/pages/legacy.tsx
@@ -7,7 +7,6 @@ import { GetServerSideProps, NextPage } from 'next';
 
 import { scaffold } from 'utils/next';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'core/l10n/messageIds';
 
 export const getServerSideProps: GetServerSideProps = scaffold(

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { Box, Chip, Grid, Typography, useTheme } from '@mui/material';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import DefaultLayout from 'utils/layout/DefaultLayout';
@@ -13,7 +14,6 @@ import { scaffold } from 'utils/next';
 import { useApiClient } from 'core/hooks';
 import useCreateJourneyInstance from 'features/journeys/hooks/useCreateJourneyInstance';
 import useJourney from 'features/journeys/hooks/useJourney';
-import { useRouter } from 'next/router';
 import ZUIAutoTextArea from 'zui/ZUIAutoTextArea';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -1,7 +1,7 @@
-import DuplicateCard from 'features/duplicates/components/DuplicateCard';
 import { GetServerSideProps } from 'next';
 import { Box, Typography } from '@mui/material';
 
+import DuplicateCard from 'features/duplicates/components/DuplicateCard';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import PeopleLayout from 'features/views/layout/PeopleLayout';

--- a/src/pages/organize/[orgId]/people/folders/[folderId].tsx
+++ b/src/pages/organize/[orgId]/people/folders/[folderId].tsx
@@ -7,7 +7,6 @@ import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
 import ViewBrowser from 'features/views/components/ViewBrowser';
-
 import messageIds from 'features/views/l10n/messageIds';
 
 const scaffoldOptions = {

--- a/src/pages/organize/[orgId]/people/lists/callblocked.tsx
+++ b/src/pages/organize/[orgId]/people/lists/callblocked.tsx
@@ -1,7 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { isEqualWith } from 'lodash';
-import { scaffold } from 'utils/next';
 
+import { scaffold } from 'utils/next';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { getBrowserLanguage } from 'utils/locale';
 import getServerMessages from 'core/i18n/server';

--- a/src/pages/organize/[orgId]/projects/[campId]/calendar/tasks/[taskId]/assignees.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/calendar/tasks/[taskId]/assignees.tsx
@@ -1,7 +1,9 @@
-import BackendApiClient from 'core/api/client/BackendApiClient';
 import { Box } from '@mui/material';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
+import { useState } from 'react';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import { QUERY_STATUS } from 'features/smartSearch/components/types';
@@ -13,7 +15,6 @@ import TaskAssigneesList from 'features/tasks/components/TaskAssigneesList';
 import useAssignedTasks from 'features/tasks/hooks/useAssignedTasks';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
-import { useState } from 'react';
 import useTask from 'features/tasks/hooks/useTask';
 import useTaskMutations from 'features/tasks/hooks/useTaskMutations';
 import ZUIFuture from 'zui/ZUIFuture';

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
@@ -17,7 +17,6 @@ import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from 'features/callAssignments/l10n/messageIds';
 import useCallAssignment from 'features/callAssignments/hooks/useCallAssignment';
 import useCallers from 'features/callAssignments/hooks/useCallers';

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -1,11 +1,11 @@
 import { Box } from '@mui/material';
 import Head from 'next/head';
+import { GetServerSideProps } from 'next';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import EmailTargets from 'features/emails/components/EmailTargets';
 import EmailTargetsBlocked from 'features/emails/components/EmailTargetsBlocked';
 import EmailTargetsReady from 'features/emails/components/EmailTargetsReady';
-import { GetServerSideProps } from 'next';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useEmail from 'features/emails/hooks/useEmail';

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+
 import { scaffold } from 'utils/next';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -1,9 +1,9 @@
-import BackendApiClient from 'core/api/client/BackendApiClient';
 import { GetServerSideProps } from 'next';
 import { Grid } from '@mui/material';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
-
 import EventLayout from 'features/events/layout/EventLayout';
 import EventOverviewCard from 'features/events/components/EventOverviewCard';
 import EventParticipantsCard from 'features/events/components/EventParticipantsCard';

--- a/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+
 import { scaffold } from 'utils/next';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/index.tsx
@@ -1,13 +1,13 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { Box, Grid, Typography } from '@mui/material';
+import { Suspense } from 'react';
 
 import ActivitiesOverview from 'features/campaigns/components/ActivitiesOverview';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SingleCampaignLayout from 'features/campaigns/layout/SingleCampaignLayout';
-import { Suspense } from 'react';
 import useCampaign from 'features/campaigns/hooks/useCampaign';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/index.tsx
@@ -1,8 +1,8 @@
-import BackendApiClient from 'core/api/client/BackendApiClient';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { Box, Grid } from '@mui/material';
 
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import EmptyOverview from 'features/surveys/components/EmptyOverview';
 import { getSurveyCampId } from 'features/surveys/utils/getSurveyUrl';
 import { PageWithLayout } from 'utils/types';

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { Box, Grid } from '@mui/material';
+import { ChangeEvent, useState } from 'react';
 
 import ActivityList from 'features/campaigns/components/ActivityList';
 import AllCampaignsLayout from 'features/campaigns/layout/AllCampaignsLayout';
@@ -14,7 +15,6 @@ import useServerSide from 'core/useServerSide';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ACTIVITIES, CampaignActivity } from 'features/campaigns/types';
-import { ChangeEvent, useState } from 'react';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {

--- a/src/pages/organize/[orgId]/projects/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/archive/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import { Box, Grid } from '@mui/material';
+import { ChangeEvent, useState } from 'react';
 
 import ActivityList from 'features/campaigns/components/ActivityList';
 import AllCampaignsLayout from 'features/campaigns/layout/AllCampaignsLayout';
@@ -14,7 +15,6 @@ import useServerSide from 'core/useServerSide';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ACTIVITIES, CampaignActivity } from 'features/campaigns/types';
-import { ChangeEvent, useState } from 'react';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {

--- a/src/pages/organize/index.tsx
+++ b/src/pages/organize/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
+
 import messageIds from 'features/organizations/l10n/messageIds';
 import NoMenuLayout from 'utils/layout/NoMenuLayout';
 import { PageWithLayout } from 'utils/types';

--- a/src/tools/make-yaml.ts
+++ b/src/tools/make-yaml.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import yaml from 'yaml';
+
 import { AnyMessage, MessageMap } from 'core/i18n/messages';
 
 run();

--- a/src/utils/dateUtils.spec.ts
+++ b/src/utils/dateUtils.spec.ts
@@ -1,6 +1,5 @@
 import mockEvent from 'utils/testing/mocks/mockEvent';
 import { ZetkinEvent } from 'utils/types/zetkin';
-
 import { getFirstAndLastEvent, removeOffset } from './dateUtils';
 
 describe('getFirstAndLastEvent()', () => {

--- a/src/utils/layout/NoMenuLayout.tsx
+++ b/src/utils/layout/NoMenuLayout.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@mui/material';
 import { FunctionComponent } from 'react';
-
 import makeStyles from '@mui/styles/makeStyles';
+
 import ZUIOrganizeSidebarNoMenu from 'zui/ZUIOrganizeSidebarNoMenu';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/utils/organize/people.spec.ts
+++ b/src/utils/organize/people.spec.ts
@@ -1,5 +1,6 @@
-import { flatOrgs } from './organizations.spec';
 import { isEqual } from 'lodash';
+
+import { flatOrgs } from './organizations.spec';
 import { getConnectedOrganizations, getPersonOrganizations } from './people';
 
 const personConnections = [

--- a/src/zui/ZUIAccessList/index.tsx
+++ b/src/zui/ZUIAccessList/index.tsx
@@ -6,7 +6,6 @@ import { ZetkinObjectAccess } from 'core/api/types';
 import { ZetkinOfficial } from 'utils/types/zetkin';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import { Msg, useMessages } from 'core/i18n';
-
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'zui/l10n/messageIds';
 

--- a/src/zui/ZUIAutoTextArea/index.tsx
+++ b/src/zui/ZUIAutoTextArea/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { lighten, TextareaAutosize } from '@mui/material';
-
 import makeStyles from '@mui/styles/makeStyles';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/zui/ZUIButtonMenu.tsx
+++ b/src/zui/ZUIButtonMenu.tsx
@@ -3,8 +3,9 @@ import { ArrowDropDown } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import { MenuItem } from '@mui/material';
-import theme from 'theme';
 import { FC, MouseEvent, useState } from 'react';
+
+import theme from 'theme';
 
 type ZUIButtonMenuProps = {
   items: {

--- a/src/zui/ZUICollapse/index.stories.tsx
+++ b/src/zui/ZUICollapse/index.stories.tsx
@@ -1,5 +1,6 @@
-import ZUICollapse from '.';
 import { Meta, StoryFn } from '@storybook/react';
+
+import ZUICollapse from '.';
 
 export default {
   component: ZUICollapse,

--- a/src/zui/ZUICollapse/index.tsx
+++ b/src/zui/ZUICollapse/index.tsx
@@ -3,7 +3,6 @@ import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { useCallback, useState } from 'react';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from 'zui/l10n/messageIds';
 
 interface ZUICollapseProps {

--- a/src/zui/ZUIConfirmDialog/index.tsx
+++ b/src/zui/ZUIConfirmDialog/index.tsx
@@ -3,7 +3,6 @@ import { Typography } from '@mui/material';
 import { useMessages } from 'core/i18n';
 import ZUIDialog from 'zui/ZUIDialog';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
-
 import messageIds from 'zui/l10n/messageIds';
 
 export interface ZUIConfirmDialogProps {

--- a/src/zui/ZUIConfirmDialogProvider.tsx
+++ b/src/zui/ZUIConfirmDialogProvider.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import React, { useContext, useState } from 'react';
+
 import ZUIConfirmDialog, { ZUIConfirmDialogProps } from 'zui/ZUIConfirmDialog';
 
 export const ZUIConfirmDialogContext = React.createContext<{

--- a/src/zui/ZUICopyToClipboard.tsx
+++ b/src/zui/ZUICopyToClipboard.tsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 
 import { CopyIcon } from './ZUIInlineCopyToClipBoard';
 import { Msg } from 'core/i18n';
-
 import messageIds from './l10n/messageIds';
 
 const ZUICopyToClipboard: React.FunctionComponent<{

--- a/src/zui/ZUIDataTableSorting/index.tsx
+++ b/src/zui/ZUIDataTableSorting/index.tsx
@@ -21,7 +21,6 @@ import {
 
 import { Msg } from 'core/i18n';
 import ShiftKeyIcon from '../../features/views/components/ViewDataTable/ShiftKeyIcon';
-
 import messageIds from 'zui/l10n/messageIds';
 
 const useStyles = makeStyles({

--- a/src/zui/ZUIDateTime/index.tsx
+++ b/src/zui/ZUIDateTime/index.tsx
@@ -1,5 +1,6 @@
-import convertDateTimeToLocal from './utils/convertDateTimeToLocal';
 import { FormattedDate, FormattedTime } from 'react-intl';
+
+import convertDateTimeToLocal from './utils/convertDateTimeToLocal';
 
 interface ZUIDateTimeProps {
   convertToLocal?: boolean;

--- a/src/zui/ZUIEditTextInPlace/index.spec.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.spec.tsx
@@ -1,10 +1,10 @@
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import { act, render } from 'utils/testing';
 import ZUIEditTextinPlace, {
   ZUIEditTextinPlaceProps,
 } from 'zui/ZUIEditTextInPlace';
-
 import messageIds from 'zui/l10n/messageIds';
 
 const props: ZUIEditTextinPlaceProps = {

--- a/src/zui/ZUIEllipsisMenu/index.tsx
+++ b/src/zui/ZUIEllipsisMenu/index.tsx
@@ -1,6 +1,4 @@
 import { MoreVert } from '@mui/icons-material';
-import noPropagate from 'utils/noPropagate';
-import theme from 'theme';
 import {
   Button,
   ListItemIcon,
@@ -9,6 +7,9 @@ import {
   Typography,
 } from '@mui/material';
 import { FunctionComponent, ReactElement, useState } from 'react';
+
+import noPropagate from 'utils/noPropagate';
+import theme from 'theme';
 
 type horizontalType = 'left' | 'center' | 'right';
 type verticalType = 'top' | 'center' | 'bottom';

--- a/src/zui/ZUIEmptyState/index.stories.tsx
+++ b/src/zui/ZUIEmptyState/index.stories.tsx
@@ -1,5 +1,6 @@
-import ZUIEmptyState from '.';
 import { Meta, StoryFn } from '@storybook/react';
+
+import ZUIEmptyState from '.';
 
 export default {
   component: ZUIEmptyState,

--- a/src/zui/ZUIFutures/index.tsx
+++ b/src/zui/ZUIFutures/index.tsx
@@ -4,7 +4,6 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 
 import { IFuture } from 'core/caching/futures';
 import { Msg } from 'core/i18n';
-
 import messageIds from 'zui/l10n/messageIds';
 
 interface ZUIFuturesProps<G extends Record<string, unknown>> {

--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -13,7 +13,6 @@ import {
 import BreadcrumbTrail from 'features/breadcrumbs/components/BreadcrumbTrail';
 import { Msg } from 'core/i18n';
 import ZUIEllipsisMenu, { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
-
 import messageIds from './l10n/messageIds';
 
 interface StyleProps {

--- a/src/zui/ZUIIconLabelRow.tsx
+++ b/src/zui/ZUIIconLabelRow.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import { FC } from 'react';
+
 import ZUIIconLabel, { ZUIIconLabelProps } from './ZUIIconLabel';
 
 interface ZUIIconLabelRowProps {

--- a/src/zui/ZUIInlineCopyToClipBoard.tsx
+++ b/src/zui/ZUIInlineCopyToClipBoard.tsx
@@ -5,7 +5,6 @@ import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
 import { useMessages } from 'core/i18n';
 import ZUISnackbarContext from './ZUISnackbarContext';
-
 import messageIds from './l10n/messageIds';
 
 interface IconProps {

--- a/src/zui/ZUIList/index.tsx
+++ b/src/zui/ZUIList/index.tsx
@@ -2,7 +2,6 @@ import { List, ListItem, ListItemText } from '@mui/material';
 import React, { useState } from 'react';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from 'zui/l10n/messageIds';
 
 interface ZUIListProps {

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -1,13 +1,7 @@
 import makeStyles from '@mui/styles/makeStyles';
-import messageIds from '../l10n/messageIds';
 import NextLink from 'next/link';
-import useCurrentUser from 'features/user/hooks/useCurrentUser';
-import useLocalStorage from '../hooks/useLocalStorage';
-import { useMessages } from 'core/i18n';
-import { useNumericRouteParams } from 'core/hooks';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import ZUIEllipsisMenu from '../ZUIEllipsisMenu';
 import {
   Architecture,
   Close,
@@ -36,6 +30,12 @@ import {
   Typography,
 } from '@mui/material';
 
+import messageIds from '../l10n/messageIds';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
+import useLocalStorage from '../hooks/useLocalStorage';
+import { useMessages } from 'core/i18n';
+import { useNumericRouteParams } from 'core/hooks';
+import ZUIEllipsisMenu from '../ZUIEllipsisMenu';
 import OrganizationSwitcher from 'features/organizations/components/OrganizationSwitcher';
 import SearchDialog from 'features/search/components/SearchDialog';
 import SidebarListItem from './SidebarListItem';

--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -21,7 +21,6 @@ import { useMessages } from 'core/i18n';
 import { usePersonSelect } from './ZUIPersonSelect';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
-
 import messageIds from './l10n/messageIds';
 
 const ZUIPersonGridEditCell: FC<{

--- a/src/zui/ZUIPersonHoverCard.tsx
+++ b/src/zui/ZUIPersonHoverCard.tsx
@@ -11,12 +11,12 @@ import {
   Typography,
 } from '@mui/material';
 import { FC, useEffect, useState } from 'react';
+import MailIcon from '@mui/icons-material/Mail';
+import PhoneIcon from '@mui/icons-material/Phone';
 
 import { CopyIcon } from './ZUIInlineCopyToClipBoard';
-import MailIcon from '@mui/icons-material/Mail';
 import messageIds from 'features/profile/l10n/messageIds';
 import { Msg } from 'core/i18n';
-import PhoneIcon from '@mui/icons-material/Phone';
 import TagsList from 'features/tags/components/TagManager/components/TagsList';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from 'features/profile/hooks/usePerson';

--- a/src/zui/ZUIPersonSelect.tsx
+++ b/src/zui/ZUIPersonSelect.tsx
@@ -13,9 +13,9 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { PersonAdd } from '@mui/icons-material';
 
 import messageIds from './l10n/messageIds';
-import { PersonAdd } from '@mui/icons-material';
 import { useNumericRouteParams } from 'core/hooks';
 import usePersonSearch from 'features/profile/hooks/usePersonSearch';
 import { ZetkinPerson } from 'utils/types/zetkin';

--- a/src/zui/ZUISnackbarContext.tsx
+++ b/src/zui/ZUISnackbarContext.tsx
@@ -4,7 +4,6 @@ import { Alert, AlertColor } from '@mui/material';
 import { createContext, useState } from 'react';
 
 import { useMessages } from 'core/i18n';
-
 import messageIds from './l10n/messageIds';
 
 interface ZUISnackbarContextProps {

--- a/src/zui/ZUISpeedDial/actions/createTask.tsx
+++ b/src/zui/ZUISpeedDial/actions/createTask.tsx
@@ -3,10 +3,8 @@ import { useRouter } from 'next/router';
 
 import TaskDetailsForm from 'features/tasks/components/TaskDetailsForm';
 import { ZetkinTaskRequestBody } from 'features/tasks/components/types';
-
 import { ACTIONS } from '../constants';
 import { ActionConfig, DialogContentBaseProps } from './types';
-
 import useCreateTask from 'features/tasks/hooks/useCreateTask';
 
 const DialogContent: React.FunctionComponent<DialogContentBaseProps> = ({

--- a/src/zui/ZUIStackedStatusBar/index.stories.tsx
+++ b/src/zui/ZUIStackedStatusBar/index.stories.tsx
@@ -1,8 +1,8 @@
 import { useState } from '@storybook/preview-api';
 import { Box, Button } from '@mui/material';
+import { Meta, StoryFn } from '@storybook/react';
 
 import ZUIStackedStatusBar from '.';
-import { Meta, StoryFn } from '@storybook/react';
 
 export default {
   component: ZUIStackedStatusBar,

--- a/src/zui/ZUISubmitCancelButtons.tsx
+++ b/src/zui/ZUISubmitCancelButtons.tsx
@@ -1,7 +1,6 @@
 import { Box, Button, ButtonProps } from '@mui/material';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from './l10n/messageIds';
 
 const ZUISubmitCancelButtons: React.FunctionComponent<{

--- a/src/zui/ZUISuffixedNumber/index.stories.tsx
+++ b/src/zui/ZUISuffixedNumber/index.stories.tsx
@@ -1,5 +1,6 @@
-import ZUISuffixedNumber from '.';
 import { Meta, StoryFn } from '@storybook/react';
+
+import ZUISuffixedNumber from '.';
 
 export default {
   component: ZUISuffixedNumber,

--- a/src/zui/ZUISuffixedNumber/index.tsx
+++ b/src/zui/ZUISuffixedNumber/index.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
 import { FormattedNumber } from 'react-intl';
 import { Tooltip } from '@mui/material';
-import { useMessages } from 'core/i18n';
 
+import { useMessages } from 'core/i18n';
 import messageIds from 'zui/l10n/messageIds';
 
 type ZUISuffixedNumberProps = {

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import { isEqual } from 'lodash';
 import { makeStyles } from '@mui/styles';
-import { markdownToSlate } from './utils/markdownToSlate';
 import { withHistory } from 'slate-history';
 import { Box, ClickAwayListener, Collapse } from '@mui/material';
 import {
@@ -28,6 +27,7 @@ import React, {
   useState,
 } from 'react';
 
+import { markdownToSlate } from './utils/markdownToSlate';
 import './types';
 import { FileUpload } from 'features/files/hooks/useFileUploads';
 import TextElement from './TextElement';

--- a/src/zui/ZUITextfieldToClipboard.tsx
+++ b/src/zui/ZUITextfieldToClipboard.tsx
@@ -3,7 +3,6 @@ import { Box, Button, TextField } from '@mui/material';
 import React, { useState } from 'react';
 
 import { Msg } from 'core/i18n';
-
 import messageIds from './l10n/messageIds';
 
 const ZUITextfieldToClipboard: React.FunctionComponent<{

--- a/src/zui/ZUITimeline/TimelineAddNote.tsx
+++ b/src/zui/ZUITimeline/TimelineAddNote.tsx
@@ -8,7 +8,6 @@ import ZUITextEditor from '../ZUITextEditor';
 import useFileUploads, {
   FileUploadState,
 } from 'features/files/hooks/useFileUploads';
-
 import messageIds from './l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 

--- a/src/zui/ZUITimeline/index.tsx
+++ b/src/zui/ZUITimeline/index.tsx
@@ -19,7 +19,6 @@ import useFilterUpdates, {
   UPDATE_TYPE_FILTER_OPTIONS,
 } from './useFilterUpdates';
 import { ZetkinNote, ZetkinNoteBody } from 'utils/types/zetkin';
-
 import messageIds from './l10n/messageIds';
 
 export interface ZUITimelineProps {

--- a/src/zui/ZUITimeline/l10n/messageIds.ts
+++ b/src/zui/ZUITimeline/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('zui.timeline', {

--- a/src/zui/ZUITimeline/updates/TimelineAssigned.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineAssigned.tsx
@@ -5,7 +5,6 @@ import {
   UPDATE_TYPES,
   ZetkinUpdateJourneyInstanceAssignee,
 } from 'zui/ZUITimeline/types';
-
 import messageIds from '../l10n/messageIds';
 
 interface Props {

--- a/src/zui/ZUITimeline/updates/TimelineGeneric.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineGeneric.tsx
@@ -2,7 +2,6 @@ import UpdateContainer from './elements/UpdateContainer';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
 import { AnyMessage, Msg } from 'core/i18n';
 import { UPDATE_TYPES, ZetkinUpdate } from 'zui/ZUITimeline/types';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineGenericProps {

--- a/src/zui/ZUITimeline/updates/TimelineJourneyClose.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyClose.tsx
@@ -5,7 +5,6 @@ import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinUpdateJourneyInstanceClose } from 'zui/ZUITimeline/types';
 import ZUIJourneyInstanceCard from 'zui/ZUIJourneyInstanceCard';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineJourneyCloseProps {

--- a/src/zui/ZUITimeline/updates/TimelineJourneyConvert.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyConvert.tsx
@@ -2,7 +2,6 @@ import { Msg } from 'core/i18n';
 import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinUpdateJourneyInstanceConvert } from 'zui/ZUITimeline/types';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineJourneyConvertProps {

--- a/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
@@ -6,7 +6,6 @@ import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinUpdateJourneyInstance } from 'zui/ZUITimeline/types';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
 import { Msg, useMessages } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface Props {

--- a/src/zui/ZUITimeline/updates/TimelineJourneyMilestone.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyMilestone.tsx
@@ -8,7 +8,6 @@ import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinUpdateJourneyInstanceMilestone } from 'zui/ZUITimeline/types';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
-
 import messageIds from '../l10n/messageIds';
 
 interface Props {

--- a/src/zui/ZUITimeline/updates/TimelineJourneyStart.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyStart.tsx
@@ -4,7 +4,6 @@ import { ZetkinUpdateJourneyInstanceStart } from 'zui/ZUITimeline/types';
 import ZUIJourneyInstanceCard from 'zui/ZUIJourneyInstanceCard';
 import ZUIMarkdown from 'zui/ZUIMarkdown';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineJourneyStartProps {

--- a/src/zui/ZUITimeline/updates/TimelineJourneySubject.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneySubject.tsx
@@ -5,7 +5,6 @@ import {
   UPDATE_TYPES,
   ZetkinUpdateJourneyInstanceSubject,
 } from 'zui/ZUITimeline/types';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineJourneySubjectProps {

--- a/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
@@ -14,7 +14,6 @@ import ZUIPersonLink from 'zui/ZUIPersonLink';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import ZUITextEditor from '../../ZUITextEditor';
 import { ZetkinFile, ZetkinNote } from 'utils/types/zetkin';
-
 import messageIds from '../l10n/messageIds';
 
 interface Props {

--- a/src/zui/ZUITimeline/updates/TimelineTags.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineTags.tsx
@@ -2,9 +2,7 @@ import TagsList from 'features/tags/components/TagManager/components/TagsList';
 import UpdateContainer from './elements/UpdateContainer';
 import { ZetkinUpdateTags } from 'zui/ZUITimeline/types';
 import ZUIPersonLink from 'zui/ZUIPersonLink';
-
 import { Msg } from 'core/i18n';
-
 import messageIds from '../l10n/messageIds';
 
 interface TimelineTagsProps {

--- a/src/zui/ZUITimeline/updates/elements/PrettyEmail.stories.tsx
+++ b/src/zui/ZUITimeline/updates/elements/PrettyEmail.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryFn } from '@storybook/react';
+
 import {
   MULTIPART,
   MULTIPART_WITH_REPLY,
   PLAINTEXT,
   PLAINTEXT_MULTI_CC,
 } from 'utils/testing/mocks/email';
-
 import PrettyEmail from './PrettyEmail';
 
 export default {

--- a/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
+++ b/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
@@ -14,7 +14,6 @@ import { useEffect, useState } from 'react';
 import { Msg } from 'core/i18n';
 import ZUICleanHtml from 'zui/ZUICleanHtml';
 import ZUICollapse from 'zui/ZUICollapse';
-
 import messageIds from 'zui/ZUITimeline/l10n/messageIds';
 
 interface PrettyEmailProps {

--- a/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
@@ -1,4 +1,5 @@
 import { GridColDef } from '@mui/x-data-grid-pro';
+
 import useConfigurableDataGridColumns, {
   StorageBackend,
 } from './useConfigurableDataGridColumns';

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('zui', {


### PR DESCRIPTION
## Description
This PR replaces the previous `sort-imports` eslint rule with `import/order` which is able to sort imports into groups and not care about alphabetical order. The rule is also capable of auto-fixing and this PR fixes all current linting problems using `yarn eslint --fix`.

This PR supersedes #1657, which solved the same task using a custom rule, but does so using a built-in eslint rule which will likely be easier (for us) to support.

## Screenshots
None

## Changes
* Replaces `sort-imports` with `import/order` in `.eslintrc.js`
* Applies auto-fixing to all source files

## Notes to reviewer
Please review the spirit/intent of this PR as expressed in `.eslintrc.js` and exemplified by the many changes to source files. No need to go through every touched file.

## Related issues
Undocumented