### PR TITLE
WIP Undocumented/area visit stats

### DIFF
--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/areasstats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/areasstats/route.ts
@@ -74,7 +74,10 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
         type: model.type,
       }));
 
-      type PlacesWithAreaId = ZetkinPlace & { areaId: ZetkinArea['id'] };
+      type PlacesWithAreaId = ZetkinPlace & {
+        areaId: ZetkinArea['id'];
+        areaTitle: ZetkinArea['title'];
+      };
 
       const placesInArea: PlacesWithAreaId[] = [];
       uniqueAreas.forEach((area) => {
@@ -85,7 +88,11 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
           );
 
           if (placeIsInArea) {
-            placesInArea.push({ ...place, areaId: area.id });
+            placesInArea.push({
+              ...place,
+              areaId: area.id,
+              areaTitle: area.title,
+            });
           }
         });
       });
@@ -104,6 +111,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
         // First, process the areas that have places
         places.forEach((place) => {
           const areaId = place.areaId;
+          const title = place.areaTitle;
 
           let areaStats = results.find((stat) => stat.id === areaId);
 
@@ -114,6 +122,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
               num_places: 0,
               num_visited_households: 0,
               num_visited_places: 0,
+              title: title || null,
             };
             results.push(areaStats);
           }
@@ -154,6 +163,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
               num_places: 0,
               num_visited_households: 0,
               num_visited_places: 0,
+              title: area.title,
             });
           }
         });

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/areasstats/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/areasstats/route.ts
@@ -1,0 +1,173 @@
+import mongoose from 'mongoose';
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  AreaModel,
+  CanvassAssignmentModel,
+  PlaceModel,
+} from 'features/areas/models';
+import {
+  ZetkinArea,
+  ZetkinCanvassAssignmentAreaStats,
+  ZetkinPlace,
+} from 'features/areas/types';
+import asOrgAuthorized from 'utils/api/asOrgAuthorized';
+import isPointInsidePolygon from 'features/areas/utils/isPointInsidePolygon';
+
+type RouteMeta = {
+  params: {
+    canvassAssId: string;
+    orgId: string;
+  };
+};
+
+export async function GET(request: NextRequest, { params }: RouteMeta) {
+  return asOrgAuthorized(
+    {
+      orgId: params.orgId,
+      request: request,
+      roles: ['admin', 'organizer'],
+    },
+    async ({ orgId }) => {
+      await mongoose.connect(process.env.MONGODB_URL || '');
+
+      const model = await CanvassAssignmentModel.findOne({
+        _id: params.canvassAssId,
+      });
+
+      if (!model) {
+        return new NextResponse(null, { status: 404 });
+      }
+
+      const areaList: ZetkinArea[] = [];
+
+      for await (const sessionData of model.sessions) {
+        const area = await AreaModel.findOne({
+          _id: sessionData.areaId,
+        });
+
+        if (area) {
+          areaList.push({
+            description: area.description,
+            id: area._id.toString(),
+            organization: {
+              id: orgId,
+            },
+            points: area.points,
+            title: area.title,
+          });
+        }
+      }
+
+      const uniqueAreas = [
+        ...new Map(areaList.map((area) => [area['id'], area])).values(),
+      ];
+
+      const allPlaceModels = await PlaceModel.find({ orgId });
+      const allPlaces: ZetkinPlace[] = allPlaceModels.map((model) => ({
+        description: model.description,
+        households: model.households,
+        id: model._id.toString(),
+        orgId: orgId,
+        position: model.position,
+        title: model.title,
+        type: model.type,
+      }));
+
+      type PlacesWithAreaId = ZetkinPlace & { areaId: ZetkinArea['id'] };
+
+      const placesInArea: PlacesWithAreaId[] = [];
+      uniqueAreas.forEach((area) => {
+        allPlaces.forEach((place) => {
+          const placeIsInArea = isPointInsidePolygon(
+            { lat: place.position.lat, lng: place.position.lng },
+            area.points.map((point) => ({ lat: point[0], lng: point[1] }))
+          );
+
+          if (placeIsInArea) {
+            placesInArea.push({ ...place, areaId: area.id });
+          }
+        });
+      });
+
+      const uniquePlacesInArea = [
+        ...new Map(placesInArea.map((place) => [place['id'], place])).values(),
+      ];
+
+      function calculateAreaStats(
+        places: PlacesWithAreaId[],
+        areas: ZetkinArea[],
+        canvassAssId: string
+      ): ZetkinCanvassAssignmentAreaStats[] {
+        const results: ZetkinCanvassAssignmentAreaStats[] = [];
+
+        // First, process the areas that have places
+        places.forEach((place) => {
+          const areaId = place.areaId;
+
+          let areaStats = results.find((stat) => stat.id === areaId);
+
+          if (!areaStats) {
+            areaStats = {
+              id: areaId,
+              num_households: 0,
+              num_places: 0,
+              num_visited_households: 0,
+              num_visited_places: 0,
+            };
+            results.push(areaStats);
+          }
+
+          areaStats.num_places += 1;
+
+          const numHouseholdsInPlace = place.households.length;
+          areaStats.num_households += numHouseholdsInPlace;
+
+          let visitedHouseholdsCount = 0;
+          let placeHasVisited = false;
+
+          place.households.forEach((household) => {
+            const hasVisited = household.visits.some(
+              (visit) => visit.canvassAssId === canvassAssId
+            );
+            if (hasVisited) {
+              visitedHouseholdsCount += 1;
+              placeHasVisited = true;
+            }
+          });
+
+          areaStats.num_visited_households += visitedHouseholdsCount;
+
+          if (placeHasVisited) {
+            areaStats.num_visited_places += 1;
+          }
+        });
+
+        //Process areas without places
+        areas.forEach((area) => {
+          const areaHasPlace = results.some((stat) => stat.id === area.id);
+
+          if (!areaHasPlace) {
+            results.push({
+              id: area.id,
+              num_households: 0,
+              num_places: 0,
+              num_visited_households: 0,
+              num_visited_places: 0,
+            });
+          }
+        });
+
+        return results;
+      }
+
+      const areasStats = calculateAreaStats(
+        uniquePlacesInArea,
+        uniqueAreas,
+        params.canvassAssId
+      );
+
+      return Response.json({ data: areasStats });
+    }
+  );
+}

--- a/src/features/areas/hooks/useAreasStatsByCanvassAssignment.tsx
+++ b/src/features/areas/hooks/useAreasStatsByCanvassAssignment.tsx
@@ -1,0 +1,28 @@
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import {
+  areasByCanvassAssignmentLoad,
+  areasByCanvassAssignmentLoaded,
+} from '../store';
+import { ZetkinCanvassAssignmentAreaStats } from '../types';
+
+export default function useAreasStatsByCanvassAssignment(
+  orgId: number,
+  canvassAssId: string
+) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const areaStats = useAppSelector(
+    (state) => state.areas.areasStatsByCanvassAssignmentId[canvassAssId]
+  );
+
+  return loadListIfNecessary(areaStats, dispatch, {
+    actionOnLoad: () => areasByCanvassAssignmentLoad(canvassAssId),
+    actionOnSuccess: (data) =>
+      areasByCanvassAssignmentLoaded([canvassAssId, data]),
+    loader: () =>
+      apiClient.get<ZetkinCanvassAssignmentAreaStats[]>(
+        `/beta/orgs/${orgId}/canvassassignments/${canvassAssId}/areasstats`
+      ),
+  });
+}

--- a/src/features/areas/l10n/messageIds.ts
+++ b/src/features/areas/l10n/messageIds.ts
@@ -17,6 +17,13 @@ export default makeMessages('feat.areas', {
       title: m('Untitled canvass assignment'),
     },
     overview: {
+      areaStats: {
+        closeButton: m('Close'),
+        households: m('Households'),
+        householdsLog: m(' Households have log visits'),
+        places: m('Places'),
+        placesLog: m('Places have log visits'),
+      },
       areas: {
         defineButton: m('Plan now'),
         editButton: m('Edit plan'),

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -14,6 +14,7 @@ import {
   ZetkinCanvassAssignment,
   ZetkinCanvassSession,
   ZetkinPlace,
+  ZetkinCanvassAssignmentAreaStats,
 } from './types';
 
 export interface AreasStoreSlice {
@@ -23,6 +24,11 @@ export interface AreasStoreSlice {
     string,
     RemoteList<ZetkinCanvassSession & { id: number }>
   >;
+  areasStatsByCanvassAssignmentId: Record<
+    string,
+    RemoteList<ZetkinCanvassAssignmentAreaStats>
+  >;
+
   assigneesByCanvassAssignmentId: Record<
     string,
     RemoteList<ZetkinCanvassAssignee>
@@ -37,6 +43,7 @@ export interface AreasStoreSlice {
 
 const initialState: AreasStoreSlice = {
   areaList: remoteList(),
+  areasStatsByCanvassAssignmentId: {},
   assigneesByCanvassAssignmentId: {},
   canvassAssignmentList: remoteList(),
   mySessionsList: remoteList(),
@@ -94,6 +101,27 @@ const areasSlice = createSlice({
 
       item.data = area;
       item.loaded = new Date().toISOString();
+    },
+    areasByCanvassAssignmentLoad: (state, action: PayloadAction<string>) => {
+      const assignmentId = action.payload;
+
+      if (!state.areasStatsByCanvassAssignmentId[assignmentId]) {
+        state.areasStatsByCanvassAssignmentId[assignmentId] = remoteList();
+      }
+
+      state.areasStatsByCanvassAssignmentId[assignmentId].isLoading = true;
+    },
+    areasByCanvassAssignmentLoaded: (
+      state,
+      action: PayloadAction<[string, ZetkinCanvassAssignmentAreaStats[]]>
+    ) => {
+      const [canvassAssId, areasStats] = action.payload;
+
+      state.areasStatsByCanvassAssignmentId[canvassAssId] =
+        remoteList(areasStats);
+
+      state.areasStatsByCanvassAssignmentId[canvassAssId].loaded =
+        new Date().toISOString();
     },
     areasLoad: (state) => {
       state.areaList.isLoading = true;
@@ -364,6 +392,8 @@ export const {
   areaDeleted,
   areaLoad,
   areaLoaded,
+  areasByCanvassAssignmentLoad,
+  areasByCanvassAssignmentLoaded,
   areasLoad,
   areasLoaded,
   areaUpdated,

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -17,6 +17,7 @@ export type ZetkinCanvassAssignmentAreaStats = {
   num_places: number;
   num_visited_households: number;
   num_visited_places: number;
+  title: string | null;
 };
 
 export type PointData = [number, number];

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -11,6 +11,14 @@ export type ZetkinCanvassAssignmentStats = {
   num_visited_places_outside_areas: number;
 };
 
+export type ZetkinCanvassAssignmentAreaStats = {
+  id: string;
+  num_households: number;
+  num_places: number;
+  num_visited_households: number;
+  num_visited_places: number;
+};
+
 export type PointData = [number, number];
 
 export type Visit = {

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Card, Divider, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Typography,
+} from '@mui/material';
 import { GetServerSideProps } from 'next';
 import { Edit } from '@mui/icons-material';
 import { useRouter } from 'next/router';
@@ -15,6 +22,7 @@ import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 import useCanvassAssignmentStats from 'features/areas/hooks/useCanvassAssignmentStats';
 import ZUIStackedStatusBar from 'zui/ZUIStackedStatusBar';
 import { getContrastColor } from 'utils/colorUtils';
+import useAreasStatsByCanvassAssignment from 'features/areas/hooks/useAreasStatsByCanvassAssignment';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -64,17 +72,22 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
   const theme = useTheme();
   const assignmentFuture = useCanvassAssignment(parseInt(orgId), canvassAssId);
   const statsFuture = useCanvassAssignmentStats(parseInt(orgId), canvassAssId);
+  const areasListFuture = useAreasStatsByCanvassAssignment(
+    parseInt(orgId),
+    canvassAssId
+  );
   const classes = useStyles();
   const router = useRouter();
 
   return (
     <ZUIFutures
       futures={{
+        areas: areasListFuture,
         assignment: assignmentFuture,
         stats: statsFuture,
       }}
     >
-      {({ data: { assignment, stats } }) => {
+      {({ data: { areas, assignment, stats } }) => {
         const planUrl = `/organize/${orgId}/projects/${
           assignment.campaign.id || 'standalone'
         }/canvassassignments/${assignment.id}/plan`;
@@ -133,6 +146,112 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 </Box>
               )}
             </Card>
+            <Box display="flex" justifyContent="space-evenly">
+              {areas.map((area) => {
+                return (
+                  <Card key={area.id}>
+                    <Box
+                      alignItems="baseline"
+                      display="flex"
+                      justifyContent="space-between"
+                      p={2}
+                    >
+                      <Typography mb={1} variant="h5">
+                        {area.title || 'Untitle area'}
+                      </Typography>
+                      <Button variant="outlined">
+                        <Msg
+                          id={
+                            messageIds.canvassAssignment.overview.areaStats
+                              .closeButton
+                          }
+                        />
+                      </Button>
+                    </Box>
+                    <Divider />
+                    <CardContent>
+                      <Typography
+                        alignItems="baseline"
+                        display="flex"
+                        mb={1}
+                        variant="h5"
+                      >
+                        <Msg
+                          id={
+                            messageIds.canvassAssignment.overview.areaStats
+                              .places
+                          }
+                        />
+                        <Divider orientation="vertical" />
+                        <Typography ml={1}>{area.num_places}</Typography>
+                      </Typography>
+                      <ZUIStackedStatusBar
+                        values={[
+                          {
+                            color: theme.palette.statusColors.green,
+                            value: area.num_visited_places,
+                          },
+                          {
+                            color: theme.palette.statusColors.orange,
+                            value: area.num_places - area.num_visited_places,
+                          },
+                        ]}
+                      />
+                      <Typography mb={1} mt={1}>
+                        {area.num_visited_places + ' '}
+                        <Msg
+                          id={
+                            messageIds.canvassAssignment.overview.areaStats
+                              .placesLog
+                          }
+                        />
+                      </Typography>
+
+                      <Typography
+                        alignItems="baseline"
+                        display="flex"
+                        mb={1}
+                        variant="h5"
+                      >
+                        <Msg
+                          id={
+                            messageIds.canvassAssignment.overview.areaStats
+                              .households
+                          }
+                        />
+                        <Divider
+                          orientation="vertical"
+                          sx={{ color: theme.palette.secondary.dark }}
+                        />
+                        <Typography ml={1}>{area.num_households}</Typography>
+                      </Typography>
+                      <ZUIStackedStatusBar
+                        values={[
+                          {
+                            color: theme.palette.statusColors.green,
+                            value: area.num_visited_households,
+                          },
+                          {
+                            color: theme.palette.statusColors.orange,
+                            value:
+                              area.num_households - area.num_visited_households,
+                          },
+                        ]}
+                      />
+                      <Typography mb={1} mt={1}>
+                        {area.num_visited_households + ' '}
+                        <Msg
+                          id={
+                            messageIds.canvassAssignment.overview.areaStats
+                              .householdsLog
+                          }
+                        />
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </Box>
             <Card>
               <Box padding={2}>
                 <Typography variant="h4">Progress</Typography>

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -5,6 +5,7 @@ export default function mockState(overrides?: RootState) {
   const emptyState: RootState = {
     areas: {
       areaList: remoteList(),
+      areasStatsByCanvassAssignmentId: {},
       assigneesByCanvassAssignmentId: {},
       canvassAssignmentList: remoteList(),
       mySessionsList: remoteList(),


### PR DESCRIPTION
## Description
This PR displays the areas stats in the overview page of a Canvass assignment. 


## Screenshots
![image](https://github.com/user-attachments/assets/66b0792c-d5b8-4c82-95f7-2619b1af9271)



## Changes
* Adds a new API route called /`areasstats`
* Adds a new hook called `useAreasStatsByCanvassAssignment` to get the area stats data.
* Adds a new type called `ZetkinCanvassAssignmentAreaStats`
* Implements areas stats in `CanvassAssignmentPage`


## Notes to reviewer
Title of areas exists twice in our store, and that's not ideal. We will need a refactor of the stats to structure the data in a better way. 


## Related issues
None
