### PR TITLE
Invalidate map size on resize event

### DIFF
--- a/src/features/geography/components/GeographyMap/index.tsx
+++ b/src/features/geography/components/GeographyMap/index.tsx
@@ -45,6 +45,7 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
 
   const { orgId } = useNumericRouteParams();
   const createArea = useCreateArea(orgId);
+  const containerElm = useRef<HTMLElement | undefined>();
 
   useEffect(() => {
     const map = mapRef.current;
@@ -128,6 +129,18 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     }
   };
 
+  useEffect(() => {
+    if (containerElm.current !== undefined) {
+      const resizeObserver = new ResizeObserver(() => {
+        mapRef.current?.invalidateSize();
+      });
+      resizeObserver.observe(containerElm.current);
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+  }, [containerElm]);
+
   return (
     <AreaFilterProvider>
       <Box
@@ -138,7 +151,13 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
           width: '100%',
         }}
       >
-        <Box display="flex" justifyContent="space-between" px={2} py={1}>
+        <Box
+          ref={(ref) => (containerElm.current = ref as HTMLElement)}
+          display="flex"
+          justifyContent="space-between"
+          px={2}
+          py={1}
+        >
           <Box alignItems="center" display="flex" gap={1}>
             <ButtonGroup variant="contained">
               {!drawingPoints && (


### PR DESCRIPTION
## Description
This PR runs `invalidateSize();` on the geography map whenever it's containing element changes size, so fix an issue where the edge of the map screen would be grey when panning.

It will call invalidateResize multiple times (around 12 in my case) when you expand or contract the sidebar. I didn't notice it leading to performance issues (though I tested it using my stationary computer). Since the user probably won't expand/collapse the sidebar that often it should be fine. I tried to add a debounce which delayed calling the function until after the sidebar had stopped moving, but this created a noticeable jump in the map.


## Changes
* Adds a resize observer to GeographyMap which calls invalidateSize()


## Related issues
Resolves #2608 
