### PR TITLE
Issue 2150/spacing on timestamps

### DIFF
--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Basic: StoryObj<typeof ZUIDuration> = {
   args: {
-    seconds: 12345,
+    seconds: 123456789.5,
     withDays: true,
     withHours: true,
     withMinutes: true,

--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Basic: StoryObj<typeof ZUIDuration> = {
   args: {
-    seconds: 123456789.5,
+    seconds: 12345,
     withDays: true,
     withHours: true,
     withMinutes: true,

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -49,7 +49,7 @@ const ZUIDuration: FC<Props> = ({
       {fields
         .filter((field) => field.visible)
         .filter((field) => field.n > 0)
-        .map((field, index, array) => (
+        .map((field) => (
           <span key={field.msgId}>
             <Msg
               id={messageIds.duration[field.msgId]}

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -49,12 +49,14 @@ const ZUIDuration: FC<Props> = ({
       {fields
         .filter((field) => field.visible)
         .filter((field) => field.n > 0)
-        .map((field) => (
-          <span key={field.msgId} style={{ marginRight: 4 }}>
+        .map((field, index, array) => (
+          <span key={field.msgId}>
             <Msg
               id={messageIds.duration[field.msgId]}
               values={{ n: field.n }}
             />
+            {/* Add a space after the hours field */}
+            {field.msgId === 'h' && index < array.length - 1 && ' '}
           </span>
         ))}
     </>

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -54,9 +54,7 @@ const ZUIDuration: FC<Props> = ({
             <Msg
               id={messageIds.duration[field.msgId]}
               values={{ n: field.n }}
-            />
-            {/* Add a space after the hours field */}
-            {field.msgId === 'h' && index < array.length - 1 && ' '}
+            />{' '}
           </span>
         ))}
     </>


### PR DESCRIPTION
## Description
This PR added a space after every time-variable (days, h, m, s, ms) in an array.


## Screenshots
There's no visible change to storybook but when the user copies the timestamp to clipboard, the space remains. 


## Changes

* Adds a simple whitespace (` `) behind a timevalue 
* Removes the old way of doing it which was adding a margin-right of 4 px to a span 


## Notes to reviewer
Test by copying the timestamp to the clipboard and insert somewhere, the spaces should remain


## Related issues
Resolves #2150 
