### PR TITLE
Rename button to reduce potential confusion

### DIFF
--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -41,7 +41,7 @@ export default makeMessages('feat.canvass', {
     areas: m('Areas'),
     instructionsHeader: m('Instructions'),
     ready: m('You are ready to go'),
-    start: m('Start assignment'),
+    start: m('Begin assignment'),
     visitedHouseholds: m('Households visited'),
     visitedLocations: m('Locations visited'),
   },


### PR DESCRIPTION
## Description
This PR renames the `Start assignment` button in the activity lobby to `Begin assignment` to make it more obvious that this is not a global action on the activity but rather just an action that the user takes for themselves. 

## Related issues
Resolves #2528
