### PR TITLE
Update error message for unlocked targets.

### DIFF
--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -22,7 +22,7 @@ export default makeMessages('feat.emails', {
       'Your email has no targets. Go to the Targets section in the Overview tab to create a Smart Search that defines your targets.'
     ),
     targetsNotLocked: m(
-      'The targets are not locked. Go to the Ready section in the Overview tab to do this.'
+      'The targets are not locked. Go to the Targets section in the Overview tab to do this.'
     ),
   },
   deliveryStatus: {


### PR DESCRIPTION
## Description
This PR adds a small update to an error message for email delivery, that was missed when moving the "lock targets" button from the "Ready" section to the "Targets" section.

## Screenshots
none

## Changes
* changes the error message.

## Notes to reviewer
none

## Related issues
none
