### PR TITLE
Email insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
     "@nivo/pie": "^0.80.0",
+    "@nivo/radial-bar": "^0.80.0",
     "@reduxjs/toolkit": "^1.8.6",
     "@types/dompurify": "^2.3.3",
     "@types/mjml": "^4.7.4",

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -16,6 +16,7 @@ import { moveParticipantsDef } from 'features/events/rpc/moveParticipants';
 import { setOfficialRoleDef } from 'features/settings/rpc/setOfficialRole';
 import { updateEventsDef } from 'features/events/rpc/updateEvents';
 import { getEmailInsightsDef } from 'features/emails/rpc/getEmailInsights';
+import { renderEmailDef } from 'features/emails/rpc/renderEmail/server';
 
 export function createRPCRouter() {
   const rpcRouter = new RPCRouter();
@@ -37,6 +38,7 @@ export function createRPCRouter() {
   rpcRouter.register(getOfficialMembershipsDef);
   rpcRouter.register(setOfficialRoleDef);
   rpcRouter.register(getEmailInsightsDef);
+  rpcRouter.register(renderEmailDef);
 
   return rpcRouter;
 }

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -15,6 +15,7 @@ import { getUserOrgTreeDef } from 'features/organizations/rpc/getUserOrgTree';
 import { moveParticipantsDef } from 'features/events/rpc/moveParticipants';
 import { setOfficialRoleDef } from 'features/settings/rpc/setOfficialRole';
 import { updateEventsDef } from 'features/events/rpc/updateEvents';
+import { getEmailInsightsDef } from 'features/emails/rpc/getEmailInsights';
 
 export function createRPCRouter() {
   const rpcRouter = new RPCRouter();
@@ -35,6 +36,7 @@ export function createRPCRouter() {
   rpcRouter.register(deleteEventsDef);
   rpcRouter.register(getOfficialMembershipsDef);
   rpcRouter.register(setOfficialRoleDef);
+  rpcRouter.register(getEmailInsightsDef);
 
   return rpcRouter;
 }

--- a/src/features/emails/components/ClickedInsightsSection.tsx
+++ b/src/features/emails/components/ClickedInsightsSection.tsx
@@ -1,8 +1,8 @@
-import { Box } from '@mui/system';
 import DOMPurify from 'dompurify';
 import { OpenInNew } from '@mui/icons-material';
 import { FC, useState } from 'react';
 import {
+  Box,
   Link,
   Table,
   TableCell,

--- a/src/features/emails/components/ClickedInsightsSection.tsx
+++ b/src/features/emails/components/ClickedInsightsSection.tsx
@@ -66,7 +66,11 @@ const ClickedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
             {({ data: { secondaryEmail, secondaryStats } }) => (
               <>
                 <EmailKPIChart
-                  email={email}
+                  mainEmail={email}
+                  mainTotal={
+                    clickMetric == 'ctr' ? stats.numSent : stats.numOpened
+                  }
+                  mainValue={stats.numClicked}
                   secondaryEmail={secondaryEmail}
                   secondaryTotal={
                     clickMetric == 'ctr'
@@ -75,8 +79,6 @@ const ClickedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
                   }
                   secondaryValue={secondaryStats?.num_clicks ?? null}
                   title={messages.insights.clicked.gauge.headers[clickMetric]()}
-                  total={clickMetric == 'ctr' ? stats.numSent : stats.numOpened}
-                  value={stats.numClicked}
                 />
                 <Box display="flex" justifyContent="center">
                   <ToggleButtonGroup

--- a/src/features/emails/components/ClickedInsightsSection.tsx
+++ b/src/features/emails/components/ClickedInsightsSection.tsx
@@ -1,0 +1,155 @@
+import { Box } from '@mui/system';
+import DOMPurify from 'dompurify';
+import { OpenInNew } from '@mui/icons-material';
+import { FC, useState } from 'react';
+import {
+  Link,
+  Table,
+  TableCell,
+  TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+  useTheme,
+} from '@mui/material';
+
+import ZUICard from 'zui/ZUICard';
+import ZUIFutures from 'zui/ZUIFutures';
+import ZUINumberChip from 'zui/ZUINumberChip';
+import EmailKPIChart from './EmailKPIChart';
+import ZUIFuture from 'zui/ZUIFuture';
+import EmailMiniature from './EmailMiniature';
+import { useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+import useEmailStats from '../hooks/useEmailStats';
+import useSecondaryEmailInsights from '../hooks/useSecondaryEmailInsights';
+import { ZetkinEmail } from 'utils/types/zetkin';
+import useEmailInsights from '../hooks/useEmailInsights';
+
+type Props = {
+  email: ZetkinEmail;
+  secondaryEmailId: number;
+};
+
+const ClickedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
+  const theme = useTheme();
+  const messages = useMessages(messageIds);
+  const stats = useEmailStats(email.organization.id, email.id);
+  const [clickMetric, setClickMetric] = useState<'ctr' | 'ctor'>('ctr');
+  const [selectedLinkTag, setSelectedLinkTag] = useState<string | null>(null);
+  const insightsFuture = useEmailInsights(email.organization.id, email.id);
+  const secondary = useSecondaryEmailInsights(
+    email.organization.id,
+    secondaryEmailId
+  );
+
+  const sanitizer = DOMPurify();
+
+  return (
+    <ZUICard
+      header={messages.insights.clicked.header()}
+      status={
+        <ZUINumberChip
+          color={theme.palette.grey[200]}
+          value={stats.numClicked}
+        />
+      }
+    >
+      <Box display="flex" gap={2}>
+        <Box flexGrow={0} maxWidth={300}>
+          <ZUIFutures
+            futures={{
+              secondaryEmail: secondary.emailFuture,
+              secondaryStats: secondary.statsFuture,
+            }}
+          >
+            {({ data: { secondaryEmail, secondaryStats } }) => (
+              <>
+                <EmailKPIChart
+                  email={email}
+                  secondaryEmail={secondaryEmail}
+                  secondaryTotal={
+                    clickMetric == 'ctr'
+                      ? secondaryStats?.num_sent ?? null
+                      : secondaryStats?.num_opened ?? null
+                  }
+                  secondaryValue={secondaryStats?.num_clicks ?? null}
+                  title={messages.insights.clicked.gauge.headers[clickMetric]()}
+                  total={clickMetric == 'ctr' ? stats.numSent : stats.numOpened}
+                  value={stats.numClicked}
+                />
+                <Box display="flex" justifyContent="center">
+                  <ToggleButtonGroup
+                    exclusive
+                    onChange={(_, value) =>
+                      setClickMetric(value || clickMetric)
+                    }
+                    size="small"
+                    value={clickMetric}
+                  >
+                    <ToggleButton value="ctr">
+                      {messages.insights.clicked.metrics.ctr()}
+                    </ToggleButton>
+                    <ToggleButton value="ctor">
+                      {messages.insights.clicked.metrics.ctor()}
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+                </Box>
+                <Typography mb={2} mt={1} variant="body2">
+                  {messages.insights.clicked.descriptions[clickMetric]()}
+                </Typography>
+              </>
+            )}
+          </ZUIFutures>
+        </Box>
+        <Box flexGrow={1} minHeight={500}>
+          <ZUIFuture future={insightsFuture}>
+            {(insights) => (
+              <Box alignItems="flex-start" display="flex">
+                <Table>
+                  {insights.links
+                    .concat()
+                    .sort((a, b) => b.clicks - a.clicks)
+                    .map((link) => (
+                      <TableRow
+                        key={link.id}
+                        onMouseEnter={() => setSelectedLinkTag(link.tag)}
+                        onMouseLeave={() => setSelectedLinkTag(null)}
+                      >
+                        <TableCell>{link.clicks}</TableCell>
+                        <TableCell>
+                          {sanitizer.sanitize(link.text, {
+                            // Remove all inline tags that may exist here
+                            ALLOWED_TAGS: ['#text'],
+                          })}
+                        </TableCell>
+                        <TableCell>
+                          <Link
+                            display="flex"
+                            gap={1}
+                            href={link.url}
+                            target="_blank"
+                          >
+                            {link.url}
+                            <OpenInNew fontSize="small" />
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                </Table>
+                <EmailMiniature
+                  emailId={email.id}
+                  orgId={email.organization.id}
+                  selectedTag={selectedLinkTag}
+                  width={150}
+                />
+              </Box>
+            )}
+          </ZUIFuture>
+        </Box>
+      </Box>
+    </ZUICard>
+  );
+};
+
+export default ClickedInsightsSection;

--- a/src/features/emails/components/EmailDiagramHoverCard.tsx
+++ b/src/features/emails/components/EmailDiagramHoverCard.tsx
@@ -1,0 +1,133 @@
+import { FC } from 'react';
+import { FormattedTime } from 'react-intl';
+import { Box, Divider, Paper, Typography } from '@mui/material';
+
+import { Msg } from 'core/i18n';
+import ZUIDuration from 'zui/ZUIDuration';
+import messageIds from '../l10n/messageIds';
+import { EmailInsights, ZetkinEmailStats } from '../types';
+import getRelevantDataPoints from '../utils/getRelevantDataPoints';
+import { ZetkinEmail } from 'utils/types/zetkin';
+
+type Props = {
+  mainInsights: EmailInsights;
+  mainStats: ZetkinEmailStats | null;
+  pointId: string;
+  publishDate: Date;
+  secondaryEmail: ZetkinEmail | null;
+  secondaryInsights: EmailInsights | null;
+  secondaryStats: ZetkinEmailStats | null;
+};
+
+const EmailDiagramHoverCard: FC<Props> = ({
+  mainInsights,
+  mainStats,
+  pointId,
+  publishDate,
+  secondaryEmail,
+  secondaryInsights,
+  secondaryStats,
+}) => {
+  const { mainPoint, secondaryPoint } = getRelevantDataPoints(
+    { id: pointId },
+    {
+      startDate: publishDate,
+      values: mainInsights.opensByDate,
+    },
+    secondaryInsights && secondaryEmail?.published
+      ? {
+          startDate: new Date(secondaryEmail.published),
+          values: secondaryInsights.opensByDate,
+        }
+      : null
+  );
+  if (!mainPoint) {
+    return null;
+  }
+
+  const count = mainPoint.accumulatedOpens;
+  const date = new Date(mainPoint.date);
+
+  const secondsAfterPublish = (date.getTime() - publishDate.getTime()) / 1000;
+  return (
+    <Paper sx={{ minWidth: 240 }}>
+      <Box p={2}>
+        <Typography variant="h6">
+          <ZUIDuration seconds={secondsAfterPublish} />
+        </Typography>
+        <Typography variant="body2">
+          <Msg id={messageIds.insights.opened.chart.afterSend} />
+        </Typography>
+      </Box>
+      <Divider />
+      <Box p={2}>
+        <Box
+          alignItems="center"
+          display="flex"
+          gap={2}
+          justifyContent="space-between"
+        >
+          <Box>
+            <Typography variant="body2">
+              <FormattedTime day="numeric" month="short" value={date} />
+            </Typography>
+            <Typography variant="body2">
+              <Msg
+                id={messageIds.insights.opened.chart.opened}
+                values={{
+                  count: count,
+                }}
+              />
+            </Typography>
+          </Box>
+          <Box>
+            <Typography color="primary" variant="h5">
+              {Math.round((count / (mainStats?.num_sent || 1)) * 100)}%
+            </Typography>
+          </Box>
+        </Box>
+        {secondaryPoint && secondaryStats && (
+          <>
+            <Divider sx={{ my: 1 }} />
+            <Box
+              alignItems="center"
+              display="flex"
+              gap={2}
+              justifyContent="space-between"
+            >
+              <Box>
+                <Typography variant="body2">
+                  <FormattedTime
+                    day="numeric"
+                    month="short"
+                    value={secondaryPoint.date}
+                  />
+                </Typography>
+                <Typography variant="body2">
+                  <Msg
+                    id={messageIds.insights.opened.chart.opened}
+                    values={{
+                      count: secondaryPoint.accumulatedOpens,
+                    }}
+                  />
+                </Typography>
+              </Box>
+              <Box>
+                <Typography color="secondary" variant="h5">
+                  {Math.round(
+                    (secondaryPoint.accumulatedOpens /
+                      secondaryStats.num_sent) *
+                      100
+                  )}
+                  %
+                </Typography>
+              </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default EmailDiagramHoverCard;

--- a/src/features/emails/components/EmailKPIChart.tsx
+++ b/src/features/emails/components/EmailKPIChart.tsx
@@ -1,7 +1,8 @@
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Paper, Typography, useTheme } from '@mui/material';
 import { ResponsiveRadialBar } from '@nivo/radial-bar';
 import { FC } from 'react';
 
+import { truncateOnMiddle } from 'utils/stringUtils';
 import { ZetkinEmail } from 'utils/types/zetkin';
 
 type Props = {
@@ -29,15 +30,15 @@ const EmailKPIChart: FC<Props> = ({
     {
       data: [
         {
-          x: 'Opened',
+          x: 'main',
           y: value / total,
         },
         {
-          x: 'Opened 2',
+          x: 'secondary',
           y: 0,
         },
         {
-          x: 'Other',
+          x: 'void',
           y: 1 - value / total,
         },
       ],
@@ -49,15 +50,15 @@ const EmailKPIChart: FC<Props> = ({
     data.push({
       data: [
         {
-          x: 'Opened',
+          x: 'main',
           y: 0,
         },
         {
-          x: 'Opened 2',
+          x: 'secondary',
           y: secondaryValue / secondaryTotal,
         },
         {
-          x: 'Other',
+          x: 'void',
           y: 1 - secondaryValue / secondaryTotal,
         },
       ],
@@ -94,7 +95,9 @@ const EmailKPIChart: FC<Props> = ({
         }}
       >
         <Typography variant="body2">{title}</Typography>
-        <Typography variant="h4">{percentage + '%'}</Typography>
+        <Typography color="primary" variant="h4">
+          {percentage + '%'}
+        </Typography>
         <Typography color={theme.palette.grey[700]} variant="body2">
           {secondaryPercentage >= 0 &&
             secondaryPercentage.toString().concat('%')}
@@ -105,7 +108,7 @@ const EmailKPIChart: FC<Props> = ({
           circularAxisOuter={null}
           colors={[
             theme.palette.primary.main,
-            theme.palette.grey[500],
+            theme.palette.grey[400],
             theme.palette.grey[100],
           ]}
           cornerRadius={2}
@@ -116,6 +119,33 @@ const EmailKPIChart: FC<Props> = ({
           innerRadius={0.6}
           padding={0.4}
           radialAxisStart={null}
+          tooltip={(props) => {
+            if (props.bar.category == 'void') {
+              return null;
+            }
+
+            const percentage = Math.round(props.bar.value * 100);
+
+            return (
+              <Paper>
+                <Box p={1} textAlign="center">
+                  <Typography variant="body2">
+                    {truncateOnMiddle(props.bar.groupId, 40)}
+                  </Typography>
+                  <Typography
+                    color={
+                      props.bar.category == 'main'
+                        ? theme.palette.primary.main
+                        : theme.palette.secondary.main
+                    }
+                    variant="h5"
+                  >
+                    {percentage}%
+                  </Typography>
+                </Box>
+              </Paper>
+            );
+          }}
           valueFormat=">-.2f"
         />
       </Box>

--- a/src/features/emails/components/EmailKPIChart.tsx
+++ b/src/features/emails/components/EmailKPIChart.tsx
@@ -1,0 +1,82 @@
+import { Box, Typography, useTheme } from '@mui/material';
+import { ResponsiveRadialBar } from '@nivo/radial-bar';
+import { FC } from 'react';
+
+import { ZetkinEmail } from 'utils/types/zetkin';
+
+type Props = {
+  email: ZetkinEmail;
+  title: string;
+  total: number;
+  value: number;
+};
+
+const EmailKPIChart: FC<Props> = ({ email, title, total, value }) => {
+  const theme = useTheme();
+
+  const data = [
+    {
+      data: [
+        {
+          x: 'Opened',
+          y: value,
+        },
+        {
+          x: 'Opened 2',
+          y: 0,
+        },
+      ],
+      id: email.title || '',
+    },
+  ];
+
+  const percentage = Math.round((value / total) * 100);
+
+  return (
+    <Box
+      sx={{
+        aspectRatio: '1/1',
+        height: 'auto',
+        position: 'relative',
+        width: '100%',
+      }}
+    >
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '40%',
+          justifyContent: 'center',
+          left: '30%',
+          position: 'absolute',
+          top: '30%',
+          width: '40%',
+        }}
+      >
+        <Typography variant="body2">{title}</Typography>
+        <Typography variant="h4">{percentage + '%'}</Typography>
+        <Typography color={theme.palette.grey[700]} variant="body2" />
+      </Box>
+      <Box sx={{ height: '100%', width: '100%' }}>
+        <ResponsiveRadialBar
+          circularAxisOuter={null}
+          colors={[theme.palette.primary.main, theme.palette.grey[500]]}
+          cornerRadius={2}
+          data={data}
+          enableCircularGrid={false}
+          enableRadialGrid={false}
+          endAngle={360}
+          innerRadius={0.6}
+          maxValue={total}
+          padding={0.4}
+          radialAxisStart={null}
+          tracksColor={theme.palette.grey[100]}
+          valueFormat=">-.2f"
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default EmailKPIChart;

--- a/src/features/emails/components/EmailKPIChart.tsx
+++ b/src/features/emails/components/EmailKPIChart.tsx
@@ -6,12 +6,23 @@ import { ZetkinEmail } from 'utils/types/zetkin';
 
 type Props = {
   email: ZetkinEmail;
+  secondaryEmail?: ZetkinEmail | null;
+  secondaryTotal?: number | null;
+  secondaryValue?: number | null;
   title: string;
   total: number;
   value: number;
 };
 
-const EmailKPIChart: FC<Props> = ({ email, title, total, value }) => {
+const EmailKPIChart: FC<Props> = ({
+  email,
+  secondaryEmail,
+  secondaryTotal,
+  secondaryValue,
+  title,
+  total,
+  value,
+}) => {
   const theme = useTheme();
 
   const data = [
@@ -19,18 +30,46 @@ const EmailKPIChart: FC<Props> = ({ email, title, total, value }) => {
       data: [
         {
           x: 'Opened',
-          y: value,
+          y: value / total,
         },
         {
           x: 'Opened 2',
           y: 0,
+        },
+        {
+          x: 'Other',
+          y: 1 - value / total,
         },
       ],
       id: email.title || '',
     },
   ];
 
+  if (secondaryEmail && secondaryTotal && secondaryValue) {
+    data.push({
+      data: [
+        {
+          x: 'Opened',
+          y: 0,
+        },
+        {
+          x: 'Opened 2',
+          y: secondaryValue / secondaryTotal,
+        },
+        {
+          x: 'Other',
+          y: 1 - secondaryValue / secondaryTotal,
+        },
+      ],
+      id: secondaryEmail.title || '',
+    });
+  }
+
   const percentage = Math.round((value / total) * 100);
+  const secondaryPercentage =
+    secondaryValue && secondaryTotal
+      ? Math.round((secondaryValue / secondaryTotal) * 100)
+      : -1;
 
   return (
     <Box
@@ -56,22 +95,27 @@ const EmailKPIChart: FC<Props> = ({ email, title, total, value }) => {
       >
         <Typography variant="body2">{title}</Typography>
         <Typography variant="h4">{percentage + '%'}</Typography>
-        <Typography color={theme.palette.grey[700]} variant="body2" />
+        <Typography color={theme.palette.grey[700]} variant="body2">
+          {secondaryPercentage >= 0 &&
+            secondaryPercentage.toString().concat('%')}
+        </Typography>
       </Box>
       <Box sx={{ height: '100%', width: '100%' }}>
         <ResponsiveRadialBar
           circularAxisOuter={null}
-          colors={[theme.palette.primary.main, theme.palette.grey[500]]}
+          colors={[
+            theme.palette.primary.main,
+            theme.palette.grey[500],
+            theme.palette.grey[100],
+          ]}
           cornerRadius={2}
           data={data}
           enableCircularGrid={false}
           enableRadialGrid={false}
           endAngle={360}
           innerRadius={0.6}
-          maxValue={total}
           padding={0.4}
           radialAxisStart={null}
-          tracksColor={theme.palette.grey[100]}
           valueFormat=">-.2f"
         />
       </Box>

--- a/src/features/emails/components/EmailKPIChart.tsx
+++ b/src/features/emails/components/EmailKPIChart.tsx
@@ -9,9 +9,9 @@ type Props = {
   mainEmail: ZetkinEmail;
   mainTotal: number;
   mainValue: number;
-  secondaryEmail?: ZetkinEmail | null;
-  secondaryTotal?: number | null;
-  secondaryValue?: number | null;
+  secondaryEmail: ZetkinEmail | null;
+  secondaryTotal: number | null;
+  secondaryValue: number | null;
   title: string;
 };
 

--- a/src/features/emails/components/EmailKPIChart.tsx
+++ b/src/features/emails/components/EmailKPIChart.tsx
@@ -6,23 +6,23 @@ import { truncateOnMiddle } from 'utils/stringUtils';
 import { ZetkinEmail } from 'utils/types/zetkin';
 
 type Props = {
-  email: ZetkinEmail;
+  mainEmail: ZetkinEmail;
+  mainTotal: number;
+  mainValue: number;
   secondaryEmail?: ZetkinEmail | null;
   secondaryTotal?: number | null;
   secondaryValue?: number | null;
   title: string;
-  total: number;
-  value: number;
 };
 
 const EmailKPIChart: FC<Props> = ({
-  email,
+  mainEmail,
+  mainTotal,
+  mainValue,
   secondaryEmail,
   secondaryTotal,
   secondaryValue,
   title,
-  total,
-  value,
 }) => {
   const theme = useTheme();
 
@@ -31,7 +31,7 @@ const EmailKPIChart: FC<Props> = ({
       data: [
         {
           x: 'main',
-          y: value / total,
+          y: mainValue / mainTotal,
         },
         {
           x: 'secondary',
@@ -39,10 +39,10 @@ const EmailKPIChart: FC<Props> = ({
         },
         {
           x: 'void',
-          y: 1 - value / total,
+          y: 1 - mainValue / mainTotal,
         },
       ],
-      id: email.title || '',
+      id: mainEmail.title || '',
     },
   ];
 
@@ -66,7 +66,7 @@ const EmailKPIChart: FC<Props> = ({
     });
   }
 
-  const percentage = Math.round((value / total) * 100);
+  const percentage = Math.round((mainValue / mainTotal) * 100);
   const secondaryPercentage =
     secondaryValue && secondaryTotal
       ? Math.round((secondaryValue / secondaryTotal) * 100)

--- a/src/features/emails/components/EmailMiniature.tsx
+++ b/src/features/emails/components/EmailMiniature.tsx
@@ -1,0 +1,57 @@
+import { Box } from '@mui/material';
+import { FC, useEffect, useState } from 'react';
+
+import { useApiClient } from 'core/hooks';
+import renderEmail from '../rpc/renderEmail/client';
+import ZUICleanHtml from 'zui/ZUICleanHtml';
+
+type Props = {
+  emailId: number;
+  orgId: number;
+  width: number;
+};
+
+const EmailMiniature: FC<Props> = ({ emailId, orgId, width }) => {
+  const [html, setHtml] = useState('');
+  const [height, setHeight] = useState(0);
+  const apiClient = useApiClient();
+
+  useEffect(() => {
+    async function load() {
+      const renderData = await apiClient.rpc(renderEmail, { emailId, orgId });
+      setHtml(renderData.html);
+    }
+
+    load();
+  });
+
+  return (
+    <Box
+      sx={{
+        height: height,
+        position: 'relative',
+        width: width,
+      }}
+    >
+      <div
+        ref={(elem) => {
+          if (elem) {
+            setHeight(0.2 * elem.clientHeight);
+          }
+        }}
+        style={{
+          left: 0,
+          position: 'absolute',
+          top: 0,
+          transform: 'scale(0.2)',
+          transformOrigin: 'top left',
+          width: width / 0.2,
+        }}
+      >
+        <ZUICleanHtml dirtyHtml={html} />;
+      </div>
+    </Box>
+  );
+};
+
+export default EmailMiniature;

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -110,13 +110,13 @@ const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
             {({ data: { secondaryEmail, secondaryStats } }) => (
               <>
                 <EmailKPIChart
-                  email={email}
+                  mainEmail={email}
+                  mainTotal={stats.numSent}
+                  mainValue={stats.numOpened}
                   secondaryEmail={secondaryEmail}
                   secondaryTotal={secondaryStats?.num_sent}
                   secondaryValue={secondaryStats?.num_opened}
                   title={messages.insights.opened.gauge.header()}
-                  total={stats.numSent}
-                  value={stats.numOpened}
                 />
                 <Typography mb={2} mt={1} variant="body2">
                   {messages.insights.opened.description()}

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -114,8 +114,8 @@ const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
                   mainTotal={stats.numSent}
                   mainValue={stats.numOpened}
                   secondaryEmail={secondaryEmail}
-                  secondaryTotal={secondaryStats?.num_sent}
-                  secondaryValue={secondaryStats?.num_opened}
+                  secondaryTotal={secondaryStats?.num_sent ?? null}
+                  secondaryValue={secondaryStats?.num_opened ?? null}
                   title={messages.insights.opened.gauge.header()}
                 />
                 <Typography mb={2} mt={1} variant="body2">

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -1,17 +1,8 @@
 import { AxisProps } from '@nivo/axes';
-import { FormattedTime } from 'react-intl';
 import { ResponsiveLine } from '@nivo/line';
 import { linearGradientDef } from '@nivo/core';
 import { FC, useState } from 'react';
-import {
-  Box,
-  Divider,
-  MenuItem,
-  Paper,
-  TextField,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import { Box, MenuItem, TextField, Typography, useTheme } from '@mui/material';
 
 import { Msg, useMessages } from 'core/i18n';
 import ZUICard from 'zui/ZUICard';
@@ -19,13 +10,12 @@ import ZUINumberChip from 'zui/ZUINumberChip';
 import messageIds from '../l10n/messageIds';
 import ZUIFutures from 'zui/ZUIFutures';
 import EmailKPIChart from './EmailKPIChart';
-import getRelevantDataPoints from '../utils/getRelevantDataPoints';
-import ZUIDuration from 'zui/ZUIDuration';
 import { ZetkinEmail } from 'utils/types/zetkin';
 import useEmailInsights from '../hooks/useEmailInsights';
 import useEmailStats from '../hooks/useEmailStats';
 import useSecondaryEmailInsights from '../hooks/useSecondaryEmailInsights';
 import { EmailInsights } from '../types';
+import EmailDiagramHoverCard from './EmailDiagramHoverCard';
 
 type Props = {
   email: ZetkinEmail;
@@ -244,117 +234,16 @@ const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
                     top: 20,
                   }}
                   sliceTooltip={(props) => {
-                    const publishDate = new Date(emailPublished);
-                    const { mainPoint, secondaryPoint } = getRelevantDataPoints(
-                      props.slice.points[0],
-                      {
-                        startDate: new Date(emailPublished),
-                        values: mainInsights.opensByDate,
-                      },
-                      secondaryInsights && secondaryEmail?.published
-                        ? {
-                            startDate: new Date(secondaryEmail.published),
-                            values: secondaryInsights.opensByDate,
-                          }
-                        : null
-                    );
-
-                    if (!mainPoint) {
-                      return null;
-                    }
-
-                    const count = mainPoint.accumulatedOpens;
-                    const date = new Date(mainPoint.date);
-
-                    const secondsAfterPublish =
-                      (date.getTime() - publishDate.getTime()) / 1000;
-
                     return (
-                      <Paper sx={{ minWidth: 240 }}>
-                        <Box p={2}>
-                          <Typography variant="h6">
-                            <ZUIDuration seconds={secondsAfterPublish} />
-                          </Typography>
-                          <Typography variant="body2">
-                            <Msg
-                              id={messageIds.insights.opened.chart.afterSend}
-                            />
-                          </Typography>
-                        </Box>
-                        <Divider />
-                        <Box p={2}>
-                          <Box
-                            alignItems="center"
-                            display="flex"
-                            gap={2}
-                            justifyContent="space-between"
-                          >
-                            <Box>
-                              <Typography variant="body2">
-                                <FormattedTime
-                                  day="numeric"
-                                  month="short"
-                                  value={date}
-                                />
-                              </Typography>
-                              <Typography variant="body2">
-                                <Msg
-                                  id={messageIds.insights.opened.chart.opened}
-                                  values={{
-                                    count: count,
-                                  }}
-                                />
-                              </Typography>
-                            </Box>
-                            <Box>
-                              <Typography color="primary" variant="h5">
-                                {Math.round((count / stats.numSent) * 100)}%
-                              </Typography>
-                            </Box>
-                          </Box>
-                          {secondaryPoint && secondaryStats && (
-                            <>
-                              <Divider sx={{ my: 1 }} />
-                              <Box
-                                alignItems="center"
-                                display="flex"
-                                gap={2}
-                                justifyContent="space-between"
-                              >
-                                <Box>
-                                  <Typography variant="body2">
-                                    <FormattedTime
-                                      day="numeric"
-                                      month="short"
-                                      value={secondaryPoint.date}
-                                    />
-                                  </Typography>
-                                  <Typography variant="body2">
-                                    <Msg
-                                      id={
-                                        messageIds.insights.opened.chart.opened
-                                      }
-                                      values={{
-                                        count: secondaryPoint.accumulatedOpens,
-                                      }}
-                                    />
-                                  </Typography>
-                                </Box>
-                                <Box>
-                                  <Typography color="secondary" variant="h5">
-                                    {Math.round(
-                                      (secondaryPoint.accumulatedOpens /
-                                        secondaryStats.num_sent) *
-                                        100
-                                    )}
-                                    %
-                                  </Typography>
-                                </Box>
-                              </Box>
-                            </>
-                          )}
-                        </Box>
-                      </Paper>
+                      <EmailDiagramHoverCard
+                        mainInsights={mainInsights}
+                        mainStats={stats.data}
+                        pointId={props.slice.points[0].id}
+                        publishDate={new Date(emailPublished)}
+                        secondaryEmail={secondaryEmail}
+                        secondaryInsights={secondaryInsights}
+                        secondaryStats={secondaryStats}
+                      />
                     );
                   }}
                   xScale={{

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -1,0 +1,361 @@
+import { AxisProps } from '@nivo/axes';
+import { FormattedTime } from 'react-intl';
+import { ResponsiveLine } from '@nivo/line';
+import { linearGradientDef } from '@nivo/core';
+import { FC, useState } from 'react';
+import {
+  Box,
+  Divider,
+  MenuItem,
+  Paper,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+
+import { Msg, useMessages } from 'core/i18n';
+import ZUICard from 'zui/ZUICard';
+import ZUINumberChip from 'zui/ZUINumberChip';
+import messageIds from '../l10n/messageIds';
+import ZUIFutures from 'zui/ZUIFutures';
+import EmailKPIChart from './EmailKPIChart';
+import getRelevantDataPoints from '../utils/getRelevantDataPoints';
+import ZUIDuration from 'zui/ZUIDuration';
+import { ZetkinEmail } from 'utils/types/zetkin';
+import useEmailInsights from '../hooks/useEmailInsights';
+import useEmailStats from '../hooks/useEmailStats';
+import useSecondaryEmailInsights from '../hooks/useSecondaryEmailInsights';
+
+type Props = {
+  email: ZetkinEmail;
+  secondaryEmailId: number;
+};
+
+const HOURS_BY_SPAN: Record<string, number> = {
+  first24: 24,
+  first48: 48,
+  firstMonth: 24 * 30,
+  firstWeek: 24 * 7,
+};
+
+function hoursFromSpanValue(value: string): number | undefined {
+  return HOURS_BY_SPAN[value];
+}
+
+function axisFromSpanValue(value: string): AxisProps {
+  if (value == 'first24' || value == 'first48') {
+    const output: number[] = [];
+    for (let i = 0; i < 48; i += 4) {
+      output.push(i * 60 * 60);
+    }
+
+    return {
+      format: (val) => Math.round(val / 60 / 60),
+      tickValues: output,
+    };
+  } else {
+    return {
+      format: (val) => Math.round(val / 60 / 60 / 24),
+      tickValues: value == 'firstWeek' ? 7 : 15,
+    };
+  }
+}
+
+const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
+  const theme = useTheme();
+  const messages = useMessages(messageIds);
+  const [timeSpan, setTimeSpan] = useState<string>('first48');
+  const stats = useEmailStats(email.organization.id, email.id);
+  const insightsFuture = useEmailInsights(email.organization.id, email.id);
+  const secondary = useSecondaryEmailInsights(
+    email.organization.id,
+    secondaryEmailId
+  );
+
+  const timeSpanHours = hoursFromSpanValue(timeSpan);
+
+  const emailPublished = email.published;
+  if (!emailPublished || !email.processed) {
+    return null;
+  }
+
+  return (
+    <ZUICard
+      header={messages.insights.opened.header()}
+      status={
+        <ZUINumberChip
+          color={theme.palette.grey[200]}
+          value={stats.numOpened}
+        />
+      }
+      sx={{ mb: 2 }}
+    >
+      <Box display="flex" gap={2}>
+        <Box flexGrow={0} maxWidth={300}>
+          <ZUIFutures
+            futures={{
+              secondaryEmail: secondary.emailFuture,
+              secondaryStats: secondary.statsFuture,
+            }}
+          >
+            {({ data: { secondaryEmail, secondaryStats } }) => (
+              <>
+                <EmailKPIChart
+                  email={email}
+                  secondaryEmail={secondaryEmail}
+                  secondaryTotal={secondaryStats?.num_sent}
+                  secondaryValue={secondaryStats?.num_opened}
+                  title={messages.insights.opened.gauge.header()}
+                  total={stats.numSent}
+                  value={stats.numOpened}
+                />
+                <Typography mb={2} mt={1} variant="body2">
+                  {messages.insights.opened.description()}
+                </Typography>
+              </>
+            )}
+          </ZUIFutures>
+        </Box>
+        <Box flexGrow={1} height={550} position="relative">
+          <Box
+            bgcolor={theme.palette.background.paper}
+            bottom={40}
+            position="absolute"
+            right={0}
+            width={160}
+            zIndex={1000}
+          >
+            <TextField
+              fullWidth
+              onChange={(ev) => setTimeSpan(ev.target.value)}
+              select
+              size="small"
+              value={timeSpan}
+            >
+              <MenuItem value="first24">
+                <Msg id={messageIds.insights.opened.chart.spans.first24} />
+              </MenuItem>
+              <MenuItem value="first48">
+                <Msg id={messageIds.insights.opened.chart.spans.first48} />
+              </MenuItem>
+              <MenuItem value="firstWeek">
+                <Msg id={messageIds.insights.opened.chart.spans.firstWeek} />
+              </MenuItem>
+              <MenuItem value="firstMonth">
+                <Msg id={messageIds.insights.opened.chart.spans.firstMonth} />
+              </MenuItem>
+              <MenuItem value="allTime">
+                <Msg id={messageIds.insights.opened.chart.spans.allTime} />
+              </MenuItem>
+            </TextField>
+          </Box>
+          <ZUIFutures
+            futures={{
+              mainInsights: insightsFuture,
+              secondaryEmail: secondary.emailFuture,
+              secondaryInsights: secondary.insightsFuture,
+              secondaryStats: secondary.statsFuture,
+            }}
+          >
+            {({
+              data: {
+                mainInsights,
+                secondaryEmail,
+                secondaryInsights,
+                secondaryStats,
+              },
+            }) => {
+              const lineData = [
+                {
+                  data: mainInsights.opensByDate.map((openEvent) => ({
+                    x:
+                      (new Date(openEvent.date).getTime() -
+                        new Date(mainInsights.opensByDate[0].date).getTime()) /
+                      1000,
+                    y: openEvent.accumulatedOpens / stats.numSent,
+                  })),
+                  id: 'main',
+                },
+              ];
+
+              if (secondaryInsights && secondaryStats) {
+                lineData.push({
+                  data: secondaryInsights.opensByDate.map((openEvent) => ({
+                    x:
+                      (new Date(openEvent.date).getTime() -
+                        new Date(
+                          secondaryInsights.opensByDate[0].date
+                        ).getTime()) /
+                      1000,
+                    y: openEvent.accumulatedOpens / secondaryStats.num_sent,
+                  })),
+                  id: 'secondary',
+                });
+              }
+
+              return (
+                <ResponsiveLine
+                  animate={false}
+                  axisBottom={axisFromSpanValue(timeSpan)}
+                  axisLeft={{
+                    format: (val) => Math.round(val * 100) + '%',
+                  }}
+                  colors={[theme.palette.primary.main, theme.palette.grey[600]]}
+                  curve="basis"
+                  data={lineData}
+                  defs={[
+                    linearGradientDef('gradientA', [
+                      { color: 'inherit', offset: 0 },
+                      { color: 'inherit', offset: 100, opacity: 0 },
+                    ]),
+                    linearGradientDef('transparent', [
+                      { color: 'white', offset: 0, opacity: 0 },
+                      { color: 'white', offset: 100, opacity: 0 },
+                    ]),
+                  ]}
+                  enableArea={true}
+                  enableGridX={false}
+                  enableGridY={false}
+                  enablePoints={false}
+                  enableSlices="x"
+                  fill={[
+                    { id: 'gradientA', match: { id: 'main' } },
+                    { id: 'transparent', match: { id: 'secondary' } },
+                  ]}
+                  isInteractive={true}
+                  lineWidth={3}
+                  margin={{
+                    bottom: 30,
+                    left: 40,
+                    right: 8,
+                    top: 20,
+                  }}
+                  sliceTooltip={(props) => {
+                    const publishDate = new Date(emailPublished);
+                    const { mainPoint, secondaryPoint } = getRelevantDataPoints(
+                      props.slice.points[0],
+                      {
+                        startDate: new Date(emailPublished),
+                        values: mainInsights.opensByDate,
+                      },
+                      secondaryInsights && secondaryEmail?.published
+                        ? {
+                            startDate: new Date(secondaryEmail.published),
+                            values: secondaryInsights.opensByDate,
+                          }
+                        : null
+                    );
+
+                    if (!mainPoint) {
+                      return null;
+                    }
+
+                    const count = mainPoint.accumulatedOpens;
+                    const date = new Date(mainPoint.date);
+
+                    const secondsAfterPublish =
+                      (date.getTime() - publishDate.getTime()) / 1000;
+
+                    return (
+                      <Paper sx={{ minWidth: 240 }}>
+                        <Box p={2}>
+                          <Typography variant="h6">
+                            <ZUIDuration seconds={secondsAfterPublish} />
+                          </Typography>
+                          <Typography variant="body2">
+                            <Msg
+                              id={messageIds.insights.opened.chart.afterSend}
+                            />
+                          </Typography>
+                        </Box>
+                        <Divider />
+                        <Box p={2}>
+                          <Box
+                            alignItems="center"
+                            display="flex"
+                            gap={2}
+                            justifyContent="space-between"
+                          >
+                            <Box>
+                              <Typography variant="body2">
+                                <FormattedTime
+                                  day="numeric"
+                                  month="short"
+                                  value={date}
+                                />
+                              </Typography>
+                              <Typography variant="body2">
+                                <Msg
+                                  id={messageIds.insights.opened.chart.opened}
+                                  values={{
+                                    count: count,
+                                  }}
+                                />
+                              </Typography>
+                            </Box>
+                            <Box>
+                              <Typography color="primary" variant="h5">
+                                {Math.round((count / stats.numSent) * 100)}%
+                              </Typography>
+                            </Box>
+                          </Box>
+                          {secondaryPoint && secondaryStats && (
+                            <>
+                              <Divider sx={{ my: 1 }} />
+                              <Box
+                                alignItems="center"
+                                display="flex"
+                                gap={2}
+                                justifyContent="space-between"
+                              >
+                                <Box>
+                                  <Typography variant="body2">
+                                    <FormattedTime
+                                      day="numeric"
+                                      month="short"
+                                      value={secondaryPoint.date}
+                                    />
+                                  </Typography>
+                                  <Typography variant="body2">
+                                    <Msg
+                                      id={
+                                        messageIds.insights.opened.chart.opened
+                                      }
+                                      values={{
+                                        count: secondaryPoint.accumulatedOpens,
+                                      }}
+                                    />
+                                  </Typography>
+                                </Box>
+                                <Box>
+                                  <Typography color="secondary" variant="h5">
+                                    {Math.round(
+                                      (secondaryPoint.accumulatedOpens /
+                                        secondaryStats.num_sent) *
+                                        100
+                                    )}
+                                    %
+                                  </Typography>
+                                </Box>
+                              </Box>
+                            </>
+                          )}
+                        </Box>
+                      </Paper>
+                    );
+                  }}
+                  xScale={{
+                    max: timeSpanHours ? timeSpanHours * 60 * 60 : undefined,
+                    type: 'linear',
+                  }}
+                />
+              );
+            }}
+          </ZUIFutures>
+        </Box>
+      </Box>
+    </ZUICard>
+  );
+};
+
+export default OpenedInsightsSection;

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -63,13 +63,18 @@ function axisFromSpanValue(value: string): AxisProps {
 }
 
 function lineDataFromInsights(
+  email: ZetkinEmail,
   insights: EmailInsights,
   numSent: number
 ): { x: number; y: number }[] {
+  const startTime = email.published;
+  if (!startTime) {
+    return [];
+  }
+
   return insights.opensByDate.map((openEvent) => ({
     x:
-      (new Date(openEvent.date).getTime() -
-        new Date(insights.opensByDate[0].date).getTime()) /
+      (new Date(openEvent.date).getTime() - new Date(startTime).getTime()) /
       1000,
     y: openEvent.accumulatedOpens / numSent,
   }));
@@ -181,14 +186,19 @@ const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
             }) => {
               const lineData = [
                 {
-                  data: lineDataFromInsights(mainInsights, stats.numSent),
+                  data: lineDataFromInsights(
+                    email,
+                    mainInsights,
+                    stats.numSent
+                  ),
                   id: 'main',
                 },
               ];
 
-              if (secondaryInsights && secondaryStats) {
+              if (secondaryEmail && secondaryInsights && secondaryStats) {
                 lineData.push({
                   data: lineDataFromInsights(
+                    secondaryEmail,
                     secondaryInsights,
                     secondaryStats.num_sent
                   ),

--- a/src/features/emails/components/OpenedInsightsSection.tsx
+++ b/src/features/emails/components/OpenedInsightsSection.tsx
@@ -25,6 +25,7 @@ import { ZetkinEmail } from 'utils/types/zetkin';
 import useEmailInsights from '../hooks/useEmailInsights';
 import useEmailStats from '../hooks/useEmailStats';
 import useSecondaryEmailInsights from '../hooks/useSecondaryEmailInsights';
+import { EmailInsights } from '../types';
 
 type Props = {
   email: ZetkinEmail;
@@ -59,6 +60,19 @@ function axisFromSpanValue(value: string): AxisProps {
       tickValues: value == 'firstWeek' ? 7 : 15,
     };
   }
+}
+
+function lineDataFromInsights(
+  insights: EmailInsights,
+  numSent: number
+): { x: number; y: number }[] {
+  return insights.opensByDate.map((openEvent) => ({
+    x:
+      (new Date(openEvent.date).getTime() -
+        new Date(insights.opensByDate[0].date).getTime()) /
+      1000,
+    y: openEvent.accumulatedOpens / numSent,
+  }));
 }
 
 const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
@@ -167,28 +181,17 @@ const OpenedInsightsSection: FC<Props> = ({ email, secondaryEmailId }) => {
             }) => {
               const lineData = [
                 {
-                  data: mainInsights.opensByDate.map((openEvent) => ({
-                    x:
-                      (new Date(openEvent.date).getTime() -
-                        new Date(mainInsights.opensByDate[0].date).getTime()) /
-                      1000,
-                    y: openEvent.accumulatedOpens / stats.numSent,
-                  })),
+                  data: lineDataFromInsights(mainInsights, stats.numSent),
                   id: 'main',
                 },
               ];
 
               if (secondaryInsights && secondaryStats) {
                 lineData.push({
-                  data: secondaryInsights.opensByDate.map((openEvent) => ({
-                    x:
-                      (new Date(openEvent.date).getTime() -
-                        new Date(
-                          secondaryInsights.opensByDate[0].date
-                        ).getTime()) /
-                      1000,
-                    y: openEvent.accumulatedOpens / secondaryStats.num_sent,
-                  })),
+                  data: lineDataFromInsights(
+                    secondaryInsights,
+                    secondaryStats.num_sent
+                  ),
                   id: 'secondary',
                 });
               }

--- a/src/features/emails/hooks/useEmailInsights.ts
+++ b/src/features/emails/hooks/useEmailInsights.ts
@@ -1,0 +1,23 @@
+import { IFuture } from 'core/caching/futures';
+import { EmailInsights } from '../types';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { loadItemIfNecessary } from 'core/caching/cacheUtils';
+import { insightsLoad, insightsLoaded } from '../store';
+import getEmailInsights from '../rpc/getEmailInsights';
+
+export default function useEmailInsights(
+  orgId: number,
+  emailId: number
+): IFuture<EmailInsights> {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const item = useAppSelector(
+    (state) => state.emails.insightsByEmailId[emailId]
+  );
+
+  return loadItemIfNecessary(item, dispatch, {
+    actionOnLoad: () => insightsLoad(emailId),
+    actionOnSuccess: (data) => insightsLoaded(data),
+    loader: () => apiClient.rpc(getEmailInsights, { emailId, orgId }),
+  });
+}

--- a/src/features/emails/hooks/useEmailStats.ts
+++ b/src/features/emails/hooks/useEmailStats.ts
@@ -4,24 +4,10 @@ import { loadItemIfNecessary } from 'core/caching/cacheUtils';
 import useEmail from './useEmail';
 import { statsLoad, statsLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-
-export interface EmailStats {
-  id: number;
-  num_target_matches: number;
-  num_locked_targets: number | null;
-  num_blocked: {
-    any: number;
-    blacklisted: number;
-    no_email: number;
-    unsubscribed: number;
-  };
-  num_sent: number;
-  num_opened: number;
-  num_clicked: number;
-}
+import { ZetkinEmailStats } from '../types';
 
 interface UseEmailStatsReturn {
-  data: EmailStats | null;
+  data: ZetkinEmailStats | null;
   error: unknown | null;
   isLoading: boolean;
   lockedReadyTargets: number | null;
@@ -52,7 +38,7 @@ export default function useEmailStats(
     actionOnLoad: () => statsLoad(emailId),
     actionOnSuccess: (data) => statsLoaded(data),
     loader: async () => {
-      const data = await apiClient.get<EmailStats & { id: number }>(
+      const data = await apiClient.get<ZetkinEmailStats & { id: number }>(
         `/api/orgs/${orgId}/emails/${emailId}/stats`
       );
       return { ...data, id: emailId };
@@ -72,7 +58,8 @@ export default function useEmailStats(
         no_email: 0,
         unsubscribed: 0,
       },
-      num_clicked: 0,
+      num_clicks: 0,
+      num_clicks_by_link: {},
       num_locked_targets: 0,
       num_opened: 0,
       num_sent: 0,
@@ -95,7 +82,7 @@ export default function useEmailStats(
       noEmail: statsFuture.data?.num_blocked.no_email ?? 0,
       unsubscribed: statsFuture.data?.num_blocked.unsubscribed ?? 0,
     },
-    numClicked: statsFuture.data?.num_clicked ?? 0,
+    numClicked: statsFuture.data?.num_clicks ?? 0,
     numLockedTargets: statsFuture.data?.num_locked_targets ?? 0,
     numOpened: statsFuture.data?.num_opened ?? 0,
     numSent: statsFuture.data?.num_sent ?? 0,

--- a/src/features/emails/hooks/useSecondaryEmailInsights.ts
+++ b/src/features/emails/hooks/useSecondaryEmailInsights.ts
@@ -1,0 +1,71 @@
+import { IFuture, ResolvedFuture } from 'core/caching/futures';
+import { EmailInsights, ZetkinEmailStats } from '../types';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { loadItemIfNecessary } from 'core/caching/cacheUtils';
+import {
+  emailLoad,
+  emailLoaded,
+  insightsLoad,
+  insightsLoaded,
+  statsLoad,
+  statsLoaded,
+} from '../store';
+import getEmailInsights from '../rpc/getEmailInsights';
+import { ZetkinEmail } from 'utils/types/zetkin';
+
+type UseSecondaryEmailInsightsReturn = {
+  emailFuture: IFuture<ZetkinEmail | null>;
+  insightsFuture: IFuture<EmailInsights | null>;
+  statsFuture: IFuture<ZetkinEmailStats | null>;
+};
+
+export default function useSecondaryEmailInsights(
+  orgId: number,
+  emailId: number | null
+): UseSecondaryEmailInsightsReturn {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const state = useAppSelector((state) => state.emails);
+
+  if (!emailId) {
+    return {
+      emailFuture: new ResolvedFuture(null),
+      insightsFuture: new ResolvedFuture(null),
+      statsFuture: new ResolvedFuture(null),
+    };
+  }
+
+  const emailItem = state.emailList.items.find((item) => item.id == emailId);
+  const emailFuture = loadItemIfNecessary(emailItem, dispatch, {
+    actionOnLoad: () => emailLoad(emailId),
+    actionOnSuccess: (email) => emailLoaded(email),
+    loader: () => apiClient.get(`/api/orgs/${orgId}/emails/${emailId}`),
+  });
+
+  const insightsFuture = loadItemIfNecessary(
+    state.insightsByEmailId[emailId],
+    dispatch,
+    {
+      actionOnLoad: () => insightsLoad(emailId),
+      actionOnSuccess: (data) => insightsLoaded(data),
+      loader: () => apiClient.rpc(getEmailInsights, { emailId, orgId }),
+    }
+  );
+
+  const statsFuture = loadItemIfNecessary(state.statsById[emailId], dispatch, {
+    actionOnLoad: () => statsLoad(emailId),
+    actionOnSuccess: (data) => statsLoaded(data),
+    loader: async () => {
+      const data = await apiClient.get<ZetkinEmailStats & { id: number }>(
+        `/api/orgs/${orgId}/emails/${emailId}/stats`
+      );
+      return { ...data, id: emailId };
+    },
+  });
+
+  return {
+    emailFuture,
+    insightsFuture,
+    statsFuture,
+  };
+}

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -124,6 +124,15 @@ export default makeMessages('feat.emails', {
     goBackButton: m('Go back'),
   },
   insights: {
+    clicked: {
+      description: m(
+        'Click rate is the percentage of recipients who not only opened the email but also clicked one of the links. A high rate is an indicator of a well-targeted email with convincing copy.'
+      ),
+      gauge: {
+        header: m('Click rate'),
+      },
+      header: m('Clicked'),
+    },
     opened: {
       description: m(
         'Open rate is the percentage of recipients who opened the email. A high rate is an indicator of good targeting and a compelling subject line.'

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -123,6 +123,17 @@ export default makeMessages('feat.emails', {
     ),
     goBackButton: m('Go back'),
   },
+  insights: {
+    opened: {
+      description: m(
+        'Open rate is the percentage of recipients who opened the email. A high rate is an indicator of good targeting and a compelling subject line.'
+      ),
+      gauge: {
+        header: m('Open rate'),
+      },
+      header: m('Opened'),
+    },
+  },
   ready: {
     loading: m('Loading...'),
     lockButton: m('Lock for delivery'),
@@ -154,6 +165,7 @@ export default makeMessages('feat.emails', {
   },
   tabs: {
     compose: m('Compose'),
+    insights: m('Insights'),
     overview: m('Overview'),
   },
   targets: {

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -156,8 +156,8 @@ export default makeMessages('feat.emails', {
           allTime: m('All time'),
           first24: m('First 24 hours'),
           first48: m('First 48 hours'),
-          firstMonth: m('First month'),
-          firstWeek: m('First week'),
+          firstMonth: m('First 30 days'),
+          firstWeek: m('First 7 days'),
         },
       },
       description: m(

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -135,7 +135,6 @@ export default makeMessages('feat.emails', {
     },
     comparison: {
       label: m('Compare with'),
-      noneOption: m('(No other email)'),
     },
     opened: {
       chart: {

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -134,6 +134,10 @@ export default makeMessages('feat.emails', {
       header: m('Clicked'),
     },
     opened: {
+      chart: {
+        afterSend: m('After it was sent'),
+        opened: m<{ count: number }>('{count} opened'),
+      },
       description: m(
         'Open rate is the percentage of recipients who opened the email. A high rate is an indicator of good targeting and a compelling subject line.'
       ),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -125,13 +125,25 @@ export default makeMessages('feat.emails', {
   },
   insights: {
     clicked: {
-      description: m(
-        'Click rate is the percentage of recipients who not only opened the email but also clicked one of the links. A high rate is an indicator of a well-targeted email with convincing copy.'
-      ),
+      descriptions: {
+        ctor: m(
+          'Click-to-open rate (CTOR) is the share of those who have opened the email that also clicked one of the links. A high rate is an indicator of a well-targeted email with convincing copy.'
+        ),
+        ctr: m(
+          'Clickthrough rate (CTR) is the percentage of recipients who not only opened the email but also clicked one of the links. A high rate is an indicator of a well-targeted email with convincing copy.'
+        ),
+      },
       gauge: {
-        header: m('Click rate'),
+        headers: {
+          ctor: m('CTOR'),
+          ctr: m('CTR'),
+        },
       },
       header: m('Clicked'),
+      metrics: {
+        ctor: m('CTOR'),
+        ctr: m('CTR'),
+      },
     },
     comparison: {
       label: m('Compare with'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -133,6 +133,10 @@ export default makeMessages('feat.emails', {
       },
       header: m('Clicked'),
     },
+    comparison: {
+      label: m('Compare with'),
+      noneOption: m('(No other email)'),
+    },
     opened: {
       chart: {
         afterSend: m('After it was sent'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -137,6 +137,13 @@ export default makeMessages('feat.emails', {
       chart: {
         afterSend: m('After it was sent'),
         opened: m<{ count: number }>('{count} opened'),
+        spans: {
+          allTime: m('All time'),
+          first24: m('First 24 hours'),
+          first48: m('First 48 hours'),
+          firstMonth: m('First month'),
+          firstWeek: m('First week'),
+        },
       },
       description: m(
         'Open rate is the percentage of recipients who opened the email. A high rate is an indicator of good targeting and a compelling subject line.'

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -40,6 +40,24 @@ const EmailLayout: FC<EmailLayoutProps> = ({
     return null;
   }
 
+  const tabs = [
+    {
+      href: '/',
+      label: messages.tabs.overview(),
+    },
+    {
+      href: '/compose',
+      label: messages.tabs.compose(),
+    },
+  ];
+
+  if (email.processed) {
+    tabs.push({
+      href: '/insights',
+      label: messages.tabs.insights(),
+    });
+  }
+
   return (
     <>
       <TabbedLayout
@@ -91,20 +109,7 @@ const EmailLayout: FC<EmailLayoutProps> = ({
             </Box>
           </Box>
         }
-        tabs={[
-          {
-            href: '/',
-            label: messages.tabs.overview(),
-          },
-          {
-            href: '/compose',
-            label: messages.tabs.compose(),
-          },
-          {
-            href: '/insights',
-            label: messages.tabs.insights(),
-          },
-        ]}
+        tabs={tabs}
         title={
           <ZUIEditTextinPlace
             onChange={(newTitle) => {

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -100,6 +100,10 @@ const EmailLayout: FC<EmailLayoutProps> = ({
             href: '/compose',
             label: messages.tabs.compose(),
           },
+          {
+            href: '/insights',
+            label: messages.tabs.insights(),
+          },
         ]}
         title={
           <ZUIEditTextinPlace

--- a/src/features/emails/rpc/getEmailInsights.ts
+++ b/src/features/emails/rpc/getEmailInsights.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import { EmailInsights, ZetkinEmailRecipient } from '../types';
+
+const paramsSchema = z.object({
+  emailId: z.number(),
+  orgId: z.number(),
+});
+type Params = z.input<typeof paramsSchema>;
+type Result = EmailInsights;
+
+export const getEmailInsightsDef = {
+  handler: handle,
+  name: 'getEmailInsights',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, Result>(getEmailInsightsDef.name);
+
+async function handle(params: Params, apiClient: IApiClient) {
+  const { emailId, orgId } = params;
+
+  const recipients = await apiClient.get<ZetkinEmailRecipient[]>(
+    `/api/orgs/${orgId}/emails/${emailId}/recipients`
+  );
+
+  const sortedOpens = recipients
+    .filter((recipient) => !!recipient.opened)
+    .sort(
+      (a, b) =>
+        new Date(a.opened || 0).getTime() - new Date(b.opened || 0).getTime()
+    );
+
+  const output: Result = {
+    id: emailId,
+    opensByDate: [],
+  };
+
+  const firstEvent = sortedOpens[0];
+
+  if (firstEvent?.opened) {
+    let dateOfLastPoint = new Date(0);
+    const minPointDiff = 5 * 60 * 1000; // 5 minutes
+
+    sortedOpens.forEach((recipient, index) => {
+      const openDate = new Date(recipient.opened || 0);
+
+      const diff = openDate.getTime() - dateOfLastPoint.getTime();
+      const isLast = index == sortedOpens.length - 1;
+
+      if (diff > minPointDiff || isLast) {
+        dateOfLastPoint = new Date(openDate);
+        output.opensByDate.push({
+          accumulatedOpens: index + 1,
+          date: openDate.toISOString(),
+        });
+      }
+    });
+  }
+
+  return output;
+}

--- a/src/features/emails/rpc/renderEmail/client.ts
+++ b/src/features/emails/rpc/renderEmail/client.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import { makeRPCDef } from 'core/rpc/types';
+
+export const paramsSchema = z.object({
+  emailId: z.number(),
+  orgId: z.number(),
+});
+export type Params = z.input<typeof paramsSchema>;
+export type Result = {
+  html: string;
+};
+
+export default makeRPCDef<Params, Result>('renderEmail');

--- a/src/features/emails/rpc/renderEmail/server.ts
+++ b/src/features/emails/rpc/renderEmail/server.ts
@@ -1,0 +1,30 @@
+import IApiClient from 'core/api/client/IApiClient';
+import { ZetkinEmail, ZetkinUser } from 'utils/types/zetkin';
+import renderEmailHtml from '../../utils/rendering/renderEmailHtml';
+import { Params, paramsSchema } from './client';
+
+export const renderEmailDef = {
+  handler: handle,
+  name: 'renderEmail',
+  schema: paramsSchema,
+};
+
+async function handle(params: Params, apiClient: IApiClient) {
+  const { emailId, orgId } = params;
+
+  const user = await apiClient.get<ZetkinUser>('/api/users/me');
+
+  const email = await apiClient.get<ZetkinEmail>(
+    `/api/orgs/${orgId}/emails/${emailId}`
+  );
+
+  const html = renderEmailHtml(email, {
+    'target.first_name': user.first_name,
+    'target.full_name': `${user.first_name} ${user.last_name}`,
+    'target.last_name': user.last_name,
+  });
+
+  return {
+    html: html,
+  };
+}

--- a/src/features/emails/store.ts
+++ b/src/features/emails/store.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { EmailStats } from './hooks/useEmailStats';
-import { EmailTheme } from './types';
+import { EmailInsights, EmailTheme } from './types';
 import {
   RemoteItem,
   remoteItem,
@@ -15,10 +15,12 @@ export interface EmailStoreSlice {
   themeList: RemoteList<EmailTheme>;
   linksByEmailId: Record<number, RemoteList<ZetkinLink>>;
   statsById: Record<number, RemoteItem<EmailStats>>;
+  insightsByEmailId: Record<number, RemoteItem<EmailInsights>>;
 }
 
 const initialState: EmailStoreSlice = {
   emailList: remoteList(),
+  insightsByEmailId: {},
   linksByEmailId: {},
   statsById: {},
   themeList: remoteList(),
@@ -120,6 +122,18 @@ const emailsSlice = createSlice({
       state.emailList.loaded = timestamp;
       state.emailList.items.forEach((item) => (item.loaded = timestamp));
     },
+    insightsLoad: (state, action: PayloadAction<number>) => {
+      const emailId = action.payload;
+      state.insightsByEmailId[emailId] ||= remoteItem<EmailInsights>(emailId);
+      state.insightsByEmailId[emailId].isLoading = true;
+    },
+    insightsLoaded: (state, action: PayloadAction<EmailInsights>) => {
+      const insights = action.payload;
+      state.insightsByEmailId[insights.id] = remoteItem(insights.id, {
+        data: insights,
+        loaded: new Date().toISOString(),
+      });
+    },
     statsLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const statsItem = state.statsById[id];
@@ -181,6 +195,8 @@ export const {
   emailUpdated,
   emailsLoad,
   emailsLoaded,
+  insightsLoad,
+  insightsLoaded,
   themesLoad,
   themesLoaded,
   statsLoad,

--- a/src/features/emails/store.ts
+++ b/src/features/emails/store.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { EmailStats } from './hooks/useEmailStats';
-import { EmailInsights, EmailTheme } from './types';
+import { EmailInsights, EmailTheme, ZetkinEmailStats } from './types';
 import {
   RemoteItem,
   remoteItem,
@@ -14,7 +13,7 @@ export interface EmailStoreSlice {
   emailList: RemoteList<ZetkinEmail>;
   themeList: RemoteList<EmailTheme>;
   linksByEmailId: Record<number, RemoteList<ZetkinLink>>;
-  statsById: Record<number, RemoteItem<EmailStats>>;
+  statsById: Record<number, RemoteItem<ZetkinEmailStats>>;
   insightsByEmailId: Record<number, RemoteItem<EmailInsights>>;
 }
 
@@ -137,7 +136,7 @@ const emailsSlice = createSlice({
     statsLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const statsItem = state.statsById[id];
-      state.statsById[id] = remoteItem<EmailStats>(id, {
+      state.statsById[id] = remoteItem<ZetkinEmailStats>(id, {
         data: statsItem?.data || {
           id,
           num_blocked: {
@@ -146,7 +145,8 @@ const emailsSlice = createSlice({
             no_email: 0,
             unsubscribed: 0,
           },
-          num_clicked: 0,
+          num_clicks: 0,
+          num_clicks_by_link: {},
           num_locked_targets: 0,
           num_opened: 0,
           num_sent: 0,
@@ -157,9 +157,9 @@ const emailsSlice = createSlice({
     },
     statsLoaded: (
       state,
-      action: PayloadAction<EmailStats & { id: number }>
+      action: PayloadAction<ZetkinEmailStats & { id: number }>
     ) => {
-      state.statsById[action.payload.id] = remoteItem<EmailStats>(
+      state.statsById[action.payload.id] = remoteItem<ZetkinEmailStats>(
         action.payload.id,
         {
           data: action.payload,

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -191,8 +191,21 @@ export type ZetkinEmailRecipient = {
   status: 'pending' | 'sent' | 'opened';
 };
 
+export type ZetkinEmailLink = {
+  email: {
+    id: number;
+    title: string;
+  };
+  id: number;
+  tag: string;
+  url: string;
+};
+
+type EmailLinkWithMeta = ZetkinEmailLink & { clicks: number; text: string };
+
 export type EmailInsights = {
   id: number;
+  links: EmailLinkWithMeta[];
   opensByDate: {
     accumulatedOpens: number;
     date: string;

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -171,3 +171,30 @@ export type EmailTheme = {
   frame_mjml: MJMLJsonObject | null;
   id: number;
 };
+
+export type ZetkinEmailRecipient = {
+  delivered: string | null;
+  email: {
+    id: number;
+    title: string;
+  };
+  email_address: null;
+  error: null;
+  id: number;
+  opened: string | null;
+  person: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
+  sent: string | null;
+  status: 'pending' | 'sent' | 'opened';
+};
+
+export type EmailInsights = {
+  id: number;
+  opensByDate: {
+    accumulatedOpens: number;
+    date: string;
+  }[];
+};

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -198,3 +198,19 @@ export type EmailInsights = {
     date: string;
   }[];
 };
+
+export type ZetkinEmailStats = {
+  id: number;
+  num_blocked: {
+    any: number;
+    blacklisted: number;
+    no_email: number;
+    unsubscribed: number;
+  };
+  num_clicks: number;
+  num_clicks_by_link: Record<number, number | undefined>;
+  num_locked_targets: number | null;
+  num_opened: number;
+  num_sent: number;
+  num_target_matches: number;
+};

--- a/src/features/emails/utils/deliveryProblems.spec.ts
+++ b/src/features/emails/utils/deliveryProblems.spec.ts
@@ -23,6 +23,7 @@ const mockEmail = (emailOverrides?: Partial<ZetkinEmail>): ZetkinEmail => {
     id: 1,
     locked: '2024-02-26T12:27:32.237413',
     organization: { id: 1, title: 'My Organization' },
+    processed: null,
     published: null,
     subject: 'Hello new member!',
     target: {

--- a/src/features/emails/utils/getRelevantDataPoints.spec.ts
+++ b/src/features/emails/utils/getRelevantDataPoints.spec.ts
@@ -1,0 +1,180 @@
+import getRelevantDataPoints from './getRelevantDataPoints';
+
+describe('getRelevantDataPoints()', () => {
+  it('returns exact point from main if secondary is null', () => {
+    const input = {
+      id: 'main.1',
+    };
+
+    const mainSeries = {
+      startDate: new Date('1857-07-05T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1857-07-05T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1857-07-05T13:38:00.000Z',
+        },
+      ],
+    };
+
+    const result = getRelevantDataPoints(input, mainSeries, null);
+
+    expect(result.secondaryPoint).toBeNull();
+    expect(result.mainPoint).toEqual(mainSeries.values[1]);
+  });
+
+  it('returns nearest preceding from secondary for main input', () => {
+    const input = {
+      id: 'main.1',
+    };
+
+    const mainSeries = {
+      startDate: new Date('1857-07-05T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1857-07-05T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1857-07-05T13:38:00.000Z',
+        },
+      ],
+    };
+
+    const secondarySeries = {
+      startDate: new Date('1933-06-20T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1933-06-20T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1933-06-20T13:39:00.000Z',
+        },
+      ],
+    };
+
+    const result = getRelevantDataPoints(input, mainSeries, secondarySeries);
+
+    expect(result.mainPoint).toEqual(mainSeries.values[1]);
+    expect(result.secondaryPoint).toEqual(secondarySeries.values[0]);
+  });
+
+  it('returns nearest preceding from secondary when main is in the past', () => {
+    const input = {
+      id: 'main.0',
+    };
+
+    const secondarySeries = {
+      startDate: new Date('1857-07-05T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1857-07-05T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1857-07-05T13:38:00.000Z',
+        },
+      ],
+    };
+
+    const mainSeries = {
+      startDate: new Date('1933-06-20T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1933-06-20T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1933-06-20T13:39:00.000Z',
+        },
+      ],
+    };
+
+    const result = getRelevantDataPoints(input, mainSeries, secondarySeries);
+
+    expect(result.mainPoint).toEqual(mainSeries.values[0]);
+    expect(result.secondaryPoint).toEqual(secondarySeries.values[0]);
+  });
+
+  it('returns nearest preceding from main for secondary input', () => {
+    const input = {
+      id: 'secondary.1',
+    };
+
+    const secondarySeries = {
+      startDate: new Date('1933-06-20T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1933-06-20T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1933-06-20T13:38:00.000Z',
+        },
+      ],
+    };
+
+    const mainSeries = {
+      startDate: new Date('1857-07-05T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1857-07-05T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1857-07-05T13:39:00.000Z',
+        },
+      ],
+    };
+
+    const result = getRelevantDataPoints(input, mainSeries, secondarySeries);
+
+    expect(result.secondaryPoint).toEqual(secondarySeries.values[1]);
+    expect(result.mainPoint).toEqual(mainSeries.values[0]);
+  });
+
+  it('returns last from secondary if main exceeds duration', () => {
+    const input = {
+      id: 'main.1',
+    };
+
+    const mainSeries = {
+      startDate: new Date('1857-07-05T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1857-07-05T13:37:00.000Z',
+        },
+        {
+          accumulatedOpens: 125,
+          date: '1857-07-05T14:37:00.000Z', // 1 hour later
+        },
+      ],
+    };
+
+    const secondarySeries = {
+      startDate: new Date('1933-06-20T13:37:00.000Z'),
+      values: [
+        {
+          accumulatedOpens: 123,
+          date: '1933-06-20T13:37:00.000Z',
+        },
+      ],
+    };
+
+    const result = getRelevantDataPoints(input, mainSeries, secondarySeries);
+
+    expect(result.mainPoint).toEqual(mainSeries.values[1]);
+    expect(result.secondaryPoint).toEqual(secondarySeries.values[0]);
+  });
+});

--- a/src/features/emails/utils/getRelevantDataPoints.ts
+++ b/src/features/emails/utils/getRelevantDataPoints.ts
@@ -1,0 +1,75 @@
+import { EmailInsights } from '../types';
+
+type InputPoint = {
+  id: string;
+};
+
+type OutputPoint = EmailInsights['opensByDate'][0];
+
+type GetRelevantDataPoints = {
+  mainPoint: OutputPoint;
+  secondaryPoint: OutputPoint | null;
+};
+
+type Series = {
+  startDate: Date;
+  values: OutputPoint[];
+};
+
+export default function getRelevantDataPoints(
+  inputPoint: InputPoint,
+  main: Series,
+  secondary: Series | null
+): GetRelevantDataPoints {
+  const [serieId, indexStr] = inputPoint.id.split('.');
+  const index = parseInt(indexStr);
+  if (serieId == 'main') {
+    const mainPoint = main.values[index];
+    const mainDate = new Date(mainPoint.date);
+    const mainOffset = mainDate.getTime() - main.startDate.getTime();
+
+    const secondaryPoint =
+      secondary?.values.find((_, index) => {
+        const nextPoint = secondary.values[index + 1];
+        if (!nextPoint) {
+          return true;
+        }
+
+        const nextOffset =
+          new Date(nextPoint.date).getTime() - secondary.startDate.getTime();
+
+        return nextOffset > mainOffset;
+      }) ?? null;
+
+    return {
+      mainPoint: mainPoint,
+      secondaryPoint: secondaryPoint,
+    };
+  } else if (secondary) {
+    const secondaryPoint = secondary.values[index];
+    const secondaryDate = new Date(secondaryPoint.date);
+    const secondaryOffset =
+      secondaryDate.getTime() - secondary.startDate.getTime();
+
+    const mainPoint = main.values.find((item, index) => {
+      const nextPoint = main.values[index + 1];
+      if (!nextPoint) {
+        return true;
+      }
+
+      const nextOffset =
+        new Date(nextPoint.date).getTime() - main.startDate.getTime();
+
+      return nextOffset > secondaryOffset;
+    });
+
+    return {
+      mainPoint: mainPoint!,
+      secondaryPoint,
+    };
+  } else {
+    throw new Error(
+      'Secondary series must be supplied when input point is from secondary'
+    );
+  }
+}

--- a/src/features/emails/utils/getRelevantDataPoints.ts
+++ b/src/features/emails/utils/getRelevantDataPoints.ts
@@ -7,7 +7,7 @@ type InputPoint = {
 type OutputPoint = EmailInsights['opensByDate'][0];
 
 type GetRelevantDataPoints = {
-  mainPoint: OutputPoint;
+  mainPoint: OutputPoint | null;
   secondaryPoint: OutputPoint | null;
 };
 
@@ -64,7 +64,7 @@ export default function getRelevantDataPoints(
     });
 
     return {
-      mainPoint: mainPoint!,
+      mainPoint: mainPoint || null,
       secondaryPoint,
     };
   } else {

--- a/src/features/emails/utils/rendering/EmailMJMLConverter.ts
+++ b/src/features/emails/utils/rendering/EmailMJMLConverter.ts
@@ -38,6 +38,7 @@ export default class EmailMJMLConverter {
           tagName: 'mj-button',
           attributes: {
             ...frame?.block_attributes?.button,
+            'css-class': `email-link-${block.data.tag}`,
             href: block.data.href,
           },
           content: block.data.text,
@@ -113,7 +114,7 @@ function inlineNodesToPlainHTML(nodes: EmailContentInlineNode[]): string {
       output += `<i>${htmlContent}</i>`;
     } else if (node.kind == 'link') {
       const htmlContent = inlineNodesToPlainHTML(node.content);
-      output += `<a href="${node.href}">${htmlContent}</a>`;
+      output += `<a class="email-link-${node.tag}" href="${node.href}">${htmlContent}</a>`;
     } else if (node.kind == 'lineBreak') {
       output += '<br>';
     }

--- a/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
@@ -325,6 +325,7 @@ export default function mockEmail(
       title: 'Organization',
     },
     published: null,
+    processed: null,
     subject: 'This is the subject',
     target: {
       id: 1,

--- a/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
@@ -126,11 +126,12 @@ describe('renderEmailHtml', () => {
                       tagName: 'mj-text',
                       attributes: {},
                       content:
-                        '<p>We want to invite you to <a href="https://zetkin.org">our <b>PARTY</b></a>, friend</p>',
+                        '<p>We want to invite you to <a class="email-link-thelink" href="https://zetkin.org">our <b>PARTY</b></a>, friend</p>',
                     },
                     {
                       tagName: 'mj-button',
                       attributes: {
+                        'css-class': 'email-link-thebutton',
                         href: 'https://zetkin.org',
                       },
                       content: 'I want to come',
@@ -288,6 +289,7 @@ describe('renderEmailHtml', () => {
                           tagName: 'mj-button',
                           attributes: {
                             'background-color': 'green',
+                            'css-class': 'email-link-thebutton',
                             'font-size': '22px',
                             href: 'https://zetkin.org',
                             padding: '20px',

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -13,6 +13,7 @@ import { ResponsiveLine } from '@nivo/line';
 import { linearGradientDef } from '@nivo/core';
 import { FormattedTime } from 'react-intl';
 import { OpenInNew } from '@mui/icons-material';
+import DOMPurify from 'dompurify';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
@@ -54,6 +55,8 @@ const EmailPage: PageWithLayout = () => {
   if (onServer || !email) {
     return null;
   }
+
+  const sanitizer = DOMPurify();
 
   return (
     <>
@@ -179,7 +182,12 @@ const EmailPage: PageWithLayout = () => {
                   {insights.links.map((link) => (
                     <TableRow key={link.id}>
                       <TableCell>{link.clicks}</TableCell>
-                      <TableCell>{link.text}</TableCell>
+                      <TableCell>
+                        {sanitizer.sanitize(link.text, {
+                          // Remove all inline tags that may exist here
+                          ALLOWED_TAGS: ['#text'],
+                        })}
+                      </TableCell>
                       <TableCell>
                         <Link
                           display="flex"

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -362,6 +362,11 @@ const EmailPage: PageWithLayout = () => {
                               }
                             : null
                         );
+
+                      if (!mainPoint) {
+                        return null;
+                      }
+
                       const count = mainPoint.accumulatedOpens;
                       const date = new Date(mainPoint.date);
 

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -21,7 +21,7 @@ import { linearGradientDef } from '@nivo/core';
 import { OpenInNew } from '@mui/icons-material';
 import DOMPurify from 'dompurify';
 import { useState } from 'react';
-import { FormattedDate } from 'react-intl';
+import { FormattedTime } from 'react-intl';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
@@ -357,7 +357,7 @@ const EmailPage: PageWithLayout = () => {
                         (date.getTime() - publishDate.getTime()) / 1000;
 
                       return (
-                        <Paper sx={{ minWidth: 200 }}>
+                        <Paper sx={{ minWidth: 240 }}>
                           <Box p={2}>
                             <Typography variant="h6">
                               <ZUIDuration seconds={secondsAfterPublish} />
@@ -378,7 +378,11 @@ const EmailPage: PageWithLayout = () => {
                             >
                               <Box>
                                 <Typography variant="body2">
-                                  <FormattedDate value={date} />
+                                  <FormattedTime
+                                    day="numeric"
+                                    month="short"
+                                    value={date}
+                                  />
                                 </Typography>
                                 <Typography variant="body2">
                                   <Msg
@@ -406,7 +410,9 @@ const EmailPage: PageWithLayout = () => {
                                 >
                                   <Box>
                                     <Typography variant="body2">
-                                      <FormattedDate
+                                      <FormattedTime
+                                        day="numeric"
+                                        month="short"
                                         value={secondaryPoint.date}
                                       />
                                     </Typography>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -12,6 +12,8 @@ import {
   TableCell,
   TableRow,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
   useTheme,
 } from '@mui/material';
@@ -87,6 +89,7 @@ function axisFromSpanValue(value: string): AxisProps {
 }
 
 const EmailPage: PageWithLayout = () => {
+  const [clickMetric, setClickMetric] = useState<'ctr' | 'ctor'>('ctr');
   const [secondaryEmailId, setSecondaryEmailId] = useState(0);
   const [timeSpan, setTimeSpan] = useState<string>('first48');
   const messages = useMessages(messageIds);
@@ -479,14 +482,39 @@ const EmailPage: PageWithLayout = () => {
                   <EmailKPIChart
                     email={email}
                     secondaryEmail={secondaryEmail}
-                    secondaryTotal={secondaryStats?.num_sent ?? null}
+                    secondaryTotal={
+                      clickMetric == 'ctr'
+                        ? secondaryStats?.num_sent ?? null
+                        : secondaryStats?.num_opened ?? null
+                    }
                     secondaryValue={secondaryStats?.num_clicks ?? null}
-                    title={messages.insights.clicked.gauge.header()}
-                    total={stats.numSent}
+                    title={messages.insights.clicked.gauge.headers[
+                      clickMetric
+                    ]()}
+                    total={
+                      clickMetric == 'ctr' ? stats.numSent : stats.numOpened
+                    }
                     value={stats.numClicked}
                   />
+                  <Box display="flex" justifyContent="center">
+                    <ToggleButtonGroup
+                      exclusive
+                      onChange={(_, value) =>
+                        setClickMetric(value || clickMetric)
+                      }
+                      size="small"
+                      value={clickMetric}
+                    >
+                      <ToggleButton value="ctr">
+                        {messages.insights.clicked.metrics.ctr()}
+                      </ToggleButton>
+                      <ToggleButton value="ctor">
+                        {messages.insights.clicked.metrics.ctor()}
+                      </ToggleButton>
+                    </ToggleButtonGroup>
+                  </Box>
                   <Typography mb={2} mt={1} variant="body2">
-                    {messages.insights.clicked.description()}
+                    {messages.insights.clicked.descriptions[clickMetric]()}
                   </Typography>
                 </>
               )}

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -1,10 +1,18 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { Paper, Typography } from '@mui/material';
+import {
+  Link,
+  Paper,
+  Table,
+  TableCell,
+  TableRow,
+  Typography,
+} from '@mui/material';
 import { Box, useTheme } from '@mui/system';
 import { ResponsiveLine } from '@nivo/line';
 import { linearGradientDef } from '@nivo/core';
 import { FormattedTime } from 'react-intl';
+import { OpenInNew } from '@mui/icons-material';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
@@ -60,8 +68,9 @@ const EmailPage: PageWithLayout = () => {
             value={stats.numOpened}
           />
         }
+        sx={{ mb: 2 }}
       >
-        <Box display="flex" gap={1}>
+        <Box display="flex" gap={2}>
           <Box flexGrow={0} maxWidth={300}>
             <EmailKPIChart
               email={email}
@@ -137,6 +146,54 @@ const EmailPage: PageWithLayout = () => {
                     useUTC: false,
                   }}
                 />
+              )}
+            </ZUIFuture>
+          </Box>
+        </Box>
+      </ZUICard>
+      <ZUICard
+        header={messages.insights.clicked.header()}
+        status={
+          <ZUINumberChip
+            color={theme.palette.grey[200]}
+            value={stats.numClicked}
+          />
+        }
+      >
+        <Box display="flex" gap={2}>
+          <Box flexGrow={0} maxWidth={300}>
+            <EmailKPIChart
+              email={email}
+              title={messages.insights.clicked.gauge.header()}
+              total={stats.numSent}
+              value={stats.numClicked}
+            />
+            <Typography mb={2} mt={1} variant="body2">
+              {messages.insights.clicked.description()}
+            </Typography>
+          </Box>
+          <Box flexGrow={1} minHeight={500}>
+            <ZUIFuture future={insightsFuture}>
+              {(insights) => (
+                <Table>
+                  {insights.links.map((link) => (
+                    <TableRow key={link.id}>
+                      <TableCell>{link.clicks}</TableCell>
+                      <TableCell>{link.text}</TableCell>
+                      <TableCell>
+                        <Link
+                          display="flex"
+                          gap={1}
+                          href={link.url}
+                          target="_blank"
+                        >
+                          {link.url}
+                          <OpenInNew fontSize="small" />
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </Table>
               )}
             </ZUIFuture>
           </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -120,7 +120,7 @@ const EmailPage: PageWithLayout = () => {
         <ZUIFuture future={emailsFuture}>
           {(emails) => (
             <TextField
-              label="Compare with"
+              label={messages.insights.comparison.label()}
               onChange={(ev) =>
                 setSecondaryEmailId(parseInt(ev.target.value) || 0)
               }
@@ -128,7 +128,9 @@ const EmailPage: PageWithLayout = () => {
               size="small"
               value={secondaryEmailId}
             >
-              <MenuItem value={0}>Nothing</MenuItem>
+              <MenuItem value={0}>
+                {messages.insights.comparison.noneOption()}
+              </MenuItem>
               {emails
                 .filter((email) => email.id != emailId)
                 .map((email) => (
@@ -152,15 +154,29 @@ const EmailPage: PageWithLayout = () => {
       >
         <Box display="flex" gap={2}>
           <Box flexGrow={0} maxWidth={300}>
-            <EmailKPIChart
-              email={email}
-              title={messages.insights.opened.gauge.header()}
-              total={stats.numSent}
-              value={stats.numOpened}
-            />
-            <Typography mb={2} mt={1} variant="body2">
-              {messages.insights.opened.description()}
-            </Typography>
+            <ZUIFutures
+              futures={{
+                secondaryEmail: secondaryEmailFuture,
+                secondaryStats: secondaryStatsFuture,
+              }}
+            >
+              {({ data: { secondaryEmail, secondaryStats } }) => (
+                <>
+                  <EmailKPIChart
+                    email={email}
+                    secondaryEmail={secondaryEmail}
+                    secondaryTotal={secondaryStats?.num_sent}
+                    secondaryValue={secondaryStats?.num_opened}
+                    title={messages.insights.opened.gauge.header()}
+                    total={stats.numSent}
+                    value={stats.numOpened}
+                  />
+                  <Typography mb={2} mt={1} variant="body2">
+                    {messages.insights.opened.description()}
+                  </Typography>
+                </>
+              )}
+            </ZUIFutures>
           </Box>
           <Box flexGrow={1} height={550} position="relative">
             <Box
@@ -414,15 +430,29 @@ const EmailPage: PageWithLayout = () => {
       >
         <Box display="flex" gap={2}>
           <Box flexGrow={0} maxWidth={300}>
-            <EmailKPIChart
-              email={email}
-              title={messages.insights.clicked.gauge.header()}
-              total={stats.numSent}
-              value={stats.numClicked}
-            />
-            <Typography mb={2} mt={1} variant="body2">
-              {messages.insights.clicked.description()}
-            </Typography>
+            <ZUIFutures
+              futures={{
+                secondaryEmail: secondaryEmailFuture,
+                secondaryStats: secondaryStatsFuture,
+              }}
+            >
+              {({ data: { secondaryEmail, secondaryStats } }) => (
+                <>
+                  <EmailKPIChart
+                    email={email}
+                    secondaryEmail={secondaryEmail}
+                    secondaryTotal={secondaryStats?.num_sent ?? null}
+                    secondaryValue={secondaryStats?.num_clicks ?? null}
+                    title={messages.insights.clicked.gauge.header()}
+                    total={stats.numSent}
+                    value={stats.numClicked}
+                  />
+                  <Typography mb={2} mt={1} variant="body2">
+                    {messages.insights.clicked.description()}
+                  </Typography>
+                </>
+              )}
+            </ZUIFutures>
           </Box>
           <Box flexGrow={1} minHeight={500}>
             <ZUIFuture future={insightsFuture}>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -134,7 +134,6 @@ const EmailPage: PageWithLayout = () => {
               }
               getOptionLabel={(option) => option.title || ''}
               onChange={(_, value) => setSecondaryEmailId(value?.id ?? 0)}
-              onReset={() => setSecondaryEmailId(0)}
               options={emails.filter(
                 // Can only compare with published emails, and not itself
                 (email) => email.id != emailId && email.published

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -310,7 +310,7 @@ const EmailPage: PageWithLayout = () => {
                     }}
                     colors={[
                       theme.palette.primary.main,
-                      theme.palette.secondary.dark,
+                      theme.palette.grey[600],
                     ]}
                     curve="basis"
                     data={lineData}

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -1,9 +1,11 @@
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import {
+  Autocomplete,
   Box,
   Divider,
   Link,
+  ListItem,
   MenuItem,
   Paper,
   Table,
@@ -119,26 +121,56 @@ const EmailPage: PageWithLayout = () => {
       <Box display="flex" justifyContent="flex-end" mb={1}>
         <ZUIFuture future={emailsFuture}>
           {(emails) => (
-            <TextField
-              label={messages.insights.comparison.label()}
-              onChange={(ev) =>
-                setSecondaryEmailId(parseInt(ev.target.value) || 0)
+            <Autocomplete
+              filterOptions={(options, state) =>
+                options.filter(
+                  (email) =>
+                    email.title
+                      ?.toLowerCase()
+                      .includes(state.inputValue.toLowerCase()) ||
+                    email.campaign?.title
+                      .toLowerCase()
+                      .includes(state.inputValue.toLowerCase())
+                )
               }
-              select
-              size="small"
-              value={secondaryEmailId}
-            >
-              <MenuItem value={0}>
-                {messages.insights.comparison.noneOption()}
-              </MenuItem>
-              {emails
-                .filter((email) => email.id != emailId)
-                .map((email) => (
-                  <MenuItem key={email.id} value={email.id}>
-                    {email.title}
-                  </MenuItem>
-                ))}
-            </TextField>
+              getOptionLabel={(option) => option.title || ''}
+              onChange={(_, value) => setSecondaryEmailId(value?.id ?? 0)}
+              onReset={() => setSecondaryEmailId(0)}
+              options={emails.filter(
+                // Can only compare with published emails, and not itself
+                (email) => email.id != emailId && email.published
+              )}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label={messages.insights.comparison.label()}
+                  size="small"
+                  variant="outlined"
+                />
+              )}
+              renderOption={(props, option) => (
+                <ListItem {...props}>
+                  <Box
+                    sx={{
+                      alignItems: 'stretch',
+                      display: 'flex',
+                      flexDirection: 'column',
+                    }}
+                  >
+                    <Typography>{option.title}</Typography>
+                    <Typography variant="body2">
+                      {option.campaign?.title}
+                    </Typography>
+                  </Box>
+                </ListItem>
+              )}
+              sx={{
+                minWidth: 300,
+              }}
+              value={
+                emails.find((email) => email.id == secondaryEmailId) || null
+              }
+            />
           )}
         </ZUIFuture>
       </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -1,0 +1,153 @@
+import { GetServerSideProps } from 'next';
+import Head from 'next/head';
+import { Paper, Typography } from '@mui/material';
+import { Box, useTheme } from '@mui/system';
+import { ResponsiveLine } from '@nivo/line';
+import { linearGradientDef } from '@nivo/core';
+import { FormattedTime } from 'react-intl';
+
+import EmailLayout from 'features/emails/layout/EmailLayout';
+import { PageWithLayout } from 'utils/types';
+import { scaffold } from 'utils/next';
+import useEmail from 'features/emails/hooks/useEmail';
+import useEmailStats from 'features/emails/hooks/useEmailStats';
+import { useNumericRouteParams } from 'core/hooks';
+import useServerSide from 'core/useServerSide';
+import ZUICard from 'zui/ZUICard';
+import ZUINumberChip from 'zui/ZUINumberChip';
+import EmailKPIChart from 'features/emails/components/EmailKPIChart';
+import useEmailInsights from 'features/emails/hooks/useEmailInsights';
+import ZUIFuture from 'zui/ZUIFuture';
+import { useMessages } from 'core/i18n';
+import messageIds from 'features/emails/l10n/messageIds';
+
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async () => {
+    return {
+      props: {},
+    };
+  },
+  {
+    authLevelRequired: 2,
+    localeScope: ['layout.organize.email', 'pages.organizeEmail'],
+  }
+);
+
+const EmailPage: PageWithLayout = () => {
+  const messages = useMessages(messageIds);
+  const { orgId, emailId } = useNumericRouteParams();
+  const theme = useTheme();
+  const { data: email } = useEmail(orgId, emailId);
+  const stats = useEmailStats(orgId, emailId);
+  const insightsFuture = useEmailInsights(orgId, emailId);
+
+  const onServer = useServerSide();
+
+  if (onServer || !email) {
+    return null;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{email.title}</title>
+      </Head>
+      <ZUICard
+        header={messages.insights.opened.header()}
+        status={
+          <ZUINumberChip
+            color={theme.palette.grey[200]}
+            value={stats.numOpened}
+          />
+        }
+      >
+        <Box display="flex" gap={1}>
+          <Box flexGrow={0} maxWidth={300}>
+            <EmailKPIChart
+              email={email}
+              title={messages.insights.opened.gauge.header()}
+              total={stats.numSent}
+              value={stats.numOpened}
+            />
+            <Typography mb={2} mt={1} variant="body2">
+              {messages.insights.opened.description()}
+            </Typography>
+          </Box>
+          <Box flexGrow={1} height={550}>
+            <ZUIFuture future={insightsFuture}>
+              {(insights) => (
+                <ResponsiveLine
+                  animate={false}
+                  axisBottom={{
+                    format: '%b %d',
+                  }}
+                  colors={[theme.palette.primary.main]}
+                  curve="basis"
+                  data={[
+                    {
+                      data: insights.opensByDate.map((openEvent) => ({
+                        x: new Date(openEvent.date),
+                        y: openEvent.accumulatedOpens,
+                      })),
+                      id: email.title || '',
+                    },
+                  ]}
+                  defs={[
+                    linearGradientDef('gradientA', [
+                      { color: 'inherit', offset: 0 },
+                      { color: 'inherit', offset: 100, opacity: 0 },
+                    ]),
+                  ]}
+                  enableArea={true}
+                  enableGridX={false}
+                  enableGridY={false}
+                  enablePoints={false}
+                  enableSlices="x"
+                  fill={[{ id: 'gradientA', match: '*' }]}
+                  isInteractive={true}
+                  lineWidth={3}
+                  margin={{
+                    bottom: 30,
+                    // Calculate the left margin from the number of digits
+                    // in the y axis labels, to make sure the labels will fit
+                    // inside the clipping rectangle.
+                    left:
+                      15 + insights.opensByDate.length.toString().length * 8,
+                    top: 20,
+                  }}
+                  sliceTooltip={(props) => {
+                    const dataPoint = props.slice.points[0];
+                    const date = new Date(dataPoint.data.xFormatted);
+
+                    return (
+                      <Paper>
+                        <Box p={1}>
+                          <Typography variant="h6">
+                            <FormattedTime value={date} />
+                          </Typography>
+                        </Box>
+                      </Paper>
+                    );
+                  }}
+                  xFormat="time:%Y-%m-%d %H:%M:%S.%L"
+                  xScale={{
+                    format: '%Y-%m-%d %H:%M:%S.%L',
+                    precision: 'minute',
+                    type: 'time',
+                    useUTC: false,
+                  }}
+                />
+              )}
+            </ZUIFuture>
+          </Box>
+        </Box>
+      </ZUICard>
+    </>
+  );
+};
+
+EmailPage.getLayout = function getLayout(page) {
+  return <EmailLayout>{page}</EmailLayout>;
+};
+
+export default EmailPage;

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -29,6 +29,7 @@ import useEmailInsights from 'features/emails/hooks/useEmailInsights';
 import ZUIFuture from 'zui/ZUIFuture';
 import { useMessages } from 'core/i18n';
 import messageIds from 'features/emails/l10n/messageIds';
+import EmailMiniature from 'features/emails/components/EmailMiniature';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -178,33 +179,42 @@ const EmailPage: PageWithLayout = () => {
           <Box flexGrow={1} minHeight={500}>
             <ZUIFuture future={insightsFuture}>
               {(insights) => (
-                <Table>
-                  {insights.links
-                    .concat()
-                    .sort((a, b) => b.clicks - a.clicks)
-                    .map((link) => (
-                      <TableRow key={link.id}>
-                        <TableCell>{link.clicks}</TableCell>
-                        <TableCell>
-                          {sanitizer.sanitize(link.text, {
-                            // Remove all inline tags that may exist here
-                            ALLOWED_TAGS: ['#text'],
-                          })}
-                        </TableCell>
-                        <TableCell>
-                          <Link
-                            display="flex"
-                            gap={1}
-                            href={link.url}
-                            target="_blank"
-                          >
-                            {link.url}
-                            <OpenInNew fontSize="small" />
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                </Table>
+                <Box alignItems="flex-start" display="flex">
+                  <Table>
+                    {insights.links
+                      .concat()
+                      .sort((a, b) => b.clicks - a.clicks)
+                      .map((link) => (
+                        <TableRow key={link.id}>
+                          <TableCell>{link.clicks}</TableCell>
+                          <TableCell>
+                            {sanitizer.sanitize(link.text, {
+                              // Remove all inline tags that may exist here
+                              ALLOWED_TAGS: ['#text'],
+                            })}
+                          </TableCell>
+                          <TableCell>
+                            <Link
+                              display="flex"
+                              gap={1}
+                              href={link.url}
+                              target="_blank"
+                            >
+                              {link.url}
+                              <OpenInNew fontSize="small" />
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                  </Table>
+                  <Box>
+                    <EmailMiniature
+                      emailId={emailId}
+                      orgId={orgId}
+                      width={150}
+                    />
+                  </Box>
+                </Box>
               )}
             </ZUIFuture>
           </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -14,6 +14,7 @@ import { linearGradientDef } from '@nivo/core';
 import { FormattedTime } from 'react-intl';
 import { OpenInNew } from '@mui/icons-material';
 import DOMPurify from 'dompurify';
+import { useState } from 'react';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
@@ -50,6 +51,7 @@ const EmailPage: PageWithLayout = () => {
   const { data: email } = useEmail(orgId, emailId);
   const stats = useEmailStats(orgId, emailId);
   const insightsFuture = useEmailInsights(orgId, emailId);
+  const [selectedLinkTag, setSelectedLinkTag] = useState<string | null>(null);
 
   const onServer = useServerSide();
 
@@ -185,7 +187,11 @@ const EmailPage: PageWithLayout = () => {
                       .concat()
                       .sort((a, b) => b.clicks - a.clicks)
                       .map((link) => (
-                        <TableRow key={link.id}>
+                        <TableRow
+                          key={link.id}
+                          onMouseEnter={() => setSelectedLinkTag(link.tag)}
+                          onMouseLeave={() => setSelectedLinkTag(null)}
+                        >
                           <TableCell>{link.clicks}</TableCell>
                           <TableCell>
                             {sanitizer.sanitize(link.text, {
@@ -207,13 +213,12 @@ const EmailPage: PageWithLayout = () => {
                         </TableRow>
                       ))}
                   </Table>
-                  <Box>
-                    <EmailMiniature
-                      emailId={emailId}
-                      orgId={orgId}
-                      width={150}
-                    />
-                  </Box>
+                  <EmailMiniature
+                    emailId={emailId}
+                    orgId={orgId}
+                    selectedTag={selectedLinkTag}
+                    width={150}
+                  />
                 </Box>
               )}
             </ZUIFuture>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -179,28 +179,31 @@ const EmailPage: PageWithLayout = () => {
             <ZUIFuture future={insightsFuture}>
               {(insights) => (
                 <Table>
-                  {insights.links.map((link) => (
-                    <TableRow key={link.id}>
-                      <TableCell>{link.clicks}</TableCell>
-                      <TableCell>
-                        {sanitizer.sanitize(link.text, {
-                          // Remove all inline tags that may exist here
-                          ALLOWED_TAGS: ['#text'],
-                        })}
-                      </TableCell>
-                      <TableCell>
-                        <Link
-                          display="flex"
-                          gap={1}
-                          href={link.url}
-                          target="_blank"
-                        >
-                          {link.url}
-                          <OpenInNew fontSize="small" />
-                        </Link>
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {insights.links
+                    .concat()
+                    .sort((a, b) => b.clicks - a.clicks)
+                    .map((link) => (
+                      <TableRow key={link.id}>
+                        <TableCell>{link.clicks}</TableCell>
+                        <TableCell>
+                          {sanitizer.sanitize(link.text, {
+                            // Remove all inline tags that may exist here
+                            ALLOWED_TAGS: ['#text'],
+                          })}
+                        </TableCell>
+                        <TableCell>
+                          <Link
+                            display="flex"
+                            gap={1}
+                            href={link.url}
+                            target="_blank"
+                          >
+                            {link.url}
+                            <OpenInNew fontSize="small" />
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    ))}
                 </Table>
               )}
             </ZUIFuture>

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -100,11 +100,7 @@ const EmailPage: PageWithLayout = () => {
   const insightsFuture = useEmailInsights(orgId, emailId);
   const [selectedLinkTag, setSelectedLinkTag] = useState<string | null>(null);
   const emailsFuture = useEmails(orgId);
-  const {
-    emailFuture: secondaryEmailFuture,
-    insightsFuture: secondaryInsightsFuture,
-    statsFuture: secondaryStatsFuture,
-  } = useSecondaryEmailInsights(orgId, secondaryEmailId);
+  const secondary = useSecondaryEmailInsights(orgId, secondaryEmailId);
 
   const onServer = useServerSide();
 
@@ -200,8 +196,8 @@ const EmailPage: PageWithLayout = () => {
           <Box flexGrow={0} maxWidth={300}>
             <ZUIFutures
               futures={{
-                secondaryEmail: secondaryEmailFuture,
-                secondaryStats: secondaryStatsFuture,
+                secondaryEmail: secondary.emailFuture,
+                secondaryStats: secondary.statsFuture,
               }}
             >
               {({ data: { secondaryEmail, secondaryStats } }) => (
@@ -258,9 +254,9 @@ const EmailPage: PageWithLayout = () => {
             <ZUIFutures
               futures={{
                 mainInsights: insightsFuture,
-                secondaryEmail: secondaryEmailFuture,
-                secondaryInsights: secondaryInsightsFuture,
-                secondaryStats: secondaryStatsFuture,
+                secondaryEmail: secondary.emailFuture,
+                secondaryInsights: secondary.insightsFuture,
+                secondaryStats: secondary.statsFuture,
               }}
             >
               {({
@@ -487,8 +483,8 @@ const EmailPage: PageWithLayout = () => {
           <Box flexGrow={0} maxWidth={300}>
             <ZUIFutures
               futures={{
-                secondaryEmail: secondaryEmailFuture,
-                secondaryStats: secondaryStatsFuture,
+                secondaryEmail: secondary.emailFuture,
+                secondaryStats: secondary.statsFuture,
               }}
             >
               {({ data: { secondaryEmail, secondaryStats } }) => (

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -3,48 +3,25 @@ import Head from 'next/head';
 import {
   Autocomplete,
   Box,
-  Divider,
-  Link,
   ListItem,
-  MenuItem,
-  Paper,
-  Table,
-  TableCell,
-  TableRow,
   TextField,
-  ToggleButton,
-  ToggleButtonGroup,
   Typography,
-  useTheme,
 } from '@mui/material';
-import { AxisProps } from '@nivo/axes';
-import { ResponsiveLine } from '@nivo/line';
-import { linearGradientDef } from '@nivo/core';
-import { OpenInNew } from '@mui/icons-material';
-import DOMPurify from 'dompurify';
 import { useState } from 'react';
-import { FormattedDate, FormattedTime } from 'react-intl';
+import { FormattedDate } from 'react-intl';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useEmail from 'features/emails/hooks/useEmail';
-import useEmailStats from 'features/emails/hooks/useEmailStats';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
-import ZUICard from 'zui/ZUICard';
-import ZUINumberChip from 'zui/ZUINumberChip';
-import EmailKPIChart from 'features/emails/components/EmailKPIChart';
-import useEmailInsights from 'features/emails/hooks/useEmailInsights';
 import ZUIFuture from 'zui/ZUIFuture';
-import { Msg, useMessages } from 'core/i18n';
+import { useMessages } from 'core/i18n';
 import messageIds from 'features/emails/l10n/messageIds';
-import EmailMiniature from 'features/emails/components/EmailMiniature';
-import ZUIDuration from 'zui/ZUIDuration';
-import ZUIFutures from 'zui/ZUIFutures';
-import useSecondaryEmailInsights from 'features/emails/hooks/useSecondaryEmailInsights';
-import getRelevantDataPoints from 'features/emails/utils/getRelevantDataPoints';
 import useEmails from 'features/emails/hooks/useEmails';
+import OpenedInsightsSection from 'features/emails/components/OpenedInsightsSection';
+import ClickInsightsSection from 'features/emails/components/ClickedInsightsSection';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -58,49 +35,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   }
 );
 
-const HOURS_BY_SPAN: Record<string, number> = {
-  first24: 24,
-  first48: 48,
-  firstMonth: 24 * 30,
-  firstWeek: 24 * 7,
-};
-
-function hoursFromSpanValue(value: string): number | undefined {
-  return HOURS_BY_SPAN[value];
-}
-
-function axisFromSpanValue(value: string): AxisProps {
-  if (value == 'first24' || value == 'first48') {
-    const output: number[] = [];
-    for (let i = 0; i < 48; i += 4) {
-      output.push(i * 60 * 60);
-    }
-
-    return {
-      format: (val) => Math.round(val / 60 / 60),
-      tickValues: output,
-    };
-  } else {
-    return {
-      format: (val) => Math.round(val / 60 / 60 / 24),
-      tickValues: value == 'firstWeek' ? 7 : 15,
-    };
-  }
-}
-
 const EmailPage: PageWithLayout = () => {
-  const [clickMetric, setClickMetric] = useState<'ctr' | 'ctor'>('ctr');
   const [secondaryEmailId, setSecondaryEmailId] = useState(0);
-  const [timeSpan, setTimeSpan] = useState<string>('first48');
   const messages = useMessages(messageIds);
   const { orgId, emailId } = useNumericRouteParams();
-  const theme = useTheme();
   const { data: email } = useEmail(orgId, emailId);
-  const stats = useEmailStats(orgId, emailId);
-  const insightsFuture = useEmailInsights(orgId, emailId);
-  const [selectedLinkTag, setSelectedLinkTag] = useState<string | null>(null);
   const emailsFuture = useEmails(orgId);
-  const secondary = useSecondaryEmailInsights(orgId, secondaryEmailId);
 
   const onServer = useServerSide();
 
@@ -112,10 +52,6 @@ const EmailPage: PageWithLayout = () => {
   if (!emailPublished || !email.processed) {
     return null;
   }
-
-  const sanitizer = DOMPurify();
-
-  const timeSpanHours = hoursFromSpanValue(timeSpan);
 
   return (
     <>
@@ -186,396 +122,11 @@ const EmailPage: PageWithLayout = () => {
           )}
         </ZUIFuture>
       </Box>
-      <ZUICard
-        header={messages.insights.opened.header()}
-        status={
-          <ZUINumberChip
-            color={theme.palette.grey[200]}
-            value={stats.numOpened}
-          />
-        }
-        sx={{ mb: 2 }}
-      >
-        <Box display="flex" gap={2}>
-          <Box flexGrow={0} maxWidth={300}>
-            <ZUIFutures
-              futures={{
-                secondaryEmail: secondary.emailFuture,
-                secondaryStats: secondary.statsFuture,
-              }}
-            >
-              {({ data: { secondaryEmail, secondaryStats } }) => (
-                <>
-                  <EmailKPIChart
-                    email={email}
-                    secondaryEmail={secondaryEmail}
-                    secondaryTotal={secondaryStats?.num_sent}
-                    secondaryValue={secondaryStats?.num_opened}
-                    title={messages.insights.opened.gauge.header()}
-                    total={stats.numSent}
-                    value={stats.numOpened}
-                  />
-                  <Typography mb={2} mt={1} variant="body2">
-                    {messages.insights.opened.description()}
-                  </Typography>
-                </>
-              )}
-            </ZUIFutures>
-          </Box>
-          <Box flexGrow={1} height={550} position="relative">
-            <Box
-              bgcolor={theme.palette.background.paper}
-              bottom={40}
-              position="absolute"
-              right={0}
-              width={160}
-              zIndex={1000}
-            >
-              <TextField
-                fullWidth
-                onChange={(ev) => setTimeSpan(ev.target.value)}
-                select
-                size="small"
-                value={timeSpan}
-              >
-                <MenuItem value="first24">
-                  <Msg id={messageIds.insights.opened.chart.spans.first24} />
-                </MenuItem>
-                <MenuItem value="first48">
-                  <Msg id={messageIds.insights.opened.chart.spans.first48} />
-                </MenuItem>
-                <MenuItem value="firstWeek">
-                  <Msg id={messageIds.insights.opened.chart.spans.firstWeek} />
-                </MenuItem>
-                <MenuItem value="firstMonth">
-                  <Msg id={messageIds.insights.opened.chart.spans.firstMonth} />
-                </MenuItem>
-                <MenuItem value="allTime">
-                  <Msg id={messageIds.insights.opened.chart.spans.allTime} />
-                </MenuItem>
-              </TextField>
-            </Box>
-            <ZUIFutures
-              futures={{
-                mainInsights: insightsFuture,
-                secondaryEmail: secondary.emailFuture,
-                secondaryInsights: secondary.insightsFuture,
-                secondaryStats: secondary.statsFuture,
-              }}
-            >
-              {({
-                data: {
-                  mainInsights,
-                  secondaryEmail,
-                  secondaryInsights,
-                  secondaryStats,
-                },
-              }) => {
-                const lineData = [
-                  {
-                    data: mainInsights.opensByDate.map((openEvent) => ({
-                      x:
-                        (new Date(openEvent.date).getTime() -
-                          new Date(
-                            mainInsights.opensByDate[0].date
-                          ).getTime()) /
-                        1000,
-                      y: openEvent.accumulatedOpens / stats.numSent,
-                    })),
-                    id: 'main',
-                  },
-                ];
-
-                if (secondaryInsights && secondaryStats) {
-                  lineData.push({
-                    data: secondaryInsights.opensByDate.map((openEvent) => ({
-                      x:
-                        (new Date(openEvent.date).getTime() -
-                          new Date(
-                            secondaryInsights.opensByDate[0].date
-                          ).getTime()) /
-                        1000,
-                      y: openEvent.accumulatedOpens / secondaryStats.num_sent,
-                    })),
-                    id: 'secondary',
-                  });
-                }
-
-                return (
-                  <ResponsiveLine
-                    animate={false}
-                    axisBottom={axisFromSpanValue(timeSpan)}
-                    axisLeft={{
-                      format: (val) => Math.round(val * 100) + '%',
-                    }}
-                    colors={[
-                      theme.palette.primary.main,
-                      theme.palette.grey[600],
-                    ]}
-                    curve="basis"
-                    data={lineData}
-                    defs={[
-                      linearGradientDef('gradientA', [
-                        { color: 'inherit', offset: 0 },
-                        { color: 'inherit', offset: 100, opacity: 0 },
-                      ]),
-                      linearGradientDef('transparent', [
-                        { color: 'white', offset: 0, opacity: 0 },
-                        { color: 'white', offset: 100, opacity: 0 },
-                      ]),
-                    ]}
-                    enableArea={true}
-                    enableGridX={false}
-                    enableGridY={false}
-                    enablePoints={false}
-                    enableSlices="x"
-                    fill={[
-                      { id: 'gradientA', match: { id: 'main' } },
-                      { id: 'transparent', match: { id: 'secondary' } },
-                    ]}
-                    isInteractive={true}
-                    lineWidth={3}
-                    margin={{
-                      bottom: 30,
-                      left: 40,
-                      right: 8,
-                      top: 20,
-                    }}
-                    sliceTooltip={(props) => {
-                      const publishDate = new Date(emailPublished);
-                      const { mainPoint, secondaryPoint } =
-                        getRelevantDataPoints(
-                          props.slice.points[0],
-                          {
-                            startDate: new Date(emailPublished),
-                            values: mainInsights.opensByDate,
-                          },
-                          secondaryInsights && secondaryEmail?.published
-                            ? {
-                                startDate: new Date(secondaryEmail.published),
-                                values: secondaryInsights.opensByDate,
-                              }
-                            : null
-                        );
-
-                      if (!mainPoint) {
-                        return null;
-                      }
-
-                      const count = mainPoint.accumulatedOpens;
-                      const date = new Date(mainPoint.date);
-
-                      const secondsAfterPublish =
-                        (date.getTime() - publishDate.getTime()) / 1000;
-
-                      return (
-                        <Paper sx={{ minWidth: 240 }}>
-                          <Box p={2}>
-                            <Typography variant="h6">
-                              <ZUIDuration seconds={secondsAfterPublish} />
-                            </Typography>
-                            <Typography variant="body2">
-                              <Msg
-                                id={messageIds.insights.opened.chart.afterSend}
-                              />
-                            </Typography>
-                          </Box>
-                          <Divider />
-                          <Box p={2}>
-                            <Box
-                              alignItems="center"
-                              display="flex"
-                              gap={2}
-                              justifyContent="space-between"
-                            >
-                              <Box>
-                                <Typography variant="body2">
-                                  <FormattedTime
-                                    day="numeric"
-                                    month="short"
-                                    value={date}
-                                  />
-                                </Typography>
-                                <Typography variant="body2">
-                                  <Msg
-                                    id={messageIds.insights.opened.chart.opened}
-                                    values={{
-                                      count: count,
-                                    }}
-                                  />
-                                </Typography>
-                              </Box>
-                              <Box>
-                                <Typography color="primary" variant="h5">
-                                  {Math.round((count / stats.numSent) * 100)}%
-                                </Typography>
-                              </Box>
-                            </Box>
-                            {secondaryPoint && secondaryStats && (
-                              <>
-                                <Divider sx={{ my: 1 }} />
-                                <Box
-                                  alignItems="center"
-                                  display="flex"
-                                  gap={2}
-                                  justifyContent="space-between"
-                                >
-                                  <Box>
-                                    <Typography variant="body2">
-                                      <FormattedTime
-                                        day="numeric"
-                                        month="short"
-                                        value={secondaryPoint.date}
-                                      />
-                                    </Typography>
-                                    <Typography variant="body2">
-                                      <Msg
-                                        id={
-                                          messageIds.insights.opened.chart
-                                            .opened
-                                        }
-                                        values={{
-                                          count:
-                                            secondaryPoint.accumulatedOpens,
-                                        }}
-                                      />
-                                    </Typography>
-                                  </Box>
-                                  <Box>
-                                    <Typography color="secondary" variant="h5">
-                                      {Math.round(
-                                        (secondaryPoint.accumulatedOpens /
-                                          secondaryStats.num_sent) *
-                                          100
-                                      )}
-                                      %
-                                    </Typography>
-                                  </Box>
-                                </Box>
-                              </>
-                            )}
-                          </Box>
-                        </Paper>
-                      );
-                    }}
-                    xScale={{
-                      max: timeSpanHours ? timeSpanHours * 60 * 60 : undefined,
-                      type: 'linear',
-                    }}
-                  />
-                );
-              }}
-            </ZUIFutures>
-          </Box>
-        </Box>
-      </ZUICard>
-      <ZUICard
-        header={messages.insights.clicked.header()}
-        status={
-          <ZUINumberChip
-            color={theme.palette.grey[200]}
-            value={stats.numClicked}
-          />
-        }
-      >
-        <Box display="flex" gap={2}>
-          <Box flexGrow={0} maxWidth={300}>
-            <ZUIFutures
-              futures={{
-                secondaryEmail: secondary.emailFuture,
-                secondaryStats: secondary.statsFuture,
-              }}
-            >
-              {({ data: { secondaryEmail, secondaryStats } }) => (
-                <>
-                  <EmailKPIChart
-                    email={email}
-                    secondaryEmail={secondaryEmail}
-                    secondaryTotal={
-                      clickMetric == 'ctr'
-                        ? secondaryStats?.num_sent ?? null
-                        : secondaryStats?.num_opened ?? null
-                    }
-                    secondaryValue={secondaryStats?.num_clicks ?? null}
-                    title={messages.insights.clicked.gauge.headers[
-                      clickMetric
-                    ]()}
-                    total={
-                      clickMetric == 'ctr' ? stats.numSent : stats.numOpened
-                    }
-                    value={stats.numClicked}
-                  />
-                  <Box display="flex" justifyContent="center">
-                    <ToggleButtonGroup
-                      exclusive
-                      onChange={(_, value) =>
-                        setClickMetric(value || clickMetric)
-                      }
-                      size="small"
-                      value={clickMetric}
-                    >
-                      <ToggleButton value="ctr">
-                        {messages.insights.clicked.metrics.ctr()}
-                      </ToggleButton>
-                      <ToggleButton value="ctor">
-                        {messages.insights.clicked.metrics.ctor()}
-                      </ToggleButton>
-                    </ToggleButtonGroup>
-                  </Box>
-                  <Typography mb={2} mt={1} variant="body2">
-                    {messages.insights.clicked.descriptions[clickMetric]()}
-                  </Typography>
-                </>
-              )}
-            </ZUIFutures>
-          </Box>
-          <Box flexGrow={1} minHeight={500}>
-            <ZUIFuture future={insightsFuture}>
-              {(insights) => (
-                <Box alignItems="flex-start" display="flex">
-                  <Table>
-                    {insights.links
-                      .concat()
-                      .sort((a, b) => b.clicks - a.clicks)
-                      .map((link) => (
-                        <TableRow
-                          key={link.id}
-                          onMouseEnter={() => setSelectedLinkTag(link.tag)}
-                          onMouseLeave={() => setSelectedLinkTag(null)}
-                        >
-                          <TableCell>{link.clicks}</TableCell>
-                          <TableCell>
-                            {sanitizer.sanitize(link.text, {
-                              // Remove all inline tags that may exist here
-                              ALLOWED_TAGS: ['#text'],
-                            })}
-                          </TableCell>
-                          <TableCell>
-                            <Link
-                              display="flex"
-                              gap={1}
-                              href={link.url}
-                              target="_blank"
-                            >
-                              {link.url}
-                              <OpenInNew fontSize="small" />
-                            </Link>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                  </Table>
-                  <EmailMiniature
-                    emailId={emailId}
-                    orgId={orgId}
-                    selectedTag={selectedLinkTag}
-                    width={150}
-                  />
-                </Box>
-              )}
-            </ZUIFuture>
-          </Box>
-        </Box>
-      </ZUICard>
+      <OpenedInsightsSection
+        email={email}
+        secondaryEmailId={secondaryEmailId}
+      />
+      <ClickInsightsSection email={email} secondaryEmailId={secondaryEmailId} />
     </>
   );
 };

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -337,12 +337,7 @@ const EmailPage: PageWithLayout = () => {
                     lineWidth={3}
                     margin={{
                       bottom: 30,
-                      // Calculate the left margin from the number of digits
-                      // in the y axis labels, to make sure the labels will fit
-                      // inside the clipping rectangle.
-                      left:
-                        15 +
-                        mainInsights.opensByDate.length.toString().length * 8,
+                      left: 40,
                       right: 8,
                       top: 20,
                     }}

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -23,7 +23,7 @@ import { linearGradientDef } from '@nivo/core';
 import { OpenInNew } from '@mui/icons-material';
 import DOMPurify from 'dompurify';
 import { useState } from 'react';
-import { FormattedTime } from 'react-intl';
+import { FormattedDate, FormattedTime } from 'react-intl';
 
 import EmailLayout from 'features/emails/layout/EmailLayout';
 import { PageWithLayout } from 'utils/types';
@@ -160,10 +160,19 @@ const EmailPage: PageWithLayout = () => {
                       flexDirection: 'column',
                     }}
                   >
-                    <Typography>{option.title}</Typography>
-                    <Typography variant="body2">
-                      {option.campaign?.title}
-                    </Typography>
+                    <Box>
+                      <Typography>{option.title}</Typography>
+                    </Box>
+                    <Box display="flex" gap={1}>
+                      <Typography variant="body2">
+                        {option.published && (
+                          <FormattedDate value={option.published} />
+                        )}
+                      </Typography>
+                      <Typography variant="body2">
+                        {option.campaign?.title}
+                      </Typography>
+                    </Box>
                   </Box>
                 </ListItem>
               )}

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/insights.tsx
@@ -108,6 +108,11 @@ const EmailPage: PageWithLayout = () => {
     return null;
   }
 
+  const emailPublished = email.published;
+  if (!emailPublished || !email.processed) {
+    return null;
+  }
+
   const sanitizer = DOMPurify();
 
   const timeSpanHours = hoursFromSpanValue(timeSpan);
@@ -342,12 +347,12 @@ const EmailPage: PageWithLayout = () => {
                       top: 20,
                     }}
                     sliceTooltip={(props) => {
-                      const publishDate = new Date(email?.published || 0);
+                      const publishDate = new Date(emailPublished);
                       const { mainPoint, secondaryPoint } =
                         getRelevantDataPoints(
                           props.slice.points[0],
                           {
-                            startDate: new Date(email.published!),
+                            startDate: new Date(emailPublished),
                             values: mainInsights.opensByDate,
                           },
                           secondaryInsights && secondaryEmail?.published

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -23,6 +23,7 @@ export default function mockState(overrides?: RootState) {
     },
     emails: {
       emailList: remoteList(),
+      insightsByEmailId: {},
       linksByEmailId: {},
       statsById: {},
       themeList: remoteList(),

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -510,6 +510,7 @@ export interface ZetkinEmail {
   id: number;
   locked: string | null;
   published: string | null;
+  processed: string | null;
   subject: string | null;
   organization: { id: number; title: string };
   content: string | null;

--- a/src/zui/ZUICard/index.tsx
+++ b/src/zui/ZUICard/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, Typography } from '@mui/material';
+import { Box, Card, CardProps, Typography } from '@mui/material';
 import { FC, ReactNode } from 'react';
 
 type ZUICardProps = {
@@ -6,11 +6,18 @@ type ZUICardProps = {
   header: string | JSX.Element;
   status?: ReactNode;
   subheader?: string;
+  sx?: CardProps['sx'];
 };
 
-const ZUICard: FC<ZUICardProps> = ({ children, header, status, subheader }) => {
+const ZUICard: FC<ZUICardProps> = ({
+  children,
+  header,
+  status,
+  subheader,
+  sx,
+}) => {
   return (
-    <Card>
+    <Card sx={sx}>
       <Box display="flex" justifyContent="space-between" m={2}>
         <Box>
           <Typography variant="h5">{header}</Typography>

--- a/src/zui/ZUICleanHtml.tsx
+++ b/src/zui/ZUICleanHtml.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-danger */
 import DOMPurify from 'isomorphic-dompurify';
 import { Box, BoxProps } from '@mui/material';
+import { useMemo } from 'react';
 
 interface ZUICleanHtmlProps {
   dirtyHtml: string;
@@ -11,7 +12,7 @@ const ZUICleanHtml = ({
   BoxProps,
   dirtyHtml,
 }: ZUICleanHtmlProps): JSX.Element => {
-  const cleanHtml = DOMPurify.sanitize(dirtyHtml);
+  const cleanHtml = useMemo(() => DOMPurify.sanitize(dirtyHtml), [dirtyHtml]);
   return <Box dangerouslySetInnerHTML={{ __html: cleanHtml }} {...BoxProps} />;
 };
 

--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryFn } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 
 import ZUIDuration from '.';
 
@@ -7,23 +7,13 @@ export default {
   title: 'Atoms/ZUIDuration',
 } as Meta<typeof ZUIDuration>;
 
-const Template: StoryFn<typeof ZUIDuration> = (args) => (
-  <ZUIDuration
-    enableDays={args.enableDays}
-    enableHours={args.enableHours}
-    enableMilliseconds={args.enableMilliseconds}
-    enableMinutes={args.enableMinutes}
-    enableSeconds={args.enableSeconds}
-    seconds={args.seconds}
-  />
-);
-
-export const basic = Template.bind({});
-basic.args = {
-  enableDays: true,
-  enableHours: true,
-  enableMilliseconds: false,
-  enableMinutes: true,
-  enableSeconds: false,
-  seconds: 12345,
+export const Basic: StoryObj<typeof ZUIDuration> = {
+  args: {
+    enableDays: true,
+    enableHours: true,
+    enableMilliseconds: false,
+    enableMinutes: true,
+    enableSeconds: false,
+    seconds: 12345,
+  },
 };

--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryFn } from '@storybook/react';
+
+import ZUIDuration from '.';
+
+export default {
+  component: ZUIDuration,
+  title: 'Atoms/ZUIDuration',
+} as Meta<typeof ZUIDuration>;
+
+const Template: StoryFn<typeof ZUIDuration> = (args) => (
+  <ZUIDuration
+    enableDays={args.enableDays}
+    enableHours={args.enableHours}
+    enableMilliseconds={args.enableMilliseconds}
+    enableMinutes={args.enableMinutes}
+    enableSeconds={args.enableSeconds}
+    seconds={args.seconds}
+  />
+);
+
+export const basic = Template.bind({});
+basic.args = {
+  enableDays: true,
+  enableHours: true,
+  enableMilliseconds: false,
+  enableMinutes: true,
+  enableSeconds: false,
+  seconds: 12345,
+};

--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -9,11 +9,11 @@ export default {
 
 export const Basic: StoryObj<typeof ZUIDuration> = {
   args: {
-    enableDays: true,
-    enableHours: true,
-    enableMilliseconds: false,
-    enableMinutes: true,
-    enableSeconds: false,
     seconds: 12345,
+    withDays: true,
+    withHours: true,
+    withMinutes: true,
+    withSeconds: false,
+    withThousands: false,
   },
 };

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -4,6 +4,10 @@ import messageIds from 'zui/l10n/messageIds';
 import { Msg } from 'core/i18n';
 
 type Props = {
+  /**
+   * The duration in seconds that should be visualized. Only positive durations
+   * are supported and negative values will result in no rendered output.
+   */
   seconds: number;
   withDays?: boolean;
   withHours?: boolean;

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react';
+
+import messageIds from 'zui/l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+type Props = {
+  enableDays?: boolean;
+  enableHours?: boolean;
+  enableMilliseconds?: boolean;
+  enableMinutes?: boolean;
+  enableSeconds?: boolean;
+  seconds: number;
+};
+
+type DurField = {
+  msgId: keyof typeof messageIds.duration;
+  n: number;
+  visible: boolean;
+};
+
+const ZUIDuration: FC<Props> = ({
+  enableDays = true,
+  enableHours = true,
+  enableMilliseconds = false,
+  enableMinutes = true,
+  enableSeconds = false,
+  seconds,
+}) => {
+  const ms = (seconds * 1000) % 1000;
+  const s = Math.floor(seconds) % 60;
+  const m = Math.floor(seconds / 60) % 60;
+  const h = Math.floor(seconds / 60 / 60) % 24;
+  const days = Math.floor(seconds / 60 / 60 / 24);
+
+  const fields: DurField[] = [
+    { msgId: 'days', n: days, visible: enableDays },
+    { msgId: 'h', n: h, visible: enableHours },
+    { msgId: 'm', n: m, visible: enableMinutes },
+    { msgId: 's', n: s, visible: enableSeconds },
+    { msgId: 'ms', n: ms, visible: enableMilliseconds },
+  ];
+
+  return (
+    <>
+      {fields
+        .filter((field) => field.visible)
+        .filter((field) => field.n > 0)
+        .map((field) => (
+          <span key={field.msgId} style={{ marginRight: 4 }}>
+            <Msg
+              id={messageIds.duration[field.msgId]}
+              values={{ n: field.n }}
+            />
+          </span>
+        ))}
+    </>
+  );
+};
+
+export default ZUIDuration;

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -4,12 +4,12 @@ import messageIds from 'zui/l10n/messageIds';
 import { Msg } from 'core/i18n';
 
 type Props = {
-  enableDays?: boolean;
-  enableHours?: boolean;
-  enableMilliseconds?: boolean;
-  enableMinutes?: boolean;
-  enableSeconds?: boolean;
   seconds: number;
+  withDays?: boolean;
+  withHours?: boolean;
+  withMinutes?: boolean;
+  withSeconds?: boolean;
+  withThousands?: boolean;
 };
 
 type DurField = {
@@ -19,11 +19,11 @@ type DurField = {
 };
 
 const ZUIDuration: FC<Props> = ({
-  enableDays = true,
-  enableHours = true,
-  enableMilliseconds = false,
-  enableMinutes = true,
-  enableSeconds = false,
+  withDays = true,
+  withHours = true,
+  withThousands = false,
+  withMinutes = true,
+  withSeconds = false,
   seconds,
 }) => {
   const ms = (seconds * 1000) % 1000;
@@ -33,11 +33,11 @@ const ZUIDuration: FC<Props> = ({
   const days = Math.floor(seconds / 60 / 60 / 24);
 
   const fields: DurField[] = [
-    { msgId: 'days', n: days, visible: enableDays },
-    { msgId: 'h', n: h, visible: enableHours },
-    { msgId: 'm', n: m, visible: enableMinutes },
-    { msgId: 's', n: s, visible: enableSeconds },
-    { msgId: 'ms', n: ms, visible: enableMilliseconds },
+    { msgId: 'days', n: days, visible: withDays },
+    { msgId: 'h', n: h, visible: withHours },
+    { msgId: 'm', n: m, visible: withMinutes },
+    { msgId: 's', n: s, visible: withSeconds },
+    { msgId: 'ms', n: ms, visible: withThousands },
   ];
 
   return (

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -104,6 +104,13 @@ export default makeMessages('zui', {
     }>('{date}'),
     singleDayToday: m('Today'),
   },
+  duration: {
+    days: m<{ n: number }>('{n, plural, =1 {1 day} other {# days}}'),
+    h: m<{ n: number }>('{n}h'),
+    m: m<{ n: number }>('{n}m'),
+    ms: m<{ n: number }>('{n}ms'),
+    s: m<{ n: number }>('{n}s'),
+  },
   editTextInPlace: {
     tooltip: {
       edit: m('Click to edit'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,6 +2951,30 @@
     "@nivo/tooltip" "0.80.0"
     d3-shape "^1.3.5"
 
+"@nivo/polar-axes@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@nivo/polar-axes/-/polar-axes-0.80.0.tgz#7fad6292c45470cede28f5548f3b71e8181d6da2"
+  integrity sha512-lhk8ZtpEg7qT6/UFnrXOd0Tg5M6ZipTxjT2JmC6gxAADDiha5BzlAuBZaSudgbwhWbnzTdNGqHBkR5Dp/yqUcA==
+  dependencies:
+    "@nivo/arcs" "0.80.0"
+    "@nivo/scales" "0.80.0"
+    "@react-spring/web" "9.4.5"
+
+"@nivo/radial-bar@^0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@nivo/radial-bar/-/radial-bar-0.80.0.tgz#1f928f5caefac07d11ab32fc50072804e0b9e6ce"
+  integrity sha512-IJ+IvGCXcy3y0uwcAsMyjyV5WTPe3vP5aUuV+bglTOUd1PmyD+6XY5FIAX0x3049t8mpHZnVRTewPpfaAZYLPw==
+  dependencies:
+    "@nivo/arcs" "0.80.0"
+    "@nivo/colors" "0.80.0"
+    "@nivo/legends" "0.80.0"
+    "@nivo/polar-axes" "0.80.0"
+    "@nivo/scales" "0.80.0"
+    "@nivo/tooltip" "0.80.0"
+    "@react-spring/web" "9.4.5"
+    d3-scale "^3.2.3"
+    d3-shape "^1.3.5"
+
 "@nivo/recompose@0.80.0":
   version "0.80.0"
   resolved "https://registry.yarnpkg.com/@nivo/recompose/-/recompose-0.80.0.tgz#572048aed793321a0bada1fd176b72df5a25282e"
@@ -12867,7 +12891,8 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-"prettier-fallback@npm:prettier@^3":
+"prettier-fallback@npm:prettier@^3", prettier@^3.1.1:
+  name prettier-fallback
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
   integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
@@ -12876,11 +12901,6 @@ prettier@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-
-prettier@^3.1.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
-  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -14312,16 +14332,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14425,14 +14436,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15683,16 +15687,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description
This PR implements an Insights page for emails, presenting key metrics for the user to assess the success of their email and compare it with other emails sent previously.


## Screenshots
### Open rate graphs
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/3339a553-0146-4676-8e13-43c742bb1e3f)

### Click rate gauge and table
![image](https://github.com/zetkin/app.zetkin.org/assets/550212/69f5fbd3-1088-4c68-b030-5d0ed34a4cd9)

### Video
https://github.com/zetkin/app.zetkin.org/assets/550212/c7bb5175-e3ac-4ac8-a717-c0f330fb4b93

## Changes
* Adds new "Insights" tab to email page
* Creates an RPC to load insights data
* Renders information about email opens:
  * A gauge for the open rate, including optionally comparing to another email
  * A line chart of open rate over time, with support for optionally comparing to another email
  * A brief description of what "opens" mean and how to improve
* Renders information about clicks
  * A gauge for the click rate measured as CTR or CTOR, including optionally comparing to another email
  * A list of all the links in the email and how many times they have been clicked
  * A miniature of the email that highlights the links when hovering them in the list
  * A brief description of what CTR and CTOR mean, and how to improve them

## Notes to reviewer
This can't be tested on the dev server yet, because it requires a new API that hasn't been deployed yet. This feature does not make a huge sense for the dummy data that is on the dev server anyway, which is why I have tried it with real data during development.

## Related issues
Undocumented