### PR TITLE
ZUIActivityListItem and more

### DIFF
--- a/src/zui/components/ZUIActivityListItem/EventWarningIcons.tsx
+++ b/src/zui/components/ZUIActivityListItem/EventWarningIcons.tsx
@@ -1,0 +1,66 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+import {
+  EmojiPeople,
+  FaceRetouchingOff,
+  MailOutline,
+} from '@mui/icons-material';
+
+import ZUIIcon from '../ZUIIcon';
+import ZUITooltip from '../ZUITooltip';
+import { useMessages } from 'core/i18n';
+import messageIds from 'zui/l10n/messageIds';
+
+export type EventWarningIconsProps = {
+  hasContact: boolean;
+  numBooked: number;
+  numRemindersSent: number;
+  numSignups: number;
+};
+
+const EventWarningIcons: FC<EventWarningIconsProps> = ({
+  hasContact,
+  numBooked,
+  numRemindersSent,
+  numSignups,
+}) => {
+  const messages = useMessages(messageIds);
+
+  return (
+    <Box sx={{ alignItems: 'center', display: 'flex', gap: '0.75rem' }}>
+      <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {!hasContact && (
+          <ZUITooltip label={messages.eventWarningIcons.contact()}>
+            <span style={{ alignItems: 'center', display: 'flex' }}>
+              <ZUIIcon color="danger" icon={FaceRetouchingOff} size="small" />
+            </span>
+          </ZUITooltip>
+        )}
+      </Box>
+      <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {numSignups > 0 && (
+          <ZUITooltip label={messages.eventWarningIcons.signUps()}>
+            <span style={{ alignItems: 'center', display: 'flex' }}>
+              <ZUIIcon color="danger" icon={EmojiPeople} size="small" />
+            </span>
+          </ZUITooltip>
+        )}
+      </Box>
+      <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {numRemindersSent < numBooked && (
+          <ZUITooltip
+            label={messages.eventWarningIcons.reminders({
+              numMissing: numBooked - numRemindersSent,
+            })}
+          >
+            <span style={{ alignItems: 'center', display: 'flex' }}>
+              <ZUIIcon color="danger" icon={MailOutline} size="small" />
+            </span>
+          </ZUITooltip>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default EventWarningIcons;

--- a/src/zui/components/ZUIActivityListItem/EventWarningIcons.tsx
+++ b/src/zui/components/ZUIActivityListItem/EventWarningIcons.tsx
@@ -13,6 +13,7 @@ import messageIds from 'zui/l10n/messageIds';
 
 export type EventWarningIconsProps = {
   hasContact: boolean;
+  isUrgent: boolean;
   numBooked: number;
   numRemindersSent: number;
   numSignups: number;
@@ -21,6 +22,7 @@ export type EventWarningIconsProps = {
 const EventWarningIcons: FC<EventWarningIconsProps> = ({
   hasContact,
   numBooked,
+  isUrgent,
   numRemindersSent,
   numSignups,
 }) => {
@@ -29,24 +31,56 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
   return (
     <Box sx={{ alignItems: 'center', display: 'flex', gap: '0.75rem' }}>
       <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {hasContact && (
+          <FaceRetouchingOff
+            sx={(theme) => ({
+              color: theme.palette.grey[200],
+              fontSize: '1.25rem',
+            })}
+          />
+        )}
         {!hasContact && (
           <ZUITooltip label={messages.eventWarningIcons.contact()}>
             <span style={{ alignItems: 'center', display: 'flex' }}>
-              <ZUIIcon color="danger" icon={FaceRetouchingOff} size="small" />
+              <ZUIIcon
+                color={isUrgent ? 'danger' : 'primary'}
+                icon={FaceRetouchingOff}
+                size="small"
+              />
             </span>
           </ZUITooltip>
         )}
       </Box>
       <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {numSignups == 0 && (
+          <EmojiPeople
+            sx={(theme) => ({
+              color: theme.palette.grey[200],
+              fontSize: '1.25rem',
+            })}
+          />
+        )}
         {numSignups > 0 && (
           <ZUITooltip label={messages.eventWarningIcons.signUps()}>
             <span style={{ alignItems: 'center', display: 'flex' }}>
-              <ZUIIcon color="danger" icon={EmojiPeople} size="small" />
+              <ZUIIcon
+                color={isUrgent ? 'danger' : 'primary'}
+                icon={EmojiPeople}
+                size="small"
+              />
             </span>
           </ZUITooltip>
         )}
       </Box>
       <Box sx={{ alignItems: 'center', display: 'flex', width: '1.25rem' }}>
+        {numRemindersSent >= numBooked && (
+          <MailOutline
+            sx={(theme) => ({
+              color: theme.palette.grey[200],
+              fontSize: '1.25rem',
+            })}
+          />
+        )}
         {numRemindersSent < numBooked && (
           <ZUITooltip
             label={messages.eventWarningIcons.reminders({
@@ -54,7 +88,11 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
             })}
           >
             <span style={{ alignItems: 'center', display: 'flex' }}>
-              <ZUIIcon color="danger" icon={MailOutline} size="small" />
+              <ZUIIcon
+                color={isUrgent ? 'danger' : 'primary'}
+                icon={MailOutline}
+                size="small"
+              />
             </span>
           </ZUITooltip>
         )}

--- a/src/zui/components/ZUIActivityListItem/index.stories.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.stories.tsx
@@ -1,0 +1,138 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Box } from '@mui/material';
+import { useState } from 'react';
+
+import ZUIActivityListItem from '.';
+import { activities } from './storybookActivities';
+
+const meta: Meta<typeof ZUIActivityListItem> = {
+  component: ZUIActivityListItem,
+  title: 'Components/ZUIActivityListItem',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIActivityListItem>;
+
+export const Default: Story = {
+  render: function Render() {
+    return (
+      <Box>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem key={`Default-${index}`} {...activity} />
+        ))}
+      </Box>
+    );
+  },
+};
+
+export const DefaultCheckboxes: Story = {
+  render: function Render() {
+    const [checked, setChecked] = useState<number[]>([]);
+    return (
+      <Box>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem
+            key={`DefaultCheckboxes-${index}`}
+            {...activity}
+            checkboxProps={{
+              checked: checked.includes(index),
+              onChange: (newCheckedState) => {
+                if (newCheckedState) {
+                  setChecked(checked.concat([index]));
+                } else {
+                  setChecked(checked.filter((i) => i != index));
+                }
+              },
+            }}
+          />
+        ))}
+      </Box>
+    );
+  },
+};
+
+export const Wide: Story = {
+  render: function Render() {
+    return (
+      <Box>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem
+            key={`Wide-${index}`}
+            {...activity}
+            variant="wide"
+          />
+        ))}
+      </Box>
+    );
+  },
+};
+
+export const WideCheckboxes: Story = {
+  render: function Render() {
+    const [checked, setChecked] = useState<number[]>([]);
+    return (
+      <Box>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem
+            key={`WideCheckboxes-${index}`}
+            {...activity}
+            checkboxProps={{
+              checked: checked.includes(index),
+              onChange: (newCheckedState) => {
+                if (newCheckedState) {
+                  setChecked(checked.concat([index]));
+                } else {
+                  setChecked(checked.filter((i) => i != index));
+                }
+              },
+            }}
+            variant="wide"
+          />
+        ))}
+      </Box>
+    );
+  },
+};
+
+export const Narrow: Story = {
+  render: function Render() {
+    return (
+      <Box sx={{ width: '400px' }}>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem
+            key={`Narrow-${index}`}
+            {...activity}
+            variant="narrow"
+          />
+        ))}
+      </Box>
+    );
+  },
+};
+
+export const NarrowCheckboxes: Story = {
+  render: function Render() {
+    const [checked, setChecked] = useState<number[]>([]);
+    return (
+      <Box sx={{ width: '400px' }}>
+        {activities.map((activity, index) => (
+          <ZUIActivityListItem
+            key={`NarrowCheckboxes-${index}`}
+            {...activity}
+            checkboxProps={{
+              checked: checked.includes(index),
+              onChange: (newCheckedState) => {
+                if (newCheckedState) {
+                  setChecked(checked.concat([index]));
+                } else {
+                  setChecked(checked.filter((i) => i != index));
+                }
+              },
+            }}
+            variant="narrow"
+          />
+        ))}
+      </Box>
+    );
+  },
+};

