### PR TITLE
Issue-2496 Adding amount of people per tag

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
@@ -69,12 +69,13 @@ const AddedTags: FC<AddedTagsProps> = ({
           }}
         />
       </Typography>
-      <Box display="inline" flexWrap="wrap" gap={1} paddingTop={1}>
+      <Box display="flex" flexWrap="wrap" gap={1} paddingTop={1}>
         {addedTags.map((tag) => (
-          <Box key={tag.id} display="flex" paddingTop={1}>
-            <TagChip tag={tag} />
-            <Typography fontWeight="bold"> : {peoplePerTag[tag.id]}</Typography>
-          </Box>
+          <TagChip
+            key={tag.id}
+            optionalString={` (${peoplePerTag[tag.id]})`}
+            tag={tag}
+          />
         ))}
       </Box>
     </Box>

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
@@ -73,8 +73,10 @@ const AddedTags: FC<AddedTagsProps> = ({
         {addedTags.map((tag) => (
           <TagChip
             key={tag.id}
-            optionalString={` (${peoplePerTag[tag.id]})`}
-            tag={tag}
+            tag={{
+              ...tag,
+              title: `${tag.title} (${peoplePerTag[tag.id]})`,
+            }}
           />
         ))}
       </Box>

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedTags.tsx
@@ -10,12 +10,14 @@ import { ZetkinTag } from 'utils/types/zetkin';
 interface AddedTagsProps {
   addedTags: ZetkinTag[];
   numPeopleWithTagsAdded: number;
+  peoplePerTag: { [key: number]: number };
   tense: 'past' | 'future';
 }
 
 const AddedTags: FC<AddedTagsProps> = ({
   addedTags,
   numPeopleWithTagsAdded,
+  peoplePerTag,
   tense,
 }) => {
   const theme = useTheme();
@@ -67,9 +69,12 @@ const AddedTags: FC<AddedTagsProps> = ({
           }}
         />
       </Typography>
-      <Box display="flex" flexWrap="wrap" gap={1} paddingTop={1}>
+      <Box display="inline" flexWrap="wrap" gap={1} paddingTop={1}>
         {addedTags.map((tag) => (
-          <TagChip key={tag.id} tag={tag} />
+          <Box key={tag.id} display="flex" paddingTop={1}>
+            <TagChip tag={tag} />
+            <Typography fontWeight="bold"> : {peoplePerTag[tag.id]}</Typography>
+          </Box>
         ))}
       </Box>
     </Box>

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
@@ -44,6 +44,7 @@ const ImpactSummary: FC<Props> = ({ orgId, summary, tense }) => {
           <AddedTags
             addedTags={addedTags}
             numPeopleWithTagsAdded={summary.tagged.total}
+            peoplePerTag={summary.tagged.byTag}
             tense={tense}
           />
         )}

--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -103,17 +103,9 @@ const TagChip: React.FunctionComponent<{
   noWrappedLabel?: boolean;
   onClick?: (tag: ZetkinTag) => void;
   onDelete?: (tag: ZetkinTag) => void;
-  optionalString?: string;
   size?: TagChipSize;
   tag: ZetkinTag;
-}> = ({
-  disabled = false,
-  onClick,
-  onDelete,
-  optionalString,
-  size = 'medium',
-  tag,
-}) => {
+}> = ({ disabled = false, onClick, onDelete, size = 'medium', tag }) => {
   const [hover, setHover] = useState(false);
   const classes = useStyles({
     clickable: !!onClick,
@@ -167,7 +159,6 @@ const TagChip: React.FunctionComponent<{
         <TagToolTip tag={tag}>
           <Box className={classes.label + ' ' + classes.deleteContainer}>
             {tag.title}
-            {optionalString}
             {deleteButton}
           </Box>
         </TagToolTip>

--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -103,9 +103,17 @@ const TagChip: React.FunctionComponent<{
   noWrappedLabel?: boolean;
   onClick?: (tag: ZetkinTag) => void;
   onDelete?: (tag: ZetkinTag) => void;
+  optionalString?: string;
   size?: TagChipSize;
   tag: ZetkinTag;
-}> = ({ disabled = false, onClick, onDelete, size = 'medium', tag }) => {
+}> = ({
+  disabled = false,
+  onClick,
+  onDelete,
+  optionalString,
+  size = 'medium',
+  tag,
+}) => {
   const [hover, setHover] = useState(false);
   const classes = useStyles({
     clickable: !!onClick,
@@ -159,6 +167,7 @@ const TagChip: React.FunctionComponent<{
         <TagToolTip tag={tag}>
           <Box className={classes.label + ' ' + classes.deleteContainer}>
             {tag.title}
+            {optionalString}
             {deleteButton}
           </Box>
         </TagToolTip>


### PR DESCRIPTION
## Description
This PR adds information about the amount of people that will receive each added tag when importing a list


## Screenshots
![image](https://github.com/user-attachments/assets/2e82fd68-030d-4a5b-8ef8-eca296de9c65)


## Changes

* Adds Box containing the TagChip and number of people that will receive that tag
* Changes the Box layout to be inline to display each tag separately


## Notes to reviewer

1. Go to https://app.dev.zetkin.org/organize/1/people and sign as [testadmin@exampl.com](mailto:testadmin@exampl.com)
2. Click on "Create" (big button, top right)
3. Click "Import people"
4. Drag and drop a CSV file with the content described under "Example file" in the linked issue
5. Select "FNAME" and configure to import as "First name"
6. Select "LNAME" and configure to import as "Last name"
7. Select "TAG1" and configure to import as tag
8. Map "x" to 2 tags of your choosing
9. Select "TAG2" and configure to import as tag
10. Map "x" to 1-2 tags of your choosing
11. Click "Validate"
12. Do NOT actually execute the import in the next step – just look at the summary

The tags should now display the amount of people who will receive each tag

## Related issues
Partially Resolves #2496
Still needs design