### PR TITLE
Move locking of targets to targets section

### DIFF
--- a/src/features/emails/components/EmailTargetsReady.tsx
+++ b/src/features/emails/components/EmailTargetsReady.tsx
@@ -76,17 +76,19 @@ const EmailTargetsReady: FC<EmailTargetsReadyProps> = ({
           </ZUIAnimatedNumber>
         </Box>
       </Box>
-      <Divider />
-      <Box padding={2}>
-        {missingEmail > 0 && state != EmailState.SENT && (
-          <Typography>
-            <Msg
-              id={messageIds.ready.missingEmailsDescription}
-              values={{ numPeople: missingEmail }}
-            />
-          </Typography>
-        )}
-      </Box>
+      {missingEmail > 0 && state != EmailState.SENT && (
+        <>
+          <Divider />
+          <Box padding={2}>
+            <Typography>
+              <Msg
+                id={messageIds.ready.missingEmailsDescription}
+                values={{ numPeople: missingEmail }}
+              />
+            </Typography>
+          </Box>
+        </>
+      )}
     </Card>
   );
 };

--- a/src/features/emails/components/EmailTargetsReady.tsx
+++ b/src/features/emails/components/EmailTargetsReady.tsx
@@ -1,14 +1,5 @@
 import { FC } from 'react';
-import {
-  Box,
-  Button,
-  Card,
-  CircularProgress,
-  Divider,
-  Typography,
-  useTheme,
-} from '@mui/material';
-import { Lock, LockOpen } from '@mui/icons-material';
+import { Box, Card, Divider, Typography, useTheme } from '@mui/material';
 
 import { EmailState } from '../hooks/useEmailState';
 import messageIds from '../l10n/messageIds';
@@ -16,24 +7,19 @@ import { Msg } from 'core/i18n';
 import ZUIAnimatedNumber from 'zui/ZUIAnimatedNumber';
 
 interface EmailTargetsReadyProps {
-  isLocked: boolean;
-  isLoading: boolean;
   lockedReadyTargets: number | null;
-  onToggleLocked: () => void;
+  missingEmail: number;
   readyTargets: number;
   state: EmailState;
 }
 
 const EmailTargetsReady: FC<EmailTargetsReadyProps> = ({
-  isLocked,
-  isLoading,
   lockedReadyTargets,
-  onToggleLocked,
+  missingEmail,
   readyTargets,
   state,
 }) => {
   const theme = useTheme();
-  const showUnlockInfo = state != EmailState.SENT;
 
   return (
     <Card>
@@ -58,17 +44,6 @@ const EmailTargetsReady: FC<EmailTargetsReadyProps> = ({
           </Typography>
         </Box>
         <Box alignItems="center" display="flex" gap={2}>
-          {isLocked && (
-            <Box
-              bgcolor={theme.palette.grey[300]}
-              borderRadius="2em"
-              padding={1}
-            >
-              <Typography variant="body2">
-                <Msg id={messageIds.ready.locked} />
-              </Typography>
-            </Box>
-          )}
           <ZUIAnimatedNumber
             value={
               lockedReadyTargets === null ? readyTargets : lockedReadyTargets
@@ -101,56 +76,17 @@ const EmailTargetsReady: FC<EmailTargetsReadyProps> = ({
           </ZUIAnimatedNumber>
         </Box>
       </Box>
-      {showUnlockInfo && (
-        <>
-          <Divider />
-          <Box
-            alignItems="flex-start"
-            display="flex"
-            flexDirection="column"
-            gap={2}
-            padding={2}
-          >
-            <Typography>
-              {state === EmailState.SCHEDULED ? (
-                <Msg id={messageIds.ready.scheduledDescription} />
-              ) : (
-                <Msg
-                  id={
-                    isLocked
-                      ? messageIds.ready.unlockDescription
-                      : messageIds.ready.lockDescription
-                  }
-                />
-              )}
-            </Typography>
-            {isLoading && (
-              <Button
-                startIcon={<CircularProgress size="1em" />}
-                variant="outlined"
-              >
-                <Msg id={messageIds.ready.loading} />
-              </Button>
-            )}
-            {!isLoading && (
-              <Button
-                disabled={readyTargets === 0 || state === EmailState.SCHEDULED}
-                onClick={onToggleLocked}
-                startIcon={isLocked ? <LockOpen /> : <Lock />}
-                variant={isLocked ? 'outlined' : 'contained'}
-              >
-                <Msg
-                  id={
-                    isLocked
-                      ? messageIds.ready.unlockButton
-                      : messageIds.ready.lockButton
-                  }
-                />
-              </Button>
-            )}
-          </Box>
-        </>
-      )}
+      <Divider />
+      <Box padding={2}>
+        {missingEmail > 0 && state != EmailState.SENT && (
+          <Typography>
+            <Msg
+              id={messageIds.ready.missingEmailsDescription}
+              values={{ numPeople: missingEmail }}
+            />
+          </Typography>
+        )}
+      </Box>
     </Card>
   );
 };

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -171,20 +171,12 @@ export default makeMessages('feat.emails', {
     },
   },
   ready: {
-    loading: m('Loading...'),
-    lockButton: m('Lock for delivery'),
-    lockDescription: m('Lock to enable email delivery'),
-    locked: m('Locked'),
-    scheduledDescription: m(
-      'This email is scheduled for delivery. If you want to unlock the targets, cancel the delivery first.'
+    missingEmailsDescription: m<{ numPeople: number }>(
+      'There {numPeople, plural, one {is a person} other {are people}} with a missing email address in the target group. If you resolve it they will be included in the target group.'
     ),
     sentSubtitle: m('Targets that were available for delivery'),
     subtitle: m('Targets currently available for delivery'),
     title: m('Ready'),
-    unlockButton: m('Unlock'),
-    unlockDescription: m(
-      'Proceed to delivery or unlock recipients to edit targeting. Unlocking may add or remove some targets depending on what results the Smart Search will produce.'
-    ),
   },
   state: {
     draft: m('Draft'),
@@ -207,12 +199,32 @@ export default makeMessages('feat.emails', {
   targets: {
     defineButton: m('Define target group'),
     editButton: m('Edit target group'),
+    loading: m('Loading...'),
+    lockButton: m('Lock for delivery'),
     locked: m('Targets are locked for delivery'),
-    sentSubtitle: m(
-      'You can look at the Smart Search that was used to define the recipients of this email'
-    ),
-    subtitle: m('Use Smart Search to define the recipients of this email.'),
+    lockedChip: m('Locked'),
+    subtitle: {
+      notTargeted: m(
+        'Use Smart Search to define the recipients of this email.'
+      ),
+      scheduled: m(
+        'This email is scheduled for delivery. If you want to unlock the targets to edit the Smart Search, cancel the delivery first.'
+      ),
+      sent: m(
+        'You can look at the Smart Search that was used to define the recipients of this email'
+      ),
+      targetedAndLocked: m(
+        'Proceed to delivery or unlock recipients if you want to edit the Smart Search that is used to define the recipients of this email.'
+      ),
+      targetedNotLocked: m(
+        'Edit the Smart Search that is used to define the recipients of this email, or lock the target group to enable email delivery.'
+      ),
+    },
     title: m('Targets'),
+    unlockAlert: m(
+      'Unlocking may add or remove people from the target group depending on what results the Smart Search will produce.'
+    ),
+    unlockButton: m('Unlock'),
     viewButton: m('View target group'),
   },
   unsubscribePage: {

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -55,8 +55,11 @@ const EmailPage: PageWithLayout = () => {
         <Box display="flex" flexDirection="column">
           <EmailTargets
             email={email}
+            isLoading={mutating.includes('locked')}
             isLocked={isLocked}
             isTargeted={isTargeted}
+            onToggleLocked={() => updateEmail({ locked: !email.locked })}
+            readyTargets={readyTargets}
             state={emailState}
             targets={numTargetMatches}
             updateTargets={updateTargets}
@@ -72,10 +75,8 @@ const EmailPage: PageWithLayout = () => {
             </Box>
             <Box flex={1}>
               <EmailTargetsReady
-                isLoading={mutating.includes('locked')}
-                isLocked={isLocked}
                 lockedReadyTargets={lockedReadyTargets}
-                onToggleLocked={() => updateEmail({ locked: !email.locked })}
+                missingEmail={numBlocked.noEmail}
                 readyTargets={readyTargets}
                 state={emailState}
               />


### PR DESCRIPTION
## Description
This PR attempts to make it mort clear for the user that the group that is locked when you lock the targets of the email, is the whole group found by the smart search, and not just the ones that are in the "ready" section when the person presses the "lock" button.

We do this by moving the button and info texts around locking and unlocking the targets up to the "targets" section. 

## Screenshots
![bild](https://github.com/user-attachments/assets/8b8d5004-7c62-4992-9c20-66ef7a0ce519)

![bild](https://github.com/user-attachments/assets/6ea98b88-ef1d-44f2-83d4-a8157a789094)

![bild](https://github.com/user-attachments/assets/4e7860c5-9e20-4fc8-b072-f83da21ad701)

![bild](https://github.com/user-attachments/assets/1acba743-6041-48bd-913a-aa5b64e04710)

## Changes
* Moves the lock/unlock button to the Targets section
* Changes the messages a bit
* Adds an explanation about missing emails

## Notes to reviewer
Does the texts and things make more sense this way?


## Related issues
Resolves #1806 
