### PR TITLE
Issue 2371/floor state retention bug

### DIFF
--- a/src/features/canvassAssignments/components/PlaceDialog/pages/CreateHouseholdsPage.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/CreateHouseholdsPage.tsx
@@ -43,8 +43,8 @@ const CreateHouseholdsPage: FC<Props> = ({
         width: widthPerHousehold * 5,
       };
 
-      const maxHeight = rect.width / widthPerHousehold - 2;
-      const maxWidth = rect.height / heightPerFloor - 1;
+      const maxHeight = rect.height / (heightPerFloor - 1);
+      const maxWidth = rect.width / (widthPerHousehold - 1);
       const scaleX = Math.min(1.0, maxWidth / newNumAptsPerFloor);
       const scaleY = Math.min(1.0, maxHeight / newNumFloors);
       const newScale = Math.min(scaleX, scaleY);

--- a/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
@@ -13,14 +13,15 @@ type Props = {
 
 const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
   const [title, setTitle] = useState(household.title || '');
-  const [floor, setFloor] = useState(household.floor || NaN);
+  const [floor, setFloor] = useState(household.floor?.toString() || '');
 
   useEffect(() => {
     setTitle(household.title || '');
+    setFloor(household.floor?.toString() || '');
   }, [household]);
 
   const nothingHasBeenEdited =
-    title == household.title && floor == household.floor;
+    title == household.title && floor == household.floor?.toString();
 
   return (
     <PageBase
@@ -28,7 +29,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
         <Button
           disabled={nothingHasBeenEdited}
           onClick={() => {
-            onSave(title, floor || null);
+            onSave(title, floor ? parseInt(floor) : null);
           }}
           variant="contained"
         >
@@ -42,7 +43,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
       <form
         onSubmit={(ev) => {
           ev.preventDefault();
-          onSave(title, floor || null);
+          onSave(title, floor ? parseInt(floor) : null);
         }}
       >
         <Box display="flex" flexDirection="column" gap={2}>
@@ -55,7 +56,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
           <TextField
             fullWidth
             label="Floor"
-            onChange={(ev) => setFloor(parseInt(ev.target.value))}
+            onChange={(ev) => setFloor(ev.target.value)}
             type="number"
             value={floor}
           />

--- a/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
@@ -13,11 +13,11 @@ type Props = {
 
 const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
   const [title, setTitle] = useState(household.title || '');
-  const [floor, setFloor] = useState<number | ''>(household.floor ?? '');
+  const [floor, setFloor] = useState(household.floor ?? NaN);
 
   useEffect(() => {
     setTitle(household.title || '');
-    setFloor(household.floor ?? '');
+    setFloor(household.floor ?? NaN);
   }, [household]);
 
   const nothingHasBeenEdited =
@@ -29,7 +29,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
         <Button
           disabled={nothingHasBeenEdited}
           onClick={() => {
-            onSave(title, floor == '' ? null : floor);
+            onSave(title, Number.isNaN(floor) ? null : floor);
           }}
           variant="contained"
         >
@@ -43,7 +43,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
       <form
         onSubmit={(ev) => {
           ev.preventDefault();
-          onSave(title, floor == '' ? null : floor);
+          onSave(title, Number.isNaN(floor) ? null : floor);
         }}
       >
         <Box display="flex" flexDirection="column" gap={2}>

--- a/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
@@ -29,7 +29,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
         <Button
           disabled={nothingHasBeenEdited}
           onClick={() => {
-            onSave(title, Number.isNaN(floor) ? null : floor);
+            onSave(title, floor || null);
           }}
           variant="contained"
         >
@@ -43,7 +43,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
       <form
         onSubmit={(ev) => {
           ev.preventDefault();
-          onSave(title, Number.isNaN(floor) ? null : floor);
+          onSave(title, floor || null);
         }}
       >
         <Box display="flex" flexDirection="column" gap={2}>

--- a/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/EditHousehold.tsx
@@ -13,15 +13,15 @@ type Props = {
 
 const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
   const [title, setTitle] = useState(household.title || '');
-  const [floor, setFloor] = useState(household.floor?.toString() || '');
+  const [floor, setFloor] = useState<number | ''>(household.floor ?? '');
 
   useEffect(() => {
     setTitle(household.title || '');
-    setFloor(household.floor?.toString() || '');
+    setFloor(household.floor ?? '');
   }, [household]);
 
   const nothingHasBeenEdited =
-    title == household.title && floor == household.floor?.toString();
+    title == household.title && floor == household.floor;
 
   return (
     <PageBase
@@ -29,7 +29,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
         <Button
           disabled={nothingHasBeenEdited}
           onClick={() => {
-            onSave(title, floor ? parseInt(floor) : null);
+            onSave(title, floor == '' ? null : floor);
           }}
           variant="contained"
         >
@@ -43,7 +43,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
       <form
         onSubmit={(ev) => {
           ev.preventDefault();
-          onSave(title, floor ? parseInt(floor) : null);
+          onSave(title, floor == '' ? null : floor);
         }}
       >
         <Box display="flex" flexDirection="column" gap={2}>
@@ -56,7 +56,7 @@ const EditHousehold: FC<Props> = ({ onClose, onBack, onSave, household }) => {
           <TextField
             fullWidth
             label="Floor"
-            onChange={(ev) => setFloor(ev.target.value)}
+            onChange={(ev) => setFloor(parseInt(ev.target.value))}
             type="number"
             value={floor}
           />


### PR DESCRIPTION
## Description
This PR fixes a bug where the floor state was retained when changing to a different household after editing one.


## Screenshots
![bild](https://github.com/user-attachments/assets/90560620-1f45-4bff-916d-d1d440af7b33)

![bild](https://github.com/user-attachments/assets/930326b0-d8b7-47d1-bd64-5d827e54b8e5)

![bild](https://github.com/user-attachments/assets/8fa43e00-84cf-4066-9664-f8ccaa0f76bf)


## Changes
- Add setFloor to useEffect.


## Notes to reviewer
None


## Related issues
Resolves #2371
