### PR TITLE
Wrap ZUIPersonLink in div instead of p

### DIFF
--- a/src/zui/ZUIPersonLink/index.stories.tsx
+++ b/src/zui/ZUIPersonLink/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as Meta<typeof ZUIPersonLink>;
 
 const Template: StoryFn<typeof ZUIPersonLink> = (args) => (
-  <Typography>
+  <Typography component={'div'}>
     <ZUIPersonLink person={args.person} />
   </Typography>
 );


### PR DESCRIPTION
## Description
This PR changes the wrapping from `p` to `div` in Storybook/Atoms/ZetkinPersonLink.

`ZUIPersonLink` contains `div` so it should never be wrapped in `p`.

## Notes to reviewer
Without this fix, Storybook logs a warning in the console:

	<div> cannot appear as a descendant of <p>.
	div
	...
	Box@...
	ZUIPersonHoverCard@...
	ZUIPersonLink@...
	p
	...
	Typography@...
	div