### PR TITLE
Correctly handle empty reports when calculating stats

### DIFF
--- a/src/features/canvassAssignments/components/PlaceDialog/pages/Place.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/Place.tsx
@@ -92,10 +92,7 @@ const Place: FC<PlaceProps> = ({
               <Typography>History</Typography>
               <List>
                 {visits.map((visit) => {
-                  const householdsPerMetric = visit.responses.map((response) =>
-                    response.responseCounts.reduce((sum, value) => sum + value)
-                  );
-                  const households = Math.max(...householdsPerMetric);
+                  const households = estimateVisitedHouseholds(visit);
                   return (
                     <ListItem key={visit.id}>
                       <Box

--- a/src/features/canvassAssignments/hooks/useSidebarStats.ts
+++ b/src/features/canvassAssignments/hooks/useSidebarStats.ts
@@ -8,6 +8,7 @@ import {
   visitsLoaded,
 } from '../store';
 import useMembership from 'features/organizations/hooks/useMembership';
+import estimateVisitedHouseholds from '../utils/estimateVisitedHouseholds';
 
 type UseSidebarReturn = {
   loading: boolean;
@@ -107,10 +108,7 @@ export default function useSidebarStats(
 
   if (visitListFuture.data) {
     visitListFuture.data.forEach((visit) => {
-      const householdsPerMetric = visit.responses.map((response) =>
-        response.responseCounts.reduce((sum, value) => sum + value, 0)
-      );
-      const numHouseholds = Math.max(...householdsPerMetric);
+      const numHouseholds = estimateVisitedHouseholds(visit);
 
       teamPlaces.add(visit.placeId);
       stats.allTime.numHouseholds += numHouseholds;

--- a/src/features/canvassAssignments/utils/estimateVisitedHouseholds.ts
+++ b/src/features/canvassAssignments/utils/estimateVisitedHouseholds.ts
@@ -6,5 +6,5 @@ export default function estimateVisitedHouseholds(
   const householdsPerMetric = visit.responses.map((response) =>
     response.responseCounts.reduce((sum, value) => sum + value)
   );
-  return Math.max(...householdsPerMetric);
+  return Math.max(0, ...householdsPerMetric);
 }


### PR DESCRIPTION
## Description
This PR fixes a bug in the sidebar introduced in #2357. The use of `Math.max(...values)` would sometimes generate `-Infinite` because `values` was empty, and that would then poison all further calculations.

## Screenshots
|Before|After|
|-|-|
|![localhost_3000_my_canvassassignments(iPhone XR)](https://github.com/user-attachments/assets/9fb5912b-d85e-4b47-ba1e-9997bdc77b23)|![localhost_3000_my_canvassassignments(iPhone XR) (1)](https://github.com/user-attachments/assets/82942210-a26f-443e-8489-12b916e7ba5e)|

## Changes
* Always includes `0` in `Math.max()`
* Changes calculation in sidebar to use the reusable `estimateVisitedHouseholds()` utility

## Notes to reviewer
None

## Related issues
Undocumented