### PR TITLE
Improve accesibility by increasing opacity

### DIFF
--- a/src/features/home/layouts/HomeLayout.tsx
+++ b/src/features/home/layouts/HomeLayout.tsx
@@ -81,7 +81,7 @@ const HomeLayout: FC<Props> = ({ children, title }) => {
         flexDirection="column"
         mx={1}
         my={2}
-        sx={{ opacity: 0.5 }}
+        sx={{ opacity: 0.75 }}
       >
         <ZUILogo />
         <Typography variant="body2">Zetkin</Typography>


### PR DESCRIPTION
## Description
This PR fixes the opacity of the Zetkin logo and privacy policy link on the home page to meet WCAG 2AA color contrast ratios. 


## Screenshots
![CleanShot 2025-02-01 at 17 28 29@2x](https://github.com/user-attachments/assets/66caa6f3-8587-4d79-b544-05d682f9fb95)

![CleanShot 2025-02-01 at 17 31 26@2x](https://github.com/user-attachments/assets/91a52b70-15d7-4735-b3ed-61c4d1712b8b)

## Changes

* Changes opacity from 0.5 to 0.75

## Notes to reviewer
Used Axe Developer tools to run an audit on this page


## Related issues
#254 
