### PR TITLE
Change Canvass Assignment button label in Activist Portal

### DIFF
--- a/src/features/home/l10n/messageIds.ts
+++ b/src/features/home/l10n/messageIds.ts
@@ -3,7 +3,7 @@ import { m, makeMessages } from 'core/i18n/messages';
 export default makeMessages('feat.home', {
   activityList: {
     actions: {
-      areaAssignment: m('Start assignment'),
+      areaAssignment: m('Join'),
       call: m('Start calling'),
       signUp: m('Sign up'),
       undoSignup: m('Undo signup'),


### PR DESCRIPTION
## Description
This PR changes the button label to join a canvass assignemnt in the activist portal.


## Screenshots
![image](https://github.com/user-attachments/assets/48c5e2c7-23c6-4f3d-91ee-b6af1969ba9e)


## Changes
* Changes button label fomr "Start assignment" to "Join"


## Notes to reviewer
none

## Related issues
Resolves #2527 
