### PR TITLE
Undocumented/log household visit design

### DIFF
--- a/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/ratings/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/ratings/route.ts
@@ -6,6 +6,7 @@ import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 
 type RouteMeta = {
   params: {
+    householdId: string;
     orgId: string;
     placeId: string;
   };
@@ -27,20 +28,17 @@ export async function POST(request: NextRequest, { params }: RouteMeta) {
         { _id: params.placeId, orgId },
         {
           $push: {
-            households: {
-              $each: [
-                {
-                  id: new mongoose.Types.ObjectId().toString(),
-                  ratings: [],
-                  title: payload.title,
-                  visits: [],
-                },
-              ],
-              $position: 0,
+            'households.$[elem].ratings': {
+              id: new mongoose.Types.ObjectId().toString(),
+              rate: payload.rate,
+              timestamp: payload.timestamp,
             },
           },
         },
-        { new: true }
+        {
+          arrayFilters: [{ 'elem.id': { $eq: params.householdId } }],
+          new: true,
+        }
       );
 
       if (!model) {

--- a/src/features/areas/components/PlaceDialog.tsx
+++ b/src/features/areas/components/PlaceDialog.tsx
@@ -1,12 +1,19 @@
-import { Forward } from '@mui/icons-material';
+import {
+  ArrowBackIos,
+  Check,
+  Edit,
+  ThumbDown,
+  ThumbUp,
+} from '@mui/icons-material';
 import { FC, useState } from 'react';
 import {
   Box,
   Button,
+  ButtonGroup,
+  CircularProgress,
   Dialog,
   Divider,
   FormControl,
-  IconButton,
   InputLabel,
   MenuItem,
   Select,
@@ -15,11 +22,13 @@ import {
   Typography,
 } from '@mui/material';
 
-import { ZetkinPlace } from '../types';
-import { Msg, useMessages } from 'core/i18n';
+import theme from 'theme';
+import { isWithinLast24Hours } from '../utils/isWithinLast24Hours';
 import messageIds from '../l10n/messageIds';
 import usePlaceMutations from '../hooks/usePlaceMutations';
+import { ZetkinPlace } from '../types';
 import ZUIDateTime from 'zui/ZUIDateTime';
+import { Msg, useMessages } from 'core/i18n';
 
 type PlaceDialogProps = {
   dialogStep: 'place' | 'edit' | 'household';
@@ -42,10 +51,16 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
   orgId,
   place,
 }) => {
-  const { addHousehold, addVisit, updateHousehold, updatePlace } =
-    usePlaceMutations(orgId, place.id);
+  const {
+    addHousehold,
+    addRating,
+    addVisit,
+    updateHousehold,
+    updatePlace,
+    isAddVisitLoading,
+    isRatingLoading,
+  } = usePlaceMutations(orgId, place.id);
   const messages = useMessages(messageIds);
-  const timestamp = new Date().toISOString();
 
   const [selectedHouseholdId, setSelectedHouseholdId] = useState<string | null>(
     null
@@ -86,8 +101,7 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
     type == place.type &&
     (description == place.description || (!description && !place.description));
 
-  const saveButtonDisabled =
-    (dialogStep == 'household' && !note) || nothingHasBeenEdited;
+  const saveButtonDisabled = nothingHasBeenEdited;
 
   const getBackButtonMessage = () => {
     if (dialogStep == 'edit') {
@@ -97,7 +111,7 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
         return messageIds.place.cancelButton;
       }
     } else if (dialogStep == 'household') {
-      return messageIds.place.backButton;
+      return messageIds.place.closeButton;
     } else {
       return messageIds.place.closeButton;
     }
@@ -109,19 +123,46 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
         <Box
           paddingBottom={1}
           sx={{
-            alignItems: 'baseline',
+            alignItems: 'center',
             display: 'flex',
             justifyContent: 'space-between',
           }}
         >
           {dialogStep !== 'edit' && (
             <>
-              <Typography variant="h6">
-                {place?.title || <Msg id={messageIds.place.empty.title} />}
-              </Typography>
+              {dialogStep !== 'household' && (
+                <Typography alignItems="center" display="flex" variant="h6">
+                  {place?.title || <Msg id={messageIds.place.empty.title} />}
+                </Typography>
+              )}
+              {selectedHousehold && dialogStep == 'household' && (
+                <Typography alignItems="center" display="flex" variant="h6">
+                  <ArrowBackIos
+                    onClick={() => {
+                      onUpdateDone();
+                    }}
+                    sx={{ marginRight: 2 }}
+                  />
+                  {selectedHousehold.title || (
+                    <Msg id={messageIds.place.household.empty.title} />
+                  )}
+                </Typography>
+              )}
+
+              {selectedHousehold && dialogStep == 'household' && (
+                <Button
+                  onClick={() => {
+                    setHousholdTitle(selectedHousehold.title);
+                    setEditingHouseholdTitle(true);
+                  }}
+                  variant="outlined"
+                >
+                  <Edit />
+                </Button>
+              )}
               {dialogStep === 'place' && (
                 <Button onClick={onEdit} variant="outlined">
-                  <Msg id={messageIds.place.editButton} />
+                  <Edit />
                 </Button>
               )}
             </>
@@ -194,7 +235,8 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
               <Typography variant="h6">
                 <Msg id={messageIds.place.description} />
               </Typography>
-              <Typography>
+              <Divider />
+              <Typography color="secondary">
                 {place.description || (
                   <Msg id={messageIds.place.empty.description} />
                 )}
@@ -202,7 +244,8 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
               <Box
                 display="flex"
                 flexDirection="column"
-                flexGrow={1}
+                flexGrow={2}
+                gap={1}
                 overflow="hidden"
               >
                 <Typography variant="h6">
@@ -211,16 +254,7 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                     values={{ numberOfHouseholds: place.households.length }}
                   />
                 </Typography>
-                <Button
-                  onClick={async () => {
-                    const newlyAddedHousehold = await addHousehold();
-                    setSelectedHouseholdId(newlyAddedHousehold.id);
-                    onSelectHousehold();
-                    setEditingHouseholdTitle(true);
-                  }}
-                >
-                  <Msg id={messageIds.place.addHouseholdButton} />
-                </Button>
+                <Divider />
                 <Box
                   display="flex"
                   flexDirection="column"
@@ -232,19 +266,25 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                       alignItems="center"
                       display="flex"
                       justifyContent="space-between"
+                      mb={1}
+                      mt={1}
+                      onClick={() => {
+                        setSelectedHouseholdId(household.id);
+                        onSelectHousehold();
+                      }}
                       width="100%"
                     >
                       {household.title || (
                         <Msg id={messageIds.place.household.empty.title} />
                       )}
-                      <IconButton
-                        onClick={() => {
-                          setSelectedHouseholdId(household.id);
-                          onSelectHousehold();
-                        }}
-                      >
-                        <Forward />
-                      </IconButton>
+
+                      {isWithinLast24Hours(
+                        household.visits.map((t) => t.timestamp)
+                      ) ? (
+                        <Check />
+                      ) : (
+                        ''
+                      )}
                     </Box>
                   ))}
                 </Box>
@@ -260,23 +300,6 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
               paddingTop={1}
             >
               <Box>
-                {!editingHouseholdTitle && (
-                  <Box alignItems="center" display="flex">
-                    <Typography>
-                      {selectedHousehold.title || (
-                        <Msg id={messageIds.place.household.empty.title} />
-                      )}
-                    </Typography>
-                    <Button
-                      onClick={() => {
-                        setHousholdTitle(selectedHousehold.title);
-                        setEditingHouseholdTitle(true);
-                      }}
-                    >
-                      Edit
-                    </Button>
-                  </Box>
-                )}
                 {editingHouseholdTitle && (
                   <Box alignItems="center" display="flex">
                     <TextField
@@ -295,6 +318,9 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                     >
                       Save
                     </Button>
+                    <Button onClick={() => setEditingHouseholdTitle(false)}>
+                      Cancel
+                    </Button>
                   </Box>
                 )}
               </Box>
@@ -304,31 +330,153 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                 flexGrow={1}
                 overflow="hidden"
               >
-                <Box paddingTop={1}>
-                  <ZUIDateTime datetime={timestamp} />
-                  <TextField
+                <Box
+                  alignSelf="center"
+                  display="flex"
+                  flexDirection="column"
+                  padding={6}
+                  width="100%"
+                >
+                  <Button
+                    disabled={
+                      isWithinLast24Hours(
+                        selectedHousehold.visits.map((t) => t.timestamp)
+                      )
+                        ? true
+                        : false
+                    }
+                    endIcon={
+                      isWithinLast24Hours(
+                        selectedHousehold.visits.map((t) => t.timestamp)
+                      ) ? (
+                        <Check />
+                      ) : (
+                        ''
+                      )
+                    }
+                    onClick={() => {
+                      addVisit(selectedHousehold.id, {
+                        note,
+                        timestamp: new Date().toISOString(),
+                      });
+                    }}
+                    startIcon={
+                      isAddVisitLoading ? (
+                        <CircularProgress
+                          size={20}
+                          sx={{ color: theme.palette.common.white }}
+                        />
+                      ) : (
+                        ''
+                      )
+                    }
+                    sx={{ marginBottom: 2 }}
+                    variant="contained"
+                  >
+                    <Msg
+                      id={
+                        isWithinLast24Hours(
+                          selectedHousehold.visits.map((t) => t.timestamp)
+                        )
+                          ? messageIds.place.visitedButton
+                          : messageIds.place.visitButton
+                      }
+                    />
+                  </Button>
+                  <ButtonGroup
                     fullWidth
-                    multiline
-                    onChange={(ev) => setNote(ev.target.value)}
-                    placeholder={messages.place.notePlaceholder()}
-                    sx={{ paddingTop: 1 }}
-                    value={note}
-                  />
+                    sx={{ alignSelf: 'center', display: 'flex' }}
+                    variant="outlined"
+                  >
+                    {!isRatingLoading && (
+                      <>
+                        <Button
+                          onClick={() =>
+                            addRating(selectedHousehold.id, {
+                              rate: 'good',
+                              timestamp: new Date().toISOString(),
+                            })
+                          }
+                        >
+                          <ThumbUp />
+                        </Button>
+                        <Button
+                          onClick={() =>
+                            addRating(selectedHousehold.id, {
+                              rate: 'bad',
+                              timestamp: new Date().toISOString(),
+                            })
+                          }
+                        >
+                          <ThumbDown />
+                        </Button>
+                      </>
+                    )}
+                    {isRatingLoading && (
+                      <Button variant="outlined">
+                        <CircularProgress size={25} />
+                      </Button>
+                    )}
+                  </ButtonGroup>
                 </Box>
                 <Box
                   display="flex"
                   flexDirection="column"
-                  sx={{ overflowY: 'auto' }}
+                  sx={{ marginTop: 2, overflowY: 'auto' }}
                 >
-                  {sortedVisits.length == 0 && (
-                    <Msg id={messageIds.place.noActivity} />
-                  )}
+                  <Typography
+                    marginBottom={2}
+                    sx={{ alignItems: 'baseline', display: 'flex' }}
+                    variant="h6"
+                  >
+                    <Msg id={messageIds.place.logList} />
+                    <Typography sx={{ marginLeft: 1 }}>
+                      {sortedVisits.length + selectedHousehold.ratings.length}
+                    </Typography>
+                  </Typography>
+                  <Divider />
+                  {sortedVisits.length == 0 &&
+                    selectedHousehold.ratings.length == 0 && (
+                      <Msg id={messageIds.place.noActivity} />
+                    )}
                   {sortedVisits.map((visit) => (
                     <Box key={visit.id} paddingTop={1}>
-                      <Typography color="secondary">
+                      <Typography>{messages.place.visitLog()}</Typography>
+                      <Typography
+                        color="secondary"
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                        }}
+                      >
                         <ZUIDateTime datetime={visit.timestamp} />
+                        <Check />
                       </Typography>
-                      <Typography>{visit.note}</Typography>
+                    </Box>
+                  ))}
+                  {selectedHousehold.ratings?.map((rating) => (
+                    <Box key={rating.id} paddingTop={1}>
+                      <Typography>
+                        {rating.rate === 'good' ? (
+                          <Msg id={messageIds.place.goodRatingLog} />
+                        ) : (
+                          <Msg id={messageIds.place.badRatingLog} />
+                        )}
+                      </Typography>
+                      <Typography
+                        color="secondary"
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                        }}
+                      >
+                        <ZUIDateTime datetime={rating.timestamp} />
+                        {rating.rate === 'good' ? (
+                          <ThumbUp sx={{ fontSize: 20 }} />
+                        ) : (
+                          <ThumbDown sx={{ fontSize: 20 }} />
+                        )}
+                      </Typography>
                     </Box>
                   ))}
                 </Box>
