### PR TITLE
JoinForm gender field

### DIFF
--- a/src/core/i18n/globalMessageIds.ts
+++ b/src/core/i18n/globalMessageIds.ts
@@ -7,8 +7,8 @@ export default makeMessages('glob', {
     readonly: m('Read-only'),
   },
   genderOptions: {
-    f: m('Male'),
-    m: m('Female'),
+    f: m('Female'),
+    m: m('Male'),
     o: m('Other'),
     unspecified: m('Unspecified'),
   },

--- a/src/core/i18n/globalMessageIds.ts
+++ b/src/core/i18n/globalMessageIds.ts
@@ -6,6 +6,12 @@ export default makeMessages('glob', {
     edit: m('Editing'),
     readonly: m('Read-only'),
   },
+  genderOptions: {
+    f: m('Male'),
+    m: m('Female'),
+    o: m('Other'),
+    unspecified: m('Unspecified'),
+  },
   personFields: {
     alt_phone: m('Alternate Phone Number'),
     city: m('City'),

--- a/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
+++ b/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
@@ -22,10 +22,15 @@ export default async function submitJoinForm(
     Iron.defaults
   )) as EmbeddedJoinFormData;
 
-  const outputFormData: Record<string, string> = {};
+  const outputFormData: Record<string, string | null> = {};
 
   joinFormInfo.fields.forEach((field) => {
-    outputFormData[field.s] = inputFormData.get(field.s)?.toString() || '';
+    const value = inputFormData.get(field.s)?.toString() || '';
+    if (field.s == 'gender' && value == 'unspecified') {
+      outputFormData[field.s] = null;
+    } else {
+      outputFormData[field.s] = value;
+    }
   });
 
   await apiClient.post(

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -64,7 +64,14 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
                 <label>
                   {label}
                   <div>
-                    {field.s != 'gender' && <input name={field.s} />}
+                    {field.s != 'gender' && (
+                      <input
+                        name={field.s}
+                        required={
+                          field.s == 'first_name' || field.s == 'last_name'
+                        }
+                      />
+                    )}
                     {field.s == 'gender' && (
                       <select name={field.s}>
                         <option value="unspecified">

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -64,7 +64,23 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
                 <label>
                   {label}
                   <div>
-                    <input name={field.s} />
+                    {field.s != 'gender' && <input name={field.s} />}
+                    {field.s == 'gender' && (
+                      <select name={field.s}>
+                        <option value="unspecified">
+                          {globalMessages.genderOptions.unspecified()}
+                        </option>
+                        <option value="m">
+                          {globalMessages.genderOptions.m()}
+                        </option>
+                        <option value="f">
+                          {globalMessages.genderOptions.f()}
+                        </option>
+                        <option value="o">
+                          {globalMessages.genderOptions.o()}
+                        </option>
+                      </select>
+                    )}
                   </div>
                 </label>
               </div>


### PR DESCRIPTION
## Description
This PR modifies embeddable join forms so that the "gender" field is no longer a text input field, but a dropdown with only the allowed values as options.

## Screenshots
![image](https://github.com/user-attachments/assets/8f5a2300-27c5-4169-af76-bddd9fa3eb0f)

## Changes
* Changes the `gender` field to be rendered with a `<select>`
* Changes the `first_name` and `last_name` fields to be required

## Notes to reviewer
None

## Related issues
Resolves #2365 