### PR TITLE
Add confirm dialog to "Convert to static list"

### DIFF
--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -421,7 +421,7 @@ export default makeMessages('feat.views', {
       makeDynamic: m('Convert to Smart Search list'),
       makeStatic: {
         confirmDialogInfo: m(
-          'If you convert this list to a static list the Smart Search will be removed and the list will be empty, as all the people the Smart Search returned will no longer be there.'
+          'If you convert this list to a static list the Smart Search will be removed and all the people the Smart Search returned will no longer be there.'
         ),
         confirmDialogSubmitLabel: m('Convert'),
         confirmDialogTitle: m('Convert to static list'),

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -419,7 +419,14 @@ export default makeMessages('feat.views', {
       delete: m('Delete list'),
       editQuery: m('Edit Smart Search query'),
       makeDynamic: m('Convert to Smart Search list'),
-      makeStatic: m('Convert to static list'),
+      makeStatic: {
+        confirmDialogInfo: m(
+          'If you convert this list to a static list the Smart Search will be removed and the list will be empty, as all the people the Smart Search returned will no longer be there.'
+        ),
+        confirmDialogSubmitLabel: m('Convert'),
+        confirmDialogTitle: m('Convert to static list'),
+        label: m('Convert to static list'),
+      },
     },
     jumpMenu: {
       placeholder: m('Start typing to find list'),

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -102,9 +102,15 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
       onSelect: () => setQueryDialogOpen(true),
     });
     ellipsisMenu.push({
-      label: messages.viewLayout.ellipsisMenu.makeStatic(),
+      label: messages.viewLayout.ellipsisMenu.makeStatic.label(),
       onSelect: () => {
-        deleteContentQuery();
+        showConfirmDialog({
+          onSubmit: deleteContentQuery,
+          title:
+            messages.viewLayout.ellipsisMenu.makeStatic.confirmDialogTitle(),
+          warningText:
+            messages.viewLayout.ellipsisMenu.makeStatic.confirmDialogInfo(),
+        });
       },
     });
   } else {


### PR DESCRIPTION
## Description
This PR adds a confirm dialog with some info that highlights that converting from a dynamic to a static list will delete the Smart Search, which means the list will be emptied of people


## Screenshots
![bild](https://github.com/user-attachments/assets/ba2d6aaf-cdb2-4a4b-9a82-f38bb359930a)



## Changes
* Adds confirm dialog with info when selecting "Convert to static list"



## Notes to reviewer
no specific ones


## Related issues
Resolves #532 
