### PR TITLE
fixing package.json to add a license field: 'unlicensed' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app.zetkin.org",
   "version": "41.0.0",
   "private": true,
+  "license": "UNLICENSED",
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",


### PR DESCRIPTION
As far as i can tell Zetkin has no software license and yarn and other tools complain. So i've added a license field to package.json saying that the software is unlicensed. I'd suggest using something like MIT if the goal is a minimal license or GPL/AGPL if a more strict FSF license is prefered. 

## Description
This is a simple PR removing one warning from the scripts. 


## Changes
* Adds unlicensed license field to package.json

## Notes to reviewer
Just build the software, i used node: v23.5.0 for this, which might be why the warning showedup. 

