### PR TITLE
Disable email sender after email has been sent

### DIFF
--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -88,6 +88,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ email, onSave }) => {
             <Box display="flex" gap={2} py={2}>
               <FormControl fullWidth sx={{ flex: 2 }}>
                 <TextField
+                  disabled={readOnly}
                   fullWidth
                   label={messages.editor.settings.tabs.settings.senderInputLabel()}
                   onChange={(ev) => {


### PR DESCRIPTION
## Description
This PR disables the email sender dropdown menu in the 'Compose' tab when an email has been sent.


## Screenshots
![disabled-email-sender](https://github.com/user-attachments/assets/b345f5e0-e24d-4890-b453-80294e4206fd)


## Changes
* Add a condition to the select element, prohibiting the user from editing the sender after the email has been sent.


## Notes to reviewer
None


## Related issues
Resolves #2462 
