### PR TITLE
person can be excluded if there's only two in the list

### DIFF
--- a/src/features/duplicates/components/MergeCandidateList.tsx
+++ b/src/features/duplicates/components/MergeCandidateList.tsx
@@ -19,12 +19,14 @@ interface MergeCandidateListProps {
   buttonLabel: string;
   onButtonClick: (person: ZetkinPerson) => void;
   rows: ZetkinPerson[];
+  showActionButton?: boolean;
 }
 
 const MergeCandidateList: FC<MergeCandidateListProps> = ({
   buttonLabel,
   onButtonClick,
   rows,
+  showActionButton = true,
 }) => {
   const { orgId } = useNumericRouteParams();
 
@@ -82,16 +84,18 @@ const MergeCandidateList: FC<MergeCandidateListProps> = ({
                   }
                 />
               </ListItem>
-              <Button
-                onClick={() => {
-                  onButtonClick(person);
-                }}
-                size="small"
-                sx={{ marginRight: 2 }}
-                variant="outlined"
-              >
-                {buttonLabel}
-              </Button>
+              {showActionButton && (
+                <Button
+                  onClick={() => {
+                    onButtonClick(person);
+                  }}
+                  size="small"
+                  sx={{ marginRight: 2 }}
+                  variant="outlined"
+                >
+                  {buttonLabel}
+                </Button>
+              )}
             </Box>
           </>
         );

--- a/src/features/duplicates/components/PotentialDuplicatesLists.tsx
+++ b/src/features/duplicates/components/PotentialDuplicatesLists.tsx
@@ -28,6 +28,7 @@ const PotentialDuplicatesLists: FC<PotentialDuplicatesListsProps> = ({
         buttonLabel={messages.modal.notDuplicateButton()}
         onButtonClick={onDeselect}
         rows={peopleToMerge}
+        showActionButton={peopleNotToMerge.length + peopleToMerge.length > 2}
       />
       {peopleToMerge.length > 0 && <Divider />}
       {peopleNotToMerge.length > 0 && (


### PR DESCRIPTION
## Description
This PR prevents excluding people if there's only two in the list of potential duplicates.


## Screenshots



## Changes
Adds a prop to PotentialDuplicatesList to be able not to show the button.

## Notes to reviewer



## Related issues
Resolves #2032 (https://github.com/zetkin/app.zetkin.org/issues/2032)
