### PR TITLE
Caller instruction form minimum height

### DIFF
--- a/src/features/callAssignments/components/CallerInstructions.tsx
+++ b/src/features/callAssignments/components/CallerInstructions.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  Link,
-  Paper,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material';
+import { Box, Button, Link, Paper, Typography } from '@mui/material';
 import { useContext, useState } from 'react';
 
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
@@ -27,9 +19,6 @@ const CallerInstructions = ({
   const messages = useMessages(messageIds);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
 
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
   const {
     hasNewText,
     instructions,
@@ -49,14 +38,13 @@ const CallerInstructions = ({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        maxHeight: isMobile ? '90vh' : 'calc(100vh - 300px)',
-        minHeight: 0,
       }}
     >
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
+          maxHeight: 'calc(max(35ch, 100vh - 300px))',
           minHeight: 0,
           padding: 2,
         }}


### PR DESCRIPTION
## Description
This PR sets the minimum max-height of the caller instruction form. Just setting min-height didn't work since max-height is dependent on the viewport height, which means that max-height would be less than min-height.

## Screenshots
![Screen Shot 2024-11-09 at 14 45 57](https://github.com/user-attachments/assets/cf394ab9-3759-4744-8ee0-1148ced1ee03)

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds `maxHeight: 'calc(max(35ch, 100vh - 300px))'` to the input form

## Notes to reviewer
35ch is a magic number which looked good. Since it uses the size of a character it should be fine in most browsers, but best to test if it looks good on multiple machines.


## Related issues
Resolves #2304 
