### PR TITLE
Handle join form sub-org sharing in UI

### DIFF
--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -14,6 +14,7 @@ export default makeMessages('feat.joinForms', {
       addField: m('Add field'),
       description: m('Description'),
       requireEmailVerification: m('Require e-mail verification'),
+      shareWithSuborgs: m('Share with sub-organizations'),
       title: m('Title'),
     },
     title: m('Edit form'),

--- a/src/features/joinForms/panes/JoinFormPane.tsx
+++ b/src/features/joinForms/panes/JoinFormPane.tsx
@@ -159,6 +159,19 @@ const JoinFormPane: FC<Props> = ({ orgId, formId }) => {
           }
           label={messages.formPane.labels.requireEmailVerification()}
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={joinForm.org_access == 'suborgs'}
+              onChange={(evt) =>
+                updateForm({
+                  org_access: evt.target.checked ? 'suborgs' : 'sameorg',
+                })
+              }
+            />
+          }
+          label={messages.formPane.labels.shareWithSuborgs()}
+        />
       </Box>
     </>
   );

--- a/src/features/joinForms/types.ts
+++ b/src/features/joinForms/types.ts
@@ -9,6 +9,7 @@ export type ZetkinJoinForm = {
   embeddable: boolean;
   fields: string[];
   id: number;
+  org_access: 'sameorg' | 'suborgs';
   organization: {
     id: number;
     title: string;

--- a/src/pages/organize/[orgId]/people/joinforms/index.tsx
+++ b/src/pages/organize/[orgId]/people/joinforms/index.tsx
@@ -30,9 +30,13 @@ const JoinFormsPage: PageWithLayout<PageProps> = ({ orgId }) => {
     return null;
   }
 
+  const ownJoinForms = joinForms.filter(
+    (form) => form.organization.id == parseInt(orgId)
+  );
+
   return (
     <JoinFormList
-      forms={joinForms}
+      forms={ownJoinForms}
       onItemClick={(form) => {
         openPane({
           render: () => (


### PR DESCRIPTION
## Description
This PR adds changes to the UI to better accommodate recent changes to the backend with regards to sub-org sharing of join forms.

## Screenshots
### Configuring join form for sharing
![image](https://github.com/user-attachments/assets/1429a91d-c616-4ce2-8a14-32512eb186a4)

### Join form not listed in sub-org
![image](https://github.com/user-attachments/assets/b55cece9-dcd3-42d1-80d2-840e04e1e02a)

## Changes
* Hides join forms from list if they belong to parent organization (and can't be edited)
* Adds UI for changing whether a join form is shared down or not

## Notes to reviewer
None

## Related issues
Undocumented