### PR TITLE
`ZUIEditor` tools: Ordered list, bullet list, bold and italic

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
@@ -31,6 +31,7 @@ const EmailPage: PageWithLayout = () => {
           enableHeading
           enableImage
           enableItalic
+          enableLink
           enableLists
           enableVariable
         />

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
@@ -26,9 +26,11 @@ const EmailPage: PageWithLayout = () => {
       </Head>
       <Box>
         <ZUIEditor
+          enableBold
           enableButton
           enableHeading
           enableImage
+          enableItalic
           enableLists
           enableVariable
         />

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/newEditor.tsx
@@ -25,7 +25,13 @@ const EmailPage: PageWithLayout = () => {
         <title>hejj</title>
       </Head>
       <Box>
-        <ZUIEditor enableButton enableHeading enableImage enableVariable />
+        <ZUIEditor
+          enableButton
+          enableHeading
+          enableImage
+          enableLists
+          enableVariable
+        />
       </Box>
     </>
   );

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -5,10 +5,14 @@ import { FC, useEffect, useState } from 'react';
 import { NodeWithPosition } from '../LinkExtensionUI';
 import VariableToolButton from './VariableToolButton';
 import { VariableName } from '../extensions/VariableExtension';
+import BoldToolButton from './BoldToolButton';
+import ItalicToolButton from './ItalicToolButton';
 
 type BlockToolbarProps = {
   curBlockType: string;
   curBlockY: number;
+  enableBold: boolean;
+  enableItalic: boolean;
   enableVariable: boolean;
   pos: number;
 };
@@ -16,6 +20,8 @@ type BlockToolbarProps = {
 const BlockToolbar: FC<BlockToolbarProps> = ({
   curBlockType,
   curBlockY,
+  enableBold,
+  enableItalic,
   enableVariable,
   pos,
 }) => {
@@ -111,6 +117,8 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
                 >
                   Link
                 </Button>
+                {enableBold && <BoldToolButton />}
+                {enableItalic && <ItalicToolButton />}
               </>
             )}
             {enableVariable &&

--- a/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BlockToolbar.tsx
@@ -1,18 +1,19 @@
 import { Box, Button, Paper } from '@mui/material';
-import { useActive, useCommands, useEditorState } from '@remirror/react';
-import { FC, useEffect, useState } from 'react';
+import { useCommands } from '@remirror/react';
+import { FC } from 'react';
 
-import { NodeWithPosition } from '../LinkExtensionUI';
 import VariableToolButton from './VariableToolButton';
 import { VariableName } from '../extensions/VariableExtension';
 import BoldToolButton from './BoldToolButton';
 import ItalicToolButton from './ItalicToolButton';
+import LinkToolButton from './LinkToolButton';
 
 type BlockToolbarProps = {
   curBlockType: string;
   curBlockY: number;
   enableBold: boolean;
   enableItalic: boolean;
+  enableLink: boolean;
   enableVariable: boolean;
   pos: number;
 };
@@ -22,40 +23,12 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
   curBlockY,
   enableBold,
   enableItalic,
+  enableLink,
   enableVariable,
   pos,
 }) => {
-  const active = useActive();
-  const state = useEditorState();
-  const {
-    convertParagraph,
-    focus,
-    insertEmptyLink,
-    insertVariable,
-    toggleHeading,
-    pickImage,
-    removeLink,
-    removeAllLinksInRange,
-    setLink,
-  } = useCommands();
-
-  const [selectedNodes, setSelectedNodes] = useState<NodeWithPosition[]>([]);
-
-  useEffect(() => {
-    const linkNodes: NodeWithPosition[] = [];
-    state.doc.nodesBetween(
-      state.selection.from,
-      state.selection.to,
-      (node, index) => {
-        if (node.isText) {
-          if (node.marks.some((mark) => mark.type.name == 'zlink')) {
-            linkNodes.push({ from: index, node, to: index + node.nodeSize });
-          }
-        }
-      }
-    );
-    setSelectedNodes(linkNodes);
-  }, [state.selection]);
+  const { convertParagraph, focus, insertVariable, toggleHeading, pickImage } =
+    useCommands();
 
   return (
     <Box position="relative">
@@ -90,33 +63,7 @@ const BlockToolbar: FC<BlockToolbarProps> = ({
                 <Button onClick={() => toggleHeading()}>
                   Convert to heading
                 </Button>
-                <Button
-                  onClick={() => {
-                    if (!active.zlink()) {
-                      if (state.selection.empty) {
-                        insertEmptyLink();
-                        focus();
-                      } else {
-                        setLink();
-                        focus();
-                      }
-                    } else {
-                      if (selectedNodes.length == 1) {
-                        removeLink({
-                          from: selectedNodes[0].from,
-                          to: selectedNodes[0].to,
-                        });
-                      } else if (selectedNodes.length > 1) {
-                        removeAllLinksInRange({
-                          from: state.selection.from,
-                          to: state.selection.to,
-                        });
-                      }
-                    }
-                  }}
-                >
-                  Link
-                </Button>
+                {enableLink && <LinkToolButton />}
                 {enableBold && <BoldToolButton />}
                 {enableItalic && <ItalicToolButton />}
               </>

--- a/src/zui/ZUIEditor/EditorOverlays/BoldToolButton.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/BoldToolButton.tsx
@@ -1,0 +1,23 @@
+import { FormatBold } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { useActive, useCommands } from '@remirror/react';
+import { FC } from 'react';
+
+const BoldToolButton: FC = () => {
+  const active = useActive();
+  const { focus, toggleBold } = useCommands();
+
+  return (
+    <IconButton
+      color={active.bold() ? 'primary' : 'secondary'}
+      onClick={() => {
+        toggleBold();
+        focus();
+      }}
+    >
+      <FormatBold />
+    </IconButton>
+  );
+};
+
+export default BoldToolButton;

--- a/src/zui/ZUIEditor/EditorOverlays/ItalicToolButton.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/ItalicToolButton.tsx
@@ -1,0 +1,23 @@
+import { FormatItalic } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { useActive, useCommands } from '@remirror/react';
+import { FC } from 'react';
+
+const ItalicToolButton: FC = () => {
+  const active = useActive();
+  const { focus, toggleItalic } = useCommands();
+
+  return (
+    <IconButton
+      color={active.italic() ? 'primary' : 'secondary'}
+      onClick={() => {
+        toggleItalic();
+        focus();
+      }}
+    >
+      <FormatItalic />
+    </IconButton>
+  );
+};
+
+export default ItalicToolButton;

--- a/src/zui/ZUIEditor/EditorOverlays/LinkToolButton.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/LinkToolButton.tsx
@@ -1,0 +1,63 @@
+import { IconButton } from '@mui/material';
+import { useActive, useCommands, useEditorState } from '@remirror/react';
+import { FC, useEffect, useState } from 'react';
+import { InsertLink, LinkOff } from '@mui/icons-material';
+
+import { NodeWithPosition } from '../LinkExtensionUI';
+
+const LinkToolButton: FC = () => {
+  const active = useActive();
+  const state = useEditorState();
+  const { focus, insertEmptyLink, removeAllLinksInRange, removeLink, setLink } =
+    useCommands();
+
+  const [selectedNodes, setSelectedNodes] = useState<NodeWithPosition[]>([]);
+
+  useEffect(() => {
+    const linkNodes: NodeWithPosition[] = [];
+    state.doc.nodesBetween(
+      state.selection.from,
+      state.selection.to,
+      (node, index) => {
+        if (node.isText) {
+          if (node.marks.some((mark) => mark.type.name == 'zlink')) {
+            linkNodes.push({ from: index, node, to: index + node.nodeSize });
+          }
+        }
+      }
+    );
+    setSelectedNodes(linkNodes);
+  }, [state.selection]);
+
+  return (
+    <IconButton
+      onClick={() => {
+        if (!active.zlink()) {
+          if (state.selection.empty) {
+            insertEmptyLink();
+            focus();
+          } else {
+            setLink();
+            focus();
+          }
+        } else {
+          if (selectedNodes.length == 1) {
+            removeLink({
+              from: selectedNodes[0].from,
+              to: selectedNodes[0].to,
+            });
+          } else if (selectedNodes.length > 1) {
+            removeAllLinksInRange({
+              from: state.selection.from,
+              to: state.selection.to,
+            });
+          }
+        }
+      }}
+    >
+      {active.zlink() ? <LinkOff /> : <InsertLink />}
+    </IconButton>
+  );
+};
+
+export default LinkToolButton;

--- a/src/zui/ZUIEditor/EditorOverlays/index.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/index.tsx
@@ -27,10 +27,17 @@ type Props = {
     id: string;
     label: string;
   }[];
+  enableBold: boolean;
+  enableItalic: boolean;
   enableVariable: boolean;
 };
 
-const EditorOverlays: FC<Props> = ({ blocks, enableVariable }) => {
+const EditorOverlays: FC<Props> = ({
+  blocks,
+  enableBold,
+  enableItalic,
+  enableVariable,
+}) => {
   const view = useEditorView();
   const state = useEditorState();
   const positioner = usePositioner('cursor');
@@ -145,6 +152,8 @@ const EditorOverlays: FC<Props> = ({ blocks, enableVariable }) => {
         <BlockToolbar
           curBlockType={currentBlock.type}
           curBlockY={currentBlock.rect.y}
+          enableBold={enableBold}
+          enableItalic={enableItalic}
           enableVariable={enableVariable}
           pos={state.selection.$anchor.pos}
         />

--- a/src/zui/ZUIEditor/EditorOverlays/index.tsx
+++ b/src/zui/ZUIEditor/EditorOverlays/index.tsx
@@ -29,6 +29,7 @@ type Props = {
   }[];
   enableBold: boolean;
   enableItalic: boolean;
+  enableLink: boolean;
   enableVariable: boolean;
 };
 
@@ -36,6 +37,7 @@ const EditorOverlays: FC<Props> = ({
   blocks,
   enableBold,
   enableItalic,
+  enableLink,
   enableVariable,
 }) => {
   const view = useEditorView();
@@ -154,6 +156,7 @@ const EditorOverlays: FC<Props> = ({
           curBlockY={currentBlock.rect.y}
           enableBold={enableBold}
           enableItalic={enableItalic}
+          enableLink={enableLink}
           enableVariable={enableVariable}
           pos={state.selection.$anchor.pos}
         />

--- a/src/zui/ZUIEditor/extensions/BlockMenuExtension.ts
+++ b/src/zui/ZUIEditor/extensions/BlockMenuExtension.ts
@@ -1,17 +1,14 @@
-import { Node } from '@remirror/pm/model';
-import { TextSelection } from '@remirror/pm/state';
 import { Suggester } from '@remirror/pm/suggest';
 import {
   legacyCommand as command,
   CommandFunction,
   extension,
-  getActiveNode,
   Handler,
   PlainExtension,
 } from 'remirror';
 
 type BlockMenuOptions = {
-  blockFactories: Record<string, () => Node>;
+  blockFactories: Record<string, CommandFunction>;
   onBlockQuery?: Handler<(query: string | null) => void>;
 };
 
@@ -40,31 +37,13 @@ class BlockMenuExtension extends PlainExtension<BlockMenuOptions> {
   //@ts-ignore
   @command()
   insertBlock(type: string): CommandFunction {
-    return ({ dispatch, state, tr }) => {
-      const oldNode = getActiveNode({
-        state,
-        type: 'paragraph',
-      });
-      if (oldNode) {
-        const factory = this.options.blockFactories[type];
-        if (factory) {
-          const newNode = factory();
-          if (dispatch && newNode) {
-            tr = tr.replaceWith(oldNode.pos, oldNode.end, newNode);
-            tr = tr.setSelection(
-              TextSelection.create(
-                tr.doc,
-                oldNode.pos + 1,
-                oldNode.pos + newNode.nodeSize - 1
-              )
-            );
-            dispatch(tr);
-          }
+    return (props) => {
+      const { state, tr } = props;
+      const resolved = state.doc.resolve(state.selection.$head.pos);
+      tr.deleteRange(resolved.start(), resolved.end());
 
-          return true;
-        }
-      }
-      return false;
+      const factoryCommand = this.options.blockFactories[type];
+      return factoryCommand(props);
     };
   }
 

--- a/src/zui/ZUIEditor/extensions/BlockMenuExtension.ts
+++ b/src/zui/ZUIEditor/extensions/BlockMenuExtension.ts
@@ -23,11 +23,17 @@ class BlockMenuExtension extends PlainExtension<BlockMenuOptions> {
     return [
       {
         char: '/',
-        isValidPosition: (range) => range.$from.parentOffset == 0,
+        isValidPosition: (range) => {
+          return range.$from.parentOffset == 0;
+        },
         name: 'slash',
-        onChange: (details) => {
+        onChange: (details, tr) => {
+          const resolved = tr.doc.resolve(details.range.to);
           const exited = !!details.exitReason;
-          this.options.onBlockQuery(exited ? null : details.query.full);
+          const inParagraph = resolved.node(1).type.name == 'paragraph';
+          this.options.onBlockQuery(
+            exited || !inParagraph ? null : details.query.full
+          );
         },
       },
     ];

--- a/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+import { TextSelection } from '@remirror/pm/state';
 import {
   ApplySchemaAttributes,
   legacyCommand as command, //Because of NEXTjs, see Remirror docs
@@ -63,19 +64,9 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
       },
     };
   }
+
   createTags() {
     return [ExtensionTag.Block, ExtensionTag.FormattingNode];
-  }
-
-  /* eslint-disable @typescript-eslint/ban-ts-comment */
-  //@ts-ignore
-  @command()
-  insertButton(pos: number): CommandFunction {
-    return ({ tr, dispatch }) => {
-      const node = this.type.create(null, this.type.schema.text('Foobar'));
-      dispatch?.(tr.insert(pos, node));
-      return true;
-    };
   }
 
   get name() {
@@ -105,6 +96,34 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
       tr.replaceWith(resolved.start(), resolved.end(), newTextNode);
 
       dispatch?.(tr);
+      return true;
+    };
+  }
+
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  toggleButton(): CommandFunction {
+    return (props) => {
+      const { dispatch, state, tr } = props;
+      const newNode = this.type.create(
+        null,
+        this.type.schema.text('Foo button')
+      );
+      if (dispatch) {
+        const pos = state.selection.$from.pos;
+        const parentOffset = state.doc.resolve(pos).parentOffset;
+        const blockLength = 1;
+
+        tr.insert(pos - parentOffset - blockLength, newNode);
+
+        const resolved = tr.doc.resolve(pos);
+        tr.setSelection(
+          TextSelection.create(tr.doc, resolved.start(), resolved.end())
+        );
+        dispatch(tr);
+      }
+
       return true;
     };
   }

--- a/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
+++ b/src/zui/ZUIEditor/extensions/ButtonExtension.tsx
@@ -69,6 +69,31 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
     return [ExtensionTag.Block, ExtensionTag.FormattingNode];
   }
 
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  insertButton(text: string): CommandFunction {
+    return (props) => {
+      const { dispatch, state, tr } = props;
+      const newNode = this.type.create(null, this.type.schema.text(text));
+      if (dispatch) {
+        const pos = state.selection.$from.pos;
+        const parentOffset = state.doc.resolve(pos).parentOffset;
+        const blockLength = 1;
+
+        tr.insert(pos - parentOffset - blockLength, newNode);
+
+        const resolved = tr.doc.resolve(pos);
+        tr.setSelection(
+          TextSelection.create(tr.doc, resolved.start(), resolved.end())
+        );
+        dispatch(tr);
+      }
+
+      return true;
+    };
+  }
+
   get name() {
     return 'zbutton' as const;
   }
@@ -96,34 +121,6 @@ class ButtonExtension extends NodeExtension<ButtonOptions> {
       tr.replaceWith(resolved.start(), resolved.end(), newTextNode);
 
       dispatch?.(tr);
-      return true;
-    };
-  }
-
-  /* eslint-disable @typescript-eslint/ban-ts-comment */
-  //@ts-ignore
-  @command()
-  toggleButton(): CommandFunction {
-    return (props) => {
-      const { dispatch, state, tr } = props;
-      const newNode = this.type.create(
-        null,
-        this.type.schema.text('Foo button')
-      );
-      if (dispatch) {
-        const pos = state.selection.$from.pos;
-        const parentOffset = state.doc.resolve(pos).parentOffset;
-        const blockLength = 1;
-
-        tr.insert(pos - parentOffset - blockLength, newNode);
-
-        const resolved = tr.doc.resolve(pos);
-        tr.setSelection(
-          TextSelection.create(tr.doc, resolved.start(), resolved.end())
-        );
-        dispatch(tr);
-      }
-
       return true;
     };
   }

--- a/src/zui/ZUIEditor/extensions/ImageExtension.ts
+++ b/src/zui/ZUIEditor/extensions/ImageExtension.ts
@@ -24,15 +24,23 @@ type ImageOptions = {
   staticKeys: [],
 })
 export default class ImageExtension extends NodeExtension<ImageOptions> {
-  createAndPick() {
-    const pos = this.store.getState().selection.$from.pos;
-    const parentOffset = this.store.getState().doc.resolve(pos).parentOffset;
-    const blockLength = 1;
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  //@ts-ignore
+  @command()
+  createAndPick(): CommandFunction {
+    return ({ dispatch, tr, state }) => {
+      const pos = state.selection.$from.pos;
+      const parentOffset = state.doc.resolve(pos).parentOffset;
+      const blockLength = 1;
 
-    const node = this.type.create();
-    this.options.onCreate(pos - parentOffset - blockLength);
+      const node = this.type.create();
+      tr.insert(pos - parentOffset - blockLength, node);
+      dispatch?.(tr);
 
-    return node;
+      this.options.onCreate(pos - parentOffset - blockLength);
+
+      return true;
+    };
   }
 
   createNodeSpec(

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -10,6 +10,7 @@ import {
   BulletListExtension,
   HardBreakExtension,
   HeadingExtension,
+  ItalicExtension,
   OrderedListExtension,
 } from 'remirror/extensions';
 import { Extension, PasteRulesExtension } from 'remirror';
@@ -37,25 +38,31 @@ type BlockExtension =
   | BulletListExtension;
 
 type Props = {
+  enableBold?: boolean;
   enableButton?: boolean;
   enableHeading?: boolean;
   enableImage?: boolean;
+  enableItalic?: boolean;
   enableLists?: boolean;
   enableVariable?: boolean;
 };
 
 const ZUIEditor: FC<Props> = ({
+  enableBold,
   enableButton,
   enableHeading,
   enableImage,
+  enableItalic,
   enableLists,
   enableVariable,
 }) => {
   const messages = useMessages(messageIds.editor);
   const theme = useTheme();
 
+  const boldExtension = new BoldExtension({});
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
+  const italicExtension = new ItalicExtension();
   const olExtension = new OrderedListExtension();
   const ulExtension = new BulletListExtension({});
   const headingExtension = new HeadingExtension({});
@@ -65,15 +72,24 @@ const ZUIEditor: FC<Props> = ({
     last_name: messages.variables.lastName(),
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const otherExtensions: Extension<any>[] = [];
   const blockExtensions: BlockExtension[] = [];
-  const otherExtensions: Extension[] = [];
 
   if (enableButton) {
     blockExtensions.push(btnExtension);
   }
 
+  if (enableBold) {
+    otherExtensions.push(boldExtension);
+  }
+
   if (enableImage) {
     blockExtensions.push(imgExtension);
+  }
+
+  if (enableItalic) {
+    otherExtensions.push(italicExtension);
   }
 
   if (enableHeading) {
@@ -108,7 +124,6 @@ const ZUIEditor: FC<Props> = ({
     },
     extensions: () => [
       new PasteRulesExtension({}),
-      new BoldExtension({}),
       ...blockExtensions,
       ...otherExtensions,
       new HardBreakExtension(),
@@ -168,6 +183,8 @@ const ZUIEditor: FC<Props> = ({
               id: ext.name,
               label: messages.blockLabels[ext.name](),
             }))}
+            enableBold={!!enableBold}
+            enableItalic={!!enableItalic}
             enableVariable={!!enableVariable}
           />
           <EmptyBlockPlaceholder placeholder={messages.placeholder()} />

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -138,7 +138,10 @@ const ZUIEditor: FC<Props> = ({
           bulletList: (props) => ulExtension.toggleBulletList()(props),
           heading: (props) => headingExtension.toggleHeading()(props),
           orderedList: (props) => olExtension.toggleOrderedList()(props),
-          zbutton: (props) => btnExtension.toggleButton()(props),
+          zbutton: (props) =>
+            btnExtension.insertButton(messages.extensions.button.defaultText())(
+              props
+            ),
           zimage: (props) => imgExtension.createAndPick()(props),
         },
       }),

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -94,13 +94,9 @@ const ZUIEditor: FC<Props> = ({
       new LinkExtension(),
       new BlockMenuExtension({
         blockFactories: {
-          heading: () => headingExtension.type.create({}),
-          zbutton: () =>
-            btnExtension.type.create(
-              {},
-              btnExtension.type.schema.text('Add button label here')
-            ),
-          zimage: () => imgExtension.createAndPick(),
+          heading: (props) => headingExtension.toggleHeading()(props),
+          zbutton: (props) => btnExtension.toggleButton()(props),
+          zimage: (props) => imgExtension.createAndPick()(props),
         },
       }),
     ],

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -5,7 +5,12 @@ import {
   useRemirror,
 } from '@remirror/react';
 import { FC } from 'react';
-import { BoldExtension, HeadingExtension } from 'remirror/extensions';
+import {
+  BoldExtension,
+  BulletListExtension,
+  HeadingExtension,
+  OrderedListExtension,
+} from 'remirror/extensions';
 import { Extension, PasteRulesExtension } from 'remirror';
 import { Box, useTheme } from '@mui/material';
 
@@ -23,12 +28,18 @@ import VariableExtension from './extensions/VariableExtension';
 import LinkExtensionUI from './LinkExtensionUI';
 import ButtonExtensionUI from './ButtonExtensionUI';
 
-type ZetkinExtension = ButtonExtension | HeadingExtension | ImageExtension;
+type BlockExtension =
+  | ButtonExtension
+  | HeadingExtension
+  | ImageExtension
+  | OrderedListExtension
+  | BulletListExtension;
 
 type Props = {
   enableButton?: boolean;
   enableHeading?: boolean;
   enableImage?: boolean;
+  enableLists?: boolean;
   enableVariable?: boolean;
 };
 
@@ -36,6 +47,7 @@ const ZUIEditor: FC<Props> = ({
   enableButton,
   enableHeading,
   enableImage,
+  enableLists,
   enableVariable,
 }) => {
   const messages = useMessages(messageIds.editor);
@@ -43,6 +55,8 @@ const ZUIEditor: FC<Props> = ({
 
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
+  const olExtension = new OrderedListExtension();
+  const ulExtension = new BulletListExtension({});
   const headingExtension = new HeadingExtension({});
   const varExtension = new VariableExtension({
     first_name: messages.variables.firstName(),
@@ -50,7 +64,7 @@ const ZUIEditor: FC<Props> = ({
     last_name: messages.variables.lastName(),
   });
 
-  const blockExtensions: ZetkinExtension[] = [];
+  const blockExtensions: BlockExtension[] = [];
   const otherExtensions: Extension[] = [];
 
   if (enableButton) {
@@ -63,6 +77,11 @@ const ZUIEditor: FC<Props> = ({
 
   if (enableHeading) {
     blockExtensions.push(headingExtension);
+  }
+
+  if (enableLists) {
+    blockExtensions.push(olExtension);
+    blockExtensions.push(ulExtension);
   }
 
   if (enableVariable) {
@@ -94,7 +113,9 @@ const ZUIEditor: FC<Props> = ({
       new LinkExtension(),
       new BlockMenuExtension({
         blockFactories: {
+          bulletList: (props) => ulExtension.toggleBulletList()(props),
           heading: (props) => headingExtension.toggleHeading()(props),
+          orderedList: (props) => olExtension.toggleOrderedList()(props),
           zbutton: (props) => btnExtension.toggleButton()(props),
           zimage: (props) => imgExtension.createAndPick()(props),
         },

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -13,7 +13,7 @@ import {
   ItalicExtension,
   OrderedListExtension,
 } from 'remirror/extensions';
-import { Extension, PasteRulesExtension } from 'remirror';
+import { AnyExtension, PasteRulesExtension } from 'remirror';
 import { Box, useTheme } from '@mui/material';
 
 import LinkExtension from './extensions/LinkExtension';
@@ -43,6 +43,7 @@ type Props = {
   enableHeading?: boolean;
   enableImage?: boolean;
   enableItalic?: boolean;
+  enableLink?: boolean;
   enableLists?: boolean;
   enableVariable?: boolean;
 };
@@ -53,6 +54,7 @@ const ZUIEditor: FC<Props> = ({
   enableHeading,
   enableImage,
   enableItalic,
+  enableLink,
   enableLists,
   enableVariable,
 }) => {
@@ -63,6 +65,7 @@ const ZUIEditor: FC<Props> = ({
   const btnExtension = new ButtonExtension();
   const imgExtension = new ImageExtension({});
   const italicExtension = new ItalicExtension();
+  const linkExtension = new LinkExtension();
   const olExtension = new OrderedListExtension();
   const ulExtension = new BulletListExtension({});
   const headingExtension = new HeadingExtension({});
@@ -72,8 +75,7 @@ const ZUIEditor: FC<Props> = ({
     last_name: messages.variables.lastName(),
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const otherExtensions: Extension<any>[] = [];
+  const otherExtensions: AnyExtension[] = [];
   const blockExtensions: BlockExtension[] = [];
 
   if (enableButton) {
@@ -90,6 +92,10 @@ const ZUIEditor: FC<Props> = ({
 
   if (enableItalic) {
     otherExtensions.push(italicExtension);
+  }
+
+  if (enableLink) {
+    otherExtensions.push(linkExtension);
   }
 
   if (enableHeading) {
@@ -127,7 +133,6 @@ const ZUIEditor: FC<Props> = ({
       ...blockExtensions,
       ...otherExtensions,
       new HardBreakExtension(),
-      new LinkExtension(),
       new BlockMenuExtension({
         blockFactories: {
           bulletList: (props) => ulExtension.toggleBulletList()(props),
@@ -185,6 +190,7 @@ const ZUIEditor: FC<Props> = ({
             }))}
             enableBold={!!enableBold}
             enableItalic={!!enableItalic}
+            enableLink={!!enableLink}
             enableVariable={!!enableVariable}
           />
           <EmptyBlockPlaceholder placeholder={messages.placeholder()} />

--- a/src/zui/ZUIEditor/index.tsx
+++ b/src/zui/ZUIEditor/index.tsx
@@ -8,6 +8,7 @@ import { FC } from 'react';
 import {
   BoldExtension,
   BulletListExtension,
+  HardBreakExtension,
   HeadingExtension,
   OrderedListExtension,
 } from 'remirror/extensions';
@@ -110,6 +111,7 @@ const ZUIEditor: FC<Props> = ({
       new BoldExtension({}),
       ...blockExtensions,
       ...otherExtensions,
+      new HardBreakExtension(),
       new LinkExtension(),
       new BlockMenuExtension({
         blockFactories: {

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -128,7 +128,9 @@ export default makeMessages('zui', {
   },
   editor: {
     blockLabels: {
+      bulletList: m('Bullet list'),
       heading: m('Heading'),
+      orderedList: m('Ordered list'),
       zbutton: m('Button'),
       zimage: m('Image'),
     },

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -135,6 +135,9 @@ export default makeMessages('zui', {
       zimage: m('Image'),
     },
     extensions: {
+      button: {
+        defaultText: m('Button text'),
+      },
       link: {
         apply: m('Apply'),
         cancel: m('Cancel'),


### PR DESCRIPTION
## Description
This PR integrates four builtin remirror extensions into the editor, and introduces the link extension into the same patterns as all other tools.

## Screenshots
![image](https://github.com/user-attachments/assets/fbffa939-04a3-40fb-9c29-66caed63fd5f)

## Changes
* Refactors block factories to support more arbitrary commands
* Enable built-in ordered list extension
* Enable built-in unordered (bullet) list extension extension
* Enable built-in bold extension
* Enable built-in italic extension
* Fix bug causing block toolbar to be available in non-paragraph blocks
* Introduce new pattern for toolbar buttons that are more self-contained components

## Notes to reviewer
None

## Related issues
Undocumented