### PR TITLE
Add task feature flag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default async function RootLayout({
           <ClientContext
             envVars={{
               FEAT_AREAS: process.env.FEAT_AREAS,
+              FEAT_TASKS: process.env.FEAT_TASKS,
               INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
               INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
               MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -21,6 +21,7 @@ import IApiClient from 'core/api/client/IApiClient';
  */
 export type EnvVars = {
   FEAT_AREAS?: string;
+  FEAT_TASKS?: string;
   INSTANCE_OWNER_HREF?: string;
   INSTANCE_OWNER_NAME?: string;
   MUIX_LICENSE_KEY?: string;

--- a/src/features/campaigns/components/ActivityList/FilterActivities.tsx
+++ b/src/features/campaigns/components/ActivityList/FilterActivities.tsx
@@ -14,7 +14,7 @@ import messageIds from 'features/campaigns/l10n/messageIds';
 import useDebounce from 'utils/hooks/useDebounce';
 import { useMessages } from 'core/i18n';
 import useFeature from 'utils/featureFlags/useFeature';
-import { AREAS } from 'utils/featureFlags';
+import { AREAS, TASKS } from 'utils/featureFlags';
 
 interface FilterActivitiesProps {
   filters: ACTIVITIES[];
@@ -31,6 +31,7 @@ const FilterActivities = ({
 }: FilterActivitiesProps) => {
   const messages = useMessages(messageIds);
   const hasAreaAssignments = useFeature(AREAS);
+  const hasTasks = useFeature(TASKS)
 
   const debouncedFinishedTyping = useDebounce(
     async (evt: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -91,6 +92,7 @@ const FilterActivities = ({
               label={messages.all.filter.areaAssignments()}
             />
           )}
+          {hasTasks && (
           <FormControlLabel
             control={
               <Checkbox
@@ -102,6 +104,7 @@ const FilterActivities = ({
             }
             label={messages.tasks()}
           />
+          )}
           <FormControlLabel
             control={
               <Checkbox

--- a/src/features/campaigns/components/ActivityList/FilterActivities.tsx
+++ b/src/features/campaigns/components/ActivityList/FilterActivities.tsx
@@ -31,7 +31,7 @@ const FilterActivities = ({
 }: FilterActivitiesProps) => {
   const messages = useMessages(messageIds);
   const hasAreaAssignments = useFeature(AREAS);
-  const hasTasks = useFeature(TASKS)
+  const hasTasks = useFeature(TASKS);
 
   const debouncedFinishedTyping = useDebounce(
     async (evt: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
@@ -93,17 +93,17 @@ const FilterActivities = ({
             />
           )}
           {hasTasks && (
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={filters.includes(ACTIVITIES.TASK)}
-                disabled={!filterTypes.includes(ACTIVITIES.TASK)}
-                onChange={onFiltersChange}
-                value={ACTIVITIES.TASK}
-              />
-            }
-            label={messages.tasks()}
-          />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={filters.includes(ACTIVITIES.TASK)}
+                  disabled={!filterTypes.includes(ACTIVITIES.TASK)}
+                  onChange={onFiltersChange}
+                  value={ACTIVITIES.TASK}
+                />
+              }
+              label={messages.tasks()}
+            />
           )}
           <FormControlLabel
             control={

--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -30,7 +30,7 @@ import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import { Msg, useMessages } from 'core/i18n';
 import useCreateAreaAssignment from 'features/areaAssignments/hooks/useCreateAreaAssignment';
 import useFeature from 'utils/featureFlags/useFeature';
-import { AREAS } from 'utils/featureFlags';
+import { AREAS, TASKS } from 'utils/featureFlags';
 import areaAssignmentMessageIds from 'features/areaAssignments/l10n/messageIds';
 import useEmailConfigs from 'features/emails/hooks/useEmailConfigs';
 
@@ -51,6 +51,7 @@ const CampaignActionButtons: React.FunctionComponent<
   const areaAssignmentMessages = useMessages(areaAssignmentMessageIds);
   const { orgId, campId } = useNumericRouteParams();
   const hasAreaAssignments = useFeature(AREAS);
+  const hasTasks = useFeature(TASKS);
 
   // Dialogs
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -110,12 +111,15 @@ const CampaignActionButtons: React.FunctionComponent<
           title: campaginMessages.form.createSurvey.newSurvey(),
         }),
     },
-    {
+  ];
+
+  if (hasTasks) {
+    menuItems.push({  
       icon: <CheckBoxOutlined />,
       label: campaginMessages.createButton.createTask(),
       onClick: () => setCreateTaskDialogOpen(true),
-    },
-  ];
+    })
+  }
 
   if (hasAreaAssignments) {
     menuItems.push({

--- a/src/features/campaigns/components/CampaignActionButtons.tsx
+++ b/src/features/campaigns/components/CampaignActionButtons.tsx
@@ -114,11 +114,11 @@ const CampaignActionButtons: React.FunctionComponent<
   ];
 
   if (hasTasks) {
-    menuItems.push({  
+    menuItems.push({
       icon: <CheckBoxOutlined />,
       label: campaginMessages.createButton.createTask(),
       onClick: () => setCreateTaskDialogOpen(true),
-    })
+    });
   }
 
   if (hasAreaAssignments) {

--- a/src/features/campaigns/hooks/useTaskActivities.ts
+++ b/src/features/campaigns/hooks/useTaskActivities.ts
@@ -15,6 +15,8 @@ import {
   ResolvedFuture,
 } from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { TASKS } from 'utils/featureFlags';
+import useFeature from 'utils/featureFlags/useFeature';
 
 export default function useTaskActivities(
   orgId: number,
@@ -23,6 +25,11 @@ export default function useTaskActivities(
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const tasksSlice = useAppSelector((state) => state.tasks);
+
+  const hasTasks = useFeature(TASKS);
+    if (!hasTasks) {
+      return new ResolvedFuture([]);
+    }
 
   const activities: CampaignActivity[] = [];
 

--- a/src/features/campaigns/hooks/useTaskActivities.ts
+++ b/src/features/campaigns/hooks/useTaskActivities.ts
@@ -27,9 +27,9 @@ export default function useTaskActivities(
   const tasksSlice = useAppSelector((state) => state.tasks);
 
   const hasTasks = useFeature(TASKS);
-    if (!hasTasks) {
-      return new ResolvedFuture([]);
-    }
+  if (!hasTasks) {
+    return new ResolvedFuture([]);
+  }
 
   const activities: CampaignActivity[] = [];
 

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -2,3 +2,4 @@ export { default as hasFeature } from './hasFeature';
 
 export const AREAS = 'FEAT_AREAS';
 export const CALL = 'FEAT_CALL';
+export const TASKS = 'FEAT_TASKS';

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -207,6 +207,7 @@ export const scaffold =
         ...result.props,
         envVars: omitUndefined({
           FEAT_AREAS: process.env.FEAT_AREAS,
+          FEAT_TASKS: process.env.FEAT_TASKS,
           INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
           INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
           MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,


### PR DESCRIPTION
## Description
This PR adds a task feature flag. It follows the same pattern and repurposes the code
 implemented for the Areas feature flag.


## Screenshots
![noTask](https://github.com/user-attachments/assets/7a845e6a-bebd-4e32-8438-f063f6e9b61c)

## Changes

* Adds a feature flag for tasks
* Sets up environment variable and reading of it for `FEAT_TASKS`

## Notes to reviewer

Without the `FEAT_TASKS=*` in .env

1. Go to [https://app.dev.zetkin.org/organize/1](https://app.dev.zetkin.org/organize/1)
2. Go to "Activities", Tasks should not show up as filter in side bar
3. Go to any project
4. Go to the activities tab, Tasks should be visible
5. Click "Create" in top right, Task should not be selectable
6. No Tasks should be visible in activity list

Afterwards, set `FEAT_TASKS=*` in `.env.development.local` and repeat but seeing Tasks 


## Related issues
Resolves #2623 
