### PR TITLE
Issue 2158: Adding store RemoteList utility methods

### DIFF
--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -103,9 +103,9 @@ const areaAssignmentSlice = createSlice({
     },
     areaAssignmentSessionsLoad: (state, action: PayloadAction<string>) => {
       const assignmentId = action.payload;
-      const areaAssignmentList = state.sessionsByAssignmentId[assignmentId];
-      state.sessionsByAssignmentId[assignmentId] =
-        remoteListLoad(areaAssignmentList);
+      state.sessionsByAssignmentId[assignmentId] = remoteListLoad(
+        state.sessionsByAssignmentId[assignmentId]
+      );
     },
     areaAssignmentSessionsLoaded: (
       state,
@@ -113,13 +113,13 @@ const areaAssignmentSlice = createSlice({
     ) => {
       const [assignmentId, sessions] = action.payload;
 
-      const loadedAreaAssignments = sessions.map((session) => ({
+      const areaAssignmentSessions = sessions.map((session) => ({
         ...session,
         id: session.assignee.id,
       }));
 
       state.sessionsByAssignmentId[assignmentId] = remoteListLoaded(
-        loadedAreaAssignments
+        areaAssignmentSessions
       );
     },
     areaAssignmentUpdated: (

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -51,7 +51,8 @@ const areasSlice = createSlice({
       state.areaList = remoteListLoad(state.areaList);
     },
     areasLoaded: (state, action: PayloadAction<ZetkinArea[]>) => {
-      state.areaList = remoteListLoaded(action.payload);
+      const areas = action.payload;
+      state.areaList = remoteListLoaded(areas);
     },
     tagAssigned: (state, action: PayloadAction<[string, ZetkinTag]>) => {
       const [areaId, tag] = action.payload;

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -6,6 +6,9 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import { ZetkinArea } from './types';
 import { ZetkinTag } from 'utils/types/zetkin';
@@ -45,19 +48,17 @@ const areasSlice = createSlice({
       remoteItemUpdated(state.areaList, area);
     },
     areasLoad: (state) => {
-      state.areaList.isLoading = true;
+      state.areaList = remoteListLoad(state.areaList);
     },
     areasLoaded: (state, action: PayloadAction<ZetkinArea[]>) => {
-      const timestamp = new Date().toISOString();
-      const areas = action.payload;
-      state.areaList = remoteList(areas);
-      state.areaList.loaded = timestamp;
-      state.areaList.items.forEach((item) => (item.loaded = timestamp));
+      state.areaList = remoteListLoaded(action.payload);
     },
     tagAssigned: (state, action: PayloadAction<[string, ZetkinTag]>) => {
       const [areaId, tag] = action.payload;
-      state.tagsByAreaId[areaId] ||= remoteList();
 
+      state.tagsByAreaId[areaId] ||= remoteListCreated(
+        state.tagsByAreaId[areaId]
+      );
       remoteItemUpdated(state.tagsByAreaId[areaId], tag);
 
       const areaItem = state.areaList.items.find((item) => item.id == areaId);
@@ -81,13 +82,11 @@ const areasSlice = createSlice({
     },
     tagsLoad: (state, action: PayloadAction<string>) => {
       const areaId = action.payload;
-      state.tagsByAreaId[areaId] ||= remoteList();
-      state.tagsByAreaId[areaId].isLoading = true;
+      state.tagsByAreaId[areaId] = remoteListLoad(state.tagsByAreaId[areaId]);
     },
     tagsLoaded: (state, action: PayloadAction<[string, ZetkinTag[]]>) => {
       const [areaId, tags] = action.payload;
-      state.tagsByAreaId[areaId] = remoteList(tags);
-      state.tagsByAreaId[areaId].loaded = new Date().toISOString();
+      state.tagsByAreaId[areaId] = remoteListLoaded(tags);
     },
   },
 });

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -83,7 +83,8 @@ const joinFormsSlice = createSlice({
       state,
       action: PayloadAction<ZetkinJoinSubmission[]>
     ) => {
-      state.submissionList = remoteListLoaded(action.payload);
+      const submissions = action.payload;
+      state.submissionList = remoteListLoaded(submissions);
     },
   },
 });

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -7,6 +7,8 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import { ZetkinJoinForm, ZetkinJoinSubmission } from './types';
 
@@ -30,10 +32,7 @@ const joinFormsSlice = createSlice({
     },
     joinFormDeleted: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
-      const item = state.formList.items.find((item) => item.id == formId);
-      if (item) {
-        item.deleted = true;
-      }
+      remoteItemDeleted(state.formList, formId);
     },
     joinFormLoad: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
@@ -52,11 +51,10 @@ const joinFormsSlice = createSlice({
       remoteItemUpdated(state.formList, form);
     },
     joinFormsLoad: (state) => {
-      state.formList.isLoading = true;
+      state.formList = remoteListLoad(state.formList);
     },
     joinFormsLoaded: (state, action: PayloadAction<ZetkinJoinForm[]>) => {
-      state.formList = remoteList(action.payload);
-      state.formList.loaded = new Date().toISOString();
+      state.formList = remoteListLoaded(action.payload);
     },
     submissionDeleted: (state, action: PayloadAction<number>) => {
       const submissionId = action.payload;
@@ -79,14 +77,13 @@ const joinFormsSlice = createSlice({
       remoteItemUpdated(state.submissionList, submission);
     },
     submissionsLoad: (state) => {
-      state.submissionList.isLoading = true;
+      state.submissionList = remoteListLoad(state.submissionList);
     },
     submissionsLoaded: (
       state,
       action: PayloadAction<ZetkinJoinSubmission[]>
     ) => {
-      state.submissionList = remoteList(action.payload);
-      state.submissionList.loaded = new Date().toISOString();
+      state.submissionList = remoteListLoaded(action.payload);
     },
   },
 });

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -70,7 +70,6 @@ const tagsSlice = createSlice({
     },
     tagGroupCreated: (state, action: PayloadAction<ZetkinTagGroup>) => {
       const tagGroup = action.payload;
-      state.tagGroupList.isLoading = false;
       remoteItemUpdated(state.tagGroupList, tagGroup);
     },
     tagGroupsLoad: (state) => {

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -7,6 +7,9 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';
 
@@ -28,21 +31,17 @@ const tagsSlice = createSlice({
   reducers: {
     personTagsLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
-      if (!state.tagsByPersonId[id]) {
-        state.tagsByPersonId[id] = remoteList();
-      }
-      state.tagsByPersonId[id].isLoading = true;
+      state.tagsByPersonId[id] = remoteListLoad(state.tagsByPersonId[id]);
     },
     personTagsLoaded: (state, action: PayloadAction<[number, ZetkinTag[]]>) => {
       const [id, tags] = action.payload;
-      state.tagsByPersonId[id] = remoteList(tags);
-      state.tagsByPersonId[id].loaded = new Date().toISOString();
+      state.tagsByPersonId[id] = remoteListLoaded(tags);
     },
     tagAssigned: (state, action: PayloadAction<[number, ZetkinTag]>) => {
       const [personId, tag] = action.payload;
-      if (!state.tagsByPersonId[personId]) {
-        state.tagsByPersonId[personId] = remoteList();
-      }
+      state.tagsByPersonId[personId] ||= remoteListCreated(
+        state.tagsByPersonId[personId]
+      );
       remoteItemUpdated(state.tagsByPersonId[personId], tag);
     },
     tagCreate: (state) => {
@@ -75,15 +74,11 @@ const tagsSlice = createSlice({
       remoteItemUpdated(state.tagGroupList, tagGroup);
     },
     tagGroupsLoad: (state) => {
-      state.tagGroupList.isLoading = true;
+      state.tagGroupList = remoteListLoad(state.tagGroupList);
     },
     tagGroupsLoaded: (state, action: PayloadAction<ZetkinTagGroup[]>) => {
       const tagGroups = action.payload;
-      const timestamp = new Date().toISOString();
-
-      state.tagGroupList = remoteList(tagGroups);
-      state.tagGroupList.loaded = timestamp;
-      state.tagGroupList.items.forEach((item) => (item.loaded = timestamp));
+      state.tagGroupList = remoteListLoaded(tagGroups);
     },
     tagLoad: (state, action: PayloadAction<number>) => {
       const tagId = action.payload;
@@ -95,9 +90,8 @@ const tagsSlice = createSlice({
     },
     tagUnassigned: (state, action: PayloadAction<[number, number]>) => {
       const [personId, tagId] = action.payload;
-      const tagsByPersonId = state.tagsByPersonId[personId];
 
-      if (!tagsByPersonId) {
+      if (!state.tagsByPersonId[personId]) {
         return;
       }
 
@@ -121,15 +115,11 @@ const tagsSlice = createSlice({
       });
     },
     tagsLoad: (state) => {
-      state.tagList.isLoading = true;
+      state.tagList = remoteListLoad(state.tagList);
     },
     tagsLoaded: (state, action: PayloadAction<ZetkinTag[]>) => {
       const tags = action.payload;
-      const timestamp = new Date().toISOString();
-
-      state.tagList = remoteList(tags);
-      state.tagList.loaded = timestamp;
-      state.tagList.items.forEach((item) => (item.loaded = timestamp));
+      state.tagList = remoteListLoaded(tags);
     },
   },
 });

--- a/src/utils/storeUtils/index.ts
+++ b/src/utils/storeUtils/index.ts
@@ -141,6 +141,13 @@ export function remoteList<DataType extends RemoteData>(
 }
 
 export {
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
+  remoteListInvalidated,
+} from 'utils/storeUtils/remoteListUtils';
+
+export {
   remoteItemCreated,
   remoteItemUpdate,
   remoteItemLoad,

--- a/src/utils/storeUtils/remoteItemUpdated.spec.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.spec.ts
@@ -80,6 +80,18 @@ describe('remoteItemUpdated', () => {
     expect(resultUpdated.isLoading).toBeFalsy();
   });
 
+  it('Sets isStale to false', () => {
+    const list = remoteList();
+
+    const existingItem = findOrAddItem(list, existingId);
+    existingItem.data = existingData;
+    existingItem.isStale = true;
+
+    const resultUpdated = remoteItemUpdated(list, existingUpdatedData);
+
+    expect(resultUpdated.isStale).toBeFalsy();
+  });
+
   it('Returns the updated/fetched item', () => {
     const list = remoteList();
 

--- a/src/utils/storeUtils/remoteItemUpdated.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.ts
@@ -9,6 +9,7 @@ export function remoteItemUpdated<DataType extends RemoteData>(
   item.data = updatedData;
   item.mutating = [];
   item.isLoading = false;
+  item.isStale = false;
   item.loaded = new Date().toISOString();
   return item;
 }

--- a/src/utils/storeUtils/remoteListUtils.spec.ts
+++ b/src/utils/storeUtils/remoteListUtils.spec.ts
@@ -1,0 +1,102 @@
+import { remoteList } from 'utils/storeUtils';
+import {
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
+  remoteListInvalidated,
+} from 'utils/storeUtils/remoteListUtils';
+
+describe('remoteListCreated', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  it('Sets loaded to recent time if list is created', () => {
+    const testDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(testDate);
+
+    const resultList = remoteListCreated(null);
+
+    expect(resultList.loaded).toBe(testDate.toISOString());
+  });
+
+  it('Leaves loaded untouched if list already exists', () => {
+    const existingList = remoteList();
+    const correctDate = new Date('2020-01-01');
+    const incorrectDate = new Date('2025-01-01');
+    jest.useFakeTimers().setSystemTime(incorrectDate);
+    existingList.loaded = correctDate.toISOString();
+
+    const resultList = remoteListCreated(existingList);
+
+    expect(resultList.loaded).toBe(correctDate.toISOString());
+  });
+});
+
+describe('remoteListLoad', () => {
+  it('Sets isLoading to true for an existing list', () => {
+    const existingList = remoteList();
+    existingList.isLoading = false;
+
+    const resultList = remoteListLoad(existingList);
+
+    expect(resultList.isLoading).toBe(true);
+  });
+
+  it('Sets isLoading to true for a new list', () => {
+    const resultList = remoteListLoad(null);
+
+    expect(resultList.isLoading).toBe(true);
+  });
+});
+
+describe('remoteListLoaded', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  it('Sets loaded to recent time for the list', () => {
+    const correctDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(correctDate);
+    const loadedData = [{ id: 'Loaded example data' }];
+
+    const resultList = remoteListLoaded(loadedData);
+
+    expect(resultList.loaded).toBe(correctDate.toISOString());
+  });
+
+  it('Sets loaded to recent time for the items in the list', () => {
+    const correctDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(correctDate);
+    const loadedData = [
+      { id: 'Loaded example data A' },
+      { id: 'Loaded example data B' },
+    ];
+
+    const resultList = remoteListLoaded(loadedData);
+
+    expect(resultList.items.length).toBe(loadedData.length);
+    resultList.items.forEach((item) => {
+      expect(item.loaded).toBe(correctDate.toISOString());
+    });
+  });
+});
+
+describe('remoteListInvalidated', () => {
+  it('Sets isStale to true for an existing list', () => {
+    const existingList = remoteList();
+    existingList.isStale = false;
+
+    const resultList = remoteListInvalidated(existingList);
+
+    expect(resultList.isStale).toBe(true);
+  });
+
+  it('Sets isStale to true for a new list', () => {
+    const resultList = remoteListInvalidated(null);
+
+    expect(resultList.isStale).toBe(true);
+  });
+});

--- a/src/utils/storeUtils/remoteListUtils.ts
+++ b/src/utils/storeUtils/remoteListUtils.ts
@@ -1,0 +1,41 @@
+import { RemoteData, RemoteList, remoteList } from 'utils/storeUtils';
+
+export function remoteListCreated<DataType extends RemoteData>(
+  list: RemoteList<DataType> | null
+): RemoteList<DataType> {
+  if (!list) {
+    list = remoteList();
+    list.loaded = new Date().toISOString();
+  }
+  return list;
+}
+
+export function remoteListLoad<DataType extends RemoteData>(
+  list: RemoteList<DataType> | null
+): RemoteList<DataType> {
+  if (!list) {
+    list = remoteList();
+  }
+  list.isLoading = true;
+  return list;
+}
+
+export function remoteListLoaded<DataType extends RemoteData>(
+  items: DataType[]
+): RemoteList<DataType> {
+  const list = remoteList(items);
+  const timeStamp = new Date().toISOString();
+  list.loaded = timeStamp;
+  list.items.forEach((item) => (item.loaded = timeStamp));
+  return list;
+}
+
+export function remoteListInvalidated<DataType extends RemoteData>(
+  list: RemoteList<DataType> | null
+): RemoteList<DataType> {
+  if (!list) {
+    list = remoteList();
+  }
+  list.isStale = true;
+  return list;
+}


### PR DESCRIPTION
## Description
This PR is a complement to PR #2482, which added store utility methods for items in list. This PR adds store utility methods for the lists themselves. 

Furthermore, just like the last PR, this PR also updates four features with the new utility methods:
areas, areaAssignments, tags and joinForms. There's also one or two small fixes related to the last PR.

The purpose of the refactoring is to align how we use store methods, to avoid pitfalls and common errors. 

After this PR, there's still two data types that might be relevant to make utility methods for, namely records <string, remoteItem> and <string, remoteList>. 

## Screenshots
No changes to UI. ( Unless I introduced bugs 😅 )

## Changes
* Adds remoteList store utility methods: remoteListCreated, remoteListLoad, remoteListLoaded and remoteListInvalidated.
* Changes areas, areaAssignments, tags and joinForms to use the new utility methods. 

## Notes to reviewer
We should test CRUDL for the related features. It is not only 

## Related issues
Doesn't resolve the related issue completely. 
