### PR TITLE
Paste text instead of typing it in test

### DIFF
--- a/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
@@ -31,10 +31,10 @@ describe('<TagDialog />', () => {
       />
     );
 
-    // Fill in dialog
+    // Fill in dialog with paste, as keyboard is slow with many characters
     const titleField = getByTestId('TagManager-TagDialog-titleField');
     await userEvent.click(titleField);
-    await userEvent.keyboard('Spongeworthy');
+    await userEvent.paste('Spongeworthy');
 
     const submit = getByTestId('SubmitCancelButtons-submitButton');
     await userEvent.click(submit);
@@ -61,14 +61,14 @@ describe('<TagDialog />', () => {
       />
     );
 
-    // Fill in dialog
+    // Fill in dialog with paste, as keyboard is slow with many characters
     const titleField = getByTestId('TagManager-TagDialog-titleField');
     await userEvent.click(titleField);
-    await userEvent.keyboard('Tag Title');
+    await userEvent.paste('Tag Title');
 
     const groupField = getByTestId('TagManager-TagDialog-tagGroupSelect');
     await userEvent.click(groupField);
-    await userEvent.keyboard('New Group');
+    await userEvent.paste('New Group');
     const newGroupOption = getByMessageId(messageIds.dialog.groupCreatePrompt);
     await userEvent.click(newGroupOption);
 


### PR DESCRIPTION
The TagDialog tests `creates a basic tag` and `When creating a new group, sends the new group properties to the onSubmit callback instead of groupId` are consistently slow enough on my laptop to trip Jest's default timeout of 5 seconds.

If I run the tests serially, it more or less narrowly fits into 5 seconds but by default, Jest runs tests in parallel and then execution is always too slow for this particular test.

```
 FAIL  src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx (24.71 s)
  ● <TagDialog /> › creates a basic tag

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      21 |   });
      22 |
    > 23 |   it('creates a basic tag', async () => {
         |   ^
      24 |     const { getByTestId } = render(
      25 |       <TagDialog
      26 |         groups={[]}

      at src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx:23:3
      at Object.<anonymous> (src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx:12:1)

  ● <TagDialog /> › 
      When creating a new group, sends the new group properties
      to the onSubmit callback instead of groupId
    

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      48 |   });
      49 |
    > 50 |   it(`
         |   ^
      51 |       When creating a new group, sends the new group properties
      52 |       to the onSubmit callback instead of groupId
      53 |     `, async () => {

      at src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx:50:3
      at Object.<anonymous> (src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx:12:1)
```

Profiling `When creating a new group, sends the new group properties` I found that a lot of time is spent typing the characters into the fields. While it's more realistic to type the text, _how_ the text is entered does not seem to be what the authors were concerned about.

## Description

This PR pastes instead of typing text into fields, cutting enough of the execution time to comfortably fit in Jest's default timeout, even when other tests are running concurrently.

With `paste` instead of `keyboard`, execution time is approximately halved on my potato machine. It won't make a significant impact on suite time, but it makes a big difference for me, in that the suite succeeds. =)

## Screenshots

### main

`When creating a new group, sends the new group properties`
![image](https://github.com/zetkin/app.zetkin.org/assets/7813515/e07b27ca-57ff-4c4d-9c09-f23bc19b0309)

### fixed

`When creating a new group, sends the new group properties`
![image](https://github.com/zetkin/app.zetkin.org/assets/7813515/4c67c86e-2732-43e6-9292-4242c15f5b50)

## Notes to reviewer

Profiling can be done with Node's `--cpu-prof`:

```
node --cpu-prof node_modules/jest-cli/bin/jest.js -i \
    --testPathPattern TagDialog
    --testNamePattern 'When creating a new group, sends the new group properties'
```

You can view recorded profiles as a flame graph with Visual Studio Code extension Flame Chart Visualizer for JavaScript Profiles (`ms-vscode.vscode-js-profile-flame`)

The other tests for `<TagDialog />` use keyboard too, but not with as many total characters, which makes them fast enough.