### PR TITLE
Correctly calculate maxHeight and maxWidth

### DIFF
--- a/src/features/canvassAssignments/components/PlaceDialog/pages/CreateHouseholdsPage.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/CreateHouseholdsPage.tsx
@@ -43,8 +43,8 @@ const CreateHouseholdsPage: FC<Props> = ({
         width: widthPerHousehold * 5,
       };
 
-      const maxHeight = rect.width / widthPerHousehold - 2;
-      const maxWidth = rect.height / heightPerFloor - 1;
+      const maxHeight = rect.height / (heightPerFloor - 1);
+      const maxWidth = rect.width / (widthPerHousehold - 1);
       const scaleX = Math.min(1.0, maxWidth / newNumAptsPerFloor);
       const scaleY = Math.min(1.0, maxHeight / newNumFloors);
       const newScale = Math.min(scaleX, scaleY);


### PR DESCRIPTION
## Description
This PR will correctly calculate the variables maxHeigth and maxWidth so that the buildnings can scale properly

## Screenshots
![Small screen](https://github.com/user-attachments/assets/82de149d-ac83-4e32-86ce-e6660c0c9c87)

## Changes

* Fixes bug of scaling for many buildings


## Notes to reviewer
I've tested for large(>1000), small(<500) and normal sized screens.


## Related issues
Resolves #2372 
