### PR TITLE
fix: Sort people import UI column values

### DIFF
--- a/src/features/import/hooks/useUIDataColumn.ts
+++ b/src/features/import/hooks/useUIDataColumn.ts
@@ -30,7 +30,16 @@ export default function useUIDataColumn(
   const cellValues = rows.map((row) => row.data[columnIndex]);
   const numRowsByUniqueValue = new Map<string | number, number>();
 
-  cellValues.forEach((value, idx) => {
+  let cellValuesSorted = [];
+  if (firstRowIsHeaders) {
+    const headerItem = cellValues[0];
+    const values = cellValues.slice(1);
+    cellValuesSorted = [headerItem, ...values.sort()];
+  } else {
+    cellValuesSorted = cellValues.sort();
+  }
+
+  cellValuesSorted.forEach((value, idx) => {
     if (firstRowIsHeaders && idx == 0) {
       return;
     }


### PR DESCRIPTION
## Description
This PR sorts the values displayed when mapping imported people fields


## Screenshots
csv:
```
ID,FIRST NAME,LAST NAME,CHAPTER,NETWORK
1,Clara,Zetkin,Malmo,Network 2
2,Jane,Doe,Leipzig,
3,Joe,Ham,Leipzig,Malmo
4,Clara,,Leipzig,Feminist network
5,Alex,Zander,Berlin,Malmo
```
sorted values:
![image](https://github.com/user-attachments/assets/43e46599-5055-4812-ba38-66fc48e27a67)



## Changes

* Changes the order of imported column values to be alphabetical when mapping


## Notes to reviewer
Can be tested as per issue description in #2499


## Related issues
Resolves #2499 
