### PR TITLE
Fix URL param bug by forcing pageload

### DIFF
--- a/src/features/organizations/components/OrganizationsList.tsx
+++ b/src/features/organizations/components/OrganizationsList.tsx
@@ -61,15 +61,9 @@ const OrganizationsList = () => {
                       src={`/api/orgs/${orgId}/avatar`}
                       style={{ margin: '15px' }}
                     />
-                    <NextLink
-                      href={`/organize/${orgId}`}
-                      legacyBehavior
-                      passHref
-                    >
-                      <Link underline="hover">
-                        {membership.organization.title}
-                      </Link>
-                    </NextLink>
+                    <Link href={`/organize/${orgId}`} underline="hover">
+                      {membership.organization.title}
+                    </Link>
                   </ListItem>
                 );
               })}


### PR DESCRIPTION
## Description
This PR works around the weird bug that has been causing `orgId` to be undefined on "Projects & Activities" page when navigated to from the organization list. It's solved by changing the list so that it links using regular browser links instead of NEXT.js links. While NEXT.js links listen for clicks, loads page data and re-renders the UI all client-side, regular browser links cause a pageload, which is required for the `orgId` parameter to be there properly.

## Screenshots
None

## Changes
* Removes NEXT.js link

## Notes to reviewer
None

## Related issues
Resolves #2502 