### PR TITLE
Sorting based on flagging status

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -27,6 +27,27 @@ import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
+const sortByOa = (
+  v1: ZetkinOrganizerAction[],
+  v2: ZetkinOrganizerAction[]
+): number => {
+  const hasActions = (v: ZetkinOrganizerAction[]): boolean => {
+    return v.length > 0;
+  };
+
+  const getSortValue = (v: ZetkinOrganizerAction[]): number => {
+    if (!hasActions(v)) {
+      return 2;
+    }
+    if (v.every((oan) => oan.organizer_action_taken)) {
+      return 1;
+    }
+    return 0;
+  };
+
+  return getSortValue(v1) - getSortValue(v2);
+};
+
 export default class OrganizerActionColumnType implements IColumnType {
   cellToString(cell: OrganizerActionViewCell): string {
     const requiresAction = cell?.length
@@ -53,6 +74,7 @@ export default class OrganizerActionColumnType implements IColumnType {
           />
         );
       },
+      sortComparator: (v1, v2) => sortByOa(v1, v2),
     };
   }
 

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -28,12 +28,8 @@ import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
 const sortByOa = (v1: ZetkinOrganizerAction[], v2: ZetkinOrganizerAction[]) => {
-  const hasActions = (v: ZetkinOrganizerAction[]): boolean => {
-    return v.length > 0;
-  };
-
   const getSortValue = (v: ZetkinOrganizerAction[]) => {
-    if (!hasActions(v)) {
+    if (v.length === 0) {
       return 2;
     }
     if (v.every((oan) => oan.organizer_action_taken)) {

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -28,7 +28,7 @@ import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
 const sortByOa = (v1: ZetkinOrganizerAction[], v2: ZetkinOrganizerAction[]) => {
-  const getSortValue = (v: ZetkinOrganizerAction[]) => {
+  const getPriority = (v: ZetkinOrganizerAction[]) => {
     if (v.length === 0) {
       return 2;
     }
@@ -38,7 +38,7 @@ const sortByOa = (v1: ZetkinOrganizerAction[], v2: ZetkinOrganizerAction[]) => {
     return 0;
   };
 
-  return getSortValue(v1) - getSortValue(v2);
+  return getPriority(v1) - getPriority(v2);
 };
 
 export default class OrganizerActionColumnType implements IColumnType {

--- a/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/OrganizerActionColumnType.tsx
@@ -27,15 +27,12 @@ import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 
 type OrganizerActionViewCell = null | ZetkinOrganizerAction[];
 
-const sortByOa = (
-  v1: ZetkinOrganizerAction[],
-  v2: ZetkinOrganizerAction[]
-): number => {
+const sortByOa = (v1: ZetkinOrganizerAction[], v2: ZetkinOrganizerAction[]) => {
   const hasActions = (v: ZetkinOrganizerAction[]): boolean => {
     return v.length > 0;
   };
 
-  const getSortValue = (v: ZetkinOrganizerAction[]): number => {
+  const getSortValue = (v: ZetkinOrganizerAction[]) => {
     if (!hasActions(v)) {
       return 2;
     }


### PR DESCRIPTION
## Description
This PR enables sorting based on flagging status (action needed, action taken, empty) in the 'Organizer action needed' table.


## Screenshots
![asc](https://github.com/user-attachments/assets/654f73e7-761b-467a-8db4-88de313ff2b7)
![desc](https://github.com/user-attachments/assets/54d0a1f4-9109-479e-87b2-066135300dd8)
![none](https://github.com/user-attachments/assets/1543aa64-8ee5-4fda-8e16-2da63d8af3f5)

## Changes
* Adds a sortComparator to the 'organizer action' column type. Rows are sorted based on flagging status:
Highest priority: there are flagged calls (organizer_action_needed), and at least one call has an unresolved issue (organizer action has not been taken)
Medium: there are flagged calls, and none of them has an unresolved issue
Lowest: empty/white


## Notes to reviewer
I am a bit confused regarding what would be considered 'asc' or 'desc' sorting in this case, but that could easily be altered in the code.


## Related issues
Resolves #2474 
