### PR TITLE
Issue 2497/duplicate list from list page

### DIFF
--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -417,6 +417,7 @@ export default makeMessages('feat.views', {
     },
     ellipsisMenu: {
       delete: m('Delete list'),
+      duplicate: m('Duplicate'),
       editQuery: m('Edit Smart Search query'),
       makeDynamic: m('Convert to Smart Search list'),
       makeStatic: {

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -156,12 +156,12 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
     label: messages.viewLayout.ellipsisMenu.duplicate(),
     onSelect: async () => {
       if (view != null) {
-        const copy = await duplicateView(
+        const copiedList = await duplicateView(
           viewId,
           view.folder?.id ?? null,
           messages.browser.menu.viewCopy({ viewName: view.title })
         );
-        router.push(`/organize/${orgId}/people/lists/${copy.id}`);
+        router.push(`/organize/${orgId}/people/lists/${copiedList.id}`);
       }
     },
   });

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -52,7 +52,11 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
-  const { deleteView: deleteList, updateView } = useViewMutations(orgId);
+  const {
+    deleteView: deleteList,
+    duplicateView,
+    updateView,
+  } = useViewMutations(orgId);
   const viewFuture = useView(orgId, viewId);
   const { deleteContentQuery } = useViewDataTableMutations(orgId, viewId);
   const { columnsFuture, rowsFuture } = useViewGrid(orgId, viewId);
@@ -116,7 +120,6 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   } else {
     ellipsisMenu.push({
       label: messages.viewLayout.ellipsisMenu.makeDynamic(),
-      onSelect: () => setQueryDialogOpen(true),
     });
   }
 
@@ -144,6 +147,21 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
         title: messages.deleteDialog.title(),
         warningText: messages.deleteDialog.warningText(),
       });
+    },
+  });
+
+  ellipsisMenu.push({
+    id: 'duplicate-view',
+    label: messages.viewLayout.ellipsisMenu.duplicate(),
+    onSelect: async () => {
+      if (view != null) {
+        const copy = await duplicateView(
+          viewId,
+          view.folder?.id ?? null,
+          messages.browser.menu.viewCopy({ viewName: view.title })
+        );
+        router.push(`/organize/${orgId}/people/lists/${copy.id}`);
+      }
     },
   });
 

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -120,6 +120,7 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   } else {
     ellipsisMenu.push({
       label: messages.viewLayout.ellipsisMenu.makeDynamic(),
+      onSelect: () => setQueryDialogOpen(true),
     });
   }
 


### PR DESCRIPTION
## Description
This PR adds an option in the ellipsis menu for duplicating a list from the single-list page. When 'Duplicate' is clicked, the list is duplicated, and the user is redirected to the page of the new list.

## Screenshots
The option 'Duplicate' in the ellipsis menu:
![billede](https://github.com/user-attachments/assets/fac28dff-6193-4dca-8e29-c74155b5a285)
The page of the copied list:
![billede](https://github.com/user-attachments/assets/4e4f58b3-be75-49f4-8caf-0eec14a167f1)

## Changes
* Fixes bug #2497 by adding an option to duplicate a list from the single-list page

## Notes to reviewer

1. Go to https://app.dev.zetkin.org/organize/1/people and sign in as [testadmin@example.com](mailto:testadmin@example.com)
2.  Click on "Create"
3. Create a list
4. Add some people and columns
5. Click the ellipsis menu in the top right
6. Click 'Duplicate' from the menu
7. See that a duplicate is created and you are redirected to the page of the new list.

## Related issues
Resolves #2497 
