### PR TITLE
Revert #2341

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -118,25 +118,6 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       },
     };
 
-    // What this event handler does is prevent the editor.js-window from
-    // hijacking the focus when typing a '/' anywhere else outside of the editor
-    // Unfortunately, this is not an ideal fix, as it prevents any other event
-    // handlers from firing, not just the ones inside the editor.js, unless they
-    // were added before this one.
-    // This seems to be the only viable fix, since there is no way to disable
-    // the event listeners in editor.js, except by making the editor readonly,
-    // which we obviously don't want to do.
-    // This is where the event handlers are attached: https://github.com/codex-team/editor.js/blob/58a7a9eeeadbfaef3c256576c8f37d64cb5d0edf/src/components/modules/ui.ts#L393-L395
-    const keyDownHandler = (e: KeyboardEvent) => {
-      const inside = !!(e.target as HTMLElement).closest?.(
-        '#ClientOnlyEditor-container'
-      );
-      if (!inside) {
-        e.stopImmediatePropagation();
-      }
-    };
-    document.addEventListener('keydown', keyDownHandler, true);
-
     // Create the EditorJS instance
     editorInstance.current = new EditorJS(editorConfig);
 
@@ -148,7 +129,6 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
     setEditorJSApiRef();
 
     return () => {
-      document.removeEventListener('keydown', keyDownHandler, true);
       // Cleanup when the component is unmounted
       if (editorInstance.current) {
         try {

--- a/src/features/search/components/SearchDialog/index.tsx
+++ b/src/features/search/components/SearchDialog/index.tsx
@@ -35,25 +35,21 @@ const SearchDialog: React.FunctionComponent<{
     setOpen(false);
   };
 
-  // We want this `keydown` event handler to run in the capturing-phase, and
-  // that it is only attached on mount. This is to make sure that this handler
-  // runs before the `keydown` event handler in `EmailEditorFrontend`, which
-  // stops propagation in order to prevent editor.js from hijacking focus.
-  useEffect(() => {
-    const handleKeydown = (e: KeyboardEvent) => {
-      if (!isUserTyping(e)) {
-        if (e.key === '/') {
-          e.preventDefault();
-          setOpen(true);
-        }
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (!isUserTyping(e)) {
+      if (e.key === '/') {
+        e.preventDefault();
+        setOpen(true);
       }
-    };
+    }
+  };
 
-    document.addEventListener('keydown', handleKeydown, true);
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeydown);
     return () => {
-      document.removeEventListener('keydown', handleKeydown, true);
+      document.removeEventListener('keydown', handleKeydown);
     };
-  }, []);
+  });
 
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChange);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,9 +1635,9 @@
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
 "@editorjs/editorjs@^2.28.2":
-  version "2.30.6"
-  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.6.tgz#a77292da7433bc912e4beaf359b13812cab89c4d"
-  integrity sha512-6eQMc4Di3Hz9p4o+NGRgKaCeAF7eAk106m+bsDLc4eo94VGYO1M163OiGFdmanE+w503qTmXOzycWff5blEOAQ==
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.29.0.tgz#1c9846af19b2afab62a6bb3a815641721c0587f1"
+  integrity sha512-w2BVboSHokMBd/cAOZn0UU328o3gSZ8XUvFPA2e9+ciIGKILiRSPB70kkNdmhHkuNS3q2px+vdaIFaywBl7wGA==
 
 "@editorjs/header@^2.8.1":
   version "2.8.1"


### PR DESCRIPTION
## Description
This PR reverts the changes from #2341, after it was found that they introduced bugs that are more critical than the ones they were fixing. The following bugs were introduced:

* The upgrade of Editor.js broke the inline tool menu (links, variables, bold, italic etc)
* Search modal could not be closed using the ESC button

## Screenshots
Non

## Changes
* Reverts changes from #2341 

## Notes to reviewer
None

## Related issues
Reopens #2282 