### PR TITLE
Fix styling flicker on page load

### DIFF
--- a/src/core/Providers.tsx
+++ b/src/core/Providers.tsx
@@ -1,4 +1,6 @@
 import { AdapterDayjs } from '@mui/x-date-pickers-pro/AdapterDayjs';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { IntlProvider } from 'react-intl';
@@ -56,30 +58,34 @@ const Providers: FC<ProvidersProps> = ({
     };
   }
 
+  const cache = createCache({ key: 'css', prepend: true });
+
   return (
     <ReduxProvider store={store}>
       <EnvProvider env={env}>
         <UserContext.Provider value={user}>
           <StyledEngineProvider injectFirst>
-            <ThemeProvider theme={themeWithLocale(lang)}>
-              <LocalizationProvider dateAdapter={AdapterDayjs}>
-                <IntlProvider
-                  defaultLocale="en"
-                  locale={lang}
-                  messages={messages}
-                >
-                  <ZUISnackbarProvider>
-                    <ZUIConfirmDialogProvider>
-                      <EventPopperProvider>
-                        <DndProvider backend={HTML5Backend}>
-                          {children}
-                        </DndProvider>
-                      </EventPopperProvider>
-                    </ZUIConfirmDialogProvider>
-                  </ZUISnackbarProvider>
-                </IntlProvider>
-              </LocalizationProvider>
-            </ThemeProvider>
+            <CacheProvider value={cache}>
+              <ThemeProvider theme={themeWithLocale(lang)}>
+                <LocalizationProvider dateAdapter={AdapterDayjs}>
+                  <IntlProvider
+                    defaultLocale="en"
+                    locale={lang}
+                    messages={messages}
+                  >
+                    <ZUISnackbarProvider>
+                      <ZUIConfirmDialogProvider>
+                        <EventPopperProvider>
+                          <DndProvider backend={HTML5Backend}>
+                            {children}
+                          </DndProvider>
+                        </EventPopperProvider>
+                      </ZUIConfirmDialogProvider>
+                    </ZUISnackbarProvider>
+                  </IntlProvider>
+                </LocalizationProvider>
+              </ThemeProvider>
+            </CacheProvider>
           </StyledEngineProvider>
         </UserContext.Provider>
       </EnvProvider>

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import CssBaseline from '@mui/material/CssBaseline';
+import { CacheProvider } from '@emotion/react';
+import createCache from '@emotion/cache';
 import { IntlProvider } from 'react-intl';
 import { Provider as ReduxProvider } from 'react-redux';
 import { FC, ReactNode } from 'react';
@@ -52,24 +54,27 @@ const ClientContext: FC<ClientContextProps> = ({
     : new BrowserApiClient();
 
   const env = new Environment(apiClient, envVars);
+  const cache = createCache({ key: 'css', prepend: true });
 
   return (
     <ReduxProvider store={store}>
       <StyledEngineProvider injectFirst>
-        <ThemeProvider theme={themeWithLocale(lang)}>
-          <EnvProvider env={env}>
-            <UserProvider user={user}>
-              <IntlProvider
-                defaultLocale="en"
-                locale={lang}
-                messages={messages}
-              >
-                <CssBaseline />
-                {children}
-              </IntlProvider>
-            </UserProvider>
-          </EnvProvider>
-        </ThemeProvider>
+        <CacheProvider value={cache}>
+          <ThemeProvider theme={themeWithLocale(lang)}>
+            <EnvProvider env={env}>
+              <UserProvider user={user}>
+                <IntlProvider
+                  defaultLocale="en"
+                  locale={lang}
+                  messages={messages}
+                >
+                  <CssBaseline />
+                  {children}
+                </IntlProvider>
+              </UserProvider>
+            </EnvProvider>
+          </ThemeProvider>
+        </CacheProvider>
       </StyledEngineProvider>
     </ReduxProvider>
   );


### PR DESCRIPTION
## Description
This PR fixes an undocumented visual issue that would sometimes manifest on initial load. The problem seems to be that the DOM is rendered before loading JS, which is where the styling is. The changes in this PR were suggested to a similar problem [reported as an MUI issue](https://github.com/mui/material-ui/issues/34652).

## Screenshots
This video first browses to a survey running on `main`, and then on this branch. Note how the page flickers with a huge icon and unstyled text in the first tab, but not in the second tab.

https://github.com/user-attachments/assets/0015bef7-7cd3-4978-9d2d-cd87f19959c6

## Changes
* Adds a provider for the emotion cache to pages in both the app router and the pages router

## Notes to reviewer
This problem manifests most clearly on the new surveys page. You should be able to see the problem on any survey page running`main` but not on this branch.

* [Example on main](https://app.dev.zetkin.org/o/1/surveys/8)
* [Same survey running on this branch](https://app-zetkin-org-git-undocumented-fix-styling-flicker-zetkin.vercel.app/o/1/surveys/8)

## Related issues
Undocumented