### PR TITLE
Issue 2163/zui tooltip

### DIFF
--- a/src/zui/ZUITooltip/index.stories.tsx
+++ b/src/zui/ZUITooltip/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 
 import ZUITooltip from './index';
 
@@ -10,10 +10,26 @@ export default meta;
 
 type Story = StoryObj<typeof ZUITooltip>;
 
-export const Default: Story = {
+export const Basic: Story = {
   args: {
+    arrow: 'Down',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip default',
+    label: 'A tiny tooltip',
+  },
+  render: function Render(args) {
+    return (
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          height: 400,
+          justifyContent: 'center',
+          width: 400,
+        }}
+      >
+        <ZUITooltip {...args} />
+      </Box>
+    );
   },
 };
 
@@ -21,38 +37,43 @@ export const None: Story = {
   args: {
     arrow: 'None',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip with no arrow',
+    label: 'A tiny tooltip',
   },
+  render: Basic.render,
 };
 
 export const Down: Story = {
   args: {
     arrow: 'Down',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip with down arrow',
+    label: 'A tiny tooltip',
   },
+  render: Basic.render,
 };
 
 export const Up: Story = {
   args: {
     arrow: 'Up',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip with up arrow',
+    label: 'A tiny tooltip',
   },
+  render: Basic.render,
 };
 
 export const Left: Story = {
   args: {
     arrow: 'Left',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip with left arrow',
+    label: 'A tiny tooltip',
   },
+  render: Basic.render,
 };
 
 export const Right: Story = {
   args: {
     arrow: 'Right',
     children: <Button>Hover me</Button>,
-    label: 'A tiny tooltip with left arrow',
+    label: 'A tiny tooltip',
   },
+  render: Basic.render,
 };

--- a/src/zui/ZUITooltip/index.stories.tsx
+++ b/src/zui/ZUITooltip/index.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUITooltip from './index';
+
+const meta: Meta<typeof ZUITooltip> = {
+    component: ZUITooltip,
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUITooltip>;
+
+export const Default: Story = {
+  args: {
+    label: 'A tiny tooltip default',
+  },
+};
+
+export const None: Story = {
+  args: {
+    label: 'A tiny tooltip with no arrow',
+    arrow: 'None',
+  },
+};
+
+export const Down: Story = {
+  args: {
+    label: 'A tiny tooltip with down arrow',
+    arrow: 'Down',
+  },
+};
+
+export const Up: Story = {
+  args: {
+    label: 'A tiny tooltip with up arrow',
+    arrow: 'Up',
+  },
+};
+
+export const Left: Story = {
+  args: {
+    label: 'A tiny tooltip with left arrow',
+    arrow: 'Left',
+  },
+};
+
+export const Right: Story = {
+  args: {
+    label: 'A tiny tooltip with left arrow',
+    arrow: 'Right',
+  },
+};

--- a/src/zui/ZUITooltip/index.stories.tsx
+++ b/src/zui/ZUITooltip/index.stories.tsx
@@ -1,59 +1,58 @@
 import { Meta, StoryObj } from '@storybook/react';
-
-import ZUITooltip from './index';
 import { Button } from '@mui/material';
 
+import ZUITooltip from './index';
+
 const meta: Meta<typeof ZUITooltip> = {
-    component: ZUITooltip,
+  component: ZUITooltip,
 };
 export default meta;
 
 type Story = StoryObj<typeof ZUITooltip>;
 
-
 export const Default: Story = {
   args: {
-    label: 'A tiny tooltip default',
     children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip default',
   },
 };
 
 export const None: Story = {
   args: {
-    label: 'A tiny tooltip with no arrow',
-    children: <Button>Hover me</Button>,
     arrow: 'None',
+    children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip with no arrow',
   },
 };
 
 export const Down: Story = {
   args: {
-    label: 'A tiny tooltip with down arrow',
-    children: <Button>Hover me</Button>,
     arrow: 'Down',
+    children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip with down arrow',
   },
 };
 
 export const Up: Story = {
   args: {
-    label: 'A tiny tooltip with up arrow',
-    children: <Button>Hover me</Button>,
     arrow: 'Up',
+    children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip with up arrow',
   },
 };
 
 export const Left: Story = {
   args: {
-    label: 'A tiny tooltip with left arrow',
-    children: <Button>Hover me</Button>,
     arrow: 'Left',
+    children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip with left arrow',
   },
 };
 
 export const Right: Story = {
   args: {
-    label: 'A tiny tooltip with left arrow',
-    children: <Button>Hover me</Button>,
     arrow: 'Right',
+    children: <Button>Hover me</Button>,
+    label: 'A tiny tooltip with left arrow',
   },
 };

--- a/src/zui/ZUITooltip/index.stories.tsx
+++ b/src/zui/ZUITooltip/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import ZUITooltip from './index';
+import { Button } from '@mui/material';
 
 const meta: Meta<typeof ZUITooltip> = {
     component: ZUITooltip,
@@ -9,15 +10,18 @@ export default meta;
 
 type Story = StoryObj<typeof ZUITooltip>;
 
+
 export const Default: Story = {
   args: {
     label: 'A tiny tooltip default',
+    children: <Button>Hover me</Button>,
   },
 };
 
 export const None: Story = {
   args: {
     label: 'A tiny tooltip with no arrow',
+    children: <Button>Hover me</Button>,
     arrow: 'None',
   },
 };
@@ -25,6 +29,7 @@ export const None: Story = {
 export const Down: Story = {
   args: {
     label: 'A tiny tooltip with down arrow',
+    children: <Button>Hover me</Button>,
     arrow: 'Down',
   },
 };
@@ -32,6 +37,7 @@ export const Down: Story = {
 export const Up: Story = {
   args: {
     label: 'A tiny tooltip with up arrow',
+    children: <Button>Hover me</Button>,
     arrow: 'Up',
   },
 };
@@ -39,6 +45,7 @@ export const Up: Story = {
 export const Left: Story = {
   args: {
     label: 'A tiny tooltip with left arrow',
+    children: <Button>Hover me</Button>,
     arrow: 'Left',
   },
 };
@@ -46,6 +53,7 @@ export const Left: Story = {
 export const Right: Story = {
   args: {
     label: 'A tiny tooltip with left arrow',
+    children: <Button>Hover me</Button>,
     arrow: 'Right',
   },
 };

--- a/src/zui/ZUITooltip/index.tsx
+++ b/src/zui/ZUITooltip/index.tsx
@@ -1,0 +1,37 @@
+import { Tooltip, TooltipProps, Button } from '@mui/material';
+import { FC } from 'react';
+
+export interface ZUITooltipProps {
+    arrow?: 'None' | 'Up' | 'Down' | 'Left' | 'Right';
+    label: string;
+}
+
+const ZUITooltip: FC<ZUITooltipProps> = ({
+    arrow,
+    label
+  }) => {
+    let showArrow = true;
+    let placement: TooltipProps["placement"] = 'top';
+    if (arrow == 'None') {
+      showArrow = false;
+      placement = 'top';
+    } else if (arrow == 'Up') {
+      placement = 'top';
+    } else if (arrow == 'Down') {
+      placement = 'bottom';
+    } else if (arrow == 'Left') {
+      placement = 'right';
+    } else if (arrow == 'Right') {
+      placement = 'left';
+    }
+
+    return (
+        <Tooltip title={label} placement={placement} arrow={showArrow}>
+            <Button>
+                {label}
+            </Button>
+        </Tooltip>
+    );
+  };
+  
+export default ZUITooltip;

--- a/src/zui/ZUITooltip/index.tsx
+++ b/src/zui/ZUITooltip/index.tsx
@@ -14,9 +14,9 @@ const ZUITooltip: FC<ZUITooltipProps> = ({ children, arrow, label }) => {
     showArrow = false;
     placement = 'top';
   } else if (arrow == 'Up') {
-    placement = 'top';
-  } else if (arrow == 'Down') {
     placement = 'bottom';
+  } else if (arrow == 'Down') {
+    placement = 'top';
   } else if (arrow == 'Left') {
     placement = 'right';
   } else if (arrow == 'Right') {

--- a/src/zui/ZUITooltip/index.tsx
+++ b/src/zui/ZUITooltip/index.tsx
@@ -1,38 +1,33 @@
-import { Tooltip, TooltipProps, Button } from '@mui/material';
-import { Box } from '@mui/system';
-import { FC, ReactComponentElement, ReactElement, ReactNode } from 'react';
+import { Tooltip, TooltipProps } from '@mui/material';
+import { FC, ReactElement } from 'react';
 
 export interface ZUITooltipProps {
-    children: ReactElement;
-    arrow?: 'None' | 'Up' | 'Down' | 'Left' | 'Right';
-    label: string;
+  children: ReactElement;
+  arrow?: 'None' | 'Up' | 'Down' | 'Left' | 'Right';
+  label: string;
 }
 
-const ZUITooltip: FC<ZUITooltipProps> = ({
-    children,
-    arrow,
-    label
-  }) => {
-    let showArrow = true;
-    let placement: TooltipProps["placement"] = 'top';
-    if (arrow == 'None') {
-      showArrow = false;
-      placement = 'top';
-    } else if (arrow == 'Up') {
-      placement = 'top';
-    } else if (arrow == 'Down') {
-      placement = 'bottom';
-    } else if (arrow == 'Left') {
-      placement = 'right';
-    } else if (arrow == 'Right') {
-      placement = 'left';
-    }
+const ZUITooltip: FC<ZUITooltipProps> = ({ children, arrow, label }) => {
+  let showArrow = true;
+  let placement: TooltipProps['placement'] = 'top';
+  if (arrow == 'None') {
+    showArrow = false;
+    placement = 'top';
+  } else if (arrow == 'Up') {
+    placement = 'top';
+  } else if (arrow == 'Down') {
+    placement = 'bottom';
+  } else if (arrow == 'Left') {
+    placement = 'right';
+  } else if (arrow == 'Right') {
+    placement = 'left';
+  }
 
-    return (
-        <Tooltip title={label} placement={placement} arrow={showArrow}>
-          {children}
-        </Tooltip>
-    );
-  };
-  
+  return (
+    <Tooltip arrow={showArrow} placement={placement} title={label}>
+      {children}
+    </Tooltip>
+  );
+};
+
 export default ZUITooltip;

--- a/src/zui/ZUITooltip/index.tsx
+++ b/src/zui/ZUITooltip/index.tsx
@@ -1,12 +1,15 @@
 import { Tooltip, TooltipProps, Button } from '@mui/material';
-import { FC } from 'react';
+import { Box } from '@mui/system';
+import { FC, ReactComponentElement, ReactElement, ReactNode } from 'react';
 
 export interface ZUITooltipProps {
+    children: ReactElement;
     arrow?: 'None' | 'Up' | 'Down' | 'Left' | 'Right';
     label: string;
 }
 
 const ZUITooltip: FC<ZUITooltipProps> = ({
+    children,
     arrow,
     label
   }) => {
@@ -27,9 +30,7 @@ const ZUITooltip: FC<ZUITooltipProps> = ({
 
     return (
         <Tooltip title={label} placement={placement} arrow={showArrow}>
-            <Button>
-                {label}
-            </Button>
+          {children}
         </Tooltip>
     );
   };


### PR DESCRIPTION
## Description
This PR adds a new component: ZUITooltip that can be used for tooltips

## Screenshots

This image shows a tooltip with arrow set to left

![image](https://github.com/user-attachments/assets/376c3062-2719-45c5-a59d-ee0f84787978)

## Changes

* Adds a new zui component: ZUITooltip

## Notes to reviewer

Nothing really

## Related issues
Resolves #2163 
