### PR TITLE
Provides additional info for unavailable links

### DIFF
--- a/src/features/smartSearch/components/filters/EmailClick/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/index.tsx
@@ -103,6 +103,8 @@ const EmailClick = ({
     });
   };
 
+  const selectedEmail = emails.find((email) => email.id == filter.config.email);
+
   return (
     <FilterForm
       disableSubmit={
@@ -220,7 +222,17 @@ const EmailClick = ({
                     getOptionDisabled={(link) =>
                       filter.config.links?.includes(link.id) || false
                     }
-                    noOptionsText={<Msg id={messageIds.misc.noOptionsLinks} />}
+                    noOptionsText={
+                      selectedEmail ? (
+                        selectedEmail.processed ? (
+                          <Msg id={messageIds.misc.noOptionsLinks} />
+                        ) : (
+                          <Msg id={messageIds.misc.noOptionsEmailNotSent} />
+                        )
+                      ) : (
+                        <Msg id={messageIds.misc.noOptionsInvalidEmail} />
+                      )
+                    }
                     onChange={(_, value) =>
                       setValueToKey(
                         'links',
@@ -265,7 +277,7 @@ const EmailClick = ({
                   value={filter.config.campaign || ''}
                 >
                   {projectsFuture?.map((project) => (
-                    <MenuItem key={`proejct-${project.id}`} value={project.id}>
+                    <MenuItem key={`project-${project.id}`} value={project.id}>
                       {`"${project.title}"`}
                     </MenuItem>
                   ))}

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -775,6 +775,10 @@ export default makeMessages('feat.smartSearch', {
   },
   misc: {
     noOptions: m('No matching tags'),
+    noOptionsEmailNotSent: m(
+      'Email not sent. Links included in the email are added after it has been sent.'
+    ),
+    noOptionsInvalidEmail: m('Invalid email. Select an email first.'),
     noOptionsLinks: m('No matching links'),
   },
   operators: {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -509,6 +509,7 @@ export interface ZetkinEmail {
   theme: EmailTheme | null;
   id: number;
   locked: string | null;
+  processed: string | null;
   published: string | null;
   subject: string | null;
   organization: { id: number; title: string };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -509,7 +509,7 @@ export interface ZetkinEmail {
   theme: EmailTheme | null;
   id: number;
   locked: string | null;
-  processed?: string | null | undefined;
+  processed?: string | null;
   published: string | null;
   subject: string | null;
   organization: { id: number; title: string };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -509,7 +509,7 @@ export interface ZetkinEmail {
   theme: EmailTheme | null;
   id: number;
   locked: string | null;
-  processed: string | null;
+  processed: string | null | undefined;
   published: string | null;
   subject: string | null;
   organization: { id: number; title: string };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -509,7 +509,7 @@ export interface ZetkinEmail {
   theme: EmailTheme | null;
   id: number;
   locked: string | null;
-  processed: string | null | undefined;
+  processed?: string | null | undefined;
   published: string | null;
   subject: string | null;
   organization: { id: number; title: string };


### PR DESCRIPTION

## Description
This PR provides users with additional information about why links do not show up in the Email Smart Search.
The additional texts added are if no email has been selected, and if the email has not been sent.

## Screenshots
![image](https://github.com/user-attachments/assets/8fcc9ccb-1b3b-4b9d-8a92-df5053988874)
![image](https://github.com/user-attachments/assets/9e5ce519-c5a6-477e-a2c6-51708d1aaaee)
![image](https://github.com/user-attachments/assets/8016ab80-d7a2-4385-bae8-7b9ca1be7bad)


## Changes

* Adds selectedEmail variable which is used to check if the email has been sent
* Adds additional error messages for user feedback on why links are not available, such as no email selected or email not sent 
* Processed string is now included in ZetkinEmail to know if the email has been sent
* Fixes a found spelling error


## Notes to reviewer

1. Schedule and compose an email for tomorrow.
2. For sanity check also send another email right now containing links.
3. Go to a list and add a filter "Based on their interaction with links emails" and select "any of the following links in the specific email".
4. Attempt to add links before selecting an email. See message.
5. Add the email you scheduled for tomorrow.
6. Attempt to add links. See message.
7. Change the email to the one that contained link and was sent.
8. Attempt to add links. Should display links as normal. (Might not work in testing, since emails are never actually sent)


## Related issues
Resolves #1975 
