### PR TITLE
Add locked/unlocked feature 

### DIFF
--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -167,19 +167,20 @@ export default makeMessages('feat.areaAssignments', {
       select: m('Select'),
     },
     lockCard: {
-      add: m('Add questions'),
-      change: m('Change question that defines successful visit'),
-      description: m('Protecting report data due to started assignment'),
-      descriptionUnlock: m(
-        'Editing questions might cause inconsistent report data'
+      add: m('Adding questions'),
+      change: m('Changing question that defines successful visit'),
+      description: m(
+        'This survey has started receiving submissions. Editing the survey now may cause problems with the data. Proceed with caution.'
       ),
-      fix: m('Fix spelling'),
+      descriptionUnlock: m(
+        'Be careful not to make changes that may cause data to be lost or corrupted.'
+      ),
+      fix: m('Fixing spelling'),
       header: m('Report locked'),
       headerUnlock: m('Report unlocked'),
-      rename: m('Rename questions in ways that change their meaning'),
-      reorder: m('Reorder questions'),
+      rename: m('Rephrasing questions in ways that change their meaning'),
       safe: m('Safe changes'),
-      unsafe: m('Unsafe questions'),
+      unsafe: m('Unsafe changes'),
     },
     metricCard: {
       choice: m('Choice question'),

--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -166,6 +166,21 @@ export default makeMessages('feat.areaAssignments', {
       ),
       select: m('Select'),
     },
+    lockCard: {
+      add: m('Add questions'),
+      change: m('Change question that defines successful visit'),
+      description: m('Protecting report data due to started assignment'),
+      descriptionUnlock: m(
+        'Editing questions might cause inconsistent report data'
+      ),
+      fix: m('Fix spelling'),
+      header: m('Report locked'),
+      headerUnlock: m('Report unlocked'),
+      rename: m('Rename questions in ways that change their meaning'),
+      reorder: m('Reorder questions'),
+      safe: m('Safe changes'),
+      unsafe: m('Unsafe questions'),
+    },
     metricCard: {
       choice: m('Choice question'),
       ratingDescription: m(

--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -170,7 +170,7 @@ export default makeMessages('feat.areaAssignments', {
       add: m('Adding questions'),
       change: m('Changing question that defines successful visit'),
       description: m(
-        'This survey has started receiving submissions. Editing the survey now may cause problems with the data. Proceed with caution.'
+        'This assignment has started. Editing the assignment now may cause problems with the data. Proceed with caution.'
       ),
       descriptionUnlock: m(
         'Be careful not to make changes that may cause data to be lost or corrupted.'

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -143,8 +143,8 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
     });
   };
 
-  const blockedInitialState = hasVisitedData(areaAssignmentStats);
-  const [checked, setChecked] = useState(blockedInitialState);
+  const lockState = hasVisitedData(areaAssignmentStats);
+  const [unlocked, setUnlocked] = useState(lockState);
 
   return (
     <ZUIFuture future={areaAssignmentFuture}>
@@ -206,46 +206,49 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                 </Typography>
                               </Box>
                             )}
-                            <Button
-                              onClick={() => setMetricBeingEdited(metric)}
-                            >
-                              <Edit />
-                            </Button>
-                            {(metric.kind === 'scale5' ||
-                              (metric.kind === 'boolean' &&
-                                assignment.metrics.filter(
-                                  (m) => m.kind === 'boolean'
-                                ).length > 1)) && (
+                            {unlocked && (
                               <Button
-                                onClick={(ev) => {
-                                  if (metric.definesDone) {
-                                    setMetricBeingDeleted(metric);
-                                    setAnchorEl(ev.currentTarget);
-                                  } else {
-                                    showConfirmDialog({
-                                      onCancel: () => {
-                                        setMetricBeingDeleted(null),
-                                          setAnchorEl(null);
-                                      },
-                                      onSubmit: () => {
-                                        handleDeleteMetric(metric.id);
-                                        setAnchorEl(null);
-                                        setMetricBeingDeleted(null);
-                                      },
-                                      title: `${
-                                        messages.report.card.delete() +
-                                        ' ' +
-                                        metric.question
-                                      }`,
-                                      warningText:
-                                        messages.report.delete.dialog(),
-                                    });
-                                  }
-                                }}
+                                onClick={() => setMetricBeingEdited(metric)}
                               >
-                                <Delete />
+                                <Edit />
                               </Button>
                             )}
+                            {unlocked &&
+                              (metric.kind === 'scale5' ||
+                                (metric.kind === 'boolean' &&
+                                  assignment.metrics.filter(
+                                    (m) => m.kind === 'boolean'
+                                  ).length > 1)) && (
+                                <Button
+                                  onClick={(ev) => {
+                                    if (metric.definesDone) {
+                                      setMetricBeingDeleted(metric);
+                                      setAnchorEl(ev.currentTarget);
+                                    } else {
+                                      showConfirmDialog({
+                                        onCancel: () => {
+                                          setMetricBeingDeleted(null),
+                                            setAnchorEl(null);
+                                        },
+                                        onSubmit: () => {
+                                          handleDeleteMetric(metric.id);
+                                          setAnchorEl(null);
+                                          setMetricBeingDeleted(null);
+                                        },
+                                        title: `${
+                                          messages.report.card.delete() +
+                                          ' ' +
+                                          metric.question
+                                        }`,
+                                        warningText:
+                                          messages.report.delete.dialog(),
+                                      });
+                                    }
+                                  }}
+                                >
+                                  <Delete />
+                                </Button>
+                              )}
                             {assignment.metrics.filter(
                               (metric) => metric.kind === 'boolean'
                             ).length <= 1 &&
@@ -293,35 +296,37 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
               </Dialog>
             )}
             <Box>
-              <Card
-                sx={{
-                  backgroundColor: theme.palette.grey[200],
-                  border: 'none',
-                  marginTop: 2,
-                  padding: 2,
-                }}
-              >
-                <Typography color="secondary">
-                  <Msg id={messagesIds.report.toolBar.title} />
-                </Typography>
-                <Box alignItems="center" display="flex" mt={2}>
-                  <Button
-                    onClick={() => handleAddNewMetric('boolean')}
-                    startIcon={<SwitchLeft />}
-                    sx={{ marginRight: 1 }}
-                    variant="outlined"
-                  >
-                    <Msg id={messagesIds.report.metricCard.choice} />
-                  </Button>
-                  <Button
-                    onClick={() => handleAddNewMetric('scale5')}
-                    startIcon={<LinearScale />}
-                    variant="outlined"
-                  >
-                    <Msg id={messagesIds.report.metricCard.scale} />
-                  </Button>
-                </Box>
-              </Card>
+              {unlocked && (
+                <Card
+                  sx={{
+                    backgroundColor: theme.palette.grey[200],
+                    border: 'none',
+                    marginTop: 2,
+                    padding: 2,
+                  }}
+                >
+                  <Typography color="secondary">
+                    <Msg id={messagesIds.report.toolBar.title} />
+                  </Typography>
+                  <Box alignItems="center" display="flex" mt={2}>
+                    <Button
+                      onClick={() => handleAddNewMetric('boolean')}
+                      startIcon={<SwitchLeft />}
+                      sx={{ marginRight: 1 }}
+                      variant="outlined"
+                    >
+                      <Msg id={messagesIds.report.metricCard.choice} />
+                    </Button>
+                    <Button
+                      onClick={() => handleAddNewMetric('scale5')}
+                      startIcon={<LinearScale />}
+                      variant="outlined"
+                    >
+                      <Msg id={messagesIds.report.metricCard.scale} />
+                    </Button>
+                  </Box>
+                </Card>
+              )}
               <Dialog onClose={() => setAnchorEl(null)} open={!!anchorEl}>
                 <Box display="flex" flexDirection="column" gap={1} padding={2}>
                   <Box
@@ -414,7 +419,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
             {assignment.start_date && (
               <ZUICard
                 header={
-                  !checked ? (
+                  !unlocked ? (
                     <Msg id={messagesIds.report.lockCard.header} />
                   ) : (
                     <Msg id={messagesIds.report.lockCard.headerUnlock} />
@@ -422,18 +427,18 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                 }
                 status={
                   <Switch
-                    checked={!checked}
-                    onChange={(event) => setChecked(!event.target.checked)}
+                    checked={!unlocked}
+                    onChange={(event) => setUnlocked(!event.target.checked)}
                   />
                 }
                 subheader={
-                  !checked
+                  !unlocked
                     ? messages.report.lockCard.description()
                     : messages.report.lockCard.descriptionUnlock()
                 }
                 sx={{ mb: 2 }}
               >
-                {checked && (
+                {unlocked && (
                   <Box>
                     <Divider />
                     <Typography my={1}>
@@ -486,6 +491,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                 <InputLabel>{messages.report.card.definesSuccess()}</InputLabel>
                 <Select
                   disabled={
+                    !unlocked ||
                     assignment.metrics.filter(
                       (metric) => metric.kind === 'boolean'
                     ).length <= 1
@@ -550,13 +556,13 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                     <Msg id={messagesIds.report.dataCard.info} />
                   </Typography>
                   <FormControlLabel
-                    control={<Radio />}
+                    control={<Radio disabled={!unlocked} />}
                     label={messages.report.dataCard.household()}
                     sx={{ ml: 1 }}
                     value="household"
                   />
                   <FormControlLabel
-                    control={<Radio />}
+                    control={<Radio disabled={!unlocked} />}
                     label={messages.report.dataCard.location()}
                     sx={{ ml: 1 }}
                     value="location"

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -437,12 +437,6 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                     <Box alignItems="center" display="flex">
                       <Check style={{ color: theme.palette.success.main }} />
                       <Typography ml={1}>
-                        <Msg id={messagesIds.report.lockCard.reorder} />
-                      </Typography>
-                    </Box>
-                    <Box alignItems="center" display="flex">
-                      <Check style={{ color: theme.palette.success.main }} />
-                      <Typography ml={1}>
                         <Msg id={messagesIds.report.lockCard.add} />
                       </Typography>
                     </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -145,7 +145,9 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
   };
 
   const lockState = hasVisitedData(areaAssignmentStats);
-  const [unlocked, setUnlocked] = useState(lockState);
+  const [unlocked, setUnlocked] = useState(
+    areaAssignmentFuture.data?.start_date ? lockState : true
+  );
 
   return (
     <ZUIFuture future={areaAssignmentFuture}>
@@ -208,11 +210,12 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                               </Box>
                             )}
                             {unlocked && (
-                              <Button
+                              <IconButton
+                                color="secondary"
                                 onClick={() => setMetricBeingEdited(metric)}
                               >
                                 <Edit />
-                              </Button>
+                              </IconButton>
                             )}
                             {unlocked &&
                               (metric.kind === 'scale5' ||
@@ -220,7 +223,8 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                   assignment.metrics.filter(
                                     (m) => m.kind === 'boolean'
                                   ).length > 1)) && (
-                                <Button
+                                <IconButton
+                                  color="secondary"
                                   onClick={(ev) => {
                                     if (metric.definesDone) {
                                       setMetricBeingDeleted(metric);
@@ -248,7 +252,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                   }}
                                 >
                                   <Delete />
-                                </Button>
+                                </IconButton>
                               )}
                             {unlocked &&
                               assignment.metrics.filter(

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -414,50 +414,62 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
             {assignment.start_date && (
               <ZUICard
                 header={
-                  <Box
-                    style={{
-                      alignItems: 'center',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                    }}
-                  >
-                    <Typography variant="h5">Report Locked</Typography>
-                    <Switch
-                      checked={!checked}
-                      onChange={(event) => setChecked(!event.target.checked)}
-                    />
-                  </Box>
+                  !checked ? (
+                    <Msg id={messagesIds.report.lockCard.header} />
+                  ) : (
+                    <Msg id={messagesIds.report.lockCard.headerUnlock} />
+                  )
                 }
-                subheader="Protecting report data due to started assignment"
+                status={
+                  <Switch
+                    checked={!checked}
+                    onChange={(event) => setChecked(!event.target.checked)}
+                  />
+                }
+                subheader={
+                  !checked
+                    ? messages.report.lockCard.description()
+                    : messages.report.lockCard.descriptionUnlock()
+                }
                 sx={{ mb: 2 }}
               >
                 {checked && (
                   <Box>
                     <Divider />
-                    <Typography my={1}>Safe changes</Typography>
+                    <Typography my={1}>
+                      <Msg id={messagesIds.report.lockCard.safe} />
+                    </Typography>
                     <Box alignItems="center" display="flex">
                       <Check style={{ color: theme.palette.success.main }} />
-                      <Typography ml={1}>Fix spelling</Typography>
+                      <Typography ml={1}>
+                        <Msg id={messagesIds.report.lockCard.fix} />
+                      </Typography>
                     </Box>
                     <Box alignItems="center" display="flex">
                       <Check style={{ color: theme.palette.success.main }} />
-                      <Typography ml={1}>Reorder questions</Typography>
+                      <Typography ml={1}>
+                        <Msg id={messagesIds.report.lockCard.reorder} />
+                      </Typography>
                     </Box>
                     <Box alignItems="center" display="flex">
                       <Check style={{ color: theme.palette.success.main }} />
-                      <Typography ml={1}>Add questions</Typography>
+                      <Typography ml={1}>
+                        <Msg id={messagesIds.report.lockCard.add} />
+                      </Typography>
                     </Box>
-                    <Typography my={1}>Unsafe changes</Typography>
+                    <Typography my={1}>
+                      <Msg id={messagesIds.report.lockCard.unsafe} />
+                    </Typography>
                     <Box alignItems="start" display="flex">
                       <Close color="error" />
                       <Typography ml={1}>
-                        Rename questions in ways that change their meaning
+                        <Msg id={messagesIds.report.lockCard.rename} />
                       </Typography>
                     </Box>
                     <Box alignItems="start" display="flex">
                       <Close color="error" />
                       <Typography ml={1}>
-                        Change question that defines successful visit
+                        <Msg id={messagesIds.report.lockCard.change} />
                       </Typography>
                     </Box>
                   </Box>

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -10,6 +10,7 @@ import { GetServerSideProps } from 'next';
 import { useContext, useState } from 'react';
 import {
   alpha,
+  Badge,
   Box,
   Button,
   Card,
@@ -249,9 +250,10 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                   <Delete />
                                 </Button>
                               )}
-                            {assignment.metrics.filter(
-                              (metric) => metric.kind === 'boolean'
-                            ).length <= 1 &&
+                            {unlocked &&
+                              assignment.metrics.filter(
+                                (metric) => metric.kind === 'boolean'
+                              ).length <= 1 &&
                               metric.kind == 'boolean' && (
                                 <Tooltip title={messages.report.card.tooltip()}>
                                   <Delete color="disabled" sx={{ mx: 1 }} />
@@ -540,7 +542,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
               sx={{ mb: 2 }}
             >
               <Divider />
-              <FormControl>
+              <FormControl fullWidth>
                 <RadioGroup
                   onChange={(ev) => {
                     const value = ev.target.value;
@@ -550,23 +552,52 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                       });
                     }
                   }}
+                  sx={{ mr: 2 }}
                   value={assignment.reporting_level}
                 >
                   <Typography mt={1}>
                     <Msg id={messagesIds.report.dataCard.info} />
                   </Typography>
-                  <FormControlLabel
-                    control={<Radio disabled={!unlocked} />}
-                    label={messages.report.dataCard.household()}
-                    sx={{ ml: 1 }}
-                    value="household"
-                  />
-                  <FormControlLabel
-                    control={<Radio disabled={!unlocked} />}
-                    label={messages.report.dataCard.location()}
-                    sx={{ ml: 1 }}
-                    value="location"
-                  />
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                  >
+                    <FormControlLabel
+                      control={<Radio disabled={!unlocked} />}
+                      label={messages.report.dataCard.household()}
+                      sx={{ ml: 1 }}
+                      value="household"
+                    />
+                    {unlocked && (
+                      <Badge
+                        badgeContent={
+                          areaAssignmentStats?.num_visited_households
+                        }
+                        color="secondary"
+                      />
+                    )}
+                  </Box>
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    justifyContent="space-between"
+                  >
+                    <FormControlLabel
+                      control={<Radio disabled={!unlocked} />}
+                      label={messages.report.dataCard.location()}
+                      sx={{ ml: 1 }}
+                      value="location"
+                    />
+                    {unlocked && (
+                      <Badge
+                        badgeContent={
+                          areaAssignmentStats?.num_visited_locations
+                        }
+                        color="secondary"
+                      />
+                    )}
+                  </Box>
                 </RadioGroup>
               </FormControl>
             </ZUICard>

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -47,7 +47,6 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { Msg, useMessages } from 'core/i18n';
 import {
   ZetkinAreaAssignment,
-  ZetkinAreaAssignmentStats,
   ZetkinMetric,
 } from 'features/areaAssignments/types';
 
@@ -126,28 +125,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
     });
   };
 
-  const hasVisitedData = (assignment: ZetkinAreaAssignmentStats | null) => {
-    if (!assignment) {
-      return false;
-    }
-    const visitedProperties: (keyof ZetkinAreaAssignmentStats)[] = [
-      'num_visited_areas',
-      'num_visited_households',
-      'num_visited_households_outside_areas',
-      'num_visited_locations',
-      'num_visited_locations_outside_areas',
-    ];
-
-    return visitedProperties.some((prop) => {
-      const value = assignment[prop];
-      return typeof value === 'number' && value > 0;
-    });
-  };
-
-  const lockState = hasVisitedData(areaAssignmentStats);
-  const [unlocked, setUnlocked] = useState(
-    areaAssignmentFuture.data?.start_date ? lockState : true
-  );
+  const [unlocked, setUnlocked] = useState(false);
 
   return (
     <ZUIFuture future={areaAssignmentFuture}>


### PR DESCRIPTION
## Description
This PR adds the logic to lock and unlock an area assignment. The assignment gets locked automatically once it has started. 


## Screenshots
![image](https://github.com/user-attachments/assets/fe0b3f8c-6654-4f44-a0de-b012e70a0a6e)
![image](https://github.com/user-attachments/assets/3fd6d3eb-7ff0-4c88-bfc6-ec59aae3d1c9)




## Changes
* Adds lock/unlock card component and logic
* Use `IconButton ` instead of `Button` component for Delete and Edit buttons 
* Fix minor style issues


## Notes to reviewer
None


## Related issues
Resolves none
