### PR TITLE
add option to move person lists in a mobile-friendly dialog

### DIFF
--- a/src/features/views/components/MoveViewDialog.tsx
+++ b/src/features/views/components/MoveViewDialog.tsx
@@ -144,6 +144,12 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
       maxWidth={'sm'}
       onClose={close}
       open={true}
+      PaperProps={{
+        sx: {
+          height: '80vh',
+          maxHeight: '600px',
+        },
+      }}
       scroll="paper"
     >
       <DialogTitle>
@@ -154,7 +160,7 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
         />
       </DialogTitle>
 
-      <DialogContent sx={{ height: '100%' }}>
+      <DialogContent>
         <ZUIFuture future={itemsFuture}>
           {(data) => {
             const relevantItems = data.filter(

--- a/src/features/views/components/MoveViewDialog.tsx
+++ b/src/features/views/components/MoveViewDialog.tsx
@@ -1,0 +1,208 @@
+import { range } from 'lodash';
+import { FunctionComponent } from 'react';
+import { Close, Folder, SubdirectoryArrowRight } from '@mui/icons-material';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Icon,
+  IconButton,
+  List,
+  ListItem,
+  useMediaQuery,
+} from '@mui/material';
+import { Box } from '@mui/system';
+
+import { useNumericRouteParams } from 'core/hooks';
+import theme from 'theme';
+import ZUIFuture from 'zui/ZUIFuture';
+import { ZetkinViewFolder } from './types';
+import { ViewBrowserItem } from '../hooks/useViewBrowserItems';
+import useViewBrowserMutations from '../hooks/useViewBrowserMutations';
+import useViewTree from '../hooks/useViewTree';
+import { useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+
+type FolderInsideTreeStructure = {
+  folder: ZetkinViewFolder;
+  insideMovedItem: boolean;
+  nestingLevel: number;
+};
+
+/** For each subfolder of `id`, add it to the list, followed by its subfolders (and their subfolders, recursively), creating a tree-like structure */
+const sortFoldersByTreeStructureRecursive = (
+  id: number | null,
+  nestingLevel: number,
+  folderToMove: number | null,
+  alreadyInsideMovedItem: boolean,
+  allFolders: ZetkinViewFolder[]
+): FolderInsideTreeStructure[] => {
+  // Find all subfolders and sort them alphabetically
+  const subfolders = allFolders
+    .filter((f) => f.parent?.id == id)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  return subfolders.flatMap((folder) => {
+    // We cannot move a folder inside itself, or inside one of its children (or their children, recursively)
+    // This condition makes it so that once we have encountered the folder-to-be-moved, we keep passing `true` all the way down the recursive tree
+    const insideMovedItem = alreadyInsideMovedItem || folder.id == folderToMove;
+    return [
+      {
+        folder,
+        insideMovedItem,
+        nestingLevel,
+      },
+      ...sortFoldersByTreeStructureRecursive(
+        folder.id,
+        nestingLevel + 1,
+        folderToMove,
+        insideMovedItem,
+        allFolders
+      ),
+    ];
+  });
+};
+
+const sortFoldersByTreeStructure = (
+  itemToMove: number | null,
+  allFolders: ZetkinViewFolder[]
+): FolderInsideTreeStructure[] => {
+  return sortFoldersByTreeStructureRecursive(
+    null,
+    0,
+    itemToMove,
+    false,
+    allFolders
+  );
+};
+
+export type MoveViewDialogProps = {
+  close: () => void;
+  itemToMove: ViewBrowserItem;
+};
+const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
+  close,
+  itemToMove,
+}) => {
+  const messages = useMessages(messageIds);
+  const { orgId } = useNumericRouteParams();
+
+  const itemsFuture = useViewTree(orgId);
+
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const { moveItem } = useViewBrowserMutations(orgId);
+
+  if (itemToMove.type == 'back') {
+    throw new Error('Should not be possible to move a back button');
+  }
+
+  const doMove = (folderId: number | null) => {
+    moveItem(itemToMove.type, itemToMove.data.id, folderId);
+    close();
+  };
+
+  return (
+    <Dialog
+      fullScreen={fullScreen}
+      fullWidth
+      maxWidth={'sm'}
+      onClose={close}
+      open={true}
+    >
+      <DialogContent>
+        <Box display="flex" justifyContent="space-between">
+          <DialogTitle variant="h5">
+            {messages.moveViewDialog.title({ itemName: itemToMove.title })}
+          </DialogTitle>
+
+          <IconButton onClick={close}>
+            <Close color="secondary" />
+          </IconButton>
+        </Box>
+
+        <Box display="flex" flexDirection="column" rowGap={1}>
+          <ZUIFuture future={itemsFuture}>
+            {(data) => {
+              const treeified = sortFoldersByTreeStructure(
+                itemToMove.type == 'folder' ? itemToMove.data.id : null,
+                data.folders
+              );
+
+              return (
+                <>
+                  <Button onClick={() => doMove(null)} variant="outlined">
+                    {messages.moveViewDialog.moveToRoot()}
+                  </Button>
+                  <Box>
+                    <List>
+                      {treeified.map(
+                        ({ nestingLevel, folder, insideMovedItem }) => {
+                          return (
+                            <ListItem key={folder.id}>
+                              <Box
+                                alignItems="center"
+                                display="flex"
+                                width="100%"
+                              >
+                                <Box
+                                  alignItems="flex-start"
+                                  display="flex"
+                                  marginRight={2}
+                                >
+                                  {nestingLevel > 0 && (
+                                    <>
+                                      {range(nestingLevel - 1).map((idx) => (
+                                        <Icon key={idx} />
+                                      ))}
+                                      <SubdirectoryArrowRight />
+                                    </>
+                                  )}
+                                  <Folder />
+                                </Box>
+
+                                <Box
+                                  alignItems="center"
+                                  display="flex"
+                                  flexGrow={1}
+                                  marginRight={2}
+                                >
+                                  {folder.title}
+                                </Box>
+
+                                <Box alignItems="center" display="flex">
+                                  {folder.id == itemToMove.folderId ? (
+                                    <Button disabled variant="outlined">
+                                      {messages.moveViewDialog.alreadyInThisFolder()}
+                                    </Button>
+                                  ) : insideMovedItem ? (
+                                    <Button disabled variant="outlined">
+                                      {messages.moveViewDialog.cannotMoveHere()}
+                                    </Button>
+                                  ) : (
+                                    <Button
+                                      onClick={() => doMove(folder.id)}
+                                      variant="outlined"
+                                    >
+                                      {messages.moveViewDialog.moveHere()}
+                                    </Button>
+                                  )}
+                                </Box>
+                              </Box>
+                            </ListItem>
+                          );
+                        }
+                      )}
+                    </List>
+                  </Box>
+                </>
+              );
+            }}
+          </ZUIFuture>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default MoveViewDialog;

--- a/src/features/views/components/MoveViewDialog.tsx
+++ b/src/features/views/components/MoveViewDialog.tsx
@@ -19,9 +19,8 @@ import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ZetkinViewFolder } from './types';
 import useViewBrowserItems, {
-  ViewBrowserFolderItem,
+  ViewBrowserBackItem,
   ViewBrowserItem,
-  ViewBrowserViewItem,
 } from '../hooks/useViewBrowserItems';
 import useViewBrowserMutations from '../hooks/useViewBrowserMutations';
 import useViewTree from '../hooks/useViewTree';
@@ -109,7 +108,7 @@ const MoveItemBreadcrumbs = ({
   );
 };
 
-export type MoveViewDialogProps = {
+type MoveViewDialogProps = {
   close: () => void;
   itemToMove: ViewBrowserItem;
 };
@@ -164,8 +163,7 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
         <ZUIFuture future={itemsFuture}>
           {(data) => {
             const relevantItems = data.filter(
-              // This explicit typing should not be necessary, but it is. Don't know why.
-              (item): item is ViewBrowserFolderItem | ViewBrowserViewItem =>
+              (item): item is Exclude<typeof item, ViewBrowserBackItem> =>
                 item.type != 'back'
             );
             if (relevantItems.length == 0) {

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -28,6 +28,7 @@ import useViewBrowserItems, {
   ViewBrowserItem,
 } from 'features/views/hooks/useViewBrowserItems';
 import messageIds from 'features/views/l10n/messageIds';
+import MoveViewDialog from '../MoveViewDialog';
 
 interface ViewBrowserProps {
   basePath: string;
@@ -59,6 +60,10 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
   const { renameItem } = useViewBrowserMutations(orgId);
   const itemsFuture = useViewBrowserItems(orgId, folderId);
   const { deleteFolder, recentlyCreatedFolder } = useFolder(orgId);
+
+  const [itemToBeMoved, setItemToBeMoved] = useState<ViewBrowserItem | null>(
+    null
+  );
 
   // If a folder was created, go into rename state
   useEffect(() => {
@@ -175,6 +180,14 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
                   });
                 },
               },
+              {
+                id: 'move-item',
+                label: messages.browser.menu.move(),
+                onSelect: (e) => {
+                  e.stopPropagation();
+                  setItemToBeMoved(item);
+                },
+              },
             ]}
           />
         );
@@ -242,6 +255,12 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
               sortingMode="server"
               sx={{ borderWidth: 0 }}
             />
+            {itemToBeMoved && (
+              <MoveViewDialog
+                close={() => setItemToBeMoved(null)}
+                itemToMove={itemToBeMoved}
+              />
+            )}
           </>
         );
       }}

--- a/src/features/views/hooks/useViewBrowserItems.ts
+++ b/src/features/views/hooks/useViewBrowserItems.ts
@@ -20,7 +20,7 @@ export interface ViewBrowserViewItem {
   folderId: number | null;
 }
 
-type ViewBrowserBackItem = {
+export type ViewBrowserBackItem = {
   folderId: number | null;
   id: string;
   title: string | null;

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -30,6 +30,7 @@ export default makeMessages('feat.views', {
     },
     menu: {
       delete: m('Delete'),
+      move: m('Move'),
       rename: m('Rename'),
     },
     moveToFolder: m<{ folder: ReactElement }>('Move to {folder}'),
@@ -337,6 +338,13 @@ export default makeMessages('feat.views', {
   footer: {
     addPlaceholder: m('Start typing to add person to list'),
     alreadyInView: m('Already in list'),
+  },
+  moveViewDialog: {
+    alreadyInThisFolder: m('Already in this folder'),
+    cannotMoveHere: m('Cannot move here'),
+    moveHere: m('Move'),
+    moveToRoot: m('Move to root'),
+    title: m<{ itemName: string }>('Move {itemName}'),
   },
   newFolderTitle: m('New Folder'),
   newViewFields: {

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -340,11 +340,9 @@ export default makeMessages('feat.views', {
     alreadyInView: m('Already in list'),
   },
   moveViewDialog: {
-    alreadyInThisFolder: m('Already in this folder'),
-    cannotMoveHere: m('Cannot move here'),
-    moveHere: m('Move'),
-    moveToRoot: m('Move to root'),
-    title: m<{ itemName: string }>('Move {itemName}'),
+    cancel: m('Cancel'),
+    emptyFolder: m('Empty folder'),
+    moveHere: m('Move here'),
   },
   newFolderTitle: m('New Folder'),
   newViewFields: {


### PR DESCRIPTION
## Description
This PR implements a dialog for moving a People list, that is accessible from the ellipsis menu on the right side of the People list. This does not replace the current drag-and-drop functionality, but complements it.


## Screenshots
Moving a list:
![Screenshot 2024-09-28 at 16 45 28](https://github.com/user-attachments/assets/c44f4398-4f89-4e18-9326-cc939c6baa68)
![Screenshot 2024-09-29 at 12 08 52](https://github.com/user-attachments/assets/abeac422-0cdf-450b-83ad-89da9ac09937)


Moving a folder:
![Screenshot 2024-09-28 at 16 45 41](https://github.com/user-attachments/assets/2023e915-e1c9-46f4-9249-742b1fd123fc)
![Screenshot 2024-09-29 at 12 09 12](https://github.com/user-attachments/assets/511c8dd3-7d7f-4208-9c47-74075790c02b)


Mobile view:
![Screenshot 2024-09-29 at 12 25 15](https://github.com/user-attachments/assets/ba3dfdc1-3201-4c53-bbba-b8a4e8c04767)



## Changes
* Adds new `MoveViewDialog` component
* Changes `ViewBrowser` so that it can open the dialog using the ellipsis menu


## Notes to reviewer
Nothing in particular


## Related issues
Resolves #2126 
