### PR TITLE
Issue 2129/Changing event date should change both start and end date

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -149,7 +149,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                               newStartDate.utc().toDate()
                             );
                             setStartDate(startDateString);
-                            if (newStartDate > dayjs(endDate)) {
+                            if (newStartDate > dayjs(endDate) || !showEndDate) {
                               setEndDate(startDateString);
                             }
                           }


### PR DESCRIPTION
## Description
This PR fix the issue of- changing start date will not change end date in a single date event


## Screenshots
<img width="449" alt="Screenshot 2024-09-21 at 14 52 34" src="https://github.com/user-attachments/assets/a76b7870-e1be-4d11-a761-20a274549b2c">


## Changes
checking if the end date is shown, and if not- changing the end date as well


## Notes to reviewer
same as issue instruction


## Related issues
Resolves #2129
