### PR TITLE
Organizer Map: Split up map into multiple layers and components

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -25,6 +25,7 @@ import {
 import { getBoundSize } from '../../canvass/utils/getBoundSize';
 import MarkerIcon from 'features/canvass/components/MarkerIcon';
 import { getVisitPercentage } from 'features/canvass/utils/getVisitPercentage';
+import { ZetkinPerson } from '../../../utils/types/zetkin';
 
 const LocationMarker: FC<{
   areaAssId: string;
@@ -118,6 +119,171 @@ type OrganizerMapRendererProps = {
   selectedId: string;
   sessions: ZetkinAreaAssignmentSession[];
 };
+
+function HouseholdOverlayMarker(props: {
+  numberOfHouseholds: number;
+  numberOfLocations: number;
+}) {
+  const theme = useTheme();
+  return (
+    <Box
+      alignItems="center"
+      bgcolor="white"
+      borderRadius={1}
+      boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
+      display="inline-flex"
+      flexDirection="column"
+      gap="2px"
+      padding="2px 6px"
+      sx={{ translate: '-50% -50%' }}
+    >
+      <Typography alignItems="center" display="flex" fontSize="14px">
+        <DoorFront fontSize="small" sx={{ color: theme.palette.grey[300] }} />
+        {props.numberOfHouseholds}
+      </Typography>
+      <Divider
+        sx={{
+          width: '100%',
+        }}
+      />
+      <Typography alignItems="center" display="flex" fontSize="14px">
+        <Place fontSize="small" sx={{ color: theme.palette.grey[300] }} />
+
+        {props.numberOfLocations}
+      </Typography>
+    </Box>
+  );
+}
+
+function ProgressOverlayMarker(props: {
+  successfulVisitsColorPercent: number;
+  visitsColorPercent: number;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      bgcolor="white"
+      borderRadius={1}
+      boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
+      display="inline-flex"
+      flexDirection="column"
+      padding={0.5}
+      sx={{ translate: '-50% -50%' }}
+    >
+      <div
+        style={{
+          alignItems: 'center',
+          background: `conic-gradient(${theme.palette.primary.main} ${
+            props.successfulVisitsColorPercent
+          }%, ${lighten(theme.palette.primary.main, 0.7)} ${
+            props.successfulVisitsColorPercent
+          }% ${props.visitsColorPercent}%, ${theme.palette.grey[400]} ${
+            props.visitsColorPercent
+          }%)`,
+          borderRadius: '2em',
+          display: 'flex',
+          flexDirection: 'row',
+          height: '30px',
+          justifyContent: 'center',
+          width: '30px',
+        }}
+      />
+    </Box>
+  );
+}
+
+function NumberOverlayMarker(props: { value: number }) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        alignItems: 'center',
+        backgroundColor: theme.palette.primary.main,
+        borderRadius: 10,
+        boxShadow: '0 0 8px rgba(0,0,0,0.3)',
+        color: theme.palette.primary.contrastText,
+        display: 'flex',
+        fontWeight: 'bold',
+        height: 30,
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        transform: 'translate(-50%, -50%)',
+        width: 30,
+      }}
+    >
+      <Box>{props.value}</Box>
+    </Box>
+  );
+}
+
+function AssigneeOverlayMarker({
+  organizationID,
+  people,
+  zoom,
+}: {
+  organizationID: number;
+  people: ZetkinPerson[];
+  zoom: number;
+}) {
+  return (
+    <Box
+      alignItems="center"
+      display="inline-flex"
+      flexWrap="wrap"
+      gap="2px"
+      justifyContent="center"
+      sx={{
+        pointerEvents: 'none',
+        transform: 'translate(-50%, -50%)',
+      }}
+      width={zoom >= 16 ? '95px' : '65px'}
+    >
+      {people.map((person, index) => {
+        if (index <= 4) {
+          return (
+            <Box
+              //TODO: only use person id once we have logic preventing
+              //assigning the same person to an area more than once
+              key={`${person.id}-${index}`}
+              sx={{
+                borderRadius: '50%',
+                boxShadow: '0 0 8px rgba(0,0,0,0.3)',
+              }}
+            >
+              <ZUIAvatar
+                size={zoom >= 16 ? 'sm' : 'xs'}
+                url={`/api/orgs/${organizationID}/people/${person.id}/avatar`}
+              />
+            </Box>
+          );
+        } else if (index == 5) {
+          return (
+            <Box
+              alignItems="center"
+              bgcolor="white"
+              borderRadius="100%"
+              display="flex"
+              height={zoom >= 16 ? '30px' : '20px'}
+              justifyContent="center"
+              padding={1}
+              sx={{ boxShadow: '0 0 8px rgba(0,0,0,0.3)' }}
+              width={zoom >= 16 ? '30px' : '20px'}
+            >
+              <Typography
+                color="secondary"
+                fontSize={zoom >= 16 ? 14 : 11}
+              >{`+${people.length - 5}`}</Typography>
+            </Box>
+          );
+        } else {
+          return null;
+        }
+      })}
+    </Box>
+  );
+}
 
 const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
   areas,
@@ -446,172 +612,51 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               100
             : 0;
 
-          return (
-            <>
-              {overlayStyle == 'households' && (
-                <DivIconMarker
-                  iconAnchor={[0, 0]}
-                  position={mid}
-                  zIndexOffset={100}
-                >
-                  <Box
-                    alignItems="center"bgcolor="white"
-                    borderRadius={1}
-                    boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
-                    display="inline-flex"
-                    flexDirection="column"
-                    gap="2px"
-                    padding="2px 6px"
-                    sx={{ translate: '-50% -50%' }}
-                  >
-                    <TypographyalignItems="center"
-                        display="flex"
-                        fontSize="14px"><DoorFront
-                          fontSize="small"
-                          sx={{ color: theme.palette.grey[300] }}
-                        />
-                        {numberOfHouseholds}</Typography>
-                    <Divider
-                    sx={{
-                          width: '100%',
-                        }}
-                      />
-                      <Typography
-                        alignItems="center"
-                        display="flex"
-                        fontSize="14px">
-                      <Place
-                          fontSize="small"
-                          sx={{ color: theme.palette.grey[300] }}
-                        />
+          const markerToRender = () => {
+            if (overlayStyle === 'households') {
+              return (
+                <HouseholdOverlayMarker
+                  numberOfHouseholds={numberOfHouseholds}
+                  numberOfLocations={numberOfLocations}
+                />
+              );
+            }
+            if (overlayStyle == 'progress') {
+              return (
+                <ProgressOverlayMarker
+                  successfulVisitsColorPercent={successfulVisitsColorPercent}
+                  visitsColorPercent={visitsColorPercent}
+                />
+              );
+            }
+            if (overlayStyle === 'assignees' && area.hasPeople) {
+              if (detailed) {
+                return (
+                  <AssigneeOverlayMarker
+                    organizationID={assignment.organization.id}
+                    people={people}
+                    zoom={zoom}
+                  />
+                );
+              }
+              return <NumberOverlayMarker value={people.length} />;
+            }
+            return null;
+          };
 
-                        {numberOfLocations}
-                    </Typography>
-                  </Box>
-                </DivIconMarker>
-              )}
-              {overlayStyle == 'progress' && stats && (
-                <DivIconMarker
-                  iconAnchor={[0, 0]}
-                  position={mid}
-                  zIndexOffset={100}
-                >
-                  <Box
-                    bgcolor="white"
-                    borderRadius={1}
-                    boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
-                    display="inline-flex"
-                    flexDirection="column"
-                    padding={0.5}
-                    sx={{ translate: '-50% -50%' }}
-                  >
-                    <div
-                      style={{
-                        alignItems: 'center',
-                        background: `conic-gradient(${
-                          theme.palette.primary.main
-                        } ${successfulVisitsColorPercent}%, ${lighten(
-                          theme.palette.primary.main,
-                          0.7
-                        )} ${successfulVisitsColorPercent}% ${visitsColorPercent}%, ${
-                          theme.palette.grey[400]
-                        } ${visitsColorPercent}%)`,
-                        borderRadius: '2em',
-                        display: 'flex',
-                        flexDirection: 'row',
-                        height: '30px',
-                        justifyContent: 'center',
-                        width: '30px',
-                      }}
-                    />
-                  </Box>
-                </DivIconMarker>
-              )}
-              {overlayStyle == 'assignees' && area.hasPeople && (
-                <DivIconMarker
-                  iconAnchor={[0, 0]}
-                  position={mid}
-                  zIndexOffset={100}
-                >
-                  {detailed && (
-                    <Box
-                      alignItems="center"
-                      display="inline-flex"
-                      flexWrap="wrap"
-                      gap="2px"
-                      justifyContent="center"
-                      sx={{
-                        pointerEvents: 'none',
-                        transform: 'translate(-50%, -50%)',
-                      }}
-                      width={zoom >= 16 ? '95px' : '65px'}
-                    >
-                      {people.map((person, index) => {
-                        if (index <= 4) {
-                          return (
-                            <Box
-                              //TODO: only use person id once we have logic preventing
-                              //assigning the same person to an area more than once
-                              key={`${person.id}-${index}`}
-                              sx={{
-                                borderRadius: '50%',
-                                boxShadow: '0 0 8px rgba(0,0,0,0.3)',
-                              }}
-                            >
-                              <ZUIAvatar
-                                size={zoom >= 16 ? 'sm' : 'xs'}
-                                url={`/api/orgs/${assignment.organization.id}/people/${person.id}/avatar`}
-                              />
-                            </Box>
-                          );
-                        } else if (index == 5) {
-                          return (
-                            <Box
-                              alignItems="center"
-                              bgcolor="white"
-                              borderRadius="100%"
-                              display="flex"
-                              height={zoom >= 16 ? '30px' : '20px'}
-                              justifyContent="center"
-                              padding={1}
-                              sx={{ boxShadow: '0 0 8px rgba(0,0,0,0.3)' }}
-                              width={zoom >= 16 ? '30px' : '20px'}
-                            >
-                              <Typography
-                                color="secondary"
-                                fontSize={zoom >= 16 ? 14 : 11}
-                              >{`+${people.length - 5}`}</Typography>
-                            </Box>
-                          );
-                        } else {
-                          return null;
-                        }
-                      })}
-                    </Box>
-                  )}
-                  {!detailed && (
-                    <Box
-                      sx={{
-                        alignItems: 'center',
-                        backgroundColor: theme.palette.primary.main,
-                        borderRadius: 10,
-                        boxShadow: '0 0 8px rgba(0,0,0,0.3)',
-                        color: theme.palette.primary.contrastText,
-                        display: 'flex',
-                        fontWeight: 'bold',
-                        height: 30,
-                        justifyContent: 'center',
-                        pointerEvents: 'none',
-                        transform: 'translate(-50%, -50%)',
-                        width: 30,
-                      }}
-                    >
-                      <Box>{people.length}</Box>
-                    </Box>
-                  )}
-                </DivIconMarker>
-              )}
-            </>
+          const marker = markerToRender();
+          if (marker === null) {
+            return null;
+          }
+          return (
+            <DivIconMarker
+              key={area.id}
+              iconAnchor={[0, 0]}
+              position={mid}
+              zIndexOffset={100}
+            >
+              {marker}
+            </DivIconMarker>
           );
         })}
       </FeatureGroup>

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -235,6 +235,28 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
     }
   });
 
+  const filteredAreas = areas
+    .map((area) => {
+      const people = sessions
+        .filter((session) => session.area.id == area.id)
+        .map((session) => session.assignee);
+      const hasPeople = !!people.length;
+      return { ...area, hasPeople };
+    })
+    .filter((area) => {
+      // Right now there is only one kind of filter
+      if (assigneesFilter === null) {
+        return true;
+      }
+
+      if (area.hasPeople && assigneesFilter == 'unassigned') {
+        return false;
+      } else if (!area.hasPeople && assigneesFilter == 'assigned') {
+        return false;
+      }
+      return true;
+    });
+
   return (
     <>
       <AttributionControl position="bottomright" prefix={false} />
@@ -247,7 +269,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
           reactFGref.current = fgRef;
         }}
       >
-        {areas
+        {filteredAreas
           .sort((a0, a1) => {
             // Always render selected last, so that it gets
             // rendered on top of the unselected ones in case
@@ -266,46 +288,13 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
           .map((area) => {
             const selected = selectedId == area.id;
 
-            const mid: [number, number] = [0, 0];
-            if (area.points.length) {
-              area.points
-                .map((input) => {
-                  if ('lat' in input && 'lng' in input) {
-                    return [input.lat as number, input.lng as number];
-                  } else {
-                    return input;
-                  }
-                })
-                .forEach((point) => {
-                  mid[0] += point[0];
-                  mid[1] += point[1];
-                });
-
-              mid[0] /= area.points.length;
-              mid[1] /= area.points.length;
-            }
-
-            const detailed = zoom >= 15;
-
-            const people = sessions
-              .filter((session) => session.area.id == area.id)
-              .map((session) => session.assignee);
-
-            const hasPeople = !!people.length;
-
-            if (hasPeople && assigneesFilter == 'unassigned') {
-              return null;
-            } else if (!hasPeople && assigneesFilter == 'assigned') {
-              return null;
-            }
-
             // The key changes when selected, to force redraw of polygon
             // to reflect new state through visual style
             const key =
               area.id +
               (selected ? '-selected' : '-default') +
               `-${areaStyle}` +
-              (hasPeople ? '-assigned' : '');
+              (area.hasPeople ? '-assigned' : '');
 
             const stats = areaStats.stats.find(
               (stat) => stat.areaId == area.id
@@ -315,8 +304,6 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
             locationsByAreaId[area.id].forEach(
               (location) => (numberOfHouseholds += location.households.length)
             );
-            const numberOfLocations = locationsByAreaId[area.id].length;
-
             const householdColorPercent =
               (numberOfHouseholds / highestHousholds) * 100;
 
@@ -324,207 +311,32 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               ? (stats.num_visited_households / stats.num_households) * 100
               : 0;
 
-            const successfulVisitsColorPercent = stats?.num_households
-              ? (stats.num_successful_visited_households /
-                  stats.num_households) *
-                100
-              : 0;
-
             return (
-              <>
-                {overlayStyle == 'households' && (
-                  <DivIconMarker
-                    iconAnchor={[0, 0]}
-                    position={mid}
-                    zIndexOffset={100}
-                  >
-                    <Box
-                      alignItems="center"
-                      bgcolor="white"
-                      borderRadius={1}
-                      boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
-                      display="inline-flex"
-                      flexDirection="column"
-                      gap="2px"
-                      padding="2px 6px"
-                      sx={{ translate: '-50% -50%' }}
-                    >
-                      <Typography
-                        alignItems="center"
-                        display="flex"
-                        fontSize="14px"
-                      >
-                        <DoorFront
-                          fontSize="small"
-                          sx={{ color: theme.palette.grey[300] }}
-                        />
-                        {numberOfHouseholds}
-                      </Typography>
-                      <Divider
-                        sx={{
-                          width: '100%',
-                        }}
-                      />
-                      <Typography
-                        alignItems="center"
-                        display="flex"
-                        fontSize="14px"
-                      >
-                        <Place
-                          fontSize="small"
-                          sx={{ color: theme.palette.grey[300] }}
-                        />
-
-                        {numberOfLocations}
-                      </Typography>
-                    </Box>
-                  </DivIconMarker>
+              <Polygon
+                key={key}
+                color={areaStyle == 'hide' ? '' : 'black'}
+                dashArray={!area.hasPeople ? '5px 7px' : ''}
+                eventHandlers={{
+                  click: () => {
+                    onSelectedIdChange(selected ? '' : area.id);
+                  },
+                }}
+                fillColor={getAreaColor(
+                  area.hasPeople,
+                  householdColorPercent,
+                  visitsColorPercent
                 )}
-                {overlayStyle == 'progress' && stats && (
-                  <DivIconMarker
-                    iconAnchor={[0, 0]}
-                    position={mid}
-                    zIndexOffset={100}
-                  >
-                    <Box
-                      bgcolor="white"
-                      borderRadius={1}
-                      boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
-                      display="inline-flex"
-                      flexDirection="column"
-                      padding={0.5}
-                      sx={{ translate: '-50% -50%' }}
-                    >
-                      <div
-                        style={{
-                          alignItems: 'center',
-                          background: `conic-gradient(${
-                            theme.palette.primary.main
-                          } ${successfulVisitsColorPercent}%, ${lighten(
-                            theme.palette.primary.main,
-                            0.7
-                          )} ${successfulVisitsColorPercent}% ${visitsColorPercent}%, ${
-                            theme.palette.grey[400]
-                          } ${visitsColorPercent}%)`,
-                          borderRadius: '2em',
-                          display: 'flex',
-                          flexDirection: 'row',
-                          height: '30px',
-                          justifyContent: 'center',
-                          width: '30px',
-                        }}
-                      />
-                    </Box>
-                  </DivIconMarker>
-                )}
-                {overlayStyle == 'assignees' && hasPeople && (
-                  <DivIconMarker
-                    iconAnchor={[0, 0]}
-                    position={mid}
-                    zIndexOffset={100}
-                  >
-                    {detailed && (
-                      <Box
-                        alignItems="center"
-                        display="inline-flex"
-                        flexWrap="wrap"
-                        gap="2px"
-                        justifyContent="center"
-                        sx={{
-                          pointerEvents: 'none',
-                          transform: 'translate(-50%, -50%)',
-                        }}
-                        width={zoom >= 16 ? '95px' : '65px'}
-                      >
-                        {people.map((person, index) => {
-                          if (index <= 4) {
-                            return (
-                              <Box
-                                //TODO: only use person id once we have logic preventing
-                                //assigning the same person to an area more than once
-                                key={`${person.id}-${index}`}
-                                sx={{
-                                  borderRadius: '50%',
-                                  boxShadow: '0 0 8px rgba(0,0,0,0.3)',
-                                }}
-                              >
-                                <ZUIAvatar
-                                  size={zoom >= 16 ? 'sm' : 'xs'}
-                                  url={`/api/orgs/${assignment.organization.id}/people/${person.id}/avatar`}
-                                />
-                              </Box>
-                            );
-                          } else if (index == 5) {
-                            return (
-                              <Box
-                                alignItems="center"
-                                bgcolor="white"
-                                borderRadius="100%"
-                                display="flex"
-                                height={zoom >= 16 ? '30px' : '20px'}
-                                justifyContent="center"
-                                padding={1}
-                                sx={{ boxShadow: '0 0 8px rgba(0,0,0,0.3)' }}
-                                width={zoom >= 16 ? '30px' : '20px'}
-                              >
-                                <Typography
-                                  color="secondary"
-                                  fontSize={zoom >= 16 ? 14 : 11}
-                                >{`+${people.length - 5}`}</Typography>
-                              </Box>
-                            );
-                          } else {
-                            return null;
-                          }
-                        })}
-                      </Box>
-                    )}
-                    {!detailed && (
-                      <Box
-                        sx={{
-                          alignItems: 'center',
-                          backgroundColor: theme.palette.primary.main,
-                          borderRadius: 10,
-                          boxShadow: '0 0 8px rgba(0,0,0,0.3)',
-                          color: theme.palette.primary.contrastText,
-                          display: 'flex',
-                          fontWeight: 'bold',
-                          height: 30,
-                          justifyContent: 'center',
-                          pointerEvents: 'none',
-                          transform: 'translate(-50%, -50%)',
-                          width: 30,
-                        }}
-                      >
-                        <Box>{people.length}</Box>
-                      </Box>
-                    )}
-                  </DivIconMarker>
-                )}
-                <Polygon
-                  key={key}
-                  color={areaStyle == 'hide' ? '' : 'black'}
-                  dashArray={!hasPeople ? '5px 7px' : ''}
-                  eventHandlers={{
-                    click: () => {
-                      onSelectedIdChange(selected ? '' : area.id);
-                    },
-                  }}
-                  fillColor={getAreaColor(
-                    hasPeople,
-                    householdColorPercent,
-                    visitsColorPercent
-                  )}
-                  fillOpacity={1}
-                  interactive={areaStyle != 'hide'}
-                  positions={area.points}
-                  weight={selected ? 5 : 2}
-                />
-              </>
+                fillOpacity={1}
+                interactive={areaStyle != 'hide'}
+                positions={area.points}
+                weight={selected ? 5 : 2}
+              />
             );
           })}
-        {locationStyle != 'hide' &&
-          locations.map((location) => {
+      </FeatureGroup>
+      {locationStyle != 'hide' && (
+        <FeatureGroup>
+          {locations.map((location) => {
             //Find ids of area/s that the location is in
             const areaIds: string[] = [];
             areas.forEach((area) => {
@@ -588,6 +400,220 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               />
             );
           })}
+        </FeatureGroup>
+      )}
+      <FeatureGroup>
+        {filteredAreas.map((area) => {
+          const mid: [number, number] = [0, 0];
+          if (area.points.length) {
+            area.points
+              .map((input) => {
+                if ('lat' in input && 'lng' in input) {
+                  return [input.lat as number, input.lng as number];
+                } else {
+                  return input;
+                }
+              })
+              .forEach((point) => {
+                mid[0] += point[0];
+                mid[1] += point[1];
+              });
+
+            mid[0] /= area.points.length;
+            mid[1] /= area.points.length;
+          }
+
+          const detailed = zoom >= 15;
+
+          const people = sessions
+            .filter((session) => session.area.id == area.id)
+            .map((session) => session.assignee);
+
+          const stats = areaStats.stats.find((stat) => stat.areaId == area.id);
+
+          let numberOfHouseholds = 0;
+          locationsByAreaId[area.id].forEach(
+            (location) => (numberOfHouseholds += location.households.length)
+          );
+          const numberOfLocations = locationsByAreaId[area.id].length;
+
+          const visitsColorPercent = stats?.num_households
+            ? (stats.num_visited_households / stats.num_households) * 100
+            : 0;
+
+          const successfulVisitsColorPercent = stats?.num_households
+            ? (stats.num_successful_visited_households / stats.num_households) *
+              100
+            : 0;
+
+          return (
+            <>
+              {overlayStyle == 'households' && (
+                <DivIconMarker
+                  iconAnchor={[0, 0]}
+                  position={mid}
+                  zIndexOffset={100}
+                >
+                  <Box
+                    alignItems="center"bgcolor="white"
+                    borderRadius={1}
+                    boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
+                    display="inline-flex"
+                    flexDirection="column"
+                    gap="2px"
+                    padding="2px 6px"
+                    sx={{ translate: '-50% -50%' }}
+                  >
+                    <TypographyalignItems="center"
+                        display="flex"
+                        fontSize="14px"><DoorFront
+                          fontSize="small"
+                          sx={{ color: theme.palette.grey[300] }}
+                        />
+                        {numberOfHouseholds}</Typography>
+                    <Divider
+                    sx={{
+                          width: '100%',
+                        }}
+                      />
+                      <Typography
+                        alignItems="center"
+                        display="flex"
+                        fontSize="14px">
+                      <Place
+                          fontSize="small"
+                          sx={{ color: theme.palette.grey[300] }}
+                        />
+
+                        {numberOfLocations}
+                    </Typography>
+                  </Box>
+                </DivIconMarker>
+              )}
+              {overlayStyle == 'progress' && stats && (
+                <DivIconMarker
+                  iconAnchor={[0, 0]}
+                  position={mid}
+                  zIndexOffset={100}
+                >
+                  <Box
+                    bgcolor="white"
+                    borderRadius={1}
+                    boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
+                    display="inline-flex"
+                    flexDirection="column"
+                    padding={0.5}
+                    sx={{ translate: '-50% -50%' }}
+                  >
+                    <div
+                      style={{
+                        alignItems: 'center',
+                        background: `conic-gradient(${
+                          theme.palette.primary.main
+                        } ${successfulVisitsColorPercent}%, ${lighten(
+                          theme.palette.primary.main,
+                          0.7
+                        )} ${successfulVisitsColorPercent}% ${visitsColorPercent}%, ${
+                          theme.palette.grey[400]
+                        } ${visitsColorPercent}%)`,
+                        borderRadius: '2em',
+                        display: 'flex',
+                        flexDirection: 'row',
+                        height: '30px',
+                        justifyContent: 'center',
+                        width: '30px',
+                      }}
+                    />
+                  </Box>
+                </DivIconMarker>
+              )}
+              {overlayStyle == 'assignees' && area.hasPeople && (
+                <DivIconMarker
+                  iconAnchor={[0, 0]}
+                  position={mid}
+                  zIndexOffset={100}
+                >
+                  {detailed && (
+                    <Box
+                      alignItems="center"
+                      display="inline-flex"
+                      flexWrap="wrap"
+                      gap="2px"
+                      justifyContent="center"
+                      sx={{
+                        pointerEvents: 'none',
+                        transform: 'translate(-50%, -50%)',
+                      }}
+                      width={zoom >= 16 ? '95px' : '65px'}
+                    >
+                      {people.map((person, index) => {
+                        if (index <= 4) {
+                          return (
+                            <Box
+                              //TODO: only use person id once we have logic preventing
+                              //assigning the same person to an area more than once
+                              key={`${person.id}-${index}`}
+                              sx={{
+                                borderRadius: '50%',
+                                boxShadow: '0 0 8px rgba(0,0,0,0.3)',
+                              }}
+                            >
+                              <ZUIAvatar
+                                size={zoom >= 16 ? 'sm' : 'xs'}
+                                url={`/api/orgs/${assignment.organization.id}/people/${person.id}/avatar`}
+                              />
+                            </Box>
+                          );
+                        } else if (index == 5) {
+                          return (
+                            <Box
+                              alignItems="center"
+                              bgcolor="white"
+                              borderRadius="100%"
+                              display="flex"
+                              height={zoom >= 16 ? '30px' : '20px'}
+                              justifyContent="center"
+                              padding={1}
+                              sx={{ boxShadow: '0 0 8px rgba(0,0,0,0.3)' }}
+                              width={zoom >= 16 ? '30px' : '20px'}
+                            >
+                              <Typography
+                                color="secondary"
+                                fontSize={zoom >= 16 ? 14 : 11}
+                              >{`+${people.length - 5}`}</Typography>
+                            </Box>
+                          );
+                        } else {
+                          return null;
+                        }
+                      })}
+                    </Box>
+                  )}
+                  {!detailed && (
+                    <Box
+                      sx={{
+                        alignItems: 'center',
+                        backgroundColor: theme.palette.primary.main,
+                        borderRadius: 10,
+                        boxShadow: '0 0 8px rgba(0,0,0,0.3)',
+                        color: theme.palette.primary.contrastText,
+                        display: 'flex',
+                        fontWeight: 'bold',
+                        height: 30,
+                        justifyContent: 'center',
+                        pointerEvents: 'none',
+                        transform: 'translate(-50%, -50%)',
+                        width: 30,
+                      }}
+                    >
+                      <Box>{people.length}</Box>
+                    </Box>
+                  )}
+                </DivIconMarker>
+              )}
+            </>
+          );
+        })}
       </FeatureGroup>
     </>
   );


### PR DESCRIPTION
## Description
This is a proposal for some refactoring based on the work that I started in #2530. When I was working on that task, I found it a bit difficult to understand how the map is structured. In this change I split the content of the map into layers and components.

Everything should still look and behave as it did before.


## Changes
- The first commit pulls the three distinct things that we show (areas, center markers and individual markers) into three distinct leaflet `FeatureGroup`s
- The second commit splits the markers in the center of the areas (the overlay markers) into separate components to reduce nesting

## Notes to reviewer
This is the same as  #2553 but recreated with a branch in the zetkin repo instead of my fork.