### PR TITLE
Close place dialog after submitting quick report.

### DIFF
--- a/src/features/canvassAssignments/components/PlaceDialog/index.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/index.tsx
@@ -183,7 +183,6 @@ const PlaceDialog: FC<PlaceDialogProps> = ({
                 responses,
               });
               setShowSparkle(true);
-              back();
             }}
           />
         </Box>

--- a/src/features/canvassAssignments/components/PlaceDialog/pages/PlaceVisitPage.tsx
+++ b/src/features/canvassAssignments/components/PlaceDialog/pages/PlaceVisitPage.tsx
@@ -76,6 +76,7 @@ const PlaceVisitPage: FC<Props> = ({
                 }))
               );
               setSubmitting(false);
+              onClose();
             }}
             startIcon={
               submitting ? (


### PR DESCRIPTION
## Description
This PR adds that the place dialog closes automatically when you have submitted a quick report. 


## Screenshots
none

## Changes
* Runs the `onClose` function of the PlaceVisitPage after submitting the report is finished.



## Notes to reviewer
none


## Related issues
none
