### PR TITLE
`ZUIEditor` variables

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
@@ -25,7 +25,7 @@ const EmailPage: PageWithLayout = () => {
         <title>hejj</title>
       </Head>
       <Box>
-        <ZUIEditor enableButton enableHeading enableImage />
+        <ZUIEditor enableButton enableHeading enableImage enableVariable />
       </Box>
     </>
   );

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -2,6 +2,9 @@ import { Box, Button, Paper } from '@mui/material';
 import { useCommands } from '@remirror/react';
 import { FC } from 'react';
 
+import VariableToolButton from './VariableToolButton';
+import { VariableName } from '../extensions/VariableExtension';
+
 type BlockToolbarProps = {
   curBlockType: string;
   curBlockY: number;
@@ -50,14 +53,12 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
           )}
           {enableVariable &&
             (curBlockType == 'paragraph' || curBlockType == 'heading') && (
-              <Button
-                onClick={() => {
-                  insertVariable('first_name');
+              <VariableToolButton
+                onSelect={(varName: VariableName) => {
+                  insertVariable(varName);
                   focus();
                 }}
-              >
-                Insert variable
-              </Button>
+              />
             )}
         </Paper>
       </Box>

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -5,15 +5,18 @@ import { FC } from 'react';
 type BlockToolbarProps = {
   curBlockType: string;
   curBlockY: number;
+  enableVariable: boolean;
   pos: number;
 };
 
 const BlockToolbar: FC<BlockToolbarProps> = ({
   curBlockType,
   curBlockY,
+  enableVariable,
   pos,
 }) => {
-  const { convertParagraph, toggleHeading, pickImage } = useCommands();
+  const { convertParagraph, focus, insertVariable, toggleHeading, pickImage } =
+    useCommands();
 
   return (
     <Box position="relative">
@@ -45,6 +48,17 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
           {curBlockType == 'paragraph' && (
             <Button onClick={() => toggleHeading()}>Convert to heading</Button>
           )}
+          {enableVariable &&
+            (curBlockType == 'paragraph' || curBlockType == 'heading') && (
+              <Button
+                onClick={() => {
+                  insertVariable('first_name');
+                  focus();
+                }}
+              >
+                Insert variable
+              </Button>
+            )}
         </Paper>
       </Box>
     </Box>

--- a/src/zui/ZUIEditor/EditorOverlays/VariableToolButton.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/VariableToolButton.tsx
@@ -1,0 +1,45 @@
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import { FC, useState } from 'react';
+import { DataObject } from '@mui/icons-material';
+
+import { VariableName } from '../extensions/VariableExtension';
+import { Msg } from 'core/i18n';
+import messageIds from 'zui/l10n/messageIds';
+
+type Props = {
+  onSelect: (varName: VariableName) => void;
+};
+
+const VariableToolButton: FC<Props> = ({ onSelect }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const handleSelect = (varName: VariableName) => {
+    onSelect(varName);
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <IconButton
+        onClick={(ev) => {
+          setAnchorEl(ev.currentTarget);
+        }}
+      >
+        <DataObject />
+      </IconButton>
+      <Menu anchorEl={anchorEl} open={!!anchorEl} sx={{ zIndex: 99999 }}>
+        <MenuItem onClick={() => handleSelect('first_name')}>
+          <Msg id={messageIds.editor.variables.firstName} />
+        </MenuItem>
+        <MenuItem onClick={() => handleSelect('last_name')}>
+          <Msg id={messageIds.editor.variables.lastName} />
+        </MenuItem>
+        <MenuItem onClick={() => handleSelect('full_name')}>
+          <Msg id={messageIds.editor.variables.fullName} />
+        </MenuItem>
+      </Menu>
+    </>
+  );
+};
+
+export default VariableToolButton;

--- a/src/zui/ZUIEditor/EditorOverlays/VariableToolButton.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/VariableToolButton.tsx
@@ -27,7 +27,12 @@ const VariableToolButton: FC<Props> = ({ onSelect }) => {
       >
         <DataObject />
       </IconButton>
-      <Menu anchorEl={anchorEl} open={!!anchorEl} sx={{ zIndex: 99999 }}>
+      <Menu
+        anchorEl={anchorEl}
+        onClose={() => setAnchorEl(null)}
+        open={!!anchorEl}
+        sx={{ zIndex: 99999 }}
+      >
         <MenuItem onClick={() => handleSelect('first_name')}>
           <Msg id={messageIds.editor.variables.firstName} />
         </MenuItem>

--- a/src/zui/ZUIEditor/EditorOverlays/index.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/index.tsx
@@ -5,7 +5,6 @@ import {
   usePositioner,
 } from '@remirror/react';
 import { FC, useCallback, useEffect, useState } from 'react';
-import { findParentNode, isNodeSelection, ProsemirrorNode } from 'remirror';
 import { Box } from '@mui/material';
 
 import BlockToolbar from './BlockToolbar';
@@ -42,53 +41,29 @@ const EditorOverlays: FC<Props> = ({ blocks, enableVariable }) => {
   const [currentBlock, setCurrentBlock] = useState<BlockData | null>(null);
 
   const findSelectedNode = useCallback(() => {
-    let node: ProsemirrorNode | null = null;
-    let nodeElem: HTMLElement | null = null;
-    if (isNodeSelection(state.selection)) {
-      const elem = view.nodeDOM(state.selection.$from.pos);
+    const pos = state.selection.$head.pos;
+    const resolved = state.doc.resolve(pos);
+    const node = resolved.node(1);
+    if (node) {
+      const posBeforeTextContent = resolved.before(1);
+      const elem = view.nodeDOM(posBeforeTextContent);
       if (elem instanceof HTMLElement) {
-        node = state.selection.node;
-        nodeElem = elem;
+        const nodeElem = elem;
+        const editorRect = view.dom.getBoundingClientRect();
+        const nodeRect = nodeElem.getBoundingClientRect();
+        const x = nodeRect.x - editorRect.x;
+        const y = nodeRect.y - editorRect.y;
+        setCurrentBlock({
+          rect: {
+            ...nodeRect.toJSON(),
+            left: x,
+            top: y,
+            x: x,
+            y: y,
+          },
+          type: node.type.name,
+        });
       }
-    } else {
-      const result = findParentNode({
-        predicate: () => true,
-        selection: state.selection,
-      });
-
-      if (result) {
-        node = result.node;
-        let elem = view.nodeDOM(result.start);
-
-        while (
-          elem &&
-          elem.parentNode &&
-          elem.parentElement?.contentEditable != 'true'
-        ) {
-          elem = elem.parentNode;
-        }
-
-        if (elem instanceof HTMLElement) {
-          nodeElem = elem;
-        }
-      }
-    }
-
-    if (node && nodeElem) {
-      const editorRect = view.dom.getBoundingClientRect();
-      const nodeRect = nodeElem.getBoundingClientRect();
-      const x = nodeRect.x - editorRect.x;
-      const y = nodeRect.y - editorRect.y;
-      setCurrentBlock({
-        rect: {
-          ...nodeRect.toJSON(),
-          left: x,
-          top: y,
-          x: x,
-          y: y,
-        },
-        type: node.type.name,
-      });
     }
   }, [view, state.selection]);
 

--- a/src/zui/ZUIEditor/EditorOverlays/index.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/index.tsx
@@ -145,8 +145,7 @@ const EditorOverlays: FC<Props> = ({ blocks, enableVariable }) => {
     }),
   ];
 
-  const showBlockToolbar =
-    !showBlockMenu && !!currentBlock && view.hasFocus() && !typing;
+  const showBlockToolbar = !showBlockMenu && !!currentBlock && !typing;
 
   const showBlockInsert = !showBlockMenu && !typing;
 

--- a/src/zui/ZUIEditor/EditorOverlays/index.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/index.tsx
@@ -28,9 +28,10 @@ type Props = {
     id: string;
     label: string;
   }[];
+  enableVariable: boolean;
 };
 
-const EditorOverlays: FC<Props> = ({ blocks }) => {
+const EditorOverlays: FC<Props> = ({ blocks, enableVariable }) => {
   const view = useEditorView();
   const state = useEditorState();
   const positioner = usePositioner('cursor');
@@ -170,6 +171,7 @@ const EditorOverlays: FC<Props> = ({ blocks }) => {
         <BlockToolbar
           curBlockType={currentBlock.type}
           curBlockY={currentBlock.rect.y}
+          enableVariable={enableVariable}
           pos={state.selection.$anchor.pos}
         />
       )}

--- a/src/zui/ZUIEditor/extensions/VariableExtension.ts
+++ b/src/zui/ZUIEditor/extensions/VariableExtension.ts
@@ -1,0 +1,85 @@
+import {
+  ApplySchemaAttributes,
+  legacyCommand as command,
+  CommandFunction,
+  NodeExtension,
+  NodeExtensionSpec,
+  NodeSpecOverride,
+  omitExtraAttributes,
+} from 'remirror';
+
+type VariableName = 'first_name' | 'last_name' | 'full_name';
+
+export default class VariableExtension extends NodeExtension {
+  createNodeSpec(
+    extra: ApplySchemaAttributes,
+    override: NodeSpecOverride
+  ): NodeExtensionSpec {
+    return {
+      atom: true,
+      draggable: true,
+      group: 'inline',
+      inline: true,
+      marks: '',
+      selectable: true,
+      ...override,
+      attrs: {
+        ...extra.defaults(),
+        name: {
+          default: 'first_name',
+        },
+      },
+      parseDOM: [
+        {
+          getAttrs: (element) => {
+            return {
+              ...extra.parse(element),
+              name: element.getAttribute('name'),
+            };
+          },
+          tag: 'span',
+        },
+      ],
+      toDOM: (node) => {
+        const attrs = omitExtraAttributes(node.attrs, extra);
+        const name = attrs.name as string;
+        return [
+          'span',
+          {
+            ...extra.dom(node),
+            ...attrs,
+            class: 'zvariable',
+            type: 'variable',
+          },
+          name,
+        ];
+      },
+    };
+  }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  insertVariable(name: VariableName, pos?: number): CommandFunction {
+    return ({ dispatch, state, tr }) => {
+      const node = this.type.create({ name });
+      pos ||= state.selection.$head.pos;
+      tr.insert(pos, node);
+      dispatch?.(tr);
+      return true;
+    };
+  }
+
+  get name() {
+    return 'zvariable' as const;
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-namespace */
+declare global {
+  namespace Remirror {
+    interface AllExtensions {
+      zvariable: VariableExtension;
+    }
+  }
+}

--- a/src/zui/ZUIEditor/extensions/VariableExtension.ts
+++ b/src/zui/ZUIEditor/extensions/VariableExtension.ts
@@ -9,8 +9,18 @@ import {
 } from 'remirror';
 
 type VariableName = 'first_name' | 'last_name' | 'full_name';
+type VariableLabelMap = {
+  [name in VariableName]: string;
+};
 
 export default class VariableExtension extends NodeExtension {
+  private _varLabels: VariableLabelMap;
+
+  constructor(varLabels: VariableLabelMap) {
+    super();
+    this._varLabels = varLabels;
+  }
+
   createNodeSpec(
     extra: ApplySchemaAttributes,
     override: NodeSpecOverride
@@ -42,7 +52,7 @@ export default class VariableExtension extends NodeExtension {
       ],
       toDOM: (node) => {
         const attrs = omitExtraAttributes(node.attrs, extra);
-        const name = attrs.name as string;
+        const name = attrs.name as VariableName;
         return [
           'span',
           {
@@ -51,7 +61,7 @@ export default class VariableExtension extends NodeExtension {
             class: 'zvariable',
             type: 'variable',
           },
-          name,
+          this._varLabels[name],
         ];
       },
     };

--- a/src/zui/ZUIEditor/extensions/VariableExtension.ts
+++ b/src/zui/ZUIEditor/extensions/VariableExtension.ts
@@ -8,7 +8,7 @@ import {
   omitExtraAttributes,
 } from 'remirror';
 
-type VariableName = 'first_name' | 'last_name' | 'full_name';
+export type VariableName = 'first_name' | 'last_name' | 'full_name';
 type VariableLabelMap = {
   [name in VariableName]: string;
 };

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -41,7 +41,11 @@ const ZUIEditor: FC<Props> = ({
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
   const headingExtension = new HeadingExtension({});
-  const varExtension = new VariableExtension();
+  const varExtension = new VariableExtension({
+    first_name: messages.variables.firstName(),
+    full_name: messages.variables.fullName(),
+    last_name: messages.variables.lastName(),
+  });
 
   const blockExtensions: ZetkinExtension[] = [];
   const otherExtensions: Extension[] = [];

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -7,7 +7,7 @@ import {
 import { FC } from 'react';
 import { BoldExtension, HeadingExtension } from 'remirror/extensions';
 import { Extension, PasteRulesExtension } from 'remirror';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 
 import LinkExtension from './extensions/LinkExtension';
 import ButtonExtension from './extensions/ButtonExtension';
@@ -37,6 +37,7 @@ const ZUIEditor: FC<Props> = ({
   enableVariable,
 }) => {
   const messages = useMessages(messageIds.editor);
+  const theme = useTheme();
 
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
@@ -118,6 +119,18 @@ const ZUIEditor: FC<Props> = ({
         },
         '.zimage-image': {
           maxWidth: '100%',
+        },
+        '.zvariable': {
+          '&.ProseMirror-selectednode': {
+            outlineColor: theme.palette.grey[600],
+            outlineStyle: 'solid',
+            outlineWidth: 1,
+          },
+          bgcolor: theme.palette.grey[400],
+          borderRadius: '1em',
+          display: 'inline-block',
+          mx: 0.25,
+          px: 1,
         },
         ['[contenteditable="true"]']: {
           padding: 1,

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@remirror/react';
 import { FC } from 'react';
 import { BoldExtension, HeadingExtension } from 'remirror/extensions';
-import { PasteRulesExtension } from 'remirror';
+import { Extension, PasteRulesExtension } from 'remirror';
 import { Box } from '@mui/material';
 
 import LinkExtension from './extensions/LinkExtension';
@@ -19,6 +19,7 @@ import { useNumericRouteParams } from 'core/hooks';
 import { useMessages } from 'core/i18n';
 import messageIds from 'zui/l10n/messageIds';
 import EditorOverlays from './EditorOverlays';
+import VariableExtension from './extensions/VariableExtension';
 
 type ZetkinExtension = ButtonExtension | HeadingExtension | ImageExtension;
 
@@ -26,27 +27,39 @@ type Props = {
   enableButton?: boolean;
   enableHeading?: boolean;
   enableImage?: boolean;
+  enableVariable?: boolean;
 };
 
-const ZUIEditor: FC<Props> = ({ enableButton, enableHeading, enableImage }) => {
+const ZUIEditor: FC<Props> = ({
+  enableButton,
+  enableHeading,
+  enableImage,
+  enableVariable,
+}) => {
   const messages = useMessages(messageIds.editor);
 
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
   const headingExtension = new HeadingExtension({});
+  const varExtension = new VariableExtension();
 
-  const extensions: ZetkinExtension[] = [];
+  const blockExtensions: ZetkinExtension[] = [];
+  const otherExtensions: Extension[] = [];
 
   if (enableButton) {
-    extensions.push(btnExtension);
+    blockExtensions.push(btnExtension);
   }
 
   if (enableImage) {
-    extensions.push(imgExtension);
+    blockExtensions.push(imgExtension);
   }
 
   if (enableHeading) {
-    extensions.push(headingExtension);
+    blockExtensions.push(headingExtension);
+  }
+
+  if (enableVariable) {
+    otherExtensions.push(varExtension);
   }
 
   const { orgId } = useNumericRouteParams();
@@ -69,7 +82,8 @@ const ZUIEditor: FC<Props> = ({ enableButton, enableHeading, enableImage }) => {
     extensions: () => [
       new PasteRulesExtension({}),
       new BoldExtension({}),
-      ...extensions,
+      ...blockExtensions,
+      ...otherExtensions,
       new LinkExtension(),
       new BlockMenuExtension({
         blockFactories: {
@@ -112,10 +126,11 @@ const ZUIEditor: FC<Props> = ({ enableButton, enableHeading, enableImage }) => {
       <div style={{ minHeight: '200px' }}>
         <Remirror initialContent={state} manager={manager}>
           <EditorOverlays
-            blocks={extensions.map((ext) => ({
+            blocks={blockExtensions.map((ext) => ({
               id: ext.name,
               label: messages.blockLabels[ext.name](),
             }))}
+            enableVariable={!!enableVariable}
           />
           <EmptyBlockPlaceholder placeholder={messages.placeholder()} />
           {enableImage && <ImageExtensionUI orgId={orgId} />}

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -133,6 +133,11 @@ export default makeMessages('zui', {
       zimage: m('Image'),
     },
     placeholder: m('Type / to insert block or just type some text'),
+    variables: {
+      firstName: m('First Name'),
+      fullName: m('Full Name'),
+      lastName: m('Last Name'),
+    },
   },
   futures: {
     errorLoading: m('There was an error loading the data.'),


### PR DESCRIPTION
## Description
This PR implements variables in the new `ZUIEditor`.

## Screenshots
![image](https://github.com/user-attachments/assets/1e05891d-eab4-4369-8c6c-cd87f7eecd78)

## Changes
* Adds a `VariableExtension` with a command to insert a variable
* Adds a new button to the toolbar, with a menu to select the variable to be created
* Styles the editor DOM elements for variables to look similar to old editor

## Notes to reviewer
None

## Related issues
Undocumented