### PR TITLE
Issue2070/Updating the Delete User warning message

### DIFF
--- a/src/features/profile/components/PersonDeleteCard.tsx
+++ b/src/features/profile/components/PersonDeleteCard.tsx
@@ -10,6 +10,7 @@ import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
+import useOrganization from 'features/organizations/hooks/useOrganization';
 
 const PersonDeleteCard: React.FunctionComponent<{
   orgId: number;
@@ -20,6 +21,11 @@ const PersonDeleteCard: React.FunctionComponent<{
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { deletePerson } = usePersonMutations(orgId, person.id);
+
+  const orgTitle = useOrganization(orgId).data?.title;
+  if (!orgTitle) {
+    return null;
+  }
 
   const handleDelete = () => {
     showConfirmDialog({
@@ -33,6 +39,7 @@ const PersonDeleteCard: React.FunctionComponent<{
       },
       warningText: messages.delete.confirm({
         name: person.first_name + ' ' + person.last_name,
+        org: orgTitle,
       }),
     });
   };

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -4,7 +4,7 @@ export default makeMessages('feat.profile', {
   delete: {
     button: m('Remove person'),
     confirm: m<{ name: string }>(
-      'Are you sure you want to delete {name}? This is a permanent action.'
+      'Are you sure you want to delete {name} from all connected organizations? This is a permanent action.'
     ),
     title: m('Delete account'),
     warning: m('This cannot be undone!'),

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -3,8 +3,8 @@ import { m, makeMessages } from 'core/i18n';
 export default makeMessages('feat.profile', {
   delete: {
     button: m('Remove person'),
-    confirm: m<{ name: string }>(
-      'Are you sure you want to delete {name} from all connected organizations? This is a permanent action.'
+    confirm: m<{ name: string; org: string }>(
+      'Are you sure you want to delete {name} from {org}, and all related organizations? This is a permanent action.'
     ),
     title: m('Delete account'),
     warning: m('This cannot be undone!'),

--- a/src/locale/da.yml
+++ b/src/locale/da.yml
@@ -530,7 +530,6 @@ feat:
   profile:
     delete:
       button: Fjern person
-      confirm: Er du sikker på, du vil slette {name}? Denne handling er permanent
       title: Slet profil
       warning: Dette kan ikke gøres om!
     details:

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -1176,8 +1176,6 @@ feat:
   profile:
     delete:
       button: Person entfernen
-      confirm: Bist du sicher, dass du {name} löschen möchtest? Diese Aktion kann
-        nicht rückgängig gemacht werden.
       title: Profil löschen
       warning: Diese Aktion kann nicht rückgängig gemacht werden!
     details:

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -1189,7 +1189,6 @@ feat:
   profile:
     delete:
       button: Remove person
-      confirm: Are you sure you want to delete {name}? This is a permanent action.
       title: Delete account
       warning: This cannot be undone!
     details:

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -1183,7 +1183,6 @@ feat:
   profile:
     delete:
       button: Fjern person
-      confirm: Er du sikker på at du vil slette {name}? Dette er permanent.
       title: Slett konto
       warning: Dette kan ikke angres!
     details:

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -1178,7 +1178,6 @@ feat:
   profile:
     delete:
       button: Ta bort person
-      confirm: Är du säker på att du vill radera {name}? Detta kan inte ångras.
       title: Radera konto
       warning: Detta kan inte ångras!
     details:


### PR DESCRIPTION
## Description
This PR clarifies that removing a member also removes them from all connected organizations.

## Screenshots
![image](https://github.com/user-attachments/assets/5ec45d3d-80f2-486b-9a4a-5bebde17488f)


## Changes
- Changes the wording of the delete message to make it more clear that the user is deleted from all organizations.

## Notes to reviewer
Attempt to remove a member of an organization. The new message should be displayed


## Related issues
Partially Resolves #2070 
