### PR TITLE
Set or clear value when switching to/from gender filter

### DIFF
--- a/src/features/smartSearch/components/filters/PersonData/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/index.tsx
@@ -98,10 +98,20 @@ const PersonData = ({
     if (field === REMOVE_FIELD) {
       setCriteria(criteria.filter((criterion) => criterion.field !== c.field));
     } else {
+      let value = c.value;
+      // Default value for gender is 'f'
+      if (field === DATA_FIELD.GENDER) {
+        value = 'f';
+      }
+
+      // It doesn't make sense to use the gender value when changing to other fields
+      if (c.field === DATA_FIELD.GENDER) {
+        value = '';
+      }
       setCriteria(
         criteria.map((criterion) => {
           return criterion.field === c.field
-            ? { ...criterion, field: field as DATA_FIELD }
+            ? { field: field as DATA_FIELD, value }
             : criterion;
         })
       );


### PR DESCRIPTION
## Description
When switching filters in smart search to gender, this PR sets 'f' as the default so that the user can press save if they want to have it as female without having to switch to male and back.
This also fixes a issue where you could enter a name, switch to gender and press save which would throw an exception.


## Screenshots
![Screenshot 2024-11-09 115301](https://github.com/user-attachments/assets/f34967cb-ed3e-40ac-8bb5-aaf7736b4007)

## Changes
* Sets the default value to 'f' when switching to gender filter
* Sets the value to empty string when switching from gender to anything else

## Related issues
Resolves #2330 
