### PR TITLE
Remove spinner animation on active call assignment status chip

### DIFF
--- a/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { makeStyles } from '@mui/styles';
-import { Box, CircularProgress } from '@mui/material';
+import { Box } from '@mui/material';
 
 import { CallAssignmentState } from '../hooks/useCallAssignmentState';
 import { Msg } from 'core/i18n';
@@ -32,9 +32,6 @@ const useStyles = makeStyles((theme) => ({
   scheduled: {
     backgroundColor: theme.palette.statusColors.blue,
   },
-  spinner: {
-    marginLeft: '0.5em',
-  },
 }));
 
 const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
@@ -60,15 +57,6 @@ const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
   return (
     <Box className={`${colorClassName} ${classes.chip}`}>
       <Msg id={messageIds.state[state]} />
-      {state == CallAssignmentState.ACTIVE && (
-        <CircularProgress
-          className={classes.spinner}
-          size={14}
-          style={{ color: 'white' }}
-          value={75}
-          variant="determinate"
-        />
-      )}
     </Box>
   );
 };

--- a/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
+++ b/src/features/callAssignments/components/CallAssignmentStatusChip.tsx
@@ -65,6 +65,8 @@ const CallAssignmentStatusChip: FC<CallAssignmentStatusChipProps> = ({
           className={classes.spinner}
           size={14}
           style={{ color: 'white' }}
+          value={75}
+          variant="determinate"
         />
       )}
     </Box>


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/960. I loved the description of this in the issue.

> stressing for the eyes and steals attention

There's actually a whole [WCAG success criterion about this exact phenomenon](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html) which describes it almost identically.

> Moving content can also be a severe distraction for some people

| Before | After |
|-|-|
| ![2024-07-21 11 53 01](https://github.com/user-attachments/assets/87407c2e-5856-4b53-8f06-3652e63ec6bb) | ![Screenshot 2024-07-21 at 11-52-49 My call assignment](https://github.com/user-attachments/assets/b7316ddf-281a-4bd9-8a40-fe4457c35f35) |