### PR TITLE
Fix off-by-one error in importer error messages when first row is header

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessage.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessage.tsx
@@ -17,7 +17,7 @@ type Props = {
   description?: string;
   onCheck?: (checked: boolean) => void;
   onClickBack?: () => void;
-  rowIndices?: number[];
+  rowNumbers?: number[];
   status: 'error' | 'info' | 'success' | 'warning';
   title: string;
 };
@@ -26,13 +26,11 @@ const ImportMessage: FC<Props> = ({
   description,
   onCheck,
   onClickBack,
-  rowIndices,
+  rowNumbers,
   status,
   title,
 }) => {
   const messages = useMessages(messageIds);
-
-  const rowNumbers = rowIndices?.map((rowIndex) => rowIndex + 1);
 
   return (
     <Alert

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
@@ -26,7 +26,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
       <ImportMessage
         onCheck={onCheck}
         onClickBack={onClickBack}
-        rowIndices={problem.indices}
+        rowNumbers={problem.rows}
         status="error"
         title={messages.preflight.messages.invalidFormat.title({
           field: getFieldTitle(problem.field),
@@ -52,7 +52,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
         description={messages.preflight.messages.missingIdAndName.description()}
         onCheck={onCheck}
         onClickBack={onClickBack}
-        rowIndices={problem.indices}
+        rowNumbers={problem.rows}
         status="error"
         title={messages.preflight.messages.missingIdAndName.title()}
       />
@@ -103,7 +103,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
         description={messages.preflight.messages.unknownPerson.description()}
         onCheck={onCheck}
         onClickBack={onClickBack}
-        rowIndices={problem.indices}
+        rowNumbers={problem.rows}
         status="error"
         title={messages.preflight.messages.unknownPerson.title()}
       />
@@ -114,7 +114,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
         description={messages.preflight.messages.unknownError.description()}
         onCheck={onCheck}
         onClickBack={onClickBack}
-        rowIndices={problem.indices}
+        rowNumbers={problem.rows}
         status="error"
         title={messages.preflight.messages.unknownError.title()}
       />

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -59,6 +59,13 @@ export default function usePreflight(orgId: number) {
     );
   }
 
+  const rowModifier = sheet.firstRowIsHeaders ? 2 : 1;
+  problems.map((problem) => {
+    if ('indices' in problem) {
+      problem.rows = problem.indices.map((index) => index + rowModifier);
+    }
+  });
+
   const hasError = problems.some(
     (problem) => levelForProblem(problem) == 'error'
   );

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -60,10 +60,11 @@ export default function usePreflight(orgId: number) {
   }
 
   const rowModifier = sheet.firstRowIsHeaders ? 2 : 1;
-  problems.map((problem) => {
+  problems.forEach((problem) => {
     if ('indices' in problem) {
       problem.rows = problem.indices.map((index) => index + rowModifier);
     }
+    return problem;
   });
 
   const hasError = problems.some(

--- a/src/features/import/utils/problems/types.ts
+++ b/src/features/import/utils/problems/types.ts
@@ -14,6 +14,7 @@ export type ImportFieldProblem = {
   field: string;
   indices: number[];
   kind: ImportProblemKind.INVALID_FORMAT;
+  rows?: number[];
 };
 
 export type ImportFieldMetaProblem = {
@@ -29,6 +30,7 @@ export type ImportRowProblem = {
     | ImportProblemKind.UNEXPECTED_ERROR
     | ImportProblemKind.UNKNOWN_PERSON
     | ImportProblemKind.UNKNOWN_ERROR;
+  rows?: number[];
 };
 
 export type ImportSheetProblem = {


### PR DESCRIPTION
## Description
This PR fixes the off-by-one error in the importer error messages when the first row of the imported document is a header.


## Screenshots
![image](https://github.com/user-attachments/assets/4ac3901c-4cab-424e-860f-f164e3f7d3ba)

## Changes
* Changes `ImportRowProblem` and `ImportFieldProblem` types to also include an array `rows` in addition to `indices`.
* Changes `usePreflight` to map indices to rows, +1 or +2 depending on whether the first row is a header.
* Renames the `rowIndices` property to `rowNumbers` in `ImportMessage` in order to reflect the fact that these are row numbers and not merely indices of the array.
* Passes `problem.rows` instead of `problem.indices` to `ImportMessage` in `ImportMessageItem`
* Removes mapping of indices to rows from `ImportMessage`

## Related issues
Resolves #2325 