### PR TITLE
Update OpenStreetMap URL

### DIFF
--- a/src/features/events/components/LocationModal/Map.tsx
+++ b/src/features/events/components/LocationModal/Map.tsx
@@ -103,8 +103,8 @@ const Map: FC<MapProps> = ({
           return (
             <>
               <TileLayer
-                attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                attribution='&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
               />
               {filteredLocations.map((location) => {
                 const isSelectedMarker = selectedLocation?.id == location.id;


### PR DESCRIPTION
## Description
This PR updates to copyright link for OpenStreetMap to use HTTPS and the official domain name. This PR also removes the subdomain from the tile server URL as there are no subdomains documented for that tile server.

https://wiki.openstreetmap.org/wiki/Raster_tile_providers

https://osmfoundation.org/wiki/Licence/Attribution_Guidelines

## Notes to reviewer

Open an event, for example `/organize/1/projects/2/events/36`,  click EDIT EVENT INFORMATION and the map icon to open the location modal. The attribution link will be in the bottom right of the map.

## Related issues

Amends #1185