### PR TITLE
Add missing joinformverified page

### DIFF
--- a/src/app/o/[orgId]/joinformverified/page.tsx
+++ b/src/app/o/[orgId]/joinformverified/page.tsx
@@ -1,0 +1,29 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinOrganization } from 'utils/types/zetkin';
+import JoinFormVerifiedPage from 'features/joinForms/components/JoinFormVerifiedPage';
+
+type PageProps = {
+  params: {
+    orgId: string;
+  };
+};
+
+export default async function Page({ params }: PageProps) {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+
+  try {
+    const org = await apiClient.get<ZetkinOrganization>(
+      `/api/orgs/${params.orgId}`
+    );
+
+    return <JoinFormVerifiedPage org={org} />;
+  } catch (err) {
+    return notFound();
+  }
+}

--- a/src/features/joinForms/components/JoinFormVerifiedPage.tsx
+++ b/src/features/joinForms/components/JoinFormVerifiedPage.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { ZetkinOrganization } from 'utils/types/zetkin';
+
+type Props = {
+  org: ZetkinOrganization;
+};
+
+const JoinFormVerifiedPage: FC<Props> = ({ org }) => {
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        width: '100vw',
+      }}
+    >
+      <Box maxWidth={500}>
+        <Typography mb={1} variant="h4">
+          <Msg id={messageIds.submissionVerifiedPage.h} />
+        </Typography>
+        <Typography>
+          <Msg
+            id={messageIds.submissionVerifiedPage.info}
+            values={{ org: org.title }}
+          />
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default JoinFormVerifiedPage;

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -40,4 +40,10 @@ export default makeMessages('feat.joinForms', {
     form: m('Form'),
     rejectButton: m('Reject'),
   },
+  submissionVerifiedPage: {
+    h: m('Thank you!'),
+    info: m<{ org: string }>(
+      'Your submission has been verified and organizers in {org} will review it shortly.'
+    ),
+  },
 });


### PR DESCRIPTION
## Description
This PR adds a page that was missing. This is the URL that users are directed to after verifying a join form that `requires_email_verification`. There was nothing there, so although the verification will have worked, users were being sent to a 404 afterwards. This PR makes sure they get a nice confirmation page instead.


## Screenshots
![image](https://github.com/user-attachments/assets/4e418412-c5c5-4467-8b4c-567bf603774b)

## Changes
* Adds `<JoinFormVerifiedPage>` and a route at which it's rendered

## Notes to reviewer
Just browse to http://localhost:3000/o/1/joinformverified to test.

## Related issues
Undocumented