### PR TITLE
Authorization for canvassers

### DIFF
--- a/src/app/beta/orgs/[orgId]/areas/[areaId]/tags/route.ts
+++ b/src/app/beta/orgs/[orgId]/areas/[areaId]/tags/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
+      roles: ['admin', 'organizer'],
     },
     async ({ orgId, apiClient }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/sessions/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/sessions/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
+      roles: ['admin', 'organizer'],
     },
     async ({ apiClient, orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/canvassassignments/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
+      roles: ['admin', 'organizer'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/route.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
 
-import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { PlaceModel } from 'features/canvassAssignments/models';
+import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
 
 type RouteMeta = {
   params: {
@@ -13,11 +13,10 @@ type RouteMeta = {
 };
 
 export async function PATCH(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/visits/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/households/[householdId]/visits/route.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { PlaceModel } from 'features/canvassAssignments/models';
-import asOrgAuthorized from 'utils/api/asOrgAuthorized';
+import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
 
 type RouteMeta = {
   params: {
@@ -13,11 +13,10 @@ type RouteMeta = {
 };
 
 export async function POST(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/[placeId]/households/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/households/route.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { PlaceModel } from 'features/canvassAssignments/models';
-import asOrgAuthorized from 'utils/api/asOrgAuthorized';
+import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
 
 type RouteMeta = {
   params: {
@@ -12,11 +12,10 @@ type RouteMeta = {
 };
 
 export async function POST(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/[placeId]/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/[placeId]/route.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
 
-import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { PlaceModel } from 'features/canvassAssignments/models';
+import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
 
 type RouteMeta = {
   params: {
@@ -12,11 +12,10 @@ type RouteMeta = {
 };
 
 export async function PATCH(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import mongoose from 'mongoose';
 
-import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { PlaceModel } from 'features/canvassAssignments/models';
 import { ZetkinPlace } from 'features/canvassAssignments/types';
 import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
@@ -37,11 +36,10 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
 }
 
 export async function POST(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/beta/orgs/[orgId]/places/route.ts
+++ b/src/app/beta/orgs/[orgId]/places/route.ts
@@ -4,6 +4,7 @@ import mongoose from 'mongoose';
 import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { PlaceModel } from 'features/canvassAssignments/models';
 import { ZetkinPlace } from 'features/canvassAssignments/types';
+import asCanvasserAuthorized from 'features/canvassAssignments/utils/asCanvasserAuthorized';
 
 type RouteMeta = {
   params: {
@@ -12,11 +13,10 @@ type RouteMeta = {
 };
 
 export async function GET(request: NextRequest, { params }: RouteMeta) {
-  return asOrgAuthorized(
+  return asCanvasserAuthorized(
     {
       orgId: params.orgId,
       request: request,
-      roles: ['admin', 'organizer'],
     },
     async ({ orgId }) => {
       await mongoose.connect(process.env.MONGODB_URL || '');

--- a/src/app/my/canvassassignments/[canvassAssId]/page.tsx
+++ b/src/app/my/canvassassignments/[canvassAssId]/page.tsx
@@ -1,5 +1,10 @@
 import 'leaflet/dist/leaflet.css';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+
 import MyCanvassAssignmentPage from 'features/canvassAssignments/components/MyCanvassAssignmentPage';
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinOrganization } from 'utils/types/zetkin';
 
 interface PageProps {
   params: {
@@ -7,8 +12,18 @@ interface PageProps {
   };
 }
 
-export default function Page({ params }: PageProps) {
+export default async function Page({ params }: PageProps) {
   const { canvassAssId } = params;
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
 
-  return <MyCanvassAssignmentPage canvassAssId={canvassAssId} />;
+  try {
+    await apiClient.get<ZetkinOrganization>(`/api/users/me`);
+
+    return <MyCanvassAssignmentPage canvassAssId={canvassAssId} />;
+  } catch (err) {
+    return redirect(`/login?redirect=/my/canvassassignments/${canvassAssId}`);
+  }
 }

--- a/src/app/my/canvassassignments/page.tsx
+++ b/src/app/my/canvassassignments/page.tsx
@@ -1,5 +1,5 @@
 import { headers } from 'next/headers';
-import { notFound } from 'next/navigation';
+import { redirect } from 'next/navigation';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import MyCanvassAssignmentsPage from 'features/canvassAssignments/components/MyCanvassAssignmentsPage';
@@ -16,6 +16,6 @@ export default async function Page() {
 
     return <MyCanvassAssignmentsPage />;
   } catch (err) {
-    return notFound();
+    return redirect(`/login?redirect=/my/canvassassignments`);
   }
 }

--- a/src/features/canvassAssignments/components/CanvassAssignmentMapOverlays.tsx
+++ b/src/features/canvassAssignments/components/CanvassAssignmentMapOverlays.tsx
@@ -100,7 +100,7 @@ const CanvassAssignmentMapOverlays: FC<Props> = ({
         )}
         {selectedPlace && expanded && (
           <PlaceDialog
-            canvassAssId={assignment.id}
+            assignment={assignment}
             onClose={() => {
               setExpanded(false);
             }}

--- a/src/features/canvassAssignments/components/MyCanvassAssignmentsPage.tsx
+++ b/src/features/canvassAssignments/components/MyCanvassAssignmentsPage.tsx
@@ -12,26 +12,24 @@ import {
 } from '@mui/material';
 
 import useMyCanvassAssignments from '../hooks/useMyCanvassAssignments';
-import useCanvassAssignment from '../hooks/useCanvassAssignment';
 import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFutures from 'zui/ZUIFutures';
+import { ZetkinCanvassAssignment } from '../types';
 
 const CanvassAssignmentCard: FC<{
-  assignmentId: string;
+  assignment: ZetkinCanvassAssignment;
   orgId: number;
-}> = ({ orgId, assignmentId }) => {
+}> = ({ orgId, assignment }) => {
   const router = useRouter();
-  const assignmentFuture = useCanvassAssignment(orgId, assignmentId);
   const organizationFuture = useOrganization(orgId);
 
   return (
     <ZUIFutures
       futures={{
-        assignment: assignmentFuture,
         organization: organizationFuture,
       }}
     >
-      {({ data: { assignment, organization } }) => (
+      {({ data: { organization } }) => (
         <Card>
           <CardContent>
             <Typography variant="h6">
@@ -65,7 +63,7 @@ const MyCanvassAssignmentsPage: FC = () => {
         return (
           <CanvassAssignmentCard
             key={assignment.id}
-            assignmentId={assignment.id}
+            assignment={assignment}
             orgId={assignment.organization.id}
           />
         );

--- a/src/features/canvassAssignments/components/PlaceDialog/index.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/index.tsx
@@ -5,15 +5,16 @@ import VisitWizard from './pages/VisitWizard';
 import EditPlace from './pages/EditPlace';
 import Place from './pages/Place';
 import Household from './pages/Household';
-import ZUIFuture from 'zui/ZUIFuture';
-import { ZetkinPlace } from 'features/canvassAssignments/types';
+import {
+  ZetkinCanvassAssignment,
+  ZetkinPlace,
+} from 'features/canvassAssignments/types';
 import usePlaceMutations from 'features/canvassAssignments/hooks/usePlaceMutations';
-import useCanvassAssignment from 'features/canvassAssignments/hooks/useCanvassAssignment';
 import ZUINavStack from 'zui/ZUINavStack';
 import EditHousehold from './pages/EditHousehold';
 
 type PlaceDialogProps = {
-  canvassAssId: string;
+  assignment: ZetkinCanvassAssignment;
   onClose: () => void;
   orgId: number;
   place: ZetkinPlace;
@@ -27,7 +28,7 @@ type PlaceDialogStep =
   | 'wizard';
 
 const PlaceDialog: FC<PlaceDialogProps> = ({
-  canvassAssId,
+  assignment,
   onClose,
   orgId,
   place,
@@ -37,7 +38,6 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
     orgId,
     place.id
   );
-  const assignmentFuture = useCanvassAssignment(orgId, canvassAssId);
 
   const [selectedHouseholdId, setSelectedHouseholdId] = useState<string | null>(
     null
@@ -49,87 +49,81 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
 
   return (
     <Box height="100%">
-      <ZUIFuture future={assignmentFuture}>
-        {(assignment) => {
-          return (
-            <ZUINavStack bgcolor="white" currentPage={dialogStep}>
-              <Place
-                key="place"
-                assignment={assignment}
-                onClose={onClose}
-                onCreateHousehold={(household) => {
-                  setSelectedHouseholdId(household.id);
-                  setDialogStep('household');
-                }}
-                onEdit={() => setDialogStep('edit')}
-                onSelectHousehold={(householdId: string) => {
-                  setSelectedHouseholdId(householdId);
-                  setDialogStep('household');
-                }}
-                orgId={orgId}
-                place={place}
-              />
-              <EditPlace
-                key="edit"
-                onBack={() => setDialogStep('place')}
-                onClose={onClose}
-                onSave={async (title, description) => {
-                  await updatePlace({ description, title });
-                  setDialogStep('place');
-                }}
-                place={place}
-              />
-              <Box key="household" height="100%">
-                {selectedHousehold && (
-                  <Household
-                    household={selectedHousehold}
-                    onBack={() => setDialogStep('place')}
-                    onClose={onClose}
-                    onEdit={() => setDialogStep('editHousehold')}
-                    onWizardStart={() => {
-                      setDialogStep('wizard');
-                    }}
-                    visitedInThisAssignment={selectedHousehold.visits.some(
-                      (visit) => visit.canvassAssId == canvassAssId
-                    )}
-                  />
-                )}
-              </Box>
-              <Box key="editHousehold" height="100%">
-                {selectedHousehold && (
-                  <EditHousehold
-                    household={selectedHousehold}
-                    onBack={() => setDialogStep('household')}
-                    onClose={onClose}
-                    onSave={async (title) => {
-                      await updateHousehold(selectedHousehold.id, { title });
-                      setDialogStep('household');
-                    }}
-                  />
-                )}
-              </Box>
-              <Box key="wizard" height="100%">
-                {selectedHousehold && (
-                  <VisitWizard
-                    household={selectedHousehold}
-                    metrics={assignment.metrics}
-                    onBack={() => setDialogStep('household')}
-                    onLogVisit={(responses, noteToOfficial) => {
-                      addVisit(selectedHousehold.id, {
-                        canvassAssId: assignment.id,
-                        noteToOfficial,
-                        responses,
-                        timestamp: new Date().toISOString(),
-                      });
-                      setDialogStep('place');
-                    }}
-                  />
-                )}
-              </Box>
-            </ZUINavStack>
-          );
-        }}
-      </ZUIFuture>
+      <ZUINavStack bgcolor="white" currentPage={dialogStep}>
+        <Place
+          key="place"
+          assignment={assignment}
+          onClose={onClose}
+          onCreateHousehold={(household) => {
+            setSelectedHouseholdId(household.id);
+            setDialogStep('household');
+          }}
+          onEdit={() => setDialogStep('edit')}
+          onSelectHousehold={(householdId: string) => {
+            setSelectedHouseholdId(householdId);
+            setDialogStep('household');
+          }}
+          orgId={orgId}
+          place={place}
+        />
+        <EditPlace
+          key="edit"
+          onBack={() => setDialogStep('place')}
+          onClose={onClose}
+          onSave={async (title, description) => {
+            await updatePlace({ description, title });
+            setDialogStep('place');
+          }}
+          place={place}
+        />
+        <Box key="household" height="100%">
+          {selectedHousehold && (
+            <Household
+              household={selectedHousehold}
+              onBack={() => setDialogStep('place')}
+              onClose={onClose}
+              onEdit={() => setDialogStep('editHousehold')}
+              onWizardStart={() => {
+                setDialogStep('wizard');
+              }}
+              visitedInThisAssignment={selectedHousehold.visits.some(
+                (visit) => visit.canvassAssId == assignment.id
+              )}
+            />
+          )}
+        </Box>
+        <Box key="editHousehold" height="100%">
+          {selectedHousehold && (
+            <EditHousehold
+              household={selectedHousehold}
+              onBack={() => setDialogStep('household')}
+              onClose={onClose}
+              onSave={async (title) => {
+                await updateHousehold(selectedHousehold.id, { title });
+                setDialogStep('household');
+              }}
+            />
+          )}
+        </Box>
+        <Box key="wizard" height="100%">
+          {selectedHousehold && (
+            <VisitWizard
+              household={selectedHousehold}
+              metrics={assignment.metrics}
+              onBack={() => setDialogStep('household')}
+              onLogVisit={(responses, noteToOfficial) => {
+                addVisit(selectedHousehold.id, {
+                  canvassAssId: assignment.id,
+                  noteToOfficial,
+                  responses,
+                  timestamp: new Date().toISOString(),
+                });
+                setDialogStep('place');
+              }}
+            />
+          )}
+        </Box>
+      </ZUINavStack>
     </Box>
   );
 };

--- a/src/features/canvassAssignments/utils/asCanvasserAuthorized.ts
+++ b/src/features/canvassAssignments/utils/asCanvasserAuthorized.ts
@@ -1,0 +1,59 @@
+import mongoose from 'mongoose';
+import { IncomingHttpHeaders } from 'http';
+import { NextResponse } from 'next/server';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinMembership } from 'utils/types/zetkin';
+import { ApiClientError } from 'core/api/errors';
+import { CanvassAssignmentModel } from '../models';
+
+type GuardedFnProps = {
+  apiClient: BackendApiClient;
+  orgId: number;
+  role: string | null;
+};
+
+type GuardedFn = (props: GuardedFnProps) => Promise<Response>;
+
+type AuthParams = {
+  orgId: number | string;
+  request: Request;
+};
+
+export default async function asCanvasserAuthorized(
+  params: AuthParams,
+  fn: GuardedFn
+): Promise<Response> {
+  const { request, orgId } = params;
+  const headers: IncomingHttpHeaders = {};
+  request.headers.forEach((value, key) => (headers[key] = value));
+  const apiClient = new BackendApiClient(headers);
+
+  try {
+    const membership = await apiClient.get<ZetkinMembership>(
+      `/api/users/me/memberships/${orgId}`
+    );
+
+    await mongoose.connect(process.env.MONGODB_URL || '');
+    const assignmentModels = await CanvassAssignmentModel.find({
+      orgId: membership.organization.id,
+      'sessions.personId': { $eq: membership.profile.id },
+    });
+
+    if (!assignmentModels.length) {
+      return new NextResponse(null, { status: 403 });
+    }
+
+    return fn({
+      apiClient: apiClient,
+      orgId: membership.organization.id,
+      role: membership.role,
+    });
+  } catch (err) {
+    if (err instanceof ApiClientError) {
+      return new NextResponse(null, { status: err.status });
+    } else {
+      return new NextResponse(null, { status: 500 });
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR changes authorization logic for API routes and pages that relate to canvassers, so that a user that is added as a canvasser can interact with them without being an admin or organizer.

## Screenshots
No visual changs

## Changes
* Add logic to redirect unauthenticated users from the canvasser pages to the login page
* Adds `asCanvasserAuthenticated` as an alternative to `asOrgAuthorized`
* Remove use of `useCanvassAssignment()` in some places, because it relies on the /orgs/ID/canvassassignments endpoint that is only available to officials
* Update access restrictions on all /places to allow access for canvassers
* Add organizer access to some endpoints that were incorrectly just allowing admins

## Notes to reviewer
Make sure to try this by logging in as testuser@example.com or testcaller@example.com, and that all of the canvasser flows still work (provided that the person is added as a canvasser).

Below is my breakdown of what the correct auth levels are, and which ones I have updated to be correct.

![image](https://github.com/user-attachments/assets/442a239f-0263-4a3f-9169-9d13031aece4)

## Related issues
Undocumented