### PR TITLE
Added debugging support for vscode and jetbrains IDE's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,11 @@ yarn-error.log*
 # vercel
 .vercel
 
-# vs code
-.vscode/
+# Ignore everything in the .vscode folder
+.vscode/*
+# Except the launch.json file and extensions.json file
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # intellij
 .idea

--- a/.run/chrome_debug_client_side.run.xml
+++ b/.run/chrome_debug_client_side.run.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Next.js: debug client-side (Chrome)" type="JavascriptDebugType" uri="http://localhost:3000">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/devserver.run.xml
+++ b/.run/devserver.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="devserver" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="devserver" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "firefox-devtools.vscode-firefox-debug"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+        "name": "Next.js: debug client-side (Chrome)",
+        "type": "chrome",
+        "request": "launch",
+        "url": "http://localhost:3000"
+    },
+    {
+        "name": "Next.js: debug client-side (Firefox)",
+        "type": "firefox",
+        "request": "launch",
+        "url": "http://localhost:3000",
+        "reAttach": true,
+        "pathMappings": [
+            {
+                "url": "webpack://_n_e",
+                "path": "${workspaceFolder}"
+            }
+        ]
+    }
+]
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,30 @@ Note: If you are running the backend locally and things like `dev.zetkin.org` re
 then this only works on Linux-based systems, due to the nature of `127.0.0.1` pointing to the host on Linux
 (but not on Windows/Mac, where it points to the container itself).
 
+### Debugging
+
+If you want to debug this applications you can do so through VS Code or JetBrains IDE's (as IntelliJ or WebStorm).
+
+#### VS Code
+
+For VS Code there are 2 debugging configurations within [`./.vscode/launch.json`](./.vscode/launch.json). 
+One for debugging with chrome and one for firefox.
+
+1. Start the devserver via `yarn devserver`
+2. In the sidebar on the left go to `Run and Debug`
+3. Select and run `Next.js: debug client-side (Chrome)` or `Next.js: debug client-side (Firefox)` (note that you need to have the [Debugger for Firefox Extension](https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug) installed as referenced in [`./.vscode/extensions.json`](./.vscode/extensions.json))
+4. A browser window should open itself. Navigate to the page that you need to debug (don't forget to set your breakpoints first)
+
+#### JetBrains IDE's
+
+For JetBrains IDE's unfortunately there's only a debug configuration for chrome available ([`./.idea/launch.json`](./.idea/launch.json)).
+
+1. Start the devserver via `yarn devserver`
+2. In the top bar select the run configuration `Next.js: debug client-side (Chrome)` 
+3. Run that selected configuration in the debug mode by clicking on the bug icon.
+4. A chrome window should open itself. Navigate to the page that you need to debug (don't forget to set your breakpoints first)
+
+
 ## Development server login credentials
 
 You can log in using the dummy user accounts to access dummy data from the

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "analyze": "ANALYZE=true next build",
     "build": "next build",
     "start": "next start -p 80",
-    "devserver": "next dev -p 3000",
+    "devserver": "cross-env NODE_OPTIONS='--inspect' next dev -p 3000",
     "docs:build": "storybook build -o public/storybook && typedoc",
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",


### PR DESCRIPTION
## Description

This PR adds debugging support for vscode (Chrome & FireFox) and jetbrains IDE's (only Chrome).

## Screenshots

### VS Code
![CleanShot 2025-01-06 at 14 00 35](https://github.com/user-attachments/assets/735f1aff-f61f-4eab-bed8-e715f9d7a759)

### IntelliJ
![CleanShot 2025-01-06 at 14 02 21](https://github.com/user-attachments/assets/95900e24-cbcc-44ab-9971-5e0d8492ff2b)



## Changes

* adds debugging support for vscode (Chrome & FireFox) and jetbrains IDE's (only Chrome)

## Notes to reviewer
 
Refer to the new [Debugging section within the `README.md`](https://github.com/zetkin/app.zetkin.org/blob/feature/enable-debugging/README.md#debugging) to test this out on your own