### PR TITLE
fix: make it more clear what email block is focused in the composer

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -213,6 +213,22 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
       <Box
         id="ClientOnlyEditor-container"
         sx={{
+          '& .ce-block--selected .ce-block__content': {
+            // styling for highlighting the selected block
+            '&:before': { // We need the pseudo element to hold the border so that block's height does not change
+              border: "1px solid #9ed5ff",
+              borderRadius: 1,
+              bottom: 0,
+              content: '""',
+              left: 0,
+              pointerEvents: 'none', // We don't want the pseudo element to interfere with the user's interaction
+              position: 'absolute',
+              right: 0,
+              top: 0,
+            },
+            backgroundColor: '#e1f2ff',
+            borderRadius: 1,
+          },
           '& .ce-block__content': {
             px: 2,
           },


### PR DESCRIPTION
## Description
This PR improves the email composer by more clearly highlighting the selected/focused block that is being tuned with the tune-button.


## Screenshots
Before:
<img width="1060" alt="Screenshot 2025-01-19 at 11 10 14" src="https://github.com/user-attachments/assets/114ecaf2-ef22-4230-9311-e940ea1f0740" />
After:
<img width="1060" alt="Screenshot 2025-01-19 at 11 10 40" src="https://github.com/user-attachments/assets/17a1c4ec-d6ad-4776-92fa-4a846bd79a15" />


## Changes

Adds a border to the focused block, making the highlight more distinct. The colors and size are based on the description in #2283, the main difference is using `borderRadius: 1`, which results in a 4px radius rather than the suggested 5px.


## Notes to reviewer
Should be possible to test in any email composer.


## Related issues
Resolves #2283 
