### PR TITLE
Issue 2159/delete event type

### DIFF
--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -9,6 +9,7 @@ import messageIds from '../l10n/messageIds';
 import useCreateType from '../hooks/useCreateType';
 import { useMessages } from 'core/i18n';
 import { ZetkinActivity, ZetkinEvent } from 'utils/types/zetkin';
+import useDeleteType from '../hooks/useDeleteType';
 
 interface StyleProps {
   showBorder: boolean | undefined;
@@ -74,6 +75,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   value,
 }) => {
   const createType = useCreateType(orgId);
+  const deleteType = useDeleteType(orgId);
   const messages = useMessages(messageIds);
   const uncategorizedMsg = messages.type.uncategorized();
   const [createdType, setCreatedType] = useState<string>('');
@@ -89,8 +91,10 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
     //it searches for the created event and updates event with an ID.
     if (createdType !== '') {
       const newEventType = types.find((item) => item.title === createdType);
-      setText(newEventType!.title);
-      onChangeNewOption(newEventType!.id);
+      setText(newEventType ? newEventType!.title : uncategorizedMsg);
+      if (newEventType) {
+        onChangeNewOption(newEventType!.id);
+      }
     }
   }, [types.length]);
 
@@ -224,7 +228,16 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
           return (
             <Box key={option.id}>
               {option.id != 'CREATE' && option.id != 'UNCATEGORIZED' && (
-                <li {...props}>{option.title}</li>
+                <li {...props} style={{ justifyContent: 'space-between' }}>
+                  {option.title}
+                  <Clear
+                    onClick={() => {
+                      if (typeof option.id === 'number') {
+                        deleteType(option.id);
+                      }
+                    }}
+                  />
+                </li>
               )}
               {option.id == 'UNCATEGORIZED' && (
                 <li {...props}>

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -1,19 +1,9 @@
 import Fuse from 'fuse.js';
 import { lighten } from '@mui/material/styles';
 import makeStyles from '@mui/styles/makeStyles';
-import { Add, Clear, DeleteOutline } from '@mui/icons-material';
-import {
-  Autocomplete,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  TextField,
-  Theme,
-  Tooltip,
-} from '@mui/material';
-import { FC, useEffect, useRef, useState } from 'react';
+import { Add, DeleteOutline } from '@mui/icons-material';
+import { Autocomplete, Box, TextField, Theme, Tooltip } from '@mui/material';
+import { FC, useContext, useEffect, useRef, useState } from 'react';
 
 import messageIds from '../l10n/messageIds';
 import theme from 'theme';
@@ -21,6 +11,7 @@ import useCreateType from '../hooks/useCreateType';
 import { useMessages } from 'core/i18n';
 import useDeleteType from '../hooks/useDeleteType';
 import { ZetkinActivity, ZetkinEvent } from 'utils/types/zetkin';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 
 interface StyleProps {
   showBorder: boolean | undefined;
@@ -92,15 +83,11 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   const [createdType, setCreatedType] = useState<string>('');
   const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
   const [dropdownListWidth, setDropdownListWidth] = useState(0);
-  const [open, setOpen] = useState(false);
-  const [type, setType] = useState<EventTypeOption>();
-
-  const handleDialogOpen = (shouldOpen: boolean) => {
-    setOpen(shouldOpen);
-  };
 
   const spanRef = useRef<HTMLSpanElement>(null);
   const classes = useStyles({ showBorder });
+
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
 
   useEffect(() => {
     //When a user creates a new type, it is missing an event ID.
@@ -140,178 +127,165 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   });
 
   return (
-    <>
-      <Tooltip arrow title={showBorder ? '' : messages.type.tooltip()}>
-        <Autocomplete
-          blurOnSelect
-          classes={{
-            root: classes.inputRoot,
-          }}
-          componentsProps={{
-            popper: {
-              placement: 'bottom-start',
-              style: { maxWidth: 380, minWidth: 180, width: dropdownListWidth },
+    <Tooltip arrow title={showBorder ? '' : messages.type.tooltip()}>
+      <Autocomplete
+        blurOnSelect
+        classes={{
+          root: classes.inputRoot,
+        }}
+        componentsProps={{
+          popper: {
+            placement: 'bottom-start',
+            style: { maxWidth: 380, minWidth: 180, width: dropdownListWidth },
+          },
+        }}
+        disableClearable
+        filterOptions={(options, { inputValue }) => {
+          const searchedResults = fuse.search(inputValue);
+          const inputStartWithCapital = inputValue
+            ? `${inputValue[0].toUpperCase()}${inputValue.substring(
+                1,
+                inputValue.length
+              )}`
+            : '';
+
+          const filteredResult: EventTypeOption[] = [
+            ...searchedResults.map((result) => {
+              return { id: result.item.id, title: result.item.title };
+            }),
+            {
+              id: 'UNCATEGORIZED',
+              title: uncategorizedMsg,
             },
-          }}
-          disableClearable
-          filterOptions={(options, { inputValue }) => {
-            const searchedResults = fuse.search(inputValue);
-            const inputStartWithCapital = inputValue
-              ? `${inputValue[0].toUpperCase()}${inputValue.substring(
-                  1,
-                  inputValue.length
-                )}`
-              : '';
-
-            const filteredResult: EventTypeOption[] = [
-              ...searchedResults.map((result) => {
-                return { id: result.item.id, title: result.item.title };
-              }),
-              {
-                id: 'UNCATEGORIZED',
-                title: uncategorizedMsg,
-              },
-            ];
-            if (
-              filteredResult.find(
-                (item) =>
-                  item.title?.toLocaleLowerCase() ===
-                  inputValue.toLocaleLowerCase()
-              )
-            ) {
-              return filteredResult;
-            }
-
-            filteredResult.push({
-              id: 'CREATE',
-              title: inputStartWithCapital,
-            });
-            return inputValue ? filteredResult : options;
-          }}
-          getOptionLabel={(option) => option.title!}
-          isOptionEqualToValue={(option, value) => option.title === value.title}
-          onBlur={() => {
-            // show 'uncategorized' in textField when blurring
-            if (!value && text !== uncategorizedMsg) {
-              setText(uncategorizedMsg);
-            }
-            //set text to previous input value when clicking away
-            if (value && text !== value.title) {
-              setText(value.title);
-            }
-            onBlur();
-          }}
-          onChange={(_, value) => {
-            setText(value.title);
-            if (value.id == 'CREATE') {
-              createType(value.title!);
-              setCreatedType(value.title!);
-              return;
-            }
-            onChange(
-              value.id == 'UNCATEGORIZED'
-                ? null
-                : {
-                    id: value.id,
-                    title: value.title!,
-                  }
-            );
-          }}
-          onFocus={() => onFocus()}
-          options={allTypes}
-          renderInput={(params) => (
-            <>
-              <span ref={spanRef} className={classes.span}>
-                {text}
-              </span>
-              <TextField
-                {...params}
-                InputLabelProps={{
-                  shrink: false,
-                }}
-                InputProps={{
-                  ...params.InputProps,
-                  style: {
-                    maxWidth: 380,
-                    minWidth: 60,
-                    width: dropdownListWidth + 50,
-                  },
-                }}
-                onChange={(e) => setText(e.target.value)}
-                size="small"
-              />
-            </>
-          )}
-          renderOption={(props, option) => {
-            return (
-              <Box key={option.id}>
-                {option.id != 'CREATE' && option.id != 'UNCATEGORIZED' && (
-                  <li {...props} style={{ justifyContent: 'space-between' }}>
-                    {option.title}
-                    <DeleteOutline
-                      onClick={() => {
-                        handleDialogOpen(true), setType(option);
-                      }}
-                      sx={{
-                        '&:hover': {
-                          color: theme.palette.secondary.main,
-                        },
-                        color: theme.palette.secondary.light,
-                        cursor: 'pointer',
-                        transition: 'color 0.3s ease',
-                      }}
-                    />
-                  </li>
-                )}
-                {option.id == 'UNCATEGORIZED' && (
-                  <li {...props}>
-                    <Clear />
-                    {uncategorizedMsg}
-                  </li>
-                )}
-                {option.id == 'CREATE' && (
-                  <li {...props}>
-                    <Add />
-                    {messages.type.createType({ type: option.title! })}
-                  </li>
-                )}
-              </Box>
-            );
-          }}
-          value={
-            value
-              ? value
-              : {
-                  id: 'UNCATEGORIZED',
-                  title: text,
-                }
+          ];
+          if (
+            filteredResult.find(
+              (item) =>
+                item.title?.toLocaleLowerCase() ===
+                inputValue.toLocaleLowerCase()
+            )
+          ) {
+            return filteredResult;
           }
-        />
-      </Tooltip>
-      {open && type && (
-        <Dialog open={open}>
-          <DialogContent>
-            {messages.type.deleteMessage({ eventType: type.title })}
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => handleDialogOpen(false)} variant="outlined">
-              {messages.type.cancelButton()}
-            </Button>
-            <Button
-              onClick={() => {
-                if (typeof type.id === 'number') {
-                  deleteType(type.id);
+
+          filteredResult.push({
+            id: 'CREATE',
+            title: inputStartWithCapital,
+          });
+          return inputValue ? filteredResult : options;
+        }}
+        getOptionLabel={(option) => option.title!}
+        isOptionEqualToValue={(option, value) => option.title === value.title}
+        onBlur={() => {
+          // show 'uncategorized' in textField when blurring
+          if (!value && text !== uncategorizedMsg) {
+            setText(uncategorizedMsg);
+          }
+          //set text to previous input value when clicking away
+          if (value && text !== value.title) {
+            setText(value.title);
+          }
+          onBlur();
+        }}
+        onChange={(_, value) => {
+          setText(value.title);
+          if (value.id == 'CREATE') {
+            createType(value.title!);
+            setCreatedType(value.title!);
+            return;
+          }
+          onChange(
+            value.id == 'UNCATEGORIZED'
+              ? null
+              : {
+                  id: value.id,
+                  title: value.title!,
                 }
-                handleDialogOpen(false);
+          );
+        }}
+        onFocus={() => onFocus()}
+        options={allTypes}
+        renderInput={(params) => (
+          <>
+            <span ref={spanRef} className={classes.span}>
+              {text}
+            </span>
+            <TextField
+              {...params}
+              InputLabelProps={{
+                shrink: false,
               }}
-              variant="contained"
-            >
-              {messages.type.deleteButton()}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      )}
-    </>
+              InputProps={{
+                ...params.InputProps,
+                style: {
+                  maxWidth: 380,
+                  minWidth: 60,
+                  width: dropdownListWidth + 50,
+                },
+              }}
+              onChange={(e) => setText(e.target.value)}
+              size="small"
+            />
+          </>
+        )}
+        renderOption={(props, option) => {
+          return (
+            <Box key={option.id}>
+              {option.id != 'CREATE' && option.id != 'UNCATEGORIZED' && (
+                <li {...props} style={{ justifyContent: 'space-between' }}>
+                  {option.title}
+                  <DeleteOutline
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      showConfirmDialog({
+                        onSubmit: () => {
+                          if (typeof option.id === 'number') {
+                            deleteType(option.id);
+                            //If the current event has the deleted event type,
+                            //set the current event's type to null
+                            if (value && option.id == value.id) {
+                              onChange(null);
+                            }
+                          }
+                        },
+                        warningText: messages.type.deleteMessage({
+                          eventType: option.title,
+                        }),
+                      });
+                    }}
+                    sx={{
+                      '&:hover': {
+                        color: theme.palette.secondary.main,
+                      },
+                      color: theme.palette.secondary.light,
+                      cursor: 'pointer',
+                      transition: 'color 0.3s ease',
+                    }}
+                  />
+                </li>
+              )}
+              {option.id == 'UNCATEGORIZED' && (
+                <li {...props}>{uncategorizedMsg}</li>
+              )}
+              {option.id == 'CREATE' && (
+                <li {...props}>
+                  <Add sx={{ marginRight: 1 }} />
+                  {messages.type.createType({ type: option.title! })}
+                </li>
+              )}
+            </Box>
+          );
+        }}
+        value={
+          value
+            ? value
+            : {
+                id: 'UNCATEGORIZED',
+                title: text,
+              }
+        }
+      />
+    </Tooltip>
   );
 };
 

--- a/src/features/events/hooks/useDeleteType.ts
+++ b/src/features/events/hooks/useDeleteType.ts
@@ -1,0 +1,12 @@
+import { typeDeleted } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+
+export default function useDeleteType(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  return async (typeId: number) => {
+    await apiClient.delete(`/api/orgs/${orgId}/activities/${typeId}`);
+    dispatch(typeDeleted(typeId));
+  };
+}

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -281,11 +281,9 @@ export default makeMessages('feat.events', {
   },
   tooltipContent: m('Untitled events will display type as title'),
   type: {
-    cancelButton: m('Cancel'),
     createType: m<{ type: string }>('Create "{type}"'),
-    deleteButton: m('Delete'),
     deleteMessage: m<{ eventType: string }>(
-      'Are you sure you want to delete "{eventType}" event type for everyone?'
+      'Are you sure you want to delete the "{eventType}" event type for the whole organization?'
     ),
     tooltip: m('Click to change type'),
     uncategorized: m('Uncategorized'),

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -281,7 +281,12 @@ export default makeMessages('feat.events', {
   },
   tooltipContent: m('Untitled events will display type as title'),
   type: {
+    cancelButton: m('Cancel'),
     createType: m<{ type: string }>('Create "{type}"'),
+    deleteButton: m('Delete'),
+    deleteMessage: m<{ eventType: string }>(
+      'Are you sure you want to delete "{eventType}" event type for everyone?'
+    ),
     tooltip: m('Click to change type'),
     uncategorized: m('Uncategorized'),
   },

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -541,6 +541,20 @@ const eventsSlice = createSlice({
         remoteItem(data.id, { data: data, isLoading: false }),
       ]);
     },
+    typeDeleted: (state, action: PayloadAction<number>) => {
+      const typeId = action.payload;
+      const typeListItem = state.typeList.items.find(
+        (item) => item.id === typeId
+      );
+
+      if (typeListItem) {
+        typeListItem.deleted = true;
+      }
+
+      state.typeList.items = state.typeList.items.filter(
+        (type) => type.id !== typeId
+      );
+    },
     typeLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       const item = state.typeList.items.find((item) => item.id == id);
@@ -728,6 +742,7 @@ export const {
   statsLoaded,
   typeAdd,
   typeAdded,
+  typeDeleted,
   typeLoad,
   typeLoaded,
   typesLoad,


### PR DESCRIPTION
## Description
This PR allows the user to delete event types.


## Screenshots
![image](https://github.com/user-attachments/assets/62ab2692-9d5e-4e4d-859a-d6c9e4bfe8ab)
![image](https://github.com/user-attachments/assets/e51b9c12-3afb-4338-b854-0d03d53d0bba)





## Changes
* Adds `useDeleteType()` hook and store function
* Implement deleteType function 
* Ziggi indulged in a long-lasting desire and removed the "+" in front of the "Uncategorized" option in the Autocomplete.

## Notes to reviewer
None

## Related issues
Resolves #2159 
