### PR TITLE
ZUIAvatarGroup

### DIFF
--- a/src/zui/components/ZUIAvatarGroup/index.stories.tsx
+++ b/src/zui/components/ZUIAvatarGroup/index.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUIAvatarGroup from './index';
+
+const meta: Meta<typeof ZUIAvatarGroup> = {
+  component: ZUIAvatarGroup,
+  title: 'Components/ZUIAvatarGroup',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIAvatarGroup>;
+
+export const Basic: Story = {
+  args: {
+    avatars: [
+      { firstName: 'Angela', id: 1, lastName: 'Davis' },
+      { firstName: 'James', id: 2, lastName: 'Dean' },
+      { firstName: 'Georg', id: 3, lastName: 'Schneider' },
+      { firstName: 'Bernie', id: 4, lastName: 'Sanders' },
+      { firstName: 'Peder', id: 5, lastName: 'Kofoed' },
+    ],
+  },
+};
+
+export const Max: Story = {
+  args: {
+    ...Basic.args,
+    max: 4,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    ...Basic.args,
+    max: 4,
+    size: 'small',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    ...Basic.args,
+    max: 3,
+    size: 'large',
+  },
+};
+
+export const Square: Story = {
+  args: {
+    ...Basic.args,
+    max: 4,
+    variant: 'square',
+  },
+};

--- a/src/zui/components/ZUIAvatarGroup/index.tsx
+++ b/src/zui/components/ZUIAvatarGroup/index.tsx
@@ -5,13 +5,28 @@ import ZUIAvatar from '../ZUIAvatar';
 import { ZUISize } from '../types';
 
 type ZUIAvatarGroupProps = {
+  /**
+   * List of the people you want to display as avatars.
+   */
   avatars: {
     firstName: string;
     id: number;
     lastName: string;
   }[];
+
+  /**
+   * Maximum number of avatars shown.
+   */
   max?: number;
+
+  /**
+   * The size of the avatars. Defaults to 'medium'.
+   */
   size?: ZUISize;
+
+  /**
+   * The shape of the avatars. Defaults to 'circular.
+   */
   variant?: 'circular' | 'square';
 };
 

--- a/src/zui/components/ZUIAvatarGroup/index.tsx
+++ b/src/zui/components/ZUIAvatarGroup/index.tsx
@@ -48,7 +48,8 @@ const ZUIAvatarGroup: FC<ZUIAvatarGroupProps> = ({
     fontSize = '1rem';
   }
 
-  const showOverflowNumber = max && max < avatars.length;
+  const showOverflowNumber = !!max && max < avatars.length;
+
   return (
     <Box display="flex" gap="0.25rem">
       {avatars.map((avatar, index) => {

--- a/src/zui/components/ZUIAvatarGroup/index.tsx
+++ b/src/zui/components/ZUIAvatarGroup/index.tsx
@@ -1,0 +1,77 @@
+import { Box, Typography, useTheme } from '@mui/material';
+import { FC } from 'react';
+
+import ZUIAvatar from '../ZUIAvatar';
+import { ZUISize } from '../types';
+
+type ZUIAvatarGroupProps = {
+  avatars: {
+    firstName: string;
+    id: number;
+    lastName: string;
+  }[];
+  max?: number;
+  size?: ZUISize;
+  variant?: 'circular' | 'square';
+};
+
+const ZUIAvatarGroup: FC<ZUIAvatarGroupProps> = ({
+  avatars,
+  max,
+  size = 'medium',
+  variant = 'circular',
+}) => {
+  const theme = useTheme();
+
+  let avatarSize = '2rem';
+  let fontSize = '0.875rem';
+  if (size == 'small') {
+    avatarSize = '1.5rem';
+    fontSize = '0.625rem';
+  } else if (size == 'large') {
+    avatarSize = '3rem';
+    fontSize = '1rem';
+  }
+
+  const showOverflowNumber = max && max < avatars.length;
+  return (
+    <Box display="flex" gap="0.25rem">
+      {avatars.map((avatar, index) => {
+        if (showOverflowNumber && index > max - 2) {
+          return;
+        }
+        return (
+          <ZUIAvatar
+            key={avatar.id}
+            firstName={avatar.firstName}
+            id={avatar.id}
+            lastName={avatar.lastName}
+            size={size}
+            variant={variant}
+          />
+        );
+      })}
+      {showOverflowNumber && (
+        <Box
+          alignItems="center"
+          bgcolor={theme.palette.grey[100]}
+          borderRadius={variant == 'circular' ? 100 : '0.25rem'}
+          display="flex"
+          height={avatarSize}
+          justifyContent="center"
+          width={avatarSize}
+        >
+          <Typography
+            fontFamily={theme.typography.fontFamily}
+            fontSize={fontSize}
+            fontWeight={500}
+          >
+            {'+' + (avatars.length - max + 1)}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ZUIAvatarGroup;


### PR DESCRIPTION
## Description
This PR adds a ZUIAvatarGroup component that displays avatars grouped, with an optional "overflow number" of how many avatars are not being shown.


## Screenshots
![bild](https://github.com/user-attachments/assets/560f2639-87f6-4639-8847-c8ff7850179d)
![bild](https://github.com/user-attachments/assets/dd11bb16-21fa-41be-ad95-b6aa9aa697ff)
![bild](https://github.com/user-attachments/assets/5ff81a35-0ebf-4d2f-b094-f955e0d01e86)

## Changes
* Adds `ZUIAvatarGroup` component + storybook stories

## Notes to reviewer
There was not design for the sizes of the text in the "overflow number" for small or medium, so I improvised, feedback very welcome :) 


## Related issues
none
