### PR TITLE
Enable remindAll button even after event start.

### DIFF
--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -69,6 +69,9 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
     return null;
   }
 
+  const enventHasStarted =
+    new Date(removeOffset(event.start_time)) > new Date();
+  const eventHasEnded = new Date(removeOffset(event.end_time)) < new Date();
   return (
     <Box>
       <ZUICard
@@ -173,7 +176,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               )}
             </Box>
           </Box>
-          {new Date(removeOffset(event.start_time)) > new Date() ? (
+          {enventHasStarted ? (
             <Box display="flex" flexDirection="column">
               <Typography color={'secondary'}>
                 {messages.participantSummaryCard.booked()}
@@ -207,7 +210,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                     })}
                   </Typography>
                 )}
-                {new Date(removeOffset(event.end_time)) > new Date() && (
+                {!eventHasEnded && (
                   <RemindAllToolbox
                     contactPerson={contactPerson}
                     eventId={eventId}

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -1,20 +1,17 @@
 import {
   Box,
   Button,
-  CircularProgress,
   ClickAwayListener,
   Paper,
   Popper,
   TextField,
-  Tooltip,
   Typography,
 } from '@mui/material';
-import { Check, PriorityHigh, Settings } from '@mui/icons-material';
+import { Check, Settings } from '@mui/icons-material';
 import { FC, useState } from 'react';
 
 import messageIds from 'features/events/l10n/messageIds';
 import { removeOffset } from 'utils/dateUtils';
-import { useAppSelector } from 'core/hooks';
 import useEvent from '../hooks/useEvent';
 import useEventParticipants from '../hooks/useEventParticipants';
 import useEventParticipantsMutations from '../hooks/useEventParticipantsMutations';
@@ -22,6 +19,7 @@ import useParticipantStatus from '../hooks/useParticipantsStatus';
 import ZUICard from 'zui/ZUICard';
 import ZUINumberChip from 'zui/ZUINumberChip';
 import { Msg, useMessages } from 'core/i18n';
+import RemindAllToolbox from './RemindAllBox';
 
 type ParticipantSummaryCardProps = {
   eventId: number;
@@ -66,10 +64,6 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
   const [anchorEl, setAnchorEl] = useState<
     null | (EventTarget & SVGSVGElement)
   >(null);
-
-  const isRemindingParticipants = useAppSelector(
-    (state) => state.events.remindingByEventId[eventId]
-  );
 
   if (!event) {
     return null;
@@ -186,48 +180,12 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               </Typography>
               <Box alignItems="center" display="flex">
                 <Typography variant="h4">{`${numRemindedParticipants}/${numAvailParticipants}`}</Typography>
-                <Tooltip
-                  arrow
-                  placement="top-start"
-                  title={
-                    contactPerson == null
-                      ? messages.participantSummaryCard.remindButtondisabledTooltip()
-                      : ''
-                  }
-                >
-                  <Box>
-                    <Button
-                      disabled={
-                        contactPerson == null ||
-                        isRemindingParticipants ||
-                        numRemindedParticipants >= numAvailParticipants
-                      }
-                      onClick={() => {
-                        sendReminders(eventId);
-                      }}
-                      size="small"
-                      startIcon={
-                        contactPerson ? (
-                          isRemindingParticipants ? (
-                            <CircularProgress size={20} />
-                          ) : (
-                            <Check />
-                          )
-                        ) : (
-                          <PriorityHigh />
-                        )
-                      }
-                      sx={{
-                        marginLeft: 2,
-                      }}
-                      variant="outlined"
-                    >
-                      <Msg
-                        id={messageIds.participantSummaryCard.remindButton}
-                      />
-                    </Button>
-                  </Box>
-                </Tooltip>
+                <RemindAllToolbox
+                  contactPerson={contactPerson}
+                  eventId={eventId}
+                  orgId={orgId}
+                  sendReminders={sendReminders}
+                />
               </Box>
             </Box>
           ) : (
@@ -248,6 +206,14 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                       noshows: numNoshowParticipants,
                     })}
                   </Typography>
+                )}
+                {new Date(removeOffset(event.end_time)) > new Date() && (
+                  <RemindAllToolbox
+                    contactPerson={contactPerson}
+                    eventId={eventId}
+                    orgId={orgId}
+                    sendReminders={sendReminders}
+                  />
                 )}
                 {!hasRecordedAttendance && (
                   <Box ml={2}>

--- a/src/features/events/components/ParticipantSummaryCard.tsx
+++ b/src/features/events/components/ParticipantSummaryCard.tsx
@@ -19,7 +19,7 @@ import useParticipantStatus from '../hooks/useParticipantsStatus';
 import ZUICard from 'zui/ZUICard';
 import ZUINumberChip from 'zui/ZUINumberChip';
 import { Msg, useMessages } from 'core/i18n';
-import RemindAllToolbox from './RemindAllBox';
+import RemindAllButton from './RemindAllButton';
 
 type ParticipantSummaryCardProps = {
   eventId: number;
@@ -183,7 +183,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
               </Typography>
               <Box alignItems="center" display="flex">
                 <Typography variant="h4">{`${numRemindedParticipants}/${numAvailParticipants}`}</Typography>
-                <RemindAllToolbox
+                <RemindAllButton
                   contactPerson={contactPerson}
                   eventId={eventId}
                   orgId={orgId}
@@ -211,7 +211,7 @@ const ParticipantSummaryCard: FC<ParticipantSummaryCardProps> = ({
                   </Typography>
                 )}
                 {!eventHasEnded && (
-                  <RemindAllToolbox
+                  <RemindAllButton
                     contactPerson={contactPerson}
                     eventId={eventId}
                     orgId={orgId}

--- a/src/features/events/components/RemindAllBox.tsx
+++ b/src/features/events/components/RemindAllBox.tsx
@@ -1,0 +1,75 @@
+import { FC } from 'react';
+import { Check, PriorityHigh } from '@mui/icons-material';
+import { Box, Button, CircularProgress, Tooltip } from '@mui/material';
+
+import { Msg, useMessages } from 'core/i18n';
+import { useAppSelector } from 'core/hooks';
+import messageIds from 'features/events/l10n/messageIds';
+import useEventParticipants from '../hooks/useEventParticipants';
+
+interface RemindAllToolboxProps {
+  contactPerson?: null | { id: number; name: string };
+  eventId: number;
+  orgId: number;
+  sendReminders: (eventId: number) => void;
+}
+
+const RemindAllToolbox: FC<RemindAllToolboxProps> = ({
+  contactPerson,
+  eventId,
+  orgId,
+  sendReminders,
+}) => {
+  const isRemindingParticipants = useAppSelector(
+    (state) => state.events.remindingByEventId[eventId]
+  );
+
+  const { numAvailParticipants, numRemindedParticipants } =
+    useEventParticipants(orgId, eventId);
+
+  const messages = useMessages(messageIds);
+
+  return (
+    <Tooltip
+      arrow
+      placement="top-start"
+      title={
+        contactPerson == null
+          ? messages.participantSummaryCard.remindButtondisabledTooltip()
+          : ''
+      }
+    >
+      <Box>
+        <Button
+          disabled={
+            contactPerson == null ||
+            isRemindingParticipants ||
+            numRemindedParticipants >= numAvailParticipants
+          }
+          onClick={() => {
+            sendReminders(eventId);
+          }}
+          size="small"
+          startIcon={
+            contactPerson ? (
+              isRemindingParticipants ? (
+                <CircularProgress size={20} />
+              ) : (
+                <Check />
+              )
+            ) : (
+              <PriorityHigh />
+            )
+          }
+          sx={{
+            marginLeft: 2,
+          }}
+          variant="outlined"
+        >
+          <Msg id={messageIds.participantSummaryCard.remindButton} />
+        </Button>
+      </Box>
+    </Tooltip>
+  );
+};
+export default RemindAllToolbox;

--- a/src/features/events/components/RemindAllButton.tsx
+++ b/src/features/events/components/RemindAllButton.tsx
@@ -7,14 +7,14 @@ import { useAppSelector } from 'core/hooks';
 import messageIds from 'features/events/l10n/messageIds';
 import useEventParticipants from '../hooks/useEventParticipants';
 
-interface RemindAllToolboxProps {
+interface RemindAllButtonProps {
   contactPerson?: null | { id: number; name: string };
   eventId: number;
   orgId: number;
   sendReminders: (eventId: number) => void;
 }
 
-const RemindAllToolbox: FC<RemindAllToolboxProps> = ({
+const RemindAllButton: FC<RemindAllButtonProps> = ({
   contactPerson,
   eventId,
   orgId,
@@ -72,4 +72,4 @@ const RemindAllToolbox: FC<RemindAllToolboxProps> = ({
     </Tooltip>
   );
 };
-export default RemindAllToolbox;
+export default RemindAllButton;


### PR DESCRIPTION
The remindAll button now shows both before the event and during the event

## Description
In the event page, participant tab, there is a button for sending reminders. Before this change, this button is only available before the event start date.

Logic after this change: 
* Before event start: Show remindAll button (as before)
* During the event: Still show the remindAll button (new logic)
* After the event: Do not show the remindAll (as before)

## Screenshots
How it looks during the event. You could still send reminders.
<img width="587" alt="image" src="https://github.com/user-attachments/assets/27620e2b-5076-488f-814e-ae245257bcfa" />

## Changes
* Adding the remindAll button when inbetween event.start_date and event.end_date
* Refactor the remindAll section into a component for easier readability

## Notes to reviewer
You find more details in the issue #2433

Try manipulating the event start-date and end-date for all 3 possible cases: 
- Before event start
- During the event
- After the event

## Related issues
Resolves #2433
