### PR TITLE
Add redirect parameter to `/login`-route

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,28 @@
 import { GetServerSideProps } from 'next';
+import { getIronSession } from 'iron-session';
 
 import { stringToBool } from '../utils/stringUtils';
+import { AppSession } from 'utils/types';
+import requiredEnvVar from 'utils/requiredEnvVar';
+
+// If/when `URL.parse` is supported, use that instead of this
+// https://developer.mozilla.org/en-US/docs/Web/API/URL/parse_static
+const parseUrl = (
+  urlLike: string | string[] | undefined,
+  base: string | undefined
+): URL | null => {
+  if (!urlLike) {
+    return null;
+  }
+  if (typeof urlLike !== 'string') {
+    urlLike = urlLike[0];
+  }
+  try {
+    return new URL(urlLike, base);
+  } catch {
+    return null;
+  }
+};
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -17,18 +39,37 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const protocol = process.env.ZETKIN_APP_PROTOCOL || 'http';
   const host =
     context.req.headers.host || process.env.ZETKIN_APP_HOST || 'localhost:3000';
+  const baseUrl = `${protocol}://${host}`;
 
   let scopes;
-  const { level } = context.query;
+  const { level, redirect } = context.query;
   if (level && typeof level === 'string') {
     if (parseInt(level) > 1) {
       scopes = [`level${level}`];
     }
   }
+  if (typeof redirect == 'string') {
+    // We want to remove any base-URL that was passed in the query parameter,
+    // which we do by parsing and then using only pathname and query-parameters.
+    // URL.pathname always starts with `/`.
+    const redirectAsUrl = parseUrl(redirect, baseUrl);
+    const destinationPath = redirectAsUrl
+      ? `${redirectAsUrl.pathname}${redirectAsUrl.search}`
+      : '/';
+
+    const session = await getIronSession<AppSession>(context.req, context.res, {
+      cookieName: 'zsid',
+      password: requiredEnvVar('SESSION_PASSWORD'),
+    });
+    // Store the URL that the user tried to access, so that they
+    // can be redirected back here after logging in
+    session.redirAfterLogin = destinationPath;
+    await session.save();
+  }
 
   return {
     redirect: {
-      destination: z.getLoginUrl(`${protocol}://${host}/`, scopes),
+      destination: z.getLoginUrl(`${baseUrl}/`, scopes),
       permanent: false,
     },
   };


### PR DESCRIPTION
## Description
This PR adds the option to pass a `redirect` query-parameter to the login route, which will be used to redirect the user to a specific page once logged in. 


## Screenshots
–


## Changes

* Adds an optional `redirect` query-parameter to the login route
* Reuses the `redirAfterLogin` session state to handle the actual redirection


## Notes to reviewer
Try to open routes such as http://localhost:3000/login?redirect=/organize/1/people/lists/73%3Ffilter_col_159_contains%3D2 when logged out, and see whether you end up on the right route after login or not.


## Related issues
Resolves #2247 
