### PR TITLE
Add sorting functions on survey response columns

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -36,7 +36,12 @@ export default class SurveyOptionColumnType
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },
-      sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
+      sortComparator: (
+        v1: SurveyOptionViewCell,
+        v2: SurveyOptionViewCell,
+        p1,
+        p2
+      ) => {
         const getPriority = (cell: SurveyOptionViewCell) => {
           if (cell == null || cell.length == 0) {
             return 1;
@@ -47,7 +52,18 @@ export default class SurveyOptionColumnType
           }
         };
 
-        return getPriority(v1) - getPriority(v2);
+        const result = getPriority(v1) - getPriority(v2);
+
+        if (result == 0) {
+          if (typeof p1.id == 'string' && typeof p2.id == 'string') {
+            return p1.id.localeCompare(p2.id);
+          } else if (typeof p1.id == 'number' && typeof p2.id == 'number') {
+            return p1.id - p2.id;
+          }
+          return 0;
+        }
+
+        return result;
       },
       type: 'boolean',
     };

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -38,9 +38,17 @@ export default class SurveyOptionColumnType
       },
       sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
         const v1n =
-          v1 == null || v1.length == 0 ? 0 : v1[v1.length - 1].selected ? 0 : 1;
+          v1 == null || v1.length == 0
+            ? 1
+            : v1[v1.length - 1].selected
+            ? -1
+            : 0;
         const v2n =
-          v2 == null || v2.length == 0 ? 0 : v2[v2.length - 1].selected ? 0 : 1;
+          v2 == null || v2.length == 0
+            ? 1
+            : v2[v2.length - 1].selected
+            ? -1
+            : 0;
         return v1n - v2n;
       },
       type: 'boolean',

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -37,19 +37,17 @@ export default class SurveyOptionColumnType
         return <Cell cell={params.value} />;
       },
       sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
-        const v1n =
-          v1 == null || v1.length == 0
-            ? 1
-            : v1[v1.length - 1].selected
-            ? -1
-            : 0;
-        const v2n =
-          v2 == null || v2.length == 0
-            ? 1
-            : v2[v2.length - 1].selected
-            ? -1
-            : 0;
-        return v1n - v2n;
+const getPriority = (cell: SurveyOptionViewCell) => {
+    if (cell == null || cell.length == 0) {
+       return 1
+    } else if (cell[cell.length - 1].selected {
+       return -1
+    } else {
+       return 0
+    }
+}
+
+return getPriority(v1) - getPriority(v2)
       },
       type: 'boolean',
     };

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -37,17 +37,17 @@ export default class SurveyOptionColumnType
         return <Cell cell={params.value} />;
       },
       sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
-const getPriority = (cell: SurveyOptionViewCell) => {
-    if (cell == null || cell.length == 0) {
-       return 1
-    } else if (cell[cell.length - 1].selected {
-       return -1
-    } else {
-       return 0
-    }
-}
+        const getPriority = (cell: SurveyOptionViewCell) => {
+          if (cell == null || cell.length == 0) {
+            return 1;
+          } else if (cell[cell.length - 1].selected) {
+            return -1;
+          } else {
+            return 0;
+          }
+        };
 
-return getPriority(v1) - getPriority(v2)
+        return getPriority(v1) - getPriority(v2);
       },
       type: 'boolean',
     };

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -36,6 +36,13 @@ export default class SurveyOptionColumnType
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },
+      sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
+        const v1n =
+          v1 == null || v1.length == 0 ? 0 : v1[v1.length - 1].selected ? 0 : 1;
+        const v2n =
+          v2 == null || v2.length == 0 ? 0 : v2[v2.length - 1].selected ? 0 : 1;
+        return v1n - v2n;
+      },
       type: 'boolean',
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -38,11 +38,15 @@ export default class SurveyOptionsColumnType
         return <Cell cell={params.row[params.field]} />;
       },
       sortComparator: (v1: string[][], v2: string[][]) => {
-        const v1n =
-          v1 == null || v1.length == 0 ? 0 : -(v1[v1.length - 1]?.length ?? 0);
-        const v2n =
-          v2 == null || v2.length == 0 ? 0 : -(v2[v2.length - 1]?.length ?? 0);
-        return v1n - v2n;
+        const getPriority = (cell: string[][]) => {
+          if (cell == null || cell.length == 0) {
+            return 0;
+          } else {
+            return -cell[cell.length - 1].length;
+          }
+        };
+
+        return getPriority(v1) - getPriority(v2);
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyOptionsViewCell = params.row[params.field];

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -39,9 +39,9 @@ export default class SurveyOptionsColumnType
       },
       sortComparator: (v1: string[][], v2: string[][]) => {
         const v1n =
-          v1 == null || v1.length == 0 ? 0 : v1[v1.length - 1]?.length ?? 0;
+          v1 == null || v1.length == 0 ? 0 : -(v1[v1.length - 1]?.length ?? 0);
         const v2n =
-          v2 == null || v2.length == 0 ? 0 : v2[v2.length - 1]?.length ?? 0;
+          v2 == null || v2.length == 0 ? 0 : -(v2[v2.length - 1]?.length ?? 0);
         return v1n - v2n;
       },
       valueGetter: (params: GridValueGetterParams) => {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -37,6 +37,13 @@ export default class SurveyOptionsColumnType
       renderCell: (params: GridRenderCellParams) => {
         return <Cell cell={params.row[params.field]} />;
       },
+      sortComparator: (v1: string[][], v2: string[][]) => {
+        const v1n =
+          v1 == null || v1.length == 0 ? 0 : v1[v1.length - 1]?.length ?? 0;
+        const v2n =
+          v2 == null || v2.length == 0 ? 0 : v2[v2.length - 1]?.length ?? 0;
+        return v1n - v2n;
+      },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyOptionsViewCell = params.row[params.field];
         return cell?.map((response) =>

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -43,7 +43,7 @@ export default class SurveyResponseColumnType
         if (b.length == 0 || b[b.length - 1] == '') {
           return -1;
         }
-        return (a[a.length - 1] ?? '').localeCompare(b[b.length - 1] ?? '');
+        return a[a.length - 1].localeCompare(b[b.length - 1]);
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -36,6 +36,8 @@ export default class SurveyResponseColumnType
       renderCell: (params: GridRenderCellParams) => {
         return <Cell cell={params.row[params.field]} />;
       },
+      sortComparator: (a: string[], b: string[]) =>
+        (a[a.length - 1] ?? '').localeCompare(b[b.length - 1] ?? ''),
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
         return cell.map((response) => response.text);

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -36,8 +36,15 @@ export default class SurveyResponseColumnType
       renderCell: (params: GridRenderCellParams) => {
         return <Cell cell={params.row[params.field]} />;
       },
-      sortComparator: (a: string[], b: string[]) =>
-        (a[a.length - 1] ?? '').localeCompare(b[b.length - 1] ?? ''),
+      sortComparator: (a: string[], b: string[]) => {
+        if (a.length == 0 || a[a.length - 1] == '') {
+          return 1;
+        }
+        if (b.length == 0 || b[b.length - 1] == '') {
+          return -1;
+        }
+        return (a[a.length - 1] ?? '').localeCompare(b[b.length - 1] ?? '');
+      },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
         return cell.map((response) => response.text);


### PR DESCRIPTION
## Description
This PR adds some sorting on survey responses viewed in lists.

## Screenshots

Many options
![image](https://github.com/user-attachments/assets/ac25a729-edc7-4d62-9a78-5cce7c9ad15a)

Single option
![image](https://github.com/user-attachments/assets/cfe385c9-8105-4c64-bb1a-bd3fc82d35f5)

Free text
![image](https://github.com/user-attachments/assets/5bb21dbb-5317-4816-b04b-bd1e807c9236)

## Changes

* Free text responses are sorted alphabetically with the browsers locale compare, meaning order can change depending on browser language.
* Many options are sorted by number of options selected.
* Single options are sorted by selected or not

## Notes to reviewer

A smartlist that adds people who responed to "A very open survey" has all the kinds of columns implemented.

## Related issues
Resolves #2508 
