### PR TITLE
fix: improve default naming for canvassing households

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/CreateHouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/CreateHouseholdsPage.tsx
@@ -74,10 +74,9 @@ const CreateHouseholdsPage: FC<Props> = ({
               range(numFloors).flatMap((floorIndex) =>
                 range(numAptsPerFloor).map((aptIndex) => ({
                   floor: floorIndex + 1,
-                  title:
-                    messages.households.createMultiple.householdDefaultTitle({
-                      householdNumber: aptIndex + 1,
-                    }),
+                  title: messages.households.householdDefaultTitle({
+                    householdNumber: aptIndex + 1,
+                  }),
                 }))
               )
             );

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
@@ -124,9 +124,16 @@ const HouseholdsPage: FC<Props> = ({
             disabled={adding}
             onClick={async () => {
               setAdding(true);
-              const newlyAddedHousehold = await addHousehold({
-                title: messages.default.household(),
+
+              // Since this button adds households to the unknown floor, we only count those households
+              const householdsOnUnknownFloor = sortedHouseholds.filter(
+                ({ floor }) => floor == null
+              );
+              const title = messages.households.householdDefaultTitle({
+                householdNumber: householdsOnUnknownFloor.length + 1,
               });
+
+              const newlyAddedHousehold = await addHousehold({ title });
               setAdding(false);
               onCreateHousehold(newlyAddedHousehold);
             }}

--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -6,7 +6,6 @@ export default makeMessages('feat.canvass', {
   default: {
     description: m('Empty description'),
     floor: m('Unknown floor'),
-    household: m('Untitled household'),
     location: m('Untitled location'),
   },
   households: {
@@ -15,9 +14,6 @@ export default makeMessages('feat.canvass', {
         'Create {numHouseholds, plural, one {1 household} other {# households}}'
       ),
       header: m('Create households'),
-      householdDefaultTitle: m<{ householdNumber: number }>(
-        'Household {householdNumber}'
-      ),
       numberOfFloorsInput: m('Number of floors'),
       numberOfHouseholdsInput: m('Households per floor'),
     },
@@ -27,6 +23,9 @@ export default makeMessages('feat.canvass', {
       saveButtonLabel: m('Save'),
       titleLabel: m('Edit title'),
     },
+    householdDefaultTitle: m<{ householdNumber: number }>(
+      'Household {householdNumber}'
+    ),
     page: {
       empty: m('This location does not have any households yet'),
       header: m('Households'),


### PR DESCRIPTION
## Description
This PR improves the default naming for canvassing households by giving them the title "Household X", where X counts up. This way, we avoid having multiple households with the same name. We also reuse the default household name used in the bulk-add-action, instead of having different default names based on how the household was added.


## Screenshots
<img width="435" alt="image" src="https://github.com/user-attachments/assets/e6cf310b-72e9-4be1-94d5-1d5e0f07abbe" />

It might be a bit counterintuitive that the households are seen in descending order, but that is because newly created households are added to the top of the list.



## Changes
* Reuse the `createMultiple.householdDefaultTitle` when adding single households as well
* Remove the (now) unused `default.household` message ID


## Notes to reviewer


## Related issues
Resolves #2550 
