### PR TITLE
Exploration/findings regarding Issue 2554

### DIFF
--- a/src/core/api/client/IApiClient.ts
+++ b/src/core/api/client/IApiClient.ts
@@ -1,23 +1,36 @@
 import { RPCDef } from 'core/rpc/types';
 
+export interface IApiClientFetchOptions {
+  abortOnNavigate?: boolean;
+}
+
 export default interface IApiClient {
-  delete(path: string): Promise<void>;
+  delete(path: string, options?: IApiClientFetchOptions): Promise<void>;
   put<DataType = void>(
     path: string,
-    data?: Partial<DataType>
+    data?: Partial<DataType>,
+    options?: IApiClientFetchOptions
   ): Promise<DataType>;
-  get<DataType>(path: string): Promise<DataType>;
+  get<DataType>(
+    path: string,
+    options?: IApiClientFetchOptions
+  ): Promise<DataType>;
   patch<DataType, InputType = Partial<DataType>>(
     path: string,
-    data: InputType
+    data: InputType,
+    options?: IApiClientFetchOptions
   ): Promise<DataType>;
   post<DataType, InputType = DataType>(
     path: string,
-    data: Partial<InputType>
+    data: Partial<InputType>,
+    options?: IApiClientFetchOptions
   ): Promise<DataType>;
 
   rpc<ParamsType, ResultType>(
     def: RPCDef<ParamsType, ResultType>,
-    params: ParamsType
+    params: ParamsType,
+    options?: IApiClientFetchOptions
   ): Promise<ResultType>;
+
+  cancelRequests(): void;
 }

--- a/src/core/caching/cacheUtils.ts
+++ b/src/core/caching/cacheUtils.ts
@@ -150,6 +150,12 @@ export function loadItemIfNecessary<
   dispatch: AppDispatch,
   hooks: {
     /**
+     * Called when an error occurs while loading the item.
+     * @param err The error that occurred during the loading process.
+     * @return {PayloadAction} The action to dispatch when an error occurs.
+     */
+    actionOnError?: (err: unknown) => PayloadAction<OnLoadPayload>;
+    /**
      * Called when the item begins loading.
      * @returns {PayloadAction} The action to dispatch when the item is loading.
      */
@@ -173,6 +179,9 @@ export function loadItemIfNecessary<
     const promise = hooks.loader().then((val) => {
       dispatch(hooks.actionOnSuccess(val));
       return val;
+    }).catch((err: unknown) => {
+      hooks.actionOnError && dispatch(hooks.actionOnError(err));
+      throw err;
     });
 
     return new PromiseFuture(promise, remoteItem?.data);

--- a/src/core/hooks/useApiClient.ts
+++ b/src/core/hooks/useApiClient.ts
@@ -1,5 +1,18 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
 import useEnv from './useEnv';
 
 export default function useApiClient() {
-  return useEnv().apiClient;
+  const { events } = useRouter();
+  const { apiClient } = useEnv();
+
+  useEffect(() => {
+    const handleRouteChange = () => apiClient.cancelRequests();
+
+    events.on('routeChangeStart', handleRouteChange);
+    return () => events.off('routeChangeStart', handleRouteChange);
+  }, [apiClient, events]);
+
+  return apiClient;
 }

--- a/src/features/callAssignments/hooks/useCallAssignmentStats.ts
+++ b/src/features/callAssignments/hooks/useCallAssignmentStats.ts
@@ -31,7 +31,10 @@ export default function useCallAssignmentStats(
     actionOnSuccess: (data) => statsLoaded(data),
     loader: async () => {
       const data = await apiClient.get<CallAssignmentStats & { id: number }>(
-        `/api/callAssignments/targets?org=${orgId}&assignment=${assignmentId}`
+        `/api/callAssignments/targets?org=${orgId}&assignment=${assignmentId}`,
+        {
+          abortOnNavigate: true,
+        }
       );
       return { ...data, id: assignmentId };
     },

--- a/src/features/emails/hooks/useEmailStats.ts
+++ b/src/features/emails/hooks/useEmailStats.ts
@@ -2,7 +2,7 @@ import { PlaceholderFuture, ResolvedFuture } from 'core/caching/futures';
 import { futureToObject } from 'core/caching/futures';
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
 import useEmail from './useEmail';
-import { statsLoad, statsLoaded } from '../store';
+import { statsLoad, statsLoaded, statsLoadError } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinEmailStats } from '../types';
 
@@ -35,6 +35,7 @@ export default function useEmailStats(
   const statsItem = useAppSelector((state) => state.emails.statsById[emailId]);
 
   let statsFuture = loadItemIfNecessary(statsItem, dispatch, {
+    actionOnError: () => statsLoadError(emailId),
     actionOnLoad: () => statsLoad(emailId),
     actionOnSuccess: (data) => statsLoaded(data),
     loader: async () => {

--- a/src/features/emails/hooks/useEmailStats.ts
+++ b/src/features/emails/hooks/useEmailStats.ts
@@ -39,7 +39,10 @@ export default function useEmailStats(
     actionOnSuccess: (data) => statsLoaded(data),
     loader: async () => {
       const data = await apiClient.get<ZetkinEmailStats & { id: number }>(
-        `/api/orgs/${orgId}/emails/${emailId}/stats`
+        `/api/orgs/${orgId}/emails/${emailId}/stats`,
+        {
+          abortOnNavigate: true,
+        }
       );
       return { ...data, id: emailId };
     },

--- a/src/features/emails/store.ts
+++ b/src/features/emails/store.ts
@@ -164,6 +164,11 @@ const emailsSlice = createSlice({
         isLoading: true,
       });
     },
+    statsLoadError: (state, action: PayloadAction<number>) => {
+      // This kind of works, as the loading will be retried, but unfortunately, it happens instantly, rather than after the naviation has completed
+      const id = action.payload;
+      delete state.statsById[id];
+    },
     statsLoaded: (
       state,
       action: PayloadAction<ZetkinEmailStats & { id: number }>
@@ -212,4 +217,5 @@ export const {
   themesLoaded,
   statsLoad,
   statsLoaded,
+  statsLoadError,
 } = emailsSlice.actions;

--- a/src/features/surveys/hooks/useSurveyStats.ts
+++ b/src/features/surveys/hooks/useSurveyStats.ts
@@ -17,6 +17,11 @@ export default function useSurveyStats(
   return loadItemIfNecessary(statsItem, dispatch, {
     actionOnLoad: () => statsLoad(surveyId),
     actionOnSuccess: (stats) => statsLoaded([surveyId, stats]),
-    loader: () => apiClient.rpc(getSurveyStats, { orgId, surveyId }),
+    loader: () =>
+      apiClient.rpc(
+        getSurveyStats,
+        { orgId, surveyId },
+        { abortOnNavigate: true }
+      ),
   });
 }

--- a/src/features/tasks/hooks/useTaskStats.ts
+++ b/src/features/tasks/hooks/useTaskStats.ts
@@ -21,7 +21,8 @@ export default function useTaskStats(
   const taskStatsFuture = loadItemIfNecessary(item, dispatch, {
     actionOnLoad: () => statsLoad(taskId!),
     actionOnSuccess: (data) => statsLoaded([taskId!, data]),
-    loader: () => apiClient.rpc(getStats, { orgId, taskId }),
+    loader: () =>
+      apiClient.rpc(getStats, { orgId, taskId }, { abortOnNavigate: true }),
   });
 
   return {


### PR DESCRIPTION
# ***NOTE: DO NOT MERGE!***

The changes in this PR are not fully functional. This PR was only opened in order to share my finding in hopes that someone else can pick up from where I left off.

## Description
This PR tried to fix issue #2554, and make it possible to cancel pending requests when navigating to another page. Since the user is intended on leaving the page, the pending requests aren't that relevant either way.

I managed to implement the cancellation in commit 39921e97fe2680d730125806171c6e33faaca65e, using `AbortController` based on [@Jrende's comment](https://github.com/zetkin/app.zetkin.org/issues/2554#issuecomment-2661040203), and it sped up the navigation. However, it came with the downside of never retrying those requests at a later stage, such as when the user went back to the Archive page. 

<img width="1772" alt="Screenshot 2025-04-12 at 11 13 36" src="https://github.com/user-attachments/assets/d96bb86f-e569-4a3e-888b-f3245e679f9f" />

^ Cancellation works

<img width="1772" alt="Screenshot 2025-04-12 at 11 14 09" src="https://github.com/user-attachments/assets/41c78443-b6e5-4cda-b664-1548bf05c43d" />

^ Requests aren't retried on returning to the archive page

Though not 100% certain, I believe this is caused by [returning a `RemoteItemFuture` in `loadItemsIfNecessary`](https://github.com/zetkin/app.zetkin.org/blob/39921e97fe2680d730125806171c6e33faaca65e/src/core/caching/cacheUtils.ts#L181), since the previous `PromiseFuture` has created the `remoteItem` already.


After some more experimenting, I was able to make the app retry the requests in commit 4d3d16b01763524994b0d4bc603a51b332442234, but instead, they were retried too early. Seemingly only allowing a single navigation-related request to fire before retrying all cancelled requests.
<img width="1772" alt="Screenshot 2025-04-12 at 11 28 34" src="https://github.com/user-attachments/assets/c1127d55-77ef-40ce-9f43-20d6554b4292" />

The ideal solution would of course be that these requests are not retried until the user re-visits the Archive page. I was not able to find a solution for that.

## Notes to reviewer
DO NOT MERGE! At least not as-is.


## Related issues
Relates to #2554 
