### PR TITLE
Undocumented/canvass visit stats

### DIFF
--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
@@ -130,11 +130,11 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
 
       return Response.json({
         data: {
-          numHouseholds: households.length,
-          numPlaces: uniquePlaces.length,
-          numVisitedAreas: Array.from(new Set(visitedAreas)).length,
-          numVisitedHouseholds: visits.length,
-          numVisitedPlaces: visitedPlaces.length,
+          num_households: households.length,
+          num_places: uniquePlaces.length,
+          num_visited_areas: Array.from(new Set(visitedAreas)).length,
+          num_visited_households: visits.length,
+          num_visited_places: visitedPlaces.length,
         },
       });
     }

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
@@ -1,0 +1,117 @@
+import mongoose from 'mongoose';
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  AreaModel,
+  CanvassAssignmentModel,
+  PlaceModel,
+} from 'features/areas/models';
+import {
+  Household,
+  ZetkinCanvassSession,
+  ZetkinPlace,
+} from 'features/areas/types';
+import asOrgAuthorized from 'utils/api/asOrgAuthorized';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import isPointInsidePolygon from 'features/areas/utils/isPointInsidePolygon';
+
+type RouteMeta = {
+  params: {
+    canvassAssId: string;
+    orgId: string;
+  };
+};
+
+export async function GET(request: NextRequest, { params }: RouteMeta) {
+  return asOrgAuthorized(
+    {
+      orgId: params.orgId,
+      request: request,
+      roles: ['admin', 'organizer'],
+    },
+    async ({ apiClient, orgId }) => {
+      await mongoose.connect(process.env.MONGODB_URL || '');
+
+      //Find all sessions of the assignment
+      const model = await CanvassAssignmentModel.findOne({
+        _id: params.canvassAssId,
+      });
+
+      if (!model) {
+        return new NextResponse(null, { status: 404 });
+      }
+
+      const sessions: ZetkinCanvassSession[] = [];
+
+      for await (const sessionData of model.sessions) {
+        const person = await apiClient.get<ZetkinPerson>(
+          `/api/orgs/${orgId}/people/${sessionData.personId}`
+        );
+        const area = await AreaModel.findOne({
+          _id: sessionData.areaId,
+        });
+
+        if (area && person) {
+          sessions.push({
+            area: {
+              description: area.description,
+              id: area._id.toString(),
+              organization: {
+                id: orgId,
+              },
+              points: area.points,
+              title: area.title,
+            },
+            assignee: person,
+            assignment: {
+              id: model._id.toString(),
+              title: model.title,
+            },
+          });
+        }
+      }
+
+      //Areas that are parts of the sessions
+      const areas = sessions.map((session) => session.area);
+
+      //Get all places
+      const placeModels = await PlaceModel.find({ orgId });
+      const places: ZetkinPlace[] = placeModels.map((model) => ({
+        description: model.description,
+        households: model.households,
+        id: model._id.toString(),
+        orgId: orgId,
+        position: model.position,
+        title: model.title,
+        type: model.type,
+      }));
+
+      //Find places in the given areas
+      const placesInAreas: ZetkinPlace[] = [];
+      areas.forEach((area) => {
+        places.forEach((place) => {
+          const placeIsInArea = isPointInsidePolygon(
+            { lat: place.position.lat, lng: place.position.lng },
+            area.points.map((point) => ({ lat: point[0], lng: point[1] }))
+          );
+
+          if (placeIsInArea) {
+            placesInAreas.push(place);
+          }
+        });
+      });
+
+      const uniquePlaces = Array.from(new Set(placesInAreas));
+
+      const households: Household[] = [];
+      uniquePlaces.forEach((place) => households.push(...place.households));
+
+      return Response.json({
+        data: {
+          numHouseholds: households.length,
+          numPlaces: uniquePlaces.length,
+        },
+      });
+    }
+  );
+}

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
@@ -108,11 +108,15 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
       uniquePlaces.forEach((place) => households.push(...place.households));
 
       const visits: Visit[] = [];
-      households.forEach((household) => {
-        household.visits.forEach((visit) => {
-          if (visit.canvassAssId == params.canvassAssId) {
-            visits.push(visit);
-          }
+      const visitedPlaces: ZetkinPlace[] = [];
+      uniquePlaces.forEach((place) => {
+        place.households.forEach((household) => {
+          household.visits.forEach((visit) => {
+            if (visit.canvassAssId == params.canvassAssId) {
+              visitedPlaces.push(place);
+              visits.push(visit);
+            }
+          });
         });
       });
 
@@ -121,6 +125,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
           numHouseholds: households.length,
           numPlaces: uniquePlaces.length,
           numVisitedHouseholds: visits.length,
+          numVisitedPlaces: visitedPlaces.length,
         },
       });
     }

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
@@ -8,6 +8,7 @@ import {
 } from 'features/areas/models';
 import {
   Household,
+  Visit,
   ZetkinCanvassSession,
   ZetkinPlace,
 } from 'features/areas/types';
@@ -106,10 +107,20 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
       const households: Household[] = [];
       uniquePlaces.forEach((place) => households.push(...place.households));
 
+      const visits: Visit[] = [];
+      households.forEach((household) => {
+        household.visits.forEach((visit) => {
+          if (visit.canvassAssId == params.canvassAssId) {
+            visits.push(visit);
+          }
+        });
+      });
+
       return Response.json({
         data: {
           numHouseholds: households.length,
           numPlaces: uniquePlaces.length,
+          numVisitedHouseholds: visits.length,
         },
       });
     }

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/stats/route.ts
@@ -75,6 +75,9 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
 
       //Areas that are parts of the sessions
       const areas = sessions.map((session) => session.area);
+      const uniqueAreas = [
+        ...new Map(areas.map((area) => [area['id'], area])).values(),
+      ];
 
       //Get all places
       const allPlaceModels = await PlaceModel.find({ orgId });
@@ -93,7 +96,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
 
       //Find places in the given areas
       const placesInAreas: PlaceWithAreaId[] = [];
-      areas.forEach((area) => {
+      uniqueAreas.forEach((area) => {
         allPlaces.forEach((place) => {
           const placeIsInArea = isPointInsidePolygon(
             { lat: place.position.lat, lng: place.position.lng },
@@ -152,6 +155,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
 
       return Response.json({
         data: {
+          num_areas: uniqueAreas.length,
           num_households: householdsInAreas.length,
           num_places: uniquePlacesInAreas.length,
           num_visited_areas: Array.from(new Set(visitedAreas)).length,

--- a/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/visits/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/visits/route.ts
@@ -29,6 +29,7 @@ export async function POST(request: NextRequest, { params }: RouteMeta) {
         {
           $push: {
             'households.$[elem].visits': {
+              canvassAssId: payload.canvassAssId,
               id: new mongoose.Types.ObjectId().toString(),
               note: payload.note,
               timestamp: payload.timestamp,

--- a/src/features/areas/components/AreaPage.tsx
+++ b/src/features/areas/components/AreaPage.tsx
@@ -3,6 +3,7 @@
 import { Avatar, Box, Typography } from '@mui/material';
 import { FC } from 'react';
 import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 
 import useArea from '../hooks/useArea';
 import useOrganization from 'features/organizations/hooks/useOrganization';
@@ -21,6 +22,9 @@ type AreaPageProps = {
 const AreaPage: FC<AreaPageProps> = ({ areaId, orgId }) => {
   const orgFuture = useOrganization(orgId);
   const areaFuture = useArea(orgId, areaId);
+  const searchParams = useSearchParams();
+
+  const canvassAssId = searchParams?.get('canvassAssId') || null;
 
   const isServer = useServerSide();
   if (isServer) {
@@ -51,7 +55,7 @@ const AreaPage: FC<AreaPageProps> = ({ areaId, orgId }) => {
             </Box>
           </Box>
           <Box height="90vh">
-            <PublicAreaMap area={area} />
+            <PublicAreaMap area={area} canvassAssId={canvassAssId} />
           </Box>
         </>
       )}

--- a/src/features/areas/components/MyCanvassAssignmentsPage.tsx
+++ b/src/features/areas/components/MyCanvassAssignmentsPage.tsx
@@ -47,7 +47,11 @@ const CanvassAssignmentCard: FC<{
           </CardContent>
           <CardActions>
             <Button
-              onClick={() => router.push(`/o/${orgId}/areas/${areaId}`)}
+              onClick={() =>
+                router.push(
+                  `/o/${orgId}/areas/${areaId}?canvassAssId=${assignment.id}`
+                )
+              }
               variant="outlined"
             >
               <Msg id={messageIds.canvassAssignment.canvassing.goToMapButton} />

--- a/src/features/areas/components/PlaceDialog.tsx
+++ b/src/features/areas/components/PlaceDialog.tsx
@@ -22,6 +22,7 @@ import usePlaceMutations from '../hooks/usePlaceMutations';
 import ZUIDateTime from 'zui/ZUIDateTime';
 
 type PlaceDialogProps = {
+  canvassAssId: string | null;
   dialogStep: 'place' | 'edit' | 'household';
   onClose: () => void;
   onEdit: () => void;
@@ -33,6 +34,7 @@ type PlaceDialogProps = {
 };
 
 const PlaceDialog: FC<PlaceDialogProps> = ({
+  canvassAssId,
   dialogStep,
   onClose,
   onEdit,
@@ -362,6 +364,7 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                 setNote('');
                 if (selectedHousehold && dialogStep == 'household') {
                   addVisit(selectedHousehold.id, {
+                    canvassAssId,
                     note,
                     timestamp: new Date().toISOString(),
                   });

--- a/src/features/areas/components/PublicAreaMap.tsx
+++ b/src/features/areas/components/PublicAreaMap.tsx
@@ -89,9 +89,10 @@ const useStyles = makeStyles((theme) => ({
 
 type PublicAreaMapProps = {
   area: ZetkinArea;
+  canvassAssId: string | null;
 };
 
-const PublicAreaMap: FC<PublicAreaMapProps> = ({ area }) => {
+const PublicAreaMap: FC<PublicAreaMapProps> = ({ area, canvassAssId }) => {
   const theme = useTheme();
   const classes = useStyles();
   const places = usePlaces(area.organization.id).data || [];
@@ -314,6 +315,7 @@ const PublicAreaMap: FC<PublicAreaMapProps> = ({ area }) => {
       </MapContainer>
       {selectedPlace && (
         <PlaceDialog
+          canvassAssId={canvassAssId}
           dialogStep={dialogStep}
           onClose={() => {
             setAnchorEl(null);

--- a/src/features/areas/hooks/useCanvassAssignmentStats.ts
+++ b/src/features/areas/hooks/useCanvassAssignmentStats.ts
@@ -1,6 +1,6 @@
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-import { CanvassAssignmentStats } from '../types';
+import { ZetkinCanvassAssignmentStats } from '../types';
 import { statsLoad, statsLoaded } from '../store';
 
 export default function useCanvassAssignmentStats(
@@ -17,7 +17,7 @@ export default function useCanvassAssignmentStats(
     actionOnLoad: () => statsLoad(canvassAssId),
     actionOnSuccess: (data) => statsLoaded([canvassAssId, data]),
     loader: () =>
-      apiClient.get<CanvassAssignmentStats>(
+      apiClient.get<ZetkinCanvassAssignmentStats>(
         `/beta/orgs/${orgId}/canvassassignments/${canvassAssId}/stats`
       ),
   });

--- a/src/features/areas/hooks/useCanvassAssignmentStats.ts
+++ b/src/features/areas/hooks/useCanvassAssignmentStats.ts
@@ -1,0 +1,24 @@
+import { loadItemIfNecessary } from 'core/caching/cacheUtils';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { CanvassAssignmentStats } from '../types';
+import { statsLoad, statsLoaded } from '../store';
+
+export default function useCanvassAssignmentStats(
+  orgId: number,
+  canvassAssId: string
+) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const statsItem = useAppSelector(
+    (state) => state.areas.statsByCanvassAssId[canvassAssId]
+  );
+
+  return loadItemIfNecessary(statsItem, dispatch, {
+    actionOnLoad: () => statsLoad(canvassAssId),
+    actionOnSuccess: (data) => statsLoaded([canvassAssId, data]),
+    loader: () =>
+      apiClient.get<CanvassAssignmentStats>(
+        `/beta/orgs/${orgId}/canvassassignments/${canvassAssId}/stats`
+      ),
+  });
+}

--- a/src/features/areas/models.ts
+++ b/src/features/areas/models.ts
@@ -50,7 +50,15 @@ const placeSchema = new mongoose.Schema<ZetkinPlaceModelType>({
       _id: false,
       id: String,
       title: String,
-      visits: [{ _id: false, id: String, note: String, timestamp: String }],
+      visits: [
+        {
+          _id: false,
+          canvassAssId: String,
+          id: String,
+          note: String,
+          timestamp: String,
+        },
+      ],
     },
   ],
   orgId: { required: true, type: Number },

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -333,6 +333,7 @@ const areasSlice = createSlice({
           numHouseholds: 0,
           numPlaces: 0,
           numVisitedHouseholds: 0,
+          numVisitedPlaces: 0,
         },
         isLoading: true,
       });

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -334,7 +334,9 @@ const areasSlice = createSlice({
           num_places: 0,
           num_visited_areas: 0,
           num_visited_households: 0,
+          num_visited_households_outside_areas: 0,
           num_visited_places: 0,
+          num_visited_places_outside_areas: 0,
         },
         isLoading: true,
       });

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -330,6 +330,7 @@ const areasSlice = createSlice({
       state.statsByCanvassAssId[canvassAssId] = remoteItem(canvassAssId, {
         data: statsItem?.data || {
           id: canvassAssId,
+          num_areas: 0,
           num_households: 0,
           num_places: 0,
           num_visited_areas: 0,

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -8,7 +8,7 @@ import {
   RemoteList,
 } from 'utils/storeUtils';
 import {
-  CanvassAssignmentStats,
+  ZetkinCanvassAssignmentStats,
   ZetkinArea,
   ZetkinCanvassAssignee,
   ZetkinCanvassAssignment,
@@ -31,7 +31,7 @@ export interface AreasStoreSlice {
   placeList: RemoteList<ZetkinPlace>;
   statsByCanvassAssId: Record<
     string,
-    RemoteItem<CanvassAssignmentStats & { id: string }>
+    RemoteItem<ZetkinCanvassAssignmentStats & { id: string }>
   >;
 }
 
@@ -330,18 +330,18 @@ const areasSlice = createSlice({
       state.statsByCanvassAssId[canvassAssId] = remoteItem(canvassAssId, {
         data: statsItem?.data || {
           id: canvassAssId,
-          numHouseholds: 0,
-          numPlaces: 0,
-          numVisitedAreas: 0,
-          numVisitedHouseholds: 0,
-          numVisitedPlaces: 0,
+          num_households: 0,
+          num_places: 0,
+          num_visited_areas: 0,
+          num_visited_households: 0,
+          num_visited_places: 0,
         },
         isLoading: true,
       });
     },
     statsLoaded: (
       state,
-      action: PayloadAction<[string, CanvassAssignmentStats]>
+      action: PayloadAction<[string, ZetkinCanvassAssignmentStats]>
     ) => {
       const [canvassAssId, stats] = action.payload;
 

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -332,6 +332,7 @@ const areasSlice = createSlice({
           id: canvassAssId,
           numHouseholds: 0,
           numPlaces: 0,
+          numVisitedAreas: 0,
           numVisitedHouseholds: 0,
           numVisitedPlaces: 0,
         },

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -332,6 +332,7 @@ const areasSlice = createSlice({
           id: canvassAssId,
           numHouseholds: 0,
           numPlaces: 0,
+          numVisitedHouseholds: 0,
         },
         isLoading: true,
       });

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,6 +1,7 @@
 import { ZetkinPerson } from 'utils/types/zetkin';
 
 export type ZetkinCanvassAssignmentStats = {
+  num_areas: number;
   num_households: number;
   num_places: number;
   num_visited_areas: number;

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -3,6 +3,7 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 export type PointData = [number, number];
 
 export type Visit = {
+  canvassAssId: string | null;
   id: string;
   note: string;
   timestamp: string;

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,11 +1,11 @@
 import { ZetkinPerson } from 'utils/types/zetkin';
 
-export type CanvassAssignmentStats = {
-  numHouseholds: number;
-  numPlaces: number;
-  numVisitedAreas: number;
-  numVisitedHouseholds: number;
-  numVisitedPlaces: number;
+export type ZetkinCanvassAssignmentStats = {
+  num_households: number;
+  num_places: number;
+  num_visited_areas: number;
+  num_visited_households: number;
+  num_visited_places: number;
 };
 
 export type PointData = [number, number];

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -3,6 +3,7 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 export type CanvassAssignmentStats = {
   numHouseholds: number;
   numPlaces: number;
+  numVisitedHouseholds: number;
 };
 
 export type PointData = [number, number];

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -5,7 +5,9 @@ export type ZetkinCanvassAssignmentStats = {
   num_places: number;
   num_visited_areas: number;
   num_visited_households: number;
+  num_visited_households_outside_areas: number;
   num_visited_places: number;
+  num_visited_places_outside_areas: number;
 };
 
 export type PointData = [number, number];

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -4,6 +4,7 @@ export type CanvassAssignmentStats = {
   numHouseholds: number;
   numPlaces: number;
   numVisitedHouseholds: number;
+  numVisitedPlaces: number;
 };
 
 export type PointData = [number, number];

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -3,6 +3,7 @@ import { ZetkinPerson } from 'utils/types/zetkin';
 export type CanvassAssignmentStats = {
   numHouseholds: number;
   numPlaces: number;
+  numVisitedAreas: number;
   numVisitedHouseholds: number;
   numVisitedPlaces: number;
 };

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,5 +1,10 @@
 import { ZetkinPerson } from 'utils/types/zetkin';
 
+export type CanvassAssignmentStats = {
+  numHouseholds: number;
+  numPlaces: number;
+};
+
 export type PointData = [number, number];
 
 export type Visit = {

--- a/src/features/areas/utils/isPointInsidePolygon.ts
+++ b/src/features/areas/utils/isPointInsidePolygon.ts
@@ -1,7 +1,12 @@
-import { LatLng } from 'leaflet';
-
+type LatLngData = {
+  lat: number;
+  lng: number;
+};
 /*** Stolen from comment on https://stackoverflow.com/questions/31790344/determine-if-a-point-reside-inside-a-leaflet-polygon */
-export default function isPointInsidePolygon(point: LatLng, polygon: LatLng[]) {
+export default function isPointInsidePolygon(
+  point: LatLngData,
+  polygon: LatLngData[]
+) {
   const x = point.lat;
   const y = point.lng;
 

--- a/src/features/areas/utils/isPointInsidePolygon.ts
+++ b/src/features/areas/utils/isPointInsidePolygon.ts
@@ -1,0 +1,25 @@
+import { LatLng } from 'leaflet';
+
+/*** Stolen from comment on https://stackoverflow.com/questions/31790344/determine-if-a-point-reside-inside-a-leaflet-polygon */
+export default function isPointInsidePolygon(point: LatLng, polygon: LatLng[]) {
+  const x = point.lat;
+  const y = point.lng;
+
+  let inside = false;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].lat;
+    const yi = polygon[i].lng;
+    const xj = polygon[j].lat;
+    const yj = polygon[j].lng;
+
+    const intersects =
+      yi > y != yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -122,6 +122,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
             )}
             <Box display="flex" flexDirection="column">
               <Box>{`Number of areas: ${areaCount}`}</Box>
+              <Box>{`Number of areas with visits in this assignment: ${stats.numVisitedAreas}`}</Box>
               <Box>{`Number of places: ${stats.numPlaces}`}</Box>
               <Box>{`Number of places with visits in this assignment: ${stats.numVisitedPlaces}`}</Box>
               <Box>{`Number of households: ${stats.numHouseholds}`}</Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -10,7 +10,6 @@ import { PageWithLayout } from 'utils/types';
 import useCanvassAssignment from 'features/areas/hooks/useCanvassAssignment';
 import { Msg } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
-import useCanvassSessions from 'features/areas/hooks/useCanvassSessions';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import useCanvassAssignmentStats from 'features/areas/hooks/useCanvassAssignmentStats';
@@ -64,7 +63,6 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
 }) => {
   const theme = useTheme();
   const assignmentFuture = useCanvassAssignment(parseInt(orgId), canvassAssId);
-  const sessionsFuture = useCanvassSessions(parseInt(orgId), canvassAssId);
   const statsFuture = useCanvassAssignmentStats(parseInt(orgId), canvassAssId);
   const classes = useStyles();
   const router = useRouter();
@@ -73,14 +71,10 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
     <ZUIFutures
       futures={{
         assignment: assignmentFuture,
-        sessions: sessionsFuture,
         stats: statsFuture,
       }}
     >
-      {({ data: { assignment, sessions, stats } }) => {
-        const areas = new Set(sessions.map((session) => session.area.id));
-        const areaCount = areas.size;
-
+      {({ data: { assignment, stats } }) => {
         const planUrl = `/organize/${orgId}/projects/${
           assignment.campaign.id || 'standalone'
         }/canvassassignments/${assignment.id}/plan`;
@@ -92,8 +86,8 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 <Typography variant="h4">
                   <Msg id={messageIds.canvassAssignment.overview.areas.title} />
                 </Typography>
-                {!!areaCount && (
-                  <ZUIAnimatedNumber value={areaCount}>
+                {!!stats.num_areas && (
+                  <ZUIAnimatedNumber value={stats.num_areas}>
                     {(animatedValue) => (
                       <Box className={classes.chip}>{animatedValue}</Box>
                     )}
@@ -101,7 +95,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 )}
               </Box>
               <Divider />
-              {areaCount > 0 ? (
+              {stats.num_areas > 0 ? (
                 <Box p={2}>
                   <Button
                     onClick={() => router.push(planUrl)}
@@ -152,7 +146,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     width="100%"
                   >
                     <Typography variant="h5">Areas</Typography>
-                    <ZUIAnimatedNumber value={areaCount}>
+                    <ZUIAnimatedNumber value={stats.num_areas}>
                       {(animatedValue) => (
                         <Box className={classes.statsChip}>{animatedValue}</Box>
                       )}
@@ -166,7 +160,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                       },
                       {
                         color: theme.palette.statusColors.orange,
-                        value: areaCount - stats.num_visited_areas,
+                        value: stats.num_areas - stats.num_visited_areas,
                       },
                     ]}
                   />

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -239,6 +239,17 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 </Box>
               </Box>
             </Card>
+            <Card>
+              <Box display="flex" flexDirection="column" padding={2}>
+                <Typography variant="h5">Rogue visits</Typography>
+                <Typography>
+                  {`Number of visited places outside the assigned areas: ${stats.num_visited_places_outside_areas}`}
+                </Typography>
+                <Typography>
+                  {`Number of visited households outside the assigned areas: ${stats.num_visited_households_outside_areas}`}
+                </Typography>
+              </Box>
+            </Card>
           </Box>
         );
       }}

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -123,6 +123,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
             <Box display="flex" flexDirection="column">
               <Box>{`Number of areas: ${areaCount}`}</Box>
               <Box>{`Number of places: ${stats.numPlaces}`}</Box>
+              <Box>{`Number of places with visits in this assignment: ${stats.numVisitedPlaces}`}</Box>
               <Box>{`Number of households: ${stats.numHouseholds}`}</Box>
               <Box>{`Number of households with visits in this assignment: ${stats.numVisitedHouseholds}`}</Box>
             </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -13,6 +13,7 @@ import messageIds from 'features/areas/l10n/messageIds';
 import useCanvassSessions from 'features/areas/hooks/useCanvassSessions';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
+import useCanvassAssignmentStats from 'features/areas/hooks/useCanvassAssignmentStats';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -50,14 +51,19 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
 }) => {
   const assignmentFuture = useCanvassAssignment(parseInt(orgId), canvassAssId);
   const sessionsFuture = useCanvassSessions(parseInt(orgId), canvassAssId);
+  const statsFuture = useCanvassAssignmentStats(parseInt(orgId), canvassAssId);
   const classes = useStyles();
   const router = useRouter();
 
   return (
     <ZUIFutures
-      futures={{ assignment: assignmentFuture, sessions: sessionsFuture }}
+      futures={{
+        assignment: assignmentFuture,
+        sessions: sessionsFuture,
+        stats: statsFuture,
+      }}
     >
-      {({ data: { assignment, sessions } }) => {
+      {({ data: { assignment, sessions, stats } }) => {
         const areas = new Set(sessions.map((session) => session.area));
         const areaCount = areas.size;
 
@@ -115,7 +121,8 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
               </Box>
             )}
             <Box display="flex" flexDirection="column">
-              {`Number of areas: ${areaCount}`}
+              <Box>{`Number of places: ${stats.numPlaces}`}</Box>
+              <Box>{`Number of households: ${stats.numHouseholds}`}</Box>
             </Box>
           </Card>
         );

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Card, Divider, Typography } from '@mui/material';
 import { GetServerSideProps } from 'next';
 import { Edit } from '@mui/icons-material';
 import { useRouter } from 'next/router';
-import { makeStyles } from '@mui/styles';
+import { makeStyles, useTheme } from '@mui/styles';
 
 import CanvassAssignmentLayout from 'features/areas/layouts/CanvassAssignmentLayout';
 import { scaffold } from 'utils/next';
@@ -14,6 +14,8 @@ import useCanvassSessions from 'features/areas/hooks/useCanvassSessions';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import useCanvassAssignmentStats from 'features/areas/hooks/useCanvassAssignmentStats';
+import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
+import { getContrastColor } from 'utils/colorUtils';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -43,12 +45,24 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     padding: '0.2em 0.7em',
   },
+  statsChip: {
+    backgroundColor: theme.palette.statusColors.blue,
+    borderRadius: '1em',
+    color: getContrastColor(theme.palette.statusColors.blue),
+    display: 'flex',
+    fontSize: '1rem',
+    lineHeight: 'normal',
+    marginRight: '0.1em',
+    overflow: 'hidden',
+    padding: '0.2em 0.7em',
+  },
 }));
 
 const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
   orgId,
   canvassAssId,
 }) => {
+  const theme = useTheme();
   const assignmentFuture = useCanvassAssignment(parseInt(orgId), canvassAssId);
   const sessionsFuture = useCanvassSessions(parseInt(orgId), canvassAssId);
   const statsFuture = useCanvassAssignmentStats(parseInt(orgId), canvassAssId);
@@ -72,40 +86,23 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
         }/canvassassignments/${assignment.id}/plan`;
 
         return (
-          <Card>
-            <Box display="flex" justifyContent="space-between" p={2}>
-              <Typography variant="h4">
-                <Msg id={messageIds.canvassAssignment.overview.areas.title} />
-              </Typography>
-              {!!areaCount && (
-                <ZUIAnimatedNumber value={areaCount}>
-                  {(animatedValue) => (
-                    <Box className={classes.chip}>{animatedValue}</Box>
-                  )}
-                </ZUIAnimatedNumber>
-              )}
-            </Box>
-            <Divider />
-            {areaCount > 0 ? (
-              <Box p={2}>
-                <Button
-                  onClick={() => router.push(planUrl)}
-                  startIcon={<Edit />}
-                  variant="text"
-                >
-                  <Msg
-                    id={messageIds.canvassAssignment.overview.areas.editButton}
-                  />
-                </Button>
-              </Box>
-            ) : (
-              <Box p={2}>
-                <Typography>
-                  <Msg
-                    id={messageIds.canvassAssignment.overview.areas.subtitle}
-                  />
+          <Box display="flex" flexDirection="column" gap={2}>
+            <Card>
+              <Box display="flex" justifyContent="space-between" p={2}>
+                <Typography variant="h4">
+                  <Msg id={messageIds.canvassAssignment.overview.areas.title} />
                 </Typography>
-                <Box pt={1}>
+                {!!areaCount && (
+                  <ZUIAnimatedNumber value={areaCount}>
+                    {(animatedValue) => (
+                      <Box className={classes.chip}>{animatedValue}</Box>
+                    )}
+                  </ZUIAnimatedNumber>
+                )}
+              </Box>
+              <Divider />
+              {areaCount > 0 ? (
+                <Box p={2}>
                   <Button
                     onClick={() => router.push(planUrl)}
                     startIcon={<Edit />}
@@ -113,22 +110,135 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                   >
                     <Msg
                       id={
-                        messageIds.canvassAssignment.overview.areas.defineButton
+                        messageIds.canvassAssignment.overview.areas.editButton
                       }
                     />
                   </Button>
                 </Box>
+              ) : (
+                <Box p={2}>
+                  <Typography>
+                    <Msg
+                      id={messageIds.canvassAssignment.overview.areas.subtitle}
+                    />
+                  </Typography>
+                  <Box pt={1}>
+                    <Button
+                      onClick={() => router.push(planUrl)}
+                      startIcon={<Edit />}
+                      variant="text"
+                    >
+                      <Msg
+                        id={
+                          messageIds.canvassAssignment.overview.areas
+                            .defineButton
+                        }
+                      />
+                    </Button>
+                  </Box>
+                </Box>
+              )}
+            </Card>
+            <Card>
+              <Box padding={2}>
+                <Typography variant="h4">Progress</Typography>
               </Box>
-            )}
-            <Box display="flex" flexDirection="column">
-              <Box>{`Number of areas: ${areaCount}`}</Box>
-              <Box>{`Number of areas with visits in this assignment: ${stats.numVisitedAreas}`}</Box>
-              <Box>{`Number of places: ${stats.numPlaces}`}</Box>
-              <Box>{`Number of places with visits in this assignment: ${stats.numVisitedPlaces}`}</Box>
-              <Box>{`Number of households: ${stats.numHouseholds}`}</Box>
-              <Box>{`Number of households with visits in this assignment: ${stats.numVisitedHouseholds}`}</Box>
-            </Box>
-          </Card>
+              <Box display="flex" flexDirection="column">
+                <Box display="flex" flexDirection="column" gap={1} padding={2}>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                    width="100%"
+                  >
+                    <Typography variant="h5">Areas</Typography>
+                    <ZUIAnimatedNumber value={areaCount}>
+                      {(animatedValue) => (
+                        <Box className={classes.statsChip}>{animatedValue}</Box>
+                      )}
+                    </ZUIAnimatedNumber>
+                  </Box>
+                  <ZUIStackedStatusBar
+                    values={[
+                      {
+                        color: theme.palette.statusColors.green,
+                        value: stats.numVisitedAreas,
+                      },
+                      {
+                        color: theme.palette.statusColors.orange,
+                        value: areaCount - stats.numVisitedAreas,
+                      },
+                    ]}
+                  />
+                  <Box display="flex" justifyContent="center" width="100%">
+                    <Typography>{`${stats.numVisitedAreas} logged`}</Typography>
+                  </Box>
+                </Box>
+                <Divider />
+                <Box display="flex" flexDirection="column" gap={1} padding={2}>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                    width="100%"
+                  >
+                    <Typography variant="h5">Places</Typography>
+                    <ZUIAnimatedNumber value={stats.numPlaces}>
+                      {(animatedValue) => (
+                        <Box className={classes.statsChip}>{animatedValue}</Box>
+                      )}
+                    </ZUIAnimatedNumber>
+                  </Box>
+                  <ZUIStackedStatusBar
+                    values={[
+                      {
+                        color: theme.palette.statusColors.green,
+                        value: stats.numVisitedPlaces,
+                      },
+                      {
+                        color: theme.palette.statusColors.orange,
+                        value: stats.numPlaces - stats.numVisitedPlaces,
+                      },
+                    ]}
+                  />
+                  <Box display="flex" justifyContent="center" width="100%">
+                    <Typography>{`${stats.numVisitedPlaces} logged`}</Typography>
+                  </Box>
+                </Box>
+                <Divider />
+                <Box display="flex" flexDirection="column" gap={1} padding={2}>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                    width="100%"
+                  >
+                    <Typography variant="h5">Households</Typography>
+                    <ZUIAnimatedNumber value={stats.numHouseholds}>
+                      {(animatedValue) => (
+                        <Box className={classes.statsChip}>{animatedValue}</Box>
+                      )}
+                    </ZUIAnimatedNumber>
+                  </Box>
+                  <ZUIStackedStatusBar
+                    values={[
+                      {
+                        color: theme.palette.statusColors.green,
+                        value: stats.numVisitedHouseholds,
+                      },
+                      {
+                        color: theme.palette.statusColors.orange,
+                        value: stats.numHouseholds - stats.numVisitedHouseholds,
+                      },
+                    ]}
+                  />
+                  <Box display="flex" justifyContent="center" width="100%">
+                    <Typography>{`${stats.numVisitedHouseholds} logged`}</Typography>
+                  </Box>
+                </Box>
+              </Box>
+            </Card>
+          </Box>
         );
       }}
     </ZUIFutures>

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -64,7 +64,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
       }}
     >
       {({ data: { assignment, sessions, stats } }) => {
-        const areas = new Set(sessions.map((session) => session.area));
+        const areas = new Set(sessions.map((session) => session.area.id));
         const areaCount = areas.size;
 
         const planUrl = `/organize/${orgId}/projects/${

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -121,8 +121,10 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
               </Box>
             )}
             <Box display="flex" flexDirection="column">
+              <Box>{`Number of areas: ${areaCount}`}</Box>
               <Box>{`Number of places: ${stats.numPlaces}`}</Box>
               <Box>{`Number of households: ${stats.numHouseholds}`}</Box>
+              <Box>{`Number of households with visits in this assignment: ${stats.numVisitedHouseholds}`}</Box>
             </Box>
           </Card>
         );

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -58,8 +58,8 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
       futures={{ assignment: assignmentFuture, sessions: sessionsFuture }}
     >
       {({ data: { assignment, sessions } }) => {
-        const areaIds = new Set(sessions.map((session) => session.area.id));
-        const areaCount = areaIds.size;
+        const areas = new Set(sessions.map((session) => session.area));
+        const areaCount = areas.size;
 
         const planUrl = `/organize/${orgId}/projects/${
           assignment.campaign.id || 'standalone'
@@ -114,6 +114,9 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 </Box>
               </Box>
             )}
+            <Box display="flex" flexDirection="column">
+              {`Number of areas: ${areaCount}`}
+            </Box>
           </Card>
         );
       }}

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -162,16 +162,16 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     values={[
                       {
                         color: theme.palette.statusColors.green,
-                        value: stats.numVisitedAreas,
+                        value: stats.num_visited_areas,
                       },
                       {
                         color: theme.palette.statusColors.orange,
-                        value: areaCount - stats.numVisitedAreas,
+                        value: areaCount - stats.num_visited_areas,
                       },
                     ]}
                   />
                   <Box display="flex" justifyContent="center" width="100%">
-                    <Typography>{`${stats.numVisitedAreas} logged`}</Typography>
+                    <Typography>{`${stats.num_visited_areas} logged`}</Typography>
                   </Box>
                 </Box>
                 <Divider />
@@ -183,7 +183,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     width="100%"
                   >
                     <Typography variant="h5">Places</Typography>
-                    <ZUIAnimatedNumber value={stats.numPlaces}>
+                    <ZUIAnimatedNumber value={stats.num_places}>
                       {(animatedValue) => (
                         <Box className={classes.statsChip}>{animatedValue}</Box>
                       )}
@@ -193,16 +193,16 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     values={[
                       {
                         color: theme.palette.statusColors.green,
-                        value: stats.numVisitedPlaces,
+                        value: stats.num_visited_places,
                       },
                       {
                         color: theme.palette.statusColors.orange,
-                        value: stats.numPlaces - stats.numVisitedPlaces,
+                        value: stats.num_places - stats.num_visited_places,
                       },
                     ]}
                   />
                   <Box display="flex" justifyContent="center" width="100%">
-                    <Typography>{`${stats.numVisitedPlaces} logged`}</Typography>
+                    <Typography>{`${stats.num_visited_places} logged`}</Typography>
                   </Box>
                 </Box>
                 <Divider />
@@ -214,7 +214,7 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     width="100%"
                   >
                     <Typography variant="h5">Households</Typography>
-                    <ZUIAnimatedNumber value={stats.numHouseholds}>
+                    <ZUIAnimatedNumber value={stats.num_households}>
                       {(animatedValue) => (
                         <Box className={classes.statsChip}>{animatedValue}</Box>
                       )}
@@ -224,16 +224,17 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     values={[
                       {
                         color: theme.palette.statusColors.green,
-                        value: stats.numVisitedHouseholds,
+                        value: stats.num_visited_households,
                       },
                       {
                         color: theme.palette.statusColors.orange,
-                        value: stats.numHouseholds - stats.numVisitedHouseholds,
+                        value:
+                          stats.num_households - stats.num_visited_households,
                       },
                     ]}
                   />
                   <Box display="flex" justifyContent="center" width="100%">
-                    <Typography>{`${stats.numVisitedHouseholds} logged`}</Typography>
+                    <Typography>{`${stats.num_visited_households} logged`}</Typography>
                   </Box>
                 </Box>
               </Box>

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -10,6 +10,7 @@ export default function mockState(overrides?: RootState) {
       mySessionsList: remoteList(),
       placeList: remoteList(),
       sessionsByAssignmentId: {},
+      statsByCanvassAssId: {},
     },
     breadcrumbs: {
       crumbsByPath: {},


### PR DESCRIPTION
## Description
This PR adds the first iteration of stats for a canvass assignment. 

In this version, the stats are per the whole assignment.


## Screenshots
![bild](https://github.com/user-attachments/assets/4369c57e-0f18-428e-8184-8aa22ac09770)


## Changes
* Adds a `/stats` endpoint in the `beta` api, that creates stats for a whole assignment
* Adds cards in the Overview tab of a canvass assignment to display these stats.
* Adds `canvassAssId` as a property to a household visit

## Notes to reviewer
Strings are not localised, as I don't think this version of the UI will live very long. 

## Related issues
none
