### PR TITLE
Fix non-dashed empty results after empty segment in makeSankeySegments

### DIFF
--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -537,4 +537,82 @@ describe('makeSankeySegments()', () => {
       },
     ]);
   });
+
+  it('handles adding nothing to empty stream', () => {
+    const result = makeSankeySegments([
+      {
+        change: 0,
+        filter: {
+          config: {
+            fields: {
+              first_name: 'aaaaaaaaaaa',
+            },
+            organizations: [1],
+          },
+          op: OPERATION.ADD,
+          type: FILTER_TYPE.PERSON_DATA,
+        },
+        matches: 0,
+        result: 0,
+      },
+      {
+        change: 100,
+        filter: {
+          config: {
+            fields: {
+              first_name: 'a',
+            },
+            organizations: [1],
+          },
+          op: OPERATION.ADD,
+          type: FILTER_TYPE.PERSON_DATA,
+        },
+        matches: 100,
+        result: 100,
+      },
+    ]);
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.EMPTY,
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: null,
+        side: {
+          style: SEGMENT_STYLE.STROKE,
+          width: 0,
+        },
+        stats: {
+          change: 0,
+          input: 0,
+          matches: 0,
+          output: 0,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.ADD,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.05,
+        },
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.95,
+        },
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 100,
+        style: SEGMENT_STYLE.FILL,
+        width: 1,
+      },
+    ]);
+  });
 });

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
@@ -76,7 +76,7 @@ export default function makeSankeySegments(
           kind: SEGMENT_KIND.PSEUDO_ADD,
           main: null,
           side: {
-            style: SEGMENT_STYLE.FILL,
+            style: change == 0 ? SEGMENT_STYLE.STROKE : SEGMENT_STYLE.FILL,
             width: change / maxPeople,
           },
           stats,


### PR DESCRIPTION
## Description
This PR fixes #1579 by making sure that if the first non-empty add use stroke instead of fill.


## Screenshots
![image](https://github.com/user-attachments/assets/73ff0e7c-e52c-4ff3-b930-45ac7a88ec4a)


## Notes to reviewer
See issue for reproduction steps and how it rendered previously.

We did not attempt to fix the weird join between a 0 add and the next segment.


## Related issues
Resolves #1579
