### PR TITLE
Filter list by survey responses where there are multiple responses to the same survey

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -139,7 +139,7 @@ const Cell: FC<{
         submissions={cell.map((sub, index) => ({
           id: sub.submission_id,
           matchingContent:
-            index == 0
+            index == cell.length - 1
               ? sub.selected.map((s) => (
                   <Chip
                     key={s.id}

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -38,7 +38,9 @@ export default class SurveyOptionsColumnType
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyOptionsViewCell = params.row[params.field];
-        return this.cellToString(cell);
+        return cell?.map((response) =>
+          response.selected.map((selected) => selected.text)
+        );
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -7,6 +7,7 @@ import {
   GridRenderCellParams,
   GridValueGetterParams,
 } from '@mui/x-data-grid-pro';
+import { History } from '@mui/icons-material';
 
 import { getEllipsedString } from 'utils/stringUtils';
 import { IColumnType } from '.';
@@ -52,6 +53,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     display: 'flex',
     height: '100%',
+    width: '100%',
   },
   content: {
     '-webkit-box-orient': 'vertical',
@@ -87,7 +89,10 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
         onMouseOut={() => setAnchorEl(null)}
         onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
       >
-        {sorted[0].text}
+        <Box alignItems="center" display="flex" justifyContent="space-between">
+          {sorted[0].text}
+          {cell.length > 1 && <History color="secondary" />}
+        </Box>
         <ViewSurveySubmissionPreview
           anchorEl={anchorEl}
           onOpenSubmission={(id) => {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -37,14 +37,14 @@ export default class SurveyResponseColumnType
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
-        return this.cellToString(cell);
+        return cell.map((response) => response.text);
       },
       width: 250,
     };
   }
 
   getSearchableStrings(cell: SurveyResponseViewCell): string[] {
-    return cell.map((sub) => sub.text);
+    return cell.map((response) => response.text);
   }
 }
 


### PR DESCRIPTION
## Description
This PR adjusts the functionality in the `SurveyResponse...` and `SurveyOptions..` columns in lists, to include text values in cells where there are multiple responses to the same survey.


## Screenshots
Adding little icon in `SurveyResponse..` column cells when there are multiple responses to the same survey
![bild](https://github.com/user-attachments/assets/36501770-64a0-4639-8c9c-0130fd690df0)


Prior to this PR this filtering would have yielded no results, but now it can filter by the content in the responses of people with multiple survey responses!
![bild](https://github.com/user-attachments/assets/6b805adb-8152-4af9-a5ac-516b5fdd163a)


This person has previously responded to this question saying they like "grevé".
![bild](https://github.com/user-attachments/assets/f26cbe40-d6b5-465d-9fda-46dd3ae326fd)


Prior to this PR only the oldest response would have had the options listed, now the most recent response has the options listed.
![bild](https://github.com/user-attachments/assets/c26bf124-f9cf-4ed5-8454-cd7d26a0671e)


## Changes
* Changes the `valueGetter` function of these two columns to return an array of string values
* Adds little "history" icon to cells in the `SurveyResponse` columns if there are multiple survey responses
* Fixes small thing in the rendering of the survey submission preview, where options were mistakenly only rendered for the oldest survey response instead of the newest.

## Notes to reviewer
Create a list that contains people who have responded to surveys

## Related issues
Resolves #1815 
