### PR TITLE
#2100 Add avatars to merge duplicate icons

### DIFF
--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -89,6 +89,7 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
           width="50%"
         >
           <FieldSettings
+            duplicates={peopleToMerge}
             fieldValues={fieldValues}
             onChange={(field, value) => {
               setOverrides({ ...overrides, [`${field}`]: value });

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -12,14 +12,19 @@ import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import { Msg, useMessages } from 'core/i18n';
+import { useNumericRouteParams } from 'core/hooks';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import ZUIAvatar from 'zui/ZUIAvatar';
 
 interface FieldSettingsRowProps {
+  duplicates: ZetkinPerson[];
   field: NATIVE_PERSON_FIELDS;
   onChange: (selectedValue: string) => void;
   values: string[];
 }
 
 const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
+  duplicates,
   field,
   onChange,
   values,
@@ -27,6 +32,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
   const theme = useTheme();
   const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
+  const { orgId } = useNumericRouteParams();
 
   const getLabel = (value: string) => {
     if (field === NATIVE_PERSON_FIELDS.GENDER) {
@@ -48,6 +54,25 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
     }
 
     return value;
+  };
+
+  const getAvatars = (value: String) => {
+    const peopleWithMatchingValues = duplicates.filter(
+      (person) => person[field] == value
+    );
+
+    return (
+      <Box display="flex" gap="2px">
+        {peopleWithMatchingValues.map((person) => {
+          return (
+            <ZUIAvatar
+              size={'xs'}
+              url={`/api/orgs/${orgId}/people/${person.id}/avatar`}
+            />
+          );
+        })}
+      </Box>
+    );
   };
 
   return (
@@ -89,11 +114,21 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
                 setSelectedValue(event.target.value);
                 onChange(event.target.value);
               }}
+              renderValue={() => getLabel(selectedValue)}
               value={selectedValue}
             >
               {values.map((value, index) => (
-                <MenuItem key={index} value={value}>
+                <MenuItem
+                  key={index}
+                  value={value}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    gap: 1,
+                  }}
+                >
                   {getLabel(value)}
+                  {getAvatars(value)}
                 </MenuItem>
               ))}
             </Select>

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -56,16 +56,17 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
     return value;
   };
 
-  const getAvatars = (value: String) => {
+  const getAvatars = (value: string) => {
     const peopleWithMatchingValues = duplicates.filter(
       (person) => person[field] == value
     );
 
     return (
       <Box display="flex" gap="2px">
-        {peopleWithMatchingValues.map((person) => {
+        {peopleWithMatchingValues.map((person, index) => {
           return (
             <ZUIAvatar
+              key={index}
               size={'xs'}
               url={`/api/orgs/${orgId}/people/${person.id}/avatar`}
             />
@@ -120,12 +121,12 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
               {values.map((value, index) => (
                 <MenuItem
                   key={index}
-                  value={value}
                   sx={{
                     display: 'flex',
-                    justifyContent: 'space-between',
                     gap: 1,
+                    justifyContent: 'space-between',
                   }}
+                  value={value}
                 >
                   {getLabel(value)}
                   {getAvatars(value)}

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -53,8 +53,8 @@ const FieldSettings: FC<FieldSettingsProps> = ({
             <>
               {field !== NATIVE_PERSON_FIELDS.FIRST_NAME && <Divider />}
               <FieldSettingsRow
-                duplicates={duplicates}
                 key={field}
+                duplicates={duplicates}
                 field={field as NATIVE_PERSON_FIELDS}
                 onChange={(selectedValue: string) =>
                   onChange(field as NATIVE_PERSON_FIELDS, selectedValue)

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -5,13 +5,19 @@ import FieldSettingsRow from './FieldSettingsRow';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import { useMessages } from 'core/i18n';
+import { ZetkinPerson } from 'utils/types/zetkin';
 
 interface FieldSettingsProps {
+  duplicates: ZetkinPerson[];
   fieldValues: Record<string, string[]>;
   onChange: (field: NATIVE_PERSON_FIELDS, selectedValue: string) => void;
 }
 
-const FieldSettings: FC<FieldSettingsProps> = ({ fieldValues, onChange }) => {
+const FieldSettings: FC<FieldSettingsProps> = ({
+  duplicates,
+  fieldValues,
+  onChange,
+}) => {
   const theme = useTheme();
   const messages = useMessages(messageIds);
 
@@ -47,6 +53,7 @@ const FieldSettings: FC<FieldSettingsProps> = ({ fieldValues, onChange }) => {
             <>
               {field !== NATIVE_PERSON_FIELDS.FIRST_NAME && <Divider />}
               <FieldSettingsRow
+                duplicates={duplicates}
                 key={field}
                 field={field as NATIVE_PERSON_FIELDS}
                 onChange={(selectedValue: string) =>

--- a/src/features/duplicates/hooks/useDuplicates.tsx
+++ b/src/features/duplicates/hooks/useDuplicates.tsx
@@ -1,9 +1,5 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import {
-  PotentialDuplicate,
-  potentialDuplicatesLoad,
-  potentialDuplicatesLoaded,
-} from '../store';
+import { potentialDuplicatesLoad, potentialDuplicatesLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 export default function useDuplicates(orgId: number) {

--- a/src/features/duplicates/hooks/useDuplicates.tsx
+++ b/src/features/duplicates/hooks/useDuplicates.tsx
@@ -1,5 +1,9 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { potentialDuplicatesLoad, potentialDuplicatesLoaded } from '../store';
+import {
+  PotentialDuplicate,
+  potentialDuplicatesLoad,
+  potentialDuplicatesLoaded,
+} from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 
 export default function useDuplicates(orgId: number) {

--- a/src/zui/ZUIAvatar/index.tsx
+++ b/src/zui/ZUIAvatar/index.tsx
@@ -2,13 +2,14 @@ import { Avatar } from '@mui/material';
 
 interface ZUIAvatarProps {
   url: string;
-  size: 'sm' | 'md' | 'lg';
+  size: 'xs' | 'sm' | 'md' | 'lg';
 }
 
 const SIZES = {
   lg: 50,
   md: 40,
   sm: 30,
+  xs: 20,
 };
 
 const ZUIAvatar: React.FC<ZUIAvatarProps> = ({ url, size }) => {


### PR DESCRIPTION
## Description
When merging duplicate person objects, it's hard to know which data comes from which person. This PR adds a helpful avatar icon next to the option specifying which person the data came from. 


## Screenshots
![image](https://github.com/user-attachments/assets/70049f64-19aa-456d-90ad-88cb75ddbc84)
![image](https://github.com/user-attachments/assets/7b5b2b4e-56b2-415b-aed9-4ad303731c0e)



## Changes
* Adds avatars to merge duplicate options
* Adds a new _xs_ option to the ZUIAvatar


## Notes to reviewer
To test: Make two or more similar records. Once a day, the system looks for duplicates and adds them to the duplicates page for review, where you can test this. (You can also change the useDuplicates hook to send you dummy data, if you're testing on your local Zetkin)


## Related issues
Resolves #2100
