### PR TITLE
Add new date range message for ranges with end dates in the past

### DIFF
--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -83,6 +83,7 @@ export default makeMessages('zui', {
   dateRange: {
     draft: m('No start date'),
     end: m('End'),
+    ended: m<{ time: string }>('Ended {time}'),
     finite: m<{ end: string; start: string }>('Visible from {start} to {end}'),
     indefinite: m<{ start: string }>('Visible from {start} onwards'),
     invisible: m('Not visible or scheduled'),


### PR DESCRIPTION
This is a first try at implementing the [idea I described in my second comment](https://github.com/zetkin/app.zetkin.org/issues/2078#issuecomment-2241145836) on #2078.

| Before | After |
|-|-|
| ![Screenshot 2024-07-20 at 16-08-26 My survey](https://github.com/user-attachments/assets/cd98b897-05e0-47f6-b37b-bc99e1ebb860) | ![Screenshot 2024-07-20 at 16-08-12 My survey](https://github.com/user-attachments/assets/55bd012d-8702-4a61-a75c-18b003f91524) |

I did try to search in case there was any existing code in place for this kind of relative date formatting. Let me know if I missed something.

I've gone for the simplest way here where you just start at the year level and keep zooming in until you hit a unit of time where the end date was more than one of it ago. If you look at e.g. [`distance_of_time_in_words`](https://apidock.com/rails/ActionView/Helpers/DateHelper/distance_of_time_in_words) in Rails it's a fun type of code that you can get as deep into as you like.