### PR TITLE
Issue 2345 - Redirects user if deleting person from current Org

### DIFF
--- a/src/features/profile/components/PersonOrganizationsCard/index.tsx
+++ b/src/features/profile/components/PersonOrganizationsCard/index.tsx
@@ -18,6 +18,7 @@ import usePersonOrgData from 'features/profile/hooks/usePersonOrgData';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import messageIds from 'features/profile/l10n/messageIds';
+import { useRouter } from 'next/router';
 
 interface PersonOrganizationsCardProps {
   orgId: number;
@@ -34,6 +35,7 @@ const PersonOrganizationsCard: React.FunctionComponent<
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { data, addToOrg, removeFromOrg } = usePersonOrgData(orgId, personId);
+  const router = useRouter();
 
   useEffect(() => {
     if (!editable) {
@@ -63,6 +65,9 @@ const PersonOrganizationsCard: React.FunctionComponent<
         try {
           await removeFromOrg(subOrgId);
           setSelected(undefined);
+          if (orgId == subOrgId) {
+            router.push(`/organize/${orgId}/people`);
+          }
         } catch (err) {
           showSnackbar('error', messages.organizations.removeError());
         }


### PR DESCRIPTION
User gets redirected to the Peoples page if deleting a person from the organization that is currently active

## Description
This PR adds redirect for the user back to the Peoples page when the user removes a sub org from a person, if that is the current org


## Changes
* Adds a redirect when deleting a sub org from a person if the sub org is the active org


## Notes to reviewer
1. Go to a person in an organization, via for example a list.
2. Delete the person from the organization at the bottom of the page.
3. You should be redirected to the Peoples page if the deleted organization matches the active organization


## Related issues
Resolves #2345 
