### PR TITLE
New font and ZUIText

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -11,7 +11,6 @@ body {
 
 * {
   box-sizing: border-box;
-  font-family: azo-sans-web, sans-serif;
 }
 
 blockquote {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -488,28 +488,6 @@ export const newTheme = createTheme({
               color: '#888888',
             },
           },
-          '&.MuiButtonGroup-groupedHorizontal:has(.MuiSvgIcon-root)': {
-            '&.MuiButton-sizeLarge': {
-              ' svg': {
-                fontSize: '1.75em',
-              },
-            },
-            '&.MuiButton-sizeMedium': {
-              ' svg': {
-                fontSize: '1.5rem',
-              },
-            },
-            '&.MuiButton-sizeSmall': {
-              ' svg': {
-                fontSize: '1.25rem',
-              },
-              minWidth: '30px',
-            },
-            ':has(> svg)': {
-              paddingLeft: 0,
-              paddingRight: 0,
-            },
-          },
           ':hover': {
             boxShadow: 'none',
           },
@@ -548,22 +526,22 @@ export const newTheme = createTheme({
   elevation: {
     bottom: {
       big: {
-        light: '0px 4px 40px 0px #00000014',
-        medium: '0px 4px 40px 0px #0000001F',
+        light: '0rem 0.25rem 2.5rem 0rem #00000014',
+        medium: '0rem 0.25rem 2.5rem 0rem #0000001F',
       },
       small: {
-        light: '0px 4px 20px 0px #00000014',
-        medium: '0px 4px 20px 0px #0000001F',
+        light: '0rem 0.25rem 1.25rem 0rem #00000014',
+        medium: '0rem 0.25rem 1.25rem 0rem #0000001F',
       },
     },
     top: {
       big: {
-        light: '0px -4px 40px 0px #00000014',
-        medium: '0px -4px 40px 0px #0000001F',
+        light: '0.rem -0.25rem 2.25rem 0rem #00000014',
+        medium: '0rem -0.25rem 2.25rem 0rem #0000001F',
       },
       small: {
-        light: '0px -4px 20px 0px #00000014',
-        medium: '0px -4px 20px 0px #0000001F',
+        light: '0rem -0.25rem 1.25rem 0rem #00000014',
+        medium: '0rem -0.25rem 1.25rem 0rem #0000001F',
       },
     },
   },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,8 +1,12 @@
 import type {} from '@mui/x-data-grid-pro/themeAugmentation';
 import { createElement } from 'react';
 import { createTheme } from '@mui/material/styles';
+import { Figtree } from 'next/font/google';
 import { Localization } from '@mui/x-data-grid/utils/getGridLocalization';
 import { daDK, deDE, nbNO, svSE } from '@mui/x-data-grid-pro';
+
+//Font family
+const figtree = Figtree({ subsets: ['latin-ext'] });
 
 interface PaletteIntensityOptions {
   disabled?: string;
@@ -495,6 +499,7 @@ export const newTheme = createTheme({
       fontWeight: 600,
       textTransform: 'none',
     },
+    fontFamily: figtree.style.fontFamily,
   },
 });
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,6 +20,38 @@ interface FilterCategoryColors {
   strong: string;
 }
 
+// Update the Typography's variant prop options
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    //TO-DO: set these to 'false' once the old theme is removed
+    h1: true;
+    h3: true;
+    h2: true;
+    h4: true;
+    h5: true;
+    h6: true;
+    subtitle1: true;
+    subtitle2: true;
+    body1: true;
+    body2: true;
+    caption: true;
+    button: true;
+    overline: true;
+    //Keep these as true for the new theme
+    headingLg: true;
+    headingMd: true;
+    headingSm: true;
+    bodyMdBold: true;
+    bodyMdRegular: true;
+    bodySmBold: true;
+    bodySmRegular: true;
+    linkMd: true;
+    linkSm: true;
+    labelMdMedium: true;
+    labelMdRegular: true;
+  }
+}
+
 declare module '@mui/material/styles' {
   interface Theme {
     elevation: {
@@ -69,6 +101,35 @@ declare module '@mui/material/styles' {
         };
       };
     };
+  }
+
+  interface TypographyVariants {
+    headingLg: React.CSSProperties;
+    headingMd: React.CSSProperties;
+    headingSm: React.CSSProperties;
+    bodyMdBold: React.CSSProperties;
+    bodyMdRegular: React.CSSProperties;
+    bodySmBold: React.CSSProperties;
+    bodySmRegular: React.CSSProperties;
+    linkMd: React.CSSProperties;
+    linkSm: React.CSSProperties;
+    labelMdMedium: React.CSSProperties;
+    labelMdRegular: React.CSSProperties;
+  }
+
+  // allow configuration using `createTheme`
+  interface TypographyVariantsOptions {
+    headingLg?: React.CSSProperties;
+    headingMd?: React.CSSProperties;
+    headingSm?: React.CSSProperties;
+    bodyMdBold?: React.CSSProperties;
+    bodyMdRegular?: React.CSSProperties;
+    bodySmBold?: React.CSSProperties;
+    bodySmRegular?: React.CSSProperties;
+    linkMd?: React.CSSProperties;
+    linkSm?: React.CSSProperties;
+    labelMdMedium?: React.CSSProperties;
+    labelMdRegular?: React.CSSProperties;
   }
 }
 
@@ -470,6 +531,19 @@ export const newTheme = createTheme({
         },
       },
     },
+    MuiTypography: {
+      defaultProps: {
+        variantMapping: {
+          bodyMdBold: 'p',
+          bodyMdRegular: 'p',
+          bodySmBold: 'p',
+          bodySmRegular: 'p',
+          headingLg: 'h1',
+          headingMd: 'h2',
+          headingSm: 'h3',
+        },
+      },
+    },
   },
   elevation: {
     bottom: {
@@ -495,11 +569,99 @@ export const newTheme = createTheme({
   },
   palette: newThemePalette,
   typography: {
+    body1: undefined,
+    body2: undefined,
+    bodyMdBold: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1rem',
+      fontWeight: 600,
+      letterSpacing: '0.01rem',
+      lineHeight: '1.5rem',
+    },
+    bodyMdRegular: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1rem',
+      fontWeight: 400,
+      letterSpacing: '0.01rem',
+      lineHeight: '1.5rem',
+    },
+    bodySmBold: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '0.875rem',
+      fontWeight: 600,
+      letterSpacing: '0.01rem',
+      lineHeight: '1.313rem',
+    },
+    bodySmRegular: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '0.875rem',
+      fontWeight: 400,
+      letterSpacing: '0.01rem',
+      lineHeight: '1.313rem',
+    },
     button: {
       fontWeight: 600,
       textTransform: 'none',
     },
+    caption: undefined,
     fontFamily: figtree.style.fontFamily,
+    fontSize: 16,
+    h1: undefined,
+    h2: undefined,
+    h3: undefined,
+    h4: undefined,
+    h5: undefined,
+    h6: undefined,
+    headingLg: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1.375rem',
+      fontWeight: '500',
+      letterSpacing: '-0.005rem',
+      lineHeight: '1.788rem',
+    },
+    headingMd: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1.125rem',
+      fontWeight: '500',
+      letterSpacing: '-0.005rem',
+      lineHeight: '1.463rem',
+    },
+    headingSm: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1rem',
+      fontWeight: '500',
+      letterSpacing: '-0.005rem',
+      lineHeight: '1.3rem',
+    },
+    labelMdMedium: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '0.875rem',
+      fontWeight: '500',
+      letterSpacing: '0.03rem',
+      lineHeight: '1.313rem',
+    },
+    labelMdRegular: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '0.875rem',
+      fontWeight: '400',
+      letterSpacing: '0.03rem',
+      lineHeight: '1.313rem',
+    },
+    linkMd: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '1rem',
+      fontWeight: '400',
+      lineHeight: '1.5rem',
+    },
+    linkSm: {
+      fontFamily: figtree.style.fontFamily,
+      fontSize: '0.875rem',
+      fontWeight: '400',
+      lineHeight: '1.313rem',
+    },
+    overline: undefined,
+    subtitle1: undefined,
+    subtitle2: undefined,
   },
 });
 

--- a/src/zui/ZUIBreadcrumbs/index.tsx
+++ b/src/zui/ZUIBreadcrumbs/index.tsx
@@ -74,10 +74,7 @@ const BreadCrumbSibling: FC<{
               ''
             )}
             <Typography
-              sx={{
-                fontSize: '14px',
-                fontWeight: isCurrentItem ? 'bold' : 'normal',
-              }}
+              variant={isCurrentItem ? 'bodySmBold' : 'bodySmRegular'}
             >
               {item.title}
             </Typography>
@@ -142,7 +139,7 @@ const renderTree = (
       {breadcrumbs.length > 9 && (
         <NextLink href={parentHref} legacyBehavior passHref>
           <Link>
-            <Typography sx={{ fontSize: '14px' }}>
+            <Typography variant="bodySmRegular">
               <Msg
                 id={messageIds.breadcrumbs.showMore}
                 values={{ number: breadcrumbs.length - 9 }}

--- a/src/zui/ZUIButton/index.tsx
+++ b/src/zui/ZUIButton/index.tsx
@@ -22,7 +22,7 @@ export interface ZUIButtonProps {
   variant?: ZUIButtonVariant;
 }
 
-export const getVariant = (variant: ZUIButtonVariant) => {
+export const getVariant = (variant: ZUIButtonVariant = 'secondary') => {
   if (variant === 'secondary') {
     return 'outlined';
   } else if (variant === 'tertiary') {
@@ -32,7 +32,7 @@ export const getVariant = (variant: ZUIButtonVariant) => {
   }
 };
 
-const getColor = (variant: ZUIButtonVariant) => {
+const getColor = (variant: ZUIButtonVariant = 'secondary') => {
   if (variant === 'destructive') {
     return 'error';
   } else if (variant === 'warning') {
@@ -42,7 +42,9 @@ const getColor = (variant: ZUIButtonVariant) => {
   }
 };
 
-const getLoadingIndicatorPadding = (size: 'large' | 'medium' | 'small') => {
+const getLoadingIndicatorPadding = (
+  size: 'large' | 'medium' | 'small' = 'medium'
+) => {
   if (size == 'large') {
     return '0.183rem 1.375rem 0.183rem 1.375rem';
   } else if (size == 'medium') {
@@ -53,8 +55,8 @@ const getLoadingIndicatorPadding = (size: 'large' | 'medium' | 'small') => {
 };
 
 const getTextPadding = (
-  size: 'large' | 'medium' | 'small',
-  variant: ZUIButtonVariant
+  size: 'large' | 'medium' | 'small' = 'medium',
+  variant: ZUIButtonVariant = 'secondary'
 ) => {
   if (size === 'large') {
     if (variant === 'secondary') {
@@ -77,7 +79,7 @@ const getTextPadding = (
   }
 };
 
-const getFontSize = (size: 'small' | 'medium' | 'large') => {
+const getFontSize = (size: 'small' | 'medium' | 'large' = 'medium') => {
   if (size === 'small') {
     return '0.183rem';
   } else if (size === 'medium') {
@@ -97,12 +99,12 @@ const ZUIButton: FC<ZUIButtonProps> = ({
   onKeyDown,
   size = 'medium',
   startIcon,
-  variant = 'secondary',
+  variant,
 }) => {
   const isLoading = variant === 'loading';
   return (
     <Button
-      color={getColor(variant)}
+      color={variant ? getColor(variant) : undefined}
       disabled={disabled || isLoading}
       endIcon={endIcon}
       fullWidth={fullWidth}
@@ -119,7 +121,7 @@ const ZUIButton: FC<ZUIButtonProps> = ({
           : getTextPadding(size, variant),
       }}
       type={actionType}
-      variant={getVariant(variant)}
+      variant={variant ? getVariant(variant) : undefined}
     >
       {isLoading ? <CircularProgress size={16} /> : label}
     </Button>

--- a/src/zui/ZUIButton/index.tsx
+++ b/src/zui/ZUIButton/index.tsx
@@ -42,40 +42,48 @@ const getColor = (variant: ZUIButtonVariant) => {
   }
 };
 
-const getLoadingIndicatorPadding = (
-  size: 'large' | 'medium' | 'small' = 'medium'
-) => {
+const getLoadingIndicatorPadding = (size: 'large' | 'medium' | 'small') => {
   if (size == 'large') {
-    return '13px 22px 13px 22px';
+    return '0.183rem 1.375rem 0.183rem 1.375rem';
   } else if (size == 'medium') {
-    return '10px 16px 10px 16px';
+    return '0.625rem 1rem 0.625rem 1rem';
   } else if (size == 'small') {
-    return '7px 10px 7px 10px';
+    return '0.438rem 0.625rem 0.438rem 0.625rem';
   }
 };
 
 const getTextPadding = (
-  size: 'large' | 'medium' | 'small' = 'medium',
-  variant: ZUIButtonVariant = 'secondary'
+  size: 'large' | 'medium' | 'small',
+  variant: ZUIButtonVariant
 ) => {
   if (size === 'large') {
     if (variant === 'secondary') {
-      return '7px 22px 7px 22px';
+      return '0.438rem 1.375rem 0.438rem 1.375rem';
     } else {
-      return '8px 22px 8px 22px';
+      return '0.5rem 1.375rem 0.5rem 1.375rem';
     }
   }
 
   if (size === 'medium') {
     if (variant === 'tertiary') {
-      return '6px 16px 6px 16px';
+      return '0.375rem 1rem 0.375rem 1rem';
     }
   }
 
   if (size === 'small') {
     if (variant === 'tertiary') {
-      return '4px 10px 4px 10px';
+      return '0.25rem 0.625rem 0.25rem 0.625rem';
     }
+  }
+};
+
+const getFontSize = (size: 'small' | 'medium' | 'large') => {
+  if (size === 'small') {
+    return '0.183rem';
+  } else if (size === 'medium') {
+    return '0.875rem';
+  } else {
+    return '0.938rem';
   }
 };
 
@@ -87,14 +95,14 @@ const ZUIButton: FC<ZUIButtonProps> = ({
   label,
   onClick,
   onKeyDown,
-  size,
+  size = 'medium',
   startIcon,
-  variant,
+  variant = 'secondary',
 }) => {
   const isLoading = variant === 'loading';
   return (
     <Button
-      color={variant ? getColor(variant) : undefined}
+      color={getColor(variant)}
       disabled={disabled || isLoading}
       endIcon={endIcon}
       fullWidth={fullWidth}
@@ -103,13 +111,15 @@ const ZUIButton: FC<ZUIButtonProps> = ({
       size={size}
       startIcon={startIcon}
       sx={{
-        minWidth: '35px',
+        fontSize: getFontSize(size),
+        letterSpacing: size === 'medium' ? '0.025rem' : '0.029rem',
+        minWidth: '2.188rem',
         padding: isLoading
           ? getLoadingIndicatorPadding(size)
           : getTextPadding(size, variant),
       }}
       type={actionType}
-      variant={variant ? getVariant(variant) : undefined}
+      variant={getVariant(variant)}
     >
       {isLoading ? <CircularProgress size={16} /> : label}
     </Button>

--- a/src/zui/ZUIButtonGroup/index.stories.tsx
+++ b/src/zui/ZUIButtonGroup/index.stories.tsx
@@ -47,7 +47,6 @@ export const PrimaryVertical: Story = {
 export const PrimaryVerticalWithIcon: Story = {
   args: {
     buttons: [{ label: 'Hallå' }, { icon: CatchingPokemon }],
-
     orientation: 'vertical',
   },
 };

--- a/src/zui/ZUIButtonGroup/index.tsx
+++ b/src/zui/ZUIButtonGroup/index.tsx
@@ -1,8 +1,36 @@
 import { ButtonGroup } from '@mui/material';
+import { makeStyles } from '@mui/styles';
 import { FC } from 'react';
 
 import ZUIButton, { getVariant, ZUIButtonProps } from 'zui/ZUIButton';
 import ZUIIconButton, { ZUIIconButtonProps } from 'zui/ZUIIconButton';
+
+const useStyles = makeStyles({
+  buttonGroup: {
+    '& > button': {
+      '&.MuiButtonGroup-groupedHorizontal:has(.MuiSvgIcon-root)': {
+        '&.MuiButton-sizeLarge': {
+          ' svg': {
+            fontSize: '1.75rem',
+          },
+        },
+        '&.MuiButton-sizeMedium': {
+          ' svg': {
+            fontSize: '1.5rem',
+          },
+        },
+        '&.MuiButton-sizeSmall': {
+          ' svg': {
+            fontSize: '1.25rem',
+          },
+          minWidth: '1.875rem',
+        },
+        paddingLeft: 0,
+        paddingRight: 0,
+      },
+    },
+  },
+});
 
 interface ZUIButtonGroupProps {
   buttons: (ZUIButtonProps | ZUIIconButtonProps)[];
@@ -17,8 +45,10 @@ const ZUIButtonGroup: FC<ZUIButtonGroupProps> = ({
   size = 'medium',
   variant = 'primary',
 }) => {
+  const classes = useStyles();
   return (
     <ButtonGroup
+      className={classes.buttonGroup}
       orientation={orientation}
       size={size}
       variant={getVariant(variant)}

--- a/src/zui/ZUIHeader/index.tsx
+++ b/src/zui/ZUIHeader/index.tsx
@@ -159,10 +159,9 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
               noWrap
               sx={{
                 display: 'flex',
-                fontSize: '22px',
                 transition: 'margin 0.3s ease',
               }}
-              variant="h4"
+              variant="headingLg"
             >
               {onTitleChange ? (
                 <ZUIEditTextinPlace
@@ -214,7 +213,10 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
                           )}
                           <ListItemText>{item.label}</ListItemText>
                           {item.endContent && (
-                            <Typography color="secondary" variant="body2">
+                            <Typography
+                              color="secondary"
+                              variant="bodySmRegular"
+                            >
                               {item.endContent}
                             </Typography>
                           )}

--- a/src/zui/ZUIHeader/index.tsx
+++ b/src/zui/ZUIHeader/index.tsx
@@ -140,7 +140,7 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
         <Box display="flex" flexDirection="column">
           <Box alignItems="center" display="flex">
             {breadcrumbs && (
-              <Box marginRight={avatar ? '16px' : '12px'}>
+              <Box marginRight={avatar ? '1rem' : '0.75rem'}>
                 <ZUIBreadcrumbs breadcrumbs={breadcrumbs} />
               </Box>
             )}
@@ -148,9 +148,9 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
               <Avatar
                 src={avatar}
                 sx={{
-                  height: 32,
-                  marginRight: '12px',
-                  width: 32,
+                  height: '2rem',
+                  marginRight: '0.75rem',
+                  width: '2rem',
                 }}
               />
             )}
@@ -196,7 +196,7 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
                     setactionButtonPopoverAnchorEl(null)
                   )}
                 {typeof actionButtonPopoverContent !== 'function' && (
-                  <Box minWidth={200}>
+                  <Box minWidth="12.5rem">
                     <MenuList>
                       {actionButtonPopoverContent.map((item, index) => (
                         <MenuItem
@@ -238,7 +238,7 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
         )}
       </Box>
       {showBottomRow && (
-        <Box alignItems="center" display="flex" paddingTop={1}>
+        <Box alignItems="center" display="flex" paddingTop="0.25rem">
           {(belowTitle || metaData) && (
             <Box alignItems="center" display="flex">
               {belowTitle && belowTitle}
@@ -246,12 +246,12 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
                 <Divider
                   flexItem
                   orientation="vertical"
-                  sx={{ height: '22px', marginX: '16px' }}
+                  sx={{ height: '1.375rem', marginX: '1rem' }}
                   variant="middle"
                 />
               )}
               {metaData && (
-                <Box display="flex" flexShrink={0} gap={2}>
+                <Box display="flex" flexShrink={0} gap="0.5rem">
                   {metaData.map((data) => {
                     const Icon = data.icon;
                     return (
@@ -260,16 +260,16 @@ const ZUIHeader: FC<ZUIHeaderProps> = ({
                         alignItems="center"
                         display="flex"
                         flexShrink="0"
-                        gap="6px"
+                        gap="0.375rem"
                       >
                         <Icon
-                          size={20}
+                          size="1.25rem"
                           sx={{ color: theme.palette.grey[400] }}
                         />
                         <Typography
+                          color="secondary"
                           flexShrink="0"
-                          fontSize={14}
-                          sx={{ color: theme.palette.text.secondary }}
+                          variant="bodySmRegular"
                         >
                           {data.label}
                         </Typography>

--- a/src/zui/ZUIMenu/index.tsx
+++ b/src/zui/ZUIMenu/index.tsx
@@ -1,13 +1,6 @@
 import { makeStyles } from '@mui/styles';
 import { FC, ReactNode } from 'react';
-import {
-  ListItemIcon,
-  ListItemText,
-  Menu,
-  MenuItem,
-  Theme,
-  Typography,
-} from '@mui/material';
+import { ListItemIcon, Menu, MenuItem, Theme, Typography } from '@mui/material';
 
 const useStyles = makeStyles<Theme, { maxHeight?: string; width?: string }>(
   (theme) => ({
@@ -75,9 +68,9 @@ const ZUIMenu: FC<ZUIMenuProps> = ({
           }}
         >
           {item.startIcon && <ListItemIcon>{item.startIcon}</ListItemIcon>}
-          <ListItemText>{item.label}</ListItemText>
+          <Typography variant="bodySmRegular">{item.label}</Typography>
           {item.endContent && (
-            <Typography color="secondary" variant="body2">
+            <Typography color="secondary" variant="bodySmRegular">
               {item.endContent}
             </Typography>
           )}

--- a/src/zui/ZUIStatusChip/index.tsx
+++ b/src/zui/ZUIStatusChip/index.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles<Theme, { status: ActivityStatus }>((theme) => ({
   chip: {
     alignItems: 'center',
     backgroundColor: ({ status }) => theme.palette.activityStatusColors[status],
-    borderRadius: '2em',
+    borderRadius: '2rem',
     color: ({ status }) =>
       getContrastColor(theme.palette.activityStatusColors[status]),
     display: 'inline-flex',
@@ -34,7 +34,7 @@ const ZUIStatusChip: FC<ZUIStatusChipProps> = ({ status }) => {
   const classes = useStyles({ status });
   return (
     <Box className={classes.chip}>
-      <Typography sx={{ fontSize: 13 }}>
+      <Typography sx={{ fontSize: '0.813rem' }} variant="bodySmRegular">
         <Msg id={messageIds.statusChip[status]} />
       </Typography>
     </Box>

--- a/src/zui/ZUIText/index.stories.tsx
+++ b/src/zui/ZUIText/index.stories.tsx
@@ -1,0 +1,87 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUIText from './index';
+
+const meta: Meta<typeof ZUIText> = {
+  component: ZUIText,
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIText>;
+
+export const HeadingLarge: Story = {
+  args: {
+    content: 'This is a large heading',
+    variant: 'headingLg',
+  },
+};
+
+export const HeadingMedium: Story = {
+  args: {
+    content: 'This is a medium heading',
+    variant: 'headingMd',
+  },
+};
+
+export const HeadingSmall: Story = {
+  args: {
+    content: 'This is a small heading',
+    variant: 'headingSm',
+  },
+};
+
+export const BodyMediumRegular: Story = {
+  args: {
+    content: 'This is a medium size, regular weight body text',
+    variant: 'bodyMdRegular',
+  },
+};
+
+export const BodyMediumBold: Story = {
+  args: {
+    content: 'This is a medium size, bold weight body text',
+    variant: 'bodyMdBold',
+  },
+};
+
+export const BodySmallRegular: Story = {
+  args: {
+    content: 'This is a small size, regular weight body text',
+    variant: 'bodySmRegular',
+  },
+};
+
+export const BodySmallBold: Story = {
+  args: {
+    content: 'This is a small size, bold weight body text',
+    variant: 'bodySmBold',
+  },
+};
+
+export const LabelMdMedium: Story = {
+  args: {
+    content: 'This is a medium size, medium weight label text',
+    variant: 'labelMdMedium',
+  },
+};
+
+export const LabelMdRegular: Story = {
+  args: {
+    content: 'This is a medium size, regular weight label text',
+    variant: 'labelMdRegular',
+  },
+};
+
+export const LinkMd: Story = {
+  args: {
+    content: 'This is a medium size link text',
+    variant: 'linkMd',
+  },
+};
+
+export const LinkSm: Story = {
+  args: {
+    content: 'This is a small size link text',
+    variant: 'linkSm',
+  },
+};

--- a/src/zui/ZUIText/index.tsx
+++ b/src/zui/ZUIText/index.tsx
@@ -1,0 +1,32 @@
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+type TextVariant =
+  | 'headingLg'
+  | 'headingMd'
+  | 'headingSm'
+  | 'bodyMdRegular'
+  | 'bodyMdBold'
+  | 'bodySmRegular'
+  | 'bodySmBold'
+  | 'linkMd'
+  | 'linkSm'
+  | 'labelMdMedium'
+  | 'labelMdRegular';
+
+interface ZUITextProps {
+  content: string;
+  color?: 'primary' | 'secondary';
+  component: 'a' | 'div' | 'p' | 'span';
+  variant: TextVariant;
+}
+
+const ZUIText: FC<ZUITextProps> = ({ component, color, content, variant }) => {
+  return (
+    <Typography color={color} component={component} variant={variant}>
+      {content}
+    </Typography>
+  );
+};
+
+export default ZUIText;


### PR DESCRIPTION
## Description
This PR adds the new font, [Figtree ](https://fonts.google.com/specimen/Figtree), to the project. 
It also adds styling for text in the theme, and begins the journey of replacing all uses of `px` with `rem` values. 

## Screenshots
![bild](https://github.com/user-attachments/assets/774f440e-e467-4940-b4fd-b52135e50e8a)

## Changes
* Adds the Figtree font
* Removes some unused styling from the `styles.css` file
* Adds the `ZUIText` component
* Adds styling in the theme for the MUI `Typography` component
* Removes uses of `px` values and replaces them with `rem` equivalents, in the new theme and new ZUI components. 
* Moves some bits of styling from the theme into its components.

## Notes to reviewer
Does it make sense to do this in this way? This means the "right side" of the Figma typography variants, the "component only" ones, will have to be created individually for each place that text of that type will be used - so for example in `ZUIButton` i have hardcoded font sizes for the sizes of button you can create. There is no place where the "right side" styles for typography is gathered centrally, like with the "left side" ones, that are available through the theme styling.

## Related issues
none
