### PR TITLE
Issue 2158:  Store utility methods

### DIFF
--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import {
-  findOrAddItem,
+  getOrAddItemToList,
   remoteItem,
   remoteList,
   RemoteList,
@@ -64,7 +64,7 @@ const areasSlice = createSlice({
     },
     areaUpdated: (state, action: PayloadAction<ZetkinArea>) => {
       const area = action.payload;
-      const item = findOrAddItem(state.areaList, area.id);
+      const item = getOrAddItemToList(state.areaList, area.id);
 
       item.data = area;
       item.loaded = new Date().toISOString();
@@ -82,7 +82,7 @@ const areasSlice = createSlice({
     tagAssigned: (state, action: PayloadAction<[string, ZetkinTag]>) => {
       const [areaId, tag] = action.payload;
       state.tagsByAreaId[areaId] ||= remoteList();
-      const tagItem = findOrAddItem(state.tagsByAreaId[areaId], tag.id);
+      const tagItem = getOrAddItemToList(state.tagsByAreaId[areaId], tag.id);
       tagItem.data = tag;
       tagItem.loaded = new Date().toISOString();
 

--- a/src/features/canvassAssignments/store.ts
+++ b/src/features/canvassAssignments/store.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import {
-  findOrAddItem,
+  getOrAddItemToList,
   RemoteItem,
   remoteItem,
   remoteList,
@@ -161,7 +161,10 @@ const canvassAssignmentSlice = createSlice({
       action: PayloadAction<ZetkinCanvassAssignment>
     ) => {
       const assignment = action.payload;
-      const item = findOrAddItem(state.canvassAssignmentList, assignment.id);
+      const item = getOrAddItemToList(
+        state.canvassAssignmentList,
+        assignment.id
+      );
 
       item.data = assignment;
       item.loaded = new Date().toISOString();
@@ -248,7 +251,7 @@ const canvassAssignmentSlice = createSlice({
     },
     placeUpdated: (state, action: PayloadAction<ZetkinPlace>) => {
       const place = action.payload;
-      const item = findOrAddItem(state.placeList, place.id);
+      const item = getOrAddItemToList(state.placeList, place.id);
 
       item.data = place;
       item.loaded = new Date().toISOString();

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { findOrAddItem, remoteList, RemoteList } from 'utils/storeUtils';
+import { getOrAddItemToList, remoteList, RemoteList } from 'utils/storeUtils';
 import { ZetkinJoinForm, ZetkinJoinSubmission } from './types';
 
 export interface JoinFormsStoreSlice {
@@ -19,30 +19,30 @@ const joinFormsSlice = createSlice({
   reducers: {
     joinFormCreated: (state, action: PayloadAction<ZetkinJoinForm>) => {
       const form = action.payload;
-      const item = findOrAddItem(state.formList, form.id);
+      const item = getOrAddItemToList(state.formList, form.id);
       item.loaded = new Date().toISOString();
       item.data = form;
     },
     joinFormLoad: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
-      const item = findOrAddItem(state.formList, formId);
+      const item = getOrAddItemToList(state.formList, formId);
       item.isLoading = true;
     },
     joinFormLoaded: (state, action: PayloadAction<ZetkinJoinForm>) => {
       const form = action.payload;
-      const item = findOrAddItem(state.formList, form.id);
+      const item = getOrAddItemToList(state.formList, form.id);
       item.isLoading = false;
       item.loaded = new Date().toISOString();
       item.data = form;
     },
     joinFormUpdate: (state, action: PayloadAction<[number, string[]]>) => {
       const [formId, mutating] = action.payload;
-      const item = findOrAddItem(state.formList, formId);
+      const item = getOrAddItemToList(state.formList, formId);
       item.mutating = mutating;
     },
     joinFormUpdated: (state, action: PayloadAction<ZetkinJoinForm>) => {
       const form = action.payload;
-      const item = findOrAddItem(state.formList, form.id);
+      const item = getOrAddItemToList(state.formList, form.id);
       item.data = form;
       item.mutating = [];
       item.loaded = new Date().toISOString();
@@ -56,24 +56,24 @@ const joinFormsSlice = createSlice({
     },
     submissionLoad: (state, action: PayloadAction<number>) => {
       const submissionId = action.payload;
-      const item = findOrAddItem(state.submissionList, submissionId);
+      const item = getOrAddItemToList(state.submissionList, submissionId);
       item.isLoading = true;
     },
     submissionLoaded: (state, action: PayloadAction<ZetkinJoinSubmission>) => {
       const submission = action.payload;
-      const item = findOrAddItem(state.submissionList, submission.id);
+      const item = getOrAddItemToList(state.submissionList, submission.id);
       item.isLoading = false;
       item.data = submission;
       item.loaded = new Date().toISOString();
     },
     submissionUpdate: (state, action: PayloadAction<[number, string[]]>) => {
       const [submissionId, mutating] = action.payload;
-      const item = findOrAddItem(state.submissionList, submissionId);
+      const item = getOrAddItemToList(state.submissionList, submissionId);
       item.mutating = mutating;
     },
     submissionUpdated: (state, action: PayloadAction<ZetkinJoinSubmission>) => {
       const submission = action.payload;
-      const item = findOrAddItem(state.submissionList, submission.id);
+      const item = getOrAddItemToList(state.submissionList, submission.id);
       item.mutating = [];
       item.data = submission;
       item.loaded = new Date().toISOString();

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -12,6 +12,8 @@ import {
   ZetkinSurveySubmission,
 } from 'utils/types/zetkin';
 import {
+  getOrAddItemToList,
+  getOrCreateList,
   RemoteItem,
   remoteItem,
   remoteList,
@@ -375,34 +377,30 @@ function addSubmissionToState(
   submissions: ZetkinSurveySubmission[]
 ) {
   submissions.forEach((submission) => {
-    const submissionListItem = state.submissionList.items.find(
-      (item) => item.id == submission.id
+    const remoteSubmissionBySubmissionId = getOrAddItemToList(
+      state.submissionList,
+      submission.id
     );
-    const submissionBySurveyId = state.submissionsBySurveyId[
+
+    remoteSubmissionBySubmissionId.data = {
+      ...remoteSubmissionBySubmissionId.data,
+      ...submission,
+    };
+
+    const remoteSubmissionBySurveyIdList = getOrCreateList(
+      state.submissionsBySurveyId,
       submission.survey.id
-    ]?.items.find((item) => item.id == submission.id);
+    );
 
-    if (submissionListItem) {
-      submissionListItem.data = { ...submissionListItem.data, ...submission };
-    } else {
-      state.submissionList.items.push(
-        remoteItem(submission.id, { data: submission })
-      );
-    }
+    const remoteSubmissionBySurveyId = getOrAddItemToList(
+      remoteSubmissionBySurveyIdList,
+      submission.id
+    );
 
-    if (submissionBySurveyId) {
-      submissionBySurveyId.data = {
-        ...submissionBySurveyId.data,
-        ...submission,
-      };
-    } else {
-      if (!state.submissionsBySurveyId[submission.survey.id]) {
-        state.submissionsBySurveyId[submission.survey.id] = remoteList();
-      }
-      state.submissionsBySurveyId[submission.survey.id].items.push(
-        remoteItem(submission.id, { data: submission })
-      );
-    }
+    remoteSubmissionBySurveyId.data = {
+      ...remoteSubmissionBySurveyId.data,
+      ...submission,
+    };
   });
 }
 

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -1,6 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { remoteItem, remoteList, RemoteList } from 'utils/storeUtils';
+import {
+  getOrAddItemToList,
+  getOrCreateList,
+  remoteItem,
+  remoteList,
+  RemoteList,
+} from 'utils/storeUtils';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';
 
 export interface TagsStoreSlice {
@@ -33,20 +39,9 @@ const tagsSlice = createSlice({
     },
     tagAssigned: (state, action: PayloadAction<[number, ZetkinTag]>) => {
       const [personId, tag] = action.payload;
-      if (!state.tagsByPersonId[personId]) {
-        state.tagsByPersonId[personId] = remoteList();
-      }
-      const item = state.tagsByPersonId[personId].items.find(
-        (item) => item.id == tag.id
-      );
-
-      if (item) {
-        item.data = tag;
-      } else {
-        state.tagsByPersonId[personId].items.push(
-          remoteItem(tag.id, { data: tag })
-        );
-      }
+      const remotePersonTags = getOrCreateList(state.tagsByPersonId, personId);
+      const remoteItem = getOrAddItemToList(remotePersonTags, tag.id);
+      remoteItem.data = tag;
     },
     tagCreate: (state) => {
       state.tagList.isLoading;

--- a/src/utils/storeUtils.ts
+++ b/src/utils/storeUtils.ts
@@ -1,4 +1,4 @@
-interface RemoteData {
+export interface RemoteData {
   id: number | string;
 }
 
@@ -49,16 +49,32 @@ export function remoteList<DataType extends RemoteData>(
   };
 }
 
-export function findOrAddItem<DataType extends RemoteData>(
+export function getOrAddItemToList<DataType extends RemoteData>(
   list: RemoteList<DataType>,
   id: number | string
 ): RemoteItem<DataType> {
   const existingItem = list.items.find((item) => item.id == id);
   if (existingItem) {
+    existingItem.loaded = new Date().toISOString();
     return existingItem;
   } else {
     const newItem = remoteItem<DataType>(id);
     list.items.push(newItem);
+    newItem.loaded = new Date().toISOString();
     return newItem;
+  }
+}
+
+export function getOrCreateList<
+  DataType extends RemoteData,
+  T extends string | number | symbol
+>(record: Record<T, RemoteList<DataType>>, key: T): RemoteList<DataType> {
+  const currentList = record[key];
+  if (currentList) {
+    return currentList;
+  } else {
+    const newList = remoteList<DataType>();
+    record[key] = newList;
+    return newList;
   }
 }

--- a/src/utils/storeUtils.ts
+++ b/src/utils/storeUtils.ts
@@ -71,10 +71,23 @@ export function getOrCreateList<
 >(record: Record<T, RemoteList<DataType>>, key: T): RemoteList<DataType> {
   const currentList = record[key];
   if (currentList) {
+    currentList.loaded = new Date().toISOString();
     return currentList;
   } else {
     const newList = remoteList<DataType>();
     record[key] = newList;
+    newList.loaded = new Date().toISOString();
     return newList;
   }
+}
+
+export function updateOrAddItemToList<DataType extends RemoteData>(
+  list: RemoteList<DataType>,
+  id: number | string,
+  data: DataType
+): RemoteItem<DataType> {
+  const remoteItem = getOrAddItemToList(list, id);
+  remoteItem.data = data;
+  remoteItem.loaded = new Date().toISOString();
+  return remoteItem;
 }


### PR DESCRIPTION
## Description
This PR refactors the existing store utility function and adds a new one for creating/getting lists. It refactors store methods to use the utility functions. Adds tests.


## Screenshots
No visible changes except in code.


## Changes

* Adds utility method getOrCreateList
* Changes method findOrAddItem to getOrAddItemToList
* Adds tests (TODO: currently in draft)


## Notes to reviewer
Needs more testing as of right now. Setting PR to draft.


## Related issues
Resolves #2158 
