### PR TITLE
Types for the new design system

### DIFF
--- a/src/zui/components/ZUIButton/index.tsx
+++ b/src/zui/components/ZUIButton/index.tsx
@@ -6,13 +6,9 @@ import {
   MouseEventHandler,
 } from 'react';
 
-type ZUIButtonVariant =
-  | 'primary'
-  | 'secondary'
-  | 'tertiary'
-  | 'destructive'
-  | 'warning'
-  | 'loading';
+import { ZUISize, ZUIVariant } from '../types';
+
+type ZUIButtonVariant = ZUIVariant | 'destructive' | 'warning' | 'loading';
 
 export interface ZUIButtonProps {
   actionType?: 'button' | 'reset' | 'submit';
@@ -22,7 +18,7 @@ export interface ZUIButtonProps {
   label: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
-  size?: 'large' | 'medium' | 'small';
+  size?: ZUISize;
   startIcon?: JSX.Element;
   variant?: ZUIButtonVariant;
 }
@@ -47,9 +43,7 @@ const getColor = (variant: ZUIButtonVariant = 'secondary') => {
   }
 };
 
-const getLoadingIndicatorPadding = (
-  size: 'large' | 'medium' | 'small' = 'medium'
-) => {
+const getLoadingIndicatorPadding = (size: ZUISize = 'medium') => {
   if (size == 'large') {
     return '0.183rem 1.375rem 0.183rem 1.375rem';
   } else if (size == 'medium') {
@@ -60,7 +54,7 @@ const getLoadingIndicatorPadding = (
 };
 
 const getTextPadding = (
-  size: 'large' | 'medium' | 'small' = 'medium',
+  size: ZUISize = 'medium',
   variant: ZUIButtonVariant = 'secondary'
 ) => {
   if (size === 'large') {

--- a/src/zui/components/ZUIButtonGroup/index.tsx
+++ b/src/zui/components/ZUIButtonGroup/index.tsx
@@ -9,6 +9,7 @@ import ZUIButton, {
 import ZUIIconButton, {
   ZUIIconButtonProps,
 } from 'zui/components/ZUIIconButton';
+import { ZUIOrientation, ZUISize, ZUIVariant } from '../types';
 
 const useStyles = makeStyles({
   buttonGroup: {
@@ -49,9 +50,9 @@ const useStyles = makeStyles({
 
 interface ZUIButtonGroupProps {
   buttons: (ZUIButtonProps | ZUIIconButtonProps)[];
-  orientation?: 'horizontal' | 'vertical';
-  size?: 'large' | 'medium' | 'small';
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  orientation?: ZUIOrientation;
+  size?: ZUISize;
+  variant?: ZUIVariant;
 }
 
 const ZUIButtonGroup: FC<ZUIButtonGroupProps> = ({

--- a/src/zui/components/ZUICheckbox/index.tsx
+++ b/src/zui/components/ZUICheckbox/index.tsx
@@ -2,9 +2,9 @@ import { FormControlLabel, Typography } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { FC } from 'react';
 
-type Sizes = 'small' | 'medium' | 'large';
+import { ZUIPlacement, ZUISize } from '../types';
 
-const sizes: Record<Sizes, string> = {
+const sizes: Record<ZUISize, string> = {
   large: '1.75rem',
   medium: '1.5rem',
   small: '1.25rem',
@@ -24,7 +24,7 @@ export type ZUICheckboxProps = {
   /**
    * The placement of the label. Defaults to 'end'.
    */
-  labelPlacement?: 'bottom' | 'end' | 'start' | 'top';
+  labelPlacement?: ZUIPlacement;
 
   onChange: (newCheckedState: boolean) => void;
 
@@ -32,7 +32,7 @@ export type ZUICheckboxProps = {
    * The size of the checkbox. Defaults to 'medium'.
    * This does not affect the size of the label text.
    */
-  size?: Sizes;
+  size?: ZUISize;
 };
 
 const ZUICheckbox: FC<ZUICheckboxProps> = ({

--- a/src/zui/components/ZUIHeader/index.tsx
+++ b/src/zui/components/ZUIHeader/index.tsx
@@ -25,6 +25,7 @@ import { WithRequired } from 'utils/types';
 import { ZUIIconButtonProps } from 'zui/components/ZUIIconButton';
 import ZUIText from 'zui/components/ZUIText';
 import ZUILabel from 'zui/components/ZUILabel';
+import { ZUIPrimary, ZUISecondary } from '../types';
 
 interface ZUIHeaderProps {
   /**
@@ -43,7 +44,7 @@ interface ZUIHeaderProps {
   /**
    * Variant of actionbutton. Defaults to 'secondary'
    */
-  actionButtonVariant?: 'primary' | 'secondary';
+  actionButtonVariant?: ZUIPrimary | ZUISecondary;
 
   /**The href to an avatar */
   avatar?: string;

--- a/src/zui/components/ZUILabel/index.tsx
+++ b/src/zui/components/ZUILabel/index.tsx
@@ -1,9 +1,11 @@
 import { FC, ReactNode } from 'react';
 import { BoxProps, Typography } from '@mui/material';
 
+import { ZUIPrimary, ZUISecondary } from '../types';
+
 type ZUILabelProps = {
   children: ReactNode;
-  color?: 'primary' | 'secondary';
+  color?: ZUIPrimary | ZUISecondary;
   component?: 'div' | 'p' | 'span';
   gutterBottom?: boolean;
   noWrap?: boolean;

--- a/src/zui/components/ZUILink/index.stories.tsx
+++ b/src/zui/components/ZUILink/index.stories.tsx
@@ -15,7 +15,7 @@ export const LinkMd: Story = {
   args: {
     href: 'http://www.katt.org',
     message: 'a medium size link',
-    size: 'md',
+    size: 'medium',
   },
   render: function Render(args) {
     return (
@@ -30,7 +30,7 @@ export const LinkSm: Story = {
   args: {
     href: 'http://www.zetkin.org',
     message: 'a small size link',
-    size: 'sm',
+    size: 'small',
   },
   render: function Render(args) {
     return (

--- a/src/zui/components/ZUILink/index.tsx
+++ b/src/zui/components/ZUILink/index.tsx
@@ -3,6 +3,8 @@ import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { FC } from 'react';
 
+import { ZUISize } from '../types';
+
 const useStyles = makeStyles((theme) => ({
   link: {
     '&:hover': {
@@ -16,14 +18,14 @@ type ZUILinkProps = {
   href: string;
   message: string;
   openInNewTab?: boolean;
-  size?: 'sm' | 'md';
+  size?: ZUISize;
 };
 
 const ZUILink: FC<ZUILinkProps> = ({
   href,
   message,
   openInNewTab = false,
-  size = 'sm',
+  size = 'small',
 }) => {
   const classes = useStyles();
 
@@ -34,7 +36,7 @@ const ZUILink: FC<ZUILinkProps> = ({
       href={href}
       rel={openInNewTab ? 'noopener' : ''}
       target={openInNewTab ? '_blank' : ''}
-      variant={size == 'sm' ? 'linkSm' : 'linkMd'}
+      variant={size == 'small' ? 'linkSm' : 'linkMd'}
     >
       {message}
     </Link>

--- a/src/zui/components/ZUIRadioGroup/index.stories.tsx
+++ b/src/zui/components/ZUIRadioGroup/index.stories.tsx
@@ -12,7 +12,6 @@ type Story = StoryObj<typeof ZUIRadioGroup>;
 
 export const Primary: Story = {
   args: {
-    direction: 'column',
     helperText: 'Helper text',
     label: 'Example Form',
     labelPlacement: 'end',
@@ -28,7 +27,6 @@ export const Primary: Story = {
 
 export const Disabled: Story = {
   args: {
-    direction: 'column',
     disabled: true,
     helperText: 'Helper text',
     label: 'Example Form',
@@ -45,7 +43,6 @@ export const Disabled: Story = {
 
 export const OneDisabledOption: Story = {
   args: {
-    direction: 'column',
     label: 'Example Form',
     labelPlacement: 'end',
     options: [

--- a/src/zui/components/ZUIRadioGroup/index.tsx
+++ b/src/zui/components/ZUIRadioGroup/index.tsx
@@ -8,24 +8,22 @@ import {
 } from '@mui/material';
 import { useId } from 'react';
 
+import { ZUIOrientation, ZUIPlacement, ZUISize } from '../types';
+
 type Option = {
   disabled?: boolean;
   label: string;
   value: string;
 };
 
-type LabelPlacement = 'start' | 'end' | 'top' | 'bottom';
-type Direction = 'row' | 'column';
-type Sizes = 'small' | 'medium' | 'large';
-
-const sizes: Record<Sizes, string> = {
+const sizes: Record<ZUISize, string> = {
   large: '1.75rem',
   medium: '1.5rem',
   small: '1.25rem',
 };
 
 interface ZUIRadioButtonProps {
-  direction?: Direction;
+  orientation?: ZUIOrientation;
 
   /**
    * Set this to true if you want to disable the whole
@@ -39,7 +37,7 @@ interface ZUIRadioButtonProps {
 
   helperText?: string;
 
-  labelPlacement?: LabelPlacement;
+  labelPlacement?: ZUIPlacement;
 
   /**
    * Fires when a radio is selected.
@@ -56,7 +54,7 @@ interface ZUIRadioButtonProps {
   /**
    * Small, medium or large. Only affects the size of the radios.
    */
-  size?: Sizes;
+  size?: ZUISize;
 
   /**
    * The selected radio option.
@@ -66,7 +64,7 @@ interface ZUIRadioButtonProps {
 }
 
 const ZUIRadioGroup = ({
-  direction = 'column',
+  orientation = 'vertical',
   disabled,
   label,
   helperText,
@@ -99,7 +97,7 @@ const ZUIRadioGroup = ({
         onChange={(e) => {
           onChange(e.target.value);
         }}
-        row={direction === 'row'}
+        row={orientation === 'horizontal'}
         value={value}
       >
         {options.map((option) => {

--- a/src/zui/components/ZUISwitch/index.tsx
+++ b/src/zui/components/ZUISwitch/index.tsx
@@ -1,6 +1,8 @@
 import { FormControlLabel, Switch, Typography } from '@mui/material';
 import { FC } from 'react';
 
+import { ZUIMedium, ZUIPlacement, ZUISmall } from '../types';
+
 export type ZUISwitchProps = {
   checked: boolean;
 
@@ -14,7 +16,7 @@ export type ZUISwitchProps = {
   /**
    * Placement of the label. Defaults to 'end'.
    */
-  labelPlacement?: 'bottom' | 'end' | 'start' | 'top';
+  labelPlacement?: ZUIPlacement;
 
   onChange: (newCheckedState: boolean) => void;
 
@@ -23,7 +25,7 @@ export type ZUISwitchProps = {
    *
    * This does not affect the label size.
    */
-  size?: 'small' | 'medium';
+  size?: ZUISmall | ZUIMedium;
 };
 
 const ZUISwitch: FC<ZUISwitchProps> = ({

--- a/src/zui/components/ZUIText/index.tsx
+++ b/src/zui/components/ZUIText/index.tsx
@@ -1,6 +1,8 @@
 import { FC, ReactNode } from 'react';
 import { BoxProps, Typography } from '@mui/material';
 
+import { ZUIPrimary, ZUISecondary } from '../types';
+
 type TextVariant =
   | 'bodyMdRegular'
   | 'bodyMdSemiBold'
@@ -12,7 +14,7 @@ type TextVariant =
 
 type ZUITextProps = {
   children: ReactNode;
-  color?: 'primary' | 'secondary';
+  color?: ZUIPrimary | ZUISecondary;
   component?: 'div' | 'p' | 'span';
   gutterBottom?: boolean;
   noWrap?: boolean;

--- a/src/zui/components/ZUIToggleButton/index.tsx
+++ b/src/zui/components/ZUIToggleButton/index.tsx
@@ -3,6 +3,8 @@ import { OverridableComponent } from '@mui/material/OverridableComponent';
 import { makeStyles } from '@mui/styles';
 import { FC } from 'react';
 
+import { ZUIOrientation, ZUISize } from '../types';
+
 const useStyles = makeStyles((theme) => ({
   toggleButtonGroup: {
     '& .MuiToggleButton-root': {
@@ -80,13 +82,13 @@ interface ZUIToggleButtonProps {
    * The orientation of the row of buttons.
    * Defaults to 'horizontal'.
    */
-  orientation?: 'vertical' | 'horizontal';
+  orientation?: ZUIOrientation;
 
   /**
    * The size of the buttons.
    * Defaults to 'medium'.
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: ZUISize;
 }
 
 const isTextOption = (

--- a/src/zui/components/ZUITooltip/index.stories.tsx
+++ b/src/zui/components/ZUITooltip/index.stories.tsx
@@ -64,7 +64,7 @@ export const Left: Story = {
     arrow: true,
     children: <Button>Hover me</Button>,
     label: 'A tiny tooltip',
-    placement: 'left',
+    placement: 'start',
   },
   render: Base.render,
 };
@@ -74,7 +74,7 @@ export const Right: Story = {
     arrow: true,
     children: <Button>Hover me</Button>,
     label: 'A tiny tooltip',
-    placement: 'right',
+    placement: 'end',
   },
   render: Base.render,
 };

--- a/src/zui/components/ZUITooltip/index.tsx
+++ b/src/zui/components/ZUITooltip/index.tsx
@@ -1,6 +1,8 @@
 import { Tooltip } from '@mui/material';
 import { FC, ReactElement } from 'react';
 
+import { ZUIPlacement } from '../types';
+
 type ZUITooltipProps = {
   /**
    * If the tooltip should have a small arrow or not. Defaults to 'true'
@@ -24,7 +26,7 @@ type ZUITooltipProps = {
    * to either the top of the screen or an ancestor with hidden overflow,
    * the tooltip will instead render below the child element.
    */
-  placement: 'top' | 'bottom' | 'left' | 'right';
+  placement: ZUIPlacement;
 };
 
 const ZUITooltip: FC<ZUITooltipProps> = ({
@@ -33,8 +35,18 @@ const ZUITooltip: FC<ZUITooltipProps> = ({
   placement,
   label,
 }) => {
+  const getPlacement = () => {
+    if (placement == 'end') {
+      return 'right';
+    } else if (placement == 'start') {
+      return 'left';
+    } else {
+      return placement;
+    }
+  };
+
   return (
-    <Tooltip arrow={arrow} placement={placement} title={label}>
+    <Tooltip arrow={arrow} placement={getPlacement()} title={label}>
       {children}
     </Tooltip>
   );

--- a/src/zui/components/types.ts
+++ b/src/zui/components/types.ts
@@ -1,0 +1,13 @@
+export type ZUILarge = 'large';
+export type ZUIMedium = 'medium';
+export type ZUISmall = 'small';
+export type ZUISize = ZUILarge | ZUIMedium | ZUISmall;
+
+export type ZUIOrientation = 'horizontal' | 'vertical';
+
+export type ZUIPlacement = 'top' | 'bottom' | 'start' | 'end';
+
+export type ZUIPrimary = 'primary';
+export type ZUISecondary = 'secondary';
+export type ZUITertiary = 'tertiary';
+export type ZUIVariant = ZUIPrimary | ZUISecondary | ZUITertiary;


### PR DESCRIPTION

## Description
This PR adds a `types.ts` file to the `zui/components` folder, with the beginning of a system of shared types for things like sizes, directions etc to keep the interface of zui components as similar as possible to each other (and to avoid potential spelling mistakes in wild strings). 



