### PR TITLE
Fix MonthCalendarEvent-Rendering around DST

### DIFF
--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 import { AnyClusteredEvent } from '../utils/clusterEventsForWeekCalender';
 import { getActivitiesByDay } from '../components/utils';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
@@ -45,7 +47,7 @@ export default function useMonthCalendarEvents({
   const curDate = new Date(startDate);
   while (curDate.getTime() <= endDate.getTime()) {
     const activitiesOnCurrentDay =
-      datesWithActivities[curDate.toISOString().slice(0, 10)]?.events || [];
+      datesWithActivities[dayjs(curDate).format('YYYY-MM-DD')]?.events || [];
 
     const clusters: AnyClusteredEvent[] = [
       ...clusterEvents(activitiesOnCurrentDay),

--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -17,12 +17,11 @@ export default function useEventsFromDateRange(
   const dispatch = useAppDispatch();
   const eventsState = useAppSelector((state) => state.events);
 
-  const dateRange = range(dayjs(endDate).diff(startDate, 'day') + 1).map(
-    (diff) => {
-      const curDate = new Date(startDate);
-      curDate.setDate(curDate.getDate() + diff);
-      return curDate.toISOString();
-    }
+  const dateRange = range(
+    dayjs(endDate).startOf('day').diff(dayjs(startDate).startOf('day'), 'day') +
+      1
+  ).map((diff) =>
+    dayjs(startDate).startOf('day').add(diff, 'day').utc().toISOString()
   );
 
   const mustLoad = dateRange.some((date) =>


### PR DESCRIPTION
## Description
This PR fixes the duplicated events in the `CalendarMonthView` in case of events near a DST-shift.

### Details
There were two bugs which needed to be fixed here.
Both bugs caused the event to show up twice as much resulting in `2 * 2 = 4` events being shown in the end.

1. the first one being fixed in 69313afe8285412bba3a2ad6c2d4a102ba474e04 caused the events as being loaded by `useEventsFromDateRange`-hook to occur 2 times within the returned `EventActivity[]`-array.
2. the second one being fixed in 4cff80ae1a4cc88a196d2066349175f737b38a75 caused each event to occur twice with different dates (30th and 31st of March in the case of the test event `Test Event Issue 2442`) within the returned `UseMonthCalendarEventsReturn`-object of `useMonthCalendarEvents`-hook

## Screenshots

![CleanShot 2025-01-06 at 17 34 17](https://github.com/user-attachments/assets/08c96256-448e-4aef-a153-77646502586d)


## Changes

* fixes duplicated events in the `CalendarMonthView` in case event is near a DST-shift


## Notes to reviewer

* See #2442 > Steps to reproduce. 
* Expected Behaviour should apply now.
* You can use this link when you test this on your local devserver: http://localhost:3000/organize/1/projects/calendar?focusDate=2025-03-06&timeScale=month
* There is a test-event named `Test Event Issue 2442` to test this issue


## Related issues
Resolves #2442 
