### PR TITLE
Remove margin under email write-only alert

### DIFF
--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -61,7 +61,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ email, onSave }) => {
   return (
     <Box display="flex" flexDirection="column" height="100%">
       {readOnly && (
-        <Alert severity="info" sx={{ marginBottom: 2 }}>
+        <Alert severity="info">
           <Msg id={messageIds.editor.readOnlyModeInfo} />
         </Alert>
       )}


### PR DESCRIPTION
## Description
This PR removes the margin under the write-only alarm when scheduling an email.


## Screenshots
![image](https://github.com/user-attachments/assets/a84953ae-7723-43b7-9189-c175f101e4de)


## Changes

* Removes margin


## Notes to reviewer
None

## Related issues
Resolves #2154 
