### PR TITLE
Pass true to utc() to prevent date from being the day before

### DIFF
--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -21,7 +21,7 @@ export default function useEventsFromDateRange(
     dayjs(endDate).startOf('day').diff(dayjs(startDate).startOf('day'), 'day') +
       1
   ).map((diff) =>
-    dayjs(startDate).startOf('day').add(diff, 'day').utc().toISOString()
+    dayjs(startDate).startOf('day').add(diff, 'day').utc(true).toISOString()
   );
 
   const mustLoad = dateRange.some((date) =>


### PR DESCRIPTION
## Description
This PR fixes an failing unit test, src/features/events/tests/createEvent.spec.tsx by passing true to UTC. 
Before utc() would change the date to the 23:00 day before


## Screenshots
## Related issues
Resolves #2458 
