### PR TITLE
Add pasting logic for spans in email editor

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 //@ts-ignore
 import Header from '@editorjs/header';
-//@ts-ignore
-import Paragraph from '@editorjs/paragraph';
 import { Box, useTheme } from '@mui/material';
 import EditorJS, {
   EditorConfig,
@@ -19,6 +17,7 @@ import messageIds from 'features/emails/l10n/messageIds';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import variableToolFactory from './tools/inlineVariable';
+import ParagraphWithSpanPaste from './tools/paragraphWithSpanPaste';
 
 export type EmailEditorFrontendProps = {
   apiRef: MutableRefObject<EditorJS | null>;
@@ -110,7 +109,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
           },
         },
         paragraph: {
-          class: Paragraph,
+          class: ParagraphWithSpanPaste as unknown as ToolConstructable,
         },
         variable: {
           class: variableToolFactory(messages.editor.tools.variable.title()),

--- a/src/features/emails/components/EmailEditor/tools/paragraphWithSpanPaste.ts
+++ b/src/features/emails/components/EmailEditor/tools/paragraphWithSpanPaste.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+//@ts-ignore
+import Paragraph from '@editorjs/paragraph';
+import { BlockTool, HTMLPasteEvent } from '@editorjs/editorjs';
+
+//@ts-ignore
+export default class ParagraphWithSpanPaste
+  extends Paragraph
+  implements BlockTool
+{
+  onPaste(event: HTMLPasteEvent) {
+    const text = event.detail.data.textContent;
+    event.detail.data = document.createElement('div');
+    event.detail.data.textContent = text;
+    return super.onPaste(event);
+  }
+
+  static get pasteConfig() {
+    return {
+      tags: ['P', 'SPAN'],
+    };
+  }
+}


### PR DESCRIPTION
## Description
This PR solves the bug where formatted text pasted into the email editor would be turned into inline variables.

## Screenshots
copied
![bild](https://github.com/user-attachments/assets/e071bc4a-ac0f-4ec5-ae9f-08e0215d9d4c)

pasted
![bild](https://github.com/user-attachments/assets/b8df8224-7637-43c1-9729-594c1555165c)

## Changes
* Changes the paragraph tool we use to have a paste function that handles span-tags

## Notes to reviewer
paste some stuff! preferrably on iOS! bc I have Windows and who knows what weirdness Windows does when copying things! 

## Related issues
Resolves #2394 
