### PR TITLE
Filter all duplicates that are not pending, not just dismissed.

### DIFF
--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -28,7 +28,7 @@ const DuplicatesPage: PageWithLayout = () => {
     return null;
   }
 
-  const filteredList = list.filter((cluster) => !cluster.dismissed);
+  const filteredList = list.filter((cluster) => cluster.status == 'pending');
 
   return (
     <>


### PR DESCRIPTION
## Description
This PR filters all duplicates that do not have the status "pending", rather than just those that have been dismissed.


## Changes
* Changes `src/pages/organize/[orgId]/people/duplicates/index.tsx` to filter duplicates that do not have status `pending`.
