### PR TITLE
Add empty question check for MetricCard

### DIFF
--- a/src/features/areaAssignments/components/MetricCard.tsx
+++ b/src/features/areaAssignments/components/MetricCard.tsx
@@ -77,6 +77,7 @@ const MetricCard: FC<MetricCardProps> = ({ metric, onClose, onSave }) => {
           />
           <Box display="flex" gap={1} justifyContent="right" width="100%">
             <Button
+              disabled={question == ''}
               onClick={() => {
                 onSave({
                   definesDone,


### PR DESCRIPTION
Co-authored-by: herover hi+git@leonora.app

## Description
This PR adds a empty string check for question in MetricCard, disabeling the question when it is empty.


## Screenshots
![image](https://github.com/user-attachments/assets/3d0df368-ea09-410f-ad03-c039cddddde4)


## Changes
Adds empty check

## Notes to reviewer
- Create an area assignment
- Go to reports
- Try to create a new question that is empty (should not be allowed)
- Start the assignment
- Try and edit the question, and save without a question title (should not be allowed)


## Related issues
Resolves #2598 
