### PR TITLE
ZUI tabs

### DIFF
--- a/src/features/campaigns/components/ActivitiesOverview/index.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import NextLink from 'next/link';
 import { Box, Button, Grid, Typography } from '@mui/material';
 
@@ -9,6 +9,8 @@ import ZUIEmptyState from 'zui/ZUIEmptyState';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ActivityOverview, CampaignActivity } from 'features/campaigns/types';
 import { Msg, useMessages } from 'core/i18n';
+
+import ZUITabView from 'zui/components/ZUITabView';
 
 type ActivitiesOverviewProps = {
   campaignId?: number;
@@ -36,9 +38,18 @@ const ActivitiesOverview: FC<ActivitiesOverviewProps> = ({
         item.data.organization.id != orgId
     );
   };
+  const [value, setValue] = useState('mjao');
 
   return (
     <>
+      <ZUITabView
+        items={[
+          { content: <div>hallå</div>, label: 'Hej', value: 'goddag' },
+          { content: <div>katt</div>, label: 'Katt', value: 'mjao' },
+        ]}
+        onChange={(newValue) => setValue(newValue)}
+        value={value}
+      />
       <Box
         alignItems="center"
         display="flex"

--- a/src/features/campaigns/components/ActivitiesOverview/index.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import NextLink from 'next/link';
 import { Box, Button, Grid, Typography } from '@mui/material';
 
@@ -9,8 +9,6 @@ import ZUIEmptyState from 'zui/ZUIEmptyState';
 import ZUIFuture from 'zui/ZUIFuture';
 import { ActivityOverview, CampaignActivity } from 'features/campaigns/types';
 import { Msg, useMessages } from 'core/i18n';
-
-import ZUITabView from 'zui/components/ZUITabView';
 
 type ActivitiesOverviewProps = {
   campaignId?: number;
@@ -38,18 +36,9 @@ const ActivitiesOverview: FC<ActivitiesOverviewProps> = ({
         item.data.organization.id != orgId
     );
   };
-  const [value, setValue] = useState('mjao');
 
   return (
     <>
-      <ZUITabView
-        items={[
-          { content: <div>hallå</div>, label: 'Hej', value: 'goddag' },
-          { content: <div>katt</div>, label: 'Katt', value: 'mjao' },
-        ]}
-        onChange={(newValue) => setValue(newValue)}
-        value={value}
-      />
       <Box
         alignItems="center"
         display="flex"

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import ZUITabView from './index';
+
+const meta: Meta<typeof ZUITabView> = {
+  component: ZUITabView,
+  title: 'Components/ZUITabView',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUITabView>;
+
+export const Basic: Story = {
+  args: {},
+  render: function Render(args) {
+    //const [value, setValue] = useState('mjao');
+
+    return (
+      <ZUITabView
+        items={[
+          { content: <div>hallå</div>, label: 'Hej', value: 'goddag' },
+          { content: <div>katt</div>, label: 'Katt', value: 'mjao' },
+        ]}
+        onChange={(newValue) => null}
+        value={'mjao'}
+      />
+    );
+  },
+};

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -50,7 +50,7 @@ export const Basic: Story = {
 };
 
 export const FullWidth: Story = {
-  args: { fullWidth: true },
+  args: { ...Basic.args, fullWidth: true },
   render: Basic.render,
 };
 

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -14,33 +14,34 @@ export default meta;
 type Story = StoryObj<typeof ZUITabView>;
 
 export const Basic: Story = {
-  args: {},
+  args: {
+    items: [
+      {
+        label: 'Share',
+        render: () => (
+          <Box sx={{ backgroundColor: 'peachpuff', height: '200px' }}>
+            <ZUIText>This is the rendered content of the first tab</ZUIText>
+          </Box>
+        ),
+        value: 'share',
+      },
+      {
+        label: 'Export',
+        render: () => (
+          <Box sx={{ backgroundColor: 'lightblue', height: '200px' }}>
+            <ZUIText>This is the rendered content of the other tab</ZUIText>
+          </Box>
+        ),
+        value: 'export',
+      },
+    ],
+  },
   render: function Render(args) {
     const [value, setValue] = useState('share');
 
     return (
       <ZUITabView
         {...args}
-        items={[
-          {
-            label: 'Share',
-            render: () => (
-              <Box sx={{ backgroundColor: 'peachpuff', height: '200px' }}>
-                <ZUIText>This is the rendered content of the first tab</ZUIText>
-              </Box>
-            ),
-            value: 'share',
-          },
-          {
-            label: 'Export',
-            render: () => (
-              <Box sx={{ backgroundColor: 'lightblue', height: '200px' }}>
-                <ZUIText>This is the rendered content of the other tab</ZUIText>
-              </Box>
-            ),
-            value: 'export',
-          },
-        ]}
         onSelectTab={(newValue) => setValue(newValue)}
         selectedTab={value}
       />
@@ -50,5 +51,47 @@ export const Basic: Story = {
 
 export const FullWidth: Story = {
   args: { fullWidth: true },
+  render: Basic.render,
+};
+
+export const WithBadge: Story = {
+  args: {
+    items: [
+      {
+        badge: { color: 'danger' },
+        label: 'Share',
+        render: () => (
+          <Box sx={{ backgroundColor: 'peachpuff', height: '200px' }}>
+            <ZUIText>This is the rendered content of the first tab</ZUIText>
+          </Box>
+        ),
+        value: 'share',
+      },
+      {
+        badge: { color: 'warning', number: 13 },
+        label: 'Export',
+        render: () => (
+          <Box sx={{ backgroundColor: 'lightgreen', height: '200px' }}>
+            <ZUIText>This is the rendered content of the second tab</ZUIText>
+          </Box>
+        ),
+        value: 'export',
+      },
+      {
+        badge: {
+          color: 'info',
+          number: 99999999999,
+          truncateLargeNumber: true,
+        },
+        label: 'Assignees',
+        render: () => (
+          <Box sx={{ backgroundColor: 'lightsteelblue', height: '200px' }}>
+            <ZUIText>This is the rendered content of the third tab</ZUIText>
+          </Box>
+        ),
+        value: 'assignees',
+      },
+    ],
+  },
   render: Basic.render,
 };

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -1,7 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import { Box } from '@mui/material';
 
 import ZUITabView from './index';
+import ZUIText from '../ZUIText';
 
 const meta: Meta<typeof ZUITabView> = {
   component: ZUITabView,
@@ -14,16 +16,33 @@ type Story = StoryObj<typeof ZUITabView>;
 export const Basic: Story = {
   args: {},
   render: function Render(args) {
-    //const [value, setValue] = useState('mjao');
+    const [value, setValue] = useState('share');
 
     return (
       <ZUITabView
+        {...args}
         items={[
-          { content: <div>hallå</div>, label: 'Hej', value: 'goddag' },
-          { content: <div>katt</div>, label: 'Katt', value: 'mjao' },
+          {
+            label: 'Share',
+            render: () => (
+              <Box sx={{ backgroundColor: 'peachpuff', height: '200px' }}>
+                <ZUIText>This is the rendered content of the first tab</ZUIText>
+              </Box>
+            ),
+            value: 'share',
+          },
+          {
+            label: 'Export',
+            render: () => (
+              <Box sx={{ backgroundColor: 'lightblue', height: '200px' }}>
+                <ZUIText>This is the rendered content of the other tab</ZUIText>
+              </Box>
+            ),
+            value: 'export',
+          },
         ]}
-        onChange={(newValue) => null}
-        value={'mjao'}
+        onChange={(newValue) => setValue(newValue)}
+        value={value}
       />
     );
   },

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -41,8 +41,8 @@ export const Basic: Story = {
             value: 'export',
           },
         ]}
-        onChange={(newValue) => setValue(newValue)}
-        value={value}
+        onSelectTab={(newValue) => setValue(newValue)}
+        selectedTab={value}
       />
     );
   },

--- a/src/zui/components/ZUITabView/index.stories.tsx
+++ b/src/zui/components/ZUITabView/index.stories.tsx
@@ -47,3 +47,8 @@ export const Basic: Story = {
     );
   },
 };
+
+export const FullWidth: Story = {
+  args: { fullWidth: true },
+  render: Basic.render,
+};

--- a/src/zui/components/ZUITabView/index.tsx
+++ b/src/zui/components/ZUITabView/index.tsx
@@ -2,7 +2,15 @@ import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Tab } from '@mui/material';
 import { FC } from 'react';
 
+import { ZUIBadgeProps } from '../ZUIBadge';
+import { TabBadge } from '../ZUITabbedNavBar';
+
 type TabItem = {
+  /**
+   * Send in properties that will render a badge on the tab.
+   */
+  badge?: Omit<ZUIBadgeProps, 'children'>;
+
   /**
    * The label of the tab
    */
@@ -62,6 +70,18 @@ const ZUITabView: FC<ZUITabViewProps> = ({
         {items.map((tab) => (
           <Tab
             key={`tab-${tab.value}`}
+            icon={
+              tab.badge ? (
+                <TabBadge
+                  color={tab.badge.color}
+                  number={tab.badge.number}
+                  truncateLargeNumber={tab.badge.truncateLargeNumber}
+                />
+              ) : (
+                ''
+              )
+            }
+            iconPosition="end"
             label={tab.label}
             sx={{
               fontSize: '0.875rem',

--- a/src/zui/components/ZUITabView/index.tsx
+++ b/src/zui/components/ZUITabView/index.tsx
@@ -21,6 +21,13 @@ type TabItem = {
 
 type ZUITabViewProps = {
   /**
+   * If true, the tabs take up all the available horizontal space.
+   *
+   * Defaults to "false".
+   */
+  fullWidth?: boolean;
+
+  /**
    * A list of items that contains data about each tab.
    */
   items: TabItem[];
@@ -36,7 +43,12 @@ type ZUITabViewProps = {
   value: string;
 };
 
-const ZUITabView: FC<ZUITabViewProps> = ({ items, onChange, value }) => {
+const ZUITabView: FC<ZUITabViewProps> = ({
+  fullWidth = false,
+  items,
+  onChange,
+  value,
+}) => {
   return (
     <TabContext value={value}>
       <TabList
@@ -45,6 +57,7 @@ const ZUITabView: FC<ZUITabViewProps> = ({ items, onChange, value }) => {
           borderBottom: `0.063rem solid ${theme.palette.dividers.main}`,
           minHeight: '2.438rem',
         })}
+        variant={fullWidth ? 'fullWidth' : 'standard'}
       >
         {items.map((tab) => (
           <Tab

--- a/src/zui/components/ZUITabView/index.tsx
+++ b/src/zui/components/ZUITabView/index.tsx
@@ -35,24 +35,24 @@ type ZUITabViewProps = {
   /**
    * Function that runs when user clicks a new tab.
    */
-  onChange: (newValue: string) => void;
+  onSelectTab: (newTab: string) => void;
 
   /**
    * The value of the tab view.
    */
-  value: string;
+  selectedTab: string;
 };
 
 const ZUITabView: FC<ZUITabViewProps> = ({
   fullWidth = false,
   items,
-  onChange,
-  value,
+  onSelectTab,
+  selectedTab,
 }) => {
   return (
-    <TabContext value={value}>
+    <TabContext value={selectedTab}>
       <TabList
-        onChange={(ev, newValue) => onChange(newValue)}
+        onChange={(ev, newTab) => onSelectTab(newTab)}
         sx={(theme) => ({
           borderBottom: `0.063rem solid ${theme.palette.dividers.main}`,
           minHeight: '2.438rem',

--- a/src/zui/components/ZUITabView/index.tsx
+++ b/src/zui/components/ZUITabView/index.tsx
@@ -1,0 +1,51 @@
+//import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Tab } from '@mui/material';
+import { FC } from 'react';
+
+type TabItem = {
+  /**
+   * The content to render in the tab
+   */
+  content: JSX.Element;
+
+  /**
+   * The label of the tab
+   */
+  label: string;
+
+  /**
+   * The value of the tab
+   */
+  value: string;
+};
+
+type ZUITabViewProps = {
+  /**
+   * Function that runs when user clicks a new tab.
+   */
+  onChange: (newValue: string) => void;
+
+  items: TabItem[];
+
+  /**
+   * The value of the tab view.
+   */
+  value: string;
+};
+
+const ZUITabView: FC<ZUITabViewProps> = ({ items, onChange, value }) => {
+  return <h1>HEJ</h1>;
+
+  return (
+    <TabContext value={value}>
+      <TabList onChange={(ev, newValue) => onChange(newValue)}>
+        <Tab label="hallå" value="goddag" />
+        <Tab label="katt" value="mjao" />
+      </TabList>
+      <TabPanel value="goddag">hallå</TabPanel>
+      <TabPanel value="mjao">katt</TabPanel>
+    </TabContext>
+  );
+};
+
+export default ZUITabView;

--- a/src/zui/components/ZUITabView/index.tsx
+++ b/src/zui/components/ZUITabView/index.tsx
@@ -1,17 +1,17 @@
-//import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Tab } from '@mui/material';
 import { FC } from 'react';
 
 type TabItem = {
   /**
-   * The content to render in the tab
-   */
-  content: JSX.Element;
-
-  /**
    * The label of the tab
    */
   label: string;
+
+  /**
+   * A function that returns the content to render in the tab
+   */
+  render: () => JSX.Element;
 
   /**
    * The value of the tab
@@ -21,11 +21,14 @@ type TabItem = {
 
 type ZUITabViewProps = {
   /**
+   * A list of items that contains data about each tab.
+   */
+  items: TabItem[];
+
+  /**
    * Function that runs when user clicks a new tab.
    */
   onChange: (newValue: string) => void;
-
-  items: TabItem[];
 
   /**
    * The value of the tab view.
@@ -34,16 +37,35 @@ type ZUITabViewProps = {
 };
 
 const ZUITabView: FC<ZUITabViewProps> = ({ items, onChange, value }) => {
-  return <h1>HEJ</h1>;
-
   return (
     <TabContext value={value}>
-      <TabList onChange={(ev, newValue) => onChange(newValue)}>
-        <Tab label="hallå" value="goddag" />
-        <Tab label="katt" value="mjao" />
+      <TabList
+        onChange={(ev, newValue) => onChange(newValue)}
+        sx={(theme) => ({
+          borderBottom: `0.063rem solid ${theme.palette.dividers.main}`,
+          minHeight: '2.438rem',
+        })}
+      >
+        {items.map((tab) => (
+          <Tab
+            key={`tab-${tab.value}`}
+            label={tab.label}
+            sx={{
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              minHeight: '2.438rem',
+              minWidth: '1.5rem',
+              paddingY: '0.563rem',
+            }}
+            value={tab.value}
+          />
+        ))}
       </TabList>
-      <TabPanel value="goddag">hallå</TabPanel>
-      <TabPanel value="mjao">katt</TabPanel>
+      {items.map((tab) => (
+        <TabPanel key={`tabPanel-${tab.value}`} value={tab.value}>
+          {tab.render()}
+        </TabPanel>
+      ))}
     </TabContext>
   );
 };

--- a/src/zui/components/ZUITabbedNavBar/index.stories.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.stories.tsx
@@ -51,3 +51,30 @@ export const FullWidth: Story = {
   args: { ...Basic.args, fullWidth: true },
   render: Basic.render,
 };
+
+export const WithBadge: Story = {
+  args: {
+    items: [
+      {
+        badge: { color: 'danger' },
+        href: '/?path=/docs/components-zuitabbednavbar--docs',
+        label: 'Overview',
+      },
+      {
+        badge: { color: 'warning', number: 13 },
+        href: '/?path=/docs/components',
+        label: 'Map',
+      },
+      {
+        badge: {
+          color: 'info',
+          number: 99999999999,
+          truncateLargeNumber: true,
+        },
+        href: '/?path=/docs/components-zuitabview--docs',
+        label: 'Assignees',
+      },
+    ],
+  },
+  render: Basic.render,
+};

--- a/src/zui/components/ZUITabbedNavBar/index.stories.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Box } from '@mui/material';
+
+import ZUITabbedNavBar from './index';
+import ZUIText from '../ZUIText';
+
+const meta: Meta<typeof ZUITabbedNavBar> = {
+  component: ZUITabbedNavBar,
+  title: 'Components/ZUITabbedNavBar',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUITabbedNavBar>;
+
+export const Basic: Story = {
+  args: {
+    items: [
+      {
+        href: '/?path=/docs/components',
+        label: 'Overview',
+      },
+      {
+        href: '/?path=/docs/components-zuitabbednavbar--docs',
+        label: 'Map',
+      },
+      {
+        href: '/?path=/docs/components-zuitabview--docs',
+        label: 'Assignees',
+      },
+    ],
+  },
+  render: function Render(args) {
+    const [value, setValue] = useState('/?path=/docs/components');
+
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '2' }}>
+        <ZUIText>Warning: clicking will navigate</ZUIText>
+        <ZUITabbedNavBar
+          {...args}
+          items={args.items}
+          onSelectTab={(newValue) => setValue(newValue)}
+          selectedTab={value}
+        />
+      </Box>
+    );
+  },
+};
+
+export const FullWidth: Story = {
+  args: { ...Basic.args, fullWidth: true },
+  render: Basic.render,
+};

--- a/src/zui/components/ZUITabbedNavBar/index.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.tsx
@@ -1,0 +1,67 @@
+import { Tab, Tabs } from '@mui/material';
+import { FC } from 'react';
+
+type LinkTabItem = { href: string; label: string };
+
+type ZUITabbedNavBar = {
+  /**
+   * If true, the tabs will take up all available horizontal space.
+   *
+   * Defaults to "false".
+   */
+  fullWidth?: boolean;
+
+  /**
+   * List of the items that will render as tabs.
+   */
+  items: LinkTabItem[];
+
+  /**
+   * The function that runs when the user clicks a tab.
+   */
+  onSelectTab: (newTab: string) => void;
+
+  /**
+   * The value of the tabs list.
+   */
+  selectedTab: string;
+};
+
+const ZUITabbedNavBar: FC<ZUITabbedNavBar> = ({
+  fullWidth = false,
+  items,
+  onSelectTab,
+  selectedTab,
+}) => {
+  return (
+    <Tabs
+      onChange={(ev, newTab) => onSelectTab(newTab)}
+      role="navigation"
+      sx={(theme) => ({
+        borderBottom: `0.063rem solid ${theme.palette.dividers.main}`,
+        minHeight: '2.438rem',
+      })}
+      value={selectedTab}
+      variant={fullWidth ? 'fullWidth' : 'standard'}
+    >
+      {items.map((tab) => (
+        <Tab
+          key={`navTab-${tab.href}`}
+          component="a"
+          href={tab.href}
+          label={tab.label}
+          sx={{
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            minHeight: '2.438rem',
+            minWidth: '1.5rem',
+            paddingY: '0.563rem',
+          }}
+          value={tab.href}
+        />
+      ))}
+    </Tabs>
+  );
+};
+
+export default ZUITabbedNavBar;

--- a/src/zui/components/ZUITabbedNavBar/index.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.tsx
@@ -5,8 +5,19 @@ import { ZUIBadgeProps } from '../ZUIBadge';
 import { getContrastColor } from 'utils/colorUtils';
 
 type LinkTabItem = {
+  /**
+   * Send in properties that will render a badge on the tab.
+   */
   badge?: Omit<ZUIBadgeProps, 'children'>;
+
+  /**
+   * The href the tab routes to.
+   */
   href: string;
+
+  /**
+   * The label of the tab.
+   */
   label: string;
 };
 
@@ -34,7 +45,7 @@ type ZUITabbedNavBar = {
   selectedTab: string;
 };
 
-const TabBadge: FC<Omit<ZUIBadgeProps, 'children'>> = ({
+export const TabBadge: FC<Omit<ZUIBadgeProps, 'children'>> = ({
   color,
   number,
   truncateLargeNumber = false,

--- a/src/zui/components/ZUITabbedNavBar/index.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.tsx
@@ -1,7 +1,14 @@
-import { Tab, Tabs } from '@mui/material';
+import { Box, Tab, Tabs } from '@mui/material';
 import { FC } from 'react';
 
-type LinkTabItem = { href: string; label: string };
+import { ZUIBadgeProps } from '../ZUIBadge';
+import { getContrastColor } from 'utils/colorUtils';
+
+type LinkTabItem = {
+  badge?: Omit<ZUIBadgeProps, 'children'>;
+  href: string;
+  label: string;
+};
 
 type ZUITabbedNavBar = {
   /**
@@ -27,6 +34,47 @@ type ZUITabbedNavBar = {
   selectedTab: string;
 };
 
+const TabBadge: FC<Omit<ZUIBadgeProps, 'children'>> = ({
+  color,
+  number,
+  truncateLargeNumber = false,
+}) => {
+  const colorName = color == 'danger' ? 'error' : color;
+  const hasNumber = typeof number == 'number';
+
+  const truncateLowNumber = hasNumber && truncateLargeNumber && number > 99;
+  const truncateExtremeNumber =
+    hasNumber && !truncateLargeNumber && number > 999999;
+
+  let label = number?.toString();
+  if (truncateLowNumber) {
+    label = '99+';
+  } else if (truncateExtremeNumber) {
+    label = '999999+';
+  }
+
+  return (
+    <Box
+      sx={(theme) => ({
+        alignItems: 'center',
+        backgroundColor: theme.palette[colorName].main,
+        borderRadius: '2rem',
+        color: getContrastColor(theme.palette[colorName].main),
+        display: 'flex',
+        fontSize: '0.813rem',
+        fontWeight: 500,
+        height: hasNumber ? '1.125rem' : '0.625rem',
+        justifyContent: 'center',
+        marginLeft: '0.5rem',
+        padding: hasNumber ? '0.188rem 0.438rem 0.188rem 0.438rem' : undefined,
+        width: hasNumber ? undefined : '0.625rem',
+      })}
+    >
+      {label}
+    </Box>
+  );
+};
+
 const ZUITabbedNavBar: FC<ZUITabbedNavBar> = ({
   fullWidth = false,
   items,
@@ -49,6 +97,18 @@ const ZUITabbedNavBar: FC<ZUITabbedNavBar> = ({
           key={`navTab-${tab.href}`}
           component="a"
           href={tab.href}
+          icon={
+            tab.badge ? (
+              <TabBadge
+                color={tab.badge.color}
+                number={tab.badge.number}
+                truncateLargeNumber={tab.badge.truncateLargeNumber}
+              />
+            ) : (
+              ''
+            )
+          }
+          iconPosition="end"
           label={tab.label}
           sx={{
             fontSize: '0.875rem',


### PR DESCRIPTION
## Description
This PR adds two components to render tabs - one for navigational tabs, and one for "same page" tabs.


## Screenshota
![bild](https://github.com/user-attachments/assets/232f9f1d-d651-41fb-8ba9-bcb4d200aaa2)

![bild](https://github.com/user-attachments/assets/7db005c3-fcdd-445c-a94b-d9e9de68121c)

![bild](https://github.com/user-attachments/assets/85c31ea5-775d-4277-a0f2-ebf968518a06)

![bild](https://github.com/user-attachments/assets/0a86a98f-6d72-4b6f-9d26-599ff3c05818)

![bild](https://github.com/user-attachments/assets/3a257466-3b7e-460a-b793-80204978d2fb)

## Changes
* Adds `ZUITabbedNavBar` and `ZUITabView` components + storybook stories

## Notes to reviewer
look and play!


## Related issues
none
