### PR TITLE
Add image dimensions to file picker

### DIFF
--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -38,12 +38,12 @@ const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
               }
             }}
             src={file.url}
-            unoptimized
             style={{
               height: '100%',
               objectFit: 'contain',
               width: '100%',
             }}
+            unoptimized
             width="800"
           />
         </TransparentGridBackground>

--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -51,7 +51,10 @@ const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
           {file.original_name}
         </Typography>
         <Typography color="secondary" mt={1} textAlign="center" variant="body2">
-          {dimensions.width} &times; {dimensions.height} pixels
+          <Msg
+            id={messageIds.image.dimensions}
+            values={{ height: dimensions.height, width: dimensions.width }}
+          />
         </Typography>
       </Box>
       <Box display="flex" gap={1} justifyContent="flex-end">

--- a/src/features/files/components/FileLibraryDialog/FilePreview.tsx
+++ b/src/features/files/components/FileLibraryDialog/FilePreview.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import Image from 'next/image';
 import { Box, Button, Typography } from '@mui/material';
 
@@ -14,20 +14,31 @@ type Props = {
 };
 
 const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
+  const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
+
   return (
     <Box display="flex" flexDirection="column" height="100%">
       <Box height="100%" my={2} overflow="auto">
         <TransparentGridBackground
           interactive={false}
           sx={{
-            height: 'calc(100% - 2em)',
+            height: 'calc(100% - 4em)',
             position: 'relative',
           }}
         >
           <Image
             alt={file.original_name}
             height="800"
+            onLoad={(e) => {
+              if (e.target instanceof HTMLImageElement) {
+                setDimensions({
+                  height: e.target.naturalHeight,
+                  width: e.target.naturalWidth,
+                });
+              }
+            }}
             src={file.url}
+            unoptimized
             style={{
               height: '100%',
               objectFit: 'contain',
@@ -38,6 +49,9 @@ const FilePreview: FC<Props> = ({ file, onBack, onSelect }) => {
         </TransparentGridBackground>
         <Typography color="secondary" mt={1} textAlign="center" variant="body2">
           {file.original_name}
+        </Typography>
+        <Typography color="secondary" mt={1} textAlign="center" variant="body2">
+          {dimensions.width} &times; {dimensions.height} pixels
         </Typography>
       </Box>
       <Box display="flex" gap={1} justifyContent="flex-end">

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -27,7 +27,6 @@ const LibraryImage: FC<LibraryImageProps> = ({
     if (img.current != null) {
       dimensions = [img.current.naturalWidth, img.current.naturalHeight];
     }
-    return true;
   }
 
   return (
@@ -36,16 +35,18 @@ const LibraryImage: FC<LibraryImageProps> = ({
         ref={img}
         alt={imageFile.original_name}
         height="400"
-        onLoad={() =>
-          onLoad &&
-          updateSize() &&
-          onLoad({ height: dimensions[1], width: dimensions[0] })
-        }
-        onLoadingComplete={() =>
-          onLoadingComplete &&
-          updateSize() &&
-          onLoadingComplete({ height: dimensions[1], width: dimensions[0] })
-        }
+        onLoad={() => {
+          updateSize();
+          if (onLoad) {
+            onLoad({ height: dimensions[1], width: dimensions[0] })
+          }
+        }}
+        onLoadingComplete={() => {
+          updateSize();
+          if (onLoadingComplete) {
+            onLoadingComplete({ height: dimensions[1], width: dimensions[0] })
+          }
+        }}
         src={imageFile.url}
         style={{
           aspectRatio: '1 / 1',

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef } from 'react';
+import { FC } from 'react';
 import Image from 'next/image';
 
 import TransparentGridBackground from './TransparentGridBackground';
@@ -7,44 +7,24 @@ import { ZetkinFile } from 'utils/types/zetkin';
 interface LibraryImageProps {
   imageFile: ZetkinFile;
   onLoad?: ({ height, width }: { height: number; width: number }) => void;
-  onLoadingComplete?: ({
-    height,
-    width,
-  }: {
-    height: number;
-    width: number;
-  }) => void;
 }
 
-const LibraryImage: FC<LibraryImageProps> = ({
-  imageFile,
-  onLoad,
-  onLoadingComplete,
-}) => {
-  const img = useRef<HTMLImageElement>(null);
-  let dimensions = [0, 0];
-  function updateSize() {
-    if (img.current != null) {
-      dimensions = [img.current.naturalWidth, img.current.naturalHeight];
-    }
-  }
-
+const LibraryImage: FC<LibraryImageProps> = ({ imageFile, onLoad }) => {
   return (
     <TransparentGridBackground>
       <Image
-        ref={img}
         alt={imageFile.original_name}
         height="400"
-        onLoad={() => {
-          updateSize();
+        onLoad={(e) => {
           if (onLoad) {
-            onLoad({ height: dimensions[1], width: dimensions[0] })
-          }
-        }}
-        onLoadingComplete={() => {
-          updateSize();
-          if (onLoadingComplete) {
-            onLoadingComplete({ height: dimensions[1], width: dimensions[0] })
+            if (e.target instanceof HTMLImageElement) {
+              onLoad({
+                height: e.target.naturalHeight,
+                width: e.target.naturalWidth,
+              });
+            } else {
+              onLoad({ height: 0, width: 0 });
+            }
           }
         }}
         src={imageFile.url}

--- a/src/features/files/components/LibraryImage.tsx
+++ b/src/features/files/components/LibraryImage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useRef } from 'react';
 import Image from 'next/image';
 
 import TransparentGridBackground from './TransparentGridBackground';
@@ -6,8 +6,14 @@ import { ZetkinFile } from 'utils/types/zetkin';
 
 interface LibraryImageProps {
   imageFile: ZetkinFile;
-  onLoad?: () => void;
-  onLoadingComplete?: () => void;
+  onLoad?: ({ height, width }: { height: number; width: number }) => void;
+  onLoadingComplete?: ({
+    height,
+    width,
+  }: {
+    height: number;
+    width: number;
+  }) => void;
 }
 
 const LibraryImage: FC<LibraryImageProps> = ({
@@ -15,13 +21,31 @@ const LibraryImage: FC<LibraryImageProps> = ({
   onLoad,
   onLoadingComplete,
 }) => {
+  const img = useRef<HTMLImageElement>(null);
+  let dimensions = [0, 0];
+  function updateSize() {
+    if (img.current != null) {
+      dimensions = [img.current.naturalWidth, img.current.naturalHeight];
+    }
+    return true;
+  }
+
   return (
     <TransparentGridBackground>
       <Image
+        ref={img}
         alt={imageFile.original_name}
         height="400"
-        onLoad={() => onLoad && onLoad()}
-        onLoadingComplete={() => onLoadingComplete && onLoadingComplete()}
+        onLoad={() =>
+          onLoad &&
+          updateSize() &&
+          onLoad({ height: dimensions[1], width: dimensions[0] })
+        }
+        onLoadingComplete={() =>
+          onLoadingComplete &&
+          updateSize() &&
+          onLoadingComplete({ height: dimensions[1], width: dimensions[0] })
+        }
         src={imageFile.url}
         style={{
           aspectRatio: '1 / 1',
@@ -30,6 +54,7 @@ const LibraryImage: FC<LibraryImageProps> = ({
           objectFit: 'contain',
           width: '100%',
         }}
+        unoptimized
         width="400"
       />
     </TransparentGridBackground>

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -29,10 +29,6 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
           setLoading(true);
           setDimensions(dimensions);
         }}
-        onLoadingComplete={(dimensions) => {
-          setLoading(false);
-          setDimensions(dimensions);
-        }}
       />
       <Box
         alignItems="center"
@@ -66,7 +62,7 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
           textOverflow="ellipsis"
           variant="body2"
         >
-          {dimensions.width} px x {dimensions.height} px
+          {dimensions.width} &times; {dimensions.height} pixels
         </Typography>
       </Box>
     </Box>

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -26,7 +26,7 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
       <LibraryImage
         imageFile={imageFile}
         onLoad={(dimensions) => {
-          setLoading(true);
+          setLoading(false);
           setDimensions(dimensions);
         }}
       />

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -14,6 +14,7 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
   onSelectImage,
 }) => {
   const [loading, setLoading] = useState(true);
+  const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
 
   return (
     <Box
@@ -24,10 +25,22 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
     >
       <LibraryImage
         imageFile={imageFile}
-        onLoad={() => setLoading(true)}
-        onLoadingComplete={() => setLoading(false)}
+        onLoad={(dimensions) => {
+          setLoading(true);
+          setDimensions(dimensions);
+        }}
+        onLoadingComplete={(dimensions) => {
+          setLoading(false);
+          setDimensions(dimensions);
+        }}
       />
-      <Box alignItems="center" display="flex" justifyContent="center" mt={1}>
+      <Box
+        alignItems="center"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        mt={1}
+      >
         {loading && (
           <CircularProgress color="primary" size="1em" sx={{ mr: 1 }} />
         )}
@@ -42,6 +55,18 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
           variant="body2"
         >
           {imageFile.original_name}
+        </Typography>
+        <Typography
+          alignSelf="center"
+          color="secondary"
+          component="span"
+          maxWidth="80%"
+          noWrap
+          overflow="hidden"
+          textOverflow="ellipsis"
+          variant="body2"
+        >
+          {dimensions.width} px x {dimensions.height} px
         </Typography>
       </Box>
     </Box>

--- a/src/features/files/components/LibraryImageCard.tsx
+++ b/src/features/files/components/LibraryImageCard.tsx
@@ -3,6 +3,8 @@ import { FC, useState } from 'react';
 
 import LibraryImage from './LibraryImage';
 import { ZetkinFile } from 'utils/types/zetkin';
+import messageIds from 'features/files/l10n/messageIds';
+import { Msg } from 'core/i18n';
 
 interface LibraryImageCardProps {
   imageFile: ZetkinFile;
@@ -62,7 +64,10 @@ const LibraryImageCard: FC<LibraryImageCardProps> = ({
           textOverflow="ellipsis"
           variant="body2"
         >
-          {dimensions.width} &times; {dimensions.height} pixels
+          <Msg
+            id={messageIds.image.dimensions}
+            values={{ height: dimensions.height, width: dimensions.width }}
+          />
         </Typography>
       </Box>
     </Box>

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -6,6 +6,11 @@ export default makeMessages('feat.files', {
     instructions: m(' or drag and drop'),
     selectClick: m('Click to upload'),
   },
+  image: {
+    dimensions: m<{ height: number; width: number }>(
+      '{width} × {height} pixels'
+    ),
+  },
   libraryDialog: {
     preview: {
       backButton: m('Back to library'),


### PR DESCRIPTION
## Description
This PR makes it possible to see image dimensions before picking a image using `<FileLibraryDialog />`.


## Screenshots

![image](https://github.com/user-attachments/assets/6fab6e19-86f3-4a89-93ff-518f60d3d3d2)

## Changes

* Adds small text with image width and height under its image.
* Makes the `<Image />` component load un-optimized images so that the browser can see the actual dimensions, this causes extra network usage.


## Notes to reviewer

Upload a image to ex. a event http://localhost:3000/organize/1/projects/2/events/82

## Related issues
Resolves #2285 
