### PR TITLE
Issue 2632/unwrap organization links

### DIFF
--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -1,7 +1,6 @@
 import createStyles from '@mui/styles/createStyles';
 import makeStyles from '@mui/styles/makeStyles';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import NextLink from 'next/link';
 import { Theme } from '@mui/material/styles';
 import { Breadcrumbs, Link, Typography, useMediaQuery } from '@mui/material';
 
@@ -78,20 +77,15 @@ const BreadcrumbTrail = ({
         {breadcrumbs.map((crumb, index) => {
           if (index < breadcrumbs.length - 1) {
             return (
-              <NextLink
+              <Link
                 key={crumb.href}
+                className={classes.breadcrumb}
+                color="inherit"
                 href={crumb.href}
-                legacyBehavior
-                passHref
+                underline="hover"
               >
-                <Link
-                  className={classes.breadcrumb}
-                  color="inherit"
-                  underline="hover"
-                >
-                  {getLabel(crumb)}
-                </Link>
-              </NextLink>
+                {getLabel(crumb)}
+              </Link>
             );
           } else {
             return (

--- a/src/features/organizations/components/OrganizationTree.tsx
+++ b/src/features/organizations/components/OrganizationTree.tsx
@@ -1,8 +1,7 @@
-import NextLink from 'next/link';
 import React from 'react';
 import TreeItem from '@mui/lab/TreeItem';
 import TreeView from '@mui/lab/TreeView';
-import { Box, Typography, useTheme } from '@mui/material';
+import { Box, Link, Typography, useTheme } from '@mui/material';
 import { ChevronRight, ExpandMore } from '@mui/icons-material';
 
 import ProceduralColorIcon from './ProceduralColorIcon';
@@ -24,7 +23,7 @@ function renderTree(props: OrganizationTreeProps): React.ReactNode {
     <TreeItem
       key={item.id}
       label={
-        <NextLink href={`/organize/${item.id}`} legacyBehavior>
+        <Link color="inherit" href={`/organize/${item.id}`} underline="none">
           <Box
             m={1}
             onClick={(e) => e.stopPropagation()}
@@ -40,7 +39,7 @@ function renderTree(props: OrganizationTreeProps): React.ReactNode {
               {item.title}
             </Typography>
           </Box>
-        </NextLink>
+        </Link>
       }
       nodeId={item.id.toString()}
       onClick={onSwitchOrg}


### PR DESCRIPTION
## Description
Removes use of NextLink in the sidebar and crumbtrail to fix a bug that caused faulty navigation

## Screenshots
https://github.com/user-attachments/assets/dc069e72-2c2a-443f-9286-00339a6c6c2a

## Changes

* Fixes bug triggered by clicking on the organisation in the crumb
* Fixes bug triggered when changing organization in the sidebar 

## Notes to reviewer
Sidebar
1. Go to https://app.dev.zetkin.org/organize/1
2. Click the organisation name in the crumb trail, the page should refresh and not cause an error
3. Expand the sidebar menu
5. Click the downward facing chevron next to the organization name in the top of the menu
6. In the organization list that appears, click any organization except the one already selected, no errors should show
7. On the page where you arrive, click any link (e.g. a tab) in the right part of the UI, no errors should show


## Related issues
Resolves #2632 
