### PR TITLE
Display error message when button in email still has its default text

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
@@ -33,6 +33,9 @@ const ButtonBlockListItem: FC<ButtonBlockLIstItemProps> = ({
   }, 400);
 
   const error = inputValue.length > 0 && !formatUrl(inputValue);
+  const buttonTextError =
+    !data.buttonText?.replaceAll('&nbsp;', '').trim().length ||
+    !data.buttonText;
   return (
     <BlockListItemBase
       excerpt={data.buttonText}
@@ -41,6 +44,9 @@ const ButtonBlockListItem: FC<ButtonBlockLIstItemProps> = ({
       selected={selected}
       title={messages.editor.tools.button.title()}
     >
+      {buttonTextError && (
+        <Msg id={messageIds.editor.tools.button.settings.buttonTextWarning} />
+      )}
       <Box display="flex" flexDirection="column">
         <Box paddingBottom={1} paddingTop={2}>
           <TextField

--- a/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
@@ -39,11 +39,7 @@ const ButtonBlockListItem: FC<ButtonBlockLIstItemProps> = ({
       hasErrors={hasErrors}
       readOnly={readOnly}
       selected={selected}
-      title={
-        data.buttonText
-          ? messages.editor.tools.button.title()
-          : messages.editor.tools.button.settings.defaultButtonTextWarning()
-      }
+      title={messages.editor.tools.button.title()}
     >
       <Box display="flex" flexDirection="column">
         <Box paddingBottom={1} paddingTop={2}>

--- a/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/ButtonBlockListItem.tsx
@@ -39,7 +39,11 @@ const ButtonBlockListItem: FC<ButtonBlockLIstItemProps> = ({
       hasErrors={hasErrors}
       readOnly={readOnly}
       selected={selected}
-      title={messages.editor.tools.button.title()}
+      title={
+        data.buttonText
+          ? messages.editor.tools.button.title()
+          : messages.editor.tools.button.settings.defaultButtonTextWarning()
+      }
     >
       <Box display="flex" flexDirection="column">
         <Box paddingBottom={1} paddingTop={2}>

--- a/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.ts
+++ b/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.ts
@@ -13,6 +13,8 @@ export default function blockProblems(block: OutputBlockData): BlockProblem[] {
 
     if (!block.data.buttonText) {
       blockProblems.push(BlockProblem.DEFAULT_BUTTON_TEXT);
+    } else if (!block.data.buttonText.replaceAll('&nbsp;', '').trim().length) {
+      blockProblems.push(BlockProblem.BUTTON_TEXT_MISSING);
     }
   } else if (block.type === BLOCK_TYPES.PARAGRAPH) {
     const container = document.createElement('div');

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -63,6 +63,7 @@ export default makeMessages('feat.emails', {
           noButtonText: m('Click to change this text!'),
         },
         settings: {
+          defaultButtonTextWarning: m('This button still has the default text'),
           invalidUrl: m('This is not a valid link'),
           testLink: m('Click to test link'),
           urlLabel: m('Link url'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -63,7 +63,7 @@ export default makeMessages('feat.emails', {
           noButtonText: m('Click to change this text!'),
         },
         settings: {
-          defaultButtonTextWarning: m('This button still has the default text'),
+          buttonTextWarning: m('Make sure to add your text to the button'),
           invalidUrl: m('This is not a valid link'),
           testLink: m('Click to test link'),
           urlLabel: m('Link url'),

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -108,7 +108,7 @@ export type EmailContent = {
 export enum BlockProblem {
   INVALID_BUTTON_URL = 'invalidButtonURL',
   DEFAULT_BUTTON_TEXT = 'defaultButtonText',
-  BUTTON_TEXT_MISSING = 'missingButtonText',
+  BUTTON_TEXT_MISSING = 'buttonTextMissing',
   INVALID_LINK_URL = 'invalidLinkURL',
 }
 

--- a/src/features/emails/types.ts
+++ b/src/features/emails/types.ts
@@ -108,6 +108,7 @@ export type EmailContent = {
 export enum BlockProblem {
   INVALID_BUTTON_URL = 'invalidButtonURL',
   DEFAULT_BUTTON_TEXT = 'defaultButtonText',
+  BUTTON_TEXT_MISSING = 'missingButtonText',
   INVALID_LINK_URL = 'invalidLinkURL',
 }
 


### PR DESCRIPTION
## Description
This PR adds an error message to be displayed in case the user has not changed the default text of a button in an email draft.


## Screenshots
![button-default-text-warning](https://github.com/user-attachments/assets/ef8c2c46-3666-4121-81bf-ba0d0dc37da6)


## Changes
* Adds an error message. When the default text of the button has been changed, the name of the element ('Button') is displayed in the right-hand 'Content' column.


## Notes to reviewer
When playing around a bit, I found some possible areas for improvement.

* Both the previous code and my code does allow for the button text to consist only of whitespaces. 
* Neither version allows for the button text to consist of zero characters, but as a result of this PR, the error message reads 'This button still has the default text' also in the case of an empty (0 characters) button. 

I should be able to just add a second error message (along the lines of 'This button must have some text', 'This button cannot be empty), just let me know if I should file this as a new issue or simply build on the current issue and re-PR it.


## Related issues
Resolves #2444 
