### PR TITLE
Use empty string if not editing and placeholder is not defined

### DIFF
--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -203,7 +203,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
           onKeyDown={onKeyDown}
           placeholder={placeholder}
           readOnly={!editing}
-          value={editing ? text : text || placeholder}
+          value={editing ? text : text || placeholder || ''}
         />
       </FormControl>
     </Tooltip>


### PR DESCRIPTION
## Description
This PR adds empty string as a fallback if `text` is false-like and `placeholder` is not passed to `ZUIEditTextInPlace`. A value passed to controlled components should not be undefined or null: https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable

Our test `ZUIEditTextInPlace does trigger onChange with no text if explicitly allowed` found this but only printed a warning about it.

I don't think we ever use `ZUIEditTextInPlace` with `allowEmpty` without also passing `placeholder` so the bug is not exposed anywhere in Zetkin.

## Notes to reviewer
The specific test can be run with `yarn test --testPathPattern ZUIEditTextInPlace --testNamePattern 'does trigger onChange with no text if explicitly allowed'`