### PR TITLE
ZUISelect

### DIFF
--- a/src/zui/components/ZUISelect/index.stories.tsx
+++ b/src/zui/components/ZUISelect/index.stories.tsx
@@ -24,7 +24,7 @@ export const Basic: Story = {
     label: 'Name',
   },
   render: function Render(args) {
-    const [selection, setSelection] = useState<'m' | 'j' | 'e' | ''>('');
+    const [selection, setSelection] = useState('');
 
     return (
       <ZUISelect
@@ -32,9 +32,7 @@ export const Basic: Story = {
         error={args.error}
         items={args.items}
         label={args.label}
-        onChange={(newSelection) => {
-          setSelection(newSelection as 'm' | 'j' | 'e' | '');
-        }}
+        onChange={(newSelection) => setSelection(newSelection)}
         selectedOption={selection}
         size={args.size}
       />
@@ -75,7 +73,7 @@ export const Subheaders: Story = {
         selectItems: [
           {
             label: 'Junssun',
-            value: 'j',
+            value: 'u',
           },
           { label: 'Kalliope', value: 'k' },
           { label: 'Rask', value: 'r' },

--- a/src/zui/components/ZUISelect/index.stories.tsx
+++ b/src/zui/components/ZUISelect/index.stories.tsx
@@ -1,0 +1,89 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import ZUISelect from './index';
+
+const meta: Meta<typeof ZUISelect> = {
+  component: ZUISelect,
+  title: 'Components/ZUISelect',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUISelect>;
+
+export const Basic: Story = {
+  args: {
+    items: [
+      {
+        label: 'Maria',
+        value: 'm',
+      },
+      { label: 'Joanna', value: 'j' },
+      { label: 'Elisabeth-Anne', value: 'e' },
+    ],
+    label: 'Name',
+  },
+  render: function Render(args) {
+    const [selection, setSelection] = useState<'m' | 'j' | 'e' | ''>('');
+
+    return (
+      <ZUISelect
+        disabled={args.disabled}
+        error={args.error}
+        items={args.items}
+        label={args.label}
+        onChange={(newSelection) => {
+          setSelection(newSelection as 'm' | 'j' | 'e' | '');
+        }}
+        selectedOption={selection}
+        size={args.size}
+      />
+    );
+  },
+};
+
+export const Large: Story = {
+  args: { ...Basic.args, size: 'large' },
+  render: Basic.render,
+};
+
+export const Disabled: Story = {
+  args: { ...Basic.args, disabled: true },
+  render: Basic.render,
+};
+
+export const Error: Story = {
+  args: { ...Basic.args, error: true },
+  render: Basic.render,
+};
+
+export const Subheaders: Story = {
+  args: {
+    items: [
+      {
+        selectItems: [
+          {
+            label: 'Maria',
+            value: 'm',
+          },
+          { label: 'Joanna', value: 'j' },
+          { label: 'Elisabeth-Anne', value: 'e' },
+        ],
+        title: 'First names',
+      },
+      {
+        selectItems: [
+          {
+            label: 'Junssun',
+            value: 'j',
+          },
+          { label: 'Kalliope', value: 'k' },
+          { label: 'Rask', value: 'r' },
+        ],
+        title: 'Last names',
+      },
+    ],
+    label: 'Name',
+  },
+  render: Basic.render,
+};

--- a/src/zui/components/ZUISelect/index.tsx
+++ b/src/zui/components/ZUISelect/index.tsx
@@ -85,19 +85,42 @@ const ZUISelect: FC<ZUISelectProps> = ({
       error={error}
       size={size == 'medium' ? 'small' : 'medium'}
       sx={{
+        '& > label': {
+          fontFamily: theme.typography.fontFamily,
+          fontSize: '1rem',
+          fontWeight: '500',
+          letterSpacing: '3%',
+          transform: `translate(0.875rem, ${
+            size == 'medium' ? '0.563rem' : '1rem'
+          })`,
+        },
+        '& > label[data-shrink="true"]': {
+          color: theme.palette.secondary.main,
+          fontSize: '0.813rem',
+          transform: 'translate(0.813rem, -0.563rem)',
+        },
+        '& >.MuiInputBase-root > fieldset > legend > span': {
+          fontFamily: theme.typography.fontFamily,
+          fontSize: '0.813rem',
+          fontWeight: '500',
+          letterSpacing: '3%',
+          paddingLeft: '0.25rem',
+          paddingRight: '0.25rem',
+        },
+        color: 'red',
         minWidth: '13.75rem',
       }}
     >
-      <InputLabel id={`${label}-select`}>
-        <Typography variant="labelSmMedium">{label}</Typography>
-      </InputLabel>
+      <InputLabel id={`${label}-select`}>{label}</InputLabel>
       <Select
         label={<Typography variant="labelSmMedium">{label}</Typography>}
         labelId={`${label}-select`}
         onChange={(ev) => onChange(ev.target.value)}
         size={size == 'medium' ? 'small' : 'medium'}
         sx={{
-          height: size == 'medium' ? '2.625rem' : '',
+          '& > .MuiSelect-select': {
+            paddingY: size == 'medium' ? '0.594rem' : '',
+          },
         }}
         value={selectedOption}
       >

--- a/src/zui/components/ZUISelect/index.tsx
+++ b/src/zui/components/ZUISelect/index.tsx
@@ -103,29 +103,29 @@ const ZUISelect: FC<ZUISelectProps> = ({
       >
         {items.map((item) => {
           if (isCategoryItem(item)) {
-            return (
-              <>
-                <ListSubheader>{item.title}</ListSubheader>
-                {item.selectItems.map((item) => (
-                  <MenuItem
-                    key={item.value}
-                    sx={{ paddingLeft: 4 }}
-                    value={item.value}
+            return [
+              <ListSubheader key={`subheader-${item.title}`}>
+                {item.title}
+              </ListSubheader>,
+              ...item.selectItems.map((item) => (
+                <MenuItem
+                  key={item.value}
+                  sx={{ paddingLeft: '2rem' }}
+                  value={item.value}
+                >
+                  <Typography
+                    sx={{
+                      fontFamily: theme.typography.fontFamily,
+                      fontSize: '1rem',
+                      fontWeight: 400,
+                      letterSpacing: '3%',
+                    }}
                   >
-                    <Typography
-                      sx={{
-                        fontFamily: theme.typography.fontFamily,
-                        fontSize: '1rem',
-                        fontWeight: 400,
-                        letterSpacing: '3%',
-                      }}
-                    >
-                      {item.label}
-                    </Typography>
-                  </MenuItem>
-                ))}
-              </>
-            );
+                    {item.label}
+                  </Typography>
+                </MenuItem>
+              )),
+            ];
           } else {
             return (
               <MenuItem key={item.value} value={item.value}>

--- a/src/zui/components/ZUISelect/index.tsx
+++ b/src/zui/components/ZUISelect/index.tsx
@@ -1,0 +1,151 @@
+import { FC } from 'react';
+import {
+  FormControl,
+  InputLabel,
+  ListSubheader,
+  MenuItem,
+  Select,
+  Typography,
+  useTheme,
+} from '@mui/material';
+
+import { ZUILarge, ZUIMedium } from '../types';
+
+type CategoryItem = {
+  selectItems: SelectItem[];
+  title: string;
+};
+
+type SelectItem = {
+  label: string;
+  value: string;
+};
+
+const isCategoryItem = (
+  item: CategoryItem | SelectItem
+): item is CategoryItem => {
+  return 'title' in item;
+};
+
+type ZUISelectProps = {
+  /**
+   * If the select is disabled or not.
+   */
+  disabled?: boolean;
+
+  /**
+   * If the select has an error.
+   */
+  error?: boolean;
+
+  /**
+   * The items that will render as options in the select.
+   *
+   * Can be either just a list of options, or "categories" where each
+   * object has a title to be displayed as a sub-header, and a list
+   * of options.
+   */
+  items: SelectItem[] | CategoryItem[];
+
+  /**
+   * The label of the select.
+   */
+  label: string;
+
+  /**
+   * The function that runs when an option is selected.
+   */
+  onChange: (newSelection: string) => void;
+
+  /**
+   * The currently selected option.
+   */
+  selectedOption: string;
+
+  /**
+   * The size of the select. Defaults to 'medium'.
+   */
+  size?: ZUIMedium | ZUILarge;
+};
+
+const ZUISelect: FC<ZUISelectProps> = ({
+  disabled = false,
+  error = false,
+  label,
+  onChange,
+  items,
+  size = 'medium',
+  selectedOption,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <FormControl
+      disabled={disabled}
+      error={error}
+      size={size == 'medium' ? 'small' : 'medium'}
+      sx={{
+        minWidth: '13.75rem',
+      }}
+    >
+      <InputLabel id={`${label}-select`}>
+        <Typography variant="labelSmMedium">{label}</Typography>
+      </InputLabel>
+      <Select
+        label={<Typography variant="labelSmMedium">{label}</Typography>}
+        labelId={`${label}-select`}
+        onChange={(ev) => onChange(ev.target.value)}
+        size={size == 'medium' ? 'small' : 'medium'}
+        sx={{
+          height: size == 'medium' ? '2.625rem' : '',
+        }}
+        value={selectedOption}
+      >
+        {items.map((item) => {
+          if (isCategoryItem(item)) {
+            return (
+              <>
+                <ListSubheader>{item.title}</ListSubheader>
+                {item.selectItems.map((item) => (
+                  <MenuItem
+                    key={item.value}
+                    sx={{ paddingLeft: 4 }}
+                    value={item.value}
+                  >
+                    <Typography
+                      sx={{
+                        fontFamily: theme.typography.fontFamily,
+                        fontSize: '1rem',
+                        fontWeight: 400,
+                        letterSpacing: '3%',
+                      }}
+                    >
+                      {item.label}
+                    </Typography>
+                  </MenuItem>
+                ))}
+              </>
+            );
+          } else {
+            return (
+              <MenuItem key={item.value} value={item.value}>
+                <Typography
+                  sx={{
+                    fontFamily: theme.typography.fontFamily,
+                    fontSize: '1rem',
+                    fontWeight: 400,
+                    letterSpacing: '3%',
+                  }}
+                >
+                  {item.label}
+                </Typography>
+              </MenuItem>
+            );
+          }
+        })}
+      </Select>
+    </FormControl>
+  );
+};
+
+export default ZUISelect;


### PR DESCRIPTION
## Description
This PR adds the `ZUISelect` component and Storybook stories for it.

## Screenshots
![bild](https://github.com/user-attachments/assets/ddcc2ded-890e-4b7b-9011-38ea69768404)
![bild](https://github.com/user-attachments/assets/cbbe8e39-d647-4e5d-8048-07fd25050e22)

## Changes
* Adds the `ZUISelect` component and storybook stories

## Notes to reviewer
Not sure about the naming of the types of items?

## Related issues
none
