### PR TITLE
Fix CI configuration problem

### DIFF
--- a/.github/workflows/reusable-base.yml
+++ b/.github/workflows/reusable-base.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Test
       run: yarn ${{ inputs.yarn-test-script }}
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always() && inputs.upload-path
       with:
         path: ${{ inputs.upload-path }}


### PR DESCRIPTION
## Description
This PR fixes a problem in the CI config, which was using a discontinued version of The `upload-artifact` github action.

## Screenshots
None

## Changes
* Changes `actions/upload-artifact@v4` to `actions/upload-artifact@v3`.

## Notes to reviewer
None

## Related issues
Undocumented