### PR TITLE
Only fetch pending duplicates.

### DIFF
--- a/src/features/duplicates/hooks/useDuplicates.tsx
+++ b/src/features/duplicates/hooks/useDuplicates.tsx
@@ -12,6 +12,6 @@ export default function useDuplicates(orgId: number) {
   return loadListIfNecessary(duplicatesList, dispatch, {
     actionOnLoad: () => potentialDuplicatesLoad(),
     actionOnSuccess: (duplicates) => potentialDuplicatesLoaded(duplicates),
-    loader: () => apiClient.get(`/api/orgs/${orgId}/people/duplicates`),
+    loader: () => apiClient.get(`/api/orgs/${orgId}/people/duplicates?filter=status==pending`),
   });
 }

--- a/src/features/duplicates/hooks/useDuplicates.tsx
+++ b/src/features/duplicates/hooks/useDuplicates.tsx
@@ -12,6 +12,9 @@ export default function useDuplicates(orgId: number) {
   return loadListIfNecessary(duplicatesList, dispatch, {
     actionOnLoad: () => potentialDuplicatesLoad(),
     actionOnSuccess: (duplicates) => potentialDuplicatesLoaded(duplicates),
-    loader: () => apiClient.get(`/api/orgs/${orgId}/people/duplicates?filter=status==pending`),
+    loader: () =>
+      apiClient.get(
+        `/api/orgs/${orgId}/people/duplicates?filter=status==pending`
+      ),
   });
 }


### PR DESCRIPTION
## Description
This PR changes the URL that is used to fetch duplicates to includes the "?filter=status==pending" in order to only fetch pending duplicates.

## Changes
* Changes duplicates url to add query "?filter=status==pending"

## Related issues
Resolves #2064 