### PR TITLE
fix: Change target url for Plan now button

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
@@ -61,7 +61,7 @@ const AreaAssignmentPage: PageWithLayout<AreaAssignmentPageProps> = ({
         {({ data: { assignment, stats } }) => {
           const planUrl = `/organize/${orgId}/projects/${
             assignment.campaign.id || 'standalone'
-          }/areaassignments/${assignment.id}/plan`;
+          }/areaassignments/${assignment.id}/map`;
           return (
             <Box display="flex" flexDirection="column" gap={2}>
               {stats.num_areas == 0 && (


### PR DESCRIPTION
## Description
This PR changes the target url for Plan now button

## Changes
* Changes target url for Plan now to end in `/map` rather than '/plan'


## Notes to reviewer
The Plan now button is behind a feature flag for areas


## Related issues
Resolves #2523 
