### PR TITLE
reload if orgId undefined

### DIFF
--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -16,6 +16,7 @@ import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 import { Msg, useMessages } from 'core/i18n';
+import { useRouter } from 'next/router';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -45,8 +46,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
 }, scaffoldOptions);
 
 const AllCampaignsSummaryPage: PageWithLayout = () => {
+  const router = useRouter();
   const messages = useMessages(messageIds);
   const { orgId } = useNumericRouteParams();
+  if (!orgId) {
+    router.reload();
+  }
   const { data: campaigns } = useCampaigns(orgId);
   campaigns?.reverse();
 


### PR DESCRIPTION
## Description
This PR closes #2502 


## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
* Changes…


## Notes to reviewer

I dug deep and for some reason (probably mixing pages and app router logic) orgId is sometimes undefined. A proper rewrite of the hooks to actually change when orgId changes would be required. this is a fix to help onboarding devs quicker without presenting them an error.

in the best case orgId should be passed from serversideprops to all components without any hooks


## Related issues
Resolves #[id]
