### PR TITLE
Issue 520/Add no-only-tests ESLint plugin and rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,11 +7,7 @@ module.exports = {
   parserOptions: { ecmaVersion: 8 }, // to enable features such as async/await
   // We don't want to lint generated files nor node_modules, but we want to lint .prettierrc.js (ignored by default by eslint)
   ignorePatterns: ['node_modules/*', '.next/*', '.out/*', '!.prettierrc.js'],
-  extends: [
-    'eslint:recommended',
-    'next',
-    'prettier',
-  ],
+  extends: ['eslint:recommended', 'next', 'prettier'],
   settings: { react: { version: 'detect' } },
   overrides: [
     // This configuration will apply only to TypeScript files
@@ -28,7 +24,7 @@ module.exports = {
         'plugin:react-hooks/recommended', // React hooks rules
         'plugin:jsx-a11y/recommended', // Accessibility rules
       ],
-      plugins: ['no-switch-statements'],
+      plugins: ['no-switch-statements', 'no-only-tests'],
       rules: {
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -48,9 +44,7 @@ module.exports = {
               order: 'ignore',
               orderImportKind: 'ignore',
             },
-            groups: [
-              ['external', 'builtin'],
-            ],
+            groups: [['external', 'builtin']],
             'newlines-between': 'always',
           },
         ],
@@ -98,6 +92,7 @@ module.exports = {
         ],
         'sort-keys': 'error',
         'sort-vars': 'error',
+        'no-only-tests/no-only-tests': 'error',
       },
     },
   ],

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
   playwright-test:
     uses: ./.github/workflows/reusable-base.yml
     with:
-      validation-script: exit `grep -ER "(test|describe)\.only" integrationTesting | wc -l`
       build-script: npx playwright install chromium
       yarn-test-script: playwright:ci
       upload-path: playwright-report/
@@ -30,5 +29,4 @@ jobs:
   unit-test:
     uses: ./.github/workflows/reusable-base.yml
     with:
-      validation-script: exit `grep -ER "(test|describe|it)\.only" src | wc -l`
       yarn-test-script: test

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-next": "^0.0.0",
+    "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-no-switch-statements": "^1.0.0",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,6 +7964,11 @@ eslint-plugin-next@^0.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz#f9ef680e8f68763c716ab44697c4b3cc3e0b2069"
   integrity sha512-IldNDVb6WNduggwRbYzSGZhaskUwVecJ6fhmqwX01+S1aohwAWNzU4me6y47DDzpD/g0fdayNBGxEdt9vKkUtg==
 
+eslint-plugin-no-only-tests@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz#d9d42ccd4b5d099b4872fb5046cf95441188cfb5"
+  integrity sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==
+
 eslint-plugin-no-switch-statements@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-switch-statements/-/eslint-plugin-no-switch-statements-1.0.0.tgz#fa3dff02fdbfbe4159e8c572d81458971cd01928"


### PR DESCRIPTION
## Description
This PR adds the no-only-tests ESLint plugin, and turns on the rule. By default, the rule will catch any instance of various blocks for focused tests which could prevent the entire test suite from running, and prevent those blocks from being committed. 

This PR also replaces the implementation from #507, now that the no-only-tests rule catches all the blocks previously caught by the grep search.


## Screenshots
None


## Changes
* Adds no-only-tests ESLint plugin
* Adds no-only-tests ESLint rule as an error
* Removes grep searches from CI workflow


## Notes to reviewer
In .eslintrc.js, I think Prettier has collapsed the (otherwise untouched) "extends" and "groups" arrays to one line each. If this is undesirable, please advise on how I can prevent this.


## Related issues
Resolves #520
Resolves #495, superseding implementation from #507  