### PR TITLE
ZUIEditor link and button extensions

### DIFF
--- a/src/zui/ZUIEditor/ButtonExtensionUI.tsx
+++ b/src/zui/ZUIEditor/ButtonExtensionUI.tsx
@@ -1,0 +1,123 @@
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
+import { useCommands, useEditorState, useEditorView } from '@remirror/react';
+import { FC, useEffect, useState } from 'react';
+import { ProsemirrorNode } from 'remirror';
+
+import { Msg, useMessages } from 'core/i18n';
+import formatUrl from 'utils/formatUrl';
+import messageIds from 'zui/l10n/messageIds';
+
+const ButtonExtensionUI: FC = () => {
+  const state = useEditorState();
+  const view = useEditorView();
+  const messages = useMessages(messageIds);
+  const { setButtonHref, setButtonText } = useCommands();
+
+  const [visible, setVisible] = useState(false);
+  const [linkText, setLinkText] = useState('');
+  const [linkHref, setLinkHref] = useState('');
+
+  const selectionCoords = view.coordsAtPos(state.selection.$from.pos);
+  const editorRect = view.dom.getBoundingClientRect();
+
+  const left = selectionCoords.left - editorRect.left;
+  const top = selectionCoords.top - editorRect.top;
+
+  useEffect(() => {
+    const blockNodes: ProsemirrorNode[] = [];
+    state.doc.nodesBetween(state.selection.from, state.selection.to, (node) => {
+      if (!node.isText) {
+        blockNodes.push(node);
+      }
+    });
+
+    if (blockNodes.length == 1 && blockNodes[0].type.name == 'zbutton') {
+      const buttonNode = blockNodes[0];
+      setLinkText(buttonNode.textContent || '');
+      setLinkHref(buttonNode.attrs.href || '');
+      setVisible(true);
+    } else {
+      setVisible(false);
+    }
+  }, [state.selection]);
+
+  const formattedHref = formatUrl(linkHref);
+  const canSubmit = !!formattedHref && linkText.length > 0;
+
+  return (
+    <Box position="relative">
+      <Box
+        sx={{
+          left: left,
+          minWidth: 300,
+          position: 'absolute',
+          top: top + 20,
+        }}
+      >
+        {visible && (
+          <Paper elevation={1}>
+            <Box
+              alignItems="stretch"
+              display="flex"
+              flexDirection="column"
+              gap={1}
+              padding={1}
+            >
+              <Box display="flex">
+                <TextField
+                  fullWidth
+                  onChange={(ev) => setLinkHref(ev.target.value)}
+                  size="small"
+                  value={linkHref}
+                />
+                <IconButton
+                  disabled={!formattedHref}
+                  href={formattedHref || ''}
+                  target="_blank"
+                >
+                  <OpenInNew />
+                </IconButton>
+              </Box>
+              <Box sx={{ display: 'flex', flexGrow: 1 }}>
+                <TextField
+                  fullWidth
+                  onChange={(ev) => setLinkText(ev.target.value)}
+                  placeholder={messages.editor.extensions.link.textPlaceholder()}
+                  size="small"
+                  value={linkText}
+                />
+              </Box>
+              <Box display="flex" gap={1} justifyContent="flex-end">
+                <Button
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    // TODO: Deselect button, or hide?
+                  }}
+                  size="small"
+                >
+                  <Msg id={messageIds.editor.extensions.link.cancel} />
+                </Button>
+
+                <Button
+                  disabled={!canSubmit}
+                  onClick={() => {
+                    setButtonText(state.selection.$head.pos, linkText);
+                    setButtonHref(state.selection.$head.pos, linkHref);
+                  }}
+                  size="small"
+                  variant="outlined"
+                >
+                  <Msg id={messageIds.editor.extensions.link.apply} />
+                </Button>
+              </Box>
+            </Box>
+          </Paper>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ButtonExtensionUI;

--- a/src/zui/ZUIEditor/ButtonExtensionUI.tsx
+++ b/src/zui/ZUIEditor/ButtonExtensionUI.tsx
@@ -3,6 +3,7 @@ import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
 import TextAndHrefOverlay from './elements/TextAndHrefOverlay';
+import formatUrl from 'utils/formatUrl';
 
 const ButtonExtensionUI: FC = () => {
   const state = useEditorState();
@@ -40,16 +41,22 @@ const ButtonExtensionUI: FC = () => {
   return (
     <TextAndHrefOverlay
       href={href}
+      onCancel={() => {
+        // TODO: Hide somehow
+      }}
       onChangeHref={(href) => setHref(href)}
       onChangeText={(text) => setText(text)}
       onSubmit={() => {
-        setButtonText(state.selection.$head.pos, text);
-        setButtonHref(state.selection.$head.pos, href);
+        const formattedHref = formatUrl(href);
+        if (formattedHref) {
+          setButtonText(state.selection.$head.pos, text);
+          setButtonHref(state.selection.$head.pos, formattedHref);
+        }
       }}
       open={visible}
       text={text}
       x={left}
-      y={top + 20}
+      y={top + 30}
     />
   );
 };

--- a/src/zui/ZUIEditor/ButtonExtensionUI.tsx
+++ b/src/zui/ZUIEditor/ButtonExtensionUI.tsx
@@ -1,22 +1,17 @@
-import { OpenInNew } from '@mui/icons-material';
-import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
 import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
-import { Msg, useMessages } from 'core/i18n';
-import formatUrl from 'utils/formatUrl';
-import messageIds from 'zui/l10n/messageIds';
+import TextAndHrefOverlay from './elements/TextAndHrefOverlay';
 
 const ButtonExtensionUI: FC = () => {
   const state = useEditorState();
   const view = useEditorView();
-  const messages = useMessages(messageIds);
   const { setButtonHref, setButtonText } = useCommands();
 
   const [visible, setVisible] = useState(false);
-  const [linkText, setLinkText] = useState('');
-  const [linkHref, setLinkHref] = useState('');
+  const [text, setText] = useState('');
+  const [href, setHref] = useState('');
 
   const selectionCoords = view.coordsAtPos(state.selection.$from.pos);
   const editorRect = view.dom.getBoundingClientRect();
@@ -34,89 +29,28 @@ const ButtonExtensionUI: FC = () => {
 
     if (blockNodes.length == 1 && blockNodes[0].type.name == 'zbutton') {
       const buttonNode = blockNodes[0];
-      setLinkText(buttonNode.textContent || '');
-      setLinkHref(buttonNode.attrs.href || '');
+      setText(buttonNode.textContent || '');
+      setHref(buttonNode.attrs.href || '');
       setVisible(true);
     } else {
       setVisible(false);
     }
   }, [state.selection]);
 
-  const formattedHref = formatUrl(linkHref);
-  const canSubmit = !!formattedHref && linkText.length > 0;
-
   return (
-    <Box position="relative">
-      <Box
-        sx={{
-          left: left,
-          minWidth: 300,
-          position: 'absolute',
-          top: top + 20,
-        }}
-      >
-        {visible && (
-          <Paper elevation={1}>
-            <Box
-              alignItems="stretch"
-              display="flex"
-              flexDirection="column"
-              gap={1}
-              padding={1}
-            >
-              <Box display="flex">
-                <TextField
-                  fullWidth
-                  onChange={(ev) => setLinkHref(ev.target.value)}
-                  size="small"
-                  value={linkHref}
-                />
-                <IconButton
-                  disabled={!formattedHref}
-                  href={formattedHref || ''}
-                  target="_blank"
-                >
-                  <OpenInNew />
-                </IconButton>
-              </Box>
-              <Box sx={{ display: 'flex', flexGrow: 1 }}>
-                <TextField
-                  fullWidth
-                  onChange={(ev) => setLinkText(ev.target.value)}
-                  placeholder={messages.editor.extensions.link.textPlaceholder()}
-                  size="small"
-                  value={linkText}
-                />
-              </Box>
-              <Box display="flex" gap={1} justifyContent="flex-end">
-                <Button
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    ev.preventDefault();
-                    // TODO: Deselect button, or hide?
-                  }}
-                  size="small"
-                >
-                  <Msg id={messageIds.editor.extensions.link.cancel} />
-                </Button>
-
-                <Button
-                  disabled={!canSubmit}
-                  onClick={() => {
-                    setButtonText(state.selection.$head.pos, linkText);
-                    setButtonHref(state.selection.$head.pos, linkHref);
-                  }}
-                  size="small"
-                  variant="outlined"
-                >
-                  <Msg id={messageIds.editor.extensions.link.apply} />
-                </Button>
-              </Box>
-            </Box>
-          </Paper>
-        )}
-      </Box>
-    </Box>
+    <TextAndHrefOverlay
+      href={href}
+      onChangeHref={(href) => setHref(href)}
+      onChangeText={(text) => setText(text)}
+      onSubmit={() => {
+        setButtonText(state.selection.$head.pos, text);
+        setButtonHref(state.selection.$head.pos, href);
+      }}
+      open={visible}
+      text={text}
+      x={left}
+      y={top + 20}
+    />
   );
 };
 

--- a/src/zui/ZUIEditor/ButtonExtensionUI.tsx
+++ b/src/zui/ZUIEditor/ButtonExtensionUI.tsx
@@ -42,7 +42,7 @@ const ButtonExtensionUI: FC = () => {
     <TextAndHrefOverlay
       href={href}
       onCancel={() => {
-        // TODO: Hide somehow
+        setVisible(false);
       }}
       onChangeHref={(href) => setHref(href)}
       onChangeText={(text) => setText(text)}

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -23,15 +23,14 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
     toggleHeading,
     pickImage,
     removeLink,
+    removeAllLinksInRange,
     setLink,
   } = useCommands();
 
   const [selectedNodes, setSelectedNodes] = useState<NodeWithPosition[]>([]);
-  const [selectionHasOtherNodes, setSelectionHasOtherNodes] = useState(false);
 
   useEffect(() => {
     const linkNodes: NodeWithPosition[] = [];
-    let hasOtherNodes = false;
     state.doc.nodesBetween(
       state.selection.from,
       state.selection.to,
@@ -39,14 +38,11 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
         if (node.isText) {
           if (node.marks.some((mark) => mark.type.name == 'zlink')) {
             linkNodes.push({ from: index, node, to: index + node.nodeSize });
-          } else {
-            hasOtherNodes = true;
           }
         }
       }
     );
     setSelectedNodes(linkNodes);
-    setSelectionHasOtherNodes(hasOtherNodes);
   }, [state.selection]);
 
   return (
@@ -88,13 +84,15 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
                       setLink();
                       focus();
                     } else {
-                      if (
-                        selectedNodes.length == 1 &&
-                        !selectionHasOtherNodes
-                      ) {
+                      if (selectedNodes.length == 1) {
                         removeLink({
                           from: selectedNodes[0].from,
                           to: selectedNodes[0].to,
+                        });
+                      } else if (selectedNodes.length > 1) {
+                        removeAllLinksInRange({
+                          from: state.selection.from,
+                          to: state.selection.to,
                         });
                       }
                     }

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -13,7 +13,8 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
   curBlockY,
   pos,
 }) => {
-  const { convertParagraph, toggleHeading, pickImage } = useCommands();
+  const { convertParagraph, focus, toggleHeading, pickImage, setLink } =
+    useCommands();
 
   return (
     <Box position="relative">
@@ -26,25 +27,39 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
           zIndex: 10000,
         }}
       >
-        <Paper elevation={1} sx={{ p: 1 }}>
-          {curBlockType}
-          {curBlockType == 'zimage' && (
-            <Button
-              onClick={() => {
-                pickImage(pos);
-              }}
-            >
-              Change image
-            </Button>
-          )}
-          {curBlockType == 'heading' && (
-            <Button onClick={() => convertParagraph()}>
-              Convert to paragraph
-            </Button>
-          )}
-          {curBlockType == 'paragraph' && (
-            <Button onClick={() => toggleHeading()}>Convert to heading</Button>
-          )}
+        <Paper elevation={1}>
+          <Box alignItems="center" display="flex" padding={1}>
+            {curBlockType}
+            {curBlockType == 'zimage' && (
+              <Button
+                onClick={() => {
+                  pickImage(pos);
+                }}
+              >
+                Change image
+              </Button>
+            )}
+            {curBlockType == 'heading' && (
+              <Button onClick={() => convertParagraph()}>
+                Convert to paragraph
+              </Button>
+            )}
+            {curBlockType == 'paragraph' && (
+              <>
+                <Button onClick={() => toggleHeading()}>
+                  Convert to heading
+                </Button>
+                <Button
+                  onClick={() => {
+                    setLink();
+                    focus();
+                  }}
+                >
+                  Link
+                </Button>
+              </>
+            )}
+          </Box>
         </Paper>
       </Box>
     </Box>

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -20,6 +20,7 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
   const {
     convertParagraph,
     focus,
+    insertEmptyLink,
     toggleHeading,
     pickImage,
     removeLink,
@@ -81,8 +82,13 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
                 <Button
                   onClick={() => {
                     if (!active.zlink()) {
-                      setLink();
-                      focus();
+                      if (state.selection.empty) {
+                        insertEmptyLink();
+                        focus();
+                      } else {
+                        setLink();
+                        focus();
+                      }
                     } else {
                       if (selectedNodes.length == 1) {
                         removeLink({

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -1,12 +1,9 @@
-import { OpenInNew } from '@mui/icons-material';
-import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
 import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
-import { Msg, useMessages } from 'core/i18n';
 import formatUrl from 'utils/formatUrl';
-import messageIds from 'zui/l10n/messageIds';
+import TextAndHrefOverlay from './elements/TextAndHrefOverlay';
 
 export type NodeWithPosition = {
   from: number;
@@ -17,7 +14,6 @@ export type NodeWithPosition = {
 const LinkExtensionUI: FC = () => {
   const state = useEditorState();
   const view = useEditorView();
-  const messages = useMessages(messageIds);
   const { removeLink, removeUnfinishedLinks, updateLink, updateLinkText } =
     useCommands();
 
@@ -77,100 +73,36 @@ const LinkExtensionUI: FC = () => {
   }, [state.selection]);
 
   const formattedHref = formatUrl(linkHref);
-  const canSubmit = !!formattedHref && linkText.length > 0;
 
   return (
-    <Box position="relative">
-      <Box
-        sx={{
-          left: left,
-          minWidth: 300,
-          position: 'absolute',
-          top: top + 20,
-        }}
-      >
-        {showLinkMaker && (
-          <Paper elevation={1}>
-            <Box
-              alignItems="stretch"
-              display="flex"
-              flexDirection="column"
-              gap={1}
-              padding={1}
-            >
-              <Box display="flex">
-                <TextField
-                  fullWidth
-                  onChange={(ev) => setLinkHref(ev.target.value)}
-                  size="small"
-                  value={linkHref}
-                />
-                <IconButton
-                  disabled={!formattedHref}
-                  href={formattedHref || ''}
-                  target="_blank"
-                >
-                  <OpenInNew />
-                </IconButton>
-              </Box>
-              <Box sx={{ display: 'flex', flexGrow: 1 }}>
-                <TextField
-                  fullWidth
-                  onChange={(ev) => setLinkText(ev.target.value)}
-                  placeholder={messages.editor.extensions.link.textPlaceholder()}
-                  size="small"
-                  value={linkText}
-                />
-              </Box>
-              <Box display="flex" justifyContent="space-between">
-                <Button
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    ev.preventDefault();
-                    setSelectedNodes([]);
-                  }}
-                  size="small"
-                >
-                  <Msg id={messageIds.editor.extensions.link.cancel} />
-                </Button>
-
-                <Box display="flex" gap={1}>
-                  <Button
-                    onClick={() =>
-                      removeLink({
-                        from: selectedNodes[0].from,
-                        to: selectedNodes[0].to,
-                      })
-                    }
-                    size="small"
-                    variant="text"
-                  >
-                    <Msg id={messageIds.editor.extensions.link.remove} />
-                  </Button>
-                  <Button
-                    disabled={!canSubmit}
-                    onClick={() => {
-                      updateLink({ href: formattedHref || '' });
-                      updateLinkText(
-                        {
-                          from: selectedNodes[0].from,
-                          to: selectedNodes[0].to,
-                        },
-                        linkText
-                      );
-                    }}
-                    size="small"
-                    variant="outlined"
-                  >
-                    <Msg id={messageIds.editor.extensions.link.apply} />
-                  </Button>
-                </Box>
-              </Box>
-            </Box>
-          </Paper>
-        )}
-      </Box>
-    </Box>
+    <TextAndHrefOverlay
+      href={linkHref}
+      onCancel={() => {
+        setSelectedNodes([]);
+      }}
+      onChangeHref={(href) => setLinkHref(href)}
+      onChangeText={(text) => setLinkText(text)}
+      onRemove={() => {
+        removeLink({
+          from: selectedNodes[0].from,
+          to: selectedNodes[0].to,
+        });
+      }}
+      onSubmit={() => {
+        updateLink({ href: formattedHref || '' });
+        updateLinkText(
+          {
+            from: selectedNodes[0].from,
+            to: selectedNodes[0].to,
+          },
+          linkText
+        );
+      }}
+      open={showLinkMaker}
+      text={linkText}
+      x={left}
+      y={top + 20}
+    />
   );
 };
 

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Paper, TextField } from '@mui/material';
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
 import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
@@ -79,13 +80,22 @@ const LinkExtensionUI: FC = () => {
         {showLinkMaker && (
           <Paper elevation={1}>
             <Box display="flex" flexDirection="column" gap={1} padding={1}>
+              <Box display="flex">
+                <TextField
+                  onChange={(ev) => setLinkHref(ev.target.value)}
+                  value={linkHref}
+                />
+                <IconButton
+                  disabled={!formattedHref}
+                  href={formattedHref || ''}
+                  target="_blank"
+                >
+                  <OpenInNew />
+                </IconButton>
+              </Box>
               <TextField
                 onChange={(ev) => setLinkText(ev.target.value)}
                 value={linkText}
-              />
-              <TextField
-                onChange={(ev) => setLinkHref(ev.target.value)}
-                value={linkHref}
               />
               <Box display="flex">
                 <Button

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -4,7 +4,9 @@ import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
+import { Msg } from 'core/i18n';
 import formatUrl from 'utils/formatUrl';
+import messageIds from 'zui/l10n/messageIds';
 
 export type NodeWithPosition = {
   from: number;
@@ -73,16 +75,25 @@ const LinkExtensionUI: FC = () => {
       <Box
         sx={{
           left: left,
+          minWidth: 300,
           position: 'absolute',
           top: top + 20,
         }}
       >
         {showLinkMaker && (
           <Paper elevation={1}>
-            <Box display="flex" flexDirection="column" gap={1} padding={1}>
+            <Box
+              alignItems="stretch"
+              display="flex"
+              flexDirection="column"
+              gap={1}
+              padding={1}
+            >
               <Box display="flex">
                 <TextField
+                  fullWidth
                   onChange={(ev) => setLinkHref(ev.target.value)}
+                  size="small"
                   value={linkHref}
                 />
                 <IconButton
@@ -93,45 +104,58 @@ const LinkExtensionUI: FC = () => {
                   <OpenInNew />
                 </IconButton>
               </Box>
-              <TextField
-                onChange={(ev) => setLinkText(ev.target.value)}
-                value={linkText}
-              />
-              <Box display="flex">
-                <Button
-                  disabled={!formattedHref}
-                  onClick={() => {
-                    updateLink({ href: formattedHref || '' });
-                    updateLinkText(
-                      { from: selectedNodes[0].from, to: selectedNodes[0].to },
-                      linkText
-                    );
-                  }}
-                  variant="outlined"
-                >
-                  Apply
-                </Button>
-                <Button
-                  disabled={!linkHref}
-                  onClick={() =>
-                    removeLink({
-                      from: selectedNodes[0].from,
-                      to: selectedNodes[0].to,
-                    })
-                  }
-                  variant="outlined"
-                >
-                  Remove
-                </Button>
+              <Box sx={{ display: 'flex', flexGrow: 1 }}>
+                <TextField
+                  fullWidth
+                  onChange={(ev) => setLinkText(ev.target.value)}
+                  size="small"
+                  value={linkText}
+                />
+              </Box>
+              <Box display="flex" justifyContent="space-between">
                 <Button
                   onClick={(ev) => {
                     ev.stopPropagation();
                     ev.preventDefault();
                     setSelectedNodes([]);
                   }}
+                  size="small"
                 >
-                  Cancel
+                  <Msg id={messageIds.editor.extensions.link.cancel} />
                 </Button>
+
+                <Box display="flex" gap={1}>
+                  <Button
+                    disabled={!linkHref}
+                    onClick={() =>
+                      removeLink({
+                        from: selectedNodes[0].from,
+                        to: selectedNodes[0].to,
+                      })
+                    }
+                    size="small"
+                    variant="text"
+                  >
+                    <Msg id={messageIds.editor.extensions.link.remove} />
+                  </Button>
+                  <Button
+                    disabled={!formattedHref}
+                    onClick={() => {
+                      updateLink({ href: formattedHref || '' });
+                      updateLinkText(
+                        {
+                          from: selectedNodes[0].from,
+                          to: selectedNodes[0].to,
+                        },
+                        linkText
+                      );
+                    }}
+                    size="small"
+                    variant="outlined"
+                  >
+                    <Msg id={messageIds.editor.extensions.link.apply} />
+                  </Button>
+                </Box>
               </Box>
             </Box>
           </Paper>

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -1,14 +1,17 @@
-import { Box, Paper } from '@mui/material';
-import { useEditorState, useEditorView } from '@remirror/react';
+import { Box, Button, Paper, TextField } from '@mui/material';
+import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
 const LinkExtensionUI: FC = () => {
   const state = useEditorState();
   const view = useEditorView();
+  const { updateLink } = useCommands();
 
   const [selectedNodes, setSelectedNodes] = useState<ProsemirrorNode[]>([]);
   const [selectionHasOtherNodes, setSelectionHasOtherNodes] = useState(false);
+  const [linkText, setLinkText] = useState('');
+  const [linkHref, setLinkHref] = useState('');
 
   const selectionCoords = view.coordsAtPos(state.selection.$from.pos);
   const editorRect = view.dom.getBoundingClientRect();
@@ -17,23 +20,31 @@ const LinkExtensionUI: FC = () => {
   const top = selectionCoords.top - editorRect.top;
 
   useEffect(() => {
+    const selectedNode = selectedNodes[0];
+    if (selectedNode) {
+      setLinkText(selectedNode.text || '');
+      const mark = selectedNode.marks.find((mark) => mark.type.name == 'zlink');
+      setLinkHref(mark?.attrs.href || '');
+    }
+  }, [selectedNodes[0]]);
+
+  useEffect(() => {
     const linkNodes: ProsemirrorNode[] = [];
-    setSelectedNodes(linkNodes);
-    setSelectionHasOtherNodes(false);
+    let hasOtherNodes = false;
     state.doc.nodesBetween(state.selection.from, state.selection.to, (node) => {
       if (node.isText) {
         if (node.marks.some((mark) => mark.type.name == 'zlink')) {
           linkNodes.push(node);
-          setSelectedNodes(linkNodes);
         } else {
-          setSelectionHasOtherNodes(true);
+          hasOtherNodes = true;
         }
       }
     });
+    setSelectedNodes(linkNodes);
+    setSelectionHasOtherNodes(hasOtherNodes);
   }, [state.selection]);
 
   const showLinkMaker = selectedNodes.length == 1 && !selectionHasOtherNodes;
-  console;
 
   return (
     <Box position="relative">
@@ -46,7 +57,22 @@ const LinkExtensionUI: FC = () => {
       >
         {showLinkMaker && (
           <Paper elevation={1}>
-            <Box padding={1}>Hej</Box>
+            <Box display="flex" flexDirection="column" gap={1} padding={1}>
+              <TextField
+                onChange={(ev) => setLinkText(ev.target.value)}
+                value={linkText}
+              />
+              <TextField
+                onChange={(ev) => setLinkHref(ev.target.value)}
+                value={linkHref}
+              />
+              <Button
+                onClick={() => updateLink({ href: linkHref })}
+                variant="outlined"
+              >
+                Apply
+              </Button>
+            </Box>
           </Paper>
         )}
       </Box>

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -1,0 +1,51 @@
+import { Box, Paper } from '@mui/material';
+import {
+  useActive,
+  useEditorState,
+  useEditorView,
+  useExtension,
+} from '@remirror/react';
+import { FC } from 'react';
+
+import LinkExtension from './extensions/LinkExtension';
+
+const LinkExtensionUI: FC = () => {
+  const active = useActive();
+  const state = useEditorState();
+  const linkExtension = useExtension(LinkExtension);
+  const view = useEditorView();
+
+  const selectionCoords = view.coordsAtPos(state.selection.$from.pos);
+  const editorRect = view.dom.getBoundingClientRect();
+
+  const left = selectionCoords.left - editorRect.left;
+  const top = selectionCoords.top - editorRect.top;
+
+  const linkIsSelected = state.doc.rangeHasMark(
+    state.selection.from,
+    state.selection.to,
+    linkExtension.type
+  );
+
+  const showLinkMaker = active.zlink() || linkIsSelected;
+
+  return (
+    <Box position="relative">
+      <Box
+        sx={{
+          left: left,
+          position: 'absolute',
+          top: top + 20,
+        }}
+      >
+        {showLinkMaker && (
+          <Paper elevation={1}>
+            <Box padding={1}>Hej</Box>
+          </Paper>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default LinkExtensionUI;

--- a/src/zui/ZUIEditor/LinkExtensionUI.tsx
+++ b/src/zui/ZUIEditor/LinkExtensionUI.tsx
@@ -3,6 +3,8 @@ import { useCommands, useEditorState, useEditorView } from '@remirror/react';
 import { FC, useEffect, useState } from 'react';
 import { ProsemirrorNode } from 'remirror';
 
+import formatUrl from 'utils/formatUrl';
+
 export type NodeWithPosition = {
   from: number;
   node: ProsemirrorNode;
@@ -63,6 +65,8 @@ const LinkExtensionUI: FC = () => {
     setSelectionHasOtherNodes(hasOtherNodes);
   }, [state.selection]);
 
+  const formattedHref = formatUrl(linkHref);
+
   return (
     <Box position="relative">
       <Box
@@ -85,9 +89,9 @@ const LinkExtensionUI: FC = () => {
               />
               <Box display="flex">
                 <Button
-                  disabled={!linkHref}
+                  disabled={!formattedHref}
                   onClick={() => {
-                    updateLink({ href: linkHref });
+                    updateLink({ href: formattedHref || '' });
                     updateLinkText(
                       { from: selectedNodes[0].from, to: selectedNodes[0].to },
                       linkText

--- a/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
+++ b/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
@@ -1,0 +1,109 @@
+import { OpenInNew } from '@mui/icons-material';
+import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
+import { FC } from 'react';
+
+import formatUrl from 'utils/formatUrl';
+import messageIds from 'zui/l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
+
+type Props = {
+  href: string;
+  onChangeHref: (href: string) => void;
+  onChangeText: (text: string) => void;
+  onSubmit: () => void;
+  open: boolean;
+  text: string;
+  x: number;
+  y: number;
+};
+
+const TextAndHrefOverlay: FC<Props> = ({
+  href,
+  onChangeHref,
+  onChangeText,
+  onSubmit,
+  open,
+  text,
+  x,
+  y,
+}) => {
+  const messages = useMessages(messageIds);
+
+  const formattedHref = formatUrl(href);
+  const canSubmit = !!formattedHref && text.length > 0;
+
+  return (
+    <Box position="relative">
+      <Box
+        sx={{
+          left: x,
+          minWidth: 300,
+          position: 'absolute',
+          top: y,
+        }}
+      >
+        {open && (
+          <Paper elevation={1}>
+            <Box
+              alignItems="stretch"
+              display="flex"
+              flexDirection="column"
+              gap={1}
+              padding={1}
+            >
+              <Box display="flex">
+                <TextField
+                  fullWidth
+                  onChange={(ev) => onChangeHref(ev.target.value)}
+                  size="small"
+                  value={href}
+                />
+                <IconButton
+                  disabled={!formattedHref}
+                  href={formattedHref || ''}
+                  target="_blank"
+                >
+                  <OpenInNew />
+                </IconButton>
+              </Box>
+              <Box sx={{ display: 'flex', flexGrow: 1 }}>
+                <TextField
+                  fullWidth
+                  onChange={(ev) => onChangeText(ev.target.value)}
+                  placeholder={messages.editor.extensions.link.textPlaceholder()}
+                  size="small"
+                  value={text}
+                />
+              </Box>
+              <Box display="flex" gap={1} justifyContent="flex-end">
+                <Button
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+                    // TODO: Deselect button, or hide?
+                  }}
+                  size="small"
+                >
+                  <Msg id={messageIds.editor.extensions.link.cancel} />
+                </Button>
+
+                <Button
+                  disabled={!canSubmit}
+                  onClick={() => {
+                    onSubmit();
+                  }}
+                  size="small"
+                  variant="outlined"
+                >
+                  <Msg id={messageIds.editor.extensions.link.apply} />
+                </Button>
+              </Box>
+            </Box>
+          </Paper>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default TextAndHrefOverlay;

--- a/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
+++ b/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
@@ -1,6 +1,13 @@
 import { OpenInNew } from '@mui/icons-material';
-import { Box, Button, IconButton, Paper, TextField } from '@mui/material';
-import { FC } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Popper,
+  TextField,
+} from '@mui/material';
+import { FC, useState } from 'react';
 
 import formatUrl from 'utils/formatUrl';
 import messageIds from 'zui/l10n/messageIds';
@@ -31,6 +38,7 @@ const TextAndHrefOverlay: FC<Props> = ({
   x,
   y,
 }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const messages = useMessages(messageIds);
 
   const formattedHref = formatUrl(href);
@@ -39,14 +47,14 @@ const TextAndHrefOverlay: FC<Props> = ({
   return (
     <Box position="relative">
       <Box
+        ref={(el: HTMLElement) => setAnchorEl(el)}
         sx={{
           left: x,
-          minWidth: 300,
           position: 'absolute',
           top: y,
         }}
       >
-        {open && (
+        <Popper anchorEl={anchorEl} open={open}>
           <Paper elevation={1}>
             <Box
               alignItems="stretch"
@@ -118,7 +126,7 @@ const TextAndHrefOverlay: FC<Props> = ({
               </Box>
             </Box>
           </Paper>
-        )}
+        </Popper>
       </Box>
     </Box>
   );

--- a/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
+++ b/src/zui/ZUIEditor/elements/TextAndHrefOverlay.tsx
@@ -8,8 +8,10 @@ import { Msg, useMessages } from 'core/i18n';
 
 type Props = {
   href: string;
+  onCancel: () => void;
   onChangeHref: (href: string) => void;
   onChangeText: (text: string) => void;
+  onRemove?: () => void;
   onSubmit: () => void;
   open: boolean;
   text: string;
@@ -19,8 +21,10 @@ type Props = {
 
 const TextAndHrefOverlay: FC<Props> = ({
   href,
+  onCancel,
   onChangeHref,
   onChangeText,
+  onRemove,
   onSubmit,
   open,
   text,
@@ -75,28 +79,42 @@ const TextAndHrefOverlay: FC<Props> = ({
                   value={text}
                 />
               </Box>
-              <Box display="flex" gap={1} justifyContent="flex-end">
-                <Button
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    ev.preventDefault();
-                    // TODO: Deselect button, or hide?
-                  }}
-                  size="small"
-                >
-                  <Msg id={messageIds.editor.extensions.link.cancel} />
-                </Button>
+              <Box
+                display="flex"
+                justifyContent={onRemove ? 'space-between' : 'flex-end'}
+              >
+                {!!onRemove && (
+                  <Button
+                    onClick={() => {
+                      onRemove();
+                    }}
+                    size="small"
+                    variant="text"
+                  >
+                    <Msg id={messageIds.editor.extensions.link.remove} />
+                  </Button>
+                )}
+                <Box display="flex" gap={1}>
+                  <Button
+                    onClick={() => {
+                      onCancel();
+                    }}
+                    size="small"
+                  >
+                    <Msg id={messageIds.editor.extensions.link.cancel} />
+                  </Button>
 
-                <Button
-                  disabled={!canSubmit}
-                  onClick={() => {
-                    onSubmit();
-                  }}
-                  size="small"
-                  variant="outlined"
-                >
-                  <Msg id={messageIds.editor.extensions.link.apply} />
-                </Button>
+                  <Button
+                    disabled={!canSubmit}
+                    onClick={() => {
+                      onSubmit();
+                    }}
+                    size="small"
+                    variant="outlined"
+                  >
+                    <Msg id={messageIds.editor.extensions.link.apply} />
+                  </Button>
+                </Box>
               </Box>
             </Box>
           </Paper>

--- a/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
@@ -30,6 +30,9 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
+        href: {
+          default: null,
+        },
       },
       parseDOM: [
         {
@@ -77,6 +80,33 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
 
   get name() {
     return 'zbutton' as const;
+  }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  setButtonHref(pos: number, href: string): CommandFunction {
+    return ({ dispatch, tr }) => {
+      const resolved = tr.doc.resolve(pos);
+      tr.setNodeAttribute(resolved.before(), 'href', href);
+      dispatch?.(tr);
+      return true;
+    };
+  }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  setButtonText(pos: number, text: string): CommandFunction {
+    return ({ dispatch, tr }) => {
+      const newTextNode = this.type.schema.text(text);
+      const resolved = tr.doc.resolve(pos);
+
+      tr.replaceWith(resolved.start(), resolved.end(), newTextNode);
+
+      dispatch?.(tr);
+      return true;
+    };
   }
 }
 

--- a/src/zui/ZUIEditor/extensions/LinkExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/LinkExtension.tsx
@@ -67,6 +67,28 @@ class LinkExtension extends MarkExtension<LinkOptions> {
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   //@ts-ignore
   @command()
+  removeAllLinksInRange(range: FromToProps): CommandFunction {
+    return ({ tr, dispatch }) => {
+      tr.doc.nodesBetween(range.from, range.to, (node, pos) => {
+        if (node.isText) {
+          const linkMark = node.marks.find(
+            (mark) => mark.type.name == this.type.name
+          );
+          if (linkMark) {
+            tr = tr.removeMark(pos, pos + node.nodeSize, this.type);
+          }
+        }
+      });
+
+      dispatch?.(tr);
+
+      return true;
+    };
+  }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
   removeLink(range: FromToProps): CommandFunction {
     return ({ tr, dispatch }) => {
       const { from, to } = range;

--- a/src/zui/ZUIEditor/extensions/LinkExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/LinkExtension.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 import { TagParseRule } from '@remirror/pm/model';
+import { TextSelection } from '@remirror/pm/state';
 import {
   ApplySchemaAttributes,
   extension,
@@ -65,6 +66,22 @@ class LinkExtension extends MarkExtension<LinkOptions> {
     };
   }
 
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  insertEmptyLink(): CommandFunction {
+    return ({ dispatch, state, tr }) => {
+      const mark = this.type.create();
+      const node = this.type.schema.text(String.fromCharCode(160), [mark]);
+      const pos = state.selection.$head.pos;
+      tr = tr.insert(pos, node);
+      tr = tr.setSelection(TextSelection.create(tr.doc, pos, pos + 1));
+      dispatch?.(tr);
+
+      return true;
+    };
+  }
+
   get name() {
     return 'zlink' as const;
   }
@@ -121,6 +138,9 @@ class LinkExtension extends MarkExtension<LinkOptions> {
           if (linkMark) {
             if (!linkMark.attrs.href) {
               tr = tr.removeMark(pos, pos + node.nodeSize, this.type);
+              if (node.text == String.fromCharCode(160)) {
+                tr = tr.delete(pos, pos + 1);
+              }
             }
           }
         }

--- a/src/zui/ZUIEditor/extensions/LinkExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/LinkExtension.tsx
@@ -53,7 +53,6 @@ class LinkExtension extends MarkExtension<LinkOptions> {
           {
             ...extra.dom(node),
             href: node.attrs.href,
-            style: 'text-decoration: underline;',
           },
           0,
         ];
@@ -104,13 +103,17 @@ class LinkExtension extends MarkExtension<LinkOptions> {
   /* eslint-disable @typescript-eslint/ban-ts-comment */
   //@ts-ignore
   @command()
-  updateLink(attrs: LinkAttributes, range?: FromToProps): CommandFunction {
+  updateLink(attrs: LinkAttributes, range: FromToProps): CommandFunction {
     return (props) => {
       const { tr } = props;
 
       tr.setMeta(this.name, { attrs, command: 'updateLink', range });
 
-      return updateMark({ attrs, range, type: this.type })(props);
+      return updateMark({
+        attrs,
+        range,
+        type: this.type,
+      })(props);
     };
   }
 }

--- a/src/zui/ZUIEditor/extensions/LinkExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/LinkExtension.tsx
@@ -44,7 +44,6 @@ class LinkExtension extends MarkExtension<LinkOptions> {
         {
           getAttrs: extra.parse,
           tag: 'a',
-          //Sätt href-propertyn till värdet href från options
         } as TagParseRule,
         ...(override.parseDOM ?? []),
       ],

--- a/src/zui/ZUIEditor/extensions/LinkExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/LinkExtension.tsx
@@ -116,6 +116,23 @@ class LinkExtension extends MarkExtension<LinkOptions> {
       })(props);
     };
   }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  updateLinkText(range: FromToProps, linkText: string): CommandFunction {
+    return (props) => {
+      const { tr, dispatch } = props;
+
+      tr.insertText(linkText, range.from, range.to);
+
+      if (dispatch) {
+        dispatch(tr);
+      }
+
+      return true;
+    };
+  }
 }
 
 declare global {

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -18,6 +18,7 @@ import { useNumericRouteParams } from 'core/hooks';
 import { useMessages } from 'core/i18n';
 import messageIds from 'zui/l10n/messageIds';
 import EditorOverlays from './EditorOverlays';
+import LinkExtensionUI from './LinkExtensionUI';
 
 type ZetkinExtension = ButtonExtension | HeadingExtension | ImageExtension;
 
@@ -117,6 +118,7 @@ const ZUIEditor: FC<Props> = ({ enableButton, enableHeading, enableImage }) => {
           />
           <EmptyBlockPlaceholder placeholder={messages.placeholder()} />
           {enableImage && <ImageExtensionUI orgId={orgId} />}
+          <LinkExtensionUI />
           <EditorComponent />
           <OnChangeJSON
             // eslint-disable-next-line no-console

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -20,6 +20,7 @@ import { useMessages } from 'core/i18n';
 import messageIds from 'zui/l10n/messageIds';
 import EditorOverlays from './EditorOverlays';
 import LinkExtensionUI from './LinkExtensionUI';
+import ButtonExtensionUI from './ButtonExtensionUI';
 
 type ZetkinExtension = ButtonExtension | HeadingExtension | ImageExtension;
 
@@ -120,6 +121,7 @@ const ZUIEditor: FC<Props> = ({ enableButton, enableHeading, enableImage }) => {
           />
           <EmptyBlockPlaceholder placeholder={messages.placeholder()} />
           {enableImage && <ImageExtensionUI orgId={orgId} />}
+          <ButtonExtensionUI />
           <LinkExtensionUI />
           <EditorComponent />
           <OnChangeJSON

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -132,6 +132,13 @@ export default makeMessages('zui', {
       zbutton: m('Button'),
       zimage: m('Image'),
     },
+    extensions: {
+      link: {
+        apply: m('Apply'),
+        cancel: m('Cancel'),
+        remove: m('Remove'),
+      },
+    },
     placeholder: m('Type / to insert block or just type some text'),
   },
   futures: {

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -137,6 +137,7 @@ export default makeMessages('zui', {
         apply: m('Apply'),
         cancel: m('Cancel'),
         remove: m('Remove'),
+        textPlaceholder: m('Add link text here'),
       },
     },
     placeholder: m('Type / to insert block or just type some text'),


### PR DESCRIPTION
## Description
This PR finishes link and button extensions for the new `ZUIEditor`, initially implemented by @ziggabyte and then finished by me.

They use a common `TextAndHrefOverlay` component for their UI.

## Screenshots
### Button
![image](https://github.com/user-attachments/assets/3e326b57-4934-4558-8443-f1459ddbf27b)

### Link
![image](https://github.com/user-attachments/assets/77826283-d22c-4316-98cb-39ce00720ea9)


## Changes
* Creates `LinkExtensionUI` and `ButtonExtensionUI` components that both render a `TextAndHrefOverlay`
* Adds commands to set text and href for buttons
* Adds commands to set text and href on links, as well as to clean away empty links

## Notes to reviewer
Note especially how I solved the two new commands in the `ButtonExtension`, which rely heavily on `resolve()` to find the relevant positions. The `resolve()` function could also be useful in situations where we need to find the relevant nodes, since it returns a `depth` and `node()` function to retrieve the node and it's ancestors at the current position.

For the new "Create link" feature, that inserts a link without converting an existing text range, I chose to insert a link node consisting of a single non-breaking space (`String.fromCharCode(160)`) and select it. For some reason, a regular space (`' '`) did not work reliably.

## Related issues
Undocumented