### PR TITLE
Hide canvassing features

### DIFF
--- a/src/features/areas/hooks/useCanvassAssignmentActivities.ts
+++ b/src/features/areas/hooks/useCanvassAssignmentActivities.ts
@@ -9,6 +9,8 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { canvassAssignmentsLoad, canvassAssignmentsLoaded } from '../store';
 import { ACTIVITIES, CampaignActivity } from 'features/campaigns/types';
+import useFeature from 'utils/featureFlags/useFeature';
+import { AREAS } from 'utils/featureFlags';
 
 export default function useCanvassAssignmentActivities(
   orgId: number,
@@ -17,6 +19,11 @@ export default function useCanvassAssignmentActivities(
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const list = useAppSelector((state) => state.areas.canvassAssignmentList);
+
+  const hasCanvassing = useFeature(AREAS);
+  if (!hasCanvassing) {
+    return new ResolvedFuture([]);
+  }
 
   const future = loadListIfNecessary(list, dispatch, {
     actionOnLoad: () => canvassAssignmentsLoad(),

--- a/src/features/campaigns/components/ActivityList/FilterActivities.tsx
+++ b/src/features/campaigns/components/ActivityList/FilterActivities.tsx
@@ -13,6 +13,8 @@ import { ACTIVITIES } from 'features/campaigns/types';
 import messageIds from 'features/campaigns/l10n/messageIds';
 import useDebounce from 'utils/hooks/useDebounce';
 import { useMessages } from 'core/i18n';
+import useFeature from 'utils/featureFlags/useFeature';
+import { AREAS } from 'utils/featureFlags';
 
 interface FilterActivitiesProps {
   filters: ACTIVITIES[];
@@ -28,6 +30,7 @@ const FilterActivities = ({
   onSearchStringChange,
 }: FilterActivitiesProps) => {
   const messages = useMessages(messageIds);
+  const hasCanvassing = useFeature(AREAS);
 
   const debouncedFinishedTyping = useDebounce(
     async (evt: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -75,17 +78,21 @@ const FilterActivities = ({
             }
             label={messages.all.filter.calls()}
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={filters.includes(ACTIVITIES.CANVASS_ASSIGNMENT)}
-                disabled={!filterTypes.includes(ACTIVITIES.CANVASS_ASSIGNMENT)}
-                onChange={onFiltersChange}
-                value={ACTIVITIES.CANVASS_ASSIGNMENT}
-              />
-            }
-            label={messages.all.filter.canvasses()}
-          />
+          {hasCanvassing && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={filters.includes(ACTIVITIES.CANVASS_ASSIGNMENT)}
+                  disabled={
+                    !filterTypes.includes(ACTIVITIES.CANVASS_ASSIGNMENT)
+                  }
+                  onChange={onFiltersChange}
+                  value={ACTIVITIES.CANVASS_ASSIGNMENT}
+                />
+              }
+              label={messages.all.filter.canvasses()}
+            />
+          )}
           <FormControlLabel
             control={
               <Checkbox

--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -30,6 +30,8 @@ import ZUIDialog from 'zui/ZUIDialog';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import { Msg, useMessages } from 'core/i18n';
 import useCreateCanvassAssignment from 'features/areas/hooks/useCreateCanvassAssignment';
+import useFeature from 'utils/featureFlags/useFeature';
+import { AREAS } from 'utils/featureFlags';
 
 enum CAMPAIGN_MENU_ITEMS {
   EDIT_CAMPAIGN = 'editCampaign',
@@ -47,6 +49,7 @@ const CampaignActionButtons: React.FunctionComponent<
   const messages = useMessages(messageIds);
   const { orgId, campId } = useNumericRouteParams();
   const organization = useOrganization(orgId).data;
+  const hasCanvassing = useFeature(AREAS);
 
   // Dialogs
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -88,15 +91,6 @@ const CampaignActionButtons: React.FunctionComponent<
 
   const menuItems = [
     {
-      icon: <Map />,
-      label: messages.linkGroup.createCanvassAssignment(),
-      onClick: () =>
-        createCanvassAssignment({
-          campaign_id: campaign.id,
-          title: null,
-        }),
-    },
-    {
       icon: <Event />,
       label: messages.linkGroup.createEvent(),
       onClick: handleCreateEvent,
@@ -124,6 +118,18 @@ const CampaignActionButtons: React.FunctionComponent<
       onClick: () => setCreateTaskDialogOpen(true),
     },
   ];
+
+  if (hasCanvassing) {
+    menuItems.push({
+      icon: <Map />,
+      label: messages.linkGroup.createCanvassAssignment(),
+      onClick: () =>
+        createCanvassAssignment({
+          campaign_id: campaign.id,
+          title: null,
+        }),
+    });
+  }
 
   if (organization.email && themes.length > 0) {
     menuItems.push({

--- a/src/pages/organize/[orgId]/areas/index.tsx
+++ b/src/pages/organize/[orgId]/areas/index.tsx
@@ -8,23 +8,14 @@ import { PageWithLayout } from 'utils/types';
 import useAreas from 'features/areas/hooks/useAreas';
 import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
-import hasFeature from 'utils/featureFlags/hasFeature';
 import { AREAS } from 'utils/featureFlags';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  featuresRequired: [AREAS],
 };
 
-export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
-  const { orgId } = ctx.params!;
-  const hasAreas = hasFeature(AREAS, parseInt(orgId as string), process.env);
-
-  if (!hasAreas) {
-    return {
-      notFound: true,
-    };
-  }
-
+export const getServerSideProps: GetServerSideProps = scaffold(async () => {
   return {
     props: {},
   };

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/canvassers.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/canvassers.tsx
@@ -11,9 +11,11 @@ import ZUIAvatar from 'zui/ZUIAvatar';
 import { useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
+import { AREAS } from 'utils/featureFlags';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  featuresRequired: [AREAS],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -13,9 +13,11 @@ import messageIds from 'features/areas/l10n/messageIds';
 import useCanvassSessions from 'features/areas/hooks/useCanvassSessions';
 import ZUIFutures from 'zui/ZUIFutures';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
+import { AREAS } from 'utils/featureFlags';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  featuresRequired: [AREAS],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/plan.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/plan.tsx
@@ -11,6 +11,7 @@ import useServerSide from 'core/useServerSide';
 import useCanvassSessions from 'features/areas/hooks/useCanvassSessions';
 import ZUIFuture from 'zui/ZUIFuture';
 import useCreateCanvassSession from 'features/areas/hooks/useCreateCanvassSession';
+import { AREAS } from 'utils/featureFlags';
 
 const PlanMap = dynamic(
   () => import('../../../../../../../features/areas/components/PlanMap'),
@@ -19,6 +20,7 @@ const PlanMap = dynamic(
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  featuresRequired: [AREAS],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/utils/featureFlags/useFeature.spec.ts
+++ b/src/utils/featureFlags/useFeature.spec.ts
@@ -24,6 +24,15 @@ function getOptsWithEnvVars(vars?: Partial<Environment['vars']>) {
   };
 }
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {
+      orgId: 123,
+    },
+    route: '/organize/123',
+  }),
+}));
+
 describe('useFeature()', () => {
   it('returns false for empty vars', () => {
     const opts = getOptsWithEnvVars();
@@ -53,6 +62,14 @@ describe('useFeature()', () => {
     });
     const { result } = renderHook(() => useFeature('FEAT_AREAS', 4), opts);
     expect(result.current).toBeFalsy();
+  });
+
+  it('defaults to using orgId from router', () => {
+    const opts = getOptsWithEnvVars({
+      FEAT_AREAS: '123', // orgId from mocked router
+    });
+    const { result } = renderHook(() => useFeature('FEAT_AREAS'), opts);
+    expect(result.current).toBeTruthy();
   });
 
   it.each([1, 2, 34, 567])(

--- a/src/utils/featureFlags/useFeature.ts
+++ b/src/utils/featureFlags/useFeature.ts
@@ -1,12 +1,15 @@
+import { useNumericRouteParams } from 'core/hooks';
 import useEnv from '../../core/hooks/useEnv';
 import hasFeature from './hasFeature';
 
 export default function useFeature(
   featureLabel: string,
-  orgId: number
+  orgId?: number
 ): boolean {
   const env = useEnv();
 
+  const { orgId: orgIdFromRoute } = useNumericRouteParams();
+
   const untypedVars = env.vars as Record<string, string | undefined>;
-  return hasFeature(featureLabel, orgId, untypedVars);
+  return hasFeature(featureLabel, orgId || orgIdFromRoute, untypedVars);
 }

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -15,6 +15,7 @@ import { stringToBool } from './stringUtils';
 import { ZetkinZ } from './types/sdk';
 import { ApiFetch, createApiFetch } from './apiFetch';
 import { ZetkinSession, ZetkinUser } from './types/zetkin';
+import { hasFeature } from './featureFlags';
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -49,6 +50,7 @@ interface ScaffoldOptions {
   // Level can be 1 (simple sign-in) or 2 (two-factor authentication)
   authLevelRequired?: number;
   allowNonOfficials?: boolean;
+  featuresRequired?: string[];
   localeScope?: string[];
 }
 
@@ -143,6 +145,18 @@ export const scaffold =
     }
 
     const orgId = ctx.query.orgId as string;
+
+    if (options?.featuresRequired) {
+      const isMissingFeature = options.featuresRequired.some(
+        (feature) => !hasFeature(feature, parseInt(orgId), process.env)
+      );
+
+      if (isMissingFeature) {
+        return {
+          notFound: true,
+        };
+      }
+    }
 
     //if it's an org page we check if you have access
     if (orgId) {


### PR DESCRIPTION
## Description
This PR adds feature flags for the new canvassing features, so that they can be hidden in a release.

## Screenshots
None

## Changes
* Changes `useFeature()` to make `orgId` optional
* Changes `scaffold()` to allow specifying required features (will return 404 when feature is missing)
* Hides canvass assignments from UI (lists/buttons) when `AREAS` feature is missing
* Hides canvass assignment pages when `AREAS` feature is missing

## Notes to reviewer
None

## Related issues
Undocumented
