### PR TITLE
Replace 000Z suffix with dayjs.utc call

### DIFF
--- a/src/features/tasks/utils/getTaskStatus.ts
+++ b/src/features/tasks/utils/getTaskStatus.ts
@@ -20,8 +20,7 @@ const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
     return TASK_STATUS.EXPIRED;
   }
 
-  const isPublishedPassed =
-    published && dayjs(published + '.000Z').isBefore(now);
+  const isPublishedPassed = published && dayjs.utc(published).isBefore(now);
 
   if (isPublishedPassed) {
     return TASK_STATUS.ACTIVE;


### PR DESCRIPTION
This is a partial fix for https://github.com/zetkin/app.zetkin.org/issues/2079. It addresses only the task status, not the "Invalid Date Invalid Date" further down the page. This microsecond precision thing can be as big of a project as we want it to be, and I've had a couple of doomsday-sized PRs lately, so I'm shooting for a smaller first step here. Happy to follow up with more, and then we can go as deep into this issue as you like.

As per my post on the issue, the correct status for this task is "active" as it has a published date in the past. The problem is that the date has microsecond precision, and so the addition of the `.000Z` suffix makes it unparsable to dayjs: Both `dayjs(published + '.000Z').isBefore(now)` and `dayjs(published + '.000Z').isAfter(now)` return `false` if `published` contains microseconds.

Thing is, [dayjs does actually support parsing microseconds](https://github.com/iamkun/dayjs/pull/1010). So there's no problem with that. It [supports UTC too](https://day.js.org/docs/en/plugin/utc). So my thinking here is we just need to approach this differently. Instead of chucking `.000Z` on the end to tell dayjs we want our date parsed as UTC, we can replace the `dayjs(published)` call with `dayjs.utc(published)`, which achieves the desired goal without depending on smuggling our intended timezone in via the string param.

| Before | After |
|-|-|
| ![Screenshot 2024-07-17 at 22-07-52 A second dummy task](https://github.com/user-attachments/assets/5ffb5884-5ca4-43cb-9838-0da86ef023d0) | ![Screenshot 2024-07-17 at 22-07-21 A second dummy task](https://github.com/user-attachments/assets/e2ad16a9-e7cc-4106-b84b-22b2acacf80b) |

Want excruciating detail? You got it! The following sample code runs through dayjs date comparison outcomes with three slightly different input formats to explain why I think `dayjs.utc()` is the way to go here.

```typescript
import dayjs from 'dayjs';
import dayjsPluginUTC from 'dayjs-plugin-utc'
dayjs.extend(dayjsPluginUTC)

const published = '2024-05-27T10:16:54.625596'
const now = dayjs('2024-05-27T10:00:00Z')

// In Sweden the first one here returns true and the second returns false. This
// is incorrect. It happens because the lack of a .000Z suffix causes it to be
// parsed as a local time.
console.log(dayjs(published).isBefore(now))
console.log(dayjs(published).isAfter(now))

// Both of these checks return false. This is also incorrect. This happens
// because dayjs is unable to parse '2024-05-27T10:16:54.625596.000Z'.
console.log(dayjs(published + ".000Z").isBefore(now))
console.log(dayjs(published + ".000Z").isAfter(now))

// In Sweden the first one here return false and the second returns true.
// This is the correct behavior..
console.log(dayjs.utc(published).isBefore(now))
console.log(dayjs.utc(published).isAfter(now))
```