### PR TITLE
change event state from published to draft when date is cleared

### DIFF
--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -49,9 +49,7 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     const newDateIsDifferent =
       date && date != dayjs(event.published).format('YYYY-MM-DD');
 
-    if (newDateIsDifferent) {
-      setPublished(date);
-    }
+    date && newDateIsDifferent ? setPublished(date) : setPublished(null);
   };
 
   const handleDelete = () => {

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -49,7 +49,13 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     const newDateIsDifferent =
       date && date != dayjs(event.published).format('YYYY-MM-DD');
 
-    date && newDateIsDifferent ? setPublished(date) : setPublished(null);
+    if (newDateIsDifferent) {
+      setPublished(date);
+    }
+
+    if (!date) {
+      setPublished(null);
+    }
   };
 
   const handleDelete = () => {


### PR DESCRIPTION
## Description
This PR changes the event state from published to draft when user clears the date field in the date picker.

## Screenshots

https://github.com/user-attachments/assets/d78cce5b-05bd-4211-9c11-d7e64ae65c02

## Related issues
Resolves #2264 
