### PR TITLE
Issue 2325/indexing error

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,3 @@
 #!/bin/sh
+echo "Running pre-commit hook!"
 yarn lint && yarn check-types

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,2 @@
 #!/bin/sh
-echo "Running pre-commit hook!"
 yarn lint && yarn check-types

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessage.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessage.tsx
@@ -12,6 +12,7 @@ import {
 import messageIds from 'features/import/l10n/messageIds';
 import ProblemRowsText from './ProblemRowsText';
 import { useMessages } from 'core/i18n';
+import useSheets from '../../../../hooks/useSheets';
 
 type Props = {
   description?: string;
@@ -32,7 +33,11 @@ const ImportMessage: FC<Props> = ({
 }) => {
   const messages = useMessages(messageIds);
 
-  const rowNumbers = rowIndices?.map((rowIndex) => rowIndex + 1);
+  const { firstRowIsHeaders } = useSheets();
+
+  const rowNumbers = rowIndices?.map((rowIndex) =>
+    firstRowIsHeaders ? rowIndex + 2 : rowIndex + 1
+  );
 
   return (
     <Alert


### PR DESCRIPTION
## Description
This PR fixes the off-by-one error in the importer error messages when the first row of the imported document is a header.


## Screenshots
First row is header: Checked
Expected: 2
Actual: 2

![image](https://github.com/user-attachments/assets/b7b0ca41-5080-4126-a6a2-3b820b8e8097)

First row is header: Unchecked
Expected: 1, 2
Actual: 1, 2

![image](https://github.com/user-attachments/assets/979694f9-c880-4f26-97d0-1a1ff6b589bf)



## Changes
Import UseSheets from ../hooks/useSheets.ts to ../importMessage.ts so that the state of firstRowIsHeaders is usable.

Modify rowNumbers by adding a ternary that add +2 to index if firstRowIsHeaders or +1 if false.
