### PR TITLE
Adds button for email preview in browser

### DIFF
--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -44,7 +44,7 @@ const PreviewTab: FC = () => {
           }
         />
       </Typography>
-      <Button onClick={() => window.open(previewUrl)} variant="contained">
+      <Button href={previewUrl} target="_blank" variant="contained">
         <Msg id={messageIds.editor.settings.tabs.preview.previewInBrowser} />
       </Button>
       <Typography>

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -14,6 +14,7 @@ import messageIds from 'features/emails/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import useCurrentUser from 'features/user/hooks/useCurrentUser';
 import useSendTestEmail from 'features/emails/hooks/useSendTestEmail';
+import usePreviewEmail from 'features/emails/hooks/usePreviewEmail';
 
 const emailAddressIsValid = (emailAddress: string): boolean =>
   z.string().email().safeParse(emailAddress).success;
@@ -21,6 +22,7 @@ const emailAddressIsValid = (emailAddress: string): boolean =>
 const PreviewTab: FC = () => {
   const user = useCurrentUser();
   const { emailWasSent, isLoading, reset, sendTestEmail } = useSendTestEmail();
+  const { previewUrl } = usePreviewEmail();
   const [emailError, setEmailError] = useState(false);
   const [destinationEmailAddress, setDestinationEmailAddress] = useState('');
   useEffect(() => {
@@ -35,6 +37,16 @@ const PreviewTab: FC = () => {
 
   return (
     <Box display="flex" flexDirection="column" gap={2} padding={2}>
+      <Typography>
+        <Msg
+          id={
+            messageIds.editor.settings.tabs.preview.previewInBrowserInstructions
+          }
+        />
+      </Typography>
+      <Button onClick={() => window.open(previewUrl)} variant="contained">
+        <Msg id={messageIds.editor.settings.tabs.preview.previewInBrowser} />
+      </Button>
       <Typography>
         <Msg id={messageIds.editor.settings.tabs.preview.instructions} />
       </Typography>

--- a/src/features/emails/hooks/usePreviewEmail.ts
+++ b/src/features/emails/hooks/usePreviewEmail.ts
@@ -1,0 +1,9 @@
+import { useNumericRouteParams } from 'core/hooks';
+
+export default function usePreviewEmail() {
+  const { emailId, orgId } = useNumericRouteParams();
+
+  return {
+    previewUrl: `/o/${orgId}/viewmail/${emailId}`,
+  };
+}

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -48,11 +48,11 @@ export default makeMessages('feat.emails', {
           okButton: m('OK!'),
           sendButton: m('Send'),
           sendTo: m('The email will be sent to this address:'),
-          title: m('Preview'),
           previewInBrowser: m('Preview in browser'),
           previewInBrowserInstructions: m(
             'Use the button below to preview the email in your browser.'
           ),
+          title: m('Preview'),
         },
         settings: {
           senderAddressInputLabel: m('Sender address'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -49,6 +49,10 @@ export default makeMessages('feat.emails', {
           sendButton: m('Send'),
           sendTo: m('The email will be sent to this address:'),
           title: m('Preview'),
+          previewInBrowser: m('Preview in browser'),
+          previewInBrowserInstructions: m(
+            'Use the button below to preview the email in your browser.'
+          ),
         },
         settings: {
           senderAddressInputLabel: m('Sender address'),

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -46,12 +46,12 @@ export default makeMessages('feat.emails', {
           ),
           invalidEmailAddress: m('This is not a valid email address'),
           okButton: m('OK!'),
-          sendButton: m('Send'),
-          sendTo: m('The email will be sent to this address:'),
           previewInBrowser: m('Preview in browser'),
           previewInBrowserInstructions: m(
             'Use the button below to preview the email in your browser.'
           ),
+          sendButton: m('Send'),
+          sendTo: m('The email will be sent to this address:'),
           title: m('Preview'),
         },
         settings: {


### PR DESCRIPTION
## Description
This PR adds a button to the email preview tab that links to the rendered email in a new window.


## Screenshots
![20250215_14h31m33s_grim](https://github.com/user-attachments/assets/8c905810-a9ef-4838-af22-fab9793a54e7)


## Changes

* Adds in-browser email preview button.


## Notes to reviewer
No notes.


## Related issues
Resolves #2422
