### PR TITLE
Issue-1178/render-icon-to-dom

### DIFF
--- a/src/features/events/components/LocationModal/DivIconMarker.tsx
+++ b/src/features/events/components/LocationModal/DivIconMarker.tsx
@@ -1,10 +1,5 @@
-import {
-  LeafletEventHandlerFnMap,
-  Marker as MarkerType,
-  LatLngExpression,
-  divIcon,
-} from 'leaflet';
-import { FC, ReactNode, Ref, useMemo } from 'react';
+import { LatLngExpression, divIcon, LeafletEventHandlerFnMap } from 'leaflet';
+import { FC, ReactNode, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { Marker } from 'react-leaflet';
 
@@ -12,14 +7,12 @@ export const DivIconMarker: FC<{
   children: ReactNode;
   draggable?: boolean;
   eventHandlers?: LeafletEventHandlerFnMap;
-  markerRef?: Ref<MarkerType> | undefined;
   position: LatLngExpression;
-}> = ({ children, draggable, eventHandlers, markerRef, position }) => {
+}> = ({ children, draggable, eventHandlers, position }) => {
   const iconDiv = useMemo(() => document.createElement('div'), []);
   return (
     <>
       <Marker
-        ref={markerRef}
         draggable={draggable}
         eventHandlers={eventHandlers}
         icon={divIcon({

--- a/src/features/events/components/LocationModal/DivIconMarker.tsx
+++ b/src/features/events/components/LocationModal/DivIconMarker.tsx
@@ -1,0 +1,34 @@
+import {
+  LeafletEventHandlerFnMap,
+  Marker as MarkerType,
+  LatLngExpression,
+  divIcon,
+} from 'leaflet';
+import { FC, ReactNode, Ref, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { Marker } from 'react-leaflet';
+
+export const DivIconMarker: FC<{
+  children: ReactNode;
+  draggable?: boolean;
+  eventHandlers?: LeafletEventHandlerFnMap;
+  markerRef?: Ref<MarkerType> | undefined;
+  position: LatLngExpression;
+}> = ({ children, draggable, eventHandlers, markerRef, position }) => {
+  const iconDiv = useMemo(() => document.createElement('div'), []);
+  return (
+    <>
+      <Marker
+        ref={markerRef}
+        draggable={draggable}
+        eventHandlers={eventHandlers}
+        icon={divIcon({
+          className: '',
+          html: iconDiv,
+        })}
+        position={position}
+      />
+      {createPortal(children, iconDiv)}
+    </>
+  );
+};

--- a/src/features/events/components/LocationModal/Map.tsx
+++ b/src/features/events/components/LocationModal/Map.tsx
@@ -1,9 +1,9 @@
 import 'leaflet/dist/leaflet.css';
 import Fuse from 'fuse.js';
-import { FC, useRef, useState } from 'react';
+import { FC, useState } from 'react';
 import { MapContainer, TileLayer, useMap } from 'react-leaflet';
 import { useTheme } from '@mui/material';
-import { latLngBounds, Map as MapType, Marker as MarkerType } from 'leaflet';
+import { latLngBounds, Map as MapType } from 'leaflet';
 
 import BasicMarker from './BasicMarker';
 import SelectedMarker from './SelectedMarker';
@@ -49,8 +49,6 @@ const Map: FC<MapProps> = ({
     ZetkinLocation,
     'lat' | 'lng'
   > | null>(null);
-
-  const selectedMarkerRef = useRef<MarkerType>(null);
 
   const fuse = new Fuse(locations, {
     keys: ['title'],
@@ -127,8 +125,7 @@ const Map: FC<MapProps> = ({
                         map.setView(evt.latlng, 17);
                         onMarkerClick(location.id);
                       },
-                      dragend: () => {
-                        const marker = selectedMarkerRef.current;
+                      dragend: ({ target: marker }) => {
                         if (marker !== null) {
                           setNewPosition(marker.getLatLng());
                           onMarkerDragEnd(
@@ -138,9 +135,6 @@ const Map: FC<MapProps> = ({
                         }
                       },
                     }}
-                    markerRef={
-                      inMoveState && isSelectedMarker ? selectedMarkerRef : null
-                    }
                     position={
                       isSelectedMarker && newPosition && inMoveState
                         ? newPosition

--- a/src/features/events/components/LocationModal/Map.tsx
+++ b/src/features/events/components/LocationModal/Map.tsx
@@ -1,20 +1,13 @@
 import 'leaflet/dist/leaflet.css';
 import Fuse from 'fuse.js';
-import { createPortal } from 'react-dom';
-import { FC, ReactNode, Ref, useMemo, useRef, useState } from 'react';
-import { MapContainer, Marker, TileLayer, useMap } from 'react-leaflet';
+import { FC, useRef, useState } from 'react';
+import { MapContainer, TileLayer, useMap } from 'react-leaflet';
 import { useTheme } from '@mui/material';
-import {
-  divIcon,
-  latLngBounds,
-  LatLngExpression,
-  LeafletEventHandlerFnMap,
-  Map as MapType,
-  Marker as MarkerType,
-} from 'leaflet';
+import { latLngBounds, Map as MapType, Marker as MarkerType } from 'leaflet';
 
 import BasicMarker from './BasicMarker';
 import SelectedMarker from './SelectedMarker';
+import { DivIconMarker } from './DivIconMarker';
 import { ZetkinEvent, ZetkinLocation } from 'utils/types/zetkin';
 
 interface MapProps {
@@ -177,31 +170,6 @@ const Map: FC<MapProps> = ({
         }}
       </MapWrapper>
     </MapContainer>
-  );
-};
-
-const DivIconMarker: FC<{
-  children: ReactNode;
-  draggable?: boolean;
-  eventHandlers?: LeafletEventHandlerFnMap;
-  markerRef?: Ref<MarkerType> | undefined;
-  position: LatLngExpression;
-}> = ({ children, draggable, eventHandlers, markerRef, position }) => {
-  const iconDiv = useMemo(() => document.createElement('div'), []);
-  return (
-    <>
-      <Marker
-        ref={markerRef}
-        draggable={draggable}
-        eventHandlers={eventHandlers}
-        icon={divIcon({
-          className: '',
-          html: iconDiv,
-        })}
-        position={position}
-      />
-      {createPortal(children, iconDiv)}
-    </>
   );
 };
 


### PR DESCRIPTION
## Description

This PR replaces `renderToStaticMarkup` with `createPortal` as the former is not recommended, can increase client bundle size and was made for server side rendering.

https://react.dev/reference/react-dom/server/renderToStaticMarkup#caveats

## Changes

* Adds a `DivIconMarker` between `Map` and `Marker` for hiding the portal stuff and for some neat scoping of the DOM node.
* Replaces `useRef` with `event.target` in `Map`

## Notes to reviewer

Open an event and its map. Select different markers and move them around.

## Related issues

Relates to #1178 and #1241