### PR TITLE
Add default styling for join form

### DIFF
--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -31,6 +31,33 @@ export default async function Page({ params, searchParams }: PageProps) {
         {searchParams.stylesheet && (
           <style>{`@import url(${searchParams.stylesheet})`}</style>
         )}
+        {!searchParams.stylesheet && (
+          <style>{`
+            body {
+              padding: 0.5rem;
+            }
+
+            .zetkin-joinform__field {
+              margin-bottom: 1rem;
+            }
+
+            .zetkin-joinform__field input {
+              width: 100%;
+              max-width: 600px;
+              padding: 0.3rem;
+              font-size: 1.5rem;
+            }
+
+            .zetkin-joinform__submit-button {
+              border-width: 0;
+              font-size: 1.5rem;
+              background-color: black;
+              color: white;
+              padding: 0.5rem 1rem;
+              border-radius: 0.2rem;
+            }
+          `}</style>
+        )}
       </div>
     );
   } catch (err) {

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -60,7 +60,7 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
               : globalMessages.personFields[field.s]();
 
             return (
-              <div key={field.s}>
+              <div key={field.s} className="zetkin-joinform__field">
                 <label>
                   {label}
                   <div>
@@ -93,7 +93,7 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields }) => {
               </div>
             );
           })}
-          <button type="submit">
+          <button className="zetkin-joinform__submit-button" type="submit">
             <Msg id={messageIds.embedding.submitButton} />
           </button>
         </form>


### PR DESCRIPTION
## Description
This PR adds default styling for join forms when there is no custom stylesheet defined.

## Screenshots
![image](https://github.com/user-attachments/assets/34483f24-975d-4036-8676-e950d8b0f202)


## Changes
* Adds default styling for embedded join forms
  * Make input fields bigger
  * Add ZUI-inspired styling for submit button
  * Add some margin between fields

## Notes to reviewer
None

## Related issues
Resolves #2370 