### PR TITLE
Fix access bugs in canvass assignments

### DIFF
--- a/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/sessions/route.ts
+++ b/src/app/beta/orgs/[orgId]/canvassassignments/[canvassAssId]/sessions/route.ts
@@ -35,9 +35,14 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
       const sessions: ZetkinCanvassSession[] = [];
 
       for await (const sessionData of model.sessions) {
-        const person = await apiClient.get<ZetkinPerson>(
-          `/api/orgs/${orgId}/people/${sessionData.personId}`
-        );
+        let person: ZetkinPerson | null;
+        try {
+          person = await apiClient.get<ZetkinPerson>(
+            `/api/orgs/${orgId}/people/${sessionData.personId}`
+          );
+        } catch (err) {
+          person = null;
+        }
         const area = await AreaModel.findOne({
           _id: sessionData.areaId,
         });

--- a/src/features/canvassAssignments/utils/asCanvasserAuthorized.ts
+++ b/src/features/canvassAssignments/utils/asCanvasserAuthorized.ts
@@ -34,14 +34,19 @@ export default async function asCanvasserAuthorized(
       `/api/users/me/memberships/${orgId}`
     );
 
-    await mongoose.connect(process.env.MONGODB_URL || '');
-    const assignmentModels = await CanvassAssignmentModel.find({
-      orgId: membership.organization.id,
-      'sessions.personId': { $eq: membership.profile.id },
-    });
+    if (!membership.role) {
+      await mongoose.connect(process.env.MONGODB_URL || '');
+      const assignmentModels = await CanvassAssignmentModel.find({
+        orgId: membership.organization.id,
+        'sessions.personId': { $eq: membership.profile.id },
+      });
 
-    if (!assignmentModels.length) {
-      return new NextResponse(null, { status: 403 });
+      if (!assignmentModels.length) {
+        return NextResponse.json(
+          { error: { title: 'Must be canvasser' } },
+          { status: 403 }
+        );
+      }
     }
 
     return fn({


### PR DESCRIPTION
## Description
This PR fixes three problems with the access to places for canvassers and non-canvassers. Before this fix, an official (organizer/admin) who was not also a canvasser would not be able to access places in the experimental canvassing API. This would have been resolved in the real API before release anyway, but since we are conducting user tests right now it's best to fix it in the experimental API as well.

## Screenshots
None

## Changes
* Changes `asCanvasserAuthorized()` to always allow officials (organizers/admins) to access those routes
* Changes `asCanvasserAuthorized()` to always return JSON, even when there are errors (to avoid a client-side exception from being thrown when trying to parse an empty body)
* Adds try/catch to ignore canvass sessions that were assigned to a person who no longer exists

## Notes to reviewer
Please make sure that both organizing and conducting a canvass assignment works.

## Related issues
The main bug in this PR was introduced in #2347.