### PR TITLE
remove invalid Some option from UI

### DIFF
--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -215,11 +215,13 @@ const SurveyOption = ({
                 onChange={(e) => handleConditionSelectChange(e.target.value)}
                 value={filter.config.operator}
               >
-                {Object.values(CONDITION_OPERATOR).map((o) => (
-                  <MenuItem key={o} value={o}>
-                    <Msg id={localMessageIds.conditionSelect[o]} />
-                  </MenuItem>
-                ))}
+                {Object.values(CONDITION_OPERATOR)
+                  .filter((o) => o !== CONDITION_OPERATOR.SOME)
+                  .map((o) => (
+                    <MenuItem key={o} value={o}>
+                      <Msg id={localMessageIds.conditionSelect[o]} />
+                    </MenuItem>
+                  ))}
               </StyledSelect>
             ),
             options: (

--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -9,7 +9,7 @@ import StyledSelect from '../../inputs/StyledSelect';
 import { truncateOnMiddle } from 'utils/stringUtils';
 import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
 import {
-  CONDITION_OPERATOR,
+  SURVEY_CONDITION_OP,
   FilterConfigOrgOptions,
   NewSmartSearchFilter,
   OPERATION,
@@ -45,7 +45,7 @@ interface SurveyOptionProps {
 interface InternalConfig {
   survey?: number;
   question?: number;
-  operator: CONDITION_OPERATOR;
+  operator: SURVEY_CONDITION_OP;
   options: number[];
   organizations?: FilterConfigOrgOptions;
 }
@@ -62,7 +62,7 @@ const SurveyOption = ({
   const { filter, setConfig, setOp } = useSmartSearchFilter<InternalConfig>(
     initialFilter,
     {
-      operator: CONDITION_OPERATOR.ALL,
+      operator: SURVEY_CONDITION_OP.ALL,
       options: [],
     }
   );
@@ -163,7 +163,7 @@ const SurveyOption = ({
   const handleConditionSelectChange = (conditionValue: string) => {
     setConfig({
       ...filter.config,
-      operator: conditionValue as CONDITION_OPERATOR,
+      operator: conditionValue as SURVEY_CONDITION_OP,
     });
   };
 
@@ -215,13 +215,11 @@ const SurveyOption = ({
                 onChange={(e) => handleConditionSelectChange(e.target.value)}
                 value={filter.config.operator}
               >
-                {Object.values(CONDITION_OPERATOR)
-                  .filter((o) => o !== CONDITION_OPERATOR.SOME)
-                  .map((o) => (
-                    <MenuItem key={o} value={o}>
-                      <Msg id={localMessageIds.conditionSelect[o]} />
-                    </MenuItem>
-                  ))}
+                {Object.values(SURVEY_CONDITION_OP).map((o) => (
+                  <MenuItem key={o} value={o}>
+                    <Msg id={localMessageIds.conditionSelect[o]} />
+                  </MenuItem>
+                ))}
               </StyledSelect>
             ),
             options: (

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -42,6 +42,12 @@ export enum CONDITION_OPERATOR {
   SOME = 'some',
 }
 
+export enum SURVEY_CONDITION_OP {
+  ALL = 'all',
+  ANY = 'any',
+  NONE = 'none',
+}
+
 export enum JOURNEY_CONDITION_OP {
   ALL = 'all',
   ANY = 'any',
@@ -217,7 +223,7 @@ export interface SurveyOptionFilterConfig {
   survey: number;
   question: number;
   options: number[] | string[];
-  operator: CONDITION_OPERATOR;
+  operator: SURVEY_CONDITION_OP;
   organizations?: FilterConfigOrgOptions;
 }
 


### PR DESCRIPTION
## Description
This PR removes the invalid "Some" operator in the survey options Smart Search filter from the UI.


## Screenshots
![smart-search-wo-some](https://github.com/user-attachments/assets/22bab501-66ff-4f2b-8b3e-7990cae142e8)


## Changes

* Remove the invalid operator "Some" from the Smart Search filter of survey option "Responses to checkbox questions".


## Related issues
Resolves #2314 
