### PR TITLE
Embeddable join forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@hapi/iron": "^7.0.1",
     "@messageformat/parser": "^5.1.0",
     "@mui/base": "^5.0.0-alpha.99",
     "@mui/icons-material": "^5.10.6",

--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -10,7 +10,7 @@ type PageProps = {
     orgId: string;
   };
   searchParams: {
-    css?: string;
+    stylesheet?: string;
   };
 };
 
@@ -28,8 +28,8 @@ export default async function Page({ params, searchParams }: PageProps) {
     return (
       <div>
         <EmbeddedJoinForm encrypted={formDataStr} fields={formDataObj.fields} />
-        {searchParams.css && (
-          <style>{`@import url(${searchParams.css})`}</style>
+        {searchParams.stylesheet && (
+          <style>{`@import url(${searchParams.stylesheet})`}</style>
         )}
       </div>
     );

--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -1,0 +1,39 @@
+import Iron from '@hapi/iron';
+import { notFound } from 'next/navigation';
+
+import EmbeddedJoinForm from 'features/joinForms/components/EmbeddedJoinForm';
+import { EmbeddedJoinFormData } from 'features/joinForms/types';
+
+type PageProps = {
+  params: {
+    formData: string;
+    orgId: string;
+  };
+  searchParams: {
+    css?: string;
+  };
+};
+
+export default async function Page({ params, searchParams }: PageProps) {
+  const { formData } = params;
+
+  try {
+    const formDataStr = decodeURIComponent(formData);
+    const formDataObj = (await Iron.unseal(
+      formDataStr,
+      process.env.SESSION_PASSWORD || '',
+      Iron.defaults
+    )) as EmbeddedJoinFormData;
+
+    return (
+      <div>
+        <EmbeddedJoinForm encrypted={formDataStr} fields={formDataObj.fields} />
+        {searchParams.css && (
+          <style>{`@import url(${searchParams.css})`}</style>
+        )}
+      </div>
+    );
+  } catch (err) {
+    return notFound();
+  }
+}

--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -18,6 +18,7 @@ import { updateEventsDef } from 'features/events/rpc/updateEvents';
 import { getEmailInsightsDef } from 'features/emails/rpc/getEmailInsights';
 import { renderEmailDef } from 'features/emails/rpc/renderEmail/server';
 import { createCallAssignmentDef } from 'features/callAssignments/rpc/createCallAssignment';
+import { getJoinFormEmbedDataDef } from 'features/joinForms/rpc/getJoinFormEmbedData';
 
 export function createRPCRouter() {
   const rpcRouter = new RPCRouter();
@@ -41,6 +42,7 @@ export function createRPCRouter() {
   rpcRouter.register(getEmailInsightsDef);
   rpcRouter.register(renderEmailDef);
   rpcRouter.register(createCallAssignmentDef);
+  rpcRouter.register(getJoinFormEmbedDataDef);
 
   return rpcRouter;
 }

--- a/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
+++ b/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import Iron from '@hapi/iron';
+import { headers } from 'next/headers';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { EmbeddedJoinFormData, EmbeddedJoinFormStatus } from '../types';
+
+export default async function submitJoinForm(
+  prevState: EmbeddedJoinFormStatus,
+  inputFormData: FormData
+) {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+
+  const encrypted = inputFormData.get('__joinFormData')?.toString() || '';
+  const joinFormInfo = (await Iron.unseal(
+    encrypted,
+    process.env.SESSION_PASSWORD || '',
+    Iron.defaults
+  )) as EmbeddedJoinFormData;
+
+  const outputFormData: Record<string, string> = {};
+
+  joinFormInfo.fields.forEach((field) => {
+    outputFormData[field.s] = inputFormData.get(field.s)?.toString() || '';
+  });
+
+  await apiClient.post(
+    `/api/orgs/${joinFormInfo.orgId}/join_forms/${joinFormInfo.formId}/submissions`,
+    {
+      form_data: outputFormData,
+      submit_token: joinFormInfo.token,
+    }
+  );
+
+  return 'submitted';
+}

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 // Type definitions for the new experimental stuff like useFormState in
 // react-dom are lagging behind the implementation so it's necessary to silence
 // the TypeScript error about the lack of type definitions here in order to
@@ -34,6 +34,19 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
   // with react-intl (and perhaps other libraries). So this workaround
   // allows us to pass the action to the form by pretending it's a string.
   const actionWhileTrickingTypescript = action as unknown as string;
+
+  useEffect(() => {
+    if (status == 'submitted') {
+      const url = new URL(location.toString());
+      const query = url.searchParams;
+      const redirectUrl = query.get('redirect');
+
+      if (redirectUrl) {
+        const win = window.parent || window;
+        win.location.href = redirectUrl;
+      }
+    }
+  }, [status]);
 
   return (
     <div>

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { FC } from 'react';
+// Type definitions for the new experimental stuff like useFormState in
+// react-dom are lagging behind the implementation so it's necessary to silence
+// the TypeScript error about the lack of type definitions here in order to
+// import this.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { useFormState } from 'react-dom';
+
+import { EmbeddedJoinFormData, EmbeddedJoinFormStatus } from '../types';
+import { Msg, useMessages } from 'core/i18n';
+import globalMessageIds from 'core/i18n/globalMessageIds';
+import submitJoinForm from '../actions/submitEmbeddedJoinForm';
+import messageIds from '../l10n/messageIds';
+
+type Props = {
+  encrypted: string;
+  fields: EmbeddedJoinFormData['fields'];
+};
+
+const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
+  const globalMessages = useMessages(globalMessageIds);
+
+  const [status, action] = useFormState<EmbeddedJoinFormStatus>(
+    submitJoinForm,
+    'editing'
+  );
+
+  // For some reason, the version of react (or @types/react) that we use
+  // does not understand server action functions as properties to the form,
+  // but upgrading to the most recent versions causes type-related problems
+  // with react-intl (and perhaps other libraries). So this workaround
+  // allows us to pass the action to the form by pretending it's a string.
+  const actionWhileTrickingTypescript = action as unknown as string;
+
+  return (
+    <div>
+      {status == 'editing' && (
+        <form action={actionWhileTrickingTypescript}>
+          <input name="__joinFormData" type="hidden" value={encrypted} />
+          {fields.map((field) => {
+            const isCustom = 'l' in field;
+            const label = isCustom
+              ? field.l
+              : globalMessages.personFields[field.s]();
+
+            return (
+              <div key={field.s}>
+                <label>
+                  {label}
+                  <div>
+                    <input name={field.s} />
+                  </div>
+                </label>
+              </div>
+            );
+          })}
+          <button type="submit">
+            <Msg id={messageIds.embedding.submitButton} />
+          </button>
+        </form>
+      )}
+      {status == 'submitted' && (
+        <h2>
+          <Msg id={messageIds.embedding.formSubmitted} />
+        </h2>
+      )}
+    </div>
+  );
+};
+
+export default EmbeddedJoinForm;

--- a/src/features/joinForms/components/JoinFormListItem.tsx
+++ b/src/features/joinForms/components/JoinFormListItem.tsx
@@ -1,9 +1,16 @@
-import { FormatListBulleted } from '@mui/icons-material';
+import { useContext } from 'react';
+import { FormatListBulleted, OpenInNew } from '@mui/icons-material';
 import makeStyles from '@mui/styles/makeStyles';
-import { Box, Theme, Typography } from '@mui/material';
+import { Box, Button, Theme, Typography } from '@mui/material';
 
 import theme from 'theme';
 import { ZetkinJoinForm } from '../types';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import { useApiClient } from 'core/hooks';
+import getJoinFormEmbedData from '../rpc/getJoinFormEmbedData';
+import ZUISnackbarContext from 'zui/ZUISnackbarContext';
+import { Msg, useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
@@ -50,6 +57,9 @@ type Props = {
 
 const JoinFormListItem = ({ form, onClick }: Props) => {
   const classes = useStyles();
+  const apiClient = useApiClient();
+  const { showSnackbar } = useContext(ZUISnackbarContext);
+  const messages = useMessages(messageIds);
 
   return (
     <Box
@@ -75,6 +85,43 @@ const JoinFormListItem = ({ form, onClick }: Props) => {
             />
           */}
         </Box>
+      </Box>
+      <Box>
+        <ZUIEllipsisMenu
+          items={[
+            {
+              label: messages.embedding.copyLink(),
+              onSelect: async (ev) => {
+                ev.stopPropagation();
+                const data = await apiClient.rpc(getJoinFormEmbedData, {
+                  formId: form.id,
+                  orgId: form.organization.id,
+                });
+
+                const url = `${location.protocol}//${location.host}/o/${form.organization.id}/embedjoinform/${data.data}`;
+                navigator.clipboard.writeText(url);
+
+                showSnackbar(
+                  'success',
+                  <>
+                    <Msg id={messageIds.embedding.linkCopied} />
+                    <Button
+                      endIcon={<OpenInNew />}
+                      href={url}
+                      size="small"
+                      sx={{
+                        mx: 1,
+                      }}
+                      target="_blank"
+                    >
+                      <Msg id={messageIds.embedding.openLink} />
+                    </Button>
+                  </>
+                );
+              },
+            },
+          ]}
+        />
       </Box>
     </Box>
   );

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -2,6 +2,11 @@ import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.joinForms', {
   defaultTitle: m('Untitled form'),
+  embedding: {
+    copyLink: m('Copy embed URL'),
+    linkCopied: m('Embed URL copied.'),
+    openLink: m('Visit now'),
+  },
   formPane: {
     labels: {
       addField: m('Add field'),

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -4,8 +4,10 @@ export default makeMessages('feat.joinForms', {
   defaultTitle: m('Untitled form'),
   embedding: {
     copyLink: m('Copy embed URL'),
+    formSubmitted: m('Form submitted'),
     linkCopied: m('Embed URL copied.'),
     openLink: m('Visit now'),
+    submitButton: m('Submit'),
   },
   formPane: {
     labels: {

--- a/src/features/joinForms/rpc/getJoinFormEmbedData.ts
+++ b/src/features/joinForms/rpc/getJoinFormEmbedData.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import Iron from '@hapi/iron';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import { EmbeddedJoinFormData, ZetkinJoinForm } from '../types';
+import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
+import { ZetkinCustomField } from 'utils/types/zetkin';
+
+const paramsSchema = z.object({
+  formId: z.number(),
+  orgId: z.number(),
+});
+
+type Params = z.input<typeof paramsSchema>;
+type Result = {
+  data: string;
+};
+
+export const getJoinFormEmbedDataDef = {
+  handler: handle,
+  name: 'getJoinFormEmbedData',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, Result>(getJoinFormEmbedDataDef.name);
+
+async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
+  const { formId, orgId } = params;
+
+  const joinForm = await apiClient.get<ZetkinJoinForm>(
+    `/api/orgs/${orgId}/join_forms/${formId}`
+  );
+
+  const nativeSlugs = Object.values(NATIVE_PERSON_FIELDS) as string[];
+  const hasCustomFields = joinForm.fields.some((slug) =>
+    nativeSlugs.includes(slug)
+  );
+
+  const customFields = hasCustomFields
+    ? await apiClient.get<ZetkinCustomField[]>(
+        `/api/orgs/${orgId}/people/fields`
+      )
+    : [];
+
+  const data: EmbeddedJoinFormData = {
+    fields: joinForm.fields.map((slug) => {
+      const isNative = nativeSlugs.includes(slug);
+
+      if (isNative) {
+        // This cast is safe because we are only in this execution
+        // branch if the slug was one of the native field slugs
+        const typedSlug = slug as NATIVE_PERSON_FIELDS;
+        return {
+          s: typedSlug,
+        };
+      } else {
+        const field = customFields.find((field) => field.slug == slug);
+
+        if (!field) {
+          throw new Error('Referencing unknown custom field');
+        }
+
+        return {
+          l: field.title,
+          s: slug,
+          t: field.type,
+        };
+      }
+    }),
+    token: joinForm.submit_token,
+  };
+
+  const password = process.env.SESSION_PASSWORD;
+  if (!password) {
+    throw new Error('Missing password');
+  }
+
+  const sealed = await Iron.seal(data, password, Iron.defaults);
+
+  return {
+    data: sealed,
+  };
+}

--- a/src/features/joinForms/rpc/getJoinFormEmbedData.ts
+++ b/src/features/joinForms/rpc/getJoinFormEmbedData.ts
@@ -68,6 +68,8 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
         };
       }
     }),
+    formId: formId,
+    orgId: orgId,
     token: joinForm.submit_token,
   };
 

--- a/src/features/joinForms/types.ts
+++ b/src/features/joinForms/types.ts
@@ -54,5 +54,9 @@ type EmbeddedJoinFormDataField =
 
 export type EmbeddedJoinFormData = {
   fields: EmbeddedJoinFormDataField[];
+  formId: number;
+  orgId: number;
   token: string;
 };
+
+export type EmbeddedJoinFormStatus = 'editing' | 'submitted';

--- a/src/features/joinForms/types.ts
+++ b/src/features/joinForms/types.ts
@@ -1,4 +1,8 @@
-import { ZetkinPerson } from 'utils/types/zetkin';
+import {
+  CUSTOM_FIELD_TYPE,
+  ZetkinPerson,
+  ZetkinPersonNativeFields,
+} from 'utils/types/zetkin';
 
 export type ZetkinJoinForm = {
   description: string;
@@ -41,3 +45,14 @@ export type ZetkinJoinSubmission = {
 };
 
 export type ZetkinJoinSubmissionPatchBody = Pick<ZetkinJoinSubmission, 'state'>;
+
+type EmbeddedJoinFormDataField =
+  | {
+      s: keyof ZetkinPersonNativeFields;
+    }
+  | { l: string; s: string; t: CUSTOM_FIELD_TYPE };
+
+export type EmbeddedJoinFormData = {
+  fields: EmbeddedJoinFormDataField[];
+  token: string;
+};

--- a/src/zui/ZUISnackbarContext.tsx
+++ b/src/zui/ZUISnackbarContext.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Snackbar } from '@mui/material';
 import { Alert, AlertColor } from '@mui/material';
-import { createContext, useState } from 'react';
+import { createContext, ReactNode, useState } from 'react';
 
 import { useMessages } from 'core/i18n';
 import messageIds from './l10n/messageIds';
@@ -9,7 +9,7 @@ import messageIds from './l10n/messageIds';
 interface ZUISnackbarContextProps {
   isOpen: boolean;
   hideSnackbar: () => void;
-  showSnackbar: (severity: AlertColor, message?: string) => void;
+  showSnackbar: (severity: AlertColor, message?: ReactNode) => void;
 }
 
 const ZUISnackbarContext = createContext<ZUISnackbarContextProps>({
@@ -28,7 +28,7 @@ const ZUISnackbarProvider: React.FunctionComponent<SnackbarProviderProps> = ({
   const messages = useMessages(messageIds);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarState, setSnackbarState] = useState<{
-    message: string;
+    message: ReactNode;
     severity: AlertColor;
   }>();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,6 +2098,48 @@
     intl-messageformat "10.1.4"
     tslib "2.4.0"
 
+"@hapi/b64@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/b64/-/b64-6.0.1.tgz#786b47dc070e14465af49e2428c1025bd06ed3df"
+  integrity sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==
+  dependencies:
+    "@hapi/hoek" "^11.0.2"
+
+"@hapi/boom@^10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-10.0.1.tgz#ebb14688275ae150aa6af788dbe482e6a6062685"
+  integrity sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==
+  dependencies:
+    "@hapi/hoek" "^11.0.2"
+
+"@hapi/bourne@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/bourne/-/bourne-3.0.0.tgz#f11fdf7dda62fe8e336fa7c6642d9041f30356d7"
+  integrity sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==
+
+"@hapi/cryptiles@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/cryptiles/-/cryptiles-6.0.1.tgz#7868a9d4233567ed66f0a9caf85fdcc56e980621"
+  integrity sha512-9GM9ECEHfR8lk5ASOKG4+4ZsEzFqLfhiryIJ2ISePVB92OHLp/yne4m+zn7z9dgvM98TLpiFebjDFQ0UHcqxXQ==
+  dependencies:
+    "@hapi/boom" "^10.0.1"
+
+"@hapi/hoek@^11.0.2":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-11.0.4.tgz#42a7f244fd3dd777792bfb74b8c6340ae9182f37"
+  integrity sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==
+
+"@hapi/iron@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/iron/-/iron-7.0.1.tgz#f74bace8dad9340c7c012c27c078504f070f14b5"
+  integrity sha512-tEZnrOujKpS6jLKliyWBl3A9PaE+ppuL/+gkbyPPDb/l2KSKQyH4lhMkVb+sBhwN+qaxxlig01JRqB8dk/mPxQ==
+  dependencies:
+    "@hapi/b64" "^6.0.1"
+    "@hapi/boom" "^10.0.1"
+    "@hapi/bourne" "^3.0.0"
+    "@hapi/cryptiles" "^6.0.1"
+    "@hapi/hoek" "^11.0.2"
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"


### PR DESCRIPTION
## Description
This PR introduces pages that render a join form to be embedded in an iframe on an organization's website.

Join forms were initially designed to not be rendered by Zetkin, but just configured in Zetkin as a receiving endpoint to which forms built on standalone websites could post their data. For this reason, there is no way for an anonymous user to request the join form meta-data required to render the form (not to mention the token required to submit the form).

Because join forms require privileged information to render and submit, the way this PR implements rendering of join forms is by creating a special URL that contains all the information required to render, but encrypted using a key that only the backend of this web app can access.

When an admin user requests an "Embed URL" for a join form, the backend generates an encoded string, encrypted using `Iron`, that includes:

* The IDs of the organization and the form (required for submitting the form)
* The `submit_token` (required for submitting the form)
* A list of fields, either as just a slug (in the case of native fields) or a slug, a type and a label for custom fields

The embedded page also takes to optional query string variables:

* `stylesheet` – using which the embedder can specify the URL to a CSS stylesheet that will be imported on the page in order to achieve consistent styling with the page into which the form is embedded
* `redirect` – using which the embedder can specify a URL that the user should be redirected to after submitting the form

## Screenshots
### Barebones form
![image](https://github.com/user-attachments/assets/67cb0744-0b98-486e-b228-aafcc2dd9c8a)

### Form with styling, embedded on page
![image](https://github.com/user-attachments/assets/78ff0364-df39-4b8c-aff3-fd8a312c728e)

## Changes
* Installs the `Iron` encoding and encryption library
* Adds an RPC called `getJoinFormEmbedData` to generate a URL to use when embeddeding
* Adds an ellipsis menu to the `JoinFormList` with an option that uses the RPC to get a link and copy it to the clipboard
* Adds a page at `/o/ID/embedjoinform/FORM_DATA` that renders a form as defined in the `FORM_DATA` encoded object
* Adds a server action called `submitJoinForm` that submits the join form using the encoded data and user input

## Notes to reviewer
None

## Related issues
Undocumented