### PR TITLE
Fix issue with German translation

### DIFF
--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -2030,7 +2030,7 @@ feat:
       submit: Übermitteln
       terms:
         description: Wenn Du diese Umfrage abschickst, werden die von Dir zur Verfügung
-          gestellten Informationen in Zetkin von {Organisation} gespeichert und verarbeitet,
+          gestellten Informationen in Zetkin von {organization} gespeichert und verarbeitet,
           um in Übereinstimmung mit den Zetkin-Datenschutzhinweisen Aktivitäten der
           Partei Die Linke zu organisieren.
         title: Datenschutzhinweise


### PR DESCRIPTION
## Description
This PR fixes a German translation (via translate.zetkin.org) that was causing the bug documented in #2303.

## Screenshots
![image](https://github.com/user-attachments/assets/02641577-e088-42c9-8901-39d2f6f36018)


## Changes
* Fixes incorrect variable name in German translation

## Notes to reviewer
None

## Related issues
This was causing the bug documented in #2303