### PR TITLE
Feature flags

### DIFF
--- a/src/app/o/[orgId]/areas/[areaId]/page.tsx
+++ b/src/app/o/[orgId]/areas/[areaId]/page.tsx
@@ -1,6 +1,8 @@
 import 'leaflet/dist/leaflet.css';
+import { notFound } from 'next/navigation';
 
 import AreaPage from 'features/areas/components/AreaPage';
+import { AREAS, hasFeature } from 'utils/featureFlags';
 
 interface PageProps {
   params: {
@@ -11,5 +13,11 @@ interface PageProps {
 
 export default function Page({ params }: PageProps) {
   const { orgId, areaId } = params;
+  const hasAreas = hasFeature(AREAS, parseInt(orgId), process.env);
+
+  if (!hasAreas) {
+    return notFound();
+  }
+
   return <AreaPage areaId={areaId} orgId={parseInt(orgId)} />;
 }

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -42,7 +42,7 @@ const ClientContext: FC<ClientContextProps> = ({
   messages,
   user,
 }) => {
-  const env = new Environment(store, new BrowserApiClient(), envVars);
+  const env = new Environment(new BrowserApiClient(), envVars);
   return (
     <ReduxProvider store={store}>
       <StyledEngineProvider injectFirst>

--- a/src/core/env/EnvContext.tsx
+++ b/src/core/env/EnvContext.tsx
@@ -1,13 +1,12 @@
-import { createContext, FC, ReactNode } from 'react';
+import { createContext, FC, PropsWithChildren } from 'react';
 
 import Environment from './Environment';
 
 const EnvContext = createContext<Environment | null>(null);
 
-interface EnvProviderProps {
-  children: ReactNode;
+type EnvProviderProps = PropsWithChildren & {
   env: Environment;
-}
+};
 
 const EnvProvider: FC<EnvProviderProps> = ({ children, env }) => {
   return <EnvContext.Provider value={env}>{children}</EnvContext.Provider>;

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -1,5 +1,4 @@
 import IApiClient from 'core/api/client/IApiClient';
-import { Store } from '../store';
 
 type EnvVars = {
   MUIX_LICENSE_KEY: string | null;
@@ -8,24 +7,18 @@ type EnvVars = {
 
 export default class Environment {
   private _apiClient: IApiClient;
-  private _store: Store;
   private _vars: EnvVars;
 
   get apiClient() {
     return this._apiClient;
   }
 
-  constructor(store: Store, apiClient: IApiClient, envVars?: EnvVars) {
+  constructor(apiClient: IApiClient, envVars?: EnvVars) {
     this._apiClient = apiClient;
-    this._store = store;
     this._vars = envVars || {
       MUIX_LICENSE_KEY: null,
       ZETKIN_APP_DOMAIN: null,
     };
-  }
-
-  get store() {
-    return this._store;
   }
 
   get vars() {

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -1,6 +1,7 @@
 import IApiClient from 'core/api/client/IApiClient';
 
 type EnvVars = {
+  FEAT_AREAS?: string | null;
   MUIX_LICENSE_KEY: string | null;
   ZETKIN_APP_DOMAIN: string | null;
 };
@@ -16,6 +17,7 @@ export default class Environment {
   constructor(apiClient: IApiClient, envVars?: EnvVars) {
     this._apiClient = apiClient;
     this._vars = envVars || {
+      FEAT_AREAS: null,
       MUIX_LICENSE_KEY: null,
       ZETKIN_APP_DOMAIN: null,
     };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,7 +50,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     window.__reactRendered = true;
   }
 
-  const env = new Environment(store, new BrowserApiClient(), envVars || {});
+  const env = new Environment(new BrowserApiClient(), envVars || {});
 
   // MUI-X license
   if (env.vars.MUIX_LICENSE_KEY) {

--- a/src/pages/organize/[orgId]/areas/index.tsx
+++ b/src/pages/organize/[orgId]/areas/index.tsx
@@ -9,6 +9,7 @@ import useAreas from 'features/areas/hooks/useAreas';
 import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
 import hasFeature from 'utils/featureFlags/hasFeature';
+import { AREAS } from 'utils/featureFlags';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -16,7 +17,7 @@ const scaffoldOptions = {
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
-  const hasAreas = hasFeature('AREAS', parseInt(orgId as string), process.env);
+  const hasAreas = hasFeature(AREAS, parseInt(orgId as string), process.env);
 
   if (!hasAreas) {
     return {

--- a/src/pages/organize/[orgId]/areas/index.tsx
+++ b/src/pages/organize/[orgId]/areas/index.tsx
@@ -8,12 +8,22 @@ import { PageWithLayout } from 'utils/types';
 import useAreas from 'features/areas/hooks/useAreas';
 import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
+import hasFeature from 'utils/featureFlags/hasFeature';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
 };
 
-export const getServerSideProps: GetServerSideProps = scaffold(async () => {
+export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
+  const { orgId } = ctx.params!;
+  const hasAreas = hasFeature('AREAS', parseInt(orgId as string), process.env);
+
+  if (!hasAreas) {
+    return {
+      notFound: true,
+    };
+  }
+
   return {
     props: {},
   };

--- a/src/utils/featureFlags/hasFeature.ts
+++ b/src/utils/featureFlags/hasFeature.ts
@@ -1,0 +1,13 @@
+export default function hasFeature(
+  featureLabel: string,
+  orgId: number,
+  envVars: Record<string, string | undefined>
+): boolean {
+  const envValue = envVars['FEAT_' + featureLabel];
+
+  const settings = envValue?.split(',') || [];
+
+  return settings.some((setting) => {
+    return setting == '*' || setting == orgId.toString();
+  });
+}

--- a/src/utils/featureFlags/hasFeature.ts
+++ b/src/utils/featureFlags/hasFeature.ts
@@ -3,7 +3,7 @@ export default function hasFeature(
   orgId: number,
   envVars: Record<string, string | undefined>
 ): boolean {
-  const envValue = envVars['FEAT_' + featureLabel];
+  const envValue = envVars[featureLabel];
 
   const settings = envValue?.split(',') || [];
 

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -1,0 +1,4 @@
+export { default as useFeature } from './useFeature';
+export { default as hasFeature } from './hasFeature';
+
+export const AREAS = 'FEAT_AREAS';

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -1,4 +1,3 @@
-export { default as useFeature } from './useFeature';
 export { default as hasFeature } from './hasFeature';
 
 export const AREAS = 'FEAT_AREAS';

--- a/src/utils/featureFlags/useFeature.spec.ts
+++ b/src/utils/featureFlags/useFeature.spec.ts
@@ -35,7 +35,7 @@ describe('useFeature()', () => {
     const opts = getOptsWithEnvVars({
       FEAT_AREAS: '1',
     });
-    const { result } = renderHook(() => useFeature('AREAS', 1), opts);
+    const { result } = renderHook(() => useFeature('FEAT_AREAS', 1), opts);
     expect(result.current).toBeTruthy();
   });
 
@@ -43,7 +43,7 @@ describe('useFeature()', () => {
     const opts = getOptsWithEnvVars({
       FEAT_AREAS: '1,2,3',
     });
-    const { result } = renderHook(() => useFeature('AREAS', 2), opts);
+    const { result } = renderHook(() => useFeature('FEAT_AREAS', 2), opts);
     expect(result.current).toBeTruthy();
   });
 
@@ -51,7 +51,7 @@ describe('useFeature()', () => {
     const opts = getOptsWithEnvVars({
       FEAT_AREAS: '1,2,3',
     });
-    const { result } = renderHook(() => useFeature('AREAS', 4), opts);
+    const { result } = renderHook(() => useFeature('FEAT_AREAS', 4), opts);
     expect(result.current).toBeFalsy();
   });
 
@@ -61,7 +61,7 @@ describe('useFeature()', () => {
       const opts = getOptsWithEnvVars({
         FEAT_AREAS: '*',
       });
-      const { result } = renderHook(() => useFeature('AREAS', 1), opts);
+      const { result } = renderHook(() => useFeature('FEAT_AREAS', 1), opts);
       expect(result.current).toBeTruthy();
     }
   );

--- a/src/utils/featureFlags/useFeature.spec.ts
+++ b/src/utils/featureFlags/useFeature.spec.ts
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { createElement, PropsWithChildren } from 'react';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { EnvProvider } from 'core/env/EnvContext';
+import Environment from 'core/env/Environment';
+import useFeature from './useFeature';
+
+function getOptsWithEnvVars(vars?: Partial<Environment['vars']>) {
+  return {
+    wrapper: ({ children }: PropsWithChildren) =>
+      createElement(
+        EnvProvider,
+        {
+          env: new Environment(null as unknown as IApiClient, {
+            FEAT_AREAS: null,
+            MUIX_LICENSE_KEY: null,
+            ZETKIN_APP_DOMAIN: null,
+            ...vars,
+          }),
+        },
+        children
+      ),
+  };
+}
+
+describe('useFeature()', () => {
+  it('returns false for empty vars', () => {
+    const opts = getOptsWithEnvVars();
+    const { result } = renderHook(() => useFeature('UNKNOWN', 1), opts);
+    expect(result.current).toBeFalsy();
+  });
+
+  it('returns true when org ID is in feature flag', () => {
+    const opts = getOptsWithEnvVars({
+      FEAT_AREAS: '1',
+    });
+    const { result } = renderHook(() => useFeature('AREAS', 1), opts);
+    expect(result.current).toBeTruthy();
+  });
+
+  it('returns true when org ID is listed in feature flag', () => {
+    const opts = getOptsWithEnvVars({
+      FEAT_AREAS: '1,2,3',
+    });
+    const { result } = renderHook(() => useFeature('AREAS', 2), opts);
+    expect(result.current).toBeTruthy();
+  });
+
+  it('returns false when orgId is not listed in feature flag', () => {
+    const opts = getOptsWithEnvVars({
+      FEAT_AREAS: '1,2,3',
+    });
+    const { result } = renderHook(() => useFeature('AREAS', 4), opts);
+    expect(result.current).toBeFalsy();
+  });
+
+  it.each([1, 2, 34, 567])(
+    'returns true for orgId=%p when feature flag is *',
+    () => {
+      const opts = getOptsWithEnvVars({
+        FEAT_AREAS: '*',
+      });
+      const { result } = renderHook(() => useFeature('AREAS', 1), opts);
+      expect(result.current).toBeTruthy();
+    }
+  );
+});

--- a/src/utils/featureFlags/useFeature.ts
+++ b/src/utils/featureFlags/useFeature.ts
@@ -1,0 +1,12 @@
+import useEnv from '../../core/hooks/useEnv';
+import hasFeature from './hasFeature';
+
+export default function useFeature(
+  featureLabel: string,
+  orgId: number
+): boolean {
+  const env = useEnv();
+
+  const untypedVars = env.vars as Record<string, string | undefined>;
+  return hasFeature(featureLabel, orgId, untypedVars);
+}

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -190,6 +190,7 @@ export const scaffold =
       result.props = {
         ...result.props,
         envVars: {
+          FEAT_AREAS: process.env.FEAT_AREAS || null,
           MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY || null,
           ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN || null,
         },

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -19,7 +19,7 @@ import IApiClient from 'core/api/client/IApiClient';
 import RosaLuxemburgUser from '../../../integrationTesting/mockData/users/RosaLuxemburgUser';
 import theme from 'theme';
 import { UserContext } from 'utils/hooks/useFocusDate';
-import createStore, { Store } from 'core/store';
+import { Store } from 'core/store';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -31,8 +31,7 @@ interface ZetkinAppProvidersProps {
 }
 
 const ZetkinAppProviders: FC<ZetkinAppProvidersProps> = ({ children }) => {
-  const store = createStore();
-  const env = new Environment(store, new BrowserApiClient(), {
+  const env = new Environment(new BrowserApiClient(), {
     MUIX_LICENSE_KEY: null,
     ZETKIN_APP_DOMAIN: 'https://app.zetkin.org',
   });
@@ -109,7 +108,7 @@ export const makeWrapper = (store: Store) =>
       rpc: jest.fn(),
     };
 
-    const env = new Environment(store, apiClient);
+    const env = new Environment(apiClient);
     return (
       <ReduxProvider store={store}>
         <EnvProvider env={env}>

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -43,6 +43,7 @@ import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIUserAvatar from 'zui/ZUIUserAvatar';
 import useFeature from 'utils/featureFlags/useFeature';
+import { AREAS } from 'utils/featureFlags';
 
 const drawerWidth = 300;
 
@@ -94,7 +95,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const [open, setOpen] = useState(lastOpen);
   const [searchString, setSearchString] = useState('');
   const organizationFuture = useOrganization(orgId);
-  const hasAreas = useFeature('AREAS', orgId);
+  const hasAreas = useFeature(AREAS, orgId);
 
   const handleExpansion = () => {
     setChecked(!checked);

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -42,6 +42,7 @@ import SidebarListItem from './SidebarListItem';
 import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIUserAvatar from 'zui/ZUIUserAvatar';
+import useFeature from 'utils/featureFlags/useFeature';
 
 const drawerWidth = 300;
 
@@ -93,6 +94,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const [open, setOpen] = useState(lastOpen);
   const [searchString, setSearchString] = useState('');
   const organizationFuture = useOrganization(orgId);
+  const hasAreas = useFeature('AREAS', orgId);
 
   const handleExpansion = () => {
     setChecked(!checked);
@@ -283,6 +285,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                 )}
               />
               {menuItemsMap.map(({ name, icon }) => {
+                if (name == 'areas' && !hasAreas) {
+                  return null;
+                }
+
                 return (
                   <NextLink
                     key={name}


### PR DESCRIPTION
## Description
This PR adds support for "feature flagging" using environment variables and a simple syntax that allows turning features on and off for organizations.

### Environment variable syntax
Feature flags can be defined as environment variables, one variable per feature. Variables can have any name, but as a matter of convention, I'm proposing that we use `FEAT_` as a prefix. The value (and existence) of a variable defines what organizations should be allowed to access the feature, according to these basic rules:

* An empty value (or undefined variable) means no one should be able to access the feature
* An organization ID (e.g. `1`) means that the feature should be available only to the organization with that ID
* A comma-separated list of organization IDs (e.g. `1,2,3`) enables the feature for multiple organizations
* An asterisk (`*`) enables the feature for everyone

Because of the implementation, it's technically possible to write `x,y,1,2,*` which will enable the feature for invalid organization IDs x and y, valid organization IDs 1 and 2, and _all organizations_ which effectively overrides everything.

### Using flag in code
The flag can be accessed in two ways from code.

On the server, the `hasFeature()` utility function can be used, passing `process.env` as one of the parameters. This allows for redirecting or returning a 404 on pages that should only be available to organizations for which the feature is turned on.

```tsx
const hasTheFeature = hasFeature('FEAT_THEFEATURE', 1, process.env);
if (!hasTheFeature) {
  return {
    notFound: true,
  };
}
```

In React, the `useFeature()` can be used to get the value from the environment variables available in the context. This allows for toggling the visibility of UI elements (e.g. menu items) in order to make the feature available only to organizations for which the feature is turned on.

```tsx
const hasTheFeature = useFeature('FEAT_THEFEATURE', 1);
if (!hasTheFeature) {
  return null;
}
```

I'm proposing that as a matter of convention we don't hardcode strings like `'FEAT_THEFEATURE'`. Instead, we should expose constants from the new `featureFlags` module and use those. That way, once a feature is complete and we no longer need the flag, we can easily find all the places where that constant is referenced in order to clean out the flags.

So that's what I do in this PR, e.g:

```tsx
import { AREAS } from 'utils/featureFlags';

const hasAreas = hasFeature(AREAS, parseInt(orgId as string), process.env);

if (!hasAreas) {
  return {
    notFound: true,
  };
}
```


## Screenshots
None

## Changes
* Removes store argument from `Environment` constructor. It was obsolete and not used anywhere, and was getting in the way of the changes I wanted to make in this PR.
* Adds `hasFeature()` utility function
* Adds `useFeature()` hook (including tests)
* Adds `'FEAT_AREAS'` environment variable and `featureFlags.AREAS` constant
* Conditionally hides "Areas" item from menu based on flag
* Conditionally returns 404 on /organize/ID/areas based on flag
* Conditionally returns 404 on /o/ID/areas/ID based on flag

## Notes to reviewer
Change your `.env.local` to include this:

```env
FEAT_AREAS=1
```

Then try navigating to these pages:

* /organize/1/areas (should work as before)
* /organize/2/areas (should return 404)
* /organize/2/people (the menu should not include the "Areas" item)
* /o/1/areas/<SOME_ID> (should work as before)
* /o/2/areas/<SOME_ID> (should return 404)

## Related issues
Undocumented