### PR TITLE
prevent copied links to have same tag

### DIFF
--- a/src/features/emails/components/EmailEditor/tools/Button/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/Button/index.tsx
@@ -25,11 +25,10 @@ export default class Button {
     this._readOnly = readOnly;
     this._data = {
       buttonText: data.buttonText,
-      tag: data.tag ? data.tag : Math.random().toString(36).substring(2, 10),
+      tag: data.tag || Math.random().toString(36).substring(2, 10),
       url: data.url,
     };
   }
-
   static get isReadOnlySupported() {
     return true;
   }

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -196,7 +196,6 @@ export function linkToolFactory(title: string) {
       } else {
         const anchor = document.createElement('a');
         anchor.classList.add('inlineLink');
-        anchor.dataset.tag = Math.random().toString(36).substring(2, 10);
         anchor.style.cursor = 'text';
 
         const content = range.extractContents();

--- a/src/features/emails/utils/htmlToInlineNodes.ts
+++ b/src/features/emails/utils/htmlToInlineNodes.ts
@@ -29,7 +29,7 @@ function childNodesToInlineNodes(childNodes: ChildNode[]) {
         content: childNodesToInlineNodes(Array.from(node.childNodes)),
         href: anchor.href,
         kind: InlineNodeKind.LINK,
-        tag: anchor.dataset.tag || '',
+        tag: Math.random().toString(36).substring(2, 10),
       });
     } else if (node.nodeName === 'SPAN') {
       const span = node as HTMLSpanElement;

--- a/src/features/emails/utils/htmlToInlineNodes.ts
+++ b/src/features/emails/utils/htmlToInlineNodes.ts
@@ -29,7 +29,7 @@ function childNodesToInlineNodes(childNodes: ChildNode[]) {
         content: childNodesToInlineNodes(Array.from(node.childNodes)),
         href: anchor.href,
         kind: InlineNodeKind.LINK,
-        tag: Math.random().toString(36).substring(2, 10),
+        tag: anchor.dataset.tag || Math.random().toString(36).substring(2, 10),
       });
     } else if (node.nodeName === 'SPAN') {
       const span = node as HTMLSpanElement;

--- a/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.ts
+++ b/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.ts
@@ -8,17 +8,25 @@ export default function zetkinBlocksToEditorjsBlocks(
 ) {
   const editorjsBlocks: OutputBlockData[] = [];
 
+  const buttonTagIds: string[] = [];
+
   zetkinBlocks.forEach((block) => {
     if (block.kind === BlockKind.BUTTON) {
-      editorjsBlocks.push({
-        data: {
-          buttonText: block.data.text,
-          tag: block.data.tag,
-          url: block.data.href,
-        },
-        id: Math.random().toString(36).substring(2, 10),
-        type: BLOCK_TYPES.BUTTON,
-      });
+      const tag = buttonTagIds.includes(block.data.tag)
+        ? Math.random().toString(36).substring(2, 10)
+        : block.data.tag;
+      buttonTagIds.push(tag);
+      {
+        editorjsBlocks.push({
+          data: {
+            buttonText: block.data.text,
+            tag,
+            url: block.data.href,
+          },
+          id: Math.random().toString(36).substring(2, 10),
+          type: BLOCK_TYPES.BUTTON,
+        });
+      }
     } else if (block.kind === BlockKind.HEADER) {
       editorjsBlocks.push({
         data: {

--- a/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.ts
+++ b/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.ts
@@ -16,17 +16,15 @@ export default function zetkinBlocksToEditorjsBlocks(
         ? Math.random().toString(36).substring(2, 10)
         : block.data.tag;
       buttonTagIds.push(tag);
-      {
-        editorjsBlocks.push({
-          data: {
-            buttonText: block.data.text,
-            tag,
-            url: block.data.href,
-          },
-          id: Math.random().toString(36).substring(2, 10),
-          type: BLOCK_TYPES.BUTTON,
-        });
-      }
+      editorjsBlocks.push({
+        data: {
+          buttonText: block.data.text,
+          tag,
+          url: block.data.href,
+        },
+        id: Math.random().toString(36).substring(2, 10),
+        type: BLOCK_TYPES.BUTTON,
+      });
     } else if (block.kind === BlockKind.HEADER) {
       editorjsBlocks.push({
         data: {


### PR DESCRIPTION
## Description
This PR prevents a copied/pasted link to have same "tag"


## Screenshots



## Changes
The tag is now generated later in the serialization process.


## Notes to reviewer



## Related issues
Resolves #2075 (https://github.com/zetkin/app.zetkin.org/issues/2075)
