### PR TITLE
Use locked targets as target count after an email has been sent

### DIFF
--- a/src/features/campaigns/components/ActivityList/items/EmailListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/EmailListItem.tsx
@@ -28,6 +28,7 @@ const EmailListItem: FC<EmailListItemProps> = ({ orgId, emailId }) => {
     numOpened,
     numSent,
     isLoading: statsLoading,
+    numLockedTargets,
     numBlocked,
   } = useEmailStats(orgId, emailId);
   const endNumber = numTargetMatches - numBlocked.any ?? 0;
@@ -43,7 +44,7 @@ const EmailListItem: FC<EmailListItemProps> = ({ orgId, emailId }) => {
     <ActivityListItemWithStats
       blueChipValue={numOpened}
       color={statusColors[state]}
-      endNumber={endNumber}
+      endNumber={numLockedTargets || 0}
       greenChipValue={numClicked}
       href={`/organize/${orgId}/projects/${
         email.campaign?.id ?? 'standalone'


### PR DESCRIPTION
## Description
This PR makes some minor changes to how #2118 fixed #2082, which worked well for emails before they were sent, but not once they had been sent (at which point the locked targets is the only number that makes sense).

## Screenshots
None

## Changes
* Changes `endNumber` in `EmailListItem` to display locked targets after an email has been sent

## Notes to reviewer
None

## Related issues
Resolves #2082 (again)