### PR TITLE
Add delay to closing popper in list

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -23,6 +23,7 @@ import { ZetkinOrganizerAction } from 'utils/types/zetkin';
 import { ZetkinViewRow } from '../../types';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import messageIds from 'features/views/l10n/messageIds';
+import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
@@ -83,6 +84,10 @@ const Cell: FC<{
   const viewId = parseInt(query.viewId as string);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
+  const { open: openPopper, close: closePopper } = useToggleDebounce(
+    (ev) => setAnchorEl(ev.currentTarget),
+    () => setAnchorEl(null)
+  );
 
   const [isRestricted] = useAccessLevel();
   const numUnsolved =
@@ -96,8 +101,8 @@ const Cell: FC<{
     return (
       <Box
         className={styles.organizerActionContainer}
-        onMouseOut={() => setAnchorEl(null)}
-        onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
+        onMouseOut={closePopper}
+        onMouseOver={openPopper}
       >
         {numUnsolved < 1 ? (
           <Check />

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -12,6 +12,7 @@ import theme from '../../../../../theme';
 import { usePanes } from 'utils/panes';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
 import messageIds from 'features/views/l10n/messageIds';
+import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 type SurveyOptionViewCell =
   | {
@@ -48,6 +49,10 @@ const Cell: FC<{ cell: SurveyOptionViewCell }> = ({ cell }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
   const { orgId } = useRouter().query;
+  const { open: openPopper, close: closePopper } = useToggleDebounce(
+    (ev) => setAnchorEl(ev.currentTarget),
+    () => setAnchorEl(null)
+  );
 
   if (!cell?.length) {
     return null;
@@ -75,8 +80,8 @@ const Cell: FC<{ cell: SurveyOptionViewCell }> = ({ cell }) => {
       display="flex"
       height="100%"
       justifyContent="center"
-      onMouseOut={() => setAnchorEl(null)}
-      onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
+      onMouseOut={closePopper}
+      onMouseOver={openPopper}
       width="100%"
     >
       {mostRecent.selected ? (

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -14,6 +14,7 @@ import { usePanes } from 'utils/panes';
 import { IColumnType } from '.';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
+import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 export type SurveyOptionsViewCell =
   | {
@@ -94,6 +95,10 @@ const Cell: FC<{
   const styles = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
+  const { open: openPopper, close: closePopper } = useToggleDebounce(
+    (ev) => setAnchorEl(ev.currentTarget),
+    () => setAnchorEl(null)
+  );
 
   if (!cell?.length) {
     return null;
@@ -108,8 +113,8 @@ const Cell: FC<{
   return (
     <Box
       className={styles.cell}
-      onMouseOut={() => setAnchorEl(null)}
-      onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
+      onMouseOut={closePopper}
+      onMouseOver={openPopper}
     >
       <Box className={styles.content}>
         {sorted[0].selected.map((s) => (

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -15,6 +15,7 @@ import { SurveyResponseViewColumn } from '../../types';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import { usePanes } from 'utils/panes';
 import ViewSurveySubmissionPreview from '../../ViewSurveySubmissionPreview';
+import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 export type SurveyResponseViewCell = {
   submission_id: number;
@@ -71,6 +72,10 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
   const styles = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const { openPane } = usePanes();
+  const { open: openPopper, close: closePopper } = useToggleDebounce(
+    (ev) => setAnchorEl(ev.currentTarget),
+    () => setAnchorEl(null)
+  );
 
   if (!cell?.length) {
     return null;
@@ -81,13 +86,12 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
     const d1 = new Date(sub1.submitted);
     return d1.getTime() - d0.getTime();
   });
-
   return (
     <Box className={styles.cell}>
       <Box
         className={styles.content}
-        onMouseOut={() => setAnchorEl(null)}
-        onMouseOver={(ev) => setAnchorEl(ev.currentTarget)}
+        onMouseOut={closePopper}
+        onMouseOver={openPopper}
       >
         <Box alignItems="center" display="flex" justifyContent="space-between">
           {sorted[0].text}

--- a/src/utils/hooks/useToggleDebounce.ts
+++ b/src/utils/hooks/useToggleDebounce.ts
@@ -1,0 +1,22 @@
+import { MouseEvent, useRef } from 'react';
+
+// Close will be called after a delay, which is cancelled if open is called
+// Useful to toggle poppers without closing the instant the cursor is outside the triggering element
+export default function useToggleDebounce(
+  open: (ev: MouseEvent<HTMLElement>) => void,
+  close: (ev: MouseEvent<HTMLElement>) => void,
+  delay = 250
+) {
+  const timeoutId = useRef<number | undefined>();
+  function openDebounced(ev: MouseEvent<HTMLElement>) {
+    clearTimeout(timeoutId.current);
+    open(ev);
+  }
+
+  function closeDebounced(ev: MouseEvent<HTMLElement>) {
+    timeoutId.current = window.setTimeout(() => {
+      close(ev);
+    }, delay);
+  }
+  return { close: closeDebounced, open: openDebounced };
+}


### PR DESCRIPTION
## Description
This PR prevents list survey response preview to close if user moves mouse outside of row without going into the preview


## Screenshots

[mousewiggle0001-0239.webm](https://github.com/user-attachments/assets/1405cad4-38d1-41b0-a381-044d75d779f4)


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a hook to help with debouncing toggle and not closing if user moves cursor to the intended element
* Changes OrganizerActionColumnType, SurveyOptionColumnType, SurveyOptionsColumnType to use new toggle-debouncing hook

## Related issues
Resolves #2386 
