### PR TITLE
Change locked targets number to total match number

### DIFF
--- a/src/features/campaigns/components/ActivityList/items/EmailListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EmailListItem.tsx
@@ -27,9 +27,10 @@ const EmailListItem: FC<EmailListItemProps> = ({ orgId, emailId }) => {
     numTargetMatches,
     numOpened,
     numSent,
-    lockedReadyTargets,
     isLoading: statsLoading,
+    numBlocked,
   } = useEmailStats(orgId, emailId);
+  const endNumber = numTargetMatches - numBlocked.any ?? 0;
 
   if (!email) {
     return null;
@@ -42,7 +43,7 @@ const EmailListItem: FC<EmailListItemProps> = ({ orgId, emailId }) => {
     <ActivityListItemWithStats
       blueChipValue={numOpened}
       color={statusColors[state]}
-      endNumber={lockedReadyTargets ?? 0}
+      endNumber={endNumber}
       greenChipValue={numClicked}
       href={`/organize/${orgId}/projects/${
         email.campaign?.id ?? 'standalone'
@@ -56,7 +57,7 @@ const EmailListItem: FC<EmailListItemProps> = ({ orgId, emailId }) => {
   ) : (
     <ActivityListItem
       color={statusColors[state]}
-      endNumber={email.locked ? lockedReadyTargets ?? 0 : numTargetMatches}
+      endNumber={endNumber}
       href={`/organize/${orgId}/projects/${
         email.campaign?.id ?? 'standalone'
       }/emails/${emailId}`}

--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -79,7 +79,7 @@ const EmailLayout: FC<EmailLayoutProps> = ({
                           id={messageIds.stats.lockedTargets}
                           values={{
                             numLocked:
-                              emailStats.num_locked_targets -
+                              emailStats.num_target_matches -
                               emailStats.num_blocked.any,
                           }}
                         />


### PR DESCRIPTION
## Description
This PR fixes a bug where the email target number is incorrect.


## Screenshots
- Before 
![image](https://github.com/user-attachments/assets/58cd6e3d-41ac-4951-bacf-076242d4acf5)
![image](https://github.com/user-attachments/assets/4ecc99ae-4ce8-4bc9-a4a4-2ce527a18675)

- After
![image](https://github.com/user-attachments/assets/ffcbb762-2d29-4fa8-87df-35d0b44cea6e)
![image](https://github.com/user-attachments/assets/5695682f-c201-48f5-a387-9bf405b0878c)



## Changes

* Changes `num_locked_targets` to `num_target_matches`


## Notes to reviewer


## Related issues
Resolves #2082 
