### PR TITLE
Fix incorrect operator in email history filter

### DIFF
--- a/src/features/smartSearch/components/filters/EmailHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailHistory/index.tsx
@@ -177,11 +177,16 @@ const EmailHistory = ({
                 onChange={(e) => setValueToKey('operator', e.target.value)}
                 value={filter.config.operator}
               >
-                {Object.values(MESSAGE_KEY_BY_OP).map((operator) => (
-                  <MenuItem key={operator} value={operator}>
-                    <Msg id={localMessageIds.operatorSelect[operator]} />
-                  </MenuItem>
-                ))}
+                {Object.keys(MESSAGE_KEY_BY_OP).map((operator) => {
+                  const opKey = operator as keyof typeof MESSAGE_KEY_BY_OP;
+                  const messageKey = MESSAGE_KEY_BY_OP[opKey];
+
+                  return (
+                    <MenuItem key={operator} value={operator}>
+                      <Msg id={localMessageIds.operatorSelect[messageKey]} />
+                    </MenuItem>
+                  );
+                })}
               </StyledSelect>
             ),
             projectSelect:


### PR DESCRIPTION
## Description
This PR fixes a bug which was causing crashes (and invalid configs) when configurating the `email_history` Smart Search filter. The cause of the bug was that the values for `operator` were coming from the dropdown, which in turn was getting it's values from the a record which included the operator keys for _i18n messages_, not for the backend. The messages are called `notOpened` and `notSent`, so that's why the filters were being configured as such as well.

## Screenshots
![image](https://github.com/user-attachments/assets/bcddddd1-ee28-4d47-bdaa-5b1ac037006c)

## Changes
* Changes the logic so that the operator dropdown in the UI uses the keys of `MESSAGE_KEY_BY_OP` (i.e. the operators) instead of the values (i.e. the message keys)

## Notes to reviewer
None

## Related issues
Resolves #2272 