### PR TITLE
Convert ZetkinBlocks to editorJsBlocks to make DeliveryErrors handle properly

### DIFF
--- a/src/features/emails/utils/deliveryProblems.spec.ts
+++ b/src/features/emails/utils/deliveryProblems.spec.ts
@@ -1,17 +1,29 @@
 import deliveryProblems from './deliveryProblems';
 import { ZetkinEmail } from 'utils/types/zetkin';
-import { BLOCK_TYPES, DeliveryProblem } from '../types';
+import { BlockKind, DeliveryProblem, InlineNodeKind } from '../types';
 import { FILTER_TYPE, OPERATION } from 'features/smartSearch/components/types';
 
 const mockEmailContent = JSON.stringify({
   blocks: [
     {
       data: {
+        content: [
+          {
+            kind: InlineNodeKind.STRING,
+            value: 'Hello, ',
+          },
+          {
+            kind: InlineNodeKind.VARIABLE,
+            name: 'target.first_name',
+          },
+          {
+            kind: InlineNodeKind.STRING,
+            value: '!',
+          },
+        ],
         level: 1,
-        text: 'Hello <span contenteditable="false" style="background-color: rgba(0, 0, 0, 0.1); padding: 0.1em 0.5em; border-radius: 1em; display: inline-block;" data-slug="first_name">First name</span>!',
       },
-      id: 'afcJCL8gA8',
-      type: 'header',
+      kind: BlockKind.HEADER,
     },
   ],
 });
@@ -57,20 +69,39 @@ describe('deliveryProblems()', () => {
           blocks: [
             {
               data: {
+                //No button text
                 //Invalid url
-                text: `Welcome new member, <a href="blipblop">this is a link with an invalid url</a><br>`,
+                href: 'angela',
+                tag: '21232a5f',
               },
-              id: 'w09wrejf',
-              type: BLOCK_TYPES.PARAGRAPH,
+              kind: BlockKind.BUTTON,
             },
             {
               data: {
-                //No buttonText property
                 //Invalid url
-                url: 'angela',
+                content: [
+                  {
+                    kind: InlineNodeKind.STRING,
+                    value: 'Welcome, new member! ',
+                  },
+                  {
+                    content: [
+                      {
+                        kind: InlineNodeKind.STRING,
+                        value: 'This is a link with an invalid URL.',
+                      },
+                    ],
+                    href: 'blipblop',
+                    kind: InlineNodeKind.LINK,
+                    tag: '24712a5c',
+                  },
+                  {
+                    kind: InlineNodeKind.STRING,
+                    value: 'We look forward to meeting you soon!',
+                  },
+                ],
               },
-              id: 'sldkf8ew98',
-              type: BLOCK_TYPES.BUTTON,
+              kind: BlockKind.PARAGRAPH,
             },
           ],
         }),

--- a/src/features/emails/utils/deliveryProblems.ts
+++ b/src/features/emails/utils/deliveryProblems.ts
@@ -1,8 +1,7 @@
-import { OutputData } from '@editorjs/editorjs';
-
 import blockProblems from '../components/EmailEditor/EmailSettings/utils/blockProblems';
-import { DeliveryProblem } from '../types';
+import { DeliveryProblem, EmailContent } from '../types';
 import { ZetkinEmail } from 'utils/types/zetkin';
+import zetkinBlocksToEditorjsBlocks from './zetkinBlocksToEditorjsBlocks';
 
 export default function deliveryProblems(
   email: ZetkinEmail
@@ -12,13 +11,14 @@ export default function deliveryProblems(
   if (!email.content) {
     problems.push(DeliveryProblem.EMPTY);
   } else {
-    const parsedContent: OutputData = JSON.parse(email.content);
+    const parsedContent: EmailContent = JSON.parse(email.content);
 
     if (parsedContent.blocks.length === 0) {
       problems.push(DeliveryProblem.EMPTY);
     }
+    const convertedBlocks = zetkinBlocksToEditorjsBlocks(parsedContent.blocks);
 
-    const hasProblems = parsedContent.blocks.some(
+    const hasProblems = convertedBlocks.some(
       (block) => !!blockProblems(block).length
     );
 


### PR DESCRIPTION
## Description

When investigating #2263 I found that content blocks in `deliveryProblems.ts` was passed to 
`blockProblems.ts` without being converted to match the proper data type used.

This resulted in `blockProblems()` returning an empty array because it could not find any `type` properties when 
`kind` properties were actually present.

## Screenshots

https://github.com/user-attachments/assets/1a0c1c18-3180-4fac-b111-857a46f2955b

## Changes

* Adds a conversion of blocks in `deliveryProblems.ts`


## Notes to reviewer
**Set as draft until tests are passing locally** 

My tests are failing locally atm, and I am not sure why at the moment. 
When logging output in the test `blockProblems()` returns an empty array.

1. Go to http://localhost:3000/organize/1/projects/35/emails
2. Create edit any email
3. Add a button
4. Click Delivery - Content Error should be displayed
5. Fill in text and link on button
6. Click Delivery - Content Error should not be displayed

## Related issues
Resolves #2263 
