### PR TITLE
Issue 2149 - ZUIDuration change formatting and properties of duration

### DIFF
--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -9,11 +9,8 @@ export default {
 
 export const Basic: StoryObj<typeof ZUIDuration> = {
   args: {
-    seconds: 12345,
-    withDays: true,
-    withHours: true,
-    withMinutes: true,
-    withSeconds: false,
-    withThousands: false,
+    seconds: 123456.789,
+    upperTimeUnit: 'days',
+    lowerTimeUnit: 'minutes',
   },
 };

--- a/src/zui/ZUIDuration/index.stories.tsx
+++ b/src/zui/ZUIDuration/index.stories.tsx
@@ -9,8 +9,8 @@ export default {
 
 export const Basic: StoryObj<typeof ZUIDuration> = {
   args: {
+    lowerTimeUnit: 'minutes',
     seconds: 123456.789,
     upperTimeUnit: 'days',
-    lowerTimeUnit: 'minutes',
   },
 };

--- a/src/zui/ZUIDuration/index.tsx
+++ b/src/zui/ZUIDuration/index.tsx
@@ -5,6 +5,11 @@ import { Msg } from 'core/i18n';
 
 type Props = {
   /**
+   * The lower range unit of time to display the duration in.
+   */
+  lowerTimeUnit?: 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days';
+
+  /**
    * The duration in seconds that should be visualized. Only positive durations
    * are supported and negative values will result in no rendered output.
    */
@@ -14,11 +19,6 @@ type Props = {
    * The upper range unit of time to display the duration in.
    */
   upperTimeUnit?: 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days';
-
-  /**
-   * The lower range unit of time to display the duration in.
-   */
-  lowerTimeUnit?: 'milliseconds' | 'seconds' | 'minutes' | 'hours' | 'days';
 };
 
 type DurField = {
@@ -40,14 +40,14 @@ const ZUIDuration: FC<Props> = ({
   lowerTimeUnit = 'minutes',
   seconds,
 }) => {
-  var upper = timeUnitMap.get(upperTimeUnit) ?? 4;
-  var lower = timeUnitMap.get(lowerTimeUnit) ?? 2;
+  let upper = timeUnitMap.get(upperTimeUnit) ?? 4;
+  const lower = timeUnitMap.get(lowerTimeUnit) ?? 2;
 
   if (upper < lower) {
     upper = lower;
   }
 
-  var timeUnits = [...timeUnitMap.keys()].filter(
+  const timeUnits = [...timeUnitMap.keys()].filter(
     (timeUnit) =>
       (timeUnitMap.get(timeUnit) ?? 0) <= upper &&
       (timeUnitMap.get(timeUnit) ?? 0) >= lower


### PR DESCRIPTION
## Description
This PR changes the logic and properties of the ZUIDuration component, so that even if a higher unit of time is not visible, the amount of time will be transferred to the next unit instead. I.e, 1 day and 1 hour will display as 25 hours if days are no longer visible. The PR also changes the properties of the component to accept a lower and a higher bound of units of time, because it is unlikely that a duration will (for example) need hours and seconds but not minutes. 


## Screenshots
![bild](https://github.com/user-attachments/assets/05241e13-37c2-4a9c-9e8c-5a6a6b4831e4)
![bild](https://github.com/user-attachments/assets/1be3ed8e-55b8-436a-b1b1-cf962abce8e2)



## Changes
* Changes the display of durations in the ZUIDuration to show the entire duration even if higher units of time are not visible
* Changes the properties of the ZUIDuration to accept a lower and a higher bound of units of time 


## Notes to reviewer
Play around with upper and lower bounds in playbook for the ZUIDuration. Consider if the error handling is ok, like if upper bound is lower than lower bound. I've taken some liberties here so let me know if you think something is not reasonable :P 


## Related issues
Resolves #2149 
