### PR TITLE
Remove relative time from next milestone deadline column.

### DIFF
--- a/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -261,16 +261,12 @@ export const getStaticColumns = (
       field: 'nextMilestoneDeadline',
       renderCell: (params) =>
         params.value ? (
-          <>
-            <ZUIRelativeTime datetime={params.value as string} />
-            &nbsp;(
-            <FormattedDate
-              day="numeric"
-              month="short"
-              value={params.value as string}
-            />
-            )
-          </>
+          <FormattedDate
+            day="numeric"
+            month="long"
+            value={params.value as string}
+            year="numeric"
+          />
         ) : null,
       type: 'date',
       valueFormatter: (params) => new Date(params.value),


### PR DESCRIPTION
## Description
This PR removes the relative time from the "next milestone deadline" column in the journeys overview. 

We came to this solution after @troldmand had done work into making the relative time label better for this purpose, but we came to the conclusion that relative time is not really the best thing to have here, for now a regular date will do. 

## Screenshots
![bild](https://github.com/user-attachments/assets/62e6576c-adfd-46fd-a16d-86b1abf54225)

## Changes
* Removes `ZUIRelativeTime` from the cells in the  "Next milestone deadline" column.

## Notes to reviewer
no special ones

## Related issues
Resolves #2199 
