### PR TITLE
Rename 'unpublished' survey state to 'expired'

### DIFF
--- a/src/features/surveys/components/SurveyStatusChip.tsx
+++ b/src/features/surveys/components/SurveyStatusChip.tsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles((theme) => ({
   draft: {
     backgroundColor: theme.palette.grey[500],
   },
+  expired: {
+    backgroundColor: theme.palette.error.main,
+  },
   published: {
     backgroundColor: theme.palette.success.main,
   },
@@ -31,9 +34,6 @@ const useStyles = makeStyles((theme) => ({
   },
   spinner: {
     marginLeft: '0.5em',
-  },
-  unpublished: {
-    backgroundColor: theme.palette.error.main,
   },
 }));
 
@@ -45,8 +45,8 @@ const SurveyStatusChip: FC<SurveyStatusChipProps> = ({ state }) => {
   }
 
   const classMap: Record<SurveyState, string> = {
-    [SurveyState.UNPUBLISHED]: classes.unpublished,
     [SurveyState.DRAFT]: classes.draft,
+    [SurveyState.EXPIRED]: classes.expired,
     [SurveyState.PUBLISHED]: classes.published,
     [SurveyState.SCHEDULED]: classes.scheduled,
     [SurveyState.UNKNOWN]: classes.draft,

--- a/src/features/surveys/hooks/useSurveyState.ts
+++ b/src/features/surveys/hooks/useSurveyState.ts
@@ -1,7 +1,7 @@
 import useSurvey from './useSurvey';
 
 export enum SurveyState {
-  UNPUBLISHED = 'unpublished',
+  EXPIRED = 'expired',
   DRAFT = 'draft',
   PUBLISHED = 'published',
   SCHEDULED = 'scheduled',
@@ -29,7 +29,7 @@ export default function useSurveyState(
         const expiryDate = new Date(data.expires);
 
         if (expiryDate < now) {
-          return SurveyState.UNPUBLISHED;
+          return SurveyState.EXPIRED;
         }
       }
 

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -146,9 +146,9 @@ export default makeMessages('feat.surveys', {
   },
   state: {
     draft: m('Draft'),
+    expired: m('Ended'),
     published: m('Published'),
     scheduled: m('Scheduled'),
-    unpublished: m('Unpublished'),
   },
   submissionPane: {
     anonymous: m('Anonymous'),


### PR DESCRIPTION
This is an attempt at addressing my [first comment](https://github.com/zetkin/app.zetkin.org/issues/2078#issuecomment-2241144128) on #2078.

For the user-facing text, I've gone for "ended" because it matches the word @Bagera used in the issue description to describe this state.

In the code, I've gone with `expired`, because I think it makes most sense given we have two date fields – `published` and `expires` – to have states called `published` and `expired` to match.

| Before | After |
|-|-|
| ![Screenshot 2024-07-20 at 17-56-40 My survey](https://github.com/user-attachments/assets/1c0c3d09-5b45-485c-83ac-544d3853c0e2) | ![Screenshot 2024-07-20 at 17-56-28 My survey](https://github.com/user-attachments/assets/85b46b0b-0143-4f14-91c6-87c2d2837277) |