### PR TITLE
Adds Zindex 0 to the OrganizerMap container

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -137,7 +137,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
         width: '100%',
       }}
     >
-      <Box flexGrow={1} position="relative">
+      <Box flexGrow={1} position="relative" zIndex={0}>
         <MapControls
           map={mapRef.current}
           onFitBounds={() => {


### PR DESCRIPTION

## Description
This PR fixes the map covering the drop down date picker in the areaAssignments page


## Screenshots
![image](https://github.com/user-attachments/assets/977e9334-2ec6-4882-8736-3133e0e6cf06)
![image](https://github.com/user-attachments/assets/7d2b4c6d-da73-4f83-b786-42666638c166)


## Changes

* Adds a zIndex 0 value to the Box containing the map


## Notes to reviewer
Open a Area Assignment and click the date picker above the map. The map should no longer be displayed on top.


## Related issues
Resolves #2467 
