### PR TITLE
Env var redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,11 +34,6 @@ module.exports = {
       },
       // redirects to Gen2 for MVP August 2021
       {
-        source: '/organize/:orgId/people/:personId/edit',
-        destination: `http://organize.${process.env.ZETKIN_API_DOMAIN}/people/person%3A:personId/?org=:orgId`,
-        permanent: false,
-      },
-      {
         source: '/organize/:orgId(\\d{1,})',
         destination: '/legacy?orgId=:orgId',
         permanent: false,
@@ -58,21 +53,6 @@ module.exports = {
         source:
           '/organize/:orgId(\\d{1,})/projects/:campId(\\d{1,})/calendar/events/:eventId(\\d{1,})',
         destination: '/legacy?path=/campaign/action%3A:eventId&orgId=:orgId',
-        permanent: false,
-      },
-      {
-        source: '/o/:orgId',
-        destination: `http://${process.env.ZETKIN_API_DOMAIN}/o/:orgId`,
-        permanent: false,
-      },
-      {
-        source: '/o/:orgId/events/:eventId',
-        destination: `http://${process.env.ZETKIN_API_DOMAIN}/o/:orgId`,
-        permanent: false,
-      },
-      {
-        source: '/o/:orgId/projects/:campId',
-        destination: `http://${process.env.ZETKIN_API_DOMAIN}/o/:orgId/campaigns/:campId`,
         permanent: false,
       },
       {

--- a/src/app/o/[orgId]/events/[eventId]/page.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page({ params }: { params: { orgId: string } }) {
+  redirect(`http://${process.env.ZETKIN_API_DOMAIN}/o/${params.orgId}`);
+}

--- a/src/app/o/[orgId]/page.tsx
+++ b/src/app/o/[orgId]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page({ params }: { params: { orgId: string } }) {
+  redirect(`http://${process.env.ZETKIN_API_DOMAIN}/o/${params.orgId}`);
+}

--- a/src/app/o/[orgId]/projects/[projId]/page.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+export default function Page({
+  params,
+}: {
+  params: { orgId: string; projId: string };
+}) {
+  const { orgId, projId } = params;
+  redirect(
+    `http://${process.env.ZETKIN_API_DOMAIN}/o/${orgId}/campaigns/${projId}`
+  );
+}

--- a/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+export default function Page({
+  params,
+}: {
+  params: { orgId: string; surveyId: string };
+}) {
+  const { orgId, surveyId } = params;
+  redirect(
+    `http://${process.env.ZETKIN_API_DOMAIN}/o/${orgId}/surveys/${surveyId}`
+  );
+}


### PR DESCRIPTION
## Description
This PR fixes two undocumented bugs that seem to have been caused by the recent changes to the build system. Because NEXT.js does not respect environment variables in `next.config.js` redirects during runtime, and the variables are no longer set during build time (since the docker image is prebuilt and reused for all environments), several redirects were missing a domain.

## Screenshots
None

## Changes
* Replaces three redirects from `next.config.js` with pages that redirect instead
* Adds a missing redirect (page) for surveys (that will soon be replaced by #1756)

## Notes to reviewer
The bugs can only be reproduced in production mode. Try `yarn build && yarn start -p 3000` and then browse to http://localhost:3000/o/1. This will work on this branch, but not on `main`.

## Related issues
Undocumented