### PR TITLE
Fix error when views are deleted

### DIFF
--- a/src/features/views/hooks/useViewTree.ts
+++ b/src/features/views/hooks/useViewTree.ts
@@ -21,7 +21,9 @@ export default function useViewTree(orgId: number): IFuture<ViewTreeData> {
   } else {
     return new ResolvedFuture({
       folders: views.folderList.items.map((item) => item.data!),
-      views: views.viewList.items.map((item) => item.data!),
+      views: views.viewList.items
+        .filter((item) => !item.deleted)
+        .map((item) => item.data!),
     });
   }
 }

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -388,8 +388,6 @@ const viewsSlice = createSlice({
       if (viewItem) {
         viewItem.deleted = true;
       }
-
-      state.viewList.isStale = true;
     },
     viewLoad: (state, action: PayloadAction<number>) => {
       const viewId = action.payload;


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/1208

I guess the re-fetch used to be the way stuff got removed from the index after deletion. Removing the `isStale = true` prevents the remoteList from being re-fetched. Adding the filter on `item.deleted` prevents the deleted item from being displayed on the index page.

| Before | After |
|-|-|
| ![2024-07-25 08 22 51](https://github.com/user-attachments/assets/6fe65652-cd71-44a2-88b2-4c9a42394cb6) | ![2024-07-25 08 23 26](https://github.com/user-attachments/assets/411122d7-837c-486d-921b-70ac77c79cd6) |

Can see there's lots of other places in the code filtering remotelists based on the `deleted` flag of the items so I guess this is what you meant. Looks like the new approach just never got rolled out to this page. Really enjoyed investigating this: feels great when you get to a point where you can start to retrace other people's steps in a repo this big.