### PR TITLE
Make sure country codes are only ever passed in upper case.

### DIFF
--- a/src/features/import/hooks/useConfigure.ts
+++ b/src/features/import/hooks/useConfigure.ts
@@ -23,7 +23,7 @@ export default function useConfigure(orgId: number) {
   if (!organization) {
     return;
   }
-  const countryCode = organization.country as CountryCode;
+  const countryCode = organization.country.toUpperCase() as CountryCode;
 
   const emptyStats = {
     person: {

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -46,7 +46,7 @@ export default function usePreflight(orgId: number) {
 
   const problems = predictProblems(
     sheet,
-    organization.country.toString() as CountryCode,
+    organization.country.toUpperCase() as CountryCode,
     fields
   );
 


### PR DESCRIPTION
## Description
This PR makes sure an organizations country is always uppercase when used to parse phone numbers.


## Screenshots
![bild](https://github.com/user-attachments/assets/50884c05-0b4f-4339-a8aa-1b3471641fc7)


## Changes
* uses `toUpperCase()` on the country when passing it in to `predictProblems`


## Notes to reviewer
hardcode the country code sent to predictProblems to be 'se' in lowercase to see the current behaviour

## Related issues
Resolves #2321
