### PR TITLE
Add UseEffect to render JoinFormPane when new form is added

### DIFF
--- a/src/pages/organize/[orgId]/people/joinforms/index.tsx
+++ b/src/pages/organize/[orgId]/people/joinforms/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import { useEffect, useState } from 'react';
 
 import JoinFormList from 'features/joinForms/components/JoinFormList';
 import JoinFormPane from 'features/joinForms/panes/JoinFormPane';
@@ -18,6 +19,15 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   };
 });
 
+type Organization = {
+  id: number;
+};
+
+type Form = {
+  id: number;
+  organization: Organization;
+};
+
 type PageProps = {
   orgId: string;
 };
@@ -25,10 +35,29 @@ type PageProps = {
 const JoinFormsPage: PageWithLayout<PageProps> = ({ orgId }) => {
   const { data: joinForms } = useJoinForms(parseInt(orgId));
   const { openPane } = usePanes();
+  const [formLength, setFormLength] = useState(0);
+
+  useEffect(() => {
+    if (joinForms && joinForms?.length > formLength) {
+      const newForm = joinForms[joinForms.length - 1];
+      if (newForm) {
+        openNewFormPane(newForm);
+      }
+    }
+  }, [joinForms]);
 
   if (!joinForms) {
     return null;
   }
+  const openNewFormPane = (form: Form) => {
+    setFormLength(joinForms.length);
+    openPane({
+      render: () => (
+        <JoinFormPane formId={form.id} orgId={form.organization.id} />
+      ),
+      width: 500,
+    });
+  };
 
   return (
     <JoinFormList
@@ -36,7 +65,7 @@ const JoinFormsPage: PageWithLayout<PageProps> = ({ orgId }) => {
       onItemClick={(form) => {
         openPane({
           render: () => (
-            <JoinFormPane formId={form.id} orgId={form.organization.id} />
+            <JoinFormPane formId={form.id} orgId={form.organization.id} /> // behavior to replicate
           ),
           width: 500,
         });

--- a/src/pages/organize/[orgId]/people/joinforms/index.tsx
+++ b/src/pages/organize/[orgId]/people/joinforms/index.tsx
@@ -65,7 +65,7 @@ const JoinFormsPage: PageWithLayout<PageProps> = ({ orgId }) => {
       onItemClick={(form) => {
         openPane({
           render: () => (
-            <JoinFormPane formId={form.id} orgId={form.organization.id} /> // behavior to replicate
+            <JoinFormPane formId={form.id} orgId={form.organization.id} />
           ),
           width: 500,
         });


### PR DESCRIPTION
## Description
This PR…
is to add feedback when the user adds a new joinForm. Before the form was added to the bottom of the list, possibly out of sight. 

I added a useEffect to track joinForms and state to ensure that the form pane is only rendered when a new form is added and not on initial render.

## Screenshots
<img width="1559" alt="Screenshot 2024-09-29 at 10 24 33 AM" src="https://github.com/user-attachments/assets/1e8c30a9-6eb5-4d9b-b7de-c52a91d9c951">
<img width="1113" alt="Screenshot 2024-09-29 at 10 24 22 AM" src="https://github.com/user-attachments/assets/7b94ad14-cd43-449a-9cf3-5c2788f55120">


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
  renders joinFormPane when new form is added
* Changes…
  added state and useEffect to achieve this behavior

## Notes to reviewer
navigate to organize/1/people/joinforms and select create join form from top right create button

## Related issues
Resolves #2174 
