### PR TITLE
fix: Do not reset zoom level when using GPS positioning

### DIFF
--- a/src/features/areaAssignments/components/MapControls.tsx
+++ b/src/features/areaAssignments/components/MapControls.tsx
@@ -33,12 +33,15 @@ const MapControls: React.FC<MapControlsProps> = ({ map, onFitBounds }) => {
         </Button>
         <Button
           onClick={() => {
+            if (locating) {
+              return;
+            }
             setLocating(true);
             navigator.geolocation.getCurrentPosition(
               (pos) => {
                 setLocating(false);
 
-                const zoom = 16;
+                const zoom = undefined; // We do not want to override the user's zoom level
                 const latLng = {
                   lat: pos.coords.latitude,
                   lng: pos.coords.longitude,


### PR DESCRIPTION
## Description
This PR makes it so that the user's selected zoom level is not changed when they tap the button to center the map on their current location (GPS or similar).


## Screenshots
–


## Changes

* Removes the hard-coded zoom level for panning to the user's current location


## Notes to reviewer
See related issue for detailed reproduction steps


## Related issues
Resolves #2547 
