### PR TITLE
add margin to email editor

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -216,6 +216,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
           '& .ce-block__content': {
             px: 2,
           },
+          marginLeft: 8,
           minHeight: '100%',
         }}
       />


### PR DESCRIPTION
## Description
Added a left margin to the editor to make sure the button still appears when the screen size changes from large to smaller.

## Changes
Added a left margin property to the email editor using MUI syntax. 

## Notes to reviewer
Can be manually tested, no longer creates the same issue as outlined in #2042. 

## Related issues
Resolves #2042 
