### PR TITLE
Fix typo

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -72,7 +72,7 @@ const EmailPage: PageWithLayout = () => {
             </Box>
             <Box flex={1}>
               <EmailTargetsReady
-                isLoading={mutating.includes('lock')}
+                isLoading={mutating.includes('locked')}
                 isLocked={isLocked}
                 isTargeted={isTargeted}
                 lockedReadyTargets={lockedReadyTargets}


### PR DESCRIPTION
## Description
This PR fixes a typo that caused faulty behaviour.

## Changes

* Changed string being passed to array method from `'lock'` to `'locked'`

## Notes to reviewer
None

https://github.com/user-attachments/assets/2e1e8a3f-6a64-47d4-8f2f-c6586f0dc62a



## Related issues
Resolves #2224 
