### PR TITLE
Fixed broken local devserver due to env vars

### DIFF
--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -7,8 +7,7 @@ import {
 } from 'next';
 
 import { AppSession } from './types';
-import { getBrowserLanguage } from './locale';
-import { getMessages } from './locale';
+import { getBrowserLanguage, getMessages } from './locale';
 import getUserMemberships from './getUserMemberships';
 import requiredEnvVar from './requiredEnvVar';
 import { stringToBool } from './stringUtils';
@@ -17,6 +16,7 @@ import { ApiFetch, createApiFetch } from './apiFetch';
 import { ZetkinSession, ZetkinUser } from './types/zetkin';
 import { hasFeature } from './featureFlags';
 import { EnvVars } from 'core/env/Environment';
+import { omitUndefined } from './omitUndefined';
 
 //TODO: Create module definition and revert to import.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -205,7 +205,7 @@ export const scaffold =
     if (hasProps(result)) {
       result.props = {
         ...result.props,
-        envVars: {
+        envVars: omitUndefined({
           FEAT_AREAS: process.env.FEAT_AREAS,
           INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
           INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
@@ -213,7 +213,7 @@ export const scaffold =
           ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
           ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANIZE_URL,
           ZETKIN_PRIVACY_POLICY_LINK: process.env.ZETKIN_PRIVACY_POLICY_LINK,
-        },
+        }),
         lang,
         messages,
         user: ctx.user,

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -211,7 +211,7 @@ export const scaffold =
           INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
           MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
           ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
-          ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
+          ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANIZE_URL,
           ZETKIN_PRIVACY_POLICY_LINK: process.env.ZETKIN_PRIVACY_POLICY_LINK,
         },
         lang,

--- a/src/utils/omitUndefined.ts
+++ b/src/utils/omitUndefined.ts
@@ -1,0 +1,11 @@
+import _ from 'lodash';
+
+/**
+ * Omits properties with `undefined` values from an object.
+ *
+ * @param obj - The object to process.
+ * @returns A new object with all properties that have `undefined` values removed.
+ */
+export const omitUndefined = (
+  obj: Record<string, unknown>
+): Record<string, unknown> => _.omitBy(obj, _.isUndefined);

--- a/src/utils/omitUndefined.ts
+++ b/src/utils/omitUndefined.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { isUndefined, omitBy } from 'lodash';
 
 /**
  * Omits properties with `undefined` values from an object.
@@ -8,4 +8,4 @@ import _ from 'lodash';
  */
 export const omitUndefined = (
   obj: Record<string, unknown>
-): Record<string, unknown> => _.omitBy(obj, _.isUndefined);
+): Record<string, unknown> => omitBy(obj, isUndefined);


### PR DESCRIPTION
## Description

While i was looking for the reason, my local devserver is not working anymore, I realized there was a typo 🙈 and several env vars were undefined which causes the next-server to crash

Within `process.env.ZETKIN_GEN2_ORGANZE_URL` an `I` was missing.
This caused the following error when running `yarn devserver` and going to `localhost:3000`:

Also as the error logs say env var `FEAT_AREAS` is missing (also `INSTANCE_OWNER_HREF`, `INSTANCE_OWNER_NAME` and `MUIX_LICENSE_KEY`). 
I resolved this by adding them as empty env vars to `.env.development`

## Screenshots
![CleanShot 2024-12-31 at 19 03 15](https://github.com/user-attachments/assets/b4ce2ef0-da97-4ea3-bb96-18c818cb3c86)


## Changes

* fixed typo within https://github.com/zetkin/app.zetkin.org/pull/2452 : `process.env.ZETKIN_GEN2_ORGANZE_URL` -> `process.env.ZETKIN_GEN2_ORGANIZE_URL`
* added `INSTANCE_OWNER_HREF`, `INSTANCE_OWNER_NAME` and `MUIX_LICENSE_KEY` as empty env vars to `.env.development`


## Notes to reviewer

* not sure if these empty env vars are meant to be set to empty values for the dev server and if it makes sense to also set them this way within `.env.test`