### PR TITLE
Reset date UI between mappings 

### DIFF
--- a/src/features/import/hooks/useDateConfig.ts
+++ b/src/features/import/hooks/useDateConfig.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { columnUpdate } from '../store';
 import { DateColumn } from '../utils/types';
@@ -21,6 +21,10 @@ export default function useDateConfig(column: DateColumn, columnIndex: number) {
   const cellValues = rows.map((row) => row.data[columnIndex]);
 
   const [dateFormat, setDateFormat] = useState(column.dateFormat || null);
+
+  useEffect(() => {
+    setDateFormat(column.dateFormat || null);
+  }, [columnIndex]);
 
   const noCustomFormat = dateFormat == '';
 


### PR DESCRIPTION
## Description
This PR resets the date UI between mappings when more than one column is being mapped to a date field. 


## Screenshots
![reset-date-ui](https://github.com/user-attachments/assets/0a765018-0547-4f4a-899b-102b14e05cf8)


## Changes
* Adds useEffect hook to reset the date UI when the columnIndex changes.


## Related issues
Resolves #2438 
