### PR TITLE
Add button to duplicate views

### DIFF
--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -3,6 +3,7 @@ import { addBulkOptionsDef } from 'features/surveys/rpc/addBulkOptions';
 import { copyEmailDef } from 'features/emails/rpc/copyEmail';
 import { copyEventsDef } from 'features/events/rpc/copyEvents';
 import { createNewViewRouteDef } from 'features/views/rpc/createNew/server';
+import { copyViewRouteDef } from 'features/views/rpc/copy/server';
 import { deleteEventsDef } from 'features/events/rpc/deleteEvents';
 import { deleteFolderRouteDef } from 'features/views/rpc/deleteFolder';
 import { getEventStatsDef } from 'features/events/rpc/getEventStats';
@@ -25,6 +26,7 @@ export function createRPCRouter() {
 
   rpcRouter.register(deleteFolderRouteDef);
   rpcRouter.register(createNewViewRouteDef);
+  rpcRouter.register(copyViewRouteDef);
   rpcRouter.register(getSurveyStatsDef);
   rpcRouter.register(getTaskStatsRouteDef);
   rpcRouter.register(addBulkOptionsDef);

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -197,7 +197,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
                   duplicateView(
                     item.data.id,
                     item.folderId,
-                    item.title + ' - ' + messages.browser.menu.duplicate()
+                    messages.browser.menu.folderCopy({ folderName: item.title })
                   );
                 },
               },

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -56,7 +56,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
   );
   const gridApiRef = useGridApiRef();
 
-  const { deleteView } = useViewMutations(orgId);
+  const { deleteView, duplicateView } = useViewMutations(orgId);
   const { renameItem } = useViewBrowserMutations(orgId);
   const itemsFuture = useViewBrowserItems(orgId, folderId);
   const { deleteFolder, recentlyCreatedFolder } = useFolder(orgId);
@@ -186,6 +186,19 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
                 onSelect: (e) => {
                   e.stopPropagation();
                   setItemToBeMoved(item);
+                },
+              },
+              {
+                disabled: item.type != 'view',
+                id: 'duplicate-item',
+                label: messages.browser.menu.duplicate(),
+                onSelect: (e) => {
+                  e.stopPropagation();
+                  duplicateView(
+                    item.data.id,
+                    item.folderId,
+                    item.title + ' - ' + messages.browser.menu.duplicate()
+                  );
                 },
               },
             ]}

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -197,7 +197,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
                   duplicateView(
                     item.data.id,
                     item.folderId,
-                    messages.browser.menu.folderCopy({ folderName: item.title })
+                    messages.browser.menu.viewCopy({ viewName: item.title })
                   );
                 },
               },

--- a/src/features/views/hooks/useViewMutations.ts
+++ b/src/features/views/hooks/useViewMutations.ts
@@ -5,8 +5,10 @@ import {
   viewDeleted,
   viewUpdate,
   viewUpdated,
+  viewDuplicated,
 } from '../store';
 import { useApiClient, useAppDispatch } from 'core/hooks';
