### PR TITLE
Exclude next and storybook artefacts from typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,8 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    ".next",
+    "node_modules",
+    "storybook-static"
   ]
 }


### PR DESCRIPTION
## Description
This PR adds the `.next` and `storybook-static` folders to the `tsconfig` exclude list, so that it does not trip the check-types yarn script unnecessarily.


## Screenshots
None

## Changes
* Adds `.next` (NEXT.js build output) to tsconfig exclude
* Adds `storybook-static` (Storybook build output) to tsconfig exclude

## Notes to reviewer
None

## Related issues
Undocumented