### PR TITLE
Call scaffolding + prepare page

### DIFF
--- a/src/app/call/[callAssId]/layout.tsx
+++ b/src/app/call/[callAssId]/layout.tsx
@@ -1,0 +1,13 @@
+import { FC, ReactNode } from 'react';
+
+import CallLayout from 'features/call/layouts/CallLayout';
+
+type Props = {
+  children?: ReactNode;
+};
+
+const CallPageLayout: FC<Props> = ({ children }) => {
+  return <CallLayout>{children}</CallLayout>;
+};
+
+export default CallPageLayout;

--- a/src/app/call/[callAssId]/page.tsx
+++ b/src/app/call/[callAssId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { CALL, hasFeature } from 'utils/featureFlags';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
+import AssignmentDetailsPage from 'features/call/pages/AssignmentDetailsPage';
 
 interface PageProps {
   params: {
@@ -28,7 +29,7 @@ export default async function Page({ params }: PageProps) {
   }
 
   if (hasFeature(CALL, assignment.organization.id, process.env)) {
-    return <h1>YES</h1>;
+    return <AssignmentDetailsPage assignment={assignment} />;
   } else {
     const callUrl = process.env.ZETKIN_GEN2_CALL_URL;
     const assignmentUrl = `${callUrl}/assignments/${params.callAssId}/call`;

--- a/src/app/call/[callAssId]/page.tsx
+++ b/src/app/call/[callAssId]/page.tsx
@@ -1,4 +1,9 @@
-import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { CALL, hasFeature } from 'utils/featureFlags';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
 
 interface PageProps {
   params: {
@@ -7,7 +12,26 @@ interface PageProps {
 }
 
 export default async function Page({ params }: PageProps) {
-  const callUrl = process.env.ZETKIN_GEN2_CALL_URL;
-  const assignmentUrl = callUrl + '/assignments/' + params.callAssId;
-  redirect(assignmentUrl);
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+  const assignments = await apiClient.get<ZetkinCallAssignment[]>(
+    '/api/users/me/call_assignments'
+  );
+  const assignment = assignments.find(
+    (assignment) => assignment.id == parseInt(params.callAssId)
+  );
+
+  if (!assignment) {
+    return notFound();
+  }
+
+  if (hasFeature(CALL, assignment.organization.id, process.env)) {
+    return <h1>YES</h1>;
+  } else {
+    const callUrl = process.env.ZETKIN_GEN2_CALL_URL;
+    const assignmentUrl = `${callUrl}/assignments/${params.callAssId}/call`;
+    redirect(assignmentUrl);
+  }
 }

--- a/src/app/call/[callAssId]/prepare/page.tsx
+++ b/src/app/call/[callAssId]/prepare/page.tsx
@@ -1,0 +1,34 @@
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+
+import AssignmentPreparePage from 'features/call/pages/AssignmentPreparePage';
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
+import { CALL, hasFeature } from 'utils/featureFlags';
+
+interface PageProps {
+  params: {
+    callAssId: string;
+  };
+}
+
+export default async function Page({ params }: PageProps) {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+  const assignments = await apiClient.get<ZetkinCallAssignment[]>(
+    '/api/users/me/call_assignments'
+  );
+  const assignment = assignments.find(
+    (assignment) => assignment.id == parseInt(params.callAssId)
+  );
+
+  if (!assignment) {
+    return notFound();
+  }
+
+  if (hasFeature(CALL, assignment.organization.id, process.env)) {
+    return <AssignmentPreparePage assignment={assignment} />;
+  }
+}

--- a/src/core/caching/shouldLoad.ts
+++ b/src/core/caching/shouldLoad.ts
@@ -44,20 +44,20 @@ export default function shouldLoad(
   /**
    * The remote object to check.
    */
-  item: RemoteItem<unknown> | RemoteList<unknown> | undefined
+  item: RemoteItem<unknown> | RemoteList<unknown> | undefined | null
 ): boolean;
 /**
  * @category Cache
  */
 export default function shouldLoad(
-  item: RemoteObjectRecord | undefined,
+  item: RemoteObjectRecord | undefined | null,
   ids: number[]
 ): boolean;
 /**
  * @category Cache
  */
 export default function shouldLoad(
-  item: ObjThatNeedsLoading,
+  item: ObjThatNeedsLoading | null,
   idsOrVoid?: number[]
 ): boolean {
   if (!item) {

--- a/src/core/hooks/useRemoteItem.spec.tsx
+++ b/src/core/hooks/useRemoteItem.spec.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, render } from '@testing-library/react';
+import { FC, Suspense } from 'react';
+import { Provider as ReduxProvider, useSelector } from 'react-redux';
+import { configureStore, PayloadAction } from '@reduxjs/toolkit';
+
+import { RemoteItem, remoteItem } from 'utils/storeUtils';
+import useRemoteItem from './useRemoteItem';
+
+type ItemObjectForTest = { id: number; name: string };
+type StoreState = {
+  item: RemoteItem<ItemObjectForTest> | null;
+};
+
+describe('useRemoteItem()', () => {
+  it('triggers a load when the data has not yet been loaded', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent();
+
+    const { queryByText } = render();
+
+    expect(queryByText('loading')).not.toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+    expect(store.dispatch).toHaveBeenNthCalledWith(1, {
+      payload: 1,
+      type: 'load',
+    });
+    expect(store.dispatch).toHaveBeenNthCalledWith(2, {
+      payload: { id: 1, name: 'Clara Zetkin' },
+      type: 'loaded',
+    });
+
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('loaded')).not.toBeNull();
+  });
+
+  it('returns data without load when the data has been loaded recently', async () => {
+    const { hooks, render, store } = setupWrapperComponent({
+      ...remoteItem(1, {
+        data: {
+          id: 1,
+          name: 'Clara Zetkin',
+        },
+      }),
+      loaded: new Date().toISOString(),
+    });
+
+    const { queryByText } = render();
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(hooks.loader).not.toHaveBeenCalled();
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('loaded')).not.toBeNull();
+
+    const listItem = queryByText('Clara Zetkin');
+    expect(listItem).not.toBeNull();
+  });
+
+  it('returns stale data while re-loading', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent({
+      ...remoteItem(1, {
+        data: {
+          id: 1,
+          name: 'Clara Zetkin',
+        },
+      }),
+      loaded: new Date(1857, 6, 5).toISOString(),
+    });
+
+    const { queryByText } = render();
+
+    expect(queryByText('Clara Zetkin')).not.toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+  });
+});
+
+function setupWrapperComponent(initialItem?: RemoteItem<ItemObjectForTest>) {
+  const store = configureStore<StoreState>({
+    preloadedState: {
+      item: initialItem || null,
+    },
+    reducer: (state, anyAction) => {
+      if (anyAction.type == 'load') {
+        const action = anyAction as PayloadAction<number>;
+        return {
+          item: remoteItem<ItemObjectForTest>(action.payload, {
+            data: state?.item?.data ?? null,
+            isLoading: true,
+            loaded: null,
+          }),
+        };
+      } else if (anyAction.type == 'loaded') {
+        const action = anyAction as PayloadAction<ItemObjectForTest>;
+        return {
+          item: remoteItem(action.payload.id, {
+            data: action.payload,
+            isLoading: false,
+            loaded: new Date().toISOString(),
+          }),
+        };
+      }
+
+      return (
+        state || {
+          item: null,
+        }
+      );
+    },
+  });
+  jest.spyOn(store, 'dispatch');
+
+  const promise = Promise.resolve({ id: 1, name: 'Clara Zetkin' });
+
+  const hooks = {
+    actionOnLoad: () => ({ payload: 1, type: 'load' }),
+    actionOnSuccess: (data: ItemObjectForTest) => ({
+      payload: data,
+      type: 'loaded',
+    }),
+    loader: () => promise,
+  };
+
+  jest.spyOn(hooks, 'loader');
+
+  const Component: FC = () => {
+    const item = useSelector<StoreState, RemoteItem<ItemObjectForTest> | null>(
+      (state) => state.item
+    );
+
+    const data = useRemoteItem(item, hooks);
+
+    return (
+      <div>
+        <p>loaded</p>
+        <small>{data.name}</small>
+      </div>
+    );
+  };
+
+  return {
+    hooks,
+    promise,
+    render: () =>
+      render(
+        <ReduxProvider store={store}>
+          <Suspense fallback={<p>loading</p>}>
+            <Component />
+          </Suspense>
+        </ReduxProvider>
+      ),
+    store,
+  };
+}

--- a/src/core/hooks/useRemoteItem.ts
+++ b/src/core/hooks/useRemoteItem.ts
@@ -1,0 +1,50 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import shouldLoad from 'core/caching/shouldLoad';
+import { RemoteItem } from 'utils/storeUtils';
+import { useAppDispatch } from '.';
+
+export default function useRemoteItem<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType
+>(
+  remoteItem: RemoteItem<DataType> | undefined | null,
+  hooks: {
+    actionOnError?: (err: unknown) => PayloadAction<unknown>;
+    actionOnLoad: () => PayloadAction<OnLoadPayload>;
+    actionOnSuccess: (items: DataType) => PayloadAction<OnSuccessPayload>;
+    isNecessary?: () => boolean;
+    loader: () => Promise<DataType>;
+  }
+): DataType {
+  const dispatch = useAppDispatch();
+  const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteItem);
+
+  if (loadIsNecessary) {
+    dispatch(hooks.actionOnLoad());
+
+    const promise = hooks
+      .loader()
+      .then((data) => {
+        dispatch(hooks.actionOnSuccess(data));
+      })
+      .catch((err) => {
+        if (hooks.actionOnError) {
+          dispatch(hooks.actionOnError(err));
+        }
+      });
+
+    if (remoteItem?.data) {
+      return remoteItem.data;
+    } else {
+      throw promise;
+    }
+  }
+
+  if (!remoteItem?.data) {
+    throw new Error('Item not loading or loaded');
+  }
+
+  return remoteItem.data;
+}

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -55,11 +55,13 @@ import areaAssignmentSlice, {
   AreaAssignmentsStoreSlice,
 } from 'features/areaAssignments/store';
 import canvassSlice, { CanvassStoreSlice } from 'features/canvass/store';
+import callSlice, { CallStoreSlice } from 'features/call/store';
 
 export interface RootState {
   areaAssignments: AreaAssignmentsStoreSlice;
   areas: AreasStoreSlice;
   breadcrumbs: BreadcrumbsStoreSlice;
+  call: CallStoreSlice;
   callAssignments: CallAssignmentSlice;
   campaigns: CampaignsStoreSlice;
   canvass: CanvassStoreSlice;
@@ -86,6 +88,7 @@ const reducer = {
   areaAssignments: areaAssignmentSlice.reducer,
   areas: areasSlice.reducer,
   breadcrumbs: breadcrumbsSlice.reducer,
+  call: callSlice.reducer,
   callAssignments: callAssignmentsSlice.reducer,
   campaigns: campaignsSlice.reducer,
   canvass: canvassSlice.reducer,

--- a/src/features/call/components/AssignmentStats.tsx
+++ b/src/features/call/components/AssignmentStats.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { FC } from 'react';
+import { Box } from '@mui/material';
+
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
+import useSimpleCallAssignmentStats from '../hooks/useSimpleCallAssignmentStats';
+import AssignmentStatsCard from './AssignmentStatsCard';
+import { useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+
+type Props = {
+  assignment: ZetkinCallAssignment;
+};
+
+const AssignmentStats: FC<Props> = ({ assignment }) => {
+  const messages = useMessages(messageIds);
+  const stats = useSimpleCallAssignmentStats(
+    assignment.organization.id,
+    assignment.id
+  );
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2 }}>
+      <AssignmentStatsCard
+        amount={stats.num_target_matches}
+        label={messages.stats.targetMatches()}
+      />
+      <AssignmentStatsCard
+        amount={stats.num_calls_made}
+        label={messages.stats.callsMade()}
+      />
+      <AssignmentStatsCard
+        amount={stats.num_calls_reached}
+        label={messages.stats.callsReached()}
+      />
+    </Box>
+  );
+};
+
+export default AssignmentStats;

--- a/src/features/call/components/AssignmentStatsCard.tsx
+++ b/src/features/call/components/AssignmentStatsCard.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Box, Typography } from '@mui/material';
+import { FC } from 'react';
+
+type Props = {
+  amount: number;
+  label: string;
+};
+
+const AssignmentStatsCard: FC<Props> = ({ amount, label }) => {
+  return (
+    <Box sx={{ minWidth: 200, p: 2 }}>
+      <Typography variant="h2">{amount}</Typography>
+      <Typography variant="body2">{label}</Typography>
+    </Box>
+  );
+};
+
+export default AssignmentStatsCard;

--- a/src/features/call/hooks/useActiveCampaigns.ts
+++ b/src/features/call/hooks/useActiveCampaigns.ts
@@ -1,0 +1,27 @@
+import { IFuture } from 'core/caching/futures';
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+import { ZetkinAction } from '../types';
+import { activeCampaignsLoad, activeCampaignsLoaded } from '../store';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+
+export default function useActiveCampaigns(
+  orgId: number
+): IFuture<ZetkinAction[]> {
+  const apiClient = useApiClient();
+  const list = useAppSelector((state) => state.call.activeCampaignsList);
+  const dispatch = useAppDispatch();
+
+  const todaysDate = new Date().toISOString().split('T')[0];
+
+  const activeCampaignsList = loadListIfNecessary(list, dispatch, {
+    actionOnLoad: () => activeCampaignsLoad(),
+    actionOnSuccess: (data) => activeCampaignsLoaded(data),
+    loader: () => {
+      const filterParam = encodeURIComponent(`start_time>${todaysDate}`);
+      const url = `/api/orgs/${orgId}/actions?filter=${filterParam}`;
+      return apiClient.get<ZetkinAction[]>(url);
+    },
+  });
+
+  return activeCampaignsList;
+}

--- a/src/features/call/hooks/useActiveEvents.ts
+++ b/src/features/call/hooks/useActiveEvents.ts
@@ -1,17 +1,15 @@
-import { IFuture } from 'core/caching/futures';
-import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { activeEventsLoad, activeEventsLoaded } from '../store';
-import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { useApiClient, useAppSelector } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
+import useRemoteList from 'core/hooks/useRemoteList';
 
-export default function useActiveEvents(orgId: number): IFuture<ZetkinEvent[]> {
+export default function useActiveEvents(orgId: number): ZetkinEvent[] {
   const apiClient = useApiClient();
   const list = useAppSelector((state) => state.call.activeEventList);
-  const dispatch = useAppDispatch();
 
   const todaysDate = new Date().toISOString().split('T')[0];
 
-  const activeCampaignsList = loadListIfNecessary(list, dispatch, {
+  const activeEventsList = useRemoteList(list, {
     actionOnLoad: () => activeEventsLoad(),
     actionOnSuccess: (data) => activeEventsLoaded(data),
     loader: () => {
@@ -21,5 +19,5 @@ export default function useActiveEvents(orgId: number): IFuture<ZetkinEvent[]> {
     },
   });
 
-  return activeCampaignsList;
+  return activeEventsList;
 }

--- a/src/features/call/hooks/useActiveEvents.ts
+++ b/src/features/call/hooks/useActiveEvents.ts
@@ -9,7 +9,7 @@ export default function useActiveEvents(orgId: number): ZetkinEvent[] {
 
   const todaysDate = new Date().toISOString().split('T')[0];
 
-  const activeEventsList = useRemoteList(list, {
+  return useRemoteList(list, {
     actionOnLoad: () => activeEventsLoad(),
     actionOnSuccess: (data) => activeEventsLoaded(data),
     loader: () => {
@@ -18,6 +18,4 @@ export default function useActiveEvents(orgId: number): ZetkinEvent[] {
       return apiClient.get<ZetkinEvent[]>(url);
     },
   });
-
-  return activeEventsList;
 }

--- a/src/features/call/hooks/useActiveEvents.ts
+++ b/src/features/call/hooks/useActiveEvents.ts
@@ -1,25 +1,23 @@
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { ZetkinAction } from '../types';
-import { activeCampaignsLoad, activeCampaignsLoaded } from '../store';
+import { activeEventsLoad, activeEventsLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { ZetkinEvent } from 'utils/types/zetkin';
 
-export default function useActiveCampaigns(
-  orgId: number
-): IFuture<ZetkinAction[]> {
+export default function useActiveEvents(orgId: number): IFuture<ZetkinEvent[]> {
   const apiClient = useApiClient();
-  const list = useAppSelector((state) => state.call.activeCampaignsList);
+  const list = useAppSelector((state) => state.call.activeEventList);
   const dispatch = useAppDispatch();
 
   const todaysDate = new Date().toISOString().split('T')[0];
 
   const activeCampaignsList = loadListIfNecessary(list, dispatch, {
-    actionOnLoad: () => activeCampaignsLoad(),
-    actionOnSuccess: (data) => activeCampaignsLoaded(data),
+    actionOnLoad: () => activeEventsLoad(),
+    actionOnSuccess: (data) => activeEventsLoaded(data),
     loader: () => {
       const filterParam = encodeURIComponent(`start_time>${todaysDate}`);
       const url = `/api/orgs/${orgId}/actions?filter=${filterParam}`;
-      return apiClient.get<ZetkinAction[]>(url);
+      return apiClient.get<ZetkinEvent[]>(url);
     },
   });
 

--- a/src/features/call/hooks/useCallWithTarget.ts
+++ b/src/features/call/hooks/useCallWithTarget.ts
@@ -1,0 +1,24 @@
+import useRemoteItem from 'core/hooks/useRemoteItem';
+import { ZetkinCall } from '../types';
+import { currentCallLoad, currentCallLoaded } from '../store';
+import { useApiClient, useAppSelector } from 'core/hooks';
+
+export default function useCallWithTarget(
+  orgId: number,
+  assignmentId: number
+): ZetkinCall {
+  const apiClient = useApiClient();
+  const callItem = useAppSelector((state) => state.call.currentCall);
+
+  const callWithTarget = useRemoteItem(callItem, {
+    actionOnLoad: () => currentCallLoad(),
+    actionOnSuccess: (data) => currentCallLoaded(data),
+    loader: () =>
+      apiClient.post<ZetkinCall>(
+        `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
+        {}
+      ),
+  });
+
+  return callWithTarget;
+}

--- a/src/features/call/hooks/useSimpleCallAssignmentStats.ts
+++ b/src/features/call/hooks/useSimpleCallAssignmentStats.ts
@@ -1,0 +1,26 @@
+import { useApiClient, useAppSelector } from 'core/hooks';
+import useRemoteItem from 'core/hooks/useRemoteItem';
+import { ZetkinCallAssignmentStats } from 'features/callAssignments/apiTypes';
+import {
+  simpleStatsLoad,
+  simpleStatsLoaded,
+} from 'features/callAssignments/store';
+
+export default function useSimpleCallAssignmentStats(
+  orgId: number,
+  assignmentId: number
+): ZetkinCallAssignmentStats & { id: number } {
+  const apiClient = useApiClient();
+  const statsItem = useAppSelector(
+    (state) => state.callAssignments.simpleStatsById[assignmentId]
+  );
+
+  return useRemoteItem(statsItem, {
+    actionOnLoad: () => simpleStatsLoad(assignmentId),
+    actionOnSuccess: (data) => simpleStatsLoaded([assignmentId, data]),
+    loader: () =>
+      apiClient.get<ZetkinCallAssignmentStats & { id: number }>(
+        `/api/orgs/${orgId}/call_assignments/${assignmentId}/stats`
+      ),
+  });
+}

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -10,27 +10,27 @@ export default makeMessages('feat.call', {
   },
   prepare: {
     activeCampaigns: m('Active campaigns'),
-    arePreviousActivity: m<{
-      actionTitle: string;
-      activities: number;
-      name: string;
-    }>(
-      '{name} participated in {activities} actions, the most recent being {actionTitle} {actionTime}.'
-    ),
-    arePreviousCalls: m('There are previous calls.'),
     edit: m('Edit this information?'),
     editDescription: m(
       'If something in this tab needs changing, write a message to the organizer in the report after finishing the call.'
     ),
     noActiveCampaigns: m('No active campaigns.'),
-    noPreviousActivity: m<{ name: string }>(
-      '{name} never participated in any actions.'
-    ),
     noPreviousCalls: m('Never called'),
+    noPreviousEvents: m<{ name: string }>(
+      '{name} never participated in any events.'
+    ),
     noSurveys: m('No surveys'),
     noTags: m('No tags'),
-    previousActivity: m('Previous activity'),
-    previousCalls: m<{ name: string }>('Previous calls to {name}.'),
+    previousCalls: m('There are previous calls.'),
+    previousCallsOfTarget: m<{ name: string }>('Previous calls to {name}.'),
+    previousEvents: m('Previous events'),
+    previousEventsOfTarget: m<{
+      eventTitle: string;
+      name: string;
+      numEvents: number;
+    }>(
+      '{name} participated in {numEvents} events, the most recent being {eventTitle} .'
+    ),
     summary: m('Summary'),
     surveys: m('Surveys'),
     tags: m('Tags'),

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -1,6 +1,9 @@
 import { m, makeMessages } from 'core/i18n';
 
 export default makeMessages('feat.call', {
+  instructions: {
+    title: m('Instructions'),
+  },
   nav: {
     backToHome: m('Back to home'),
     startCalling: m('Start calling'),

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -8,6 +8,34 @@ export default makeMessages('feat.call', {
     backToHome: m('Back to home'),
     startCalling: m('Start calling'),
   },
+  prepare: {
+    activeCampaigns: m('Active campaigns'),
+    arePreviousActivity: m<{
+      actionTitle: string;
+      activities: number;
+      name: string;
+    }>(
+      '{name} participated in {activities} actions, the most recent being {actionTitle} {actionTime}.'
+    ),
+    arePreviousCalls: m('There are previous calls.'),
+    edit: m('Edit this information?'),
+    editDescription: m(
+      'If something in this tab needs changing, write a message to the organizer in the report after finishing the call.'
+    ),
+    noActiveCampaigns: m('No active campaigns.'),
+    noPreviousActivity: m<{ name: string }>(
+      '{name} never participated in any actions.'
+    ),
+    noPreviousCalls: m('Never called'),
+    noSurveys: m('No surveys'),
+    noTags: m('No tags'),
+    previousActivity: m('Previous activity'),
+    previousCalls: m<{ name: string }>('Previous calls to {name}.'),
+    summary: m('Summary'),
+    surveys: m('Surveys'),
+    tags: m('Tags'),
+    title: m('Personal info'),
+  },
   stats: {
     callsMade: m('calls made'),
     callsReached: m('successful calls'),

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -1,0 +1,8 @@
+import { m, makeMessages } from 'core/i18n';
+
+export default makeMessages('feat.call', {
+  nav: {
+    backToHome: m('Back to home'),
+    startCalling: m('Start calling'),
+  },
+});

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -5,4 +5,9 @@ export default makeMessages('feat.call', {
     backToHome: m('Back to home'),
     startCalling: m('Start calling'),
   },
+  stats: {
+    callsMade: m('calls made'),
+    callsReached: m('successful calls'),
+    targetMatches: m('people in target group'),
+  },
 });

--- a/src/features/call/layouts/CallLayout.tsx
+++ b/src/features/call/layouts/CallLayout.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Box, Button } from '@mui/material';
+import Link from 'next/link';
+import { FC, ReactNode } from 'react';
+
+import { Msg } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+
+type Props = {
+  children?: ReactNode;
+};
+
+const CallLayout: FC<Props> = ({ children }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          p: 2,
+        }}
+      >
+        <Link href="/my/home" passHref>
+          <Button variant="outlined">
+            <Msg id={messageIds.nav.backToHome} />
+          </Button>
+        </Link>
+        <Button variant="contained">
+          <Msg id={messageIds.nav.startCalling} />
+        </Button>
+      </Box>
+      <Box>{children}</Box>
+    </Box>
+  );
+};
+
+export default CallLayout;

--- a/src/features/call/pages/AssignmentDetailsPage.tsx
+++ b/src/features/call/pages/AssignmentDetailsPage.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { FC, Suspense } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
+import AssignmentStats from '../components/AssignmentStats';
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+
+type Props = {
+  assignment: ZetkinCallAssignment;
+};
+
+const AssignmentDetailsPage: FC<Props> = ({ assignment }) => {
+  return (
+    <Box>
+      <Typography variant="h4">{assignment.title}</Typography>
+      {!!assignment.description.length && (
+        <Typography variant="body1">{assignment.description}</Typography>
+      )}
+      <Suspense fallback={<ZUILogoLoadingIndicator />}>
+        <AssignmentStats assignment={assignment} />
+      </Suspense>
+    </Box>
+  );
+};
+
+export default AssignmentDetailsPage;

--- a/src/features/call/pages/AssignmentDetailsPage.tsx
+++ b/src/features/call/pages/AssignmentDetailsPage.tsx
@@ -3,9 +3,12 @@
 import { FC, Suspense } from 'react';
 import { Box, Typography } from '@mui/material';
 
-import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import AssignmentStats from '../components/AssignmentStats';
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+import ZUIMarkdown from 'zui/ZUIMarkdown';
 
 type Props = {
   assignment: ZetkinCallAssignment;
@@ -13,14 +16,24 @@ type Props = {
 
 const AssignmentDetailsPage: FC<Props> = ({ assignment }) => {
   return (
-    <Box>
-      <Typography variant="h4">{assignment.title}</Typography>
-      {!!assignment.description.length && (
-        <Typography variant="body1">{assignment.description}</Typography>
-      )}
-      <Suspense fallback={<ZUILogoLoadingIndicator />}>
-        <AssignmentStats assignment={assignment} />
-      </Suspense>
+    <Box display="flex">
+      <Box>
+        <Typography variant="h4">{assignment.title}</Typography>
+        {!!assignment.description.length && (
+          <Typography variant="body1">{assignment.description}</Typography>
+        )}
+        <Suspense fallback={<ZUILogoLoadingIndicator />}>
+          <AssignmentStats assignment={assignment} />
+        </Suspense>
+      </Box>
+      <Box>
+        <Typography variant="h5">
+          <Msg id={messageIds.instructions.title} />
+        </Typography>
+        <Typography>
+          <ZUIMarkdown markdown={assignment.instructions} />
+        </Typography>
+      </Box>
     </Box>
   );
 };

--- a/src/features/call/pages/AssignmentPreparePage.tsx
+++ b/src/features/call/pages/AssignmentPreparePage.tsx
@@ -5,7 +5,7 @@ import { FC, Suspense } from 'react';
 
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
-import useActiveCampaigns from '../hooks/useActiveCampaigns';
+import useActiveEvents from '../hooks/useActiveEvents';
 import useCallWithTarget from '../hooks/useCallWithTarget';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
@@ -19,7 +19,7 @@ type Props = {
 const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
   const call = useCallWithTarget(assignment.organization.id, assignment.id);
   const surveys = useSurveys(assignment.id).data || [];
-  const campaigns = useActiveCampaigns(assignment.organization.id).data || [];
+  const events = useActiveEvents(assignment.organization.id).data || [];
 
   return (
     <Box display="flex" gap={2}>
@@ -77,7 +77,8 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
                   id={messageIds.prepare.previousEventsOfTarget}
                   values={{
                     eventTitle:
-                      call.target.past_actions.last_action.activity.title || '',
+                      call.target.past_actions.last_action.activity?.title ||
+                      '',
                     name: call.target.first_name,
                     numEvents: call.target.past_actions.num_actions,
                   }}
@@ -113,18 +114,14 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
           <Typography variant="h5">
             <Msg id={messageIds.prepare.activeCampaigns} />
           </Typography>
-          {campaigns.length == 0 && (
+          {events.length == 0 && (
             <Typography>
               <Msg id={messageIds.prepare.noActiveCampaigns} />
             </Typography>
           )}
-          {campaigns.length > 0 &&
-            campaigns.map((campaign) => {
-              return (
-                <Typography key={campaign.id}>
-                  {campaign.campaign.title}
-                </Typography>
-              );
+          {events.length > 0 &&
+            events.map((event) => {
+              return <Typography key={event.id}>{event.title}</Typography>;
             })}
           <Box mt={2}>
             <Typography variant="h5">

--- a/src/features/call/pages/AssignmentPreparePage.tsx
+++ b/src/features/call/pages/AssignmentPreparePage.tsx
@@ -18,8 +18,8 @@ type Props = {
 
 const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
   const call = useAppSelector((state) => state.call.currentCall).data;
-  const surveys = useSurveys(assignment.id).data || [];
-  const events = useActiveEvents(assignment.organization.id).data || [];
+  const surveys = useSurveys(assignment.organization.id).data || [];
+  const events = useActiveEvents(assignment.organization.id) || [];
 
   if (!call) {
     return null;

--- a/src/features/call/pages/AssignmentPreparePage.tsx
+++ b/src/features/call/pages/AssignmentPreparePage.tsx
@@ -61,12 +61,12 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
           </Box>
           <Box mt={2}>
             <Typography mt={1} variant="h5">
-              <Msg id={messageIds.prepare.previousActivity} />
+              <Msg id={messageIds.prepare.previousEvents} />
             </Typography>
             {call.target.past_actions.num_actions == 0 && (
               <Typography variant="body1">
                 <Msg
-                  id={messageIds.prepare.noPreviousActivity}
+                  id={messageIds.prepare.noPreviousEvents}
                   values={{ name: call.target.first_name }}
                 />
               </Typography>
@@ -74,12 +74,12 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
             {call.target.past_actions.num_actions > 0 && (
               <Typography variant="body1">
                 <Msg
-                  id={messageIds.prepare.arePreviousActivity}
+                  id={messageIds.prepare.previousEventsOfTarget}
                   values={{
-                    actionTitle:
+                    eventTitle:
                       call.target.past_actions.last_action.activity.title || '',
-                    activities: call.target.past_actions.num_actions,
                     name: call.target.first_name,
+                    numEvents: call.target.past_actions.num_actions,
                   }}
                 />
               </Typography>
@@ -87,7 +87,7 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
             <Box mt={2}>
               <Typography variant="h5">
                 <Msg
-                  id={messageIds.prepare.previousCalls}
+                  id={messageIds.prepare.previousCallsOfTarget}
                   values={{
                     name: call.target.first_name,
                   }}
@@ -100,7 +100,7 @@ const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
               )}
               {call.target.call_log.length > 0 && (
                 <Typography>
-                  <Msg id={messageIds.prepare.arePreviousCalls} />
+                  <Msg id={messageIds.prepare.previousCalls} />
                 </Typography>
               )}
             </Box>

--- a/src/features/call/pages/AssignmentPreparePage.tsx
+++ b/src/features/call/pages/AssignmentPreparePage.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { Box, Chip, Typography } from '@mui/material';
+import { FC, Suspense } from 'react';
+
+import messageIds from '../l10n/messageIds';
+import { Msg } from 'core/i18n';
+import useActiveCampaigns from '../hooks/useActiveCampaigns';
+import useCallWithTarget from '../hooks/useCallWithTarget';
+import useSurveys from 'features/surveys/hooks/useSurveys';
+import { ZetkinCallAssignment } from 'utils/types/zetkin';
+import ZUIAvatar from 'zui/ZUIAvatar';
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+
+type Props = {
+  assignment: ZetkinCallAssignment;
+};
+
+const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
+  const call = useCallWithTarget(assignment.organization.id, assignment.id);
+  const surveys = useSurveys(assignment.id).data || [];
+  const campaigns = useActiveCampaigns(assignment.organization.id).data || [];
+
+  return (
+    <Box display="flex" gap={2}>
+      <Suspense fallback={<ZUILogoLoadingIndicator />}>
+        <Box flex={1} m={2}>
+          <Typography>
+            <Msg id={messageIds.prepare.title} />
+          </Typography>
+          <ZUIAvatar
+            size={'lg'}
+            url={`/api/orgs/${assignment.organization.id}/people/${call.target.id}/avatar`}
+          />
+          <Typography mt={1} variant="h5">
+            {call.target.first_name + ' ' + call.target.last_name}
+          </Typography>
+          <Typography mt={1}>{call.target.email}</Typography>
+          <Box mt={2}>
+            <Typography mt={1} variant="h5">
+              <Msg id={messageIds.prepare.edit} />
+            </Typography>
+
+            <Typography variant="body1">
+              <Msg id={messageIds.prepare.editDescription} />
+            </Typography>
+          </Box>
+          <Box mt={2}>
+            <Typography mt={1} variant="h5">
+              <Msg id={messageIds.prepare.tags} />
+            </Typography>
+            {call.target.tags.length > 0 ? (
+              call.target.tags.map((tag) => {
+                return <Chip key={tag.id} label={tag.title} />;
+              })
+            ) : (
+              <Typography>
+                <Msg id={messageIds.prepare.noTags} />
+              </Typography>
+            )}
+          </Box>
+          <Box mt={2}>
+            <Typography mt={1} variant="h5">
+              <Msg id={messageIds.prepare.previousActivity} />
+            </Typography>
+            {call.target.past_actions.num_actions == 0 && (
+              <Typography variant="body1">
+                <Msg
+                  id={messageIds.prepare.noPreviousActivity}
+                  values={{ name: call.target.first_name }}
+                />
+              </Typography>
+            )}
+            {call.target.past_actions.num_actions > 0 && (
+              <Typography variant="body1">
+                <Msg
+                  id={messageIds.prepare.arePreviousActivity}
+                  values={{
+                    actionTitle:
+                      call.target.past_actions.last_action.activity.title || '',
+                    activities: call.target.past_actions.num_actions,
+                    name: call.target.first_name,
+                  }}
+                />
+              </Typography>
+            )}
+            <Box mt={2}>
+              <Typography variant="h5">
+                <Msg
+                  id={messageIds.prepare.previousCalls}
+                  values={{
+                    name: call.target.first_name,
+                  }}
+                />
+              </Typography>
+              {call.target.call_log.length == 0 && (
+                <Typography>
+                  <Msg id={messageIds.prepare.noPreviousCalls} />
+                </Typography>
+              )}
+              {call.target.call_log.length > 0 && (
+                <Typography>
+                  <Msg id={messageIds.prepare.arePreviousCalls} />
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        </Box>
+        <Box flex={1} mt={2}>
+          <Typography my={1}>
+            <Msg id={messageIds.prepare.summary} />
+          </Typography>
+          <Typography variant="h5">
+            <Msg id={messageIds.prepare.activeCampaigns} />
+          </Typography>
+          {campaigns.length == 0 && (
+            <Typography>
+              <Msg id={messageIds.prepare.noActiveCampaigns} />
+            </Typography>
+          )}
+          {campaigns.length > 0 &&
+            campaigns.map((campaign) => {
+              return (
+                <Typography key={campaign.id}>
+                  {campaign.campaign.title}
+                </Typography>
+              );
+            })}
+          <Box mt={2}>
+            <Typography variant="h5">
+              <Msg id={messageIds.prepare.surveys} />
+            </Typography>
+            {surveys.length == 0 && (
+              <Typography>
+                <Msg id={messageIds.prepare.noSurveys} />
+              </Typography>
+            )}
+            {surveys.length > 0 &&
+              surveys.map((survey) => {
+                return <Typography key={survey.id}>{survey.title}</Typography>;
+              })}
+          </Box>
+        </Box>
+      </Suspense>
+    </Box>
+  );
+};
+
+export default AssignmentPreparePage;

--- a/src/features/call/pages/AssignmentPreparePage.tsx
+++ b/src/features/call/pages/AssignmentPreparePage.tsx
@@ -6,20 +6,24 @@ import { FC, Suspense } from 'react';
 import messageIds from '../l10n/messageIds';
 import { Msg } from 'core/i18n';
 import useActiveEvents from '../hooks/useActiveEvents';
-import useCallWithTarget from '../hooks/useCallWithTarget';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+import { useAppSelector } from 'core/hooks';
 
 type Props = {
   assignment: ZetkinCallAssignment;
 };
 
 const AssignmentPreparePage: FC<Props> = ({ assignment }) => {
-  const call = useCallWithTarget(assignment.organization.id, assignment.id);
+  const call = useAppSelector((state) => state.call.currentCall).data;
   const surveys = useSurveys(assignment.id).data || [];
   const events = useActiveEvents(assignment.organization.id).data || [];
+
+  if (!call) {
+    return null;
+  }
 
   return (
     <Box display="flex" gap={2}>

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { ZetkinCall } from './types';
+import { remoteItem, RemoteItem } from 'utils/storeUtils';
+
+export interface CallStoreSlice {
+  currentCall: RemoteItem<ZetkinCall>;
+}
+
+const initialState: CallStoreSlice = {
+  currentCall: remoteItem<ZetkinCall>(0, { data: null, isLoading: false }),
+};
+
+const CallSlice = createSlice({
+  initialState,
+  name: 'call',
+  reducers: {
+    currentCallLoad: (state) => {
+      state.currentCall.isLoading = true;
+    },
+    currentCallLoaded: (state, action: PayloadAction<ZetkinCall>) => {
+      state.currentCall = remoteItem(action.payload.id, {
+        data: action.payload,
+        isLoading: false,
+        isStale: false,
+        loaded: new Date().toISOString(),
+      });
+    },
+  },
+});
+
+export default CallSlice;
+export const { currentCallLoad, currentCallLoaded } = CallSlice.actions;

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -1,20 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { ZetkinAction, ZetkinCall } from './types';
+import { ZetkinCall } from './types';
 import {
   remoteItem,
   RemoteItem,
   remoteList,
   RemoteList,
 } from 'utils/storeUtils';
+import { ZetkinEvent } from 'utils/types/zetkin';
 
 export interface CallStoreSlice {
-  activeCampaignsList: RemoteList<ZetkinAction>;
+  activeEventList: RemoteList<ZetkinEvent>;
   currentCall: RemoteItem<ZetkinCall>;
 }
 
 const initialState: CallStoreSlice = {
-  activeCampaignsList: remoteList(),
+  activeEventList: remoteList(),
   currentCall: remoteItem<ZetkinCall>(0, { data: null, isLoading: false }),
 };
 
@@ -22,12 +23,12 @@ const CallSlice = createSlice({
   initialState,
   name: 'call',
   reducers: {
-    activeCampaignsLoad: (state) => {
-      state.activeCampaignsList.isLoading = true;
+    activeEventsLoad: (state) => {
+      state.activeEventList.isLoading = true;
     },
-    activeCampaignsLoaded: (state, action: PayloadAction<ZetkinAction[]>) => {
-      state.activeCampaignsList = remoteList(action.payload);
-      state.activeCampaignsList.loaded = new Date().toISOString();
+    activeEventsLoaded: (state, action: PayloadAction<ZetkinEvent[]>) => {
+      state.activeEventList = remoteList(action.payload);
+      state.activeEventList.loaded = new Date().toISOString();
     },
     currentCallLoad: (state) => {
       state.currentCall.isLoading = true;
@@ -45,8 +46,8 @@ const CallSlice = createSlice({
 
 export default CallSlice;
 export const {
-  activeCampaignsLoad,
-  activeCampaignsLoaded,
+  activeEventsLoad,
+  activeEventsLoaded,
   currentCallLoad,
   currentCallLoaded,
 } = CallSlice.actions;

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -1,13 +1,20 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { ZetkinCall } from './types';
-import { remoteItem, RemoteItem } from 'utils/storeUtils';
+import { ZetkinAction, ZetkinCall } from './types';
+import {
+  remoteItem,
+  RemoteItem,
+  remoteList,
+  RemoteList,
+} from 'utils/storeUtils';
 
 export interface CallStoreSlice {
+  activeCampaignsList: RemoteList<ZetkinAction>;
   currentCall: RemoteItem<ZetkinCall>;
 }
 
 const initialState: CallStoreSlice = {
+  activeCampaignsList: remoteList(),
   currentCall: remoteItem<ZetkinCall>(0, { data: null, isLoading: false }),
 };
 
@@ -15,6 +22,13 @@ const CallSlice = createSlice({
   initialState,
   name: 'call',
   reducers: {
+    activeCampaignsLoad: (state) => {
+      state.activeCampaignsList.isLoading = true;
+    },
+    activeCampaignsLoaded: (state, action: PayloadAction<ZetkinAction[]>) => {
+      state.activeCampaignsList = remoteList(action.payload);
+      state.activeCampaignsList.loaded = new Date().toISOString();
+    },
     currentCallLoad: (state) => {
       state.currentCall.isLoading = true;
     },
@@ -30,4 +44,9 @@ const CallSlice = createSlice({
 });
 
 export default CallSlice;
-export const { currentCallLoad, currentCallLoaded } = CallSlice.actions;
+export const {
+  activeCampaignsLoad,
+  activeCampaignsLoaded,
+  currentCallLoad,
+  currentCallLoaded,
+} = CallSlice.actions;

--- a/src/features/call/types.ts
+++ b/src/features/call/types.ts
@@ -1,4 +1,4 @@
-import { ZetkinEvent, ZetkinTag } from 'utils/types/zetkin';
+import { ZetkinEvent, ZetkinPerson, ZetkinTag } from 'utils/types/zetkin';
 
 export type ZetkinCall = {
   allocation_time: string;
@@ -20,23 +20,25 @@ type ZetkinCaller = {
   name: string;
 };
 
-type ZetkinTarget = {
+type ZetkinTarget = Pick<
+  ZetkinPerson,
+  | 'alt_phone'
+  | 'city'
+  | 'email'
+  | 'ext_id'
+  | 'first_name'
+  | 'id'
+  | 'last_name'
+  | 'phone'
+  | 'zip_code'
+> & {
   action_responses: [];
-  alt_phone: string | null;
   call_log: [];
-  city: string | null;
-  email: string;
-  ext_id: string;
-  first_name: string;
   future_actions: [];
-  id: number;
-  last_name: string;
   name: string;
   past_actions: {
     last_action: ZetkinEvent;
     num_actions: number;
   };
-  phone: string;
   tags: ZetkinTag[];
-  zip_code: string | null;
 };

--- a/src/features/call/types.ts
+++ b/src/features/call/types.ts
@@ -1,46 +1,4 @@
-import { ZetkinTag } from 'utils/types/zetkin';
-
-export type ZetkinAction = {
-  activity: {
-    id: number;
-    title: string | null;
-  };
-  campaign: {
-    id: number;
-    title: string;
-  };
-  cancelled: string | null;
-  cancelled_by_user: string | null;
-  contact: {
-    id: number;
-    name: string;
-  };
-  cover_file: string | null;
-  end_time: string;
-  id: number;
-  info_text: string;
-  location: {
-    id: number;
-    lat: number;
-    lng: number;
-    title: string;
-  };
-  num_participants_available: number;
-  num_participants_required: number;
-  organization: {
-    id: number;
-    title: string;
-  };
-  published: string;
-  published_by_user: {
-    first_name: string;
-    id: number;
-    last_name: string;
-  };
-  start_time: string;
-  title: string | null;
-  url: string;
-};
+import { ZetkinEvent, ZetkinTag } from 'utils/types/zetkin';
 
 export type ZetkinCall = {
   allocation_time: string;
@@ -75,7 +33,7 @@ type ZetkinTarget = {
   last_name: string;
   name: string;
   past_actions: {
-    last_action: ZetkinAction;
+    last_action: ZetkinEvent;
     num_actions: number;
   };
   phone: string;

--- a/src/features/call/types.ts
+++ b/src/features/call/types.ts
@@ -1,0 +1,84 @@
+import { ZetkinTag } from 'utils/types/zetkin';
+
+export type ZetkinAction = {
+  activity: {
+    id: number;
+    title: string | null;
+  };
+  campaign: {
+    id: number;
+    title: string;
+  };
+  cancelled: string | null;
+  cancelled_by_user: string | null;
+  contact: {
+    id: number;
+    name: string;
+  };
+  cover_file: string | null;
+  end_time: string;
+  id: number;
+  info_text: string;
+  location: {
+    id: number;
+    lat: number;
+    lng: number;
+    title: string;
+  };
+  num_participants_available: number;
+  num_participants_required: number;
+  organization: {
+    id: number;
+    title: string;
+  };
+  published: string;
+  published_by_user: {
+    first_name: string;
+    id: number;
+    last_name: string;
+  };
+  start_time: string;
+  title: string | null;
+  url: string;
+};
+
+export type ZetkinCall = {
+  allocation_time: string;
+  assignment_id: number;
+  call_back_after: string | null;
+  caller: ZetkinCaller;
+  id: number;
+  message_to_organizer: string | null;
+  notes: string | null;
+  organizer_action_needed: boolean;
+  organizer_action_taken: string | null;
+  state: number;
+  target: ZetkinTarget;
+  update_time: string;
+};
+
+type ZetkinCaller = {
+  id: number;
+  name: string;
+};
+
+type ZetkinTarget = {
+  action_responses: [];
+  alt_phone: string | null;
+  call_log: [];
+  city: string | null;
+  email: string;
+  ext_id: string;
+  first_name: string;
+  future_actions: [];
+  id: number;
+  last_name: string;
+  name: string;
+  past_actions: {
+    last_action: ZetkinAction;
+    num_actions: number;
+  };
+  phone: string;
+  tags: ZetkinTag[];
+  zip_code: string | null;
+};

--- a/src/features/callAssignments/apiTypes.ts
+++ b/src/features/callAssignments/apiTypes.ts
@@ -11,6 +11,22 @@ export interface CallAssignmentCaller {
 // TODO: Consolidate these
 export type CallAssignmentData = ZetkinCallAssignment;
 
+export type ZetkinCallAssignmentStats = {
+  num_blocked: {
+    allocated: number;
+    any: number;
+    call_back_after: number;
+    cooldown: number;
+    no_number: number;
+    organizer_action_needed: number;
+  };
+  num_calls_made: number;
+  num_calls_reached: number;
+  num_goal_matches: number;
+  num_remaining_targets: number;
+  num_target_matches: number;
+};
+
 export interface CallAssignmentStats {
   id: number;
   allTargets: number;

--- a/src/features/callAssignments/store.ts
+++ b/src/features/callAssignments/store.ts
@@ -11,6 +11,7 @@ import {
   CallAssignmentCaller,
   CallAssignmentData,
   CallAssignmentStats,
+  ZetkinCallAssignmentStats,
 } from './apiTypes';
 
 export interface CallAssignmentSlice {
@@ -21,6 +22,10 @@ export interface CallAssignmentSlice {
   >;
   callersById: Record<number, RemoteList<CallAssignmentCaller>>;
   callList: RemoteList<Call>;
+  simpleStatsById: Record<
+    number,
+    RemoteItem<ZetkinCallAssignmentStats & { id: number }>
+  >;
   statsById: Record<number, RemoteItem<CallAssignmentStats>>;
   userAssignmentList: RemoteList<CallAssignmentData>;
 }
@@ -30,6 +35,7 @@ const initialState: CallAssignmentSlice = {
   callAssignmentIdsByCampaignId: {},
   callList: remoteList(),
   callersById: {},
+  simpleStatsById: {},
   statsById: {},
   userAssignmentList: remoteList(),
 };
@@ -257,6 +263,20 @@ const callAssignmentsSlice = createSlice({
         remoteList(callAssignmentIds);
       state.callAssignmentIdsByCampaignId[campaignId].loaded = timestamp;
     },
+    simpleStatsLoad: (state, action: PayloadAction<number>) => {
+      const id = action.payload;
+      state.simpleStatsById[id] = remoteItem(id, { isLoading: true });
+    },
+    simpleStatsLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinCallAssignmentStats]>
+    ) => {
+      const [id, stats] = action.payload;
+      state.simpleStatsById[id] = remoteItem(id, {
+        data: { id, ...stats },
+        loaded: new Date().toISOString(),
+      });
+    },
     statsLoad: (state, action: PayloadAction<number | string>) => {
       const id = action.payload as number;
       const statsItem = state.statsById[id];
@@ -329,6 +349,8 @@ export const {
   callersLoaded,
   campaignCallAssignmentsLoad,
   campaignCallAssignmentsLoaded,
+  simpleStatsLoad,
+  simpleStatsLoaded,
   statsLoad,
   statsLoaded,
   userAssignmentsLoad,

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -1,3 +1,4 @@
 export { default as hasFeature } from './hasFeature';
 
 export const AREAS = 'FEAT_AREAS';
+export const CALL = 'FEAT_CALL';

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -19,6 +19,7 @@ export default function mockState(overrides?: RootState) {
       crumbsByPath: {},
     },
     call: {
+      activeCampaignsList: remoteList(),
       currentCall: remoteItem(0),
     },
     callAssignments: {

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -18,6 +18,9 @@ export default function mockState(overrides?: RootState) {
     breadcrumbs: {
       crumbsByPath: {},
     },
+    call: {
+      currentCall: remoteItem(0),
+    },
     callAssignments: {
       assignmentList: remoteList(),
       callAssignmentIdsByCampaignId: {},

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -19,7 +19,7 @@ export default function mockState(overrides?: RootState) {
       crumbsByPath: {},
     },
     call: {
-      activeCampaignsList: remoteList(),
+      activeEventList: remoteList(),
       currentCall: remoteItem(0),
     },
     callAssignments: {

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -23,6 +23,7 @@ export default function mockState(overrides?: RootState) {
       callAssignmentIdsByCampaignId: {},
       callList: remoteList(),
       callersById: {},
+      simpleStatsById: {},
       statsById: {},
       userAssignmentList: remoteList(),
     },


### PR DESCRIPTION
## Description
This PR adds the scaffolding page for the new gen3 call interface and the "prepare step" page.


## Screenshots
![image](https://github.com/user-attachments/assets/42f5dbc8-e5df-42bb-bc44-088fef140180)
![image](https://github.com/user-attachments/assets/2170d997-c97f-4541-be6c-37021ab5dad7)



## Changes
* Adds new `callLayout `component.
* Adds new `AssignmentDetailsPage ` and `AssignmentDetailsPage` pages.
* Adds `null `as item type in` shouldLoad()` function.
* Adds `useRemoteItem()` hook and its tests.
* Adds` useSimpleCallAssignmentStats()` hook.
* Adds `useActiveCampaigns()` hook.
* Adds `useCallWithTarget()` hook.
* Adds new components to render stats called `AssignmentStats` and `AssignmentStatsCard`.
* Adds new `types` file with related call types
* Adds new `store `file for `call `feature 


## Notes to reviewer
Due to a bug fix we are not rendering elements in the /prepare page (call is null). But that is fix in this [PR ](https://github.com/zetkin/app.zetkin.org/pull/2607)
This pages are a placeholder, so they doesn't have a design right now

## Related issues
None