### PR TITLE
Map gender fields on CSV import

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
@@ -41,7 +41,7 @@ const GenderConfig: FC<GenderConfigProps> = ({ uiDataColumn }) => {
         <Box width="50%">
           <Typography variant="body2">
             {messages.configuration.configure.genders
-              .header()
+              .label()
               .toLocaleUpperCase()}
           </Typography>
         </Box>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import { Box, Divider, Typography } from '@mui/material';
+
+import messageIds from 'features/import/l10n/messageIds';
+import { GenderColumn } from 'features/import/utils/types';
+import { UIDataColumn } from 'features/import/hooks/useUIDataColumn';
+import { Msg, useMessages } from 'core/i18n';
+import GenderConfigRow from './GenderConfigRow';
+import useGenderMapping from 'features/import/hooks/useGenderMapping';
+
+interface GenderConfigProps {
+  uiDataColumn: UIDataColumn<GenderColumn>;
+}
+
+const GenderConfig: FC<GenderConfigProps> = ({ uiDataColumn }) => {
+  const messages = useMessages(messageIds);
+  const { selectGender, getSelectedGender, deselectGender } = useGenderMapping(
+    uiDataColumn.originalColumn,
+    uiDataColumn.columnIndex
+  );
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      overflow="hidden"
+      padding={2}
+      sx={{ overflowY: 'auto' }}
+    >
+      <Box alignItems="baseline" display="flex" justifyContent="space-between">
+        <Typography sx={{ paddingBottom: 2 }} variant="h5">
+          <Msg id={messageIds.configuration.configure.tags.header} />
+        </Typography>
+      </Box>
+      <Box alignItems="center" display="flex" paddingY={2}>
+        <Box width="50%">
+          <Typography variant="body2">
+            {uiDataColumn.title.toLocaleUpperCase()}
+          </Typography>
+        </Box>
+        <Box width="50%">
+          <Typography variant="body2">
+            {messages.configuration.configure.genders
+              .header()
+              .toLocaleUpperCase()}
+          </Typography>
+        </Box>
+      </Box>
+      {uiDataColumn.uniqueValues.map((uniqueValue, index) => (
+        <>
+          {index != 0 && <Divider sx={{ marginY: 1 }} />}
+          <GenderConfigRow
+            numRows={uiDataColumn.numRowsByUniqueValue[uniqueValue]}
+            onDeselectGender={() => deselectGender(uniqueValue)}
+            onSelectGender={(v) => selectGender(v, uniqueValue)}
+            selectedGender={getSelectedGender(uniqueValue)}
+            title={uniqueValue.toString()}
+          />
+        </>
+      ))}
+    </Box>
+  );
+};
+
+export default GenderConfig;

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfig.tsx
@@ -52,7 +52,7 @@ const GenderConfig: FC<GenderConfigProps> = ({ uiDataColumn }) => {
           <GenderConfigRow
             numRows={uiDataColumn.numRowsByUniqueValue[uniqueValue]}
             onDeselectGender={() => deselectGender(uniqueValue)}
-            onSelectGender={(v) => selectGender(v, uniqueValue)}
+            onSelectGender={(gender) => selectGender(gender, uniqueValue)}
             selectedGender={getSelectedGender(uniqueValue)}
             title={uniqueValue.toString()}
           />

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
@@ -1,0 +1,123 @@
+import { ArrowForward, Delete } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+import { FC, useState } from 'react';
+
+import messageIds from 'features/import/l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
+import { Gender, genders } from '../../../../hooks/useGenderMapping';
+
+interface GenderConfigRowProps {
+  italic?: boolean;
+  numRows: number;
+  onSelectGender: (gender: Gender) => void;
+  onDeselectGender: () => void;
+  selectedGender: Gender;
+  title: string;
+}
+
+const GenderConfigRow: FC<GenderConfigRowProps> = ({
+  italic,
+  numRows,
+  onSelectGender,
+  onDeselectGender,
+  selectedGender,
+  title,
+}) => {
+  const messages = useMessages(messageIds);
+  const [mapping, setMapping] = useState(false);
+
+  const showSelect = mapping || selectedGender;
+
+  return (
+    <Box display="flex" flexDirection="column">
+      <Box display="flex">
+        <Box
+          alignItems="flex-start"
+          display="flex"
+          justifyContent="space-between"
+          paddingTop={1}
+          width="50%"
+        >
+          <Box display="flex" sx={{ wordBreak: 'break-all' }} width="100%">
+            <Typography fontStyle={italic ? 'italic' : ''}>{title}</Typography>
+          </Box>
+          <ArrowForward color="secondary" sx={{ marginRight: 1 }} />
+        </Box>
+        <Box
+          alignItems="flex-start"
+          display="flex"
+          paddingRight={1}
+          width="50%"
+        >
+          {!showSelect && (
+            <Button onClick={() => setMapping(true)}>
+              <Msg
+                id={
+                  messageIds.configuration.configure.genders
+                    .showGenderSelectButton
+                }
+              />
+            </Button>
+          )}
+          {showSelect && (
+            <>
+              <FormControl fullWidth size="small">
+                <InputLabel>
+                  <Msg id={messageIds.configuration.configure.genders.gender} />
+                </InputLabel>
+                <Select
+                  label={messages.configuration.configure.genders.gender()}
+                  onChange={(event) => {
+                    const { value } = event.target;
+                    if (value === 'm' || value === 'f' || value === 'o') {
+                      // Just to make TypeScript happy
+                      onSelectGender(value);
+                    }
+                  }}
+                  value={selectedGender || ''}
+                >
+                  {genders.map((key) => (
+                    <MenuItem key={key} value={key}>
+                      <Msg
+                        id={
+                          messageIds.configuration.configure.genders.genders[
+                            key
+                          ]
+                        }
+                      />
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <IconButton
+                onClick={() => {
+                  onDeselectGender();
+                  setMapping(false);
+                }}
+              >
+                <Delete color="secondary" />
+              </IconButton>
+            </>
+          )}
+        </Box>
+      </Box>
+      <Typography color="secondary">
+        <Msg
+          id={messageIds.configuration.configure.tags.numberOfRows}
+          values={{ numRows }}
+        />
+      </Typography>
+    </Box>
+  );
+};
+
+export default GenderConfigRow;

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
@@ -20,7 +20,7 @@ interface GenderConfigRowProps {
   numRows: number;
   onSelectGender: (gender: Gender) => void;
   onDeselectGender: () => void;
-  selectedGender: Gender;
+  selectedGender: Gender | null;
   title: string;
 }
 
@@ -79,11 +79,13 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
                   onChange={(event) => {
                     const { value } = event.target;
                     if (value === 'm' || value === 'f' || value === 'o') {
-                      // Just to make TypeScript happy
                       onSelectGender(value);
+                    } else if (value === 'unknown') {
+                      // selecting `unknown` is like deselecting
+                      onDeselectGender();
                     }
                   }}
-                  value={selectedGender || ''}
+                  value={selectedGender || 'unknown'}
                 >
                   {genders.map((key) => (
                     <MenuItem key={key} value={key}>
@@ -96,6 +98,13 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
                       />
                     </MenuItem>
                   ))}
+                  <MenuItem value="unknown">
+                    <Msg
+                      id={
+                        messageIds.configuration.configure.genders.genders.null
+                      }
+                    />
+                  </MenuItem>
                 </Select>
               </FormControl>
               <IconButton

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
@@ -55,10 +55,10 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
         >
           <FormControl fullWidth size="small">
             <InputLabel>
-              <Msg id={messageIds.configuration.configure.genders.gender} />
+              <Msg id={messageIds.configuration.configure.genders.label} />
             </InputLabel>
             <Select
-              label={messages.configuration.configure.genders.gender()}
+              label={messages.configuration.configure.genders.label()}
               onChange={(event) => {
                 const { value } = event.target;
                 if (value === 'm' || value === 'f' || value === 'o') {
@@ -72,14 +72,19 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
               {genders.map((key) => (
                 <MenuItem key={key} value={key}>
                   <Msg
-                    id={messageIds.configuration.configure.genders.genders[key]}
+                    id={
+                      messageIds.configuration.configure.genders.selectLabels[
+                        key
+                      ]
+                    }
                   />
                 </MenuItem>
               ))}
               <MenuItem value="unknown">
                 <Msg
                   id={
-                    messageIds.configuration.configure.genders.genders.unknown
+                    messageIds.configuration.configure.genders.selectLabels
+                      .unknown
                   }
                 />
               </MenuItem>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/GenderConfigRow.tsx
@@ -1,7 +1,6 @@
 import { ArrowForward, Delete } from '@mui/icons-material';
 import {
   Box,
-  Button,
   FormControl,
   IconButton,
   InputLabel,
@@ -9,7 +8,7 @@ import {
   Select,
   Typography,
 } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC } from 'react';
 
 import messageIds from 'features/import/l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
@@ -18,9 +17,9 @@ import { Gender, genders } from '../../../../hooks/useGenderMapping';
 interface GenderConfigRowProps {
   italic?: boolean;
   numRows: number;
-  onSelectGender: (gender: Gender) => void;
+  onSelectGender: (gender: Gender | null) => void;
   onDeselectGender: () => void;
-  selectedGender: Gender | null;
+  selectedGender: Gender | 'unknown' | null;
   title: string;
 }
 
@@ -33,10 +32,6 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
   title,
 }) => {
   const messages = useMessages(messageIds);
-  const [mapping, setMapping] = useState(false);
-
-  const showSelect = mapping || selectedGender;
-
   return (
     <Box display="flex" flexDirection="column">
       <Box display="flex">
@@ -58,65 +53,45 @@ const GenderConfigRow: FC<GenderConfigRowProps> = ({
           paddingRight={1}
           width="50%"
         >
-          {!showSelect && (
-            <Button onClick={() => setMapping(true)}>
-              <Msg
-                id={
-                  messageIds.configuration.configure.genders
-                    .showGenderSelectButton
+          <FormControl fullWidth size="small">
+            <InputLabel>
+              <Msg id={messageIds.configuration.configure.genders.gender} />
+            </InputLabel>
+            <Select
+              label={messages.configuration.configure.genders.gender()}
+              onChange={(event) => {
+                const { value } = event.target;
+                if (value === 'm' || value === 'f' || value === 'o') {
+                  onSelectGender(value);
+                } else if (value === 'unknown') {
+                  onSelectGender(null);
                 }
-              />
-            </Button>
-          )}
-          {showSelect && (
-            <>
-              <FormControl fullWidth size="small">
-                <InputLabel>
-                  <Msg id={messageIds.configuration.configure.genders.gender} />
-                </InputLabel>
-                <Select
-                  label={messages.configuration.configure.genders.gender()}
-                  onChange={(event) => {
-                    const { value } = event.target;
-                    if (value === 'm' || value === 'f' || value === 'o') {
-                      onSelectGender(value);
-                    } else if (value === 'unknown') {
-                      // selecting `unknown` is like deselecting
-                      onDeselectGender();
-                    }
-                  }}
-                  value={selectedGender || 'unknown'}
-                >
-                  {genders.map((key) => (
-                    <MenuItem key={key} value={key}>
-                      <Msg
-                        id={
-                          messageIds.configuration.configure.genders.genders[
-                            key
-                          ]
-                        }
-                      />
-                    </MenuItem>
-                  ))}
-                  <MenuItem value="unknown">
-                    <Msg
-                      id={
-                        messageIds.configuration.configure.genders.genders.null
-                      }
-                    />
-                  </MenuItem>
-                </Select>
-              </FormControl>
-              <IconButton
-                onClick={() => {
-                  onDeselectGender();
-                  setMapping(false);
-                }}
-              >
-                <Delete color="secondary" />
-              </IconButton>
-            </>
-          )}
+              }}
+              value={selectedGender}
+            >
+              {genders.map((key) => (
+                <MenuItem key={key} value={key}>
+                  <Msg
+                    id={messageIds.configuration.configure.genders.genders[key]}
+                  />
+                </MenuItem>
+              ))}
+              <MenuItem value="unknown">
+                <Msg
+                  id={
+                    messageIds.configuration.configure.genders.genders.unknown
+                  }
+                />
+              </MenuItem>
+            </Select>
+          </FormControl>
+          <IconButton
+            onClick={() => {
+              onDeselectGender();
+            }}
+          >
+            <Delete color="secondary" />
+          </IconButton>
         </Box>
       </Box>
       <Typography color="secondary">

--- a/src/features/import/components/ImportDialog/Configure/Configuration/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/index.tsx
@@ -9,6 +9,7 @@ import {
   ColumnKind,
   DateColumn,
   EnumColumn,
+  GenderColumn,
   IDFieldColumn,
   OrgColumn,
   TagColumn,
@@ -17,6 +18,7 @@ import useUIDataColumn, {
   UIDataColumn,
 } from 'features/import/hooks/useUIDataColumn';
 import EnumConfig from './EnumConfig';
+import GenderConfig from './GenderConfig';
 
 interface ConfigurationProps {
   columnIndexBeingConfigured: number;
@@ -48,6 +50,12 @@ const Configuration: FC<ConfigurationProps> = ({
       {uiDataColumn &&
         uiDataColumn.originalColumn.kind == ColumnKind.ORGANIZATION && (
           <OrgConfig uiDataColumn={uiDataColumn as UIDataColumn<OrgColumn>} />
+        )}
+      {uiDataColumn &&
+        uiDataColumn.originalColumn.kind == ColumnKind.GENDER && (
+          <GenderConfig
+            uiDataColumn={uiDataColumn as UIDataColumn<GenderColumn>}
+          />
         )}
       {uiDataColumn && uiDataColumn.originalColumn.kind == ColumnKind.DATE && (
         <DateConfig uiDataColumn={uiDataColumn as UIDataColumn<DateColumn>} />

--- a/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
@@ -39,6 +39,10 @@ const FieldSelect: FC<FieldSelectProps> = ({
       return `enum:${column.originalColumn.field}`;
     }
 
+    if (column.originalColumn.kind == ColumnKind.GENDER) {
+      return `field:gender`;
+    }
+
     if (column.originalColumn.kind != ColumnKind.UNKNOWN) {
       return column.originalColumn.kind.toString();
     }
@@ -86,6 +90,14 @@ const FieldSelect: FC<FieldSelectProps> = ({
         } else if (event.target.value == 'tag') {
           onChange({
             kind: ColumnKind.TAG,
+            mapping: [],
+            selected: true,
+          });
+          onConfigureStart();
+        } else if (event.target.value == 'field:gender') {
+          onChange({
+            field: event.target.value,
+            kind: ColumnKind.GENDER,
             mapping: [],
             selected: true,
           });

--- a/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/MappingRow.tsx
@@ -29,6 +29,7 @@ const isConfigurableColumn = (column: Column): column is ConfigurableColumn => {
     ColumnKind.TAG,
     ColumnKind.DATE,
     ColumnKind.ENUM,
+    ColumnKind.GENDER,
   ].includes(column.kind);
 };
 

--- a/src/features/import/components/ImportDialog/Configure/Preview/GenderPreview.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Preview/GenderPreview.tsx
@@ -1,0 +1,49 @@
+import messageIds from 'features/import/l10n/messageIds';
+import PreviewGrid from './PreviewGrid';
+import { useMessages } from 'core/i18n';
+import { CellData, ColumnKind, Sheet } from 'features/import/utils/types';
+
+interface GenderPreviewProps {
+  currentSheet: Sheet;
+  fieldKey: string;
+  fields: Record<string, CellData> | undefined;
+}
+
+const GenderPreview = ({
+  currentSheet,
+  fieldKey,
+  fields,
+}: GenderPreviewProps) => {
+  const messages = useMessages(messageIds);
+
+  const map = currentSheet.columns.find(
+    (column) => column.kind === ColumnKind.GENDER && column.mapping.length > 0
+  );
+
+  if (!map || map.kind !== ColumnKind.GENDER) {
+    return (
+      <PreviewGrid columnHeader={'Gender'} rowValue={null} unmappedRow={true} />
+    );
+  }
+
+  const value = fields?.[fieldKey];
+  if (value !== 'm' && value !== 'f' && value !== 'o' && value !== 'null') {
+    return (
+      <PreviewGrid
+        columnHeader={messages.configuration.preview.columnHeader.gender()}
+        emptyLabel={messages.configuration.preview.noValue()}
+        rowValue={null}
+        unmappedRow={false}
+      />
+    );
+  }
+  return (
+    <PreviewGrid
+      columnHeader={'Gender'}
+      rowValue={messages.configuration.preview.genders[value]()}
+      unmappedRow={false}
+    />
+  );
+};
+
+export default GenderPreview;

--- a/src/features/import/components/ImportDialog/Configure/Preview/GenderPreview.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Preview/GenderPreview.tsx
@@ -20,27 +20,35 @@ const GenderPreview = ({
     (column) => column.kind === ColumnKind.GENDER && column.mapping.length > 0
   );
 
-  if (!map || map.kind !== ColumnKind.GENDER) {
+  if (!map) {
     return (
-      <PreviewGrid columnHeader={'Gender'} rowValue={null} unmappedRow={true} />
+      <PreviewGrid
+        columnHeader={messages.configuration.preview.columnHeader.gender()}
+        rowValue={null}
+        unmappedRow={true}
+      />
     );
   }
 
   const value = fields?.[fieldKey];
-  if (value !== 'm' && value !== 'f' && value !== 'o' && value !== 'null') {
+
+  if (value === 'o' || value === 'f' || value === 'm' || value === null) {
+    const key = value === null ? 'unknown' : value;
     return (
       <PreviewGrid
         columnHeader={messages.configuration.preview.columnHeader.gender()}
-        emptyLabel={messages.configuration.preview.noValue()}
-        rowValue={null}
+        rowValue={messages.configuration.preview.genders[key]()}
         unmappedRow={false}
       />
     );
   }
+
+  // This should never happen
   return (
     <PreviewGrid
-      columnHeader={'Gender'}
-      rowValue={messages.configuration.preview.genders[value]()}
+      columnHeader={messages.configuration.preview.columnHeader.gender()}
+      emptyLabel={messages.configuration.preview.noValue()}
+      rowValue={null}
       unmappedRow={false}
     />
   );

--- a/src/features/import/components/ImportDialog/Configure/Preview/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Preview/index.tsx
@@ -14,6 +14,7 @@ import usePersonPreview from 'features/import/hooks/usePersonPreview';
 import useSheets from 'features/import/hooks/useSheets';
 import { ColumnKind, Sheet } from 'features/import/utils/types';
 import EnumPreview from './EnumPreview';
+import GenderPreview from './GenderPreview';
 
 const Preview = () => {
   const theme = useTheme();
@@ -148,6 +149,16 @@ const Preview = () => {
                 if (column.kind === ColumnKind.ENUM) {
                   return (
                     <EnumPreview
+                      key={columnIdx}
+                      currentSheet={currentSheet}
+                      fieldKey={column.field}
+                      fields={fields}
+                    />
+                  );
+                }
+                if (column.kind === ColumnKind.GENDER) {
+                  return (
+                    <GenderPreview
                       key={columnIdx}
                       currentSheet={currentSheet}
                       fieldKey={column.field}

--- a/src/features/import/hooks/useGenderMapping.ts
+++ b/src/features/import/hooks/useGenderMapping.ts
@@ -2,7 +2,7 @@ import { columnUpdate } from '../store';
 import { useAppDispatch } from 'core/hooks';
 import { CellData, Column, ColumnKind } from '../utils/types';
 
-export const genders = ['f', 'm', 'o', 'null'] as const;
+export const genders = ['f', 'm', 'o'] as const;
 export type Gender = typeof genders[keyof typeof genders];
 
 export default function useGenderMapping(column: Column, columnIndex: number) {
@@ -11,9 +11,9 @@ export default function useGenderMapping(column: Column, columnIndex: number) {
   const getSelectedGender = (value: CellData) => {
     if (column.kind == ColumnKind.GENDER) {
       const map = column.mapping.find((m) => m.value === value);
-      return map?.gender || 'null';
+      return map?.gender ?? null;
     }
-    return 'null';
+    return null;
   };
 
   const selectGender = (gender: Gender, value: CellData) => {

--- a/src/features/import/hooks/useGenderMapping.ts
+++ b/src/features/import/hooks/useGenderMapping.ts
@@ -1,0 +1,84 @@
+import { columnUpdate } from '../store';
+import { useAppDispatch } from 'core/hooks';
+import { CellData, Column, ColumnKind } from '../utils/types';
+
+export const genders = ['f', 'm', 'o', 'null'] as const;
+export type Gender = typeof genders[keyof typeof genders];
+
+export default function useGenderMapping(column: Column, columnIndex: number) {
+  const dispatch = useAppDispatch();
+
+  const getSelectedGender = (value: CellData) => {
+    if (column.kind == ColumnKind.GENDER) {
+      const map = column.mapping.find((m) => m.value === value);
+      return map?.gender || 'null';
+    }
+    return 'null';
+  };
+
+  const selectGender = (gender: Gender, value: CellData) => {
+    if (column.kind !== ColumnKind.GENDER) {
+      return;
+    }
+
+    // Check if there is already a map for this row value to an org ID
+    const map = column.mapping.find((map) => map.value == value);
+    // If no map for that value
+    if (!map) {
+      const newMap = { gender, value: value };
+      dispatch(
+        // Add value to mapping for the column
+        columnUpdate([
+          columnIndex,
+          {
+            ...column,
+            mapping: [...column.mapping, newMap],
+          },
+        ])
+      );
+    } else {
+      // If there is already a map, replace it
+      // Find mappings that are not for this row value
+      const filteredMapping = column.mapping.filter((m) => m.value != value);
+      // New orgId for that row value
+      const updatedMap = { ...map, gender };
+
+      dispatch(
+        columnUpdate([
+          columnIndex,
+          {
+            ...column,
+            mapping: filteredMapping.concat(updatedMap), // Add the new mapping along side existing ones
+          },
+        ])
+      );
+    }
+  };
+
+  const deselectGender = (value: CellData) => {
+    if (column.kind != ColumnKind.GENDER) {
+      return;
+    }
+
+    const map = column.mapping.find((map) => map.value == value);
+    if (map) {
+      const filteredMapping = column.mapping.filter((m) => m.value != value);
+
+      dispatch(
+        columnUpdate([
+          columnIndex,
+          {
+            ...column,
+            mapping: filteredMapping,
+          },
+        ])
+      );
+    }
+  };
+
+  return {
+    deselectGender,
+    getSelectedGender,
+    selectGender,
+  };
+}

--- a/src/features/import/hooks/useGenderMapping.ts
+++ b/src/features/import/hooks/useGenderMapping.ts
@@ -11,48 +11,31 @@ export default function useGenderMapping(column: Column, columnIndex: number) {
   const getSelectedGender = (value: CellData) => {
     if (column.kind == ColumnKind.GENDER) {
       const map = column.mapping.find((m) => m.value === value);
-      return map?.gender ?? null;
+      if (!map) {
+        return null;
+      }
+      return map.gender ?? 'unknown';
     }
     return null;
   };
 
-  const selectGender = (gender: Gender, value: CellData) => {
+  const selectGender = (gender: Gender | null, value: CellData) => {
     if (column.kind !== ColumnKind.GENDER) {
       return;
     }
 
-    // Check if there is already a map for this row value to an org ID
-    const map = column.mapping.find((map) => map.value == value);
-    // If no map for that value
-    if (!map) {
-      const newMap = { gender, value: value };
-      dispatch(
-        // Add value to mapping for the column
-        columnUpdate([
-          columnIndex,
-          {
-            ...column,
-            mapping: [...column.mapping, newMap],
-          },
-        ])
-      );
-    } else {
-      // If there is already a map, replace it
-      // Find mappings that are not for this row value
-      const filteredMapping = column.mapping.filter((m) => m.value != value);
-      // New orgId for that row value
-      const updatedMap = { ...map, gender };
-
-      dispatch(
-        columnUpdate([
-          columnIndex,
-          {
-            ...column,
-            mapping: filteredMapping.concat(updatedMap), // Add the new mapping along side existing ones
-          },
-        ])
-      );
-    }
+    dispatch(
+      columnUpdate([
+        columnIndex,
+        {
+          ...column,
+          mapping: [
+            ...column.mapping.filter((m) => m.value !== value),
+            { gender, value },
+          ],
+        },
+      ])
+    );
   };
 
   const deselectGender = (value: CellData) => {

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -63,6 +63,17 @@ export default makeMessages('feat.import', {
         ),
         value: m('Value'),
       },
+      genders: {
+        gender: m('Gender'),
+        genders: {
+          f: m('female'),
+          m: m('male'),
+          null: m('unspecified'),
+          o: m('other'),
+        },
+        header: m('Gender'),
+        showGenderSelectButton: m('Map to...'),
+      },
       ids: {
         configExplanation: m(
           'Importing with IDs allows Zetkin (now or in the future) to update existing people in the database instead of creating duplicates.'
@@ -184,6 +195,7 @@ export default makeMessages('feat.import', {
       unfinished: {
         date: m('You need to configure date format'),
         enum: m('You need to map values'),
+        gender: m('You need to map values'),
         id: m('You need to configure the IDs'),
         org: m('You need to map values'),
         tag: m('You need to map values'),
@@ -197,8 +209,15 @@ export default makeMessages('feat.import', {
     },
     preview: {
       columnHeader: {
+        gender: m('Gender'),
         org: m('Organization'),
         tags: m('Tags'),
+      },
+      genders: {
+        f: m('female'),
+        m: m('male'),
+        null: m('unspecified'),
+        o: m('other'),
       },
       next: m('Next'),
       noOrg: m('No organization'),

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -66,10 +66,10 @@ export default makeMessages('feat.import', {
       genders: {
         label: m('Gender'),
         selectLabels: {
-          f: m('female'),
-          m: m('male'),
-          o: m('other'),
-          unknown: m('unspecified'),
+          f: m('Female'),
+          m: m('Male'),
+          o: m('Other'),
+          unknown: m('Unknown'),
         },
       },
       ids: {
@@ -212,10 +212,10 @@ export default makeMessages('feat.import', {
         tags: m('Tags'),
       },
       genders: {
-        f: m('female'),
-        m: m('male'),
-        o: m('other'),
-        unknown: m('unspecified'),
+        f: m('Female'),
+        m: m('Male'),
+        o: m('Other'),
+        unknown: m('Unknown'),
       },
       next: m('Next'),
       noOrg: m('No organization'),

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -70,9 +70,9 @@ export default makeMessages('feat.import', {
           m: m('male'),
           null: m('unspecified'),
           o: m('other'),
+          unknown: m('unspecified'),
         },
         header: m('Gender'),
-        showGenderSelectButton: m('Map to...'),
       },
       ids: {
         configExplanation: m(
@@ -216,8 +216,8 @@ export default makeMessages('feat.import', {
       genders: {
         f: m('female'),
         m: m('male'),
-        null: m('unspecified'),
         o: m('other'),
+        unknown: m('unspecified'),
       },
       next: m('Next'),
       noOrg: m('No organization'),

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -64,15 +64,13 @@ export default makeMessages('feat.import', {
         value: m('Value'),
       },
       genders: {
-        gender: m('Gender'),
-        genders: {
+        label: m('Gender'),
+        selectLabels: {
           f: m('female'),
           m: m('male'),
-          null: m('unspecified'),
           o: m('other'),
           unknown: m('unspecified'),
         },
-        header: m('Gender'),
       },
       ids: {
         configExplanation: m(

--- a/src/features/import/utils/createPreviewData.ts
+++ b/src/features/import/utils/createPreviewData.ts
@@ -89,6 +89,20 @@ export default function createPreviewData(
           };
         }
       }
+
+      if (column.kind === ColumnKind.GENDER) {
+        column.mapping.forEach((mappedColumn) => {
+          if (
+            (!mappedColumn.value && !row[colIdx]) ||
+            mappedColumn.value === row[colIdx]
+          ) {
+            personPreviewOp.data = {
+              ...personPreviewOp.data,
+              [column.field]: mappedColumn.gender as string,
+            };
+          }
+        });
+      }
     }
   });
 

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -148,6 +148,18 @@ export default function prepareImportOperations(
             }
           }
         }
+
+        if (column.kind === ColumnKind.GENDER) {
+          const match = column.mapping.find(
+            (c) => c.value === row.data[colIdx]
+          );
+          if (match !== undefined) {
+            personImportOps[rowIndex].data = {
+              ...personImportOps[rowIndex].data,
+              gender: match.gender as string,
+            };
+          }
+        }
       });
     }
   });

--- a/src/features/import/utils/types.ts
+++ b/src/features/import/utils/types.ts
@@ -54,7 +54,7 @@ export type GenderColumn = BaseColumn & {
   field: string;
   kind: ColumnKind.GENDER;
   mapping: {
-    gender: Gender;
+    gender: Gender | null;
     value: CellData;
   }[];
 };

--- a/src/features/import/utils/types.ts
+++ b/src/features/import/utils/types.ts
@@ -1,4 +1,5 @@
 import { ZetkinPersonImportOp } from './prepareImportOperations';
+import { Gender } from '../hooks/useGenderMapping';
 
 export type CellData = string | number | null | undefined;
 
@@ -21,6 +22,7 @@ export type Row = {
 
 export enum ColumnKind {
   FIELD = 'field',
+  GENDER = 'gender',
   DATE = 'date',
   ID_FIELD = 'id',
   TAG = 'tag',
@@ -46,6 +48,15 @@ export type DateColumn = BaseColumn & {
   dateFormat: string | null;
   field: string;
   kind: ColumnKind.DATE;
+};
+
+export type GenderColumn = BaseColumn & {
+  field: string;
+  kind: ColumnKind.GENDER;
+  mapping: {
+    gender: Gender;
+    value: CellData;
+  }[];
 };
 
 export type EnumColumn = BaseColumn & {
@@ -83,6 +94,7 @@ export type ConfigurableColumn =
   | IDFieldColumn
   | TagColumn
   | OrgColumn
+  | GenderColumn
   | EnumColumn;
 
 export type Column = UnknownColumn | FieldColumn | ConfigurableColumn;


### PR DESCRIPTION
## Description
This PR allows users to properly map the gender fields form their CSV data to the gender definition that Zetkin understands


## Screenshots
[Add screenshots here]


## Changes
Inspired by the enum and org mappings, this adds config and preview components for the gender field.

## Notes to reviewer
The null handling is pretty ugly right now (just replacing `null` with `"null"` so that it can also be used in translations). I'm also unsure how it should generally be handled and how much translations should be duplicated. Any input is appreciated. 


## Related issues
Resolves #2348 