### PR TITLE
Add connect and follow/unfollow button in public org pages

### DIFF
--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -22,6 +22,7 @@ import { createCallAssignmentDef } from 'features/callAssignments/rpc/createCall
 import { getJoinFormEmbedDataDef } from 'features/joinForms/rpc/getJoinFormEmbedData';
 import { createHouseholdsDef } from 'features/canvass/rpc/createHouseholds/server';
 import { getAllEventsDef } from 'features/events/rpc/getAllEvents';
+import { connectToOrgDef } from 'features/organizations/rpc/connectToOrg';
 
 export function createRPCRouter() {
   const rpcRouter = new RPCRouter();
@@ -49,6 +50,7 @@ export function createRPCRouter() {
   rpcRouter.register(createCallAssignmentDef);
   rpcRouter.register(getJoinFormEmbedDataDef);
   rpcRouter.register(createHouseholdsDef);
+  rpcRouter.register(connectToOrgDef);
 
   return rpcRouter;
 }

--- a/src/features/organizations/hooks/useConnectOrg.ts
+++ b/src/features/organizations/hooks/useConnectOrg.ts
@@ -1,0 +1,34 @@
+import { useApiClient, useAppDispatch } from 'core/hooks';
+import { userMembershipsLoaded } from '../store';
+import { ZetkinMembership, ZetkinPersonNativeFields } from 'utils/types/zetkin';
+import useFollowOrgMutations from './useFollowOrgMutations';
+
+export default function useConnectOrg(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const { followOrg } = useFollowOrgMutations(orgId);
+
+  const connectOrg = async () => {
+    const person = await apiClient.post<ZetkinPersonNativeFields>(
+      `/api/orgs/${orgId}/join_requests`,
+      {}
+    );
+    if (person.id) {
+      const memberships = await apiClient.get<ZetkinMembership[]>(
+        `/api/users/me/memberships`
+      );
+      dispatch(userMembershipsLoaded(memberships));
+      if (memberships) {
+        const newMembership =
+          memberships.find(
+            (membership) => membership.organization.id == orgId
+          ) || null;
+        if (newMembership) {
+          followOrg(newMembership);
+        }
+      }
+    }
+  };
+
+  return { connectOrg };
+}

--- a/src/features/organizations/hooks/useConnectOrg.ts
+++ b/src/features/organizations/hooks/useConnectOrg.ts
@@ -1,32 +1,16 @@
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import { userMembershipsLoaded } from '../store';
-import { ZetkinMembership, ZetkinPersonNativeFields } from 'utils/types/zetkin';
-import useFollowOrgMutations from './useFollowOrgMutations';
+import connectToOrg from 'features/organizations/rpc/connectToOrg';
 
 export default function useConnectOrg(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const { followOrg } = useFollowOrgMutations(orgId);
 
   const connectOrg = async () => {
-    const person = await apiClient.post<ZetkinPersonNativeFields>(
-      `/api/orgs/${orgId}/join_requests`,
-      {}
-    );
-    if (person.id) {
-      const memberships = await apiClient.get<ZetkinMembership[]>(
-        `/api/users/me/memberships`
-      );
-      dispatch(userMembershipsLoaded(memberships));
-      if (memberships) {
-        const newMembership =
-          memberships.find(
-            (membership) => membership.organization.id == orgId
-          ) || null;
-        if (newMembership) {
-          followOrg(newMembership);
-        }
-      }
+    const result = await apiClient.rpc(connectToOrg, { orgId });
+
+    if (result.memberships) {
+      dispatch(userMembershipsLoaded(result.memberships));
     }
   };
 

--- a/src/features/organizations/hooks/useFollowOrgMutations.ts
+++ b/src/features/organizations/hooks/useFollowOrgMutations.ts
@@ -1,14 +1,22 @@
 import { useApiClient, useAppDispatch } from 'core/hooks';
-import { orgUnfollowed } from '../store';
+import { orgFollowed, orgUnfollowed } from '../store';
+import { ZetkinMembership } from 'utils/types/zetkin';
 
 export default function useFollowOrgMutations(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
+
+  const followOrg = async (membership: ZetkinMembership) => {
+    await apiClient.put(`/api/users/me/following/${orgId}`, {
+      follow: true,
+    });
+    dispatch(orgFollowed(membership));
+  };
 
   const unfollowOrg = async () => {
     await apiClient.delete(`/api/users/me/following/${orgId}`);
     dispatch(orgUnfollowed(orgId));
   };
 
-  return { unfollowOrg };
+  return { followOrg, unfollowOrg };
 }

--- a/src/features/organizations/hooks/useFollowOrgMutations.ts
+++ b/src/features/organizations/hooks/useFollowOrgMutations.ts
@@ -1,0 +1,14 @@
+import { useApiClient, useAppDispatch } from 'core/hooks';
+import { orgUnfollowed } from '../store';
+
+export default function useFollowOrgMutations(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  const unfollowOrg = async () => {
+    await apiClient.delete(`/api/users/me/following/${orgId}`);
+    dispatch(orgUnfollowed(orgId));
+  };
+
+  return { unfollowOrg };
+}

--- a/src/features/organizations/hooks/useMembership.ts
+++ b/src/features/organizations/hooks/useMembership.ts
@@ -3,6 +3,7 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinMembership } from 'utils/types/zetkin';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { userMembershipsLoad, userMembershipsLoaded } from '../store';
+import useUser from 'core/hooks/useUser';
 
 export default function useMembership(
   orgId: number
@@ -12,6 +13,12 @@ export default function useMembership(
   const membershipList = useAppSelector(
     (state) => state.organizations.userMembershipList
   );
+
+  const user = useUser();
+
+  if (!user) {
+    return new ResolvedFuture(null);
+  }
 
   const membershipsFuture = loadListIfNecessary(membershipList, dispatch, {
     actionOnLoad: () => dispatch(userMembershipsLoad()),

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -21,8 +21,8 @@ export default makeMessages('feat.organizations', {
     },
     header: {
       connect: m('Connect'),
-      connectAndSignUp: m('Connect & sign up'),
       follow: m('Follow'),
+      login: m('Login & connect'),
       unfollow: m('Unfollow'),
     },
     tabs: {

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -19,6 +19,11 @@ export default makeMessages('feat.organizations', {
     footer: {
       privacyPolicy: m('Privacy policy'),
     },
+    header: {
+      connect: m('Connect'),
+      follow: m('Follow'),
+      unfollow: m('Unfollow'),
+    },
     tabs: {
       calendar: m('Calendar'),
       suborgs: m('Explore'),

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -21,6 +21,7 @@ export default makeMessages('feat.organizations', {
     },
     header: {
       connect: m('Connect'),
+      connectAndSignUp: m('Connect & sign up'),
       follow: m('Follow'),
       unfollow: m('Unfollow'),
     },

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -76,13 +76,19 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
             <ZUIAvatar size="sm" url={`/api/orgs/${org.id}/avatar`} />
             <Typography>{org.title}</Typography>
             {user && membership?.follow && (
-              <Button onClick={() => unfollowOrg()}>Unfollow</Button>
+              <Button onClick={() => unfollowOrg()}>
+                <Msg id={messageIds.home.header.unfollow} />
+              </Button>
             )}
             {user && membership?.follow === false && (
-              <Button onClick={() => followOrg(membership)}>Follow</Button>
+              <Button onClick={() => followOrg(membership)}>
+                <Msg id={messageIds.home.header.follow} />
+              </Button>
             )}
             {user && !membership && (
-              <Button onClick={() => connectOrg()}>Connect</Button>
+              <Button onClick={() => connectOrg()}>
+                <Msg id={messageIds.home.header.connect} />
+              </Button>
             )}
           </Box>
           {user && (

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -25,6 +25,7 @@ import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import usePublicSubOrgs from '../hooks/usePublicSubOrgs';
 import useMembership from '../hooks/useMembership';
 import useFollowOrgMutations from '../hooks/useFollowOrgMutations';
+import useConnectOrg from '../hooks/useConnectOrg';
 
 type Props = {
   children: ReactNode;
@@ -47,6 +48,7 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
   const membership = useMembership(org.id).data;
 
   const { followOrg, unfollowOrg } = useFollowOrgMutations(org.id);
+  const { connectOrg } = useConnectOrg(org.id);
 
   return (
     <Box
@@ -78,6 +80,9 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
             )}
             {user && membership?.follow === false && (
               <Button onClick={() => followOrg(membership)}>Follow</Button>
+            )}
+            {user && !membership && (
+              <Button onClick={() => connectOrg()}>Connect</Button>
             )}
           </Box>
           {user && (

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -46,7 +46,7 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
   const user = useUser();
   const membership = useMembership(org.id).data;
 
-  const { unfollowOrg } = useFollowOrgMutations(org.id);
+  const { followOrg, unfollowOrg } = useFollowOrgMutations(org.id);
 
   return (
     <Box
@@ -75,6 +75,9 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
             <Typography>{org.title}</Typography>
             {user && membership?.follow && (
               <Button onClick={() => unfollowOrg()}>Unfollow</Button>
+            )}
+            {user && membership?.follow === false && (
+              <Button onClick={() => followOrg(membership)}>Follow</Button>
             )}
           </Box>
           {user && (

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -90,6 +90,13 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
                 <Msg id={messageIds.home.header.connect} />
               </Button>
             )}
+            {!user && (
+              <Button
+                href={`/login?redirect=${encodeURIComponent(`/o/${org.id}`)}`}
+              >
+                <Msg id={messageIds.home.header.connectAndSignUp} />
+              </Button>
+            )}
           </Box>
           {user && (
             <NextLink href="/my">

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -94,7 +94,7 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
               <Button
                 href={`/login?redirect=${encodeURIComponent(`/o/${org.id}`)}`}
               >
-                <Msg id={messageIds.home.header.connectAndSignUp} />
+                <Msg id={messageIds.home.header.login} />
               </Button>
             )}
           </Box>

--- a/src/features/organizations/layouts/OrgHomeLayout.tsx
+++ b/src/features/organizations/layouts/OrgHomeLayout.tsx
@@ -23,6 +23,8 @@ import { useEnv } from 'core/hooks';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import usePublicSubOrgs from '../hooks/usePublicSubOrgs';
+import useMembership from '../hooks/useMembership';
+import useFollowOrgMutations from '../hooks/useFollowOrgMutations';
 
 type Props = {
   children: ReactNode;
@@ -42,6 +44,9 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
   const isMobile = useMediaQuery('(max-width: 640px)');
 
   const user = useUser();
+  const membership = useMembership(org.id).data;
+
+  const { unfollowOrg } = useFollowOrgMutations(org.id);
 
   return (
     <Box
@@ -68,6 +73,9 @@ const OrgHomeLayout: FC<Props> = ({ children, org }) => {
           <Box sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
             <ZUIAvatar size="sm" url={`/api/orgs/${org.id}/avatar`} />
             <Typography>{org.title}</Typography>
+            {user && membership?.follow && (
+              <Button onClick={() => unfollowOrg()}>Unfollow</Button>
+            )}
           </Box>
           {user && (
             <NextLink href="/my">

--- a/src/features/organizations/rpc/connectToOrg.ts
+++ b/src/features/organizations/rpc/connectToOrg.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import { ZetkinMembership, ZetkinPersonNativeFields } from 'utils/types/zetkin';
+
+const paramsSchema = z.object({
+  orgId: z.number(),
+});
+
+type Params = z.infer<typeof paramsSchema>;
+
+export type Result = {
+  memberships: ZetkinMembership[];
+};
+
+export const connectToOrgDef = {
+  handler: handle,
+  name: 'connectToOrg',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, Result>(connectToOrgDef.name);
+
+async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
+  const { orgId } = params;
+
+  const person = await apiClient.post<ZetkinPersonNativeFields>(
+    `/api/orgs/${orgId}/join_requests`,
+    {}
+  );
+
+  let memberships: ZetkinMembership[] = [];
+
+  if (person.id) {
+    memberships = await apiClient.get<ZetkinMembership[]>(
+      `/api/users/me/memberships`
+    );
+
+    const membership =
+      memberships.find((m) => m.organization.id === orgId) || null;
+    if (membership) {
+      await apiClient.put(`/api/users/me/following/${orgId}`, {
+        follow: true,
+      });
+    }
+  }
+
+  return { memberships };
+}

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -55,6 +55,7 @@ const OrganizationsSlice = createSlice({
 
       if (existingMembership?.data) {
         existingMembership.data.follow = true;
+        existingMembership.loaded = new Date().toISOString();
       } else {
         const membershipWithId: ZetkinMembership & { id: number } = {
           ...membership,
@@ -66,8 +67,6 @@ const OrganizationsSlice = createSlice({
           remoteItem(membership.organization.id, { data: membershipWithId })
         );
       }
-
-      state.userMembershipList.loaded = new Date().toISOString();
     },
     orgUnfollowed: (state, action: PayloadAction<number>) => {
       const orgId = action.payload;
@@ -78,9 +77,8 @@ const OrganizationsSlice = createSlice({
 
       if (membershipToUpdate?.data) {
         membershipToUpdate.data.follow = false;
+        membershipToUpdate.loaded = new Date().toISOString();
       }
-
-      state.userMembershipList.loaded = new Date().toISOString();
     },
     organizationLoad: (state) => {
       state.orgData.isLoading = true;

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -46,12 +46,39 @@ const OrganizationsSlice = createSlice({
       state.eventsByOrgId[orgId] = remoteList(events);
       state.eventsByOrgId[orgId].loaded = new Date().toISOString();
     },
+    orgFollowed: (state, action: PayloadAction<ZetkinMembership>) => {
+      const membership = action.payload;
+
+      const existingMembership = state.userMembershipList.items.find(
+        (item) => item?.data?.organization.id === membership.organization.id
+      );
+
+      if (existingMembership?.data) {
+        existingMembership.data.follow = true;
+      } else {
+        const membershipWithId: ZetkinMembership & { id: number } = {
+          ...membership,
+          follow: true,
+          id: membership.organization.id,
+        };
+
+        state.userMembershipList.items.push(
+          remoteItem(membership.organization.id, { data: membershipWithId })
+        );
+      }
+
+      state.userMembershipList.loaded = new Date().toISOString();
+    },
     orgUnfollowed: (state, action: PayloadAction<number>) => {
       const orgId = action.payload;
 
-      state.userMembershipList.items = state.userMembershipList.items.filter(
-        (membership) => membership.id !== orgId
+      const membershipToUpdate = state.userMembershipList.items.find(
+        (membership) => membership.id === orgId
       );
+
+      if (membershipToUpdate?.data) {
+        membershipToUpdate.data.follow = false;
+      }
 
       state.userMembershipList.loaded = new Date().toISOString();
     },
@@ -117,6 +144,7 @@ export const {
   orgEventsLoaded,
   organizationLoaded,
   organizationLoad,
+  orgFollowed,
   orgUnfollowed,
   treeDataLoad,
   treeDataLoaded,

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -46,6 +46,15 @@ const OrganizationsSlice = createSlice({
       state.eventsByOrgId[orgId] = remoteList(events);
       state.eventsByOrgId[orgId].loaded = new Date().toISOString();
     },
+    orgUnfollowed: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+
+      state.userMembershipList.items = state.userMembershipList.items.filter(
+        (membership) => membership.id !== orgId
+      );
+
+      state.userMembershipList.loaded = new Date().toISOString();
+    },
     organizationLoad: (state) => {
       state.orgData.isLoading = true;
     },
@@ -108,6 +117,7 @@ export const {
   orgEventsLoaded,
   organizationLoaded,
   organizationLoad,
+  orgUnfollowed,
   treeDataLoad,
   treeDataLoaded,
   subOrgsLoad,

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -64,7 +64,10 @@ const OrganizationsSlice = createSlice({
         };
 
         state.userMembershipList.items.push(
-          remoteItem(membership.organization.id, { data: membershipWithId })
+          remoteItem(membership.organization.id, {
+            data: membershipWithId,
+            loaded: new Date().toISOString(),
+          })
         );
       }
     },


### PR DESCRIPTION
## Description
This PR enables users to connect to, follow, and unfollow organizations. When a user connects to an organization, they automatically follow it.


## Screenshots
![image](https://github.com/user-attachments/assets/d91c38fe-f92a-498e-8c84-ccad8d23667c)

## Changes
* Adds `useFollowOrgMutations()` hook to be able to follow and unfollow organizations.
* Adds reducers `orgUnfollowed `and `orgFollowed `in organizations store.
* Adds` useConnectOrg()` hook to enable the users to connect with the organizations.
* Adds connect, follow and unfollow button in `OrgHomeLayout`.


## Notes to reviewer
Needs design review.
"Disconnect" action is not part of this MVP. 


## Related issues
None
