### PR TITLE
Open join form edit on creat. WIP only works on Join From tab

### DIFF
--- a/src/features/joinForms/hooks/useCreateJoinForm.ts
+++ b/src/features/joinForms/hooks/useCreateJoinForm.ts
@@ -1,12 +1,15 @@
 import { joinFormCreated } from '../store';
-import { useApiClient, useAppDispatch } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinJoinForm, ZetkinJoinFormPostBody } from '../types';
 
 export default function useCreateJoinForm(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
+  const joinForms = useAppSelector((state) => state.joinForms);
 
-  async function createForm(body: ZetkinJoinFormPostBody) {
+  const createForm = async (
+    body: ZetkinJoinFormPostBody
+  ): Promise<ZetkinJoinForm> => {
     const createdData = await apiClient.post<ZetkinJoinForm>(
       `/api/orgs/${orgId}/join_forms`,
       body
@@ -15,9 +18,12 @@ export default function useCreateJoinForm(orgId: number) {
     dispatch(joinFormCreated(createdData));
 
     return createdData;
-  }
+  };
+
+  const recentlyCreatedJoinForm = joinForms.recentlyCreatedJoinForm;
 
   return {
     createForm,
+    recentlyCreatedJoinForm,
   };
 }

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -5,11 +5,13 @@ import { ZetkinJoinForm, ZetkinJoinSubmission } from './types';
 
 export interface JoinFormsStoreSlice {
   formList: RemoteList<ZetkinJoinForm>;
+  recentlyCreatedJoinForm: ZetkinJoinForm | null;
   submissionList: RemoteList<ZetkinJoinSubmission>;
 }
 
 const initialState: JoinFormsStoreSlice = {
   formList: remoteList(),
+  recentlyCreatedJoinForm: null,
   submissionList: remoteList(),
 };
 
@@ -17,11 +19,16 @@ const joinFormsSlice = createSlice({
   initialState: initialState,
   name: 'joinForms',
   reducers: {
+    joinFormCreate: (state) => {
+      state.formList.isLoading = true;
+      state.recentlyCreatedJoinForm = null;
+    },
     joinFormCreated: (state, action: PayloadAction<ZetkinJoinForm>) => {
       const form = action.payload;
       const item = findOrAddItem(state.formList, form.id);
       item.loaded = new Date().toISOString();
       item.data = form;
+      state.recentlyCreatedJoinForm = form;
     },
     joinFormLoad: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
@@ -103,6 +110,7 @@ const joinFormsSlice = createSlice({
 
 export default joinFormsSlice;
 export const {
+  joinFormCreate,
   joinFormCreated,
   joinFormLoad,
   joinFormLoaded,

--- a/src/pages/organize/[orgId]/people/joinforms/index.tsx
+++ b/src/pages/organize/[orgId]/people/joinforms/index.tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+import { useEffect } from 'react';
 
 import JoinFormList from 'features/joinForms/components/JoinFormList';
 import JoinFormPane from 'features/joinForms/panes/JoinFormPane';
@@ -6,6 +7,7 @@ import { PageWithLayout } from 'utils/types';
 import PeopleLayout from 'features/views/layout/PeopleLayout';
 import { scaffold } from 'utils/next';
 import useJoinForms from 'features/joinForms/hooks/useJoinForms';
+import useCreateJoinForm from 'features/joinForms/hooks/useCreateJoinForm';
 import { usePanes } from 'utils/panes';
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
@@ -22,9 +24,20 @@ type PageProps = {
   orgId: string;
 };
 
+
 const JoinFormsPage: PageWithLayout<PageProps> = ({ orgId }) => {
   const { data: joinForms } = useJoinForms(parseInt(orgId));
+  const { recentlyCreatedJoinForm } = useCreateJoinForm(parseInt(orgId));
   const { openPane } = usePanes();
+
+  useEffect(() => {
+          openPane({
+          render: () => (recentlyCreatedJoinForm &&
+            <JoinFormPane formId={recentlyCreatedJoinForm.id} orgId={recentlyCreatedJoinForm.organization.id} />
+          ),
+          width: 500,
+        });
+  }, [recentlyCreatedJoinForm]);
 
   if (!joinForms) {
     return null;


### PR DESCRIPTION
## Description
This PR opens the Join form edit pane when new Join form is created from the Join Forms tab.


## Screenshots
![image](https://github.com/user-attachments/assets/aafe526a-a4bd-40ae-84a5-6fa89f4b1cbc)



## Changes

* Changes behaviour of Create Join form action so that instead of silently creating a new list item at the bottom, it opens the edit pane


## Notes to reviewer
Note the intention for this issue is that it would work from anywhere the `PeopleActionButton` can be used. Currently only works if triggered from the Join Forms list page.

## Related issues
Partial #2174 
