### PR TITLE
Fix sticky header

### DIFF
--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -25,7 +25,7 @@ interface StyleProps {
 
 const useStyles = makeStyles<Theme, StyleProps>(() => ({
   main: {
-    overflowX: 'hidden',
+    overflow: 'hidden',
     padding: ({ noPad }) => (noPad ? 0 : undefined),
   },
 }));
@@ -122,7 +122,6 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
         display="flex"
         flexDirection="column"
         height={fixedHeight ? 1 : 'auto'}
-        minHeight="100vh"
       >
         <Header
           actionButtons={actionButtons}


### PR DESCRIPTION

## Description
This PR fixes the header always  being  sticky. Header will be sticky only if `fixedHeight `property is true, otherwise the header will scroll with the content vertically if necessary. 


## Screenshots
FixedHeight is false:
![image](https://github.com/user-attachments/assets/f1505a6b-0263-4919-879e-38adae9c665c)


FixedHeight is true:
![image](https://github.com/user-attachments/assets/6299625f-adae-4738-8ba0-31054396f1e0)



## Changes
* Removes `minHeight `property 
* Adds `overflow: hidden` property in `main `container to avoid scrollbar in inner container


## Notes to reviewer
None

## Related issues
Resolves #2567 
