### PR TITLE
Issue 2096/error handling for notes upload

### DIFF
--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -74,6 +74,7 @@ const JourneyDetailsPage: PageWithLayout = () => {
   const { orgId, instanceId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const [isLoading, setIsLoading] = useState(false);
+  const [showPostRequestError, setShowPostRequestError] = useState(false);
 
   const journeyInstanceFuture = useJourneyInstance(orgId, instanceId);
   const timelineUpdatesFuture = useTimelineUpdates(orgId, instanceId);
@@ -116,11 +117,17 @@ const JourneyDetailsPage: PageWithLayout = () => {
                 <ZUITimeline
                   disabled={isLoading}
                   onAddNote={async (note) => {
+                    setShowPostRequestError(false);
                     setIsLoading(true);
-                    await addNote(note);
+                    try {
+                      await addNote(note);
+                    } catch (e) {
+                      setShowPostRequestError(true);
+                    }
                     setIsLoading(false);
                   }}
                   onEditNote={editNote}
+                  showPostRequestError={showPostRequestError}
                   updates={updates}
                 />
               )}

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -74,7 +74,6 @@ const JourneyDetailsPage: PageWithLayout = () => {
   const { orgId, instanceId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const [isLoading, setIsLoading] = useState(false);
-  const [showPostRequestError, setShowPostRequestError] = useState(false);
 
   const journeyInstanceFuture = useJourneyInstance(orgId, instanceId);
   const timelineUpdatesFuture = useTimelineUpdates(orgId, instanceId);
@@ -117,17 +116,11 @@ const JourneyDetailsPage: PageWithLayout = () => {
                 <ZUITimeline
                   disabled={isLoading}
                   onAddNote={async (note) => {
-                    setShowPostRequestError(false);
                     setIsLoading(true);
-                    try {
-                      await addNote(note);
-                    } catch (e) {
-                      setShowPostRequestError(true);
-                    }
+                    await addNote(note);
                     setIsLoading(false);
                   }}
                   onEditNote={editNote}
-                  showPostRequestError={showPostRequestError}
                   updates={updates}
                 />
               )}

--- a/src/zui/ZUITimeline/index.tsx
+++ b/src/zui/ZUITimeline/index.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   CardActionArea,
@@ -22,7 +22,6 @@ import { ZetkinNote, ZetkinNoteBody } from 'utils/types/zetkin';
 import messageIds from './l10n/messageIds';
 
 export interface ZUITimelineProps {
-  showPostRequestError?: boolean;
   disabled?: boolean;
   onAddNote: (note: ZetkinNoteBody) => void;
   onEditNote: (note: Pick<ZetkinNote, 'id' | 'text'>) => void;
@@ -30,7 +29,6 @@ export interface ZUITimelineProps {
 }
 
 const ZUITimeline: React.FunctionComponent<ZUITimelineProps> = ({
-  showPostRequestError,
   disabled,
   onAddNote,
   onEditNote,
@@ -44,13 +42,23 @@ const ZUITimeline: React.FunctionComponent<ZUITimelineProps> = ({
     typeFilterOptions,
   } = useFilterUpdates(updates);
 
+  const [showPostRequestError, setShowPostRequestError] = useState(false);
+
   return (
     <Fade appear in timeout={1000}>
       <Grid container direction="column" spacing={5}>
         <Grid item>
           <TimelineAddNote
             disabled={disabled}
-            onSubmit={onAddNote}
+            onSubmit={async (note) => {
+              setShowPostRequestError(false);
+              try {
+                // Await is needed here to catch the exception if the request fails
+                await onAddNote(note);
+              } catch (e) {
+                setShowPostRequestError(true);
+              }
+            }}
             showPostRequestError={showPostRequestError}
           />
         </Grid>

--- a/src/zui/ZUITimeline/index.tsx
+++ b/src/zui/ZUITimeline/index.tsx
@@ -22,6 +22,7 @@ import { ZetkinNote, ZetkinNoteBody } from 'utils/types/zetkin';
 import messageIds from './l10n/messageIds';
 
 export interface ZUITimelineProps {
+  showPostRequestError?: boolean;
   disabled?: boolean;
   onAddNote: (note: ZetkinNoteBody) => void;
   onEditNote: (note: Pick<ZetkinNote, 'id' | 'text'>) => void;
@@ -29,6 +30,7 @@ export interface ZUITimelineProps {
 }
 
 const ZUITimeline: React.FunctionComponent<ZUITimelineProps> = ({
+  showPostRequestError,
   disabled,
   onAddNote,
   onEditNote,
@@ -46,7 +48,11 @@ const ZUITimeline: React.FunctionComponent<ZUITimelineProps> = ({
     <Fade appear in timeout={1000}>
       <Grid container direction="column" spacing={5}>
         <Grid item>
-          <TimelineAddNote disabled={disabled} onSubmit={onAddNote} />
+          <TimelineAddNote
+            disabled={disabled}
+            onSubmit={onAddNote}
+            showPostRequestError={showPostRequestError}
+          />
         </Grid>
         <Grid item sm={6} xl={4} xs={12}>
           {/* Filter timeline select */}

--- a/src/zui/ZUITimeline/l10n/messageIds.ts
+++ b/src/zui/ZUITimeline/l10n/messageIds.ts
@@ -12,6 +12,9 @@ export default makeMessages('zui.timeline', {
     },
   },
   expand: m('show full timeline'),
+  fileUploadErrorMessage: m(
+    "Unable to add note. Possible reason is that it's too long."
+  ),
   filter: {
     byType: {
       all: m('All'),

--- a/src/zui/ZUITimeline/l10n/messageIds.ts
+++ b/src/zui/ZUITimeline/l10n/messageIds.ts
@@ -12,9 +12,7 @@ export default makeMessages('zui.timeline', {
     },
   },
   expand: m('show full timeline'),
-  fileUploadErrorMessage: m(
-    "Unable to add note. Possible reason is that it's too long."
-  ),
+  fileUploadErrorMessage: m('Unable to add note. It might be too long'),
   filter: {
     byType: {
       all: m('All'),


### PR DESCRIPTION
## Description
This PR makes it so you get an error message when trying to upload a too long journey note, instead of just annihilating your hard-written text.


## Screenshots
![Screen Shot 2024-09-28 at 17 44 45](https://github.com/user-attachments/assets/2060b639-a7f6-44e6-a386-37154158139a)



## Changes
* When the POST request to save a note fails, an error message is show. We don't know exactly why this happens, but we provide a helpful note.

## Related issues
Resolves #2096
