### PR TITLE
Settings page

### DIFF
--- a/integrationTesting/mockData/users/RosaLuxemburgUser.ts
+++ b/integrationTesting/mockData/users/RosaLuxemburgUser.ts
@@ -4,8 +4,11 @@ const RosaLuxemburgUser: ZetkinUser = {
   email: 'rosa@zetkin.org',
   first_name: 'Rosa',
   id: 1,
+  is_verifiend: true,
   lang: null,
   last_name: 'Luxemburg',
+  phone: null,
+  phone_is_verified: false,
   username: 'red_rosa',
 };
 

--- a/src/app/my/settings/page.tsx
+++ b/src/app/my/settings/page.tsx
@@ -1,0 +1,8 @@
+import redirectIfLoginNeeded from 'core/utils/redirectIfLoginNeeded';
+import SettingsPage from 'features/home/pages/SettingsPage';
+
+export default async function Page() {
+  await redirectIfLoginNeeded();
+
+  return <SettingsPage />;
+}

--- a/src/features/home/components/SettingsList.tsx
+++ b/src/features/home/components/SettingsList.tsx
@@ -45,7 +45,7 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
       position="relative"
     >
       <Box mt={2}>
-        <ZUICard header={'App settings'}>
+        <ZUICard header={messages.settings.appPreferences.header()}>
           <Divider />
           <Box
             sx={{
@@ -57,10 +57,10 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
           >
             <FormControl fullWidth sx={{ mt: 2 }}>
               <InputLabel shrink>
-                <Msg id={messageIds.settings.lang.label} />
+                <Msg id={messageIds.settings.appPreferences.lang.label} />
               </InputLabel>
               <Select
-                label={messages.settings.lang.label()}
+                label={messages.settings.appPreferences.lang.label()}
                 onChange={(e) => {
                   if (e.target.value == 'auto') {
                     setSelectedLanguage(null);
@@ -71,7 +71,7 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
                 value={selectedLanguage || 'auto'}
               >
                 <MenuItem key="auto" value="auto">
-                  <Msg id={messageIds.settings.lang.auto} />
+                  <Msg id={messageIds.settings.appPreferences.lang.auto} />
                 </MenuItem>
                 {Object.entries(languageOptions).map(([code, label]) => (
                   <MenuItem key={code} value={code}>
@@ -88,7 +88,7 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
               }}
               variant="contained"
             >
-              <Msg id={messageIds.settings.lang.saveButton} />
+              <Msg id={messageIds.settings.appPreferences.lang.saveButton} />
             </Button>
           </Box>
         </ZUICard>

--- a/src/features/home/components/SettingsList.tsx
+++ b/src/features/home/components/SettingsList.tsx
@@ -1,0 +1,79 @@
+import { FC, useState } from 'react';
+import {
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material';
+
+import messageIds from '../../breadcrumbs/l10n/messageIds';
+import useUserMutations from '../hooks/useUserMutations';
+import { useMessages } from 'core/i18n';
+import ZUICard from 'zui/ZUICard';
+import { ZetkinUser } from 'utils/types/zetkin';
+
+export type ZetkinLanguage = 'en' | 'sv' | 'da' | 'nn' | 'de' | null;
+
+type SettingListProps = {
+  user: ZetkinUser;
+};
+
+const SettingsList: FC<SettingListProps> = ({ user }) => {
+  const messages = useMessages(messageIds);
+
+  const languageOptions: { [key: string]: string } = {
+    da: 'Danish',
+    de: 'German',
+    en: 'English',
+    nn: 'Norwegian Nynorsk',
+    sv: 'Swedish',
+  };
+
+  const { changeUserLanguage } = useUserMutations();
+  const [selectedLanguage, setSelectedLanguage] = useState<ZetkinLanguage>(
+    user?.lang as ZetkinLanguage
+  );
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={1}
+      overflow="hidden"
+      position="relative"
+    >
+      <Typography>
+        String that changes the language: {messages.elements.activities()}
+      </Typography>
+      {user && (
+        <ZUICard header={'App settings'}>
+          <Divider />
+          <FormControl fullWidth sx={{ mt: 2 }}>
+            <InputLabel shrink>Language</InputLabel>
+            <Select
+              onChange={(e) => {
+                const lang = e.target.value as ZetkinLanguage;
+                setSelectedLanguage(lang), changeUserLanguage(lang);
+              }}
+              value={selectedLanguage}
+            >
+              {Object.entries(languageOptions).map(([code, label]) => (
+                <MenuItem key={code} value={code}>
+                  {label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </ZUICard>
+      )}
+
+      <Button />
+    </Box>
+  );
+};
+
+export default SettingsList;

--- a/src/features/home/components/SettingsList.tsx
+++ b/src/features/home/components/SettingsList.tsx
@@ -93,16 +93,6 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
           </Box>
         </ZUICard>
       </Box>
-
-      <Box mt={2}>
-        <ZUICard header={'Account settings'}>
-          <Divider />
-          {user.phone && (
-            <TextField fullWidth sx={{ mt: 2 }} value={user.phone} />
-          )}
-        </ZUICard>
-        <Button />
-      </Box>
     </Box>
   );
 };

--- a/src/features/home/components/SettingsList.tsx
+++ b/src/features/home/components/SettingsList.tsx
@@ -7,12 +7,13 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  TextField,
 } from '@mui/material';
 
 import useUserMutations from '../hooks/useUserMutations';
 import { ZetkinUser } from 'utils/types/zetkin';
 import ZUICard from 'zui/ZUICard';
+import messageIds from '../l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
 
 export type ZetkinLanguage = 'en' | 'sv' | 'da' | 'nn' | 'de' | null;
 
@@ -21,13 +22,14 @@ type SettingListProps = {
 };
 
 const SettingsList: FC<SettingListProps> = ({ user }) => {
-  const languageOptions: { [key: string]: string } = {
-    da: 'Danish',
-    de: 'German',
+  const messages = useMessages(messageIds);
+  const languageOptions = {
+    da: 'Dansk',
+    de: 'Deutsch',
     en: 'English',
-    nn: 'Norwegian Nynorsk',
-    sv: 'Swedish',
-  };
+    nn: 'Norsk',
+    sv: 'Svenska',
+  } as const;
 
   const { changeUserLanguage } = useUserMutations();
   const [selectedLanguage, setSelectedLanguage] = useState<ZetkinLanguage>(
@@ -45,23 +47,50 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
       <Box mt={2}>
         <ZUICard header={'App settings'}>
           <Divider />
-          <FormControl fullWidth sx={{ mt: 2 }}>
-            <InputLabel shrink>Language</InputLabel>
-            <Select
-              onChange={(e) => {
-                const lang = e.target.value as ZetkinLanguage;
-                setSelectedLanguage(lang), changeUserLanguage(lang);
+          <Box
+            sx={{
+              alignItems: 'flex-end',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            <FormControl fullWidth sx={{ mt: 2 }}>
+              <InputLabel shrink>
+                <Msg id={messageIds.settings.lang.label} />
+              </InputLabel>
+              <Select
+                label={messages.settings.lang.label()}
+                onChange={(e) => {
+                  if (e.target.value == 'auto') {
+                    setSelectedLanguage(null);
+                  } else {
+                    setSelectedLanguage(e.target.value as ZetkinLanguage);
+                  }
+                }}
+                value={selectedLanguage || 'auto'}
+              >
+                <MenuItem key="auto" value="auto">
+                  <Msg id={messageIds.settings.lang.auto} />
+                </MenuItem>
+                {Object.entries(languageOptions).map(([code, label]) => (
+                  <MenuItem key={code} value={code}>
+                    {label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Button
+              disabled={selectedLanguage == user.lang}
+              onClick={() => {
+                changeUserLanguage(selectedLanguage);
                 location.reload();
               }}
-              value={selectedLanguage}
+              variant="contained"
             >
-              {Object.entries(languageOptions).map(([code, label]) => (
-                <MenuItem key={code} value={code}>
-                  {label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+              <Msg id={messageIds.settings.lang.saveButton} />
+            </Button>
+          </Box>
         </ZUICard>
       </Box>
 

--- a/src/features/home/components/SettingsList.tsx
+++ b/src/features/home/components/SettingsList.tsx
@@ -7,14 +7,12 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  Typography,
+  TextField,
 } from '@mui/material';
 
-import messageIds from '../../breadcrumbs/l10n/messageIds';
 import useUserMutations from '../hooks/useUserMutations';
-import { useMessages } from 'core/i18n';
-import ZUICard from 'zui/ZUICard';
 import { ZetkinUser } from 'utils/types/zetkin';
+import ZUICard from 'zui/ZUICard';
 
 export type ZetkinLanguage = 'en' | 'sv' | 'da' | 'nn' | 'de' | null;
 
@@ -23,8 +21,6 @@ type SettingListProps = {
 };
 
 const SettingsList: FC<SettingListProps> = ({ user }) => {
-  const messages = useMessages(messageIds);
-
   const languageOptions: { [key: string]: string } = {
     da: 'Danish',
     de: 'German',
@@ -46,10 +42,7 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
       overflow="hidden"
       position="relative"
     >
-      <Typography>
-        String that changes the language: {messages.elements.activities()}
-      </Typography>
-      {user && (
+      <Box mt={2}>
         <ZUICard header={'App settings'}>
           <Divider />
           <FormControl fullWidth sx={{ mt: 2 }}>
@@ -58,6 +51,7 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
               onChange={(e) => {
                 const lang = e.target.value as ZetkinLanguage;
                 setSelectedLanguage(lang), changeUserLanguage(lang);
+                location.reload();
               }}
               value={selectedLanguage}
             >
@@ -69,9 +63,17 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
             </Select>
           </FormControl>
         </ZUICard>
-      )}
+      </Box>
 
-      <Button />
+      <Box mt={2}>
+        <ZUICard header={'Account settings'}>
+          <Divider />
+          {user.phone && (
+            <TextField fullWidth sx={{ mt: 2 }} value={user.phone} />
+          )}
+        </ZUICard>
+        <Button />
+      </Box>
     </Box>
   );
 };

--- a/src/features/home/hooks/useUserMutations.tsx
+++ b/src/features/home/hooks/useUserMutations.tsx
@@ -1,0 +1,12 @@
+import { useApiClient } from 'core/hooks';
+import { ZetkinLanguage } from '../components/SettingsList';
+
+export default function useUserMutations() {
+  const apiClient = useApiClient();
+
+  const changeUserLanguage = async (lang: ZetkinLanguage) => {
+    await apiClient.patch(`/api/users/me`, { lang });
+  };
+
+  return { changeUserLanguage };
+}

--- a/src/features/home/l10n/messageIds.ts
+++ b/src/features/home/l10n/messageIds.ts
@@ -46,15 +46,19 @@ export default makeMessages('feat.home', {
     privacyPolicy: m('Privacy policy'),
   },
   settings: {
-    lang: {
-      auto: m('Automatic (from browser)'),
-      label: m('Language'),
-      saveButton: m('Save & reload'),
+    appPreferences: {
+      header: m('App preferences'),
+      lang: {
+        auto: m('Automatic (configured in  browser)'),
+        label: m('Language'),
+        saveButton: m('Save & reload'),
+      },
     },
   },
   tabs: {
     feed: m('All events'),
     home: m('My activities'),
+    settings: m('Settings'),
   },
   title: m('My Zetkin'),
 });

--- a/src/features/home/l10n/messageIds.ts
+++ b/src/features/home/l10n/messageIds.ts
@@ -45,6 +45,13 @@ export default makeMessages('feat.home', {
   footer: {
     privacyPolicy: m('Privacy policy'),
   },
+  settings: {
+    lang: {
+      auto: m('Automatic (from browser)'),
+      label: m('Language'),
+      saveButton: m('Save & reload'),
+    },
+  },
   tabs: {
     feed: m('All events'),
     home: m('My activities'),

--- a/src/features/home/layouts/HomeLayout.tsx
+++ b/src/features/home/layouts/HomeLayout.tsx
@@ -71,6 +71,13 @@ const HomeLayout: FC<Props> = ({ children, title }) => {
             sx={{ textTransform: 'none' }}
             value="feed"
           />
+          <Tab
+            component={NextLink}
+            href="/my/settings"
+            label="Settings"
+            sx={{ textTransform: 'none' }}
+            value="settings"
+          />
         </Tabs>
       </Box>
       <Box minHeight="90dvh">{children}</Box>

--- a/src/features/home/layouts/HomeLayout.tsx
+++ b/src/features/home/layouts/HomeLayout.tsx
@@ -74,7 +74,7 @@ const HomeLayout: FC<Props> = ({ children, title }) => {
           <Tab
             component={NextLink}
             href="/my/settings"
-            label="Settings"
+            label={messages.tabs.settings()}
             sx={{ textTransform: 'none' }}
             value="settings"
           />

--- a/src/features/home/pages/SettingsPage.tsx
+++ b/src/features/home/pages/SettingsPage.tsx
@@ -4,8 +4,12 @@ import { Box } from '@mui/material';
 import { FC, Suspense } from 'react';
 
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+import SettingsList from '../components/SettingsList';
+import useCurrentUser from 'features/user/hooks/useCurrentUser';
 
 const AllEventsPage: FC = () => {
+  const user = useCurrentUser();
+
   return (
     <Suspense
       fallback={
@@ -19,7 +23,9 @@ const AllEventsPage: FC = () => {
           <ZUILogoLoadingIndicator />
         </Box>
       }
-    />
+    >
+      {user && <SettingsList user={user} />}
+    </Suspense>
   );
 };
 

--- a/src/features/home/pages/SettingsPage.tsx
+++ b/src/features/home/pages/SettingsPage.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { FC, Suspense } from 'react';
+
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+
+const AllEventsPage: FC = () => {
+  return (
+    <Suspense
+      fallback={
+        <Box
+          alignItems="center"
+          display="flex"
+          flexDirection="column"
+          height="90dvh"
+          justifyContent="center"
+        >
+          <ZUILogoLoadingIndicator />
+        </Box>
+      }
+    />
+  );
+};
+
+export default AllEventsPage;

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -135,8 +135,11 @@ export interface ZetkinUser {
   first_name: string;
   id: number;
   is_superuser?: boolean;
+  is_verifiend: boolean;
   lang: string | null;
   last_name: string;
+  phone: string | null;
+  phone_is_verified: boolean;
   username: string;
 }
 


### PR DESCRIPTION
## Description
EDIT: This is updated by Richard, who completed the PR. 

This PR implements the smallest possible settings page (with just language settings).

## Screenshots
![image](https://github.com/user-attachments/assets/5afb3817-1cd0-42fe-9942-ae3c1a6b3474)


## Changes
* Adds a settings page at /my/settings
* Adds logic and UI to update the user's preferred language

## Notes to reviewer
None

## Related issues
Undocumented