### PR TITLE
Strip invalid digits from phone number before import

### DIFF
--- a/src/features/import/utils/phoneUtils.ts
+++ b/src/features/import/utils/phoneUtils.ts
@@ -1,0 +1,3 @@
+export function cleanPhoneNumber(value: string | number): string {
+  return value.toString().replaceAll(/[^+\d]/g, '');
+}

--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -1250,6 +1250,10 @@ describe('prepareImportOperations()', () => {
           // Phone number contains U202C, a Unicode control character, to validate that it is stripped.
           data: ['+46 73278 98 87‬', 8],
         },
+        {
+          // Phone number contains 202D, a Unicode control character, to validate that it is stripped.
+          data: ['+‭46704007858', 9],
+        },
       ],
       title: 'My sheet',
     };
@@ -1308,6 +1312,13 @@ describe('prepareImportOperations()', () => {
         data: {
           id: 8,
           phone: '+46732789887',
+        },
+        op: 'person.import',
+      },
+      {
+        data: {
+          id: 9,
+          phone: '+46704007858',
         },
         op: 'person.import',
       },

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -3,6 +3,7 @@ import { CountryCode, parsePhoneNumber } from 'libphonenumber-js';
 import getUniqueTags from './getUniqueTags';
 import { CellData, ColumnKind, Sheet } from './types';
 import parserFactory from './dateParsing/parserFactory';
+import { cleanPhoneNumber } from './phoneUtils';
 
 export type ZetkinPersonImportOp = {
   data?: Record<string, CellData>;
@@ -63,7 +64,7 @@ export default function prepareImportOperations(
             //Parse phone numbers to international format
             if (fieldKey == 'phone' || fieldKey == 'alt_phone') {
               const parsedPhoneNumber = parsePhoneNumber(
-                typeof value == 'string' ? value : value.toString(),
+                cleanPhoneNumber(value),
                 countryCode
               );
               value = parsedPhoneNumber.format('E.164');

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -11,6 +11,7 @@ import {
   ImportRowProblem,
 } from './types';
 import parserFactory from '../dateParsing/parserFactory';
+import { cleanPhoneNumber } from '../phoneUtils';
 
 const VALIDATORS: Record<CUSTOM_FIELD_TYPE, (value: string) => boolean> = {
   date: (value) => {
@@ -113,8 +114,7 @@ export function predictProblems(
             ) {
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
-              const phoneValue = value.toString().replaceAll(/[^+\d]/g, '');
-              if (!isValidPhoneNumber(phoneValue.toString(), country)) {
+              if (!isValidPhoneNumber(cleanPhoneNumber(value), country)) {
                 accumulateFieldProblem(column.field, rowIndex);
               }
             } else if (column.field == 'gender') {


### PR DESCRIPTION
## Description
This PR applies the same cleanup logic for CSV import phone validation (where it was already) to the actual CSV import operation as well.


## Changes
* Adds a new shared `cleanPhoneNumber` utility that can be used in validation and preparation.

## Notes to reviewer
I wasn't sure where to best put this (currently import specific) util. Happy to hear about alternatives.

## Related issues
Resolves #2572 
