### PR TITLE
Display title of current organization in confirmation dialog 

### DIFF
--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -80,8 +80,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   const createType = useCreateType(orgId);
   const deleteType = useDeleteType(orgId);
   const messages = useMessages(messageIds);
-  const orgTitle = useOrganization(orgId).data?.title;
-  const currentDefaultOrgMsg = messages.type.currentDefaultOrgMsg();
+  const organization = useOrganization(orgId).data;
   const uncategorizedMsg = messages.type.uncategorized();
   const [createdType, setCreatedType] = useState<string>('');
   const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
@@ -251,9 +250,9 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                             }
                           }
                         },
-                        warningText: messages.type.deleteMessage({
+                        warningText: messages.type.deleteWarning({
                           eventType: option.title,
-                          orgTitle: orgTitle ? orgTitle : currentDefaultOrgMsg,
+                          orgTitle: organization?.title || '',
                         }),
                       });
                     }}

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -10,6 +10,7 @@ import theme from 'theme';
 import useCreateType from '../hooks/useCreateType';
 import { useMessages } from 'core/i18n';
 import useDeleteType from '../hooks/useDeleteType';
+import useOrganization from 'features/organizations/hooks/useOrganization';
 import { ZetkinActivity, ZetkinEvent } from 'utils/types/zetkin';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 
@@ -79,6 +80,8 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
   const createType = useCreateType(orgId);
   const deleteType = useDeleteType(orgId);
   const messages = useMessages(messageIds);
+  const orgTitle = useOrganization(orgId).data?.title;
+  const currentDefaultOrgMsg = messages.type.currentDefaultOrgMsg();
   const uncategorizedMsg = messages.type.uncategorized();
   const [createdType, setCreatedType] = useState<string>('');
   const [text, setText] = useState<string>(value?.title ?? uncategorizedMsg);
@@ -250,6 +253,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                         },
                         warningText: messages.type.deleteMessage({
                           eventType: option.title,
+                          orgTitle: orgTitle ? orgTitle : currentDefaultOrgMsg,
                         }),
                       });
                     }}

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -282,8 +282,9 @@ export default makeMessages('feat.events', {
   tooltipContent: m('Untitled events will display type as title'),
   type: {
     createType: m<{ type: string }>('Create "{type}"'),
-    deleteMessage: m<{ eventType: string }>(
-      'Are you sure you want to delete the "{eventType}" event type for the whole organization?'
+    currentDefaultOrgMsg: m('the current organization'),
+    deleteMessage: m<{ eventType: string; orgTitle: string }>(
+      'Are you sure you want to delete the "{eventType}" event type for all of {orgTitle}?'
     ),
     tooltip: m('Click to change type'),
     uncategorized: m('Uncategorized'),

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -282,8 +282,10 @@ export default makeMessages('feat.events', {
   tooltipContent: m('Untitled events will display type as title'),
   type: {
     createType: m<{ type: string }>('Create "{type}"'),
-    currentDefaultOrgMsg: m('the current organization'),
-    deleteMessage: m<{ eventType: string; orgTitle: string }>(
+    deleteMessage: m<{ eventType: string }>(
+      'Are you sure you want to delete the "{eventType}" event type for the whole organization?'
+    ),
+    deleteWarning: m<{ eventType: string; orgTitle: string }>(
       'Are you sure you want to delete the "{eventType}" event type for all of {orgTitle}?'
     ),
     tooltip: m('Click to change type'),

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -826,8 +826,6 @@ feat:
     tooltipContent: Untitled events will display type as title
     type:
       createType: Create "{type}"
-      deleteMessage: Are you sure you want to delete the "{eventType}" event type for
-        the whole organization?
       tooltip: Click to change type
       uncategorized: Uncategorized
   files:

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -826,6 +826,7 @@ feat:
     tooltipContent: Untitled events will display type as title
     type:
       createType: Create "{type}"
+      deleteMessage: Are you sure you want to delete the "{eventType}" event type for the whole organization?
       tooltip: Click to change type
       uncategorized: Uncategorized
   files:


### PR DESCRIPTION
## Description
This PR displays the name of the current organization in the confirmation dialog on selecting delete event type from an event. 


## Screenshots
![confirmation-dialog-1](https://github.com/user-attachments/assets/19af99c4-71d5-4265-aa87-4c3b4f00ab20)
![confirmation-dialog-2](https://github.com/user-attachments/assets/2dca23a5-33f1-48ba-9045-6b61992ede8a)


## Changes
* Displays the name of the current organization in the confirmation dialog.
* Displays a default message should the name of the current organization be null or undefined.


## Notes to reviewer
Not at all sure this is a good solution, even if it seems to work as intended on my end. If not, I would be happy for a hint about the right direction.


## Related issues
Resolves #2400 
