### PR TITLE
fix: time offest for multi shift event

### DIFF
--- a/src/features/calendar/components/EventShiftModal/index.tsx
+++ b/src/features/calendar/components/EventShiftModal/index.tsx
@@ -63,12 +63,12 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
 
       let startDate: Dayjs = dayjs(eventDate);
       startDate = startDate
-        .set('hour', shift.hour() + 2)
+        .set('hour', shift.hour() + 1)
         .set('minute', shift.minute());
 
       let endDate: Dayjs = dayjs(eventDate);
       endDate = endDate
-        .set('hour', endTime.hour() + 2)
+        .set('hour', endTime.hour() + 1)
         .set('minute', endTime.minute());
 
       const now = dayjs();


### PR DESCRIPTION
## Description
This PR updates the calculation of the `startDate` and `endDate` for multi shift event. 
The error occured as the `dates` prop of the `EventShiftModal` is in the `GMT` / `UTC+1` timezone.
If we then call `createEvent` we are using `dayjs().toISOString` which will format the date to `UTC`.
Therefore, we have to add one hour offset to the `startDate` / `endDate`.

## Screenshots
Old behaviour: If we create an multi shift event it is one hour off of the scheduled time.

https://github.com/user-attachments/assets/638e6651-e1fa-484f-8652-16dcb2addad9

New behaviour: The event takes place at the scheduled time.

https://github.com/user-attachments/assets/646bf51f-5c89-4258-84e7-64fcdad24d36

## Changes

* Fixes the offset of the `startDate` / `endDate`


## Notes to reviewer
The fix should be fine for now, as long as we don't use the local time of a given user.
Then the hardcoded time offest will again cause troubles.


## Related issues
Resolves #2555 
