### PR TITLE
Fix editor.js from hijacking focus when typing '/' outside of the editor

### DIFF
--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -35,21 +35,25 @@ const SearchDialog: React.FunctionComponent<{
     setOpen(false);
   };
 
-  const handleKeydown = (e: KeyboardEvent) => {
-    if (!isUserTyping(e)) {
-      if (e.key === '/') {
-        e.preventDefault();
-        setOpen(true);
-      }
-    }
-  };
-
+  // We want this `keydown` event handler to run in the capturing-phase, and
+  // that it is only attached on mount. This is to make sure that this handler
+  // runs before the `keydown` event handler in `EmailEditorFrontend`, which
+  // stops propagation in order to prevent editor.js from hijacking focus.
   useEffect(() => {
-    document.addEventListener('keydown', handleKeydown);
-    return () => {
-      document.removeEventListener('keydown', handleKeydown);
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (!isUserTyping(e)) {
+        if (e.key === '/') {
+          e.preventDefault();
+          setOpen(true);
+        }
+      }
     };
-  });
+
+    document.addEventListener('keydown', handleKeydown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeydown, true);
+    };
+  }, []);
 
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChange);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,9 +1635,9 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@editorjs/editorjs@^2.28.2":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.29.0.tgz#1c9846af19b2afab62a6bb3a815641721c0587f1"
-  integrity sha512-w2BVboSHokMBd/cAOZn0UU328o3gSZ8XUvFPA2e9+ciIGKILiRSPB70kkNdmhHkuNS3q2px+vdaIFaywBl7wGA==
+  version "2.30.6"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.6.tgz#a77292da7433bc912e4beaf359b13812cab89c4d"
+  integrity sha512-6eQMc4Di3Hz9p4o+NGRgKaCeAF7eAk106m+bsDLc4eo94VGYO1M163OiGFdmanE+w503qTmXOzycWff5blEOAQ==
 
 "@editorjs/header@^2.8.1":
   version "2.8.1"


### PR DESCRIPTION
The problem arises from the editor.js having an event listener for pressing '/' even when outside of the editor. This in combination with the editor not unselecting the edited block when the editor is blurred results in a behaviour where typing '/' anywhere else on the page resets focus back into the editor.js window. See linked code [1] in the editor.js-repo. This commit fixes the issue by using `stopImmediatePropagation` on the event when the editor.js editor is mounted, but the event is triggered outside of the editor.js editor, so that the code in [1] doesn't run. This can have some side-effects, as all other subsequent keydown event handlers on `document` will also be prevented. Luckily, we only seem to have one of these currently, and this commit also makes sure that event handle fires first so that it is not prevented.

[1]: https://github.com/codex-team/editor.js/blob/58a7a9eeeadbfaef3c256576c8f37d64cb5d0edf/src/components/modules/ui.ts#L510-L513

## Description
This PR prevents editor.js from hijacking focus when typing '/' outside of the editor.

The problem arises from the editor.js having an event listener for pressing '/' even when outside of the editor. This in combination with the editor not unselecting the edited block when the editor is blurred results in a behaviour where typing '/' anywhere else on the page resets focus back into the editor.js window. See linked code [1] in the editor.js-repo.

This PR fixes the issue by using `stopImmediatePropagation` on the event when the editor.js editor is mounted, but the event is triggered outside of the editor.js editor, so that the code in [1] doesn't run. This can have some side-effects, as all other subsequent keydown event handlers on `document` will also be prevented. Luckily, we only seem to have one of these currently, and this commit also makes sure that event handle fires first so that it is not prevented.



## Screenshots


## Changes

* Add event handler that stops propagation of keyDown events from firing when editor.js would have hijacked focus
* Refactor event handler of `SearchDialog` to fire earlier and not get prevented by the fix in `EmailEditorFrontend`
* Update editor.js version to support non-English keyboard layouts for its shorcuts


## Notes to reviewer
I could not reproduce this with a Swedish keyboard layout, but changing to an English worked. After updating the package, it was possible to reproduce with both Swedish and English layouts.


## Related issues
Resolves #2282 
