### PR TITLE
ZUICheckboxGroup and ZUISwitchGroup

### DIFF
--- a/src/zui/ZUICheckbox/index.tsx
+++ b/src/zui/ZUICheckbox/index.tsx
@@ -10,14 +10,14 @@ const sizes: Record<Sizes, string> = {
   small: '1.25rem',
 };
 
-interface ZUICheckboxProps {
+export type ZUICheckboxProps = {
   checked: boolean;
   disabled?: boolean;
   label: string;
   labelPlacement?: 'bottom' | 'end' | 'start' | 'top';
   onChange: (newCheckedState: boolean) => void;
   size?: Sizes;
-}
+};
 
 const ZUICheckbox: FC<ZUICheckboxProps> = ({
   checked,

--- a/src/zui/ZUICheckboxGroup/index.stories.tsx
+++ b/src/zui/ZUICheckboxGroup/index.stories.tsx
@@ -52,7 +52,18 @@ export const Basic: Story = {
       },
     ];
 
-    return <ZUICheckboxGroup {...args} options={options} />;
+    return (
+      <ZUICheckboxGroup
+        {...args}
+        error={
+          args.error &&
+          !selectedGroups.kitchen &&
+          !selectedGroups.party &&
+          !selectedGroups.protest
+        }
+        options={options}
+      />
+    );
   },
 };
 

--- a/src/zui/ZUICheckboxGroup/index.stories.tsx
+++ b/src/zui/ZUICheckboxGroup/index.stories.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUICheckboxGroup from './index';
+
+const meta: Meta<typeof ZUICheckboxGroup> = {
+  component: ZUICheckboxGroup,
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUICheckboxGroup>;
+
+export const Basic: Story = {
+  args: {
+    helperText: 'You can pick multiple groups',
+    label: 'Groups you belong to',
+  },
+  render: function Render(args) {
+    const [selectedGroups, setSelectedGroups] = useState({
+      kitchen: false,
+      party: false,
+      protest: false,
+    });
+
+    const options = [
+      {
+        checked: selectedGroups.kitchen,
+        label: 'Kitchen team',
+        onChange: () =>
+          setSelectedGroups({
+            ...selectedGroups,
+            kitchen: !selectedGroups.kitchen,
+          }),
+      },
+      {
+        checked: selectedGroups.party,
+        label: 'Party planners',
+        onChange: () =>
+          setSelectedGroups({
+            ...selectedGroups,
+            party: !selectedGroups.party,
+          }),
+      },
+      {
+        checked: selectedGroups.protest,
+        label: 'Protest committee',
+        onChange: () =>
+          setSelectedGroups({
+            ...selectedGroups,
+            protest: !selectedGroups.protest,
+          }),
+      },
+    ];
+
+    return <ZUICheckboxGroup {...args} options={options} />;
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    helperText: 'You can pick multiple groups',
+    label: 'Which groups do you want to participate in?',
+  },
+  render: Basic.render,
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    helperText: 'You need to pick at least one group',
+    label: 'Which groups do you want to participate in?',
+  },
+  render: Basic.render,
+};

--- a/src/zui/ZUICheckboxGroup/index.tsx
+++ b/src/zui/ZUICheckboxGroup/index.tsx
@@ -1,0 +1,95 @@
+import { FormControl, FormGroup, FormLabel, Typography } from '@mui/material';
+import { FC, useId } from 'react';
+
+import ZUICheckbox, { ZUICheckboxProps } from 'zui/ZUICheckbox';
+
+type ZUICheckboxGroupProps = {
+  /**
+   * This controls if the whole group is disabled.
+   *
+   * If you want to disable a single checkbox, do that in the options array.
+   */
+  disabled?: boolean;
+
+  error?: boolean;
+
+  helperText?: string;
+
+  label: string;
+
+  /**
+   * A list of props for checkboxes.
+   */
+  options: ZUICheckboxProps[];
+};
+
+/**
+ * This component is used to group ZUICheckbox and ZUISwitch controls.
+ */
+const ZUICheckboxGroup: FC<ZUICheckboxGroupProps> = ({
+  options,
+  disabled = false,
+  error = false,
+  helperText,
+  label,
+}) => {
+  const labelId = useId();
+  const helperTextId = useId();
+
+  return (
+    <FormControl component="fieldset" disabled={disabled} variant="standard">
+      <FormLabel id={labelId}>
+        <Typography
+          sx={(theme) => {
+            let color = theme.palette.text.primary;
+
+            if (disabled) {
+              color = theme.palette.text.disabled;
+            }
+
+            if (error) {
+              color = theme.palette.error.main;
+            }
+
+            return {
+              color,
+            };
+          }}
+          variant="labelXlMedium"
+        >
+          {label}
+        </Typography>
+      </FormLabel>
+      <FormGroup aria-describedby={helperTextId} aria-labelledby={labelId}>
+        {options.map((option) => (
+          <ZUICheckbox key={option.label} {...option} disabled={disabled} />
+        ))}
+      </FormGroup>
+      {helperText && (
+        <Typography
+          id={helperTextId}
+          sx={(theme) => {
+            let color = theme.palette.text.secondary;
+
+            if (disabled) {
+              color = theme.palette.text.disabled;
+            }
+
+            if (error) {
+              color = theme.palette.error.main;
+            }
+
+            return {
+              color,
+            };
+          }}
+          variant="labelSmMedium"
+        >
+          {helperText}
+        </Typography>
+      )}
+    </FormControl>
+  );
+};
+
+export default ZUICheckboxGroup;

--- a/src/zui/ZUIRadioGroup/index.stories.tsx
+++ b/src/zui/ZUIRadioGroup/index.stories.tsx
@@ -29,6 +29,7 @@ export const Disabled: Story = {
   args: {
     direction: 'column',
     disabled: true,
+    helperText: 'Helper text',
     label: 'Example Form',
     labelPlacement: 'end',
     options: [

--- a/src/zui/ZUIRadioGroup/index.tsx
+++ b/src/zui/ZUIRadioGroup/index.tsx
@@ -82,7 +82,14 @@ const ZUIRadioGroup = ({
   return (
     <FormControl disabled={disabled}>
       <FormLabel id={labelId}>
-        <Typography color="primary" variant="labelXlMedium">
+        <Typography
+          sx={(theme) => ({
+            color: disabled
+              ? theme.palette.text.disabled
+              : theme.palette.text.primary,
+          })}
+          variant="labelXlMedium"
+        >
           {label}
         </Typography>
       </FormLabel>
@@ -96,15 +103,16 @@ const ZUIRadioGroup = ({
         value={value}
       >
         {options.map((option) => {
+          const isDisabled = disabled || option.disabled;
           return (
             <FormControlLabel
               key={option.value}
               control={<Radio />}
-              disabled={option.disabled}
+              disabled={isDisabled}
               label={
                 <Typography
                   sx={(theme) => ({
-                    color: option.disabled ? theme.palette.text.disabled : '',
+                    color: isDisabled ? theme.palette.text.disabled : '',
                   })}
                   variant="labelXlMedium"
                 >
@@ -123,7 +131,15 @@ const ZUIRadioGroup = ({
         })}
       </RadioGroup>
       {helperText && (
-        <Typography color="secondary" id={helperTextId} variant="labelSmMedium">
+        <Typography
+          id={helperTextId}
+          sx={(theme) => ({
+            color: disabled
+              ? theme.palette.text.disabled
+              : theme.palette.text.secondary,
+          })}
+          variant="labelSmMedium"
+        >
           {helperText}
         </Typography>
       )}

--- a/src/zui/ZUISwitch/index.tsx
+++ b/src/zui/ZUISwitch/index.tsx
@@ -1,7 +1,7 @@
 import { FormControlLabel, Switch, Typography } from '@mui/material';
 import { FC } from 'react';
 
-export interface ZUISwitchProps {
+export type ZUISwitchProps = {
   checked: boolean;
 
   /**
@@ -24,7 +24,7 @@ export interface ZUISwitchProps {
    * This does not affect the label size.
    */
   size?: 'small' | 'medium';
-}
+};
 
 const ZUISwitch: FC<ZUISwitchProps> = ({
   checked,

--- a/src/zui/ZUISwitchGroup/index.stories.tsx
+++ b/src/zui/ZUISwitchGroup/index.stories.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUISwitchGroup from './index';
+
+const meta: Meta<typeof ZUISwitchGroup> = {
+  component: ZUISwitchGroup,
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUISwitchGroup>;
+
+export const Basic: Story = {
+  args: {
+    helperText: 'Make it nice and cozy.',
+    label: 'Light switches',
+  },
+  render: function Render(args) {
+    const [lights, setLights] = useState({
+      big: false,
+      disco: false,
+      reading: false,
+    });
+
+    const options = [
+      {
+        checked: lights.big,
+        label: 'Big light',
+        onChange: () =>
+          setLights({
+            ...lights,
+            big: !lights.big,
+          }),
+      },
+      {
+        checked: lights.disco,
+        label: 'Disco light',
+        onChange: () =>
+          setLights({
+            ...lights,
+            disco: !lights.disco,
+          }),
+      },
+      {
+        checked: lights.reading,
+        label: 'Reading lamp',
+        onChange: () =>
+          setLights({
+            ...lights,
+            reading: !lights.reading,
+          }),
+      },
+    ];
+
+    return (
+      <ZUISwitchGroup
+        {...args}
+        error={args.error && !lights.reading && !lights.big && !lights.disco}
+        options={options}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    helperText: 'You can turn on multiple lights',
+    label: 'Which lights should be on',
+  },
+  render: Basic.render,
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    helperText: 'You need to pick at least one light',
+    label: 'Turn on the lights',
+  },
+  render: Basic.render,
+};

--- a/src/zui/ZUISwitchGroup/index.tsx
+++ b/src/zui/ZUISwitchGroup/index.tsx
@@ -1,0 +1,92 @@
+import { FormControl, FormGroup, FormLabel, Typography } from '@mui/material';
+import { FC, useId } from 'react';
+
+import ZUISwitch, { ZUISwitchProps } from 'zui/ZUISwitch';
+
+type ZUISwitchGroupProps = {
+  /**
+   * This controls if the whole group is disabled.
+   *
+   * If you want to disable a single switch, do that in the options array.
+   */
+  disabled?: boolean;
+
+  error?: boolean;
+
+  helperText?: string;
+
+  label: string;
+
+  /**
+   * A list of props for switches.
+   */
+  options: ZUISwitchProps[];
+};
+
+const ZUISwitchGroup: FC<ZUISwitchGroupProps> = ({
+  disabled,
+  error,
+  helperText,
+  label,
+  options,
+}) => {
+  const labelId = useId();
+  const helperTextId = useId();
+
+  return (
+    <FormControl component="fieldset" disabled={disabled} variant="standard">
+      <FormLabel id={labelId}>
+        <Typography
+          sx={(theme) => {
+            let color = theme.palette.text.primary;
+
+            if (disabled) {
+              color = theme.palette.text.disabled;
+            }
+
+            if (error) {
+              color = theme.palette.error.main;
+            }
+
+            return {
+              color,
+            };
+          }}
+          variant="labelXlMedium"
+        >
+          {label}
+        </Typography>
+      </FormLabel>
+      <FormGroup aria-describedby={helperTextId} aria-labelledby={labelId}>
+        {options.map((option) => (
+          <ZUISwitch key={option.label} {...option} disabled={disabled} />
+        ))}
+      </FormGroup>
+      {helperText && (
+        <Typography
+          id={helperTextId}
+          sx={(theme) => {
+            let color = theme.palette.text.secondary;
+
+            if (disabled) {
+              color = theme.palette.text.disabled;
+            }
+
+            if (error) {
+              color = theme.palette.error.main;
+            }
+
+            return {
+              color,
+            };
+          }}
+          variant="labelSmMedium"
+        >
+          {helperText}
+        </Typography>
+      )}
+    </FormControl>
+  );
+};
+
+export default ZUISwitchGroup;


### PR DESCRIPTION
## Description
This PR adds `ZUICheckboxGroup` and `ZUISwitchGroup` components, to group checkboxes and switches in the new design system, and does a small refactor of the disabled styling on `ZUIRadioGroup`


## Screenshots
![bild](https://github.com/user-attachments/assets/70b5038f-27a6-4d73-995b-aa14fa49a202)
![bild](https://github.com/user-attachments/assets/2fc36abd-74f7-4696-82bd-00537760fa35)

## Changes
* Adds `ZUISwitchGroup` and `ZUICheckboxGroup` components
* Adds Storybook stories for both components
* Changes the styling of the disabled state of `ZUIRadioGroup`

## Notes to reviewer
Play around in Storybook

## Related issues
none (this was not documented as individual issues)