+import duplicate from '../rpc/copy/client';
 
 type ZetkinViewUpdateBody = Partial<Omit<ZetkinView, 'id' | 'folder'>> & {
   folder_id?: number | null;
@@ -19,6 +21,11 @@ interface UseViewMutationsReturn {
     viewId: number,
     data: ZetkinViewUpdateBody
   ) => PromiseFuture<ZetkinView>;
+  duplicateView: (
+    oldViewId: number,
+    folderId: number | null,
+    title: string
+  ) => Promise<ZetkinView>;
 }
 
 export default function useViewMutations(
@@ -56,5 +63,21 @@ export default function useViewMutations(
     dispatch(columnOrderUpdated([viewId, columnOrder]));
   };
 
-  return { deleteView, updateColumnOrder, updateView };
+  const duplicateView = async (
+    oldViewId: number,
+    folderId: number | null,
+    title: string
+  ) => {
+    const view = await apiClient.rpc(duplicate, {
+      folderId: typeof folderId == 'number' ? folderId : undefined,
+      oldViewId,
+      orgId,
+      title,
+    });
+    dispatch(viewDuplicated([view]));
+
+    return view;
+  };
+
+  return { deleteView, duplicateView, updateColumnOrder, updateView };
 }

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -31,9 +31,9 @@ export default makeMessages('feat.views', {
     menu: {
       delete: m('Delete'),
       duplicate: m('Duplicate'),
-      viewCopy: m<{ viewName: string }>('{viewName} - copy'),
       move: m('Move'),
       rename: m('Rename'),
+      viewCopy: m<{ viewName: string }>('{viewName} - copy'),
     },
     moveToFolder: m<{ folder: ReactElement }>('Move to {folder}'),
     moveToRoot: m('Move to all lists'),

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -31,6 +31,7 @@ export default makeMessages('feat.views', {
     menu: {
       delete: m('Delete'),
       duplicate: m('Duplicate'),
+      folderCopy: m<{ folderName: string }>('{folderName} - copy'),
       move: m('Move'),
       rename: m('Rename'),
     },

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -30,6 +30,7 @@ export default makeMessages('feat.views', {
     },
     menu: {
       delete: m('Delete'),
+      duplicate: m('Duplicate'),
       move: m('Move'),
       rename: m('Rename'),
     },

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -31,7 +31,7 @@ export default makeMessages('feat.views', {
     menu: {
       delete: m('Delete'),
       duplicate: m('Duplicate'),
-      folderCopy: m<{ folderName: string }>('{folderName} - copy'),
+      viewCopy: m<{ viewName: string }>('{viewName} - copy'),
       move: m('Move'),
       rename: m('Rename'),
     },

--- a/src/features/views/rpc/copy/client.ts
+++ b/src/features/views/rpc/copy/client.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { makeRPCDef } from 'core/rpc/types';
+import { ZetkinView } from 'utils/types/zetkin';
+
+export const paramsSchema = z.object({
+  folderId: z.number().or(z.undefined()),
+  oldViewId: z.number(),
+  orgId: z.number(),
+  title: z.string(),
+});
+
+export type Params = z.input<typeof paramsSchema>;
+export type Result = ZetkinView;
+
+export default makeRPCDef<Params, Result>('copyView');

--- a/src/features/views/rpc/copy/server.ts
+++ b/src/features/views/rpc/copy/server.ts
@@ -1,0 +1,80 @@
+import IApiClient from 'core/api/client/IApiClient';
+import {
+  PendingZetkinViewColumn,
+  ZetkinView,
+  ZetkinViewColumn,
+  ZetkinViewRow,
+} from '../../components/types';
+import { Params, paramsSchema, Result } from './client';
+import { ZetkinQuery } from 'utils/types/zetkin';
+
+export const copyViewRouteDef = {
+  handler: handle,
+  name: 'copyView',
+  schema: paramsSchema,
+};
+
+type ZetkinViewPostBody = Pick<ZetkinView, 'title'> & {
+  folder_id?: number;
+};
+
+async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
+  const { folderId, orgId, oldViewId, title } = params;
+
+  // Fetch info about column to copy
+  const oldView = await apiClient.get<ZetkinView>(
+    `/api/orgs/${orgId}/people/views/${oldViewId}`
+  );
+  const oldColumns = await apiClient.get<ZetkinViewColumn[]>(
+    `/api/orgs/${orgId}/people/views/${oldViewId}/columns`
+  );
+
+  // Create new table
+  const newView = await apiClient.post<ZetkinView, ZetkinViewPostBody>(
+    `/api/orgs/${orgId}/people/views`,
+    {
+      folder_id: folderId,
+      title,
+    }
+  );
+
+  // Populate new table columns
+  for await (const column of oldColumns) {
+    await apiClient.post<ZetkinViewColumn, PendingZetkinViewColumn>(
+      `/api/orgs/${orgId}/people/views/${newView.id}/columns`,
+      {
+        config: column.config,
+        description: column.description,
+        title: column.title,
+        type: column.type,
+      }
+    );
+  }
+
+  // Copy filters
+  if (
+    oldView.content_query != null &&
+    oldView.content_query.filter_spec.length != 0
+  ) {
+    apiClient.patch<ZetkinQuery[], Pick<ZetkinQuery, 'filter_spec'>>(
+      `/api/orgs/${orgId}/people/views/${newView.id}/content_query`,
+      {
+        filter_spec: oldView.content_query?.filter_spec,
+      }
+    );
+  }
+
+  // Copy manually added rows
+  const rows = await apiClient.get<ZetkinViewRow[]>(
+    `/api/orgs/${orgId}/people/views/${oldView.id}/rows`
+  );
+  if (rows.length != 0) {
+    for await (const person of rows) {
+      await apiClient.put(
+        `/api/orgs/${orgId}/people/views/${newView.id}/rows/${person.id}`
+      );
+    }
+  }
+
+  return newView;
+}

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -389,6 +389,12 @@ const viewsSlice = createSlice({
         viewItem.deleted = true;
       }
     },
+    viewDuplicated: (state, action: PayloadAction<[ZetkinView]>) => {
+      const [view] = action.payload;
+      state.viewList.items.push(
+        remoteItem(view.id, { data: view, loaded: new Date().toISOString() })
+      );
+    },
     viewLoad: (state, action: PayloadAction<number>) => {
       const viewId = action.payload;
       const item = state.viewList.items.find((item) => item.id == viewId);
@@ -562,4 +568,5 @@ export const {
   viewQueryUpdated,
   viewUpdate,
   viewUpdated,
+  viewDuplicated,
 } = viewsSlice.actions;


### PR DESCRIPTION
## Description
This PR adds a button on people page in the ellipsis menus for duplicating lists.

## Screenshots
![image](https://github.com/user-attachments/assets/253fa825-81dc-49b9-ac41-cd662d43e35e)

## Changes
* Changes the ellipsis menu on lists/views which now also shows a duplicate button if the selected item is a list, and now a folder.

## Notes to reviewer

Create a list with manually added people, and a "smart list". Both should be fully duplicated.

* Should we refer to this as duplicate or copy?
* Is it fine to use the title from the old list + " - duplicate"? (see screenshot)

## Related issues
Resolves #477 
