### PR TITLE
Show read-only fields as disabled

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
@@ -53,12 +53,17 @@ const FieldSelect: FC<FieldSelectProps> = ({
 
   // This has to be a function, not a component with PascalCase. If it is used
   // as a component, the `Select` below won't recognise it as a valid option.
-  const listOption = ({ value, label, key }: Option & { key?: string }) => {
+  const listOption = ({
+    disabled,
+    value,
+    label,
+    key,
+  }: Option & { key?: string }) => {
     const alreadySelected = optionAlreadySelected(value);
     return (
       <MenuItem
         key={key}
-        disabled={alreadySelected}
+        disabled={alreadySelected || disabled}
         sx={{ paddingLeft: 4 }}
         value={value}
       >
@@ -132,11 +137,13 @@ const FieldSelect: FC<FieldSelectProps> = ({
         <Msg id={messageIds.configuration.mapping.zetkinFieldGroups.id} />
       </ListSubheader>
       {listOption({
+        disabled: false,
         label: messages.configuration.mapping.zetkinID(),
         value: 'id',
       })}
 
       {listOption({
+        disabled: false,
         label: messages.configuration.mapping.externalID(),
         value: 'ext_id',
       })}
@@ -152,10 +159,12 @@ const FieldSelect: FC<FieldSelectProps> = ({
         <Msg id={messageIds.configuration.mapping.zetkinFieldGroups.other} />
       </ListSubheader>
       {listOption({
+        disabled: false,
         label: messages.configuration.mapping.organization(),
         value: 'org',
       })}
       {listOption({
+        disabled: false,
         label: messages.configuration.mapping.tags(),
         value: 'tag',
       })}

--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -1,6 +1,7 @@
 import { columnUpdate } from '../store';
 import { CUSTOM_FIELD_TYPE } from 'utils/types/zetkin';
 import globalMessageIds from 'core/i18n/globalMessageIds';
+import messageIds from '../l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import useCustomFields from 'features/profile/hooks/useCustomFields';
 import { useMessages } from 'core/i18n';
@@ -18,6 +19,7 @@ export default function useColumn(orgId: number) {
   const pendingFile = useAppSelector((state) => state.import.pendingFile);
   const columns = pendingFile.sheets[pendingFile.selectedSheetIndex].columns;
   const globalMessages = useMessages(globalMessageIds);
+  const messages = useMessages(messageIds);
   const customFields = useCustomFields(orgId).data ?? [];
 
   const updateColumn = (index: number, column: Column) => {
@@ -67,23 +69,28 @@ export default function useColumn(orgId: number) {
     const suborgsCanWrite = field.org_write == 'suborgs';
     const currentOrgCanWrite = belongsToCurrentOrg || suborgsCanWrite;
     const readOnly = !currentOrgCanWrite;
+    const label = readOnly
+      ? messages.configuration.mapping.messages.readOnlyField({
+          title: field.title,
+        })
+      : field.title;
 
     if (field.type === CUSTOM_FIELD_TYPE.DATE) {
       return {
         disabled: readOnly,
-        label: field.title,
+        label,
         value: `date:${field.slug}`,
       };
     } else if (field.type == CUSTOM_FIELD_TYPE.ENUM && field.enum_choices) {
       return {
         disabled: readOnly,
-        label: field.title,
+        label,
         value: `enum:${field.slug}`,
       };
     } else {
       return {
         disabled: readOnly,
-        label: field.title,
+        label,
         value: `field:${field.slug}`,
       };
     }

--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -63,27 +63,26 @@ export default function useColumn(orgId: number) {
     }));
 
   const customFieldsOptions: Option[] = customFields.map((field) => {
+    const belongsToCurrentOrg = field.organization.id == orgId;
+    const suborgsCanWrite = field.org_write == 'suborgs';
+    const currentOrgCanWrite = belongsToCurrentOrg || suborgsCanWrite;
+    const readOnly = !currentOrgCanWrite;
+
     if (field.type === CUSTOM_FIELD_TYPE.DATE) {
       return {
-        disabled: !(
-          field.organization.id == orgId || field.org_write == 'suborgs'
-        ),
+        disabled: readOnly,
         label: field.title,
         value: `date:${field.slug}`,
       };
     } else if (field.type == CUSTOM_FIELD_TYPE.ENUM && field.enum_choices) {
       return {
-        disabled: !(
-          field.organization.id == orgId || field.org_write == 'suborgs'
-        ),
+        disabled: readOnly,
         label: field.title,
         value: `enum:${field.slug}`,
       };
     } else {
       return {
-        disabled: !(
-          field.organization.id == orgId || field.org_write == 'suborgs'
-        ),
+        disabled: readOnly,
         label: field.title,
         value: `field:${field.slug}`,
       };

--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -8,6 +8,7 @@ import { Column, ColumnKind } from '../utils/types';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 
 export interface Option {
+  disabled: boolean;
   value: string;
   label: string;
 }
@@ -56,32 +57,38 @@ export default function useColumn(orgId: number) {
   const nativeFieldsOptions: Option[] = Object.values(NATIVE_PERSON_FIELDS)
     .filter((fieldSlug) => fieldSlug != 'id' && fieldSlug != 'ext_id')
     .map((fieldSlug) => ({
+      disabled: false,
       label: globalMessages.personFields[fieldSlug](),
       value: `field:${fieldSlug}`,
     }));
 
-  const customFieldsOptions: Option[] = customFields
-    .filter(
-      (field) => field.organization.id == orgId || field.org_write == 'suborgs'
-    )
-    .map((field) => {
-      if (field.type === CUSTOM_FIELD_TYPE.DATE) {
-        return {
-          label: field.title,
-          value: `date:${field.slug}`,
-        };
-      } else if (field.type == CUSTOM_FIELD_TYPE.ENUM && field.enum_choices) {
-        return {
-          label: field.title,
-          value: `enum:${field.slug}`,
-        };
-      } else {
-        return {
-          label: field.title,
-          value: `field:${field.slug}`,
-        };
-      }
-    });
+  const customFieldsOptions: Option[] = customFields.map((field) => {
+    if (field.type === CUSTOM_FIELD_TYPE.DATE) {
+      return {
+        disabled: !(
+          field.organization.id == orgId || field.org_write == 'suborgs'
+        ),
+        label: field.title,
+        value: `date:${field.slug}`,
+      };
+    } else if (field.type == CUSTOM_FIELD_TYPE.ENUM && field.enum_choices) {
+      return {
+        disabled: !(
+          field.organization.id == orgId || field.org_write == 'suborgs'
+        ),
+        label: field.title,
+        value: `enum:${field.slug}`,
+      };
+    } else {
+      return {
+        disabled: !(
+          field.organization.id == orgId || field.org_write == 'suborgs'
+        ),
+        label: field.title,
+        value: `field:${field.slug}`,
+      };
+    }
+  });
 
   const fieldOptions: Option[] = [
     ...nativeFieldsOptions,

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -150,6 +150,7 @@ export default makeMessages('feat.import', {
         onlyEmpty: m<{ numEmpty: number }>(
           '{numEmpty, plural, =1 {one empty row} other {# empty rows}}.'
         ),
+        readOnlyField: m<{ title: string }>('{title} (read only)'),
 
         threeValuesAndEmpty: m<{
           firstValue: string | number;


### PR DESCRIPTION
## Description
This PR makes custom fields on people imports that cannot be used visible as disabled options.


## Screenshots

In this example "Extra text" has `org_read: 'suborgs'` and `org_write: 'sameorg'`.
![image](https://github.com/user-attachments/assets/8c6864ce-7243-4760-992a-200a9e656246)

## Changes

* Adds way to see unavailable custom fields.


## Notes to reviewer

Running `fetch('/api/orgs/1/people/fields/2', { method: 'PATCH', headers: {'Content-Type': 'application/json' }, body: JSON.stringify({ org_read: 'suborgs', org_write: 'sameorg' }) })` in dev console can be used to change read/write settings on org 1 for field 2.

View on sub-org.

## Related issues
Resolves #2308
