### PR TITLE
Include theme_id when duplicating email

### DIFF
--- a/src/features/emails/rpc/copyEmail.ts
+++ b/src/features/emails/rpc/copyEmail.ts
@@ -36,6 +36,7 @@ async function handle(params: Params, apiClient: IApiClient) {
       campaign_id: email.campaign?.id || null,
       content: email.content,
       subject: email.subject,
+      theme_id: email.theme?.id || null,
       title: email.title,
     }
   );


### PR DESCRIPTION
## Description
This PR fixes a bug causing emails that are copied/duplicated to lose the theme, documented in #1986.

## Screenshots
None

## Changes
* Includes `theme_id` from the original email when creating a copy

## Notes to reviewer
None

## Related issues
Resolves #1986 