### PR TITLE
Handle value tag values when closing journey instance.

### DIFF
--- a/src/pages/api/journeyInstances/close.ts
+++ b/src/pages/api/journeyInstances/close.ts
@@ -40,9 +40,19 @@ const closeJourneyInstance = async (
     if (body.tags) {
       await Promise.all(
         body.tags.map((tag: ZetkinTag) => {
+          const data = tag.value
+            ? JSON.stringify({ value: tag.value })
+            : undefined;
+
           apiFetch(
             `/orgs/${orgId}/journey_instances/${instanceId}/tags/${tag.id}`,
-            { method: 'PUT' }
+            {
+              body: data,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              method: 'PUT',
+            }
           );
         })
       );


### PR DESCRIPTION
## Description
This PR solves a bug where value tag values where not handled when adding tags to a journey when closing it.

## Screenshots
This tag was added in the "outcomes" dialog. On main the value would not be shown. 
![bild](https://github.com/user-attachments/assets/108eada7-78a6-4b92-b821-4581d5584d72)


## Changes
- Handle values in the api call where outcome tags are added to the journey instance.

## Notes to reviewer
no specific ones.


## Related issues
Resolves #797 
