### PR TITLE
Fix type error introduced by recent merges

### DIFF
--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -531,9 +531,8 @@ export interface ZetkinEmail {
   theme: EmailTheme | null;
   id: number;
   locked: string | null;
-  processed?: string | null;
-  published: string | null;
   processed: string | null;
+  published: string | null;
   subject: string | null;
   organization: { id: number; title: string };
   content: string | null;


### PR DESCRIPTION
## Description
This PR fixes a type error caught by CI on `main`.

The error was introduced by recent merges of #2076 and #2107 that both introduced the `processed` property on emails, but with slightly different signatures. In #2107 it was optional, which doesn't correctly represent the API but was probably done because it was easier (did not require any changes to mock data etc). In #2076 it was more correctly typed as required (but possibly `null`) which better represents the API, and the mocks updated to match.

## Screenshots
None

## Changes
* Removes one of the two (duplicate) `processed` attributes on the `ZetkinEmail` type.

## Notes to reviewer
None

## Related issues
Undocumented