### PR TITLE
Issue 1922: add notProcessed message and implement logic in EmailActionButtons component

### DIFF
--- a/src/features/emails/components/EmailActionButtons.tsx
+++ b/src/features/emails/components/EmailActionButtons.tsx
@@ -36,21 +36,33 @@ const EmailActionButtons = ({
         <CancelButton onClick={() => updateEmail({ published: null })} />
       )}
       {state === EmailState.DRAFT && <DeliveryButton email={email} />}
-      {email.published && state === EmailState.SENT && (
-        <Box alignItems="center" display="flex">
-          <Send color="secondary" sx={{ mr: 1 }} />
-          <Typography color="secondary">
-            <Msg
-              id={messageIds.deliveryStatus.wasSent}
-              values={{
-                datetime: (
-                  <ZUIDateTime convertToLocal datetime={email.published} />
-                ),
-              }}
-            />
-          </Typography>
-        </Box>
-      )}
+      {email.published &&
+        state === EmailState.SENT &&
+        email.processed !== null && (
+          <Box alignItems="center" display="flex">
+            <Send color="secondary" sx={{ mr: 1 }} />
+            <Typography color="secondary">
+              <Msg
+                id={messageIds.deliveryStatus.wasSent}
+                values={{
+                  datetime: (
+                    <ZUIDateTime convertToLocal datetime={email.published} />
+                  ),
+                }}
+              />
+            </Typography>
+          </Box>
+        )}
+      {email.published &&
+        state === EmailState.SENT &&
+        email.processed === null && (
+          <Box alignItems="center" display="flex">
+            <Send color="secondary" sx={{ mr: 1 }} />
+            <Typography color="secondary">
+              <Msg id={messageIds.deliveryStatus.notProcessed} />
+            </Typography>
+          </Box>
+        )}
       <ZUIEllipsisMenu
         items={[
           {

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -27,6 +27,7 @@ export default makeMessages('feat.emails', {
   },
   deliveryStatus: {
     notLocked: m('Not locked, not scheduled'),
+    notProcessed: m('Scheduled to be delivered ASAP'),
     notScheduled: m('Not scheduled'),
     wasSent: m<{ datetime: ReactElement }>('Was sent at {datetime}'),
     willSend: m<{ datetime: ReactElement }>('Will send at {datetime}'),


### PR DESCRIPTION
## Description
This PR adds a message/logic to show the user that the email is published but not processed yet.


## Screenshots
![image](https://github.com/user-attachments/assets/489c6733-a873-440f-8181-b8a40bb60dcf)



## Changes
* Adds a new message object for the `notProcessed `case 
* Adds a new object in the `EmailActionButton `component to display the `notProcessed ` message 


## Notes to reviewer
None


## Related issues
Resolves #1922 
