### PR TITLE
Invalidate milestones on checkbox click

### DIFF
--- a/src/features/journeys/store.ts
+++ b/src/features/journeys/store.ts
@@ -48,9 +48,12 @@ const journeysSlice = createSlice({
       if (instanceItem) {
         instanceItem.isStale = true;
         if (instanceItem.data) {
-          if (state.timelineUpdatesByInstanceId[instanceItem.data?.id]) {
-            state.timelineUpdatesByInstanceId[instanceItem.data?.id].isStale =
-              true;
+          const { id } = instanceItem.data;
+          if (state.timelineUpdatesByInstanceId[id]) {
+            state.timelineUpdatesByInstanceId[id].isStale = true;
+          }
+          if (state.milestonesByInstanceId[id]) {
+            state.milestonesByInstanceId[id].isStale = true;
           }
         }
       }


### PR DESCRIPTION
## Description
This PR invalidates the milestones of a journey instance when updating the status. This should lead to the page automatically updating the visible UI state after a button is checked, rendering a manual reload unnecessary. 


## Screenshots
https://github.com/user-attachments/assets/b34b798c-3e3e-46ce-8fd7-bb4bfc62e32b


## Notes to reviewer
I have added a new invalidation call to `useUpdateMilestoneStatus`. It calls the new `invalidateJourneyInstanceMilestones` function which invalidates the `state.milestonesByInstanceId[instanceId]` of the passed journey id. 

I hope that this is the right way to do this. An alternative that I had considered was to instead change `invalidateJourneyInstance` which was exposed already to also invalidate the milestones but my understanding is that -since this function is also called from other places - it doesn't always warrant invalidating the milestones as well.



## Related issues
Resolves #2361 
