### PR TITLE
Make local person column filterable

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -24,11 +24,14 @@ import { useMessages } from 'core/i18n';
 
 type LocalPersonViewCell = null | ZetkinPerson;
 
+const makeName = (cell: { first_name: string; last_name: string }) =>
+  `${cell.first_name} ${cell.last_name}`;
+
 export default class LocalPersonColumnType
   implements IColumnType<LocalPersonViewColumn, LocalPersonViewCell>
 {
   cellToString(cell: LocalPersonViewCell): string {
-    return cell ? `${cell.first_name} ${cell.last_name}` : '';
+    return cell ? makeName(cell) : '';
   }
   getColDef(
     col: LocalPersonViewColumn
@@ -38,7 +41,6 @@ export default class LocalPersonColumnType
       editable: true,
       filterable: true,
       headerAlign: 'center',
-
       renderCell: (params: GridRenderCellParams) => {
         return <ZUIPersonGridCell person={params.value} />;
       },
@@ -52,9 +54,10 @@ export default class LocalPersonColumnType
         if (!v2) {
           return -1;
         }
-        const name1 = `${v1.first_name} ${v1.last_name}`;
-        const name2 = `${v2.first_name} ${v2.last_name}`;
-        return name1.localeCompare(name2);
+        return makeName(v1).localeCompare(makeName(v2));
+      },
+      valueGetter: (params) => {
+        return params.value ? makeName(params.value) : '';
       },
     };
   }


### PR DESCRIPTION
## Description
This PR ensures that column filtering works for the `local_person` (Assignee) cell type in people lists.


## Changes
This change adds the `valueGetter` function which can be used to get a string-representation of the cell to search through with the filter.

## Notes to reviewer
I have noticed that `getSearchableStrings` which is already used for quick *searching* returns even more fields and wondered if it would be consistent to also only return first and last name there to make it consistent. Happy to hear what you think.


## Related issues
Resolves #2581
