### PR TITLE
Change HouseholdVisitPage to use goto instead of back

### DIFF
--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -200,7 +200,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
                   timestamp: new Date().toISOString(),
                 });
                 setShowSparkle(true);
-                back();
+                goto('households');
               }}
             />
           )}


### PR DESCRIPTION
## Description
This PR changes HouseHoldVisitPage to use goto instead of back


## Screenshots



## Changes

* Changes the function passed to HouseholdsVisitPage


## Notes to reviewer



## Related issues
Resolves #2552 
