### PR TITLE
Update email when linking respondent

### DIFF
--- a/src/features/surveys/components/SurveyDialogLink.tsx
+++ b/src/features/surveys/components/SurveyDialogLink.tsx
@@ -1,0 +1,66 @@
+import { ArrowForward } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
+import { useNumericRouteParams } from 'core/hooks';
+import { useMessages } from 'core/i18n';
+import usePersonMutations from 'features/profile/hooks/usePersonMutations';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
+
+const SurveyDialogLink = ({
+  email,
+  onClose,
+  open,
+  person,
+}: {
+  email: string;
+  onClose: () => void;
+  open: boolean;
+  person: ZetkinPerson;
+}) => {
+  const messages = useMessages(messageIds);
+  const { orgId } = useNumericRouteParams();
+  const { updatePerson } = usePersonMutations(orgId, person.id);
+
+  return (
+    <Dialog open={open}>
+      <DialogTitle>{messages.surveyDialog.title()}</DialogTitle>
+      <DialogContent>
+        <Box alignItems="center" display="flex">
+          {email}
+          <Box alignItems="center" display="flex" ml={2} mr={2}>
+            <ArrowForward />
+          </Box>
+          <ZUIPersonAvatar orgId={orgId} personId={person?.id ?? 0} />
+          <Typography ml={2} variant="h6">
+            {person?.first_name} {person?.last_name}
+          </Typography>
+        </Box>
+        {messages.surveyDialog.description()}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{messages.surveyDialog.cancel()}</Button>
+        <Button
+          onClick={() => {
+            updatePerson({ email });
+            onClose();
+          }}
+          variant="contained"
+        >
+          {messages.surveyDialog.add()}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SurveyDialogLink;

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -10,6 +10,7 @@ import {
 import { FC, useEffect, useMemo, useState } from 'react';
 
 import messageIds from '../l10n/messageIds';
+import SurveyDialogLink from './SurveyDialogLink';
 import SurveySubmissionPane from '../panes/SurveySubmissionPane';
 import { useNumericRouteParams } from 'core/hooks';
 import { usePanes } from 'utils/panes';
@@ -262,6 +263,14 @@ const SurveySubmissionsList = ({
           border: 'none',
         }}
       />
+      {dialogPerson && (
+        <SurveyDialogLink
+          email={dialogEmail}
+          onClose={() => setDialogOpen(false)}
+          open={dialogOpen}
+          person={dialogPerson}
+        />
+      )}
     </Box>
   );
 };

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -7,7 +7,7 @@ import {
   GridRenderCellParams,
   useGridApiContext,
 } from '@mui/x-data-grid-pro';
-import { FC, useEffect, useMemo } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 
 import messageIds from '../l10n/messageIds';
 import SurveySubmissionPane from '../panes/SurveySubmissionPane';
@@ -30,6 +30,15 @@ const SurveySubmissionsList = ({
   const messages = useMessages(messageIds);
   const { orgId } = useRouter().query;
   const { openPane } = usePanes();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogPerson, setDialogPerson] = useState<ZetkinPerson>();
+  const [dialogEmail, setDialogEmail] = useState('');
+
+  const handleUpdateEmail = (option: ZetkinPerson, email: string) => {
+    setDialogEmail(email);
+    setDialogPerson(option);
+    setDialogOpen(true);
+  };
 
   const sortedSubmissions = useMemo(() => {
     const sorted = [...submissions].sort((subOne, subTwo) => {
@@ -198,6 +207,12 @@ const SurveySubmissionsList = ({
         id: row.id,
       });
       setRespondentId(person?.id || null);
+
+      const personHasNoEmail = person?.id !== null && person?.email === null;
+      const respondentEmail = row.respondent?.email;
+      if (personHasNoEmail && respondentEmail !== undefined) {
+        handleUpdateEmail(person, respondentEmail);
+      }
     };
 
     return (

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -171,6 +171,14 @@ export default makeMessages('feat.surveys', {
     suggestedPeople: m('Suggested people'),
     unlink: m('Unlink'),
   },
+  surveyDialog: {
+    add: m('Add'),
+    cancel: m("Don't add"),
+    description: m(
+      'The person you are about to link does not have an email address while the response does. Would you like to add it to the person?'
+    ),
+    title: m('Add email address'),
+  },
   surveyForm: {
     accept: m('I accept the terms stated below'),
     error: m(

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
+import { personUpdated } from 'features/profile/store';
 import { SurveyStats } from './rpc/getSurveyStats';
 import {
   ELEMENT_TYPE,
@@ -39,6 +40,33 @@ const initialState: SurveysStoreSlice = {
 };
 
 const surveysSlice = createSlice({
+  extraReducers: (builder) =>
+    builder.addCase(personUpdated, (state, action) => {
+      const person = action.payload;
+      const item = state.submissionList.items.find(
+        (item) => item?.data?.respondent?.id === person.id
+      );
+
+      if (item?.data?.respondent) {
+        const respondent = item.data.respondent;
+
+        if (person.email) {
+          respondent.email = person.email;
+        }
+        if (person.first_name) {
+          respondent.first_name = person.first_name;
+        }
+        if (person.last_name) {
+          respondent.last_name = person.last_name;
+        }
+      }
+      const submissionsUpdated = state.submissionList.items
+        .map((item) => item.data)
+        .filter((data): data is ZetkinSurveySubmission => data !== null);
+
+      addSubmissionToState(state, submissionsUpdated);
+    }),
+
   initialState,
   name: 'surveys',
   reducers: {


### PR DESCRIPTION
## Description
This PR adds a dialog to allow the user to add the respondent email to the person that is going to be link as a new respondent. 
It also introduces a new extra reducer in the `Survey ` store that updates de submission list when a person is updated. 


## Screenshots

https://github.com/user-attachments/assets/f8299132-391a-4a55-84f7-46f0d25cd920



## Changes
* Adds an `if` statement in `SurveySubmissionsList` when a person to be linked as a respondent doesn't have an email
* Adds a `SurveyDialogLink `component to display a Dialog when the if statement is triggered 
* Adds an extra reducer in `Survey `store to update the submissions list when `personUpdated` action is triggered. 


## Notes to reviewer
None


## Related issues
Resolves #2269 
