### PR TITLE
Change return value to fix DST not showing correctly

### DIFF
--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -287,7 +287,7 @@ export function getDstChangeAtDate(date: dayjs.Dayjs): DSTChange | undefined {
   if (change === 0) {
     return undefined;
   }
-  return change > 0 ? 'summertime' : 'wintertime';
+  return change > 0 ? 'wintertime' : 'summertime';
 }
 
 export function getTimezoneAtDate(date: dayjs.Dayjs): number {


### PR DESCRIPTION
## Description
In `features/calendar/components/utils.ts` an utility function called `getDstChangeAtDate()` calculates the difference between the timezone offset at the beginning and end of a given day. 

This difference is then used to determine different return values.

During spring we get an hour less of time and in fall we get an hour more. Which is what I think the code reflects except when doing a conditional return of a string.

## Screenshots
![month](https://github.com/user-attachments/assets/bf139397-40b7-4430-8e5a-662f0a9abbcc)
![week](https://github.com/user-attachments/assets/8eec20bd-ecb7-49df-8471-556845525b3f)
![day](https://github.com/user-attachments/assets/24a94b61-73d0-4c37-9c94-a969d54ac30b)


## Changes

* Switches return values in util function

## Notes to reviewer

Please check Day, Week and Month view in the Calendar.

Wintertime 2024 http://localhost:3000/organize/1/projects/calendar?focusDate=2024-10-30&timeScale=month
Summertime 2025 http://localhost:3000/organize/1/projects/calendar?focusDate=2025-03-30&timeScale=month


## Related issues
Resolves #2251
