### PR TITLE
Issue 2099/misleading info message

### DIFF
--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -50,7 +50,8 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
     (person) => !selectedIds.includes(person.id)
   );
 
-  const { fieldValues, initialOverrides } = useFieldSettings(peopleToMerge);
+  const { hasConflictingValues, fieldValues, initialOverrides } =
+    useFieldSettings(peopleToMerge);
   const [overrides, setOverrides] = useState(initialOverrides);
 
   useEffect(() => {
@@ -96,10 +97,12 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
             }}
           />
           <Box marginBottom={2} />
-          <Alert severity="warning">
-            <AlertTitle>{messages.modal.warningTitle()}</AlertTitle>
-            {messages.modal.warningMessage()}
-          </Alert>
+          {hasConflictingValues && (
+            <Alert severity="warning">
+              <AlertTitle>{messages.modal.warningTitle()}</AlertTitle>
+              {messages.modal.warningMessage()}
+            </Alert>
+          )}
         </Box>
       </Box>
       <DialogActions sx={{ p: 2 }}>

--- a/src/features/duplicates/components/ConfigureModal.tsx
+++ b/src/features/duplicates/components/ConfigureModal.tsx
@@ -96,9 +96,9 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
             }}
           />
           <Box marginBottom={2} />
-          <Alert severity="info">
-            <AlertTitle>{messages.modal.infoTitle()}</AlertTitle>
-            {messages.modal.infoMessage()}
+          <Alert severity="warning">
+            <AlertTitle>{messages.modal.warningTitle()}</AlertTitle>
+            {messages.modal.warningMessage()}
           </Alert>
         </Box>
       </Box>

--- a/src/features/duplicates/hooks/useFieldSettings.ts
+++ b/src/features/duplicates/hooks/useFieldSettings.ts
@@ -47,5 +47,5 @@ export default function useFieldSettings(duplicates: ZetkinPerson[]) {
     entryContainsOneValue
   );
 
-  return { hasConflictingValues, fieldValues, initialOverrides };
+  return { fieldValues, hasConflictingValues, initialOverrides };
 }

--- a/src/features/duplicates/hooks/useFieldSettings.ts
+++ b/src/features/duplicates/hooks/useFieldSettings.ts
@@ -39,5 +39,13 @@ export default function useFieldSettings(duplicates: ZetkinPerson[]) {
     }
   });
 
-  return { fieldValues, initialOverrides };
+  function entryContainsOneValue(entry: Array<string | string[]>) {
+    return entry[1].length < 2;
+  }
+
+  const hasConflictingValues = !Object.entries(fieldValues).every(
+    entryContainsOneValue
+  );
+
+  return { hasConflictingValues, fieldValues, initialOverrides };
 }

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -29,6 +29,8 @@ export default makeMessages('feat.duplicates', {
       phone: m('Phone'),
     },
     title: m('Merge duplicates'),
+    warningMessage: m('Related activity data will transfer to the merged person, but conflicting fields must be resolved. Any unmerged data will be lost.'),
+    warningTitle: m('Risk of data loss'),
   },
   page: {
     dismiss: m('Dismiss'),

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -29,7 +29,9 @@ export default makeMessages('feat.duplicates', {
       phone: m('Phone'),
     },
     title: m('Merge duplicates'),
-    warningMessage: m('Related activity data will transfer to the merged person, but conflicting fields must be resolved. Any unmerged data will be lost.'),
+    warningMessage: m(
+      'Related activity data will transfer to the merged person, but conflicting fields must be resolved. Any unmerged data will be lost.'
+    ),
     warningTitle: m('Risk of data loss'),
   },
   page: {

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -14,10 +14,6 @@ export default makeMessages('feat.duplicates', {
       noValue: m('No value'),
       title: m('Data to merge'),
     },
-    infoMessage: m(
-      'All activity history and tags from all people being merged will carry over and will be visible on the merged person.'
-    ),
-    infoTitle: m('No data will be lost'),
     isDuplicateButton: m('Include'),
     mergeButton: m('Merge'),
     notDuplicateButton: m('Exclude'),

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -30,7 +30,7 @@ export default makeMessages('feat.duplicates', {
     },
     title: m('Merge duplicates'),
     warningMessage: m(
-      'Related activity data will transfer to the merged person, but conflicting fields must be resolved. Any unmerged data will be lost.'
+      'All data related to any of the person records will transfer to the merged person. This includes event participation, survey submissions, tags etc. But the values you discard in the fields above will be lost.'
     ),
     warningTitle: m('Risk of data loss'),
   },


### PR DESCRIPTION
## Description
This PR changes the disclaimer in in the Modal when resolving duplicate persons.
A clear message to describe what happens with data and a bit more serious color to bring attention to the disclaimer.

Logic has been implemented to render the information when there is conflicting field values. I have used existing functionality in the `useFieldSettings` and added a boolean `hasConflictingValues` to its return object.

## Screenshots

### No conflicts
![noconflicts](https://github.com/user-attachments/assets/520440c5-ea44-4a6b-b9e4-27bcbd32c3ac)

### Conflicts
![conflicts](https://github.com/user-attachments/assets/7a90dd34-db90-49c0-9b9d-0985ac2f6f24)

## Changes

* Adds messageId `warningTitle` and `warningMessage`
* Removes obsolete `infoTitle` and `infoMessage`
* Changes Alert component prop to `severity='warning'`
* Add exported to `useFieldSettings` hook


## Notes to reviewer
~~Have been unable to recreate duplicates to test this on, PR is set to draft until I can.~~

If there are no duplicates present use the below codesnippet to mock duplicates in `useDuplicates.tsx`

This should present two cases of duplicate persons, one where there are two persons matching with identical personal data which should not trigger an warning about potential data loss. The other is a case with three people that should cause the the warning to render. 

```typescript
  const test: PotentialDuplicate[] = [
    {
      duplicates: [
        {
          alt_phone: '098-765-4321',
          is_user: true,
          zip_code: '54321',
          last_name: 'Smith',
          city: 'Another City',
          first_name: 'Jane',
          gender: 'f',
          street_address: '456 Another St',
          co_address: null,
          ext_id: null,
          email: 'jane.smith@example.com',
          country: 'Sample Country',
          id: 1,
          phone: '111-222-3333',
        },
        {
          alt_phone: '098-765-4321',
          is_user: true,
          zip_code: '54321',
          last_name: 'Smith',
          city: 'Another City',
          first_name: 'Jane',
          gender: 'f',
          street_address: '456 Another St',
          co_address: null,
          ext_id: null,
          email: 'jane.smith@example.com',
          country: 'Sample Country',
          id: 12,
          phone: '111-222-3333',
        },
      ],
      dismissed: null,
      id: 1,
      merged: null,
      organization: {
        id: 123,
        title: 'Sample Organization',
      },
      status: 'pending',
    },
    {
      duplicates: [
        {
          alt_phone: '123-456-7890',
          is_user: true,
          zip_code: '12345',
          last_name: 'Doe',
          city: 'Sample City',
          first_name: 'John',
          gender: 'm',
          street_address: '123 Main St',
          co_address: null,
          ext_id: null,
          email: 'john.doe@example.com',
          country: 'Sample Country',
          id: 1,
          phone: '098-765-4321',
        },
        {
          alt_phone: '098-765-4321',
          is_user: true,
          zip_code: '54321',
          last_name: 'Smith',
          city: 'Another City',
          first_name: 'Jane',
          gender: 'f',
          street_address: '456 Another St',
          co_address: null,
          ext_id: null,
          email: 'jane.smith@example.com',
          country: 'Sample Country',
          id: 2,
          phone: '111-222-3333',
        },
        {
          alt_phone: '555-555-5555',
          is_user: false,
          zip_code: '67890',
          last_name: 'Brown',
          city: 'Cityville',
          first_name: 'Charlie',
          gender: 'm',
          street_address: '789 Brown St',
          co_address: null,
          ext_id: null,
          email: 'charlie.brown@example.com',
          country: 'Sample Country',
          id: 3,
          phone: '666-666-6666',
        },
      ],
      dismissed: null,
      id: 1,
      merged: null,
      organization: {
        id: 123,
        title: 'Sample Organization',
      },
      status: 'pending',
    },
  ];

  return loadListIfNecessary(duplicatesList, dispatch, {
    actionOnLoad: () => potentialDuplicatesLoad(),
    actionOnSuccess: (duplicates) => potentialDuplicatesLoaded(duplicates),
    loader: () => Promise.resolve(test),
  });
```

## Related issues
Resolves #2099 
