### PR TITLE
Issue 2570/add show more to geography area description

### DIFF
--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -1,10 +1,9 @@
-import { FC, MouseEvent, useState } from 'react';
+import { FC } from 'react';
 import { ChevronLeft, ChevronRight, Close, Search } from '@mui/icons-material';
 import {
   Box,
   Divider,
   IconButton,
-  Link,
   TextField,
   Typography,
   useTheme,
@@ -27,6 +26,7 @@ import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import { Msg, useMessages } from 'core/i18n';
 import areaAssignmentMessageIds from '../l10n/messageIds';
 import areasMessageIds from 'features/areas/l10n/messageIds';
+import { ZUIExpandableText } from 'zui/ZUIExpandableText';
 
 type Props = {
   areaAssId: string;
@@ -121,7 +121,7 @@ const AreaSelect: FC<Props> = ({
             mb={1}
             sx={{ overflowWrap: 'anywhere' }}
           >
-            <ExpandableText
+            <ZUIExpandableText
               content={
                 selectedArea.description?.trim() ||
                 areaMessages.areas.default.description()
@@ -353,75 +353,3 @@ const AreaSelect: FC<Props> = ({
 };
 
 export default AreaSelect;
-
-interface ExpandableTextProps {
-  content: string;
-  maxVisibleChars: number;
-  color?: string;
-  fontStyle?: string;
-}
-
-export const ExpandableText: React.FC<ExpandableTextProps> = ({
-  content,
-  maxVisibleChars,
-  color,
-  fontStyle,
-}) => {
-  const areaAssignmentMessages = useMessages(areaAssignmentMessageIds);
-  const [isExpanded, setIsExpanded] = useState<boolean>(false);
-
-  const handleToggle = (event: MouseEvent) => {
-    // event.preventDefault() to prevent entering edit mode when pressing "show more" in geography view
-    event.stopPropagation();
-    setIsExpanded((prev) => !prev);
-  };
-
-  const displayedText = isExpanded
-    ? content
-    : content.slice(0, maxVisibleChars);
-
-  const isLongContent = content.length > maxVisibleChars;
-  return (
-    <Box sx={{ display: 'inline' }}>
-      <Typography
-        color={color}
-        component="span"
-        fontStyle={fontStyle}
-        sx={{
-          display: 'inline',
-          verticalAlign: 'baseline',
-          whiteSpace: 'break-spaces',
-        }}
-        variant="body1"
-      >
-        <Typography
-          component="span"
-          sx={{
-            mr: 1,
-          }}
-        >
-          {displayedText}
-          {isLongContent && !isExpanded && <span>...</span>}
-        </Typography>
-        {isLongContent && (
-          <Link
-            component="button"
-            onClick={handleToggle}
-            sx={{
-              cursor: 'pointer',
-              display: 'inline',
-              padding: 0,
-              textDecoration: 'underline',
-              verticalAlign: 'text-bottom',
-            }}
-            variant="body1"
-          >
-            {isExpanded
-              ? areaAssignmentMessages.map.areaInfo.showLess()
-              : areaAssignmentMessages.map.areaInfo.showMore()}
-          </Link>
-        )}
-      </Typography>
-    </Box>
-  );
-};

--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, MouseEvent, useState } from 'react';
 import { ChevronLeft, ChevronRight, Close, Search } from '@mui/icons-material';
 import {
   Box,
@@ -357,16 +357,22 @@ export default AreaSelect;
 interface ExpandableTextProps {
   content: string;
   maxVisibleChars: number;
+  color?: string;
+  fontStyle?: string;
 }
 
 export const ExpandableText: React.FC<ExpandableTextProps> = ({
   content,
   maxVisibleChars,
+  color,
+  fontStyle,
 }) => {
   const areaAssignmentMessages = useMessages(areaAssignmentMessageIds);
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
-  const handleToggle = () => {
+  const handleToggle = (event: MouseEvent) => {
+    // event.preventDefault() to prevent entering edit mode when pressing "show more" in geography view
+    event.stopPropagation();
     setIsExpanded((prev) => !prev);
   };
 
@@ -378,35 +384,42 @@ export const ExpandableText: React.FC<ExpandableTextProps> = ({
   return (
     <Box sx={{ display: 'inline' }}>
       <Typography
+        color={color}
         component="span"
+        fontStyle={fontStyle}
         sx={{
           display: 'inline',
           verticalAlign: 'baseline',
+          whiteSpace: 'break-spaces',
         }}
         variant="body1"
       >
-        {displayedText}
+        <Typography
+          component="span"
+          sx={{
+            mr: 1,
+          }}
+        >
+          {displayedText}
+          {isLongContent && !isExpanded && <span>...</span>}
+        </Typography>
         {isLongContent && (
-          <>
-            {!isExpanded && <span>...</span>}
-            <Link
-              component="button"
-              onClick={handleToggle}
-              sx={{
-                cursor: 'pointer',
-                display: 'inline',
-                ml: !isExpanded ? 1 : 0,
-                padding: 0,
-                textDecoration: 'underline',
-                verticalAlign: 'baseline',
-              }}
-              variant="body1"
-            >
-              {isExpanded
-                ? areaAssignmentMessages.map.areaInfo.showLess()
-                : areaAssignmentMessages.map.areaInfo.showMore()}
-            </Link>
-          </>
+          <Link
+            component="button"
+            onClick={handleToggle}
+            sx={{
+              cursor: 'pointer',
+              display: 'inline',
+              padding: 0,
+              textDecoration: 'underline',
+              verticalAlign: 'text-bottom',
+            }}
+            variant="body1"
+          >
+            {isExpanded
+              ? areaAssignmentMessages.map.areaInfo.showLess()
+              : areaAssignmentMessages.map.areaInfo.showMore()}
+          </Link>
         )}
       </Typography>
     </Box>

--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -57,8 +57,6 @@ export default makeMessages('feat.areaAssignments', {
         none: m('No assignees'),
         title: m('Assignees'),
       },
-      showLess: m('Show less'),
-      showMore: m('Show more'),
       stats: {
         households: m<{ numHouseholds: number }>(
           '{numHouseholds, plural, one {Household visited} other {Households visited}}'

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -1,4 +1,11 @@
-import { FC, useCallback, useContext, useEffect, useState } from 'react';
+import {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Close } from '@mui/icons-material';
 import {
   Box,
@@ -20,6 +27,7 @@ import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import TagsSection from './TagsSection';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
+import { ExpandableText } from 'features/areaAssignments/components/AreaSelect';
 
 type Props = {
   area: ZetkinArea;
@@ -72,7 +80,9 @@ const AreaOverlay: FC<Props> = ({
         bottom: '1rem',
         display: 'flex',
         flexDirection: 'column',
+        maxWidth: 400,
         minWidth: 400,
+        overflow: 'auto',
         padding: 2,
         position: 'absolute',
         right: '1rem',
@@ -157,7 +167,6 @@ const AreaOverlay: FC<Props> = ({
                 fullWidth
                 inputProps={props}
                 inputRef={handleDescriptionTextAreaRef}
-                maxRows={4}
                 multiline
                 onBlur={() => {
                   if (fieldEditing === 'description') {
@@ -166,26 +175,26 @@ const AreaOverlay: FC<Props> = ({
                   }
                 }}
                 onChange={(ev) => setDescription(ev.target.value)}
-                sx={{ marginTop: 2 }}
+                sx={{
+                  marginTop: 2,
+                }}
                 value={description}
               />
             )}
             renderPreview={() => (
               <Box paddingTop={1}>
-                <Typography
+                <ExpandableText
                   color="secondary"
+                  content={
+                    area.description?.trim().length
+                      ? area.description
+                      : messages.areas.default.description()
+                  }
                   fontStyle={
                     area.description?.trim().length ? 'inherit' : 'italic'
                   }
-                  maxWidth={300}
-                  sx={{ overflowWrap: 'anywhere' }}
-                >
-                  {area.description?.trim().length ? (
-                    area.description
-                  ) : (
-                    <Msg id={messageIds.areas.default.description} />
-                  )}
-                </Typography>
+                  maxVisibleChars={110}
+                />
               </Box>
             )}
             value={area.description || ''}

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -54,16 +54,24 @@ const AreaOverlay: FC<Props> = ({
     area.organization.id,
     area.id
   );
+  const tagsElement = useRef<HTMLElement>();
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+  const enteredEditableMode = useRef(false);
 
   const handleDescriptionTextAreaRef = useCallback(
     (el: HTMLTextAreaElement | null) => {
-      if (el) {
+      if (el && enteredEditableMode.current) {
         // When entering edit mode for desciption, focus the text area and put
         // caret at the end of the text
         el.focus();
         el.setSelectionRange(el.value.length, el.value.length);
-        el.scrollTop = el.scrollHeight;
+        // We want to display the last line of the textarea.
+        // We do this by scrolling the element under the textarea into view.
+        // This way we don't have to keep track of which element contains the scroll
+        setTimeout(() => {
+          tagsElement.current?.scrollIntoView();
+        }, 0);
+        enteredEditableMode.current = false;
       }
     },
     []
@@ -158,6 +166,9 @@ const AreaOverlay: FC<Props> = ({
                 : ZUIPreviewableMode.PREVIEW
             }
             onSwitchMode={(mode) => {
+              if (mode === ZUIPreviewableMode.EDITABLE) {
+                enteredEditableMode.current = true;
+              }
               setFieldEditing(
                 mode === ZUIPreviewableMode.EDITABLE ? 'description' : null
               );
@@ -202,7 +213,7 @@ const AreaOverlay: FC<Props> = ({
         </Box>
       </ClickAwayListener>
       <Divider />
-      <Box flexGrow={1} my={2}>
+      <Box ref={tagsElement} flexGrow={1} my={2}>
         <TagsSection area={area} />
       </Box>
       <Box display="flex" gap={1}>

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -27,7 +27,7 @@ import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import TagsSection from './TagsSection';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
-import { ExpandableText } from 'features/areaAssignments/components/AreaSelect';
+import { ZUIExpandableText } from 'zui/ZUIExpandableText';
 
 type Props = {
   area: ZetkinArea;
@@ -194,7 +194,7 @@ const AreaOverlay: FC<Props> = ({
             )}
             renderPreview={() => (
               <Box paddingTop={1}>
-                <ExpandableText
+                <ZUIExpandableText
                   color="secondary"
                   content={
                     area.description?.trim().length

--- a/src/zui/ZUIExpandableText.tsx
+++ b/src/zui/ZUIExpandableText.tsx
@@ -1,0 +1,76 @@
+import { MouseEvent, useState } from 'react';
+import { Box, Link, Typography } from '@mui/material';
+
+import messageIds from './l10n/messageIds';
+import { useMessages } from 'core/i18n';
+
+interface ZUIExpandableTextProps {
+  content: string;
+  maxVisibleChars: number;
+  color?: string;
+  fontStyle?: string;
+}
+
+export const ZUIExpandableText: React.FC<ZUIExpandableTextProps> = ({
+  content,
+  maxVisibleChars,
+  color,
+  fontStyle,
+}) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const messages = useMessages(messageIds);
+
+  const handleToggle = (event: MouseEvent) => {
+    event.stopPropagation();
+    setIsExpanded((prev) => !prev);
+  };
+
+  const displayedText = isExpanded
+    ? content
+    : content.slice(0, maxVisibleChars);
+
+  const isLongContent = content.length > maxVisibleChars;
+  return (
+    <Box sx={{ display: 'inline' }}>
+      <Typography
+        color={color}
+        component="span"
+        fontStyle={fontStyle}
+        sx={{
+          display: 'inline',
+          verticalAlign: 'baseline',
+          whiteSpace: 'break-spaces',
+        }}
+        variant="body1"
+      >
+        <Typography
+          component="span"
+          sx={{
+            mr: 1,
+          }}
+        >
+          {displayedText}
+          {isLongContent && !isExpanded && <span>...</span>}
+        </Typography>
+        {isLongContent && (
+          <Link
+            component="button"
+            onClick={handleToggle}
+            sx={{
+              cursor: 'pointer',
+              display: 'inline',
+              padding: 0,
+              textDecoration: 'underline',
+              verticalAlign: 'text-bottom',
+            }}
+            variant="body1"
+          >
+            {isExpanded
+              ? messages.expandableText.showLess()
+              : messages.expandableText.showMore()}
+          </Link>
+        )}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -126,6 +126,10 @@ export default makeMessages('zui', {
   editableImage: {
     add: m('Click to add image'),
   },
+  expandableText: {
+    showLess: m('Show less'),
+    showMore: m('Show more'),
+  },
   futures: {
     errorLoading: m('There was an error loading the data.'),
   },


### PR DESCRIPTION
## Description
This PR implements show/hide functionality for the geography area description for when it is too long.
It also fixes an issue where if you started typing anywhere in the description textarea it would put the focus at the end. You don't notice it when typing new text, but adding a section or fixing errors would put the focus at the end every keystroke.


## Screenshots
[show_more0001-1005.webm](https://github.com/user-attachments/assets/e97621c0-1915-4322-9756-878c69d43c99)


## Changes
* Changes ExpandableText to work for expanding text in an edit context
* Use ExpandableText in AreaOverlay
* Changes AreaOverlay to only put focus on end if the user is entering edit mode


## Notes to reviewer
* Not sure where ExpandableText should live. Right now It's an export from AreaSelect in AreaAssignments which is quite for from AreaOverlay in the folder structure. Maybe it should be it's own component, but I couldn't find an obvious place to put it in.


## Related issues
Resolves #2570
