### PR TITLE
Automatically build TypeDoc and Storybook in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ yarn-error.log*
 # typescript
 tsconfig.tsbuildinfo
 
-# typedoc
-/typedoc/
+# generated docs
+public/docs
+public/storybook

--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,16 @@ module.exports = {
   async redirects() {
     return [
       {
+        source: '/storybook',
+        destination: '/storybook/index.html',
+        permanent: true,
+      },
+      {
+        source: '/docs',
+        destination: '/docs/index.html',
+        permanent: true,
+      },
+      {
         source: '/my',
         destination: '/my/home',
         permanent: false,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start -p 80",
     "devserver": "next dev -p 3000",
+    "docs:build": "storybook build -o public/storybook && typedoc --out public/docs",
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",
     "lint:translations": "ts-node src/tools/lint-translations",
@@ -21,8 +22,7 @@
     "playwright:skipbuild": "cross-env NODE_ENV=production SKIP_BUILD=1 playwright test",
     "playwright:ci": "cross-env NODE_ENV=production playwright test",
     "storybook": "storybook dev -p 6006",
-    "make-yaml": "ts-node src/tools/make-yaml.ts",
-    "build-storybook": "storybook build"
+    "make-yaml": "ts-node src/tools/make-yaml.ts"
   },
   "dependencies": {
     "@date-io/date-fns": "1.x",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,8 @@
   "exclude": [
     ".next",
     "node_modules",
-    "storybook-static"
+    "storybook-static",
+    "public/storybook",
+    "public/docs"
   ]
 }


### PR DESCRIPTION
Following up on https://github.com/zetkin/app.zetkin.org/pull/2092. I've added the `docs:build` package script almost as described in your suggestion (corrected the output directory flag a little bit). Both looking good after running that command. The redirects are working great too. These screenshots are after running `yarn docs:build`, `yarn build`, and finally `yarn start`.

| TypeDoc | Storybook |
|-|-|
| ![Screenshot 2024-12-27 at 16 38 21](https://github.com/user-attachments/assets/3f5c2f73-300e-4fe5-b304-8743f0a5a33e) |  ![Screenshot 2024-12-27 at 16 38 26](https://github.com/user-attachments/assets/152da96d-4765-45ca-bb37-2c74bf20e3bb) |

This only deviates from your suggested diff in one other way that I'm aware of, which is that I also cut the `build-storybook` package script. I ditched it cos I don't think it's being used and because it outputs its build into a different directory. Reckon if we end up with use cases for individual package scripts for these later down the line, maybe we want to think about having something like `docs:build-all`, `docs:build-storybook` etc, and have the "all" build call the individual ones. But until then, maybe it's best to just cut the bloat?