### PR TITLE
MVP user account settings

### DIFF
--- a/src/features/home/components/AccountSettings.tsx
+++ b/src/features/home/components/AccountSettings.tsx
@@ -1,0 +1,94 @@
+import { Box, Button, Divider, TextField, Typography } from '@mui/material';
+import { FC, useState } from 'react';
+
+import { Msg, useMessages } from 'core/i18n';
+import { ZetkinUser } from 'utils/types/zetkin';
+import ZUICard from 'zui/ZUICard';
+import messageIds from '../l10n/messageIds';
+import useUserMutations from '../hooks/useUserMutations';
+
+type Props = {
+  user: ZetkinUser;
+};
+
+const AccountSettings: FC<Props> = ({ user }) => {
+  const [email, setEmail] = useState(user.email || '');
+  const [error, setError] = useState(false);
+  const [savingEmail, setSavingEmail] = useState(false);
+  const messages = useMessages(messageIds);
+  const { updateUser } = useUserMutations();
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={1}
+      overflow="hidden"
+      position="relative"
+    >
+      <Box mt={2}>
+        <ZUICard header={messages.settings.accountSettings.header()}>
+          <Divider />
+          <form
+            onSubmit={async (ev) => {
+              ev.preventDefault();
+
+              setError(false);
+              setSavingEmail(true);
+              try {
+                await updateUser({ email });
+              } catch (err) {
+                setError(true);
+              } finally {
+                setSavingEmail(false);
+              }
+            }}
+          >
+            <Box
+              sx={{
+                alignItems: 'flex-end',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 2,
+                my: 2,
+              }}
+            >
+              <Box sx={{ width: '100%' }}>
+                <Typography>
+                  {user.email
+                    ? messages.settings.accountSettings.email.changeInstructions()
+                    : messages.settings.accountSettings.email.addInstructions()}
+                </Typography>
+              </Box>
+              <TextField
+                disabled={!!user.email}
+                error={error}
+                fullWidth
+                helperText={
+                  error
+                    ? messages.settings.accountSettings.email.errorText()
+                    : ''
+                }
+                label={messages.settings.accountSettings.email.label()}
+                onChange={(ev) => setEmail(ev.target.value)}
+                type="email"
+                value={email}
+              />
+              <Button
+                disabled={savingEmail || !email.length || email == user.email}
+                type="submit"
+                variant="contained"
+              >
+                <Msg
+                  id={messageIds.settings.accountSettings.email.saveButton}
+                />
+              </Button>
+            </Box>
+          </form>
+        </ZUICard>
+      </Box>
+    </Box>
+  );
+};
+
+export default AccountSettings;

--- a/src/features/home/components/AppPreferences.tsx
+++ b/src/features/home/components/AppPreferences.tsx
@@ -31,7 +31,7 @@ const AppPreferences: FC<SettingListProps> = ({ user }) => {
     sv: 'Svenska',
   } as const;
 
-  const { changeUserLanguage } = useUserMutations();
+  const { updateUser } = useUserMutations();
   const [selectedLanguage, setSelectedLanguage] = useState<ZetkinLanguage>(
     user?.lang as ZetkinLanguage
   );
@@ -83,7 +83,7 @@ const AppPreferences: FC<SettingListProps> = ({ user }) => {
             <Button
               disabled={selectedLanguage == user.lang}
               onClick={() => {
-                changeUserLanguage(selectedLanguage);
+                updateUser({ lang: selectedLanguage });
                 location.reload();
               }}
               variant="contained"

--- a/src/features/home/components/AppPreferences.tsx
+++ b/src/features/home/components/AppPreferences.tsx
@@ -17,11 +17,11 @@ import { Msg, useMessages } from 'core/i18n';
 
 export type ZetkinLanguage = 'en' | 'sv' | 'da' | 'nn' | 'de' | null;
 
-type SettingListProps = {
+type Props = {
   user: ZetkinUser;
 };
 
-const AppPreferences: FC<SettingListProps> = ({ user }) => {
+const AppPreferences: FC<Props> = ({ user }) => {
   const messages = useMessages(messageIds);
   const languageOptions = {
     da: 'Dansk',

--- a/src/features/home/components/AppPreferences.tsx
+++ b/src/features/home/components/AppPreferences.tsx
@@ -21,7 +21,7 @@ type SettingListProps = {
   user: ZetkinUser;
 };
 
-const SettingsList: FC<SettingListProps> = ({ user }) => {
+const AppPreferences: FC<SettingListProps> = ({ user }) => {
   const messages = useMessages(messageIds);
   const languageOptions = {
     da: 'Dansk',
@@ -97,4 +97,4 @@ const SettingsList: FC<SettingListProps> = ({ user }) => {
   );
 };
 
-export default SettingsList;
+export default AppPreferences;

--- a/src/features/home/hooks/useUserMutations.tsx
+++ b/src/features/home/hooks/useUserMutations.tsx
@@ -1,12 +1,16 @@
-import { useApiClient } from 'core/hooks';
-import { ZetkinLanguage } from '../components/AppPreferences';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+import { ZetkinUser } from 'utils/types/zetkin';
+import { userUpdated } from 'features/user/store';
 
 export default function useUserMutations() {
   const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
 
-  const changeUserLanguage = async (lang: ZetkinLanguage) => {
-    await apiClient.patch(`/api/users/me`, { lang });
+  return {
+    async updateUser(data: Partial<Omit<ZetkinUser, 'id'>>) {
+      const updated = await apiClient.patch<ZetkinUser>(`/api/users/me`, data);
+
+      dispatch(userUpdated(updated));
+    },
   };
-
-  return { changeUserLanguage };
 }

--- a/src/features/home/hooks/useUserMutations.tsx
+++ b/src/features/home/hooks/useUserMutations.tsx
@@ -1,5 +1,5 @@
 import { useApiClient } from 'core/hooks';
-import { ZetkinLanguage } from '../components/SettingsList';
+import { ZetkinLanguage } from '../components/AppPreferences';
 
 export default function useUserMutations() {
   const apiClient = useApiClient();

--- a/src/features/home/l10n/messageIds.ts
+++ b/src/features/home/l10n/messageIds.ts
@@ -47,6 +47,22 @@ export default makeMessages('feat.home', {
     privacyPolicy: m('Privacy policy'),
   },
   settings: {
+    accountSettings: {
+      email: {
+        addInstructions: m(
+          'Add an email address to your account to be able to log in using a password.'
+        ),
+        changeInstructions: m(
+          'If you need to change your email address, you must reach out to info@zetkin.org.'
+        ),
+        errorText: m(
+          'An error ocurred. Try again or contact Zetkin Foundation for support.'
+        ),
+        label: m('E-mail address'),
+        saveButton: m('Save'),
+      },
+      header: m('Account settings'),
+    },
     appPreferences: {
       header: m('App preferences'),
       lang: {

--- a/src/features/home/pages/SettingsPage.tsx
+++ b/src/features/home/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { FC, Suspense } from 'react';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import AppPreferences from '../components/AppPreferences';
 import useCurrentUser from 'features/user/hooks/useCurrentUser';
+import AccountSettings from '../components/AccountSettings';
 
 const AllEventsPage: FC = () => {
   const user = useCurrentUser();
@@ -24,7 +25,12 @@ const AllEventsPage: FC = () => {
         </Box>
       }
     >
-      {user && <AppPreferences user={user} />}
+      {user && (
+        <>
+          <AppPreferences user={user} />
+          <AccountSettings user={user} />
+        </>
+      )}
     </Suspense>
   );
 };

--- a/src/features/home/pages/SettingsPage.tsx
+++ b/src/features/home/pages/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 import { FC, Suspense } from 'react';
 
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
-import SettingsList from '../components/SettingsList';
+import AppPreferences from '../components/AppPreferences';
 import useCurrentUser from 'features/user/hooks/useCurrentUser';
 
 const AllEventsPage: FC = () => {
@@ -24,7 +24,7 @@ const AllEventsPage: FC = () => {
         </Box>
       }
     >
-      {user && <SettingsList user={user} />}
+      {user && <AppPreferences user={user} />}
     </Suspense>
   );
 };

--- a/src/features/user/store.ts
+++ b/src/features/user/store.ts
@@ -44,9 +44,20 @@ const userSlice = createSlice({
       state.userItem.loaded = new Date().toISOString();
       state.userItem.isLoading = false;
     },
+    userUpdated: (state, action: PayloadAction<ZetkinUser>) => {
+      const user = action.payload;
+      state.userItem.data = user;
+      state.userItem.loaded = new Date().toISOString();
+      state.userItem.isLoading = false;
+    },
   },
 });
 
 export default userSlice;
-export const { membershipsLoad, membershipsLoaded, userLoad, userLoaded } =
-  userSlice.actions;
+export const {
+  membershipsLoad,
+  membershipsLoaded,
+  userLoad,
+  userLoaded,
+  userUpdated,
+} = userSlice.actions;


### PR DESCRIPTION
## Description
This PR adds an MVP for the user account settings, allowing a user to add an email address to their account if they signed up using only phone number.

## Screenshots
![image](https://github.com/user-attachments/assets/b7b8ba48-0a89-419b-9dd9-3a49586b0175)


## Changes
* Refactors `SettingsPage` to use separate component for separate sections of settings
* Refactors `useUserMutations()` to return a general-purpose `updateUser()` instead of specialized `changeUserLanguage()`, and connecting it to store
* Adds a section to add an email address (if not already set)

## Notes to reviewer
Sign in as testsuperuser@example.com and use the API to create a new user account with only email, e.g the following in the browser console:

```js
fetch('/api/users', {
  method: 'POST',
  headers: {'Content-Type': 'application/json' },
  body: JSON.stringify({ phone: '+46701010101', first_name: 'A', last_name: 'B', password: 'password' })
})
```

(You have to come up with a unique phone number).

## Related issues
Undocumented