### PR TITLE
Add checkbox for toggling email requirement

### DIFF
--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -13,6 +13,7 @@ export default makeMessages('feat.joinForms', {
     labels: {
       addField: m('Add field'),
       description: m('Description'),
+      requireEmailVerification: m('Require e-mail verification'),
       title: m('Title'),
     },
     title: m('Edit form'),

--- a/src/features/joinForms/panes/JoinFormPane.tsx
+++ b/src/features/joinForms/panes/JoinFormPane.tsx
@@ -1,5 +1,12 @@
 import { FC, HTMLAttributes } from 'react';
-import { Autocomplete, Box, Checkbox, Chip, TextField } from '@mui/material';
+import {
+  Autocomplete,
+  Box,
+  Checkbox,
+  Chip,
+  FormControlLabel,
+  TextField,
+} from '@mui/material';
 
 import globalMessageIds from 'core/i18n/globalMessageIds';
 import messageIds from '../l10n/messageIds';
@@ -118,6 +125,8 @@ const JoinFormPane: FC<Props> = ({ orgId, formId }) => {
                   label={slugToLabel(option)}
                   {...tagProps}
                   disabled={
+                    (joinForm.requires_email_verification &&
+                      option === NATIVE_PERSON_FIELDS.EMAIL) ||
                     option === NATIVE_PERSON_FIELDS.FIRST_NAME ||
                     option === NATIVE_PERSON_FIELDS.LAST_NAME
                   }
@@ -126,6 +135,29 @@ const JoinFormPane: FC<Props> = ({ orgId, formId }) => {
             })
           }
           value={joinForm.fields}
+        />
+      </Box>
+      <Box mb={1}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={joinForm.requires_email_verification}
+              onChange={(evt) =>
+                updateForm({
+                  fields:
+                    evt.target.checked &&
+                    !joinForm?.fields.includes(NATIVE_PERSON_FIELDS.EMAIL)
+                      ? [
+                          ...(joinForm?.fields ?? []),
+                          NATIVE_PERSON_FIELDS.EMAIL,
+                        ]
+                      : undefined,
+                  requires_email_verification: evt.target.checked,
+                })
+              }
+            />
+          }
+          label={messages.formPane.labels.requireEmailVerification()}
         />
       </Box>
     </>

--- a/src/features/joinForms/types.ts
+++ b/src/features/joinForms/types.ts
@@ -14,6 +14,7 @@ export type ZetkinJoinForm = {
     title: string;
   };
   renderable: boolean;
+  requires_email_verification: boolean;
   submit_token: string;
   tags: {
     id: number;

--- a/src/features/views/components/PeopleActionButton.tsx
+++ b/src/features/views/components/PeopleActionButton.tsx
@@ -78,7 +78,7 @@ const PeopleActionButton: FC<PeopleActionButtonProps> = ({
             onClick: async () => {
               router.push(`/organize/${orgId}/people/joinforms`);
               await createForm({
-                fields: ['first_name', 'last_name'],
+                fields: ['first_name', 'last_name', 'email'],
                 title: joinFormMessages.defaultTitle(),
               });
             },

--- a/src/features/views/components/PeopleActionButton.tsx
+++ b/src/features/views/components/PeopleActionButton.tsx
@@ -79,6 +79,7 @@ const PeopleActionButton: FC<PeopleActionButtonProps> = ({
               router.push(`/organize/${orgId}/people/joinforms`);
               await createForm({
                 fields: ['first_name', 'last_name', 'email'],
+                requires_email_verification: true,
                 title: joinFormMessages.defaultTitle(),
               });
             },


### PR DESCRIPTION
## Description
This PR adds a checkbox for controlling if a join form requires email verification, and adds the email field as a default field. If email verification is enabled without a email field, the email field will be added automatically.


## Screenshots

https://github.com/user-attachments/assets/6cbcfa5e-c9d1-4852-8f81-8707a6317a9f


## Changes

* Adds email verification checkbox.
* Changes default join form to include a email field and have email verification set to true.


## Notes to reviewer

1. Create a new join form, the email verification checkbox should start as checked.
2. Uncheck the verification checkbox.
3. Remove the email field.
4. Re-enable email verification, the email field should be re-added

## Related issues
Resolves #2369 
