### PR TITLE
Skip a few inputs during SSR of survey page

### DIFF
--- a/src/features/surveys/components/surveyForm/SurveyForm.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyForm.tsx
@@ -17,7 +17,6 @@ import SurveyPrivacyPolicy from './SurveyPrivacyPolicy';
 import SurveySignature from './SurveySignature';
 import SurveySubmitButton from './SurveySubmitButton';
 import SurveySuccess from './SurveySuccess';
-import useServerSide from 'core/useServerSide';
 import {
   ZetkinSurveyExtended,
   ZetkinSurveyFormStatus,
@@ -34,7 +33,6 @@ const SurveyForm: FC<SurveyFormProps> = ({ survey, user }) => {
     submit,
     'editing'
   );
-  const isServer = useServerSide();
 
   if (!survey) {
     return null;
@@ -54,14 +52,10 @@ const SurveyForm: FC<SurveyFormProps> = ({ survey, user }) => {
           <input name="surveyId" type="hidden" value={survey.id} />
           <Box display="flex" flexDirection="column" gap={4}>
             <SurveyElements survey={survey as ZetkinSurveyExtended} />
-            {isServer ? (
-              '...'
-            ) : (
-              <SurveySignature
-                survey={survey as ZetkinSurveyExtended}
-                user={user}
-              />
-            )}
+            <SurveySignature
+              survey={survey as ZetkinSurveyExtended}
+              user={user}
+            />
             <SurveyPrivacyPolicy survey={survey as ZetkinSurveyExtended} />
             <SurveySubmitButton />
           </Box>

--- a/src/features/surveys/components/surveyForm/SurveyForm.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyForm.tsx
@@ -17,6 +17,7 @@ import SurveyPrivacyPolicy from './SurveyPrivacyPolicy';
 import SurveySignature from './SurveySignature';
 import SurveySubmitButton from './SurveySubmitButton';
 import SurveySuccess from './SurveySuccess';
+import useServerSide from 'core/useServerSide';
 import {
   ZetkinSurveyExtended,
   ZetkinSurveyFormStatus,
@@ -33,6 +34,7 @@ const SurveyForm: FC<SurveyFormProps> = ({ survey, user }) => {
     submit,
     'editing'
   );
+  const isServer = useServerSide();
 
   if (!survey) {
     return null;
@@ -52,10 +54,14 @@ const SurveyForm: FC<SurveyFormProps> = ({ survey, user }) => {
           <input name="surveyId" type="hidden" value={survey.id} />
           <Box display="flex" flexDirection="column" gap={4}>
             <SurveyElements survey={survey as ZetkinSurveyExtended} />
-            <SurveySignature
-              survey={survey as ZetkinSurveyExtended}
-              user={user}
-            />
+            {isServer ? (
+              '...'
+            ) : (
+              <SurveySignature
+                survey={survey as ZetkinSurveyExtended}
+                user={user}
+              />
+            )}
             <SurveyPrivacyPolicy survey={survey as ZetkinSurveyExtended} />
             <SurveySubmitButton />
           </Box>

--- a/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
@@ -34,10 +34,11 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
     setDropdownValue(event.target.value);
   }, []);
 
+  const question = element.question;
   return (
     <FormControl fullWidth>
       <SurveyContainer>
-        {element.question.response_config.widget_type === 'checkbox' && (
+        {question.response_config.widget_type === 'checkbox' && (
           <FormGroup
             aria-describedby={`description-${element.id}`}
             aria-labelledby={`label-${element.id}`}
@@ -52,18 +53,16 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
             >
               <Box>
                 <FormLabel id={`label-${element.id}`}>
-                  <SurveySubheading>
-                    {element.question.question}
-                  </SurveySubheading>
+                  <SurveySubheading>{question.question}</SurveySubheading>
                 </FormLabel>
-                {element.question.description && (
+                {question.description && (
                   <SurveyQuestionDescription id={`description-${element.id}`}>
-                    {element.question.description}
+                    {question.description}
                   </SurveyQuestionDescription>
                 )}
               </Box>
               <Box display="flex" flexDirection="column" rowGap={1}>
-                {element.question.options!.map((option: ZetkinSurveyOption) => (
+                {question.options!.map((option: ZetkinSurveyOption) => (
                   <SurveyOption
                     key={option.id}
                     control={<Checkbox name={`${element.id}.options`} />}
@@ -75,9 +74,8 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
             </Box>
           </FormGroup>
         )}
-        {(element.question.response_config.widget_type === 'radio' ||
-          typeof element.question.response_config.widget_type ===
-            'undefined') && (
+        {(question.response_config.widget_type === 'radio' ||
+          typeof question.response_config.widget_type === 'undefined') && (
           <RadioGroup
             aria-describedby={`description-${element.id}`}
             aria-labelledby={`label-${element.id}`}
@@ -96,24 +94,24 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                   <FormLabel id={`label-${element.id}`}>
                     <SurveySubheading>
                       <>
-                        {element.question.question}
-                        {element.question.required &&
+                        {question.question}
+                        {question.required &&
                           ` (${messages.surveyForm.required()})`}
                       </>
                     </SurveySubheading>
                   </FormLabel>
-                  {element.question.description && (
+                  {question.description && (
                     <SurveyQuestionDescription id={`description-${element.id}`}>
-                      {element.question.description}
+                      {question.description}
                     </SurveyQuestionDescription>
                   )}
                 </Box>
               </Box>
               <Box display="flex" flexDirection="column" rowGap={1}>
-                {element.question.options!.map((option: ZetkinSurveyOption) => (
+                {question.options!.map((option: ZetkinSurveyOption) => (
                   <SurveyOption
                     key={option.id}
-                    control={<Radio required={element.question.required} />}
+                    control={<Radio required={question.required} />}
                     label={option.text}
                     value={option.id}
                   />
@@ -122,7 +120,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
             </Box>
           </RadioGroup>
         )}
-        {element.question.response_config.widget_type === 'select' && (
+        {question.response_config.widget_type === 'select' && (
           <FormGroup
             aria-describedby={`description-${element.id}`}
             aria-labelledby={`label-${element.id}`}
@@ -132,15 +130,15 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 <FormLabel id={`label-${element.id}`}>
                   <SurveySubheading>
                     <>
-                      {element.question.question}
-                      {element.question.required &&
+                      {question.question}
+                      {question.required &&
                         ` (${messages.surveyForm.required()})`}
                     </>
                   </SurveySubheading>
                 </FormLabel>
-                {element.question.description && (
+                {question.description && (
                   <SurveyQuestionDescription id={`description-${element.id}`}>
-                    {element.question.description}
+                    {question.description}
                   </SurveyQuestionDescription>
                 )}
               </Box>
@@ -149,10 +147,10 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 aria-labelledby={`label-${element.id}`}
                 name={`${element.id}.options`}
                 onChange={handleDropdownChange}
-                required={element.question.required}
+                required={question.required}
                 value={dropdownValue}
               >
-                {element.question.options!.map((option: ZetkinSurveyOption) => (
+                {question.options!.map((option: ZetkinSurveyOption) => (
                   <MenuItem key={option.id} value={option.id}>
                     {option.text}
                   </MenuItem>

--- a/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
+++ b/src/features/surveys/components/surveyForm/SurveyOptionsQuestion.tsx
@@ -18,6 +18,7 @@ import SurveyOption from './SurveyOption';
 import SurveyQuestionDescription from './SurveyQuestionDescription';
 import SurveySubheading from './SurveySubheading';
 import { useMessages } from 'core/i18n';
+import useServerSide from 'core/useServerSide';
 import {
   ZetkinSurveyOption,
   ZetkinSurveyOptionsQuestionElement,
@@ -33,6 +34,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
   const handleDropdownChange = useCallback((event: SelectChangeEvent) => {
     setDropdownValue(event.target.value);
   }, []);
+  const isServer = useServerSide();
 
   const question = element.question;
   return (
@@ -62,14 +64,16 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 )}
               </Box>
               <Box display="flex" flexDirection="column" rowGap={1}>
-                {question.options!.map((option: ZetkinSurveyOption) => (
-                  <SurveyOption
-                    key={option.id}
-                    control={<Checkbox name={`${element.id}.options`} />}
-                    label={option.text}
-                    value={option.id}
-                  />
-                ))}
+                {isServer
+                  ? '...'
+                  : question.options!.map((option: ZetkinSurveyOption) => (
+                      <SurveyOption
+                        key={option.id}
+                        control={<Checkbox name={`${element.id}.options`} />}
+                        label={option.text}
+                        value={option.id}
+                      />
+                    ))}
               </Box>
             </Box>
           </FormGroup>
@@ -108,14 +112,16 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({ element }) => {
                 </Box>
               </Box>
               <Box display="flex" flexDirection="column" rowGap={1}>
-                {question.options!.map((option: ZetkinSurveyOption) => (
-                  <SurveyOption
-                    key={option.id}
-                    control={<Radio required={question.required} />}
-                    label={option.text}
-                    value={option.id}
-                  />
-                ))}
+                {isServer
+                  ? '...'
+                  : question.options!.map((option: ZetkinSurveyOption) => (
+                      <SurveyOption
+                        key={option.id}
+                        control={<Radio required={question.required} />}
+                        label={option.text}
+                        value={option.id}
+                      />
+                    ))}
               </Box>
             </Box>
           </RadioGroup>

--- a/src/features/surveys/components/surveyForm/SurveySignature.tsx
+++ b/src/features/surveys/components/surveyForm/SurveySignature.tsx
@@ -12,6 +12,7 @@ import { FC, useCallback, useState } from 'react';
 
 import messageIds from 'features/surveys/l10n/messageIds';
 import { Msg } from 'core/i18n';
+import useServerSide from 'core/useServerSide';
 import SurveyContainer from './SurveyContainer';
 import SurveyOption from './SurveyOption';
 import SurveySubheading from './SurveySubheading';
@@ -39,6 +40,15 @@ const SurveySignature: FC<SurveySignatureProps> = ({ survey, user }) => {
     },
     [setSignatureType]
   );
+
+  const isServer = useServerSide();
+  if (isServer) {
+    return (
+      <FormControl fullWidth>
+        <SurveyContainer paddingX={2}>...</SurveyContainer>
+      </FormControl>
+    );
+  }
 
   return (
     <FormControl fullWidth>


### PR DESCRIPTION
## Description
This PR is just a quick work-around for Playwright consistently failing submitting-survey.spec

The work-around is not comprehensive but it suffices to make Playwright consistently succeed on my machine.

## Changes

Skip a few inputs during server side rendering of surveys so that Playwright will wait for hydration.

* Question option checkboxes
* Question option radiobuttons
* Signature form

## Notes to reviewer

Try opening /o/1/surveys/1 with connection thottling enabled in developer tools. You should be able to see ... instead of some UI. Ideally, you won't see that for too long without network throttling. Most of the survey will still be displayed while waiting for hydration.

I suggest you review the first commit by itself, and then review the second and third as one unit instead of separately. The first commit is just a refactoring and will be noisy if reviewed together with the other commits. The third commit reverts part of the second, so you'll lose some time but gain some insight if you review the second and third commits individually.

## Showtime!
[Screencast from 2024-09-28 00-14-07.webm](https://github.com/user-attachments/assets/2e6285a2-6983-4ebb-ba2f-f43c681c12b0)

## Related issues
This relates to  #2172 but does not resolve it.