### PR TITLE
Fix map markers visually resetting after changing their position

### DIFF
--- a/src/features/events/components/LocationModal/Map.tsx
+++ b/src/features/events/components/LocationModal/Map.tsx
@@ -121,6 +121,10 @@ const Map: FC<MapProps> = ({
                     eventHandlers={{
                       click: (evt) => {
                         evt.originalEvent.stopPropagation();
+                        // click runs after dragend, so dont reset position if we were dragging
+                        if (newPosition && isSelectedMarker) {
+                          return;
+                        }
                         setNewPosition(null);
                         map.setView(evt.latlng, 17);
                         onMarkerClick(location.id);


### PR DESCRIPTION
## Description
This PR fixes issue with moved map markers appearing on their old position.


## Screenshots

https://github.com/user-attachments/assets/65baaf68-3ebc-4099-a76a-64e4844f3129

## Changes

* Changes map click event to not run if we changed marker position, eg. we were dragging a marker before the click event.

## Notes to reviewer

Change a projects events location by clicking "edit event information" and click on the map icon next to the location text.
Click on a marker, click "move", move the marker. The marker should not reset after releasing the mouse.

## Related issues
Resolves #2509 
