### PR TITLE
Issue-1914/Incorrectly displaying "1 additional row" when showing the row number had been better

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 
-import messageIds from 'features/import/l10n/messageIds';
 import { Msg } from 'core/i18n';
+import messageIds from 'features/import/l10n/messageIds';
 
 type Props = {
   breakpoint?: number;
@@ -18,7 +18,7 @@ const ProblemRowsText: FC<Props> = ({ breakpoint = 8, rows }) => {
         values={{ row: rows[0] }}
       />
     );
-  } else if (rows.length <= breakpoint) {
+  } else if (rows.length <= breakpoint || rows.length - breakpoint == 1) {
     const commaStr = rows.slice(0, -1).join(', ');
     const lastRow = rows[rows.length - 1];
     return (

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ProblemRowsText.tsx
@@ -18,7 +18,7 @@ const ProblemRowsText: FC<Props> = ({ breakpoint = 8, rows }) => {
         values={{ row: rows[0] }}
       />
     );
-  } else if (rows.length <= breakpoint || rows.length - breakpoint == 1) {
+  } else if (rows.length <= breakpoint + 1) {
     const commaStr = rows.slice(0, -1).join(', ');
     const lastRow = rows[rows.length - 1];
     return (


### PR DESCRIPTION
## Description
This PR resolves the issue that appears in the error message when only one errored row appears as "1 additional row" instead of the row number.  

## Screenshots
![import_people](https://github.com/user-attachments/assets/2cd00c5a-30f8-45b1-96aa-41ebdc881af7)


## Changes
* Changes the conditions of the Error message to allow rows with a length of breakpoint + 1 to appear as .fewRows instead of .manyRows.


## Notes to reviewer
*Try adding another CSV file with 10 emails, as suggested in the original issue. 


## Related issues
Resolves #1914 
