### PR TITLE
ZUIItemCard

### DIFF
--- a/src/zui/components/ZUIAvatar/index.tsx
+++ b/src/zui/components/ZUIAvatar/index.tsx
@@ -48,7 +48,7 @@ const ZUIAvatar: FC<ZUIAvatarProps> = ({
     fontSize = 12;
     letterSpacing = 0.08;
   } else if (size == 'large') {
-    avatarSize = 48;
+    avatarSize = 40;
     fontSize = 20;
     letterSpacing = 0.14;
   }

--- a/src/zui/components/ZUIItemCard/index.stories.tsx
+++ b/src/zui/components/ZUIItemCard/index.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@mui/material';
+
+import ZUIItemCard from './index';
+
+const meta: Meta<typeof ZUIItemCard> = {
+  component: ZUIItemCard,
+  title: 'Components/ZUIItemCard',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIItemCard>;
+
+export const Basic: Story = {
+  args: {
+    button: { label: 'See the full program', onClick: () => null },
+    description:
+      '20 events across 5 venues with presenters from Denmark, Bulgaria, Greece and France.',
+    subtitle: 'March 5 - March 9',
+    title: 'Feminist action week',
+  },
+  render: function Render(args) {
+    return (
+      <Box width="250px">
+        <ZUIItemCard {...args} />
+      </Box>
+    );
+  },
+};
+
+export const Avatar: Story = {
+  args: {
+    avatar: { firstName: 'Angela', id: 1, lastName: 'Davis' },
+    description:
+      'Angela has been a caller in 5 call assignments, attended 14 events and participated in 3 area assignments.',
+    subtitle: 'Activist',
+    title: 'Angela Davis',
+  },
+  render: Basic.render,
+};
+
+export const Image: Story = {
+  args: {
+    button: { label: 'Configure', onClick: () => null },
+    image: <Box sx={{ backgroundColor: 'peachpuff', height: '100%' }} />,
+    subtitle: 'Find people based on the surveys they responded to',
+    title: 'Survey responses',
+  },
+  render: Basic.render,
+};

--- a/src/zui/components/ZUIItemCard/index.tsx
+++ b/src/zui/components/ZUIItemCard/index.tsx
@@ -1,0 +1,107 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import ZUIAvatar, { ZUIAvatarProps } from '../ZUIAvatar';
+import ZUIButton from '../ZUIButton';
+
+type ZUIItemCardProps = {
+  avatar?: Omit<ZUIAvatarProps, 'size' | 'variant'>;
+
+  button?: {
+    /**
+     * The label of the button
+     */
+
+    label: string;
+    /**
+     * The function that runs when pressing the button.
+     */
+    onClick: () => void;
+  };
+
+  /**
+   * The description of the card.
+   */
+  description?: string;
+
+  /**
+   * The image to display at the top of the card.
+   *
+   * This element needs to have its height set to 100%.
+   */
+  image?: JSX.Element;
+
+  /**
+   * The subtitle of the card
+   */
+  subtitle?: string;
+
+  /**
+   * The title of the card.
+   */
+  title: string;
+};
+
+const ZUIItemCard: FC<ZUIItemCardProps> = ({
+  avatar,
+  button,
+  description,
+  image,
+  subtitle,
+  title,
+}) => {
+  return (
+    <Box
+      sx={(theme) => ({
+        border: `0.063rem solid ${theme.palette.dividers.main}`,
+        borderRadius: '0.25rem',
+      })}
+    >
+      {image && <Box sx={{ height: '9.375rem' }}>{image}</Box>}
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1.25rem',
+          padding: '1.25rem',
+        }}
+      >
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <Box sx={{ alignItems: 'center', display: 'flex', gap: '0.75rem' }}>
+            {avatar && (
+              <ZUIAvatar
+                firstName={avatar.firstName}
+                id={avatar.id}
+                lastName={avatar.lastName}
+                size="large"
+              />
+            )}
+            <Box
+              sx={{ display: 'flex', flexDirection: 'column', gap: '0.125rem' }}
+            >
+              <Typography variant="bodyMdSemiBold">{title}</Typography>
+              {subtitle && (
+                <Typography variant="bodyMdRegular">{subtitle}</Typography>
+              )}
+            </Box>
+          </Box>
+          {description && (
+            <Typography variant="bodySmRegular">{description}</Typography>
+          )}
+        </Box>
+        {button && (
+          <Box sx={{ display: 'flex' }}>
+            <ZUIButton
+              label={button.label}
+              onClick={button.onClick}
+              size="large"
+              variant="secondary"
+            />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default ZUIItemCard;


### PR DESCRIPTION
## Description
This PR adds the `ZUIItemCard` component, and storybook stories.

It also fixes a mistake in the ZUIAvatar component where the size of large avatars was too big.


## Screenshots
![bild](https://github.com/user-attachments/assets/79da8737-953f-4ac0-b393-d7af95238331)
![bild](https://github.com/user-attachments/assets/a340832a-e33d-4e40-8864-a50968a27516)
![bild](https://github.com/user-attachments/assets/ec2f0b87-0f07-4a6e-a9e3-cce6387a77ac)


## Changes
* Adds the `ZUIItemCard` component + storybook stories
* Changes…


## Notes to reviewer
- I was not creative with the component naming, just took what was in Figma, but if you have a better suggestion for a name for this component I am all ears
- The width of the card is currently "as wide as the parent" and I'm not sure if this is correct.


## Related issues
none
