### PR TITLE
Issue 2153: Lists fix null pointer exception on value tag removal

### DIFF
--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -112,9 +112,15 @@ const tagsSlice = createSlice({
     },
     tagUnassigned: (state, action: PayloadAction<[number, number]>) => {
       const [personId, tagId] = action.payload;
-      state.tagsByPersonId[personId].items = state.tagsByPersonId[
-        personId
-      ].items.filter((item) => item.id != tagId);
+      const tagsByPersonId = state.tagsByPersonId[personId];
+
+      if (!tagsByPersonId) {
+        return;
+      }
+
+      tagsByPersonId.items = state.tagsByPersonId[personId].items.filter(
+        (item) => item.id != tagId
+      );
     },
     tagUpdate: (state, action: PayloadAction<[number, string[]]>) => {
       const [tagId, mutating] = action.payload;


### PR DESCRIPTION
## Description
This PR fixes an undefined value exception when removing a value tag in a list. 


## Screenshots
I didn't think an absence of an error was worth screenshotting

## Changes
* Adds a null/undefined check to the store


## Notes to reviewer
To trigger the error usually:
1) Ensure you have a list with a value tag. Add a value to a person
2) Refresh the page
3) Remove the value

Expected result: No error!


## Related issues
Resolves #2153 
