### PR TITLE
issue-2039/add editTagButton string and apply it to tag dialog

### DIFF
--- a/src/features/tags/components/TagManager/components/TagDialog/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/index.tsx
@@ -156,7 +156,12 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           <ZUISubmitCancelButtons
             onCancel={closeAndClear}
             submitDisabled={!title || !color.valid}
-            submitText={submitLabel ?? messages.dialog.createTagButton()}
+            submitText={
+              submitLabel ??
+              (editingTag
+                ? messages.dialog.editTagButton()
+                : messages.dialog.createTagButton())
+            }
           />
         </Box>
       </form>

--- a/src/features/tags/components/TagManager/components/TagDialog/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/index.tsx
@@ -28,11 +28,9 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
   onClose,
   onDelete,
   onSubmit,
-  submitLabel,
   tag,
 }) => {
   const messages = useMessages(messageIds);
-
   const [title, setTitle] = useState('');
   const [titleEdited, setTitleEdited] = useState(false);
   const [color, setColor] = useState<{ valid: boolean; value: string }>({
@@ -43,8 +41,20 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     ZetkinTagGroup | NewTagGroup | null | undefined
   >();
   const [type, setType] = useState<ZetkinTag['value_type']>(null);
-
   const editingTag = tag && 'id' in tag;
+  const isTagPage = window.location.pathname.includes('tags');
+
+  const submitLabel = () => {
+    if (isTagPage) {
+      return editingTag
+        ? messages.dialog.editTagButton()
+        : messages.dialog.createTagButton();
+    } else {
+      return editingTag
+        ? messages.dialog.editTagButton()
+        : messages.dialog.createAndApplyButton();
+    }
+  };
 
   useEffect(() => {
     setTitle(tag?.title || '');
@@ -156,12 +166,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           <ZUISubmitCancelButtons
             onCancel={closeAndClear}
             submitDisabled={!title || !color.valid}
-            submitText={
-              submitLabel ??
-              (editingTag
-                ? messages.dialog.editTagButton()
-                : messages.dialog.createTagButton())
-            }
+            submitText={submitLabel()}
           />
         </Box>
       </form>

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -6,6 +6,7 @@ export default makeMessages('feat.tags', {
   dialog: {
     colorErrorText: m('Please enter a valid hex code'),
     colorLabel: m('Color'),
+    createAndApplyButton: m('Create and apply'),
     createTagButton: m('Create'),
     createTitle: m('Create tag'),
     deleteButtonLabel: m('Delete'),

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -12,6 +12,7 @@ export default makeMessages('feat.tags', {
     deleteWarning: m(
       'Are you sure you want to delete this tag? Deleting a tag cannot be undone.'
     ),
+    editTagButton: m('Update'),
     editTitle: m('Edit tag'),
     groupCreatePrompt: m<{ groupName: string }>('Add "{groupName}"'),
     groupLabel: m('Group'),

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1238,6 +1238,10 @@ feat:
         demote: Demote
         promote: Promote
         remove: Remove
+      urlCard:
+        linkToPub: Link to public organization
+        subTitle: Users must connect to the organization before they can access Zetkin
+          as officials.
       you: You
   smartSearch:
     buttonLabels:
@@ -1886,11 +1890,13 @@ feat:
     dialog:
       colorErrorText: Please enter a valid hex code
       colorLabel: Color
+      createAndApplyButton: Create and apply
       createTagButton: Create
       createTitle: Create tag
       deleteButtonLabel: Delete
       deleteWarning: Are you sure you want to delete this tag? Deleting a tag cannot
         be undone.
+      editTagButton: Update
       editTitle: Edit tag
       groupCreatePrompt: Add "{groupName}"
       groupLabel: Group

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -4,7 +4,6 @@ import Head from 'next/head';
 import { useContext } from 'react';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import messageIds from 'features/profile/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
 import PersonDetailsCard from 'features/profile/components/PersonDetailsCard';
 import PersonJourneysCard from 'features/profile/components/PersonJourneysCard';
@@ -13,7 +12,6 @@ import SinglePersonLayout from 'features/profile/layout/SinglePersonLayout';
 import { TagManagerSection } from 'features/tags/components/TagManager';
 import useCustomFields from 'features/profile/hooks/useCustomFields';
 import useJourneys from 'features/journeys/hooks/useJourneys';
-import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from 'features/profile/hooks/usePerson';
 import usePersonTags from 'features/tags/hooks/usePersonTags';
@@ -55,7 +53,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 
 const PersonProfilePage: PageWithLayout = () => {
   const { orgId, personId } = useNumericRouteParams();
-  const messages = useMessages(messageIds);
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { assignToPerson, removeFromPerson } = useTagging(orgId);
   const fieldsFuture = useCustomFields(orgId);
@@ -102,7 +99,6 @@ const PersonProfilePage: PageWithLayout = () => {
                     showSnackbar('error');
                   }
                 }}
-                submitCreateTagLabel={messages.tags.createAndApplyLabel()}
               />
             )}
           </ZUIFuture>


### PR DESCRIPTION
## Description
This PR…


## Screenshots

![Screenshot 2024-06-30 at 1 01 35 PM](https://github.com/zetkin/app.zetkin.org/assets/52118076/10c7ca6b-3990-410a-84c7-cc335f48fc82)
![Screenshot 2024-06-30 at 1 01 49 PM](https://github.com/zetkin/app.zetkin.org/assets/52118076/18d505ad-4ebb-476b-b28f-186ff9ac36ad)
![Screenshot 2024-06-30 at 1 02 02 PM](https://github.com/zetkin/app.zetkin.org/assets/52118076/3084eb9d-a4ff-4a3b-aefd-062cd13e1de3)
![Screenshot 2024-06-30 at 1 02 17 PM](https://github.com/zetkin/app.zetkin.org/assets/52118076/50beea30-ec98-4e23-a3ef-cd114d39fe82)


## Changes
added string for the save button when editing a tag ('update' instead of 'create'), and ternary to apply it.
* Adds…
* Changes…


## Notes to reviewer
submit button should contain text update if you are editing a tag

## Related issues
Resolves #2039