### PR TITLE
Add sorting to import organization-configuration

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
@@ -29,6 +29,17 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
   if (!activeOrgs.length) {
     return null;
   }
+  const org = activeOrgs.find((org) => org.id == orgId);
+
+  const sortedActiveOrgs = activeOrgs
+    .filter((org) => org.id != orgId)
+    .sort((orgA, orgB) => {
+      return orgA.title.localeCompare(orgB.title);
+    });
+
+  if (org) {
+    sortedActiveOrgs.unshift(org);
+  }
 
   return (
     <Box
@@ -72,7 +83,7 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
             numRows={uiDataColumn.numRowsByUniqueValue[uniqueValue]}
             onDeselectOrg={() => deselectOrg(uniqueValue)}
             onSelectOrg={(orgId) => selectOrg(orgId, uniqueValue)}
-            orgs={activeOrgs}
+            orgs={sortedActiveOrgs}
             selectedOrgId={getSelectedOrgId(uniqueValue)}
             title={uniqueValue.toString()}
           />


### PR DESCRIPTION
## Description
This PR sorts the organizations in the importer. Also always puts current organization first.

## Screenshots

<img width="1438" alt="Skärmavbild 2024-09-14 kl  14 28 46" src="https://github.com/user-attachments/assets/ce4b92a2-5893-44cb-8114-3fe517ed306f">

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes: Order of organizations in import. Sorts alphabetically but always puts the current organization first.

## Related issues
Resolves #2122