@@ -337,6 +485,20 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
           )}
         </Box>
         <Box display="flex" gap={1} justifyContent="flex-end" paddingTop={1}>
+          {dialogStep === 'place' && (
+            <Button
+              onClick={async () => {
+                const newlyAddedHousehold = await addHousehold();
+                setSelectedHouseholdId(newlyAddedHousehold.id);
+                onSelectHousehold();
+                setEditingHouseholdTitle(true);
+              }}
+              sx={{ margin: 2 }}
+              variant="contained"
+            >
+              <Msg id={messageIds.place.addHouseholdButton} />
+            </Button>
+          )}
           <Button
             onClick={() => {
               if (dialogStep === 'place') {
@@ -348,24 +510,20 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                 setType(place.type);
               } else if (dialogStep == 'household') {
                 onUpdateDone();
-                setNote('');
+                onClose();
               }
             }}
+            sx={{ margin: 2 }}
             variant="outlined"
           >
             <Msg id={getBackButtonMessage()} />
           </Button>
-          {dialogStep != 'place' && (
+          {dialogStep != 'place' && dialogStep != 'household' && (
             <Button
               disabled={saveButtonDisabled}
               onClick={() => {
                 setNote('');
-                if (selectedHousehold && dialogStep == 'household') {
-                  addVisit(selectedHousehold.id, {
-                    note,
-                    timestamp: new Date().toISOString(),
-                  });
-                } else if (dialogStep == 'edit') {
+                if (dialogStep == 'edit') {
                   updatePlace({
                     description,
                     title,
@@ -373,6 +531,7 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                   });
                 }
               }}
+              sx={{ margin: 2 }}
               variant="contained"
             >
               <Msg id={messageIds.place.saveButton} />

--- a/src/features/areas/hooks/usePlaceMutations.ts
+++ b/src/features/areas/hooks/usePlaceMutations.ts
@@ -1,6 +1,9 @@
+import { useState } from 'react';
+
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import {
   HouseholdPatchBody,
+  Rating,
   Visit,
   ZetkinPlace,
   ZetkinPlacePatchBody,
@@ -10,6 +13,8 @@ import { placeUpdated } from '../store';
 export default function usePlaceMutations(orgId: number, placeId: string) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
+  const [isAddVisitLoading, setIsAddVisitLoading] = useState<boolean>(false);
+  const [isRatingLoading, setIsRatingLoading] = useState<boolean>(false);
 
   return {
     addHousehold: async () => {
@@ -20,13 +25,26 @@ export default function usePlaceMutations(orgId: number, placeId: string) {
       dispatch(placeUpdated(place));
       return place.households[0];
     },
+    addRating: async (householdId: string, data: Omit<Rating, 'id'>) => {
+      setIsRatingLoading(true);
+      const place = await apiClient.post<ZetkinPlace, Omit<Rating, 'id'>>(
+        `/beta/orgs/${orgId}/places/${placeId}/households/${householdId}/ratings`,
+        data
+      );
+      dispatch(placeUpdated(place));
+      setIsRatingLoading(false);
+    },
     addVisit: async (householdId: string, data: Omit<Visit, 'id'>) => {
+      setIsAddVisitLoading(true);
       const place = await apiClient.post<ZetkinPlace, Omit<Visit, 'id'>>(
         `/beta/orgs/${orgId}/places/${placeId}/households/${householdId}/visits`,
         data
       );
       dispatch(placeUpdated(place));
+      setIsAddVisitLoading(false);
     },
+    isAddVisitLoading,
+    isRatingLoading,
     updateHousehold: async (householdId: string, data: HouseholdPatchBody) => {
       const place = await apiClient.patch<ZetkinPlace, HouseholdPatchBody>(
         `/beta/orgs/${orgId}/places/${placeId}/households/${householdId}`,

--- a/src/features/areas/l10n/messageIds.ts
+++ b/src/features/areas/l10n/messageIds.ts
@@ -50,6 +50,7 @@ export default makeMessages('feat.areas', {
     activityHeader: m('Activity'),
     addHouseholdButton: m('Add household'),
     backButton: m('Back'),
+    badRatingLog: m('Bad rating'),
     cancelButton: m('Cancel'),
     closeButton: m('Close'),
     description: m('Description'),
@@ -61,20 +62,25 @@ export default makeMessages('feat.areas', {
       description: m('Empty description'),
       title: m('Untitled place'),
     },
+    goodRatingLog: m('Good rating'),
     household: {
       empty: {
         title: m('Untitled household'),
       },
     },
     householdsHeader: m<{ numberOfHouseholds: number }>(
-      '{numberOfHouseholds, plural, =0 {No households} =1 {1 household} other {# households}}'
+      '{numberOfHouseholds, plural, =0 {No households} =1 {Household 1} other {Households #}}'
     ),
     logActivityButton: m('Log activity'),
     logActivityHeader: m<{ title: string }>('Log activity at {title}'),
+    logList: m('Log'),
     noActivity: m('No visits have been recorded at this place.'),
     notePlaceholder: m('Note'),
     saveButton: m('Save'),
     selectType: m('Place type'),
+    visitButton: m('Log visit'),
+    visitLog: m('Visited'),
+    visitedButton: m('Visited'),
   },
   placeCard: {
     address: m('Address'),

--- a/src/features/areas/models.ts
+++ b/src/features/areas/models.ts
@@ -49,6 +49,7 @@ const placeSchema = new mongoose.Schema<ZetkinPlaceModelType>({
     {
       _id: false,
       id: String,
+      ratings: [{ _id: false, id: String, rate: String, timestamp: String }],
       title: String,
       visits: [{ _id: false, id: String, note: String, timestamp: String }],
     },

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -2,6 +2,12 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 
 export type PointData = [number, number];
 
+export type Rating = {
+  id: string;
+  rate: 'good' | 'bad';
+  timestamp: string;
+};
+
 export type Visit = {
   id: string;
   note: string;
@@ -10,6 +16,7 @@ export type Visit = {
 
 export type Household = {
   id: string;
+  ratings: Rating[];
   title: string;
   visits: Visit[];
 };

--- a/src/features/areas/utils/isWithinLast24Hours.tsx
+++ b/src/features/areas/utils/isWithinLast24Hours.tsx
@@ -1,0 +1,18 @@
+export const isWithinLast24Hours = (timestamps: string[]): boolean => {
+  if (timestamps.length === 0) {
+    return false;
+  }
+  const now = Date.now();
+  const twentyFourHoursInMillis = 24 * 60 * 60 * 1000;
+  const twentyFourHoursAgo = now - twentyFourHoursInMillis;
+
+  return timestamps.some((timestamp) => {
+    const parsedTimestamp = Date.parse(timestamp);
+
+    if (isNaN(parsedTimestamp)) {
+      return false;
+    }
+
+    return parsedTimestamp >= twentyFourHoursAgo && parsedTimestamp <= now;
+  });
+};


### PR DESCRIPTION
## Description
This PR allows the user to rate a household. It also modifies the place screen and the household screen to improve the design according to prototypes. It adds loading state when the user adds a rate and a visit in a household. 


## Screenshots
Place screen:
![image](https://github.com/user-attachments/assets/4114d93e-22c7-4a7f-a2f7-e4c46d65fb66)

Household screen without visits:
![image](https://github.com/user-attachments/assets/0815649b-0ddf-49a5-a72f-a01e043e2644)

Household screen with visits and rating:
![image](https://github.com/user-attachments/assets/f1edcc4f-44c9-4be2-96ed-58edc898f2f5)


## Changes
* Adds `ratings `property in household type and model
* Adds `ratings `route in api
* Adds `addRating`() function in `usePlaceMutations `hook
* Adds loading logic for `add rating `and `log visit `buttons
* Changes design in `PlaceDialog `component
* Implements rating action in `PlaceDialog `component


## Notes to reviewer
None

## Related issues
None

