### PR TITLE
Make map tiles and polygons render correctly on pan/zoom

### DIFF
--- a/src/features/canvassAssignments/components/CanvassAssignmentMap.tsx
+++ b/src/features/canvassAssignments/components/CanvassAssignmentMap.tsx
@@ -79,18 +79,20 @@ const CanvassAssignmentMap: FC<CanvassAssignmentMapProps> = ({
     assignment.organization.id,
     assignment.id
   );
+  const [localStorageBounds, setLocalStorageBounds] = useLocalStorage<
+    [LatLngTuple, LatLngTuple] | null
+  >(`mapBounds-${assignment.id}`, null);
 
+  const [map, setMap] = useState<Map | null>(null);
+  const [zoomed, setZoomed] = useState(false);
   const [selectedPlaceId, setSelectedPlaceId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [created, setCreated] = useState(false);
 
-  const [map, setMap] = useState<Map | null>(null);
   const crosshairRef = useRef<HTMLDivElement | null>(null);
   const reactFGref = useRef<FeatureGroupType | null>(null);
 
-  const [localStorageBounds, setLocalStorageBounds] = useLocalStorage<
-    [LatLngTuple, LatLngTuple] | null
-  >(`mapBounds-${assignment.id}`, null);
+  const selectedPlace = places.find((place) => place.id == selectedPlaceId);
 
   const saveBounds = () => {
     const bounds = map?.getBounds();
@@ -102,10 +104,6 @@ const CanvassAssignmentMap: FC<CanvassAssignmentMapProps> = ({
       ]);
     }
   };
-
-  const [zoomed, setZoomed] = useState(false);
-
-  const selectedPlace = places.find((place) => place.id == selectedPlaceId);
 
   const updateSelection = useCallback(() => {
     let nearestPlace: string | null = null;
@@ -191,12 +189,6 @@ const CanvassAssignmentMap: FC<CanvassAssignmentMapProps> = ({
       map.on('moveend', saveBounds);
 
       map.on('zoomend', () => saveBounds);
-
-      return () => {
-        map.off('move');
-        map.off('moveend');
-        map.off('movestart');
-      };
     }
   }, [map, selectedPlaceId, places, panTo, updateSelection]);
 


### PR DESCRIPTION
## Description
This PR attempts to solve the issue we've been having with the canvasser map not re-drawing the lines around areas when you zoom in, and not loading new map tiles when you pan around the map.

## Screenshots
https://github.com/user-attachments/assets/8f7d331d-edf3-4225-a403-45c7c27ebff9

## Changes
* Removes the returned function from the useEffect that attaches functionality to map actions
* Moves a couple of lines of code for a slightly more organised file


## Notes to reviewer
I have no idea *why* this works, but it works. 
I re-built the map component from scratch, adding one bit at a time, and it failed when I added this useEffect, so i removed bit by bit in it, and it turns out if you remove the return value it solves the problem.

## Related issues
none
