### PR TITLE
Issue 2039/submit button says edit instead of create when editing tags

### DIFF
--- a/src/features/tags/components/TagManager/components/TagDialog/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/index.tsx
@@ -72,9 +72,7 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     <ZUIDialog
       onClose={closeAndClear}
       open={open}
-      title={
-        editingTag ? messages.dialog.editTitle() : messages.dialog.createTitle()
-      }
+      title={editingTag ? messages.dialog.editTitle() : submitLabel}
     >
       <form
         onSubmit={(e) => {
@@ -156,7 +154,11 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
           <ZUISubmitCancelButtons
             onCancel={closeAndClear}
             submitDisabled={!title || !color.valid}
-            submitText={submitLabel ?? messages.dialog.createTagButton()}
+            submitText={
+              editingTag
+                ? messages.dialog.updateTagButton()
+                : submitLabel || messages.dialog.createTagButton()
+            }
           />
         </Box>
       </form>

--- a/src/features/tags/components/TagManager/components/TagDialog/index.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/index.tsx
@@ -72,7 +72,9 @@ const TagDialog: React.FunctionComponent<TagDialogProps> = ({
     <ZUIDialog
       onClose={closeAndClear}
       open={open}
-      title={editingTag ? messages.dialog.editTitle() : submitLabel}
+      title={
+        editingTag ? messages.dialog.editTitle() : messages.dialog.createTitle()
+      }
     >
       <form
         onSubmit={(e) => {

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -6,6 +6,7 @@ export default makeMessages('feat.tags', {
   dialog: {
     colorErrorText: m('Please enter a valid hex code'),
     colorLabel: m('Color'),
+    createAndApplyTagButton: m('Create and apply'),
     createTagButton: m('Create'),
     createTitle: m('Create tag'),
     deleteButtonLabel: m('Delete'),
@@ -23,6 +24,7 @@ export default makeMessages('feat.tags', {
       none: m('Basic (no values)'),
       text: m('Text values'),
     },
+    updateTagButton: m('Update'),
   },
   manager: {
     addTag: m('Add tag'),

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -6,7 +6,6 @@ export default makeMessages('feat.tags', {
   dialog: {
     colorErrorText: m('Please enter a valid hex code'),
     colorLabel: m('Color'),
-    createAndApplyTagButton: m('Create and apply'),
     createTagButton: m('Create'),
     createTitle: m('Create tag'),
     deleteButtonLabel: m('Delete'),

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -104,6 +104,7 @@ feat:
     selectionBar:
       deselect: Deselect
       editEvents: Edit events
+      editParticipants: Manage participants
       ellipsisMenu:
         cancel: Cancel
         cancelWarning: If you do, remember to notify all participants and sign-ups that
@@ -710,6 +711,34 @@ feat:
       remindButtondisabledTooltip: You have to assign a contact person before sending reminders
       reqParticipantsHelperText: The minimum number of participants required
       reqParticipantsLabel: Required participants
+    participantsModal:
+      affected:
+        empty: You haven't made any changes yet. Pick an event to move participants
+          around.
+        header: Affected people
+      discardButton: Discard changes
+      emptyStates:
+        booked: No one has been booked at this event. You can add participants from the
+          pool.
+        pending: There are no additional participants in the pool. You can move
+          participants from an event to the pool to work with them here.
+      participants:
+        buttons:
+          addBack: Add back
+          addHere: Add here
+          move: Move
+          undo: Undo
+        headers:
+          booked: This event
+          pending: People that can be added
+        states:
+          added: Being added to this event
+          pending: In the pool
+          removed: Moving away from this event
+      statusText: "{personCount, plural, =1 {One person} other {# people}} will be
+        moved around"
+      submitButton: Execute
+      title: Manage participants
     search: Search
     state:
       cancelled: Cancelled
@@ -1238,6 +1267,10 @@ feat:
         demote: Demote
         promote: Promote
         remove: Remove
+      urlCard:
+        linkToPub: Link to public organization
+        subTitle: Users must connect to the organization before they can access Zetkin
+          as officials.
       you: You
   smartSearch:
     buttonLabels:
@@ -1886,6 +1919,7 @@ feat:
     dialog:
       colorErrorText: Please enter a valid hex code
       colorLabel: Color
+      createAndApplyTagButton: Create and apply
       createTagButton: Create
       createTitle: Create tag
       deleteButtonLabel: Delete
@@ -1901,6 +1935,7 @@ feat:
       types:
         none: Basic (no values)
         text: Text values
+      updateTagButton: Update
     manager:
       addTag: Add tag
       addValue: Add value for "{tag}"
@@ -2485,14 +2520,14 @@ zui:
     tooltip:
       edit: Click to edit
       noEmpty: This cannot be empty
+  editableImage:
+    add: Click to add image
   futures:
     errorLoading: There was an error loading the data.
   header:
     collapseButton:
       collapse: Collapse
       expand: Expand
-  imageSelectDialog:
-    instructions: Drag and drop an image file, or click to select
   lists:
     showMore: Show more...
   orgScopeSelect:

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1919,7 +1919,6 @@ feat:
     dialog:
       colorErrorText: Please enter a valid hex code
       colorLabel: Color
-      createAndApplyTagButton: Create and apply
       createTagButton: Create
       createTitle: Create tag
       deleteButtonLabel: Delete


### PR DESCRIPTION
## Description
This pr is to fix the issue where the submit button from the tag manager says create when you are editing a tag. I had previously worked on a different branch that I abandoned today and started over from scratch.

## Screenshots
I added a string to the dialog messages for when the user is updating a tag.
<img width="267" alt="Screenshot 2024-09-28 at 5 19 57 PM" src="https://github.com/user-attachments/assets/004cfbe3-3b8d-41fe-b91f-3943fd7bd02c">

The logic allows for a string to be passed to a tagManagerSection as submitCreateTagLabel to override the default "Create" button, as shown below. 
<img width="707" alt="Screenshot 2024-09-28 at 5 27 17 PM" src="https://github.com/user-attachments/assets/e1b95058-5cac-4b43-af8f-56285d09298d">
<img width="597" alt="Screenshot 2024-09-28 at 5 27 24 PM" src="https://github.com/user-attachments/assets/7003551e-af33-4768-a4be-9e9f832dd610">

Also, here are the desired behaviors as outline in a previous PR.
<img width="650" alt="Screenshot 2024-09-28 at 5 21 58 PM" src="https://github.com/user-attachments/assets/d84d6a6a-fd3b-42a4-a8ec-95d5df984785">
<img width="956" alt="Screenshot 2024-09-28 at 5 32 45 PM" src="https://github.com/user-attachments/assets/5cc80255-3917-494e-8b77-00b3b0971559">
<img width="938" alt="Screenshot 2024-09-28 at 5 32 59 PM" src="https://github.com/user-attachments/assets/85a1171d-134a-4537-afa4-70ecbc8d18c8">
<img width="937" alt="Screenshot 2024-09-28 at 5 32 25 PM" src="https://github.com/user-attachments/assets/d5e513d3-0532-4e05-bce1-a032fb73a0db">
<img width="914" alt="Screenshot 2024-09-28 at 5 32 17 PM" src="https://github.com/user-attachments/assets/25abd4b2-6560-4da8-bddf-f78ce7a8f564">
<img width="918" alt="Screenshot 2024-09-28 at 5 32 08 PM" src="https://github.com/user-attachments/assets/6b3f5f7f-a0e3-4c41-be1c-4e4557f39375">
<img width="910" alt="Screenshot 2024-09-28 at 5 31 55 PM" src="https://github.com/user-attachments/assets/739dced2-931b-4fbf-9b2e-7ce966d7aeba">


## Changes
* Added an english string at messages.dialog.updateTagButton to be used when updating a tag instead of "create"
* added logic to default to a supplied create button if it exists and to fall back to 'create' if no submitCreateTagLabel is supplied.


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #[id]
