### PR TITLE
add multiline prop to text field

### DIFF
--- a/src/features/surveys/components/SurveyEditor/elements/PreviewableSurveyInput.tsx
+++ b/src/features/surveys/components/SurveyEditor/elements/PreviewableSurveyInput.tsx
@@ -42,6 +42,7 @@ const PreviewableSurveyInput: FC<HeadlinePreviewableInputProps> = ({
           fullWidth
           inputProps={{ ...props, sx: VARIANTS[variant] }}
           label={label}
+          multiline={variant === 'content'}
           onChange={(ev) => onChange(ev.target.value)}
           sx={{ marginBottom: 2 }}
           value={value}


### PR DESCRIPTION
## Description
This PR changes the survey text block 'Description' from a single-line input to multiline.


## Screenshots
![multiline](https://github.com/user-attachments/assets/e757069e-e862-4fec-8a24-af13452bcd0a)


## Changes

* Adds the multiline prop to the ZUIPreviewableInput TextField component for content inputs.

## Notes to reviewer
When navigating the Survey area, I noted that the 'Description' block for Open Question and Choice Question were also single-line, making them equally hard to navigate in edit mode. My proposed solution targets the 'Description' block for all three question types. If this is an incorrect approach, I can continue working with the issue.


## Related issues
Resolves #2465 
