### PR TITLE
Issue 2162: ZUI Badge initial creation

### DIFF
--- a/src/zui/ZUIBadge/index.stories.tsx
+++ b/src/zui/ZUIBadge/index.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUIBadge from './index';
+
+const meta: Meta<typeof ZUIBadge> = {
+  component: ZUIBadge,
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIBadge>;
+
+export const Published: Story = {
+  args: {
+    number: undefined,
+    status: 'published',
+  },
+};
+
+export const Draft: Story = {
+  args: {
+    number: 3,
+    status: 'draft',
+  },
+};
+
+export const Scheduled: Story = {
+  args: {
+    number: 1000,
+    status: 'scheduled',
+  },
+};
+
+export const Cancelled: Story = {
+  args: {
+    number: -15,
+    status: 'cancelled',
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    number: undefined,
+    status: 'closed',
+  },
+};
+
+export const Ended: Story = {
+  args: {
+    number: 999,
+    status: 'ended',
+  },
+};

--- a/src/zui/ZUIBadge/index.tsx
+++ b/src/zui/ZUIBadge/index.tsx
@@ -1,0 +1,57 @@
+import { Box, Theme, Typography } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import { FC } from 'react';
+
+import { getContrastColor } from 'utils/colorUtils';
+
+export interface ZUIBadgeProps {
+  number?: number;
+  status: ActivityStatus;
+}
+
+type ActivityStatus =
+  | 'cancelled'
+  | 'closed'
+  | 'draft'
+  | 'ended'
+  | 'published'
+  | 'scheduled';
+
+const useStyles = makeStyles<Theme, { status: ActivityStatus }>((theme) => ({
+  badge: {
+    alignItems: 'center',
+    backgroundColor: ({ status }) => theme.palette.activityStatusColors[status],
+    borderRadius: '1.875rem',
+    color: ({ status }) =>
+      getContrastColor(theme.palette.activityStatusColors[status]),
+    display: 'inline-flex',
+    height: '1.875rem',
+    justifyContent: 'center',
+    width: '1.875rem',
+  },
+  dot: {
+    alignItems: 'center',
+    backgroundColor: ({ status }) => theme.palette.activityStatusColors[status],
+    borderRadius: '1rem',
+    height: '1rem',
+    width: '1rem',
+  },
+}));
+
+const ZUIBadge: FC<ZUIBadgeProps> = ({ number = undefined, status }) => {
+  const classes = useStyles({ status });
+  const style = number != undefined ? 'badge' : 'dot';
+  let displayValue = '';
+
+  if (number != undefined) {
+    displayValue = number <= 99 ? number.toString() : '99+';
+  }
+
+  return (
+    <Box className={classes[style]}>
+      <Typography variant="labelSmMedium">{displayValue}</Typography>
+    </Box>
+  );
+};
+
+export default ZUIBadge;


### PR DESCRIPTION
## Description
This PR adds the ZUI Badge as defined in the Figma. There's two main variants, one with a number and one without. It also takes the status.


## Screenshots
![bild](https://github.com/user-attachments/assets/843e9f1b-075a-4ecf-812e-9fd7bc59595f)
![bild](https://github.com/user-attachments/assets/49848052-5d27-4504-a46e-ef8e8b9d3f8c)
![bild](https://github.com/user-attachments/assets/327446a3-0ae1-40a7-b1d2-0abea2719e44)
![bild](https://github.com/user-attachments/assets/ce2e7445-0288-41c3-a339-2e5495db3d71)


## Changes
* Adds the ZUIBadge component, with two main variants:
* Adds Dot variant: Small dot with no number, in the colour of the status. 
* Adds Badge variant: Slightly bigger with a number. Can handle negative numbers, and shortens numbers to 99+ if larger than 99. Does not handle very large (or small? 😅) negative numbers well, for example: 
![bild](https://github.com/user-attachments/assets/fd0f2917-60aa-4607-986f-19b5e5ba3be2)



## Notes to reviewer
The sizes of the circles are slightly bigger than in design, but the numbers didn't really fit otherwise.  I also took liberties in allowing negative numbers, but I don't really expect it to happen, so I think it's alright that we don't really handle very large negative numbers. The "99+" functionality was approved by a designer, but I'm not completely sure it's the best solution. perhaps we could just do a "..." or something. Not sure how often it would happen.  Finally, not completely sure if the font is correct compared to design either 😅


## Related issues
Resolves #2162
