### PR TITLE
Disable save button when length of title input is 0

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/EditHouseholdPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/EditHouseholdPage.tsx
@@ -36,7 +36,7 @@ const EditHouseholdPage: FC<Props> = ({
     <PageBase
       actions={
         <Button
-          disabled={nothingHasBeenEdited}
+          disabled={nothingHasBeenEdited || title.length === 0}
           onClick={() => {
             onSave(title, floor || null);
           }}

--- a/src/features/canvass/components/LocationDialog/pages/EditLocationPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/EditLocationPage.tsx
@@ -38,7 +38,7 @@ const EditLocationPage: FC<EditLocationPageProps> = ({
     <PageBase
       actions={
         <Button
-          disabled={nothingHasBeenEdited}
+          disabled={nothingHasBeenEdited || title.length === 0}
           onClick={() => {
             onSave(title, description);
           }}


### PR DESCRIPTION
## Description
This PR solves #2551 which is a bug on Households. The same bug exists in Locations and is solved by this PR


## Screenshots
![bild](https://github.com/user-attachments/assets/15262c3b-a12d-4e62-8f0a-394df2ba678f)
![bild](https://github.com/user-attachments/assets/2ceb2ade-d375-4a79-8f02-33c629e11291)



## Changes

* Adds conditions for checking the length of new title input to disable the save button


## Notes to reviewer
I assumed the same rules for locations and households. If locations should be able to have empty titles then this PR needs to be modified.


## Related issues
Resolves #2551 
