### PR TITLE
Add documentation about environment variables

### DIFF
--- a/docs/environment-variables/environment-variables.md
+++ b/docs/environment-variables/environment-variables.md
@@ -36,19 +36,31 @@ The `<RootLayout>` component in `src/app/layout.tsx` makes a set of runtime
 environment variables from the Node.js process on the server available to
 client-side code by adding them as values to a `ClientContext` provider.
 
-The [`ClientContextEnvVars`](../types/ClientContextEnvVars.html) type alias is a good starting point
-when adding a new runtime environment variable to app router code. Add your
-variable there and then fix any resulting type errors and you'll be up and
-running.
+The [`EnvVars`](../types/EnvVars.html) type alias is a good starting point when
+adding a new runtime environment variable to app router code. Add your variable
+there and then fix any resulting type errors and you'll be up and running.
 
 ## Runtime Environment Variables In Pages Router Code
 
 Just about every page component in `src/pages/` uses the `scaffold()` function
 to generate its [`getServerSideProps()`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) function.
 
-The [`ClientContextEnvVars`](../types/ScaffoldedEnvVars.html) type alias is also
-the place to look first when adding a new runtime environment variable to pages
-router code.
+The [`EnvVars`](../types/EnvVars.html) type alias is also the place to look
+first when adding a new runtime environment variable to pages router code.
+
+## Accessing Runtime Environment Variables In Components
+
+The [`useEnv`](../functions/useEnv.html) hook returns an
+[`Environment`](../classes/Environment.html) instance which provides reads access to runtime environment variables via its [`vars` property](../classes/Environment.html#vars).
+
+```typescript
+const Component = () => {
+  const env = useEnv();
+  return (
+    <a href={env.vars.ZETKIN_GEN2_ORGANIZE_URL}>Go to the old interface</a>
+  );
+};
+```
 
 ## Further Reading
 

--- a/docs/environment-variables/environment-variables.md
+++ b/docs/environment-variables/environment-variables.md
@@ -35,7 +35,7 @@ The `<RootLayout>` component in `src/app/layout.tsx` makes a set of runtime
 environment variables from the Node.js process on the server available to
 client-side code by adding them as values to a `ClientContext` provider.
 
-The [`ClientContextEnvVariables`](../types/ClientContextEnvVariables.html) type alias is a good starting point
+The [`ClientContextEnvVars`](../types/ClientContextEnvVars.html) type alias is a good starting point
 when adding a new runtime environment variable to app router code. Add your
 variable there and then fix any resulting type errors and you'll be up and
 running.

--- a/docs/environment-variables/environment-variables.md
+++ b/docs/environment-variables/environment-variables.md
@@ -1,0 +1,58 @@
+---
+title: Environment Variables
+category: Environment Variables
+---
+
+# Environment Variables
+
+## Build-Time vs Runtime Environment Variables
+
+Next.js is designed around Vercel's Platform-as-a-Service (PaaS) hosting
+business. Apps on Vercel can have multiple deployment environments such as
+staging and production, and a different build of the app is compiled for each
+environment. Next.js includes functionality to support Vercel's
+one-environment-per-build deployment model, where any environment variables
+needed by client-side code are [inlined directly into the compiled JavaScript](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser)
+bundle at build time.
+
+Outside of Vercel's hosting platform, Docker images are a common way to
+distribute and deploy software. Self-hosted open source software is often
+distributed as pre-built Docker images whose operators apply environment
+variables to them at runtime. This is a deployment model with multiple
+environments per build, where environment variables cannot be known at build
+time. It also happens to be Zetkin's deployment model.
+
+The emphasis that Next.js places on the Vercel platform's deployment
+model in its architecture and documentation can easily lead to confusion when
+working on an app like Zetkin with a different deployment model. The fact that
+handling runtime environment variables looks different under the newer app
+router paradigm compared to the older pages router code also adds to the sense
+of complexity here. So here's how
+
+## Runtime Environment Variables In App Router Code
+
+The `<RootLayout>` component in `src/app/layout.tsx` makes a set of runtime
+environment variables from the Node.js process on the server available to
+client-side code by adding them as values to a `ClientContext` provider.
+
+The [`ClientContextEnvVariables`](../types/ClientContextEnvVariables.html) type alias is a good starting point
+when adding a new runtime environment variable to app router code. Add your
+variable there and then fix any resulting type errors and you'll be up and
+running.
+
+## Runtime Environment Variables In Pages Router Code
+
+Just about every page component in `src/pages/` uses the [`scaffold()`](../functions/scaffold.html) function
+to generate its [`getServerSideProps()`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) function.
+
+The [`ScaffoldedEnvVars`](../types/ScaffoldedEnvVars.html) type alias is the
+place to look first when adding a new runtime environment variable to pages
+router code.
+
+## Further Reading
+
+Zetkin's far from the only project to have solved this problem.
+
+- [NextJS on Docker: Managing Environment Variables Across Different Environments](https://medium.com/@ihcnemed/nextjs-on-docker-managing-environment-variables-across-different-environments-972b34a76203)
+- [Next.js with Public Environment Variables in Docker](https://dev.to/vorillaz/nextjs-with-public-environment-variables-in-docker-4ogf)
+- [Runtime Environment Variables in Next.js](https://notes.dt.in.th/NextRuntimeEnv)

--- a/docs/environment-variables/environment-variables.md
+++ b/docs/environment-variables/environment-variables.md
@@ -27,7 +27,8 @@ model in its architecture and documentation can easily lead to confusion when
 working on an app like Zetkin with a different deployment model. The fact that
 handling runtime environment variables looks different under the newer app
 router paradigm compared to the older pages router code also adds to the sense
-of complexity here. So here's how
+of complexity here. So here's how Zetkin's runtime environment variables work in
+both Next.js routing paradigms.
 
 ## Runtime Environment Variables In App Router Code
 

--- a/docs/environment-variables/environment-variables.md
+++ b/docs/environment-variables/environment-variables.md
@@ -43,7 +43,7 @@ running.
 
 ## Runtime Environment Variables In Pages Router Code
 
-Just about every page component in `src/pages/` uses the [`scaffold()`](../functions/scaffold.html) function
+Just about every page component in `src/pages/` uses the `scaffold()` function
 to generate its [`getServerSideProps()`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props) function.
 
 The [`ScaffoldedEnvVars`](../types/ScaffoldedEnvVars.html) type alias is the

--- a/docs/index.ts
+++ b/docs/index.ts
@@ -1,3 +1,6 @@
+import Environment from 'core/env/Environment';
+import { useEnv } from 'core/hooks';
+
 export { type RemoteItem, type RemoteList } from 'utils/storeUtils';
 export {
   loadItemIfNecessary,
@@ -7,4 +10,5 @@ export { default as shouldLoad } from 'core/caching/shouldLoad';
 export { default as ZUIFuture, type ZUIFutureProps } from 'zui/ZUIFuture';
 export { type IFuture } from 'core/caching/futures';
 export { removeOffset } from 'utils/dateUtils';
-export { type ClientContextEnvVars } from 'core/env/ClientContext';
+export { type EnvVars } from 'core/env/Environment';
+export { Environment, useEnv };

--- a/docs/index.ts
+++ b/docs/index.ts
@@ -7,3 +7,5 @@ export { default as shouldLoad } from 'core/caching/shouldLoad';
 export { default as ZUIFuture, type ZUIFutureProps } from 'zui/ZUIFuture';
 export { type IFuture } from 'core/caching/futures';
 export { removeOffset } from 'utils/dateUtils';
+export { type ClientContextEnvVariables } from 'core/env/ClientContext';
+export { type ScaffoldedEnvVars } from 'utils/next';

--- a/docs/index.ts
+++ b/docs/index.ts
@@ -7,5 +7,5 @@ export { default as shouldLoad } from 'core/caching/shouldLoad';
 export { default as ZUIFuture, type ZUIFutureProps } from 'zui/ZUIFuture';
 export { type IFuture } from 'core/caching/futures';
 export { removeOffset } from 'utils/dateUtils';
-export { type ClientContextEnvVariables } from 'core/env/ClientContext';
+export { type ClientContextEnvVars } from 'core/env/ClientContext';
 export { type ScaffoldedEnvVars } from 'utils/next';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start -p 80",
     "devserver": "next dev -p 3000",
-    "docs:build": "storybook build -o public/storybook && typedoc --out public/docs",
+    "docs:build": "storybook build -o public/storybook && typedoc",
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",
     "lint:translations": "ts-node src/tools/lint-translations",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,15 +32,14 @@ export default async function RootLayout({
         <AppRouterCacheProvider>
           <ClientContext
             envVars={{
-              FEAT_AREAS: process.env.FEAT_AREAS || null,
-              INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF || null,
-              INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME || null,
-              MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY || null,
-              ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN || null,
-              ZETKIN_GEN2_ORGANIZE_URL:
-                process.env.ZETKIN_GEN2_ORGANZE_URL || null,
+              FEAT_AREAS: process.env.FEAT_AREAS,
+              INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
+              INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
+              MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
+              ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
+              ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
               ZETKIN_PRIVACY_POLICY_LINK:
-                process.env.ZETKIN_PRIVACY_POLICY_LINK || null,
+                process.env.ZETKIN_PRIVACY_POLICY_LINK,
             }}
             headers={headersObject}
             lang={lang}

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -38,14 +38,14 @@ declare module '@mui/styles/defaultTheme' {
  *
  * @category Environment Variables
  */
-export type ClientContextEnvVariables = {
+export type ClientContextEnvVars = {
   MUIX_LICENSE_KEY: string | null;
   ZETKIN_APP_DOMAIN: string | null;
 };
 
 type ClientContextProps = {
   children: ReactNode;
-  envVars: ClientContextEnvVariables;
+  envVars: ClientContextEnvVars;
   headers: Record<string, string>;
   lang: string;
   messages: MessageList;

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -29,12 +29,23 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
+/**
+ * Defines the set of runtime environment variables available to [app
+ * router](https://nextjs.org/docs/app) code via `ClientContext`.
+ *
+ * Environment variables specified here must be passed to the `ClientContext`
+ * provider in `<RootLayout>`.
+ *
+ * @category Environment Variables
+ */
+export type ClientContextEnvVariables = {
+  MUIX_LICENSE_KEY: string | null;
+  ZETKIN_APP_DOMAIN: string | null;
+};
+
 type ClientContextProps = {
   children: ReactNode;
-  envVars: {
-    MUIX_LICENSE_KEY: string | null;
-    ZETKIN_APP_DOMAIN: string | null;
-  };
+  envVars: ClientContextEnvVariables;
   headers: Record<string, string>;
   lang: string;
   messages: MessageList;

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -15,7 +15,7 @@ import { LicenseInfo, LocalizationProvider } from '@mui/x-date-pickers-pro';
 import { AdapterDayjs } from '@mui/x-date-pickers-pro/AdapterDayjs';
 
 import BrowserApiClient from 'core/api/client/BrowserApiClient';
-import Environment from 'core/env/Environment';
+import Environment, { EnvVars } from 'core/env/Environment';
 import { EnvProvider } from 'core/env/EnvContext';
 import { MessageList } from 'utils/locale';
 import { store } from 'core/store';
@@ -29,34 +29,9 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
-/**
- * Defines the runtime environment variables available to client-side code.
- *
- * These are made available to [app router](https://nextjs.org/docs/app) code
- * via `ClientContext` and to [pages router](https://nextjs.org/docs/pages) code
- * via `scaffold()`.
- *
- * We use the same type alias for both routers in order to
- * keep the runtime environment variables aligned across this architectural
- * boundary. Keeping them aligned in this way is intended to facilitate gradual
- * adoption of the app router by minimising friction related to environment
- * variables.
- *
- * @category Environment Variables
- */
-export type ClientContextEnvVars = {
-  FEAT_AREAS: string | null;
-  INSTANCE_OWNER_HREF: string | null;
-  INSTANCE_OWNER_NAME: string | null;
-  MUIX_LICENSE_KEY: string | null;
-  ZETKIN_APP_DOMAIN: string | null;
-  ZETKIN_GEN2_ORGANIZE_URL: string | null;
-  ZETKIN_PRIVACY_POLICY_LINK: string | null;
-};
-
 type ClientContextProps = {
   children: ReactNode;
-  envVars: ClientContextEnvVars;
+  envVars: EnvVars;
   headers: Record<string, string>;
   lang: string;
   messages: MessageList;

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -1,15 +1,47 @@
 import IApiClient from 'core/api/client/IApiClient';
 
-type EnvVars = {
-  FEAT_AREAS?: string | null;
-  INSTANCE_OWNER_HREF?: string | null;
-  INSTANCE_OWNER_NAME?: string | null;
-  MUIX_LICENSE_KEY: string | null;
-  ZETKIN_APP_DOMAIN: string | null;
-  ZETKIN_GEN2_ORGANIZE_URL?: string | null;
-  ZETKIN_PRIVACY_POLICY_LINK?: string | null;
+/**
+ * Defines the [runtime environment
+ * variables](../documents/Environment_Variables.html#md:build-time-vs-runtime-environment-variables)
+ * available.
+ 
+ * These are made available to [app router](https://nextjs.org/docs/app) code
+ * via `ClientContext` and to [pages router](https://nextjs.org/docs/pages) code
+ * via `scaffold()`. In both routers, they're provided as part of an
+ * [`Environment`](../classes/Environment.html) instance and accessed via
+ * [`useEnv()`](../functions/useEnv).
+ * 
+ * We use the same type alias for both routers in order to
+ * keep the runtime environment variables aligned across this architectural
+ * boundary. Keeping them aligned in this way is intended to facilitate gradual
+ * adoption of the app router by minimising friction related to environment
+ * variables.
+ *
+ * @category Environment Variables
+ */
+export type EnvVars = {
+  FEAT_AREAS?: string;
+  INSTANCE_OWNER_HREF?: string;
+  INSTANCE_OWNER_NAME?: string;
+  MUIX_LICENSE_KEY?: string;
+  ZETKIN_APP_DOMAIN?: string;
+  ZETKIN_GEN2_ORGANIZE_URL?: string;
+  ZETKIN_PRIVACY_POLICY_LINK?: string;
 };
 
+/**
+ * Return value of {@link useEnv `useEnv()`}.
+ *
+ * In app router code, this is added to the global context as part of
+ * [`ClientContext`](https://github.com/zetkin/app.zetkin.org/blob/main/src/core/env/ClientContext.tsx)
+ * as part of the [root
+ * layout](https://github.com/zetkin/app.zetkin.org/blob/main/src/app/layout.tsx).
+ * In pages router code, it's added by
+ * [`Providers`](https://github.com/zetkin/app.zetkin.org/blob/main/src/core/Providers.tsx)
+ * as part of the [custom app](https://github.com/zetkin/app.zetkin.org/blob/main/src/pages/_app.tsx).
+ *
+ * @category Environment Variables
+ */
 export default class Environment {
   private _apiClient: IApiClient;
   private _vars: EnvVars;
@@ -20,13 +52,7 @@ export default class Environment {
 
   constructor(apiClient: IApiClient, envVars?: EnvVars) {
     this._apiClient = apiClient;
-    this._vars = envVars || {
-      FEAT_AREAS: null,
-      MUIX_LICENSE_KEY: null,
-      ZETKIN_APP_DOMAIN: null,
-      ZETKIN_GEN2_ORGANIZE_URL: null,
-      ZETKIN_PRIVACY_POLICY_LINK: null,
-    };
+    this._vars = envVars || {};
   }
 
   get vars() {

--- a/src/core/hooks/useEnv.ts
+++ b/src/core/hooks/useEnv.ts
@@ -2,6 +2,23 @@ import { useContext } from 'react';
 
 import { EnvContext } from 'core/env/EnvContext';
 
+/**
+ * Used by components to access an API client instance and [environment
+ * variables](../documents/Environment_Variables.html).
+ *
+ * ```typescript
+ * const Component = () => {
+ *   const env = useEnv();
+ *   return (
+ *     <a href={env.vars.ZETKIN_GEN2_ORGANIZE_URL}>
+ *       Go to the old interface
+ *     </a>
+ *   )
+ * }
+ * ```
+ *
+ * @category Environment Variables
+ */
 export default function useEnv() {
   const env = useContext(EnvContext);
   if (!env) {

--- a/src/utils/featureFlags/useFeature.spec.ts
+++ b/src/utils/featureFlags/useFeature.spec.ts
@@ -3,19 +3,16 @@ import { createElement, PropsWithChildren } from 'react';
 
 import IApiClient from 'core/api/client/IApiClient';
 import { EnvProvider } from 'core/env/EnvContext';
-import Environment from 'core/env/Environment';
+import Environment, { EnvVars } from 'core/env/Environment';
 import useFeature from './useFeature';
 
-function getOptsWithEnvVars(vars?: Partial<Environment['vars']>) {
+function getOptsWithEnvVars(vars?: Partial<EnvVars>) {
   return {
     wrapper: ({ children }: PropsWithChildren) =>
       createElement(
         EnvProvider,
         {
           env: new Environment(null as unknown as IApiClient, {
-            FEAT_AREAS: null,
-            MUIX_LICENSE_KEY: null,
-            ZETKIN_APP_DOMAIN: null,
             ...vars,
           }),
         },

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -26,7 +26,25 @@ type RegularProps = {
   [key: string]: any;
 };
 
+/**
+ * Defines the set of runtime environment variables available to [pages
+ * router](https://nextjs.org/docs/pages) code via
+ * [`getServerSideProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props).
+ *
+ * Environment variables specified here must be included in the `ScaffoldedProps`
+ * object returned by `scaffold()`.
+ *
+ * @category Environment Variables
+ */
+export type ScaffoldedEnvVars = {
+  FEAT_AREAS: string | null;
+  MUIX_LICENSE_KEY: string | null;
+  ZETKIN_APP_DOMAIN: string | null;
+  ZETKIN_GEN2_ORGANIZE_URL: string | null;
+};
+
 export type ScaffoldedProps = RegularProps & {
+  envVars: ScaffoldedEnvVars;
   lang: string;
   messages: Record<string, string>;
   user: ZetkinUser | null;

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -16,7 +16,7 @@ import { ZetkinZ } from './types/sdk';
 import { ApiFetch, createApiFetch } from './apiFetch';
 import { ZetkinSession, ZetkinUser } from './types/zetkin';
 import { hasFeature } from './featureFlags';
-import { ClientContextEnvVars } from 'core/env/ClientContext';
+import { EnvVars } from 'core/env/Environment';
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -28,7 +28,7 @@ type RegularProps = {
 };
 
 export type ScaffoldedProps = RegularProps & {
-  envVars: ClientContextEnvVars;
+  envVars: EnvVars;
   lang: string;
   messages: Record<string, string>;
   user: ZetkinUser | null;
@@ -206,14 +206,13 @@ export const scaffold =
       result.props = {
         ...result.props,
         envVars: {
-          FEAT_AREAS: process.env.FEAT_AREAS || null,
-          INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF || null,
-          INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME || null,
-          MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY || null,
-          ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN || null,
-          ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL || null,
-          ZETKIN_PRIVACY_POLICY_LINK:
-            process.env.ZETKIN_PRIVACY_POLICY_LINK || null,
+          FEAT_AREAS: process.env.FEAT_AREAS,
+          INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
+          INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
+          MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
+          ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
+          ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
+          ZETKIN_PRIVACY_POLICY_LINK: process.env.ZETKIN_PRIVACY_POLICY_LINK,
         },
         lang,
         messages,

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -32,7 +32,6 @@ interface ZetkinAppProvidersProps {
 
 const ZetkinAppProviders: FC<ZetkinAppProvidersProps> = ({ children }) => {
   const env = new Environment(new BrowserApiClient(), {
-    MUIX_LICENSE_KEY: null,
     ZETKIN_APP_DOMAIN: 'https://app.zetkin.org',
   });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,7 @@
   "cleanOutputDir": true,
   "name": "Zetkin",
   "entryPoints": ["./docs/index.ts"],
-  "out": "./typedoc",
+  "out": "./public/docs",
   "sort": ["source-order"],
   "categorizeByGroup": false,
   "navigation": { "includeCategories": true },


### PR DESCRIPTION
Talked about documenting this in https://github.com/zetkin/app.zetkin.org/pull/2447. Here's a first draft!

| environment-variables.md |  ClientContextEnvVars | ScaffoldedEnvVars |
|-|-|-|
| ![127 0 0 1_8081_documents_Environment_Variables html](https://github.com/user-attachments/assets/e7a24ddc-6e03-4336-8cba-fe585c4a26dc) |  ![127 0 0 1_8080_types_ClientContextEnvVariables html (3)](https://github.com/user-attachments/assets/404c5451-72d4-4c61-b1ec-c1e23a9e94e6) | ![127 0 0 1_8080_types_ScaffoldedEnvVars html (1)](https://github.com/user-attachments/assets/37284546-ef4d-4673-b26a-f9e1b6e8f7ff) |