### PR TITLE
Issue 2177: Updates Call History Smart Search logic and YML

### DIFF
--- a/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/DisplayCallHistory.tsx
@@ -6,6 +6,7 @@ import { Msg } from 'core/i18n';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import { useNumericRouteParams } from 'core/hooks';
 import {
+  CALL_OPERATOR,
   CallHistoryFilterConfig,
   OPERATION,
   SmartSearchFilterWithId,
@@ -43,12 +44,13 @@ const DisplayCallHistory = ({
           <UnderlinedMsg id={localMessageIds.assignmentSelect.any} />
         ),
         callSelect: <UnderlinedMsg id={localMessageIds.callSelect[operator]} />,
-        minTimes: (
-          <UnderlinedMsg
-            id={localMessageIds.minTimes}
-            values={{ minTimes: minTimes || 1 }}
-          />
-        ),
+        minTimes:
+          operator == CALL_OPERATOR.NOTREACHED ? null : (
+            <UnderlinedMsg
+              id={localMessageIds.minTimes}
+              values={{ minTimes: minTimes || 1 }}
+            />
+          ),
         timeFrame: <DisplayTimeFrame config={timeFrame} />,
       }}
     />

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -171,26 +171,27 @@ const CallHistory = ({
                 ))}
               </StyledSelect>
             ),
-            minTimes: (
-              <Msg
-                id={localMessageIds.minTimesInput}
-                values={{
-                  input: (
-                    <StyledNumberInput
-                      defaultValue={filter.config.minTimes || 1}
-                      inputProps={{ min: '1' }}
-                      onChange={(e) => {
-                        setConfig({
-                          ...filter.config,
-                          minTimes: +e.target.value,
-                        });
-                      }}
-                    />
-                  ),
-                  minTimes: filter.config.minTimes || 1,
-                }}
-              />
-            ),
+            minTimes:
+              filter.config.operator != CALL_OPERATOR.NOTREACHED ? (
+                <Msg
+                  id={localMessageIds.minTimesInput}
+                  values={{
+                    input: (
+                      <StyledNumberInput
+                        defaultValue={filter.config.minTimes || 1}
+                        inputProps={{ min: '1' }}
+                        onChange={(e) => {
+                          setConfig({
+                            ...filter.config,
+                            minTimes: +e.target.value,
+                          });
+                        }}
+                      />
+                    ),
+                    minTimes: filter.config.minTimes || 1,
+                  }}
+                />
+              ) : null,
             timeFrame: (
               <TimeFrame
                 filterConfig={{

--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -156,12 +156,21 @@ const CallHistory = ({
             ),
             callSelect: (
               <StyledSelect
-                onChange={(e) =>
-                  setConfig({
-                    ...filter.config,
-                    operator: e.target.value as CALL_OPERATOR,
-                  })
-                }
+                onChange={(e) => {
+                  const callOperator = e.target.value as CALL_OPERATOR;
+                  if (callOperator == CALL_OPERATOR.NOTREACHED) {
+                    setConfig({
+                      ...filter.config,
+                      minTimes: undefined,
+                      operator: callOperator,
+                    });
+                  } else {
+                    setConfig({
+                      ...filter.config,
+                      operator: callOperator,
+                    });
+                  }
+                }}
                 value={filter.config.operator}
               >
                 {Object.values(CALL_OPERATOR).map((o) => (
@@ -172,7 +181,7 @@ const CallHistory = ({
               </StyledSelect>
             ),
             minTimes:
-              filter.config.operator != CALL_OPERATOR.NOTREACHED ? (
+              filter.config.operator == CALL_OPERATOR.NOTREACHED ? null : (
                 <Msg
                   id={localMessageIds.minTimesInput}
                   values={{
@@ -191,7 +200,7 @@ const CallHistory = ({
                     minTimes: filter.config.minTimes || 1,
                   }}
                 />
-              ) : null,
+              ),
             timeFrame: (
               <TimeFrame
                 filterConfig={{

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -166,7 +166,7 @@ export default makeMessages('feat.smartSearch', {
       },
       callSelect: {
         called: m('have been called'),
-        notreached: m('have been unsuccessfully tried'),
+        notreached: m('have not been reached'),
         reached: m('have been successfully reached'),
       },
       examples: {
@@ -181,10 +181,10 @@ export default makeMessages('feat.smartSearch', {
         addRemoveSelect: ReactElement;
         assignmentSelect: ReactElement;
         callSelect: ReactElement;
-        minTimes: ReactElement | number;
+        minTimes: ReactElement | number | null;
         timeFrame: ReactElement;
       }>(
-        '{addRemoveSelect} people who {callSelect} at least {minTimes} in {assignmentSelect} {timeFrame}.'
+        '{addRemoveSelect} people who {callSelect} {minTimes} in {assignmentSelect} {timeFrame}.'
       ),
       minTimes: m<{ minTimes: number }>(
         '{minTimes, plural, one {once} other {# times}}'
@@ -192,7 +192,7 @@ export default makeMessages('feat.smartSearch', {
       minTimesInput: m<{
         input: ReactElement;
         minTimes: number;
-      }>('{input} {minTimes, plural, one {time} other {times}}'),
+      }>('at least {input} {minTimes, plural, one {time} other {times}}'),
     },
     campaignParticipation: {
       activitySelect: {

--- a/src/locale/da.yml
+++ b/src/locale/da.yml
@@ -618,17 +618,13 @@ feat:
           none: Denne organisation har ingen ringeopgaver endnu
         callSelect:
           called: er blevet ringet op
-          notreached: er blevet forsøgt uden held
           reached: er nået med succes
         examples:
           one: Tilføj personer som vi har nået mindst to gange nogensinde i hvilken
             som helst opgave til.
           two: Fjern personer, der er blevet ringet op mindst 1 gang i opgaven 'Aktiver
             gamle medlemmer' i løbet af de sidste 30 dage.
-        inputString: '{addRemoveSelect} personer som {callSelect} mindst {minTimes}
-          i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimes} {minTimes, plural, one {gang} other {gange}}'
-        minTimesInput: '{input} {minTimes, plural, one {gang} other {gange}}'
       campaignParticipation:
         activitySelect:
           activity: type "{activity}"

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -1399,10 +1399,7 @@ feat:
             für irgendeine Aufgabe zu irgendeinem Zeitpunkt.
           two: Entferne Personen, die in den letzten 30 Tagen mindestens 1mal angerufen
             wurden für die Aufgabe "langjährige Mitglieder aktivieren".
-        inputString: '{addRemoveSelect} Personen, die {callSelect} mindestens {minTimesInput}
-          {minTimes} in {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimesInput} {minTimes, plural, one {mal} other {mal}}'
-        minTimesInput: '{input} {minTimes, plural, one {mal} other {mal}}'
       campaignParticipation:
         activitySelect:
           activity: Typ "{activity}"

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1379,17 +1379,13 @@ feat:
           none: This organization doesn't have any call assignments yet
         callSelect:
           called: have been called
-          notreached: have been unsuccessfully tried
           reached: have been successfully reached
         examples:
           one: Add people who have been successfully reached at least 2 times in any
             assignment at any point in time.
           two: Remove people who have been called at least 1 time in assignment 'Activate
             old members' during the last 30 days.
-        inputString: "{addRemoveSelect} people who {callSelect} at least {minTimes} in
-          {assignmentSelect} {timeFrame}."
         minTimes: "{minTimes, plural, one {once} other {# times}}"
-        minTimesInput: "{input} {minTimes, plural, one {time} other {times}}"
       campaignParticipation:
         activitySelect:
           activity: type "{activity}"

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -1406,17 +1406,13 @@ feat:
           none: Denne organisasjonen har ingen ringeoppdrag, ennå!
         callSelect:
           called: har blitt ringt
-          notreached: har blitt forsøkt ringt
           reached: har blitt nådd
         examples:
           one: Legg til folk som har blitt nådd minst 2 ganger i et hvilket som helst
             ringeoppdrag når som helst.
           two: Fjern folk som har blitt ringt minst en gang i ringeoppdraget "Valgkamp
             2023" de siste 30 dagene.
-        inputString: '{addRemoveSelect} folk som {callSelect} minst {minTimes} i {assignmentSelect}
-          {timeFrame}.'
         minTimes: '{minTimes} {minTimes, plural, one {gang} other {ganger}}'
-        minTimesInput: '{input} {minTimes, plural, one {gang} other {ganger}}'
       campaignParticipation:
         activitySelect:
           activity: aktiviteten "{activity}"

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -1398,17 +1398,13 @@ feat:
           none: Den här organisationen har inga ringuppdrag än
         callSelect:
           called: har blivit uppringda
-          notreached: har fått ett samtalsförsök
           reached: har blivit nådda
         examples:
           one: Lägg till personer som blivit nådda åtminstone 2 gånger i något uppdrag
             närsomhelst.
           two: Ta bort personer som blivit ringda åtminstone 1 gång i uppdraget 'Aktivera
             gamla medlemmar' under de senaste 30 dagarna.
-        inputString: '{addRemoveSelect} personer som {callSelect} minst {minTimes}
-          i {assignmentSelect} {timeFrame}.'
         minTimes: '{minTimesInput} {minTimes, plural, one {gång} other {gånger}}'
-        minTimesInput: '{input} {minTimes, plural, one {gång} other {gånger}}'
       campaignParticipation:
         activitySelect:
           activity: typen "{activity}"


### PR DESCRIPTION
## Description
This PR makes changes to the Call History Smart Search function to make the Not Reached option more accurate and removes the minTimes segment of the Sentence render when Not Reached is selected.


## Screenshots
![image](https://github.com/user-attachments/assets/93811931-431c-4105-9e8e-6c817b85a6ef)
![image](https://github.com/user-attachments/assets/4a5f20b6-2699-484f-b34c-73a0864405c1)


## Changes
- Rewords the notreached string to be more in line with what the issue states
- Changes the logic to not display the minTimes segment when notreached is selected
- Removes affected localization strings

## Notes to reviewer
1. Go to https://app.dev.zetkin.org/organize/1/people
2. Click on "Create"
3. Click on "Create list"
4. In the new list, click "Configure" under "Configure Smart Search list"
5. Click "Add/remove people"
6. Find and add the "Call history" filter
7. Open the dropdown that is by default configured to "have been called"
8. Pick the third option that should now be called "have not been reached"
9. The sentence render should now be updated to remove "at least" and the amount selection.

## Related issues
Resolves #2177 
