### PR TITLE
Fix incorrectly hardcoded path to avatars in canvass assignments

### DIFF
--- a/src/features/canvassAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/canvassAssignments/components/OrganizerMapRenderer.tsx
@@ -479,7 +479,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                               >
                                 <ZUIAvatar
                                   size={zoom >= 16 ? 'sm' : 'xs'}
-                                  url={`/api/orgs/1/people/${person.id}/avatar`}
+                                  url={`/api/orgs/${assignment.organization.id}/people/${person.id}/avatar`}
                                 />
                               </Box>
                             );


### PR DESCRIPTION
## Description
This PR fixes a silly but easy-to-make mistake that I made when I first built the canvass assignments feature back in #2146, where the organization ID is hardcoded in the path to avatars that are rendered on the organizer map.

## Screenshots
None

## Changes
* Changes a hardcoded `1` to instead use the organization ID of the assignment in the avatar URL

## Notes to reviewer
This is difficult to test in our dev environment, because all people exist in organization 1. But try to work in org 2, and look in the network panel to make sure that the URLs contain 2 as the org ID.

## Related issues
Undocumented