### PR TITLE
Set list of places as "stale" when running "sync" function.

### DIFF
--- a/src/features/canvassAssignments/hooks/useSidebarStats.ts
+++ b/src/features/canvassAssignments/hooks/useSidebarStats.ts
@@ -1,6 +1,7 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import {
+  placesInvalidated,
   placesLoad,
   placesLoaded,
   visitsInvalidated,
@@ -134,6 +135,7 @@ export default function useSidebarStats(
     stats,
     sync: () => {
       dispatch(visitsInvalidated(assignmentId));
+      dispatch(placesInvalidated);
     },
     synced: visitList?.loaded || null,
   };

--- a/src/features/canvassAssignments/hooks/useSidebarStats.ts
+++ b/src/features/canvassAssignments/hooks/useSidebarStats.ts
@@ -135,7 +135,7 @@ export default function useSidebarStats(
     stats,
     sync: () => {
       dispatch(visitsInvalidated(assignmentId));
-      dispatch(placesInvalidated);
+      dispatch(placesInvalidated());
     },
     synced: visitList?.loaded || null,
   };

--- a/src/features/canvassAssignments/store.ts
+++ b/src/features/canvassAssignments/store.ts
@@ -256,6 +256,9 @@ const canvassAssignmentSlice = createSlice({
       item.data = place;
       item.loaded = new Date().toISOString();
     },
+    placesInvalidated: (state) => {
+      state.placeList.isStale = true;
+    },
     placesLoad: (state) => {
       state.placeList.isLoading = true;
     },
@@ -361,6 +364,7 @@ export const {
   canvassSessionsLoad,
   canvassSessionsLoaded,
   placeCreated,
+  placesInvalidated,
   placesLoad,
   placesLoaded,
   placeUpdated,


### PR DESCRIPTION
## Description
This PR sets the list of places to stale when clicking the button to "sync" stats and data in the canvasser interface. 

## Screenshots
none


## Changes
* Adds store reducer that sets list of places to stale



## Notes to reviewer
I did not figure out how to test this in action, so it's just wild and crazy like that but i'm thinking the logic should work? 


## Related issues
none
