### PR TITLE
Fix problem with email inline link editor disappearing

### DIFF
--- a/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
+++ b/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
@@ -1,8 +1,6 @@
 export default class InlineToolBase {
   private static _activeInstance: InlineToolBase | null = null;
 
-  private _handleSelectionChangeBound: () => void = () => undefined;
-
   activate() {
     if (InlineToolBase._activeInstance) {
       InlineToolBase._activeInstance.deactivate();
@@ -10,24 +8,16 @@ export default class InlineToolBase {
     InlineToolBase._activeInstance = this;
   }
 
-  checkState() {
-    return true;
+  checkState(selection: Selection) {
+    this.update(selection.getRangeAt(0));
   }
 
   clear() {
     this.onToolClose();
-    this.destroy();
   }
 
   deactivate() {
     // Called by activate()
-  }
-
-  destroy() {
-    document.removeEventListener(
-      'selectionchange',
-      this._handleSelectionChangeBound
-    );
   }
 
   static get isInline() {
@@ -39,22 +29,6 @@ export default class InlineToolBase {
   }
 
   render() {
-    const handleSelectionChange = () => {
-      const selection = window.getSelection();
-      if (selection?.rangeCount) {
-        const range = window.getSelection()?.getRangeAt(0);
-        if (range) {
-          this.update(range);
-        }
-      }
-    };
-
-    this._handleSelectionChangeBound = handleSelectionChange.bind(this);
-    document.addEventListener(
-      'selectionchange',
-      this._handleSelectionChangeBound
-    );
-
     return this.renderButton();
   }
 

--- a/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
+++ b/src/features/emails/components/EmailEditor/utils/InlineToolBase.ts
@@ -10,6 +10,7 @@ export default class InlineToolBase {
 
   checkState(selection: Selection) {
     this.update(selection.getRangeAt(0));
+    return true;
   }
 
   clear() {


### PR DESCRIPTION
## Description
Our own event listening for changes to selection (and then updating tool state) triggered too early. Editor.js runs through closing and opening the toolbar every time the selection changes, with a call to checkState function meant to decide if we should open it (again).

Previously we would run our own update, where the logic for deciding to have toolbar open was, which displayed it. Then Editor.js would close it and call checkState, but because there was no code there for keeping it open, it would remain close. So the link tool would just briefly flash open.

## Changes
* Email inline link editor now visible when selecting text after link creation.
* Change inline variable editor to also use correct lifecycle.

## Related issues
Resolves #2176
