### PR TITLE
Set padding to 0 to avoid spinner orbiting center of button.

### DIFF
--- a/src/features/areaAssignments/components/MapControls.tsx
+++ b/src/features/areaAssignments/components/MapControls.tsx
@@ -28,6 +28,7 @@ const MapControls: React.FC<MapControlsProps> = ({ map, onFitBounds }) => {
         sx={{
           '& .MuiButton-root': {
             height: 40,
+            padding: 0,
             width: 40,
           },
           bgcolor: theme.palette.background.default,


### PR DESCRIPTION
## Description
This PR fixes the spinner on the map controls to be centered and not orbiting the center


## Screenshots
![bild](https://github.com/user-attachments/assets/84f842b5-9ea2-46f9-b0bf-652dfef49c5b)


## Changes

* Adds padding to ButtonGroup


## Notes to reviewer


## Related issues
Resolves #2606 