--- a/src/zui/components/ZUIActivityListItem/index.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.tsx
@@ -46,7 +46,7 @@ type ActivityListItemBase = {
   /**
    * The onClick function for the list item.
    */
-  onClick?: (event: ReactMouseEvent<HTMLLIElement, MouseEvent>) => void;
+  onClick?: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
 
   /**
    * The status of the activity.
@@ -116,7 +116,6 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
   return (
     <ListItem
       divider
-      onClick={onClick}
       sx={(theme) => ({
         '& a:focus-visible': {
           color: theme.palette.text.primary,
@@ -152,7 +151,6 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
         }}
       >
         <Box
-          component="li"
           onClick={(ev) => {
             if (onClick) {
               onClick(ev);
@@ -191,7 +189,7 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                 alignItems: 'baseline',
                 display: 'flex',
                 flexDirection: variant == 'wide' ? 'row' : 'column',
-                gap: variant == 'wide' ? '0.5rem' : '',
+                flexGrow: 1,
                 minWidth: 0,
                 paddingRight: '0.5rem',
               }}
@@ -199,10 +197,11 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
               <Typography
                 color="primary"
                 sx={{
+                  flexGrow: 1,
+                  maxWidth: variant == 'wide' ? 'fit-content' : '100%',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
-                  width: '100%',
                 }}
                 variant="bodyMdRegular"
               >
@@ -211,11 +210,13 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
               <Typography
                 color="secondary"
                 sx={{
+                  flexGrow: 1,
+                  maxWidth: '100%',
                   overflow: 'hidden',
+                  paddingLeft: variant == 'wide' ? '0.5rem' : '',
                   paddingTop: variant != 'wide' ? '0.2rem' : '',
                   textOverflow: 'ellipsis',
                   whiteSpace: 'nowrap',
-                  width: '100%',
                 }}
                 variant="bodySmRegular"
               >
@@ -234,14 +235,13 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                   : 'space-between',
             }}
           >
-            {showProgressChip && <ZUIProgressChip values={meta.values} />}
             <Box
               sx={{
                 alignItems: variant == 'narrow' ? 'flex-end' : '',
                 display: 'flex',
                 flexDirection: variant == 'narrow' ? 'column-reverse' : 'row',
                 flexGrow: 1,
-                justifyContent: showProgressChip ? 'flex-end' : 'space-between',
+                justifyContent: 'space-between',
               }}
             >
               {showBarDiagram && (
@@ -252,22 +252,25 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                   />
                 </Box>
               )}
-              {hasEventWarningIcons && (
-                <Box sx={{ paddingTop: '0.25rem' }}>
-                  <EventWarningIcons
-                    hasContact={meta.eventWarningIcons.hasContact}
-                    isUrgent={meta.eventWarningIcons.isUrgent}
-                    numBooked={meta.eventWarningIcons.numBooked}
-                    numRemindersSent={meta.eventWarningIcons.numRemindersSent}
-                    numSignups={meta.eventWarningIcons.numSignups}
-                  />
-                </Box>
-              )}
+              <Box sx={{ alignItems: 'center', display: 'flex' }}>
+                {showProgressChip && <ZUIProgressChip values={meta.values} />}
+                {hasEventWarningIcons && (
+                  <Box sx={{ paddingTop: '0.25rem' }}>
+                    <EventWarningIcons
+                      hasContact={meta.eventWarningIcons.hasContact}
+                      isUrgent={meta.eventWarningIcons.isUrgent}
+                      numBooked={meta.eventWarningIcons.numBooked}
+                      numRemindersSent={meta.eventWarningIcons.numRemindersSent}
+                      numSignups={meta.eventWarningIcons.numSignups}
+                    />
+                  </Box>
+                )}
+              </Box>
               <Box
                 sx={{
                   alignItems: 'center',
                   display: 'flex',
-                  gap: '1.25rem',
+                  gap: '1rem',
                 }}
               >
                 {showAvatars && (

--- a/src/zui/components/ZUIActivityListItem/index.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.tsx
@@ -277,7 +277,7 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                   sx={{
                     alignItems: 'center',
                     display: 'flex',
-                    gap: '0.25rem',
+                    gap: '0.5rem',
                     justifyContent: 'flex-end',
                     width: variant == 'narrow' ? 'fit-content' : '5rem',
                   }}

--- a/src/zui/components/ZUIActivityListItem/index.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.tsx
@@ -256,6 +256,7 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                 <Box sx={{ paddingTop: '0.25rem' }}>
                   <EventWarningIcons
                     hasContact={meta.eventWarningIcons.hasContact}
+                    isUrgent={meta.eventWarningIcons.isUrgent}
                     numBooked={meta.eventWarningIcons.numBooked}
                     numRemindersSent={meta.eventWarningIcons.numRemindersSent}
                     numSignups={meta.eventWarningIcons.numSignups}
@@ -277,13 +278,14 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
                     alignItems: 'center',
                     display: 'flex',
                     gap: '0.25rem',
+                    justifyContent: 'flex-end',
                     width: variant == 'narrow' ? 'fit-content' : '5rem',
                   }}
                 >
-                  <ZUIIcon color="secondary" icon={endData.icon} size="small" />
                   <Typography color="secondary" variant="bodyMdRegular">
                     <ZUISuffixedNumber number={endData.number} />
                   </Typography>
+                  <ZUIIcon color="secondary" icon={endData.icon} size="small" />
                 </Box>
               </Box>
             </Box>

--- a/src/zui/components/ZUIActivityListItem/index.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.tsx
@@ -124,7 +124,8 @@ const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
         alignItems: 'center',
         cursor: 'pointer',
         display: 'flex',
-        paddingX: '1.25rem',
+        paddingLeft: checkboxProps ? '0.625rem' : '1.25rem',
+        paddingRight: '1.25rem',
         paddingY: variant == 'wide' ? '0.875rem' : '1rem',
         width: '100%',
       })}

--- a/src/zui/components/ZUIActivityListItem/index.tsx
+++ b/src/zui/components/ZUIActivityListItem/index.tsx
@@ -1,0 +1,296 @@
+import { FC, MouseEvent as ReactMouseEvent } from 'react';
+import NextLink from 'next/link';
+import { Box, Checkbox, ListItem, Typography } from '@mui/material';
+
+import { ActivityStatus } from 'zui/types';
+import { MUIIcon } from '../types';
+import ZUIActivityStatusBadge from '../ZUIActivityStatusBadge';
+import ZUIIcon from '../ZUIIcon';
+import ZUIProgressChip, { ZUIProgressChipProps } from '../ZUIProgressChip';
+import ZUIBarDiagram, { ZUIBarDiagramProps } from '../ZUIBarDiagram';
+import EventWarningIcons, { EventWarningIconsProps } from './EventWarningIcons';
+import ZUIAvatarGroup, { AvatarData } from '../ZUIAvatarGroup';
+import ZUISuffixedNumber from '../ZUISuffixedNumber';
+import { ZUICheckboxProps } from '../ZUICheckbox';
+
+type ActivityListItemBase = {
+  /**
+   * If the list item should render avatars, send them in here.
+   */
+  avatars?: AvatarData[];
+
+  /**
+   * If you want the list item to have a checkbox,
+   * send in its props here.
+   */
+  checkboxProps?: Pick<ZUICheckboxProps, 'checked' | 'onChange'>;
+
+  /**
+   * The icon and number that is displayed at the end of the list item.
+   */
+  endData: {
+    icon: MUIIcon;
+    number: number;
+  };
+
+  /**
+   * The href of the activity.
+   */
+  href: string;
+
+  /**
+   * The main icon of the list item.
+   */
+  mainIcon: MUIIcon;
+
+  /**
+   * The onClick function for the list item.
+   */
+  onClick?: (event: ReactMouseEvent<HTMLLIElement, MouseEvent>) => void;
+
+  /**
+   * The status of the activity.
+   */
+  status: ActivityStatus;
+
+  /**
+   * The subtitle of the list item.
+   */
+  subtitle: string;
+
+  /**
+   * The title of the list item.
+   */
+  title: string;
+
+  /**
+   * The variant of the list item: "default", "narrow" or "wide".
+   *
+   * Defaults, unsurprisingly, to "default".
+   */
+  variant?: 'default' | 'narrow' | 'wide';
+};
+
+type ValuesMeta = Pick<ZUIProgressChipProps, 'values'>;
+type EventWarningIconsMeta = {
+  eventWarningIcons: EventWarningIconsProps;
+};
+type Meta = ValuesMeta | EventWarningIconsMeta;
+
+export type ZUIActivityListItemProps = ActivityListItemBase & {
+  meta: Meta;
+};
+
+const isValuesMeta = (meta: Meta): meta is ValuesMeta => {
+  return 'values' in meta;
+};
+
+const isEventWarningIconsMeta = (meta: Meta): meta is EventWarningIconsMeta => {
+  return 'eventWarningIcons' in meta;
+};
+
+const ZUIActivityListItem: FC<ZUIActivityListItemProps> = ({
+  avatars,
+  checkboxProps,
+  endData,
+  href,
+  mainIcon,
+  meta,
+  onClick,
+  status,
+  subtitle,
+  title,
+  variant = 'default',
+}) => {
+  const showProgressChip = variant != 'narrow' && isValuesMeta(meta);
+  const showBarDiagram = variant == 'narrow' && isValuesMeta(meta);
+  const hasEventWarningIcons = isEventWarningIconsMeta(meta);
+  const showAvatars = avatars && variant != 'narrow';
+
+  const makeBarDiagramValues = (values: ValuesMeta['values']) => {
+    const sum = values.reduce((prev, curr) => (prev += curr));
+    const percent = values.map((value) => Math.round((value / sum) * 100));
+    return percent.slice(0, -1) as unknown as ZUIBarDiagramProps['values'];
+  };
+
+  return (
+    <ListItem
+      divider
+      onClick={onClick}
+      sx={(theme) => ({
+        '& a:focus-visible': {
+          color: theme.palette.text.primary,
+        },
+        alignItems: 'center',
+        cursor: 'pointer',
+        display: 'flex',
+        paddingX: '1.25rem',
+        paddingY: variant == 'wide' ? '0.875rem' : '1rem',
+        width: '100%',
+      })}
+    >
+      {checkboxProps && (
+        <Checkbox
+          checked={checkboxProps.checked}
+          onChange={(ev, newCheckedState) =>
+            checkboxProps.onChange(newCheckedState)
+          }
+          sx={{
+            '& .MuiSvgIcon-root': { fontSize: '1.25rem' },
+            marginRight: '0.5rem',
+          }}
+        />
+      )}
+      <NextLink
+        href={href}
+        passHref
+        style={{
+          flexGrow: 1,
+          minWidth: 0,
+          textDecoration: 'none',
+        }}
+      >
+        <Box
+          component="li"
+          onClick={(ev) => {
+            if (onClick) {
+              onClick(ev);
+            }
+          }}
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            flexGrow: 1,
+            justifyContent: 'space-between',
+            minWidth: 0,
+          }}
+        >
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flexGrow: variant == 'narrow' ? 1 : '',
+              width: variant == 'narrow' ? '' : '50%',
+            }}
+          >
+            <Box
+              sx={{
+                alignItems: 'center',
+                display: 'flex',
+                flexDirection: variant == 'wide' ? 'row-reverse' : 'column',
+                gap: variant == 'wide' ? '0.625rem' : '0.438rem',
+                paddingRight: '1.25rem',
+              }}
+            >
+              <ZUIIcon icon={mainIcon} />
+              <ZUIActivityStatusBadge status={status} />
+            </Box>
+            <Box
+              sx={{
+                alignItems: 'baseline',
+                display: 'flex',
+                flexDirection: variant == 'wide' ? 'row' : 'column',
+                gap: variant == 'wide' ? '0.5rem' : '',
+                minWidth: 0,
+                paddingRight: '0.5rem',
+              }}
+            >
+              <Typography
+                color="primary"
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  width: '100%',
+                }}
+                variant="bodyMdRegular"
+              >
+                {title}
+              </Typography>
+              <Typography
+                color="secondary"
+                sx={{
+                  overflow: 'hidden',
+                  paddingTop: variant != 'wide' ? '0.2rem' : '',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  width: '100%',
+                }}
+                variant="bodySmRegular"
+              >
+                {subtitle}
+              </Typography>
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flexGrow: variant == 'narrow' ? 0 : 1,
+              justifyContent:
+                variant == 'narrow' || !showProgressChip
+                  ? 'flex-end'
+                  : 'space-between',
+            }}
+          >
+            {showProgressChip && <ZUIProgressChip values={meta.values} />}
+            <Box
+              sx={{
+                alignItems: variant == 'narrow' ? 'flex-end' : '',
+                display: 'flex',
+                flexDirection: variant == 'narrow' ? 'column-reverse' : 'row',
+                flexGrow: 1,
+                justifyContent: showProgressChip ? 'flex-end' : 'space-between',
+              }}
+            >
+              {showBarDiagram && (
+                <Box sx={{ paddingTop: '0.25rem', width: '5.25rem' }}>
+                  <ZUIBarDiagram
+                    size="small"
+                    values={makeBarDiagramValues(meta.values)}
+                  />
+                </Box>
+              )}
+              {hasEventWarningIcons && (
+                <Box sx={{ paddingTop: '0.25rem' }}>
+                  <EventWarningIcons
+                    hasContact={meta.eventWarningIcons.hasContact}
+                    numBooked={meta.eventWarningIcons.numBooked}
+                    numRemindersSent={meta.eventWarningIcons.numRemindersSent}
+                    numSignups={meta.eventWarningIcons.numSignups}
+                  />
+                </Box>
+              )}
+              <Box
+                sx={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  gap: '1.25rem',
+                }}
+              >
+                {showAvatars && (
+                  <ZUIAvatarGroup avatars={avatars} max={5} size="small" />
+                )}
+                <Box
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    gap: '0.25rem',
+                    width: variant == 'narrow' ? 'fit-content' : '5rem',
+                  }}
+                >
+                  <ZUIIcon color="secondary" icon={endData.icon} size="small" />
+                  <Typography color="secondary" variant="bodyMdRegular">
+                    <ZUISuffixedNumber number={endData.number} />
+                  </Typography>
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </NextLink>
+    </ListItem>
+  );
+};
+
+export default ZUIActivityListItem;

--- a/src/zui/components/ZUIActivityListItem/storybookActivities.ts
+++ b/src/zui/components/ZUIActivityListItem/storybookActivities.ts
@@ -12,36 +12,66 @@ import { ZUIActivityListItemProps } from '.';
 export const activities: ZUIActivityListItemProps[] = [
   {
     avatars: [
-      { firstName: 'Angela', id: 1, lastName: 'Davis' },
-      { firstName: 'James', id: 2, lastName: 'Dean' },
-      { firstName: 'Georg', id: 3, lastName: 'Schneider' },
-      { firstName: 'Bernie', id: 4, lastName: 'Sanders' },
-      { firstName: 'Peder', id: 5, lastName: 'Kofoed' },
-      { firstName: 'Jessee', id: 5, lastName: 'Jamthorpe' },
       { firstName: 'Jimmy', id: 34, lastName: 'Junderkud' },
       { firstName: 'Katja', id: 22, lastName: 'Karahi' },
-      { firstName: 'Goran', id: 54, lastName: 'Gogovic' },
-      { firstName: 'Bundi', id: 65, lastName: 'Binbun' },
-      { firstName: 'Jayne', id: 64, lastName: 'Jackal' },
-      { firstName: 'Evita', id: 12, lastName: 'Lopez' },
     ],
     endData: {
       icon: Group,
-      number: 12,
+      number: 6,
     },
     href: '#',
     mainIcon: EventOutlined,
     meta: {
       eventWarningIcons: {
         hasContact: true,
-        numBooked: 12,
-        numRemindersSent: 5,
+        isUrgent: true,
+        numBooked: 2,
+        numRemindersSent: 2,
+        numSignups: 1,
+      },
+    },
+    status: 'published',
+    subtitle: 'Sunday, april 13th, 14.00',
+    title: 'Meet-up for nurses',
+  },
+  {
+    avatars: [
+      { firstName: 'Jimmy', id: 34, lastName: 'Junderkud' },
+      { firstName: 'Katja', id: 22, lastName: 'Karahi' },
+      { firstName: 'Goran', id: 54, lastName: 'Gogovic' },
+    ],
+    endData: {
+      icon: Group,
+      number: 6,
+    },
+    href: '#',
+    mainIcon: EventOutlined,
+    meta: {
+      eventWarningIcons: {
+        hasContact: false,
+        isUrgent: true,
+        numBooked: 3,
+        numRemindersSent: 2,
         numSignups: 2,
       },
     },
-    status: 'scheduled',
-    subtitle: 'Friday April 23rd, 17.00-20.00',
-    title: 'Spring meeting with all the organizers',
+    status: 'published',
+    subtitle: 'Sunday april 13th, 16.00',
+    title: 'Work day at the headquarters',
+  },
+  {
+    endData: {
+      icon: Group,
+      number: 455,
+    },
+    href: '#',
+    mainIcon: CheckBoxOutlined,
+    meta: {
+      values: [200, 100, 155],
+    },
+    status: 'published',
+    subtitle: 'Sunday, April 13th',
+    title: 'Talk to 2 neighbours about rents',
   },
   {
     avatars: [
@@ -61,6 +91,7 @@ export const activities: ZUIActivityListItemProps[] = [
     meta: {
       eventWarningIcons: {
         hasContact: false,
+        isUrgent: false,
         numBooked: 6,
         numRemindersSent: 6,
         numSignups: 2,
@@ -100,17 +131,37 @@ export const activities: ZUIActivityListItemProps[] = [
     title: 'Calling for May 1st - people to the streets!',
   },
   {
+    avatars: [
+      { firstName: 'Angela', id: 1, lastName: 'Davis' },
+      { firstName: 'James', id: 2, lastName: 'Dean' },
+      { firstName: 'Georg', id: 3, lastName: 'Schneider' },
+      { firstName: 'Bernie', id: 4, lastName: 'Sanders' },
+      { firstName: 'Peder', id: 5, lastName: 'Kofoed' },
+      { firstName: 'Jessee', id: 5, lastName: 'Jamthorpe' },
+      { firstName: 'Jimmy', id: 34, lastName: 'Junderkud' },
+      { firstName: 'Katja', id: 22, lastName: 'Karahi' },
+      { firstName: 'Goran', id: 54, lastName: 'Gogovic' },
+      { firstName: 'Bundi', id: 65, lastName: 'Binbun' },
+      { firstName: 'Jayne', id: 64, lastName: 'Jackal' },
+      { firstName: 'Evita', id: 12, lastName: 'Lopez' },
+    ],
     endData: {
       icon: Group,
-      number: 455,
+      number: 12,
     },
     href: '#',
-    mainIcon: CheckBoxOutlined,
+    mainIcon: EventOutlined,
     meta: {
-      values: [200, 100, 155],
+      eventWarningIcons: {
+        hasContact: true,
+        isUrgent: false,
+        numBooked: 12,
+        numRemindersSent: 5,
+        numSignups: 2,
+      },
     },
-    status: 'published',
-    subtitle: 'Thursday, October 15th',
-    title: 'Talk to 2 neighbours about rents',
+    status: 'scheduled',
+    subtitle: 'Friday April 23rd, 17.00-20.00',
+    title: 'Spring meeting with all the organizers',
   },
 ];

--- a/src/zui/components/ZUIActivityListItem/storybookActivities.ts
+++ b/src/zui/components/ZUIActivityListItem/storybookActivities.ts
@@ -1,0 +1,116 @@
+import {
+  CheckBoxOutlined,
+  EventOutlined,
+  Group,
+  HeadsetMicOutlined,
+  MailOutline,
+  Phone,
+} from '@mui/icons-material';
+
+import { ZUIActivityListItemProps } from '.';
+
+export const activities: ZUIActivityListItemProps[] = [
+  {
+    avatars: [
+      { firstName: 'Angela', id: 1, lastName: 'Davis' },
+      { firstName: 'James', id: 2, lastName: 'Dean' },
+      { firstName: 'Georg', id: 3, lastName: 'Schneider' },
+      { firstName: 'Bernie', id: 4, lastName: 'Sanders' },
+      { firstName: 'Peder', id: 5, lastName: 'Kofoed' },
+      { firstName: 'Jessee', id: 5, lastName: 'Jamthorpe' },
+      { firstName: 'Jimmy', id: 34, lastName: 'Junderkud' },
+      { firstName: 'Katja', id: 22, lastName: 'Karahi' },
+      { firstName: 'Goran', id: 54, lastName: 'Gogovic' },
+      { firstName: 'Bundi', id: 65, lastName: 'Binbun' },
+      { firstName: 'Jayne', id: 64, lastName: 'Jackal' },
+      { firstName: 'Evita', id: 12, lastName: 'Lopez' },
+    ],
+    endData: {
+      icon: Group,
+      number: 12,
+    },
+    href: '#',
+    mainIcon: EventOutlined,
+    meta: {
+      eventWarningIcons: {
+        hasContact: true,
+        numBooked: 12,
+        numRemindersSent: 5,
+        numSignups: 2,
+      },
+    },
+    status: 'scheduled',
+    subtitle: 'Friday April 23rd, 17.00-20.00',
+    title: 'Spring meeting with all the organizers',
+  },
+  {
+    avatars: [
+      { firstName: 'Jimmy', id: 34, lastName: 'Junderkud' },
+      { firstName: 'Katja', id: 22, lastName: 'Karahi' },
+      { firstName: 'Goran', id: 54, lastName: 'Gogovic' },
+      { firstName: 'Bundi', id: 65, lastName: 'Binbun' },
+      { firstName: 'Jayne', id: 64, lastName: 'Jackal' },
+      { firstName: 'Evita', id: 12, lastName: 'Lopez' },
+    ],
+    endData: {
+      icon: Group,
+      number: 6,
+    },
+    href: '#',
+    mainIcon: EventOutlined,
+    meta: {
+      eventWarningIcons: {
+        hasContact: false,
+        numBooked: 6,
+        numRemindersSent: 6,
+        numSignups: 2,
+      },
+    },
+    status: 'published',
+    subtitle:
+      'We study the latest developments in the politics on a local and regional level',
+    title: 'Politics for the people: understand what is going on',
+  },
+  {
+    endData: {
+      icon: Group,
+      number: 23455,
+    },
+    href: '#',
+    mainIcon: MailOutline,
+    meta: {
+      values: [15456, 4359, 2389],
+    },
+    status: 'scheduled',
+    subtitle: 'May 2nd, 13.00',
+    title: 'Big email to activists: May',
+  },
+  {
+    endData: {
+      icon: Phone,
+      number: 3516,
+    },
+    href: '#',
+    mainIcon: HeadsetMicOutlined,
+    meta: {
+      values: [68, 2945, 503],
+    },
+    status: 'scheduled',
+    subtitle: 'Sunday April 6th, 19.00-21.00',
+    title: 'Calling for May 1st - people to the streets!',
+  },
+  {
+    endData: {
+      icon: Group,
+      number: 455,
+    },
+    href: '#',
+    mainIcon: CheckBoxOutlined,
+    meta: {
+      values: [200, 100, 155],
+    },
+    status: 'published',
+    subtitle: 'Thursday, October 15th',
+    title: 'Talk to 2 neighbours about rents',
+  },
+];

--- a/src/zui/components/ZUIAvatarGroup/index.tsx
+++ b/src/zui/components/ZUIAvatarGroup/index.tsx
@@ -4,15 +4,17 @@ import { FC } from 'react';
 import ZUIAvatar from '../ZUIAvatar';
 import { ZUISize } from '../types';
 
+export type AvatarData = {
+  firstName: string;
+  id: number;
+  lastName: string;
+};
+
 type ZUIAvatarGroupProps = {
   /**
    * List of the people you want to display as avatars.
    */
-  avatars: {
-    firstName: string;
-    id: number;
-    lastName: string;
-  }[];
+  avatars: AvatarData[];
 
   /**
    * Maximum number of avatars shown.
@@ -78,6 +80,7 @@ const ZUIAvatarGroup: FC<ZUIAvatarGroupProps> = ({
           width={avatarSize}
         >
           <Typography
+            color={theme.palette.text.primary}
             fontFamily={theme.typography.fontFamily}
             fontSize={fontSize}
             fontWeight={500}

--- a/src/zui/components/ZUIBarDiagram/index.tsx
+++ b/src/zui/components/ZUIBarDiagram/index.tsx
@@ -8,14 +8,15 @@ const sizes: Record<Sizes, string> = {
   small: '0.25rem',
 };
 
-interface ZUIBarDiagramProps {
+export type ZUIBarDiagramProps = {
+  size: Sizes;
+
   /**
    * Width of segments as an array of numbers whose total is < 100.
    * The final segment width is the remainder.
    */
   values: [number] | [number, number] | [number, number, number];
-  size: Sizes;
-}
+};
 
 /**
  * Renders a horizontal stacked bar. Define the percentage width of

--- a/src/zui/components/ZUIIcon/index.tsx
+++ b/src/zui/components/ZUIIcon/index.tsx
@@ -37,7 +37,7 @@ type ZUIIconProps = {
 
 const getFontSize = (size: ZUISize) => {
   if (size == 'small') {
-    return '1rem';
+    return '1.25rem';
   } else if (size == 'medium') {
     return '1.5rem';
   } else {

--- a/src/zui/components/ZUIIconLabel/index.stories.tsx
+++ b/src/zui/components/ZUIIconLabel/index.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Surfing } from '@mui/icons-material';
+
+import ZUIIconLabel from './index';
+
+const meta: Meta<typeof ZUIIconLabel> = {
+  component: ZUIIconLabel,
+  title: 'Components/ZUIIconLabel',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIIconLabel>;
+
+export const Medium: Story = {
+  args: {
+    icon: Surfing,
+    label: 'Surfing',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    ...Medium.args,
+    size: 'small',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    ...Medium.args,
+    size: 'large',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    ...Medium.args,
+    color: 'secondary',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    ...Medium.args,
+    color: 'danger',
+  },
+};

--- a/src/zui/components/ZUIIconLabel/index.tsx
+++ b/src/zui/components/ZUIIconLabel/index.tsx
@@ -1,0 +1,68 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { MUIIcon, ZUIPrimary, ZUISecondary, ZUISize } from '../types';
+import ZUIIcon from '../ZUIIcon';
+
+const TextVariants = {
+  large: 'bodyMdRegular',
+  medium: 'bodySmRegular',
+  small: 'bodySmRegular',
+} as const;
+
+export type ZUIIconLabelProps = {
+  /**
+   * The color of the icon-label pair.
+   *
+   * Defaults to "primary".
+   */
+  color?: ZUIPrimary | ZUISecondary | 'danger';
+
+  /**
+   * The icon.
+   */
+  icon: MUIIcon;
+
+  /**
+   * The label
+   */
+  label: string | JSX.Element;
+
+  /**
+   * The size of the icon-label pair.
+   *
+   * Defaults to "medium."
+   */
+  size?: ZUISize;
+};
+
+const ZUIIconLabel: FC<ZUIIconLabelProps> = ({
+  color = 'primary',
+  icon,
+  label,
+  size = 'medium',
+}) => {
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        display: 'flex',
+        flexShrink: 0,
+        gap: '0.5rem',
+      }}
+    >
+      <ZUIIcon color={color} icon={icon} size={size} />
+      <Typography
+        color={color == 'danger' ? 'error' : color}
+        sx={{
+          flexShrink: 0,
+        }}
+        variant={TextVariants[size]}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+};
+
+export default ZUIIconLabel;

--- a/src/zui/components/ZUIIconLabelRow/index.stories.tsx
+++ b/src/zui/components/ZUIIconLabelRow/index.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { CatchingPokemon, FoodBank, Surfing } from '@mui/icons-material';
+
+import ZUIIconLabelRow from './index';
+
+const meta: Meta<typeof ZUIIconLabelRow> = {
+  component: ZUIIconLabelRow,
+  title: 'Components/ZUIIconLabelRow',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUIIconLabelRow>;
+
+export const Medium: Story = {
+  args: {
+    iconLabels: [
+      {
+        icon: Surfing,
+        label: 'Surfing',
+      },
+      {
+        icon: CatchingPokemon,
+        label: 'Pokemon',
+      },
+      {
+        icon: FoodBank,
+        label: 'Food',
+      },
+    ],
+  },
+};
+
+export const Small: Story = {
+  args: { ...Medium.args, size: 'small' },
+};
+
+export const Large: Story = {
+  args: { ...Medium.args, size: 'large' },
+};
+
+export const Secondary: Story = {
+  args: { ...Medium.args, color: 'secondary' },
+};
+
+export const Danger: Story = {
+  args: { ...Medium.args, color: 'danger' },
+};

--- a/src/zui/components/ZUIIconLabelRow/index.tsx
+++ b/src/zui/components/ZUIIconLabelRow/index.tsx
@@ -1,0 +1,42 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+
+import ZUIIconLabel, { ZUIIconLabelProps } from '../ZUIIconLabel';
+
+type ZUIIconLabelRowProps = {
+  /**
+   * Use this property if you want all the icon-label pairs
+   * to have the same color
+   */
+  color?: ZUIIconLabelProps['color'];
+
+  /**
+   * The list of icon-label pairs to be rendered in the row.
+   *
+   * You can use the props for each individual pair to
+   * customize if it should look different than the other
+   * pairs in the row.
+   */
+  iconLabels: ZUIIconLabelProps[];
+
+  /**
+   * Use this property if you want all the icon-label pairs
+   * to have the same size.
+   */
+  size?: ZUIIconLabelProps['size'];
+};
+
+const ZUIIconLabelRow: FC<ZUIIconLabelRowProps> = ({
+  iconLabels,
+  ...restProps
+}) => {
+  return (
+    <Box display="flex" flexShrink="0" gap={2}>
+      {iconLabels.map((props, index) => (
+        <ZUIIconLabel key={index} {...restProps} {...props} />
+      ))}
+    </Box>
+  );
+};
+
+export default ZUIIconLabelRow;

--- a/src/zui/components/ZUIProgressChip/index.tsx
+++ b/src/zui/components/ZUIProgressChip/index.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 
 import { ZUIMedium, ZUISmall } from '../types';
 
-type ZUIProgressChipProps = {
+export type ZUIProgressChipProps = {
   /**
    * The size of the component. Defaults to 'small'.
    */

--- a/src/zui/components/ZUISuffixedNumber/index.stories.tsx
+++ b/src/zui/components/ZUISuffixedNumber/index.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import ZUISuffixedNumber from './index';
+
+const meta: Meta<typeof ZUISuffixedNumber> = {
+  component: ZUISuffixedNumber,
+  title: 'Components/ZUISuffixedNumber',
+};
+export default meta;
+
+type Story = StoryObj<typeof ZUISuffixedNumber>;
+
+export const Basic: Story = {
+  args: {
+    number: 45347576,
+  },
+};

--- a/src/zui/components/ZUISuffixedNumber/index.tsx
+++ b/src/zui/components/ZUISuffixedNumber/index.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+
+import ZUITooltip from '../ZUITooltip';
+
+type ZUISuffixedNumberProps = {
+  number: number;
+};
+
+const ZUISuffixedNumber: FC<ZUISuffixedNumberProps> = ({ number }) => {
+  return (
+    <ZUITooltip label={number.toLocaleString()}>
+      <span>
+        {number.toLocaleString('en', {
+          compactDisplay: 'short',
+          maximumFractionDigits: 1,
+          notation: 'compact',
+        })}
+      </span>
+    </ZUITooltip>
+  );
+};
+
+export default ZUISuffixedNumber;

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -132,6 +132,13 @@ export default makeMessages('zui', {
   editableImage: {
     add: m('Click to add image'),
   },
+  eventWarningIcons: {
+    contact: m('No contact person has been assigned'),
+    reminders: m<{ numMissing: number }>(
+      '{numMissing, plural, =1 {One participant} other {# participants}} have not yet received reminders'
+    ),
+    signUps: m('There are pending signups'),
+  },
   futures: {
     errorLoading: m('There was an error loading the data.'),
   },


### PR DESCRIPTION
## Description
This PR adds the `ZUIActivityListItem` component + a couple of friends: `ZUISuffixedNumber`, `ZUIIconLabel` and `ZUIIconLabelRow`.

## Screenshots
![bild](https://github.com/user-attachments/assets/8b4feab7-3d24-4a16-a050-c51e4a1e5077)

![bild](https://github.com/user-attachments/assets/74b2a131-8c48-49e3-99c6-8651f38f3955)

![bild](https://github.com/user-attachments/assets/928451f1-3fd7-40d0-95f4-0d9230b1c910)

![bild](https://github.com/user-attachments/assets/8a05954e-4e69-4d53-8da5-22a307f5a664)

## Changes
* Adds `ZUIIconLabel`, `ZUIIconLabelRow`, `ZUISuffixedNumber `and `ZUIActivityListItem `+ storybook stories
* Makes some minor changes to prop types and sizing of a few other ZUI components, that I discovered along the way were needed for the other components to work.

## Notes to reviewer
I did my best to figure out the padding and spaces etc in the `ZUIActivityListItem`, and settled for "good enough for feedback", so I absolutely assume there are things that need to change!


## Related issues
none
