### PR TITLE
Prevent importing multiple genders to a single person

### DIFF
--- a/src/features/import/hooks/useColumn.ts
+++ b/src/features/import/hooks/useColumn.ts
@@ -44,6 +44,10 @@ export default function useColumn(orgId: number) {
         return column.field == value.slice(6);
       }
 
+      if (column.kind == ColumnKind.GENDER) {
+        return column.field == value;
+      }
+
       if (column.kind == ColumnKind.DATE) {
         return column.field == value.slice(5);
       }


### PR DESCRIPTION
## Description
This PR adds a check to prevent importing multiple genders to a single person. 


## Screenshots
![gender-select](https://github.com/user-attachments/assets/91e779b9-dfea-4e3b-8537-f01077218d35)


## Changes
* When a user selects a column in a file to be imported as 'gender', they now cannot select a second column to be imported as 'gender', unless they first un-check the previously selected column.


## Notes to reviewer
This solution seems to work as intended on my end, but I am not sure it's good.


## Related issues
Resolves #2437 
