### PR TITLE
Change message to represent activist instead of caller

### DIFF
--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -20,7 +20,6 @@ export default makeMessages('feat.areaAssignments', {
       saveButton: m('Save'),
       savedMessage: m('Everything is up to date!'),
       savingButton: m('Saving...'),
-      title: m('Activist instructions'),
       unsavedMessage: m('You have unsaved changes.'),
     },
     title: m('Assignee instructions'),

--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -15,12 +15,12 @@ export default makeMessages('feat.areaAssignments', {
       confirm: m(
         'Do you want to delete all unsaved changes and go back to saved instructions?'
       ),
-      editorPlaceholder: m('Add instructions for your callers'),
+      editorPlaceholder: m('Add instructions for your activists'),
       revertLink: m('Revert to saved version?'),
       saveButton: m('Save'),
       savedMessage: m('Everything is up to date!'),
       savingButton: m('Saving...'),
-      title: m('Caller instructions'),
+      title: m('Activist instructions'),
       unsavedMessage: m('You have unsaved changes.'),
     },
     title: m('Assignee instructions'),


### PR DESCRIPTION
## Description
This PR change messages from 'Callers' to 'Activists' in the area assignment instruction editor


## Screenshots
![activists](https://github.com/user-attachments/assets/7ea2015a-2006-4060-bb9e-3dafb7a917d3)

## Changes
- Changed 'caller' to 'activist'

## Notes to reviewer
1. Go to [app.dev.zetkin.org/organize/1](https://app.dev.zetkin.org/organize/1)
2. Go to any Area assignment
3. Go to Instruction tab
4. Placeholder text in editor should say 'activists' and not 'callers'

This feature is currently hidden behind a feature flag. You need to add the feature flag `FEAT_AREAS=*` in your environment variables, and also configure a mongodb database URL in the `MONGODB_URL` environment variable. It can be any instance of mongodb.


## Related issues
Resolves #2611 