### PR TITLE
UI to reject join form

### DIFF
--- a/src/features/joinForms/components/JoinSubmissionTable.tsx
+++ b/src/features/joinForms/components/JoinSubmissionTable.tsx
@@ -28,7 +28,8 @@ const JoinSubmissionTable: FC<Props> = ({ onSelect, orgId, submissions }) => {
   const classes = useStyles();
   const messages = useMessages(messageIds);
   const theme = useTheme();
-  const { approveSubmission } = useJoinSubmissionMutations(orgId);
+  const { approveSubmission, deleteSubmission } =
+    useJoinSubmissionMutations(orgId);
 
   return (
     <Box bgcolor={theme.palette.background.paper} m={2}>
@@ -37,7 +38,7 @@ const JoinSubmissionTable: FC<Props> = ({ onSelect, orgId, submissions }) => {
           {
             disableColumnMenu: true,
             field: 'state',
-            flex: 1,
+            flex: 2,
             headerName: messages.status(),
             renderCell: (params) => {
               return (
@@ -51,28 +52,28 @@ const JoinSubmissionTable: FC<Props> = ({ onSelect, orgId, submissions }) => {
           {
             disableColumnMenu: true,
             field: 'first_name',
-            flex: 1,
+            flex: 2,
             headerName: messages.submissionList.firstName(),
             valueGetter: (params) => params.row.person_data.first_name,
           },
           {
             disableColumnMenu: true,
             field: 'last_name',
-            flex: 1,
+            flex: 2,
             headerName: messages.submissionList.lastName(),
             valueGetter: (params) => params.row.person_data.last_name,
           },
           {
             disableColumnMenu: true,
             field: 'form',
-            flex: 1,
+            flex: 2,
             headerName: messages.submissionList.form(),
             valueGetter: (params) => params.row.form.title,
           },
           {
             disableColumnMenu: true,
             field: 'submitted',
-            flex: 1,
+            flex: 2,
             headerName: messages.submissionList.timestamp(),
             type: 'dateTime',
             valueGetter: (params) => new Date(params.row.submitted),
@@ -81,16 +82,21 @@ const JoinSubmissionTable: FC<Props> = ({ onSelect, orgId, submissions }) => {
             align: 'right',
             disableColumnMenu: true,
             field: 'actions',
-            flex: 1,
+            flex: 3,
             headerName: '',
             renderCell: (params) => {
               if (params.row.state !== 'accepted') {
                 return (
                   <Box display="flex" gap={2}>
-                    {/* TODO: Handle rejectButton click */}
-                    {/* <Button variant="text">
+                    <Button
+                      onClick={(event) => {
+                        deleteSubmission(params.row.id);
+                        event.stopPropagation();
+                      }}
+                      variant="text"
+                    >
                       <Msg id={messageIds.submissionList.rejectButton} />
-                    </Button> */}
+                    </Button>
                     <Button
                       onClick={(event) => {
                         approveSubmission(params.row.id);

--- a/src/features/joinForms/hooks/useJoinSubmissionMutations.ts
+++ b/src/features/joinForms/hooks/useJoinSubmissionMutations.ts
@@ -1,9 +1,14 @@
 import { ZetkinJoinSubmission } from '../types';
-import { submissionUpdate, submissionUpdated } from '../store';
+import {
+  submissionDeleted,
+  submissionUpdate,
+  submissionUpdated,
+} from '../store';
 import { useApiClient, useAppDispatch } from 'core/hooks';
 
 interface UseJoinSubmissionMutationsReturn {
   approveSubmission: (submissionId: number) => void;
+  deleteSubmission: (submissionId: number) => void;
 }
 
 export default function useJoinSubmissionMutations(
@@ -23,7 +28,15 @@ export default function useJoinSubmissionMutations(
     dispatch(submissionUpdated(data));
   }
 
+  async function deleteSubmission(submissionId: number) {
+    await apiClient.delete(
+      `/api/orgs/${orgId}/join_submissions/${submissionId}`
+    );
+    dispatch(submissionDeleted(submissionId));
+  }
+
   return {
     approveSubmission,
+    deleteSubmission,
   };
 }

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -54,6 +54,16 @@ const joinFormsSlice = createSlice({
       state.formList = remoteList(action.payload);
       state.formList.loaded = new Date().toISOString();
     },
+    submissionDeleted: (state, action: PayloadAction<number>) => {
+      const submissionId = action.payload;
+      const item = state.submissionList.items.find(
+        (item) => item.id == submissionId
+      );
+
+      if (item) {
+        item.deleted = true;
+      }
+    },
     submissionLoad: (state, action: PayloadAction<number>) => {
       const submissionId = action.payload;
       const item = findOrAddItem(state.submissionList, submissionId);
@@ -100,6 +110,7 @@ export const {
   joinFormUpdated,
   joinFormsLoad,
   joinFormsLoaded,
+  submissionDeleted,
   submissionLoad,
   submissionLoaded,
   submissionUpdate,


### PR DESCRIPTION
## Description
This PR adds a "Reject" button to the join form submissions list, which deletes a submission without accepting the joiner to the organization.

## Screenshots
![image](https://github.com/user-attachments/assets/57138590-671c-46d1-84a9-fd6e954814ca)

## Changes
* Adds a `deleteSubmission` function to `useJoinSubmissionMutations()`
* Adds a button to the `JoinSubmissionTable` (code was partially already there, but commented out)
* Tweak flexing of columns in table to reserve some more space for button

## Notes to reviewer
To test:

1. Go to join forms list
2. On an join form, click the ellipsis menu and pick "Copy embed URL"
3. Open the embed URL
4. Fill out the form and submit
5. Back in the organizer interface, go to the "Incoming" tab
6. Find your new submission and use the "REJECT" button to delete it

## Related issues
Undocumented