### PR TITLE
issue-2152: Show in week if day is DST start or end

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/index.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/index.tsx
@@ -1,10 +1,22 @@
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
 
 import DateLabel from './DateLabel';
-import { DaySummary } from '../../utils';
+import { DaySummary, getDSTOffset } from '../../utils';
 import Event from './Event';
+import messageIds from 'features/calendar/l10n/messageIds';
+import theme from 'theme';
+import { Msg } from 'core/i18n';
 
 const Day = ({ date, dayInfo }: { date: Date; dayInfo: DaySummary }) => {
+  const dstOffset = useMemo(
+    () =>
+      getDSTOffset(dayjs(date).startOf('day').toDate()) -
+      getDSTOffset(dayjs(date).endOf('day').toDate()),
+    [date]
+  );
+
   return (
     <Box
       alignItems="flex-start"
@@ -16,8 +28,16 @@ const Day = ({ date, dayInfo }: { date: Date; dayInfo: DaySummary }) => {
         backgroundColor: '#eeeeee',
       }}
     >
-      <Box display="flex" width={'200px'}>
+      <Box display="flex" flexDirection="column" width={'200px'}>
         <DateLabel date={date} />
+        {dstOffset !== 0 && (
+          <Box padding="8px 12px">
+            <Typography color={theme.palette.grey[600]} variant="body2">
+              {dstOffset > 0 && <Msg id={messageIds.dstStarts} />}
+              {dstOffset < 0 && <Msg id={messageIds.dstEnds} />}
+            </Typography>
+          </Box>
+        )}
       </Box>
       {/* Remaining space for list of events */}
       <Box

--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -1,10 +1,14 @@
 import dayjs from 'dayjs';
 import { FormattedDate } from 'react-intl';
 import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
 
+import messageIds from '../../l10n/messageIds';
 import theme from 'theme';
 import { AnyClusteredEvent } from 'features/calendar/utils/clusterEventsForWeekCalender';
 import EventCluster from '../EventCluster';
+import { getDSTOffset } from '../utils';
+import { Msg } from 'core/i18n';
 
 type DayProps = {
   clusters: AnyClusteredEvent[];
@@ -22,6 +26,13 @@ const Day = ({
   onClick,
 }: DayProps) => {
   const isToday = dayjs(date).isSame(new Date(), 'day');
+
+  const dstOffset = useMemo(
+    () =>
+      getDSTOffset(dayjs(date).startOf('day').toDate()) -
+      getDSTOffset(dayjs(date).endOf('day').toDate()),
+    [date]
+  );
 
   let textColor = theme.palette.text.secondary;
   if (isToday) {
@@ -56,6 +67,15 @@ const Day = ({
           <FormattedDate day="numeric" value={date} />
         </Typography>
       </Box>
+      {dstOffset !== 0 && (
+        <Box paddingLeft="4px">
+          <Typography color={theme.palette.grey[500]} variant="body2">
+            <Msg
+              id={dstOffset > 0 ? messageIds.dstStarts : messageIds.dstEnds}
+            />
+          </Typography>
+        </Box>
+      )}
       {clusters.map((cluster, index) => {
         return (
           <Box

--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -1,7 +1,12 @@
 import { FormattedDate } from 'react-intl';
 import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
 
 import theme from 'theme';
+import { getDSTOffset } from './utils';
+import { Msg } from 'core/i18n';
+import messageIds from '../../l10n/messageIds';
 
 export interface DayHeaderProps {
   date: Date;
@@ -10,11 +15,18 @@ export interface DayHeaderProps {
 }
 
 const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
+  const dstChangeAmount: number = useMemo(
+    () =>
+      getDSTOffset(dayjs(date).startOf('day').toDate()) -
+      getDSTOffset(dayjs(date).endOf('day').toDate()),
+    [date]
+  );
+
   return (
     <Box
       display="grid"
       gridTemplateColumns="repeat(3, 1fr)"
-      gridTemplateRows="1fr"
+      gridTemplateRows="1fr auto"
       onClick={() => onClick()}
       sx={{
         cursor: 'pointer',
@@ -49,6 +61,14 @@ const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
       </Box>
       {/* Empty */}
       <Box />
+      {dstChangeAmount !== 0 && (
+        <Box gridColumn={'1 / span 3'} gridRow={2}>
+          <Typography color={theme.palette.grey[500]} variant="body2">
+            {dstChangeAmount > 0 && <Msg id={messageIds.dstStarts} />}
+            {dstChangeAmount < 0 && <Msg id={messageIds.dstEnds} />}
+          </Typography>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import dayjs from 'dayjs';
 
 import theme from 'theme';
-import { getDSTOffset } from './utils';
+import { getDSTOffset } from '../utils';
 import { Msg } from 'core/i18n';
 import messageIds from '../../l10n/messageIds';
 

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import DayHeader from './DayHeader';
 import EventCluster from '../EventCluster';
@@ -24,6 +24,7 @@ import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import range from 'utils/range';
 import { scrollToEarliestEvent } from './utils';
+import { getDSTOffset } from '../utils';
 import useCreateEvent from 'features/events/hooks/useCreateEvent';
 import { useNumericRouteParams } from 'core/hooks';
 import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents';
@@ -56,6 +57,15 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
     return focusWeekStartDay.day(weekday + 1).toDate();
   });
 
+  const dstChangeAmount: number = useMemo(
+    () =>
+      getDSTOffset(dayjs(focusWeekStartDay).startOf('day').toDate()) -
+      getDSTOffset(
+        dayjs(focusWeekStartDay.add(6, 'days')).endOf('day').toDate()
+      ),
+    [focusWeekStartDay]
+  );
+
   const eventsByDate = useWeekCalendarEvents({
     campaignId: campId,
     dates: dayDates,
@@ -77,10 +87,12 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
     <>
       {/* Headers across the top */}
       <Box
+        alignItems={'flex-start'}
         columnGap={1}
         display="grid"
         gridTemplateColumns={`${HOUR_COLUMN_WIDTH} repeat(7, 1fr)`}
         gridTemplateRows={'1fr'}
+        marginBottom={dstChangeAmount === 0 ? 2 : 0}
       >
         {/* Empty */}
         <HeaderWeekNumber weekNr={dayjs(dayDates[0]).isoWeek()} />
@@ -103,7 +115,6 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         gridTemplateColumns={`${HOUR_COLUMN_WIDTH} repeat(7, 1fr)`}
         gridTemplateRows={'1fr'}
         height="100%"
-        marginTop={2}
         overflow="auto"
       >
         {/* Hours column */}

--- a/src/features/calendar/components/CalendarWeekView/utils.ts
+++ b/src/features/calendar/components/CalendarWeekView/utils.ts
@@ -30,9 +30,3 @@ export function scrollToEarliestEvent(
 
   weekElement.scrollTo({ behavior: 'smooth', top: heightInPixels });
 }
-
-export function getDSTOffset(date: Date): number {
-  const jan = new Date(date.getFullYear(), 0, 1).getTimezoneOffset();
-  const jul = new Date(date.getFullYear(), 6, 1).getTimezoneOffset();
-  return (date.getTimezoneOffset() - Math.max(jan, jul)) / 60;
-}

--- a/src/features/calendar/components/CalendarWeekView/utils.ts
+++ b/src/features/calendar/components/CalendarWeekView/utils.ts
@@ -30,3 +30,9 @@ export function scrollToEarliestEvent(
 
   weekElement.scrollTo({ behavior: 'smooth', top: heightInPixels });
 }
+
+export function getDSTOffset(date: Date): number {
+  const jan = new Date(date.getFullYear(), 0, 1).getTimezoneOffset();
+  const jul = new Date(date.getFullYear(), 6, 1).getTimezoneOffset();
+  return (date.getTimezoneOffset() - Math.max(jan, jul)) / 60;
+}

--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -278,3 +278,9 @@ export const getActivitiesByDay = (
 
   return dateHashmap;
 };
+
+export function getDSTOffset(date: Date): number {
+  const jan = new Date(date.getFullYear(), 0, 1).getTimezoneOffset();
+  const jul = new Date(date.getFullYear(), 6, 1).getTimezoneOffset();
+  return (date.getTimezoneOffset() - Math.max(jan, jul)) / 60;
+}

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -7,8 +7,8 @@ export default makeMessages('feat.calendar', {
     shiftEvent: m('Create multiple events that form shifts'),
     singleEvent: m('Create single event'),
   },
-  dstEnds: m('DST ends'),
-  dstStarts: m('DST starts'),
+  dstEnds: m('Winter time'),
+  dstStarts: m('Summer time'),
   event: {
     differentLocations: m<{ numLocations: number }>(
       '{numLocations} different locations'

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -7,6 +7,8 @@ export default makeMessages('feat.calendar', {
     shiftEvent: m('Create multiple events that form shifts'),
     singleEvent: m('Create single event'),
   },
+  dstEnds: m('DST ends'),
+  dstStarts: m('DST starts'),
   event: {
     differentLocations: m<{ numLocations: number }>(
       '{numLocations} different locations'


### PR DESCRIPTION
## Description
This PR adds a label under day header in week view if daylight saving time starts of ends during that day. Should handle different locales.


## Screenshots
![Screen Shot 2024-09-28 at 14 55 12](https://github.com/user-attachments/assets/f0be98d9-579e-4964-9c21-f3bd4b5eea84)



## Changes
* Adds DST detection and display to DayHeader

## Notes to reviewer
DST ends on 27/10 in Europe.


## Related issues
Resolves #2151
