### PR TITLE
Map marker overlap

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-leaflet';
 import { Box, Divider, lighten, Typography } from '@mui/material';
 import { FC, useContext, useEffect, useRef, useState } from 'react';
-import { FeatureGroup as FeatureGroupType, latLngBounds } from 'leaflet';
+import { FeatureGroup as FeatureGroupType } from 'leaflet';
 
 import { DivIconMarker } from 'features/events/components/LocationModal/DivIconMarker';
 import ZUIAvatar from 'zui/ZUIAvatar';
@@ -19,9 +19,9 @@ import {
   ZetkinLocation,
 } from '../types';
 import { ZetkinArea } from 'features/areas/types';
-import objToLatLng from 'features/areas/utils/objToLatLng';
 import { assigneesFilterContext } from './OrganizerMapFilters/AssigneeFilterContext';
 import isPointInsidePolygon from '../../canvass/utils/isPointInsidePolygon';
+import { getBoundSize } from '../../canvass/utils/getBoundSize';
 
 const LocationMarker: FC<{
   areaAssId: string;
@@ -308,24 +308,9 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               return -1;
             } else {
               // When  none of the two areas are selected, sort them
-              // by size, so that big ones are underneith and the
+              // by size, so that big ones are underneath and the
               // smaller ones can be clicked.
-              const bounds0 = latLngBounds(a0.points.map(objToLatLng));
-              const bounds1 = latLngBounds(a1.points.map(objToLatLng));
-
-              const dimensions0 = {
-                x: bounds0.getEast() - bounds0.getWest(),
-                y: bounds0.getNorth() - bounds0.getSouth(),
-              };
-              const dimensions1 = {
-                x: bounds1.getEast() - bounds1.getWest(),
-                y: bounds1.getNorth() - bounds1.getSouth(),
-              };
-
-              const size0 = dimensions0.x * dimensions0.y;
-              const size1 = dimensions1.x * dimensions1.y;
-
-              return size1 - size0;
+              return getBoundSize(a1) - getBoundSize(a0);
             }
           })
           .map((area) => {

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -383,7 +383,11 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
             return (
               <>
                 {overlayStyle == 'households' && (
-                  <DivIconMarker iconAnchor={[0, 0]} position={mid}>
+                  <DivIconMarker
+                    iconAnchor={[0, 0]}
+                    position={mid}
+                    zIndexOffset={100}
+                  >
                     <Box
                       bgcolor="white"
                       borderRadius={1}
@@ -405,7 +409,11 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                   </DivIconMarker>
                 )}
                 {overlayStyle == 'progress' && stats && (
-                  <DivIconMarker iconAnchor={[0, 0]} position={mid}>
+                  <DivIconMarker
+                    iconAnchor={[0, 0]}
+                    position={mid}
+                    zIndexOffset={100}
+                  >
                     <Box
                       bgcolor="white"
                       borderRadius={1}
@@ -438,7 +446,11 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                   </DivIconMarker>
                 )}
                 {overlayStyle == 'assignees' && hasPeople && (
-                  <DivIconMarker iconAnchor={[0, 0]} position={mid}>
+                  <DivIconMarker
+                    iconAnchor={[0, 0]}
+                    position={mid}
+                    zIndexOffset={100}
+                  >
                     {detailed && (
                       <Box
                         alignItems="center"

--- a/src/features/canvass/utils/getBoundSize.ts
+++ b/src/features/canvass/utils/getBoundSize.ts
@@ -1,0 +1,11 @@
+import { latLngBounds } from 'leaflet';
+
+import { ZetkinArea } from '../../areas/types';
+import objToLatLng from '../../areas/utils/objToLatLng';
+
+export const getBoundSize = (area: ZetkinArea): number => {
+  const bounds0 = latLngBounds(area.points.map(objToLatLng));
+  const dx = bounds0.getEast() - bounds0.getWest();
+  const dy = bounds0.getNorth() - bounds0.getSouth();
+  return dx * dy;
+};

--- a/src/features/events/components/LocationModal/DivIconMarker.tsx
+++ b/src/features/events/components/LocationModal/DivIconMarker.tsx
@@ -1,15 +1,23 @@
-import { LatLngExpression, divIcon, LeafletEventHandlerFnMap } from 'leaflet';
-import { FC, ReactNode, useMemo } from 'react';
+import { divIcon } from 'leaflet';
+import { FC, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { Marker } from 'react-leaflet';
+import { Marker, MarkerProps } from 'react-leaflet';
 
-export const DivIconMarker: FC<{
-  children: ReactNode;
-  draggable?: boolean;
-  eventHandlers?: LeafletEventHandlerFnMap;
-  iconAnchor?: [number, number];
-  position: LatLngExpression;
-}> = ({ children, draggable, eventHandlers, iconAnchor, position }) => {
+export const DivIconMarker: FC<
+  {
+    iconAnchor?: [number, number];
+  } & Pick<
+    MarkerProps,
+    'children' | 'draggable' | 'eventHandlers' | 'position' | 'zIndexOffset'
+  >
+> = ({
+  children,
+  draggable,
+  eventHandlers,
+  iconAnchor,
+  position,
+  zIndexOffset,
+}) => {
   const iconDiv = useMemo(() => document.createElement('div'), []);
   return (
     <>
@@ -22,6 +30,7 @@ export const DivIconMarker: FC<{
           iconAnchor,
         })}
         position={position}
+        zIndexOffset={zIndexOffset}
       />
       {createPortal(children, iconDiv)}
     </>

--- a/src/features/geography/components/GeographyMap/MapRenderer.tsx
+++ b/src/features/geography/components/GeographyMap/MapRenderer.tsx
@@ -1,5 +1,5 @@
 import { Box, useTheme } from '@mui/material';
-import { FeatureGroup, latLngBounds } from 'leaflet';
+import { FeatureGroup } from 'leaflet';
 import { FC, useEffect, useRef, useState } from 'react';
 import {
   FeatureGroup as FeatureGroupComponent,
@@ -11,7 +11,7 @@ import {
 
 import { PointData, ZetkinArea } from 'features/areas/types';
 import { DivIconMarker } from 'features/events/components/LocationModal/DivIconMarker';
-import objToLatLng from 'features/areas/utils/objToLatLng';
+import { getBoundSize } from '../../../canvass/utils/getBoundSize';
 
 type Props = {
   areas: ZetkinArea[];
@@ -141,27 +141,13 @@ const MapRenderer: FC<Props> = ({
           .filter(
             (area) => area.id != editingArea?.id && area.id != selectedArea?.id
           )
+          // Sort areas by size, so that big ones are underneath and the
+          // smaller ones can more easily be clicked.
+          .map((area) => ({ area, size: getBoundSize(area) }))
           .sort((a0, a1) => {
-            // Sort areas by size, so that big ones are underneith and the
-            // smaller ones can more easily be clicked.
-            const bounds0 = latLngBounds(a0.points.map(objToLatLng));
-            const bounds1 = latLngBounds(a1.points.map(objToLatLng));
-
-            const dimensions0 = {
-              x: bounds0.getEast() - bounds0.getWest(),
-              y: bounds0.getNorth() - bounds0.getSouth(),
-            };
-            const dimensions1 = {
-              x: bounds1.getEast() - bounds1.getWest(),
-              y: bounds1.getNorth() - bounds1.getSouth(),
-            };
-
-            const size0 = dimensions0.x * dimensions0.y;
-            const size1 = dimensions1.x * dimensions1.y;
-
-            return size1 - size0;
+            return a1.size - a0.size;
           })
-          .map((area) => {
+          .map(({ area }) => {
             // The key changes when selected, to force redraw of polygon
             // to reflect new state through visual style
             const key = area.id + '-default';


### PR DESCRIPTION
## Description
This PR ensures that the markers in the center of the area in a map are positioned on top of the individual markers.


## Screenshots
|before|after|
|-|-|
| ![CleanShot 2025-02-02 at 09 02 11@2x](https://github.com/user-attachments/assets/0d71189e-1118-44d6-b2ac-34122f9bbaaa)|![CleanShot 2025-02-02 at 09 01 15@2x](https://github.com/user-attachments/assets/042cae91-03ca-4f99-a01a-c5b3c1a0fc29)|


## Changes
There are two commits:
* The first one extracts some duplicated code for ordering areas on the map (not strictly necessary for this PR)
* The second one adds the `zIndexOffset` property to the `DivIconMarker` and uses it on the markers for the center of the areas. 

The leaflet library automatically sets z indexes on all markers so that they display properly. It allows providing the zIndexOffset to explicitly place some markers on a higher level which is just what we want here.


## Related issues
Resolves #2445
