### PR TITLE
Issue 2142/Lists: Deleting a list in a folder navigates back to the root

### DIFF
--- a/src/features/views/hooks/useViewMutations.ts
+++ b/src/features/views/hooks/useViewMutations.ts
@@ -1,5 +1,3 @@
-import Router from 'next/router';
-
 import { PromiseFuture } from 'core/caching/futures';
 import { ZetkinView } from '../components/types';
 import {
@@ -31,7 +29,6 @@ export default function useViewMutations(
 
   const deleteView = async (viewId: number): Promise<void> => {
     await apiClient.delete(`/api/orgs/${orgId}/people/views/${viewId}`);
-    Router.push(`/organize/${orgId}/people`);
     dispatch(viewDeleted(viewId));
   };
 


### PR DESCRIPTION
## Description
This PR removes the re-routing after deleting a list


## Screenshots
<img width="728" alt="Screenshot 2024-09-21 at 15 37 36" src="https://github.com/user-attachments/assets/812330ac-6838-4957-a9cb-4f6ce29b7ba4">
<img width="724" alt="Screenshot 2024-09-21 at 15 38 15" src="https://github.com/user-attachments/assets/6a33cf0c-a670-4784-82a4-5148298a9eed">



## Changes
removed re-routing after deleting a view


## Notes to reviewer
this does not break the behavior when deleting a list from the ellipsis menu on the individual list page- since the SingleViewLayout also has routing on delete

## Related issues
Resolves #2142 
