### PR TITLE
CreateEvent in CalendarWeekView now adds the event to the selected project

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -254,6 +254,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                             setGhostAnchorEl(null);
                             await createEvent({
                               activity_id: null,
+                              campaign_id: campId,
                               end_time: pendingEvent[1].toISOString(),
                               location_id: null,
                               start_time: pendingEvent[0].toISOString(),


### PR DESCRIPTION

## Description
This PR fixes issue2054 by also sending the project ID when creating an event in the calendar week view.


## Screenshots
![image](https://github.com/user-attachments/assets/c8654342-e39f-433c-b42a-5ebd828866f1)
![image](https://github.com/user-attachments/assets/b4ab75a1-7bcc-43a1-b0bf-562038f6cbde)


## Changes

* Adds campID to the createEvent function


## Notes to reviewer
Select a project. Go to the Calendar. Select Week view. Drag on a day and select "Create single event" in the pop up menu. Event should be created in the chosen project instead of being a stand alone event.


## Related issues
Resolves #2054 
