### PR TITLE
Ensure area order is actually retained when rendering

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -451,16 +451,20 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               return getBoundSize(a1) - getBoundSize(a0);
             }
           })
-          .map((area) => {
+          .map((area, index) => {
             const selected = selectedId == area.id;
 
             // The key changes when selected, to force redraw of polygon
-            // to reflect new state through visual style
-            const key =
-              area.id +
-              (selected ? '-selected' : '-default') +
-              `-${areaStyle}` +
-              (area.hasPeople ? '-assigned' : '');
+            // to reflect new state through visual style. Since we also
+            // care about keeping the order form above, we include that in the
+            // key as well.
+            const key = [
+              area.id,
+              selected ? 'selected' : 'default',
+              areaStyle,
+              area.hasPeople ? 'assigned' : 'unassigned',
+              index,
+            ].join('-');
 
             const stats = areaStats.stats.find(
               (stat) => stat.areaId == area.id

--- a/src/features/geography/components/GeographyMap/MapRenderer.tsx
+++ b/src/features/geography/components/GeographyMap/MapRenderer.tsx
@@ -147,10 +147,12 @@ const MapRenderer: FC<Props> = ({
           .sort((a0, a1) => {
             return a1.size - a0.size;
           })
-          .map(({ area }) => {
+          .map(({ area }, index) => {
             // The key changes when selected, to force redraw of polygon
-            // to reflect new state through visual style
-            const key = area.id + '-default';
+            // to reflect new state through visual style. Since we also
+            // care about keeping the order form above, we include that in the
+            // key as well.
+            const key = `${area.id}-${index}-default`;
 
             return (
               <Polygon


### PR DESCRIPTION
## Description
This PR fixes issue #2609 where larger areas would sometimes be rendered on top of smaller enclaves rendering the smaller areas unclickable.


## Changes
In both places where we used this (the `OrganizerMapRenderer` and the `MapRenderer`), we already sorted the areas by size to avoid this bug. On the first render, things would usually work as an expected and only after interacting with the map, the issue would start to appear. I think the problem with this was caused by React being too helpful with not re-rendering layers. Leaflet and the code rely on the DOM order, wanting the smallest area to appear last. Since the `key`s that we used did not take into account the order of the array though (hence rendering our sorting a bit pointless on re-renders) it would put areas that *used to be selected* but aren't anymore last in the DOM, putting them in front of the smaller areas. 

With this change, we include the index (which I think is usually frowned upon in React) to ensure that array order matches the DOM order. I think this is what we actually want in this case though.


## Notes to reviewer
An alternative to this approach would have been to have a global click listener on the map and to then find all areas where the point is included to then make the decision for which area to select (there we could then compare by size or other criteria that are of interest). 

I think that the approach that I have taken is simpler though and also ensures that the map is rendered like other develops would expect with the smaller areas actually appearing on top. Happy to discuss this though.


## Related issues
Resolves #2609 
