### PR TITLE
Undocumented/graph logic

### DIFF
--- a/src/features/canvassAssignments/components/AreaCard.tsx
+++ b/src/features/canvassAssignments/components/AreaCard.tsx
@@ -56,7 +56,7 @@ const AreaCard: FC<AreaCardProps> = ({
         x: point.hour !== '0' ? `${point.date} ${point.hour}` : point.date,
         y: point.householdVisits,
       })),
-      id: `Household Visits`,
+      id: `Households Visited`,
     };
 
     const successfulVisitsSeries: NivoSeries = {
@@ -139,7 +139,7 @@ const AreaCard: FC<AreaCardProps> = ({
                     <MapIcon />
                   </IconButton>
                 ) : (
-                  <Tooltip title="This graph gather the visits made outside the assigned areas">
+                  <Tooltip title="This graph gathers the visits made outside the assigned areas">
                     <InfoOutlined
                       sx={{
                         color: theme.palette.secondary.main,

--- a/src/features/canvassAssignments/components/NumberCard.tsx
+++ b/src/features/canvassAssignments/components/NumberCard.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Card, CardContent, Typography, Box } from '@mui/material';
+import { Typography, Box } from '@mui/material';
 
 import theme from 'theme';
 
@@ -15,14 +15,17 @@ const NumberCard: FC<NumberCardProps> = ({
   secondNumber,
 }) => {
   return (
-    <Card
+    <Box
       sx={{
+        display: 'flex',
         flex: 1,
-        textAlign: 'center',
+        flexDirection: 'row',
+        margin: 1,
+        textAlign: 'left',
       }}
     >
-      <CardContent>
-        <Box alignItems="baseline" display="flex" justifyContent="center">
+      <Box sx={{ display: 'flex', flexDirection: 'column', marginRight: 2 }}>
+        <Box alignItems="baseline" display="flex" justifyContent="left">
           <Typography
             sx={{
               color: theme.palette.primary.main,
@@ -37,9 +40,11 @@ const NumberCard: FC<NumberCardProps> = ({
             /{secondNumber}
           </Typography>
         </Box>
-        <Typography sx={{ fontSize: 14 }}>{message}</Typography>
-      </CardContent>
-    </Card>
+        <Box>
+          <Typography sx={{ fontSize: 14 }}>{message}</Typography>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/features/canvassAssignments/utils/getAreaData.spec.ts
+++ b/src/features/canvassAssignments/utils/getAreaData.spec.ts
@@ -1,5 +1,5 @@
 import { Household } from '../types';
-import getAreasData from './getAreaData';
+import getAreaData from './getAreaData';
 
 describe('getAreasData()', () => {
   it('returns an empty array for empty input', () => {
@@ -7,7 +7,7 @@ describe('getAreasData()', () => {
     const idOfMetricThatDefinesDone = '2';
     const households: Household[] = [];
     const startDate = new Date();
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -35,7 +35,7 @@ describe('getAreasData()', () => {
       },
     ];
     const startDate = new Date();
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -63,7 +63,7 @@ describe('getAreasData()', () => {
     ];
     const startDate = new Date('2024-10-14T11:00:00.000Z');
     const endDate = new Date('2024-10-14T13:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -109,7 +109,7 @@ describe('getAreasData()', () => {
     ];
     const startDate = new Date('2024-10-13T11:00:00.000Z');
     const endDate = new Date('2024-10-14T13:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -149,7 +149,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-14T13:00:00.000Z');
     const startDate = new Date('2024-10-13T11:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -203,7 +203,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-13T13:00:00.000Z');
     const startDate = new Date('2024-10-11T11:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -277,7 +277,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-14T13:00:00.000Z');
     const startDate = new Date('2024-10-11T11:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -288,26 +288,26 @@ describe('getAreasData()', () => {
       {
         date: '2024-10-11',
         hour: '0',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-12',
         hour: '0',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-13',
         hour: '0',
-        householdVisits: 3,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-14',
         hour: '0',
-        householdVisits: 4,
-        successfulVisits: 3,
+        householdVisits: 2,
+        successfulVisits: 2,
       },
     ]);
   });
@@ -330,7 +330,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-15T08:00:00.000Z');
     const startDate = new Date('2024-10-13T10:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -370,7 +370,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-13T13:00:00.000Z');
     const startDate = new Date('2024-10-13T10:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -429,7 +429,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-13T15:00:00.000Z');
     const startDate = new Date('2024-10-13T10:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -469,8 +469,8 @@ describe('getAreasData()', () => {
       {
         date: '2024-10-13',
         hour: '15:00',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
     ]);
   });
@@ -507,7 +507,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-14T11:00:00.000Z');
     const startDate = new Date('2024-10-14T08:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -523,20 +523,20 @@ describe('getAreasData()', () => {
       {
         date: '2024-10-14',
         hour: '09:00',
-        householdVisits: 3,
-        successfulVisits: 3,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-14',
         hour: '10:00',
-        householdVisits: 3,
-        successfulVisits: 3,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-14',
         hour: '11:00',
-        householdVisits: 3,
-        successfulVisits: 3,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
     ]);
   });
@@ -566,7 +566,7 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-10-14T01:00:00.000Z');
     const startDate = new Date('2024-10-13T23:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -582,14 +582,14 @@ describe('getAreasData()', () => {
       {
         date: '2024-10-14',
         hour: '00:00',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-10-14',
         hour: '01:00',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
     ]);
   });
@@ -619,7 +619,178 @@ describe('getAreasData()', () => {
     ];
     const endDate = new Date('2024-11-01T02:00:00.000Z');
     const startDate = new Date('2024-10-31T23:00:00.000Z');
-    const output = getAreasData(
+    const output = getAreaData(
+      endDate,
+      households,
+      startDate,
+      idOfMetricThatDefinesDone
+    );
+    expect(output).toEqual([
+      {
+        date: '2024-10-31',
+        hour: '23:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '00:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '01:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '02:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+    ]);
+  });
+  it('returns correct numbers when the same household is visited more than once', () => {
+    const idOfMetricThatDefinesDone = '1';
+    const households: Household[] = [
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '1',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T23:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '2',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '3',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T01:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '4',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+    ];
+    const endDate = new Date('2024-11-01T02:00:00.000Z');
+    const startDate = new Date('2024-10-31T23:00:00.000Z');
+    const output = getAreaData(
+      endDate,
+      households,
+      startDate,
+      idOfMetricThatDefinesDone
+    );
+    expect(output).toEqual([
+      {
+        date: '2024-10-31',
+        hour: '23:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '00:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '01:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+      {
+        date: '2024-11-01',
+        hour: '02:00',
+        householdVisits: 1,
+        successfulVisits: 1,
+      },
+    ]);
+  });
+  it('returns correct numbers when there are not unique households is visited more than once in hours range', () => {
+    const idOfMetricThatDefinesDone = '1';
+    const households: Household[] = [
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '1',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T23:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '2',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '1',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T23:10:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '2',
+        title: 'household 2',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '3',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T01:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '4',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+    ];
+    const endDate = new Date('2024-11-01T02:00:00.000Z');
+    const startDate = new Date('2024-10-31T23:00:00.000Z');
+    const output = getAreaData(
       endDate,
       households,
       startDate,
@@ -649,6 +820,105 @@ describe('getAreasData()', () => {
         hour: '02:00',
         householdVisits: 2,
         successfulVisits: 2,
+      },
+    ]);
+  });
+  it('returns correct numbers when there are not unique households is visited more than once in days range instead of hours', () => {
+    const idOfMetricThatDefinesDone = '1';
+    const households: Household[] = [
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '1',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T23:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '2',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '1',
+        title: 'household 1',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '1',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T23:10:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '2',
+        title: 'household 2',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '3',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-10-31T01:10:00.000Z',
+          },
+          {
+            canvassAssId: '1',
+            id: '4',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T00:20:00.000Z',
+          },
+        ],
+      },
+      {
+        id: '3',
+        title: 'household 3',
+        visits: [
+          {
+            canvassAssId: '1',
+            id: '3',
+            noteToOfficial: null,
+            responses: [{ metricId: '1', response: 'yes' }],
+            timestamp: '2024-11-01T01:10:00.000Z',
+          },
+        ],
+      },
+    ];
+    const endDate = new Date('2024-11-02T23:00:00.000Z');
+    const startDate = new Date('2024-10-31T23:00:00.000Z');
+    const output = getAreaData(
+      endDate,
+      households,
+      startDate,
+      idOfMetricThatDefinesDone
+    );
+    expect(output).toEqual([
+      {
+        date: '2024-10-31',
+        hour: '0',
+        householdVisits: 2,
+        successfulVisits: 2,
+      },
+      {
+        date: '2024-11-01',
+        hour: '0',
+        householdVisits: 3,
+        successfulVisits: 3,
+      },
+      {
+        date: '2024-11-02',
+        hour: '0',
+        householdVisits: 3,
+        successfulVisits: 3,
       },
     ]);
   });

--- a/src/features/canvassAssignments/utils/getAreaData.spec.ts
+++ b/src/features/canvassAssignments/utils/getAreaData.spec.ts
@@ -905,8 +905,8 @@ describe('getAreasData()', () => {
       {
         date: '2024-10-31',
         hour: '0',
-        householdVisits: 2,
-        successfulVisits: 2,
+        householdVisits: 1,
+        successfulVisits: 1,
       },
       {
         date: '2024-11-01',

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -87,19 +87,19 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                     <Typography variant="h5">Progress</Typography>
                   </Box>
                   <Divider />
-                  <Box display="flex">
+                  <Box display="flex" width="100%">
                     <NumberCard
                       firstNumber={stats.num_successful_visited_households}
                       message={'Successful visits'}
                       secondNumber={stats.num_visited_households}
                     />
-
+                    <Divider flexItem orientation="vertical" />
                     <NumberCard
                       firstNumber={stats.num_visited_households}
                       message={'Households visited'}
                       secondNumber={stats.num_households}
                     />
-
+                    <Divider flexItem orientation="vertical" />
                     <NumberCard
                       firstNumber={stats.num_visited_places}
                       message={'Places visited'}

--- a/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/canvassassignments/[canvassAssId]/index.tsx
@@ -111,8 +111,15 @@ const CanvassAssignmentPage: PageWithLayout<CanvassAssignmentPageProps> = ({
                 <Grid container spacing={2}>
                   <ZUIFutures futures={{ areasStats, dataGraph }}>
                     {({ data: { areasStats, dataGraph } }) => {
-                      // Sort areas based on successful visits only
-                      const sortedAreas = areasStats.stats
+                      const filteredAreas = dataGraph
+                        .map((area) => {
+                          return areasStats.stats.filter(
+                            (item) => item.areaId === area.area.id
+                          );
+                        })
+                        .flat();
+
+                      const sortedAreas = filteredAreas
                         .map((area) => {
                           const successfulVisitsTotal =
                             dataGraph


### PR DESCRIPTION
## Description
This PR fixes the graph logic in Canvass Overview page. It makes also UI fixes. 


## Screenshots
![image](https://github.com/user-attachments/assets/9e37737e-900c-464e-ba92-a0632e092696)



## Changes
* Adds new test cases to test the logic working with unique visited households and unique successful visits
* Changes `getAreaData`() logic to work with unique visited households and unique successful visits
* Adds `.lean() ` function to models in areagraph `/route ` and fixes possible duplication of "noArea" data.
* Fixes filter of areas in `index `page
* Renames label in graph for "households visited" for consistenty
* Minor UI fixes 


## Notes to reviewer
None


## Related issues
None 
