### PR TITLE
Fix stray apostrophe in "Let(')s you pick..."

### DIFF
--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -144,7 +144,7 @@ export default makeMessages('feat.views', {
       },
       localPerson: {
         columnTitle: m('Assignee'),
-        description: m("Let's you pick an assignee on every row"),
+        description: m('Lets you pick an assignee on every row'),
         keywords: m(''),
         title: m('Assigned Person'),
       },

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -2429,7 +2429,7 @@ feat:
           title: Last name
         localPerson:
           columnTitle: Assignee
-          description: Let's you pick an assignee on every row
+          description: Lets you pick an assignee on every row
           keywords: ""
           title: Assigned Person
         localQuery:


### PR DESCRIPTION
## Description
This PR corrects a grammatically incorrect stray apostrophe, found in the description shown on the option for adding the "Assigned Person" column to a list. "Let's you pick..." corrected to "Lets you pick".


## Screenshots
![Screenshot From 2025-03-15 12-21-00](https://github.com/user-attachments/assets/f808a7c9-55fe-48f3-b338-adcff8c2cae5) (before)
![Screenshot From 2025-03-15 12-16-58](https://github.com/user-attachments/assets/a83aab35-9be1-462d-8e48-e9b3e78389a2) (after)


## Changes
* Removed stray apostrophe


## Notes to reviewer
None


## Related issues
None
