### PR TITLE
Manual merging of duplicates

### DIFF
--- a/src/features/duplicates/components/DuplicateCard.tsx
+++ b/src/features/duplicates/components/DuplicateCard.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Paper, Typography } from '@mui/material';
 import { FC, useContext, useState } from 'react';
 
 import theme from 'theme';
-import ConfigureModal from './ConfigureModal';
+import PotentialDuplicateModal from './PotentialDuplicateModal';
 import messageIds from '../l10n/messageIds';
 import { PotentialDuplicate } from '../store';
 import useDuplicatesMutations from '../hooks/useDuplicatesMutations';
@@ -64,7 +64,7 @@ const DuplicateCard: FC<DuplicateCardProps> = ({ cluster }) => {
           </Box>
         </Box>
       </Paper>
-      <ConfigureModal
+      <PotentialDuplicateModal
         onClose={() => setOpenModal(false)}
         open={openModal}
         potentialDuplicate={cluster}

--- a/src/features/duplicates/components/ManualMergingModal.tsx
+++ b/src/features/duplicates/components/ManualMergingModal.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react';
+import React from 'react';
+
+import MergeModal from './MergeModal';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import useMergePersons from '../hooks/useMergePersons';
+import { useNumericRouteParams } from 'core/hooks';
+
+interface Props {
+  initialPersons: ZetkinPerson[];
+  onClose: () => void;
+  open: boolean;
+}
+
+const ManualMergingModal: FC<Props> = ({ initialPersons, open, onClose }) => {
+  const { orgId } = useNumericRouteParams();
+  const mergePersons = useMergePersons(orgId);
+
+  return (
+    <MergeModal
+      initiallyShowManualSearch
+      onClose={onClose}
+      onMerge={(personIds, overrides) => {
+        mergePersons(personIds, overrides);
+        onClose();
+      }}
+      open={open}
+      persons={initialPersons}
+    />
+  );
+};
+
+export default ManualMergingModal;

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -20,13 +20,20 @@ import { useMessages } from 'core/i18n';
 import { ZetkinPerson } from 'utils/types/zetkin';
 
 type Props = {
+  initiallyShowManualSearch?: boolean;
   onClose: () => void;
   onMerge: (personIds: number[], overrides: Partial<ZetkinPerson>) => void;
   open: boolean;
   persons: ZetkinPerson[];
 };
 
-const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
+const MergeModal: FC<Props> = ({
+  initiallyShowManualSearch = false,
+  open,
+  onClose,
+  onMerge,
+  persons,
+}) => {
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const messages = useMessages(messageIds);
   const [additionalPeople, setAdditionalPeople] = useState<ZetkinPerson[]>([]);
@@ -60,6 +67,7 @@ const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
       <Box display="flex" flexGrow={1} overflow="hidden">
         <Box paddingX={2} sx={{ overflowY: 'auto' }} width="50%">
           <PotentialDuplicatesLists
+            initiallyShowManualSearch={initiallyShowManualSearch}
             onDeselect={(person: ZetkinPerson) => {
               const isPredefined = persons.some(
                 (predefinedPerson) => predefinedPerson.id == person.id
@@ -116,12 +124,27 @@ const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
         </Box>
       </Box>
       <DialogActions sx={{ p: 2 }}>
-        <Button onClick={() => onClose()} variant="text">
+        <Button
+          onClick={() => {
+            setAdditionalPeople([]);
+            onClose();
+          }}
+          variant="text"
+        >
           {messages.modal.cancelButton()}
         </Button>
         <Button
-          disabled={selectedIds.length > 1 ? false : true}
-          onClick={() => onMerge(selectedIds, overrides)}
+          disabled={
+            additionalPeople.length + selectedIds.length > 1 ? false : true
+          }
+          onClick={() => {
+            const idSet = new Set([
+              ...selectedIds,
+              ...additionalPeople.map((person) => person.id),
+            ]);
+            onMerge(Array.from(idSet), overrides);
+            setAdditionalPeople([]);
+          }}
           variant="contained"
         >
           {messages.modal.mergeButton()}

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -1,0 +1,114 @@
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogTitle,
+  useMediaQuery,
+} from '@mui/material';
+import { FC, useState } from 'react';
+import React, { useEffect } from 'react';
+
+import theme from 'theme';
+import FieldSettings from './FieldSettings';
+import messageIds from '../l10n/messageIds';
+import PotentialDuplicatesLists from './PotentialDuplicatesLists';
+import useFieldSettings from '../hooks/useFieldSettings';
+import { useMessages } from 'core/i18n';
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+type Props = {
+  onClose: () => void;
+  onMerge: (personIds: number[], overrides: Partial<ZetkinPerson>) => void;
+  open: boolean;
+  persons: ZetkinPerson[];
+};
+
+const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const messages = useMessages(messageIds);
+
+  const [selectedIds, setSelectedIds] = useState<number[]>(
+    persons.map((person) => person.id) ?? []
+  );
+
+  const peopleToMerge = persons.filter((person) =>
+    selectedIds.includes(person.id)
+  );
+
+  const peopleNotToMerge = persons.filter(
+    (person) => !selectedIds.includes(person.id)
+  );
+
+  const { hasConflictingValues, fieldValues, initialOverrides } =
+    useFieldSettings(peopleToMerge);
+  const [overrides, setOverrides] = useState(initialOverrides);
+
+  useEffect(() => {
+    setSelectedIds(persons.map((person) => person.id) ?? []);
+  }, [open]);
+
+  return (
+    <Dialog fullScreen={fullScreen} maxWidth={'lg'} open={open}>
+      <DialogTitle sx={{ paddingLeft: 2 }} variant="h5">
+        {messages.modal.title()}
+      </DialogTitle>
+      <Box display="flex" flexGrow={1} overflow="hidden">
+        <Box paddingX={2} sx={{ overflowY: 'auto' }} width="50%">
+          <PotentialDuplicatesLists
+            onDeselect={(person: ZetkinPerson) => {
+              const filteredIds = selectedIds.filter(
+                (item) => item !== person.id
+              );
+              setSelectedIds(filteredIds);
+            }}
+            onSelect={(person: ZetkinPerson) => {
+              const selectedIdsUpdated = [...selectedIds, person.id];
+              setSelectedIds(selectedIdsUpdated);
+            }}
+            peopleNotToMerge={peopleNotToMerge}
+            peopleToMerge={peopleToMerge}
+          />
+        </Box>
+        <Box
+          display="flex"
+          flexDirection="column"
+          marginRight={2}
+          sx={{ overflowY: 'auto' }}
+          width="50%"
+        >
+          <FieldSettings
+            duplicates={peopleToMerge}
+            fieldValues={fieldValues}
+            onChange={(field, value) => {
+              setOverrides({ ...overrides, [`${field}`]: value });
+            }}
+          />
+          <Box marginBottom={2} />
+          {hasConflictingValues && (
+            <Alert severity="warning">
+              <AlertTitle>{messages.modal.warningTitle()}</AlertTitle>
+              {messages.modal.warningMessage()}
+            </Alert>
+          )}
+        </Box>
+      </Box>
+      <DialogActions sx={{ p: 2 }}>
+        <Button onClick={() => onClose()} variant="text">
+          {messages.modal.cancelButton()}
+        </Button>
+        <Button
+          disabled={selectedIds.length > 1 ? false : true}
+          onClick={() => onMerge(selectedIds, overrides)}
+          variant="contained"
+        >
+          {messages.modal.mergeButton()}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MergeModal;

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -29,14 +29,16 @@ type Props = {
 const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
   const messages = useMessages(messageIds);
+  const [additionalPeople, setAdditionalPeople] = useState<ZetkinPerson[]>([]);
 
   const [selectedIds, setSelectedIds] = useState<number[]>(
     persons.map((person) => person.id) ?? []
   );
 
-  const peopleToMerge = persons.filter((person) =>
-    selectedIds.includes(person.id)
-  );
+  const peopleToMerge = [
+    ...persons.filter((person) => selectedIds.includes(person.id)),
+    ...additionalPeople,
+  ];
 
   const peopleNotToMerge = persons.filter(
     (person) => !selectedIds.includes(person.id)
@@ -59,14 +61,32 @@ const MergeModal: FC<Props> = ({ open, onClose, onMerge, persons }) => {
         <Box paddingX={2} sx={{ overflowY: 'auto' }} width="50%">
           <PotentialDuplicatesLists
             onDeselect={(person: ZetkinPerson) => {
-              const filteredIds = selectedIds.filter(
-                (item) => item !== person.id
+              const isPredefined = persons.some(
+                (predefinedPerson) => predefinedPerson.id == person.id
               );
-              setSelectedIds(filteredIds);
+
+              if (isPredefined) {
+                const filteredIds = selectedIds.filter(
+                  (item) => item !== person.id
+                );
+                setSelectedIds(filteredIds);
+              } else {
+                const filteredAdditionals = additionalPeople.filter(
+                  (item) => item.id != person.id
+                );
+                setAdditionalPeople(filteredAdditionals);
+              }
             }}
             onSelect={(person: ZetkinPerson) => {
-              const selectedIdsUpdated = [...selectedIds, person.id];
-              setSelectedIds(selectedIdsUpdated);
+              const isPredefined = persons.some(
+                (predefinedPerson) => predefinedPerson.id == person.id
+              );
+              if (isPredefined) {
+                const selectedIdsUpdated = [...selectedIds, person.id];
+                setSelectedIds(selectedIdsUpdated);
+              } else {
+                setAdditionalPeople([...additionalPeople, person]);
+              }
             }}
             peopleNotToMerge={peopleNotToMerge}
             peopleToMerge={peopleToMerge}

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -60,7 +60,7 @@ const MergeModal: FC<Props> = ({
   }, [open]);
 
   return (
-    <Dialog fullScreen={fullScreen} maxWidth={'lg'} open={open}>
+    <Dialog fullScreen={fullScreen} fullWidth maxWidth="lg" open={open}>
       <DialogTitle sx={{ paddingLeft: 2 }} variant="h5">
         {messages.modal.title()}
       </DialogTitle>

--- a/src/features/duplicates/components/PotentialDuplicateModal.tsx
+++ b/src/features/duplicates/components/PotentialDuplicateModal.tsx
@@ -22,13 +22,13 @@ import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinPerson } from 'utils/types/zetkin';
 
-interface ConfigureModalProps {
+interface Props {
   potentialDuplicate: PotentialDuplicate;
   onClose: () => void;
   open: boolean;
 }
 
-const ConfigureModal: FC<ConfigureModalProps> = ({
+const PotentialDuplicateModal: FC<Props> = ({
   potentialDuplicate,
   open,
   onClose,
@@ -123,4 +123,4 @@ const ConfigureModal: FC<ConfigureModalProps> = ({
   );
 };
 
-export default ConfigureModal;
+export default PotentialDuplicateModal;

--- a/src/features/duplicates/components/PotentialDuplicateModal.tsx
+++ b/src/features/duplicates/components/PotentialDuplicateModal.tsx
@@ -1,31 +1,15 @@
-import {
-  Alert,
-  AlertTitle,
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogTitle,
-  useMediaQuery,
-} from '@mui/material';
-import { FC, useState } from 'react';
-import React, { useEffect } from 'react';
+import { FC } from 'react';
+import React from 'react';
 
-import theme from 'theme';
-import FieldSettings from './FieldSettings';
-import messageIds from '../l10n/messageIds';
 import { PotentialDuplicate } from '../store';
-import PotentialDuplicatesLists from './PotentialDuplicatesLists';
 import useDuplicatesMutations from '../hooks/useDuplicatesMutations';
-import useFieldSettings from '../hooks/useFieldSettings';
-import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
-import { ZetkinPerson } from 'utils/types/zetkin';
+import MergeModal from './MergeModal';
 
 interface Props {
-  potentialDuplicate: PotentialDuplicate;
   onClose: () => void;
   open: boolean;
+  potentialDuplicate: PotentialDuplicate;
 }
 
 const PotentialDuplicateModal: FC<Props> = ({
@@ -34,92 +18,17 @@ const PotentialDuplicateModal: FC<Props> = ({
   onClose,
 }) => {
   const { orgId } = useNumericRouteParams();
-  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
-  const messages = useMessages(messageIds);
   const { mergeDuplicate } = useDuplicatesMutations(orgId);
 
-  const [selectedIds, setSelectedIds] = useState<number[]>(
-    potentialDuplicate?.duplicates.map((person) => person.id) ?? []
-  );
-
-  const peopleToMerge = potentialDuplicate?.duplicates.filter((person) =>
-    selectedIds.includes(person.id)
-  );
-
-  const peopleNotToMerge = potentialDuplicate?.duplicates.filter(
-    (person) => !selectedIds.includes(person.id)
-  );
-
-  const { hasConflictingValues, fieldValues, initialOverrides } =
-    useFieldSettings(peopleToMerge);
-  const [overrides, setOverrides] = useState(initialOverrides);
-
-  useEffect(() => {
-    setSelectedIds(
-      potentialDuplicate?.duplicates.map((person) => person.id) ?? []
-    );
-  }, [open]);
-
   return (
-    <Dialog fullScreen={fullScreen} maxWidth={'lg'} open={open}>
-      <DialogTitle sx={{ paddingLeft: 2 }} variant="h5">
-        {messages.modal.title()}
-      </DialogTitle>
-      <Box display="flex" flexGrow={1} overflow="hidden">
-        <Box paddingX={2} sx={{ overflowY: 'auto' }} width="50%">
-          <PotentialDuplicatesLists
-            onDeselect={(person: ZetkinPerson) => {
-              const filteredIds = selectedIds.filter(
-                (item) => item !== person.id
-              );
-              setSelectedIds(filteredIds);
-            }}
-            onSelect={(person: ZetkinPerson) => {
-              const selectedIdsUpdated = [...selectedIds, person.id];
-              setSelectedIds(selectedIdsUpdated);
-            }}
-            peopleNotToMerge={peopleNotToMerge}
-            peopleToMerge={peopleToMerge}
-          />
-        </Box>
-        <Box
-          display="flex"
-          flexDirection="column"
-          marginRight={2}
-          sx={{ overflowY: 'auto' }}
-          width="50%"
-        >
-          <FieldSettings
-            duplicates={peopleToMerge}
-            fieldValues={fieldValues}
-            onChange={(field, value) => {
-              setOverrides({ ...overrides, [`${field}`]: value });
-            }}
-          />
-          <Box marginBottom={2} />
-          {hasConflictingValues && (
-            <Alert severity="warning">
-              <AlertTitle>{messages.modal.warningTitle()}</AlertTitle>
-              {messages.modal.warningMessage()}
-            </Alert>
-          )}
-        </Box>
-      </Box>
-      <DialogActions sx={{ p: 2 }}>
-        <Button onClick={() => onClose()} variant="text">
-          {messages.modal.cancelButton()}
-        </Button>
-        <Button
-          disabled={selectedIds.length > 1 ? false : true}
-          onClick={() =>
-            mergeDuplicate(potentialDuplicate.id, selectedIds, overrides)
-          }
-          variant="contained"
-        >
-          {messages.modal.mergeButton()}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <MergeModal
+      onClose={onClose}
+      onMerge={(personIds, overrides) => {
+        mergeDuplicate(potentialDuplicate.id, personIds, overrides);
+      }}
+      open={open}
+      persons={potentialDuplicate.duplicates}
+    />
   );
 };
 

--- a/src/features/duplicates/components/PotentialDuplicatesLists.tsx
+++ b/src/features/duplicates/components/PotentialDuplicatesLists.tsx
@@ -9,6 +9,7 @@ import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 
 interface PotentialDuplicatesListsProps {
+  initiallyShowManualSearch: boolean;
   onDeselect: (person: ZetkinPerson) => void;
   onSelect: (person: ZetkinPerson) => void;
   peopleNotToMerge: ZetkinPerson[];
@@ -16,13 +17,16 @@ interface PotentialDuplicatesListsProps {
 }
 
 const PotentialDuplicatesLists: FC<PotentialDuplicatesListsProps> = ({
+  initiallyShowManualSearch,
   onDeselect,
   onSelect,
   peopleNotToMerge,
   peopleToMerge,
 }) => {
   const messages = useMessages(messageIds);
-  const [addingManually, setAddingManually] = useState(false);
+  const [addingManually, setAddingManually] = useState(
+    initiallyShowManualSearch
+  );
 
   return (
     <>

--- a/src/features/duplicates/components/PotentialDuplicatesLists.tsx
+++ b/src/features/duplicates/components/PotentialDuplicatesLists.tsx
@@ -48,6 +48,10 @@ const PotentialDuplicatesLists: FC<PotentialDuplicatesListsProps> = ({
       {addingManually && (
         <Box my={1}>
           <MUIOnlyPersonSelect
+            getOptionDisabled={(option) =>
+              peopleToMerge.some((person) => person.id == option.id) ||
+              peopleNotToMerge.some((person) => person.id == option.id)
+            }
             onChange={function (person: ZetkinPerson): void {
               onSelect(person);
             }}

--- a/src/features/duplicates/components/PotentialDuplicatesLists.tsx
+++ b/src/features/duplicates/components/PotentialDuplicatesLists.tsx
@@ -1,10 +1,12 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Box, Divider, Typography } from '@mui/material';
 
 import MergeCandidateList from './MergeCandidateList';
 import messageIds from '../l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import { ZetkinPerson } from 'utils/types/zetkin';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import { MUIOnlyPersonSelect } from 'zui/ZUIPersonSelect';
 
 interface PotentialDuplicatesListsProps {
   onDeselect: (person: ZetkinPerson) => void;
@@ -20,10 +22,36 @@ const PotentialDuplicatesLists: FC<PotentialDuplicatesListsProps> = ({
   peopleToMerge,
 }) => {
   const messages = useMessages(messageIds);
+  const [addingManually, setAddingManually] = useState(false);
 
   return (
     <>
-      <Typography variant="h6">{messages.modal.peopleToMerge()}</Typography>
+      <Box display="flex" justifyContent="space-between">
+        <Typography variant="h6">{messages.modal.peopleToMerge()}</Typography>
+        <ZUIEllipsisMenu
+          items={[
+            {
+              label: addingManually
+                ? messages.modal.lists.hideManual()
+                : messages.modal.lists.showManual(),
+              onSelect() {
+                setAddingManually(!addingManually);
+              },
+            },
+          ]}
+        />
+      </Box>
+      {addingManually && (
+        <Box my={1}>
+          <MUIOnlyPersonSelect
+            onChange={function (person: ZetkinPerson): void {
+              onSelect(person);
+            }}
+            placeholder={messages.modal.findCandidateManually()}
+            selectedPerson={null}
+          />
+        </Box>
+      )}
       <MergeCandidateList
         buttonLabel={messages.modal.notDuplicateButton()}
         onButtonClick={onDeselect}

--- a/src/features/duplicates/hooks/useDuplicatesMutations.tsx
+++ b/src/features/duplicates/hooks/useDuplicatesMutations.tsx
@@ -5,6 +5,7 @@ import {
   PotentialDuplicate,
 } from '../store';
 import { useApiClient, useAppDispatch } from 'core/hooks';
+import useMergePersons from './useMergePersons';
 
 type DuplicatesMutationsReturn = {
   dismissDuplicate: (duplicateId: number) => void;
@@ -20,15 +21,10 @@ export default function useDuplicatesMutations(
 ): DuplicatesMutationsReturn {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
+  const mergePersons = useMergePersons(orgId);
 
   type PotentialDuplicatePatchBody = {
     dismissed?: boolean;
-  };
-
-  type MergePostBody = {
-    objects: number[];
-    override: Partial<ZetkinPerson>;
-    type: 'person';
   };
 
   const dismissDuplicate = async (duplicateId: number) => {
@@ -47,15 +43,8 @@ export default function useDuplicatesMutations(
     duplicatesIds: number[],
     override: Partial<ZetkinPerson>
   ) => {
-    await apiClient
-      .post<ZetkinPerson, MergePostBody>(`/api/orgs/${orgId}/merges`, {
-        objects: duplicatesIds,
-        override,
-        type: 'person',
-      })
-      .then(() => {
-        dispatch(duplicateMerged(potentialDuplicateId));
-      });
+    await mergePersons(duplicatesIds, override);
+    dispatch(duplicateMerged(potentialDuplicateId));
   };
 
   return {

--- a/src/features/duplicates/hooks/useMergePersons.tsx
+++ b/src/features/duplicates/hooks/useMergePersons.tsx
@@ -1,0 +1,22 @@
+import { useApiClient, useAppDispatch } from 'core/hooks';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import { MergePostBody } from '../types';
+import { personsMerged } from 'features/profile/store';
+
+export default function useMergePersons(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  return async (personIds: number[], overrides: Partial<ZetkinPerson>) => {
+    await apiClient.post<ZetkinPerson, MergePostBody>(
+      `/api/orgs/${orgId}/merges`,
+      {
+        objects: personIds,
+        override: overrides,
+        type: 'person',
+      }
+    );
+
+    dispatch(personsMerged(personIds));
+  };
+}

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -14,7 +14,12 @@ export default makeMessages('feat.duplicates', {
       noValue: m('No value'),
       title: m('Data to merge'),
     },
+    findCandidateManually: m('Type to find another potential duplicate'),
     isDuplicateButton: m('Include'),
+    lists: {
+      hideManual: m('Hide manual search'),
+      showManual: m('Show manual search'),
+    },
     mergeButton: m('Merge'),
     notDuplicateButton: m('Exclude'),
     peopleNotBeingMerged: m('People not being merged'),

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -14,7 +14,7 @@ export default makeMessages('feat.duplicates', {
       noValue: m('No value'),
       title: m('Data to merge'),
     },
-    findCandidateManually: m('Type to find another potential duplicate'),
+    findCandidateManually: m('Type to find a potential duplicate'),
     isDuplicateButton: m('Include'),
     lists: {
       hideManual: m('Hide manual search'),

--- a/src/features/duplicates/types.ts
+++ b/src/features/duplicates/types.ts
@@ -1,0 +1,7 @@
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+export type MergePostBody = {
+  objects: number[];
+  override: Partial<ZetkinPerson>;
+  type: 'person';
+};

--- a/src/features/profile/components/PersonActionButtons.tsx
+++ b/src/features/profile/components/PersonActionButtons.tsx
@@ -1,0 +1,40 @@
+import { FC, useState } from 'react';
+
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import messageIds from '../l10n/messageIds';
+import { useMessages } from 'core/i18n';
+import ManualMergingModal from 'features/duplicates/components/ManualMergingModal';
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+type Props = {
+  person: ZetkinPerson;
+};
+
+const PersonActionButtons: FC<Props> = ({ person }) => {
+  const messages = useMessages(messageIds);
+  const [merging, setMerging] = useState(false);
+
+  return (
+    <>
+      <ZUIEllipsisMenu
+        items={[
+          {
+            label: messages.ellipsisMenu.merge(),
+            onSelect() {
+              setMerging(true);
+            },
+          },
+        ]}
+      />
+      <ManualMergingModal
+        initialPersons={[person]}
+        onClose={() => {
+          setMerging(false);
+        }}
+        open={merging}
+      />
+    </>
+  );
+};
+
+export default PersonActionButtons;

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -16,6 +16,9 @@ export default makeMessages('feat.profile', {
   editButtonClose: m<{ title: string }>('Stop editing {title}'),
   editButtonLabel: m('Edit Details'),
   editPersonHeader: m<{ person: string }>('Edit {person}'),
+  ellipsisMenu: {
+    merge: m('Merge with...'),
+  },
   genders: {
     f: m('Female'),
     m: m('Male'),

--- a/src/features/profile/layout/SinglePersonLayout.tsx
+++ b/src/features/profile/layout/SinglePersonLayout.tsx
@@ -6,6 +6,7 @@ import TabbedLayout from '../../../utils/layout/TabbedLayout';
 import { useNumericRouteParams } from 'core/hooks';
 import usePerson from '../hooks/usePerson';
 import { Msg, useMessages } from 'core/i18n';
+import PersonActionButtons from '../components/PersonActionButtons';
 
 interface SinglePersonLayoutProps {
   children: React.ReactNode;
@@ -26,6 +27,7 @@ const SinglePersonLayout: FunctionComponent<SinglePersonLayoutProps> = ({
 
   return (
     <TabbedLayout
+      actionButtons={<PersonActionButtons person={person} />}
       avatar={`/api/orgs/${orgId}/people/${personId}/avatar`}
       baseHref={`/organize/${orgId}/people/${personId}`}
       defaultTab="/"

--- a/src/features/profile/store.ts
+++ b/src/features/profile/store.ts
@@ -98,6 +98,21 @@ const profilesSlice = createSlice({
         item.mutating = [];
       }
     },
+    personsMerged: (state, action: PayloadAction<number[]>) => {
+      const ids = action.payload;
+
+      // The first one might be stale
+      ids.forEach((id, index) => {
+        const personItem = state.personById[id];
+        if (personItem) {
+          if (index == 0) {
+            personItem.isStale = true;
+          } else {
+            personItem.deleted = true;
+          }
+        }
+      });
+    },
   },
 });
 
@@ -113,4 +128,5 @@ export const {
   personOrgRemoved,
   personUpdate,
   personUpdated,
+  personsMerged,
 } = profilesSlice.actions;


### PR DESCRIPTION
## Description
This PR adds a new way of merging duplicates, even if they haven't been found by the automated Zetkin duplicate search. It will sometimes be the case that the automated search does not find a duplicate, or that it founds some of the duplicate person records but not all of them.

In those situations, there were previously no way of merging the duplicates, but with this PR there is, either by manually initiating a merge for a single person and then adding more, or by initiating a merge from a potential duplicate and adding additional ones.

## Screenshots
### New ellipsis menu in merge modal
![image](https://github.com/user-attachments/assets/34f6ee3c-59f1-455d-804f-d4fe7c993118)

### Searching to manually add duplicate
![image](https://github.com/user-attachments/assets/c4a089d6-22bc-4e84-a1a6-0cdb94626597)

### New ellipsis menu on person profile page
![image](https://github.com/user-attachments/assets/00eb96e7-1f88-4141-875b-f85e1e582a92)

### Manually merging from profile page
![image](https://github.com/user-attachments/assets/f82732ff-cb2b-4608-9265-c8a6ce41697c)

## Changes
* Refactors `ConfigureModal` so that it extracts the bulk of the UI and logic and reuses that in two different modals: `ManualMergingModal` and `PotentialDuplicateModal`
* Refactors the `useDuplicatesMutations()` hook so that the API call is made in reusable `useMergePersons()` hook
* Adds an ellipsis menu in the `MergeModal` to show a `ZUIPersonSelect` in order to manually add people to the merge
* Adds an ellipsis menu to the person profile page to open the `ManualMergingModal` with the person already added

## Notes to reviewer
None

## Related issues
Undocumented