### PR TITLE
Add dialog to move events between campaigns

### DIFF
--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -1,12 +1,13 @@
 import { useRouter } from 'next/router';
 import { Box, Button } from '@mui/material';
 import {
+  ArrowForward,
   CancelOutlined,
   ContentCopy,
   Delete,
   RestoreOutlined,
 } from '@mui/icons-material';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import dayjs from 'dayjs';
 
 import messageIds from '../l10n/messageIds';
@@ -17,6 +18,7 @@ import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUIDatePicker from 'zui/ZUIDatePicker';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import EventMoveDialog from './EventChangeCampaignDialog';
 
 interface EventActionButtonsProps {
   event: ZetkinEvent;
@@ -32,6 +34,7 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
   const { cancelEvent, deleteEvent, restoreEvent, setPublished } =
     useEventMutations(orgId, event.id);
   const duplicateEvent = useDuplicateEvent(orgId, event.id);
+  const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
 
   const published =
     !!event.published && new Date(event.published) <= new Date();
@@ -62,6 +65,10 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
 
   const handleCancel = () => {
     event.cancelled ? restoreEvent() : cancelEvent();
+  };
+
+  const handleMove = () => {
+    setIsMoveDialogOpen(true);
   };
 
   return (
@@ -116,6 +123,11 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
               startIcon: <ContentCopy />,
             },
             {
+              label: <>{messages.eventActionButtons.move()}</>,
+              onSelect: handleMove,
+              startIcon: <ArrowForward />,
+            },
+            {
               label: <>{messages.eventActionButtons.delete()}</>,
               onSelect: () => {
                 showConfirmDialog({
@@ -137,6 +149,12 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
       <Box>
         <ZUIDatePicker date={event.published} onChange={handleChangeDate} />
       </Box>
+
+      <EventMoveDialog
+        close={() => setIsMoveDialogOpen(false)}
+        event={event}
+        isOpen={isMoveDialogOpen}
+      />
     </Box>
   );
 };

--- a/src/features/events/components/EventChangeCampaignDialog.tsx
+++ b/src/features/events/components/EventChangeCampaignDialog.tsx
@@ -1,0 +1,193 @@
+import { Architecture, Close, Search } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  TextField,
+  useMediaQuery,
+} from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { useContext, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import theme from 'theme';
+import { useMessages } from 'core/i18n';
+import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+import useCampaigns from 'features/campaigns/hooks/useCampaigns';
+import { ZetkinCampaign, ZetkinEvent } from 'utils/types/zetkin';
+import useEventMutations from '../hooks/useEventMutations';
+import messageIds from 'features/events/l10n/messageIds';
+
+interface EventActionButtonsProps {
+  event: ZetkinEvent;
+  isOpen: boolean;
+  close: () => void;
+}
+
+const useStyles = makeStyles(() => ({
+  list: {
+    listStyle: 'none',
+  },
+  listItem: {},
+}));
+
+const EventMoveDialog: React.FunctionComponent<EventActionButtonsProps> = ({
+  event,
+  isOpen,
+  close,
+}) => {
+  const classes = useStyles();
+  const messages = useMessages(messageIds);
+
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+
+  const router = useRouter();
+  const { showSnackbar } = useContext(ZUISnackbarContext);
+  const { changeEventCampaign } = useEventMutations(
+    event.organization.id,
+    event.id
+  );
+
+  const [campaignFilter, setCampaignFilter] = useState('');
+  const [isLoadingCampaign, setIsLoadingCampaign] = useState(0);
+
+  const { data: campaigns } = useCampaigns(event.organization.id);
+  campaigns?.reverse();
+
+  const filteredCampaigns = campaigns
+    ?.filter((campaign) =>
+      campaign.title.toLowerCase().includes(campaignFilter)
+    )
+    .filter((campaign) => campaign.id !== event.campaign?.id);
+
+  const onSearchChange = (value: string) => {
+    setCampaignFilter(value);
+  };
+
+  const handleMove = async (campaign: ZetkinCampaign) => {
+    setIsLoadingCampaign(campaign.id);
+
+    changeEventCampaign(campaign.id);
+
+    showSnackbar(
+      'success',
+      messages.eventChangeCampaign.changedMessage({
+        campaignTitle: campaign.title,
+      })
+    );
+
+    router.push(
+      `/organize/${campaign.organization.id}/projects/${campaign.id}/events/${event.id}`
+    );
+
+    handleClose();
+  };
+
+  const handleClose = () => {
+    setIsLoadingCampaign(0);
+    setCampaignFilter('');
+    close();
+  };
+
+  return (
+    <Dialog
+      fullScreen={fullScreen}
+      fullWidth
+      maxWidth={'sm'}
+      onClose={() => {
+        close();
+      }}
+      open={isOpen}
+    >
+      <DialogContent
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '85vh',
+        }}
+      >
+        <Box display="flex" justifyContent="space-between">
+          <DialogTitle sx={{ paddingLeft: 2 }} variant="h5">
+            {messages.eventChangeCampaign.dialogTitle()}
+          </DialogTitle>
+
+          <IconButton onClick={handleClose}>
+            <Close
+              color="secondary"
+              sx={{
+                cursor: 'pointer',
+              }}
+            />
+          </IconButton>
+        </Box>
+
+        <Box>
+          <TextField
+            fullWidth
+            id="EventMoveDialog-inputField"
+            InputProps={{
+              startAdornment: <Search color="secondary" />,
+            }}
+            onChange={(ev) => onSearchChange(ev.target.value)}
+            value={campaignFilter}
+            variant="outlined"
+          />
+
+          <Box
+            sx={{
+              overflowY: 'scroll',
+            }}
+          >
+            <List>
+              {Array.isArray(filteredCampaigns) &&
+                filteredCampaigns.map((campaign) => {
+                  return (
+                    <ListItem
+                      key={`EventMoveDialog-campaignItem-${campaign.id}`}
+                      className={classes.listItem}
+                    >
+                      <Box
+                        alignItems="center"
+                        display="flex"
+                        justifyContent="space-between"
+                        width="100%"
+                      >
+                        <Box alignItems="center" display="flex" marginRight={2}>
+                          <Box marginRight={2}>
+                            <Architecture color="secondary" />
+                          </Box>
+                          {campaign.title}
+                        </Box>
+                        <Box alignItems="center" display="flex">
+                          {!isLoadingCampaign && (
+                            <Button
+                              color="info"
+                              onClick={() => handleMove(campaign)}
+                              variant="outlined"
+                            >
+                              Move
+                            </Button>
+                          )}
+                          {isLoadingCampaign === campaign.id && (
+                            <CircularProgress color="secondary" />
+                          )}
+                        </Box>
+                      </Box>
+                    </ListItem>
+                  );
+                })}
+            </List>
+          </Box>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default EventMoveDialog;

--- a/src/features/events/hooks/useEventMutations.ts
+++ b/src/features/events/hooks/useEventMutations.ts
@@ -22,6 +22,7 @@ export type ZetkinEventPostBody = ZetkinEventPatchBody;
 
 type useEventMutationsReturn = {
   cancelEvent: () => void;
+  changeEventCampaign: (campaignId: number) => void;
   deleteEvent: () => void;
   publishEvent: () => void;
   restoreEvent: () => void;
@@ -62,6 +63,12 @@ export default function useEventMutations(
     });
   };
 
+  const changeEventCampaign = (campaignId: number) => {
+    updateEvent({
+      campaign_id: campaignId,
+    });
+  };
+
   const setPublished = (published: string | null) => {
     updateEvent({
       cancelled: null,
@@ -90,6 +97,7 @@ export default function useEventMutations(
 
   return {
     cancelEvent,
+    changeEventCampaign,
     deleteEvent,
     publishEvent,
     restoreEvent,

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -19,6 +19,7 @@ export default makeMessages('feat.events', {
     cancel: m('Cancel'),
     delete: m('Delete'),
     duplicate: m('Duplicate'),
+    move: m('Move'),
     publish: m('Publish'),
     restore: m('Restore'),
     unpublish: m('Unpublish'),
@@ -29,6 +30,12 @@ export default makeMessages('feat.events', {
     warningRestore: m<{ eventTitle: string }>(
       '"{eventTitle}" will be restored.'
     ),
+  },
+  eventChangeCampaign: {
+    changedMessage: m<{ campaignTitle: string }>(
+      'Event moved to {campaignTitle}'
+    ),
+    dialogTitle: m('Move event'),
   },
   eventContactCard: {
     header: m('Contact'),


### PR DESCRIPTION
## Description
Adds a dialog opened from the event action buttons that allows changing the campaign the event is organized under.

Makes a call to patch the event from event mutations.

## Related issues
Resolves #1901
