### PR TITLE
Add missing type annotations & catch unhandled exceptions

### DIFF
--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -20,7 +20,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import ZUISection from 'zui/ZUISection';
 import ZUITimeline from 'zui/ZUITimeline';
 import { scaffold, ScaffoldedGetServerSideProps } from 'utils/next';
-import { ZetkinJourneyInstance, ZetkinOrganization } from 'utils/types/zetkin';
+import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
@@ -36,9 +36,6 @@ export const getJourneyInstanceScaffoldProps: ScaffoldedGetServerSideProps =
       const journeyInstance = await apiClient.get<ZetkinJourneyInstance>(
         `/api/orgs/${orgId}/journey_instances/${instanceId}`
       );
-      // Note: We don't actually care for the returned orgnaization, but we still want to perform
-      // the api request to know if this user may access this particular page.
-      await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
       if (journeyInstance.journey.id.toString() !== (journeyId as string)) {
         return {

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
@@ -21,16 +21,15 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, journeyId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const journey = await apiClient.get<ZetkinJourney>(
-    `/api/orgs/${orgId}/journeys/${journeyId}`
-  );
-
-  if (journey) {
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    await apiClient.get<ZetkinJourney>(
+      `/api/orgs/${orgId}/journeys/${journeyId}`
+    );
     return {
       props: {},
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
@@ -21,16 +21,15 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, journeyId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const journey = await apiClient.get<ZetkinJourney>(
-    `/api/orgs/${orgId}/journeys/${journeyId}`
-  );
-
-  if (journey) {
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    await apiClient.get<ZetkinJourney>(
+      `/api/orgs/${orgId}/journeys/${journeyId}`
+    );
     return {
       props: {},
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -19,7 +19,12 @@ import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import { Msg, useMessages } from 'core/i18n';
-import { ZetkinPerson, ZetkinTag } from 'utils/types/zetkin';
+import {
+  ZetkinJourney,
+  ZetkinOrganization,
+  ZetkinPerson,
+  ZetkinTag,
+} from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -34,20 +39,22 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, journeyId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const journey = await apiClient.get(
-    `/api/orgs/${orgId}/journeys/${journeyId}`
-  );
-  const organization = await apiClient.get(`/api/orgs/${orgId}`);
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    // Note: We don't actually care for the returned journey or orgnaization, but we still want to perform
+    // the api request to know if this user may access this particular page.
+    await apiClient.get<ZetkinJourney>(
+      `/api/orgs/${orgId}/journeys/${journeyId}`
+    );
+    await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
-  if (organization && journey) {
     return {
       props: {
         journeyId,
         orgId,
       },
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -19,12 +19,7 @@ import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import { Msg, useMessages } from 'core/i18n';
-import {
-  ZetkinJourney,
-  ZetkinOrganization,
-  ZetkinPerson,
-  ZetkinTag,
-} from 'utils/types/zetkin';
+import { ZetkinJourney, ZetkinPerson, ZetkinTag } from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -41,12 +36,9 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 
   try {
     const apiClient = new BackendApiClient(ctx.req.headers);
-    // Note: We don't actually care for the returned journey or orgnaization, but we still want to perform
-    // the api request to know if this user may access this particular page.
     await apiClient.get<ZetkinJourney>(
       `/api/orgs/${orgId}/journeys/${journeyId}`
     );
-    await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
     return {
       props: {

--- a/src/pages/organize/[orgId]/journeys/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/index.tsx
@@ -11,7 +11,7 @@ import { scaffold } from 'utils/next';
 import useJourneys from 'features/journeys/hooks/useJourneys';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
-import { ZetkinJourney } from 'utils/types/zetkin';
+import { ZetkinJourney, ZetkinOrganization } from 'utils/types/zetkin';
 import ZUISection from 'zui/ZUISection';
 
 const scaffoldOptions = {
@@ -23,8 +23,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
 
   const apiClient = new BackendApiClient(ctx.req.headers);
-  const journeys = await apiClient.get(`/api/orgs/${orgId}/journeys`);
-  const organization = await apiClient.get(`/api/orgs/${orgId}`);
+  const journeys = await apiClient.get<ZetkinJourney[]>(
+    `/api/orgs/${orgId}/journeys`
+  );
+  const organization = await apiClient.get<ZetkinOrganization>(
+    `/api/orgs/${orgId}`
+  );
 
   if (organization && journeys) {
     return {

--- a/src/pages/organize/[orgId]/journeys/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/index.tsx
@@ -22,21 +22,19 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const journeys = await apiClient.get<ZetkinJourney[]>(
-    `/api/orgs/${orgId}/journeys`
-  );
-  const organization = await apiClient.get<ZetkinOrganization>(
-    `/api/orgs/${orgId}`
-  );
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    // Note: We don't actually care for the returned journeys or orgnaization, but we still want to perform
+    // the api request to know if this user may access this particular page.
+    await apiClient.get<ZetkinJourney[]>(`/api/orgs/${orgId}/journeys`);
+    await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
-  if (organization && journeys) {
     return {
       props: {
         orgId,
       },
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/journeys/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/index.tsx
@@ -24,9 +24,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 
   try {
     const apiClient = new BackendApiClient(ctx.req.headers);
-    // Note: We don't actually care for the returned journeys or orgnaization, but we still want to perform
-    // the api request to know if this user may access this particular page.
-    await apiClient.get<ZetkinJourney[]>(`/api/orgs/${orgId}/journeys`);
     await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
     return {

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -21,6 +21,7 @@ import useTagging from 'features/tags/hooks/useTagging';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import { scaffold, ScaffoldedGetServerSideProps } from 'utils/next';
+import { ZetkinPerson } from 'utils/types/zetkin';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
@@ -34,7 +35,7 @@ export const getPersonScaffoldProps: ScaffoldedGetServerSideProps = async (
 
   try {
     const apiClient = new BackendApiClient(ctx.req.headers);
-    await apiClient.get(`/api/orgs/${orgId}/people/${personId}`);
+    await apiClient.get<ZetkinPerson>(`/api/orgs/${orgId}/people/${personId}`);
     return {
       props: {
         orgId,

--- a/src/pages/organize/[orgId]/people/folders/[folderId].tsx
+++ b/src/pages/organize/[orgId]/people/folders/[folderId].tsx
@@ -8,6 +8,7 @@ import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
 import ViewBrowser from 'features/views/components/ViewBrowser';
 import messageIds from 'features/views/l10n/messageIds';
+import { ZetkinViewFolder } from 'features/views/components/types';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -17,19 +18,20 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, folderId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const folder = await apiClient.get(
-    `/api/orgs/${orgId}/people/view_folders/${folderId}`
-  );
-
-  if (folder) {
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    // Note: We don't actually care for the returned folder, but we still want to perform
+    // the api request to know if this user may access this particular folder.
+    await apiClient.get<ZetkinViewFolder>(
+      `/api/orgs/${orgId}/people/view_folders/${folderId}`
+    );
     return {
       props: {
         folderId,
         orgId,
       },
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -9,6 +9,7 @@ import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
 import useServerSide from 'core/useServerSide';
 import ViewBrowser from 'features/views/components/ViewBrowser';
+import { ZetkinView } from 'features/views/components/types';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -19,7 +20,9 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
 
   const apiClient = new BackendApiClient(ctx.req.headers);
-  const views = await apiClient.get(`/api/orgs/${orgId}/people/views`);
+  const views = await apiClient.get<ZetkinView[]>(
+    `/api/orgs/${orgId}/people/views`
+  );
 
   if (views) {
     return {

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -19,18 +19,17 @@ const scaffoldOptions = {
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId } = ctx.params!;
 
-  const apiClient = new BackendApiClient(ctx.req.headers);
-  const views = await apiClient.get<ZetkinView[]>(
-    `/api/orgs/${orgId}/people/views`
-  );
-
-  if (views) {
+  try {
+    const apiClient = new BackendApiClient(ctx.req.headers);
+    // Note: We don't actually care for the returned orgnaization, but we still want to perform
+    // the api request to know if this user may access this particular page.
+    await apiClient.get<ZetkinView[]>(`/api/orgs/${orgId}/people/views`);
     return {
       props: {
         orgId,
       },
     };
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -21,8 +21,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 
   try {
     const apiClient = new BackendApiClient(ctx.req.headers);
-    // Note: We don't actually care for the returned orgnaization, but we still want to perform
-    // the api request to know if this user may access this particular page.
     await apiClient.get<ZetkinView[]>(`/api/orgs/${orgId}/people/views`);
     return {
       props: {

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -12,6 +12,7 @@ import useView from 'features/views/hooks/useView';
 import useViewGrid from 'features/views/hooks/useViewGrid';
 import ViewDataTable from 'features/views/components/ViewDataTable';
 import ZUIFutures from 'zui/ZUIFutures';
+import { ZetkinView } from 'features/views/components/types';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -23,7 +24,9 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, viewId } = ctx.params!;
 
   const apiClient = new BackendApiClient(ctx.req.headers);
-  const view = await apiClient.get(`/api/orgs/${orgId}/people/views/${viewId}`);
+  const view = await apiClient.get<ZetkinView>(
+    `/api/orgs/${orgId}/people/views/${viewId}`
+  );
 
   if (view) {
     // Check if user is an official

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -24,11 +24,16 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   const { orgId, viewId } = ctx.params!;
 
   const apiClient = new BackendApiClient(ctx.req.headers);
-  const view = await apiClient.get<ZetkinView>(
-    `/api/orgs/${orgId}/people/views/${viewId}`
-  );
 
-  if (view) {
+  // Try to fetch the view as the current user. If this is unsuccessful, and error object will
+  // be returned and the apiClient will throw an error for us to catch.
+  try {
+    // Note: We don't actually care for the returned view, but we still want to perform
+    // the api request to know if this user may access this particular view.
+    await apiClient.get<ZetkinView>(
+      `/api/orgs/${orgId}/people/views/${viewId}`
+    );
+
     // Check if user is an official
     // TODO: Consider moving this to some more general-purpose utility
     const officialMemberships = await getUserMemberships(ctx, false);
@@ -54,7 +59,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
         },
       };
     }
-  } else {
+  } catch {
     return {
       notFound: true,
     };

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -14,6 +14,7 @@ import ViewDataTable from 'features/views/components/ViewDataTable';
 import { ZetkinMembership } from 'utils/types/zetkin';
 import { ZetkinObjectAccess } from 'core/api/types';
 import ZUIFutures from 'zui/ZUIFutures';
+import { ZetkinView } from 'features/views/components/types';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -63,7 +64,9 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
   );
 
   try {
-    await apiClient.get(`/api/orgs/${orgId}/people/views/${viewId}`);
+    await apiClient.get<ZetkinView>(
+      `/api/orgs/${orgId}/people/views/${viewId}`
+    );
 
     return {
       props: {


### PR DESCRIPTION
## Description
This PR is just some minor code cleanups and bug fixes 🐞 :broom:

### Bug fixes

I found a lot of code on the following form

```typescript
const apiClient = new BackendApiClient(ctx.req.headers);
const data = await apiClient.get<T>('api/getData');
if(data) {
  return { .. };
} else {
  return {
    notFound: true
  };
}
```
The problem with this is that we can't expect `T` to be a falsy value if `apiClient.get` is able to fetch the value. `T` will in practice be some kind of object, and as such the `if`-body will always be hit.

If `get` would fail to fetch the value, it will instead throw an exception. As such, the correct form would be

```typescript
try {
  const apiClient = new BackendApiClient(ctx.req.headers);
  const data = await apiClient.get<T>('api/getData');
  return { .. };
} catch {
  return { 
    notFound: true
  };
}
```

This would correctly return `{ notFound: true }` if `data` could not be fetched.

Since `data` is seldom used, it can often be elided and we simply execute `apiClient.get<T>('api/getData')` for the side effect of maybe triggering the exception.

### Cleanups

Add type annotations to some of the aforementioned `get`-requests where they were missing. Nothing fancy

## Changes

* Catch a bunch of unhandled exceptions.
* Properly redirect in case above exceptions are found (based on how the code looked when I started working on it)
* Add type annotations to some `get`-requests.

## Notes to reviewer
Unfortunately, this is a rather boring PR to review. I guess you could try to browse all affetched pages and try to fetch invalid data. Otherwise, it is a matter of reviewing this rather mechanical code transformation by hand.