### PR TITLE
do not include filter again in API call

### DIFF
--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -27,8 +27,8 @@ interface HttpVerbMethod {
 const HTTP_VERBS_TO_ZETKIN_METHODS: Record<string, HttpVerbMethod> = {
   DELETE: (resource: ZetkinZResource) => resource.del(),
   GET: (resource: ZetkinZResource, req: NextApiRequest) => {
-    const filters = getFilters(req);
-    return resource.get(null, null, filters);
+    getFilters(req); // will throw an error if the filter is not valid
+    return resource.get();
   },
   PATCH: (resource: ZetkinZResource, req: NextApiRequest) =>
     resource.patch(req.body),
@@ -83,9 +83,7 @@ export default async function handle(
   });
 
   const resource = z.resource(
-    queryParams && !queryParams.includes('filter=')
-      ? `${pathStr}?${queryParams}`
-      : pathStr
+    queryParams ? `${pathStr}?${queryParams}` : pathStr
   );
 
   try {

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -82,7 +82,11 @@ export default async function handle(
     zetkinDomain: process.env.ZETKIN_API_DOMAIN,
   });
 
-  const resource = z.resource(pathStr + (queryParams ? '?' + queryParams : ''));
+  const resource = z.resource(
+    queryParams && !queryParams.includes('filter=')
+      ? `${pathStr}?${queryParams}`
+      : pathStr
+  );
 
   try {
     const session = await getIronSession<AppSession>(req, res, {


### PR DESCRIPTION
## Description
This PR prevents adding filter 2 times to the the query string.


## Screenshots



## Changes
Removes the whole query string if it contains a `filter` key. Filters are validated and added in another part of the code (see the definition of the `get` method of the ZetkinZResource:
```
  GET: (resource: ZetkinZResource, req: NextApiRequest) => {
    const filters = getFilters(req);
    return resource.get(null, null, filters);
  },
```
and the `getFilters` utility).
A drawback would be if the incoming request had both `filter` and another query parameter, but, by looking at the code, this should not happen. I'll let the reviewer be the judge of that.




## Notes to reviewer
see #2226 


## Related issues
Resolves #2226 
