### PR TITLE
Replace useTheme with oldTheme in some places where it crashed

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@mui/styles';
 import { DoorFront, Place } from '@mui/icons-material';
 import {
   AttributionControl,
@@ -26,6 +25,7 @@ import { getBoundSize } from '../../canvass/utils/getBoundSize';
 import MarkerIcon from 'features/canvass/components/MarkerIcon';
 import { getVisitPercentage } from 'features/canvass/utils/getVisitPercentage';
 import { ZetkinPerson } from '../../../utils/types/zetkin';
+import oldTheme from 'theme';
 
 const LocationMarker: FC<{
   areaAssId: string;
@@ -33,7 +33,6 @@ const LocationMarker: FC<{
   location: ZetkinLocation;
   locationStyle: 'dot' | 'households' | 'progress';
 }> = ({ areaAssId, idOfMetricThatDefinesDone, location, locationStyle }) => {
-  const theme = useTheme();
   if (locationStyle == 'dot') {
     return (
       <DivIconMarker
@@ -42,7 +41,7 @@ const LocationMarker: FC<{
         zIndexOffset={-1000}
       >
         <Box
-          bgcolor={theme.palette.text.primary}
+          bgcolor={oldTheme.palette.text.primary}
           borderRadius="2em"
           height={6}
           width={6}
@@ -63,7 +62,7 @@ const LocationMarker: FC<{
             bgcolor="white"
             borderRadius={1}
             boxShadow="0px 4px 20px 0px rgba(0,0,0,0.3)"
-            color={theme.palette.text.secondary}
+            color={oldTheme.palette.text.secondary}
             display="inline-flex"
             flexDirection="column"
             fontSize="14px"
@@ -124,7 +123,6 @@ function HouseholdOverlayMarker(props: {
   numberOfHouseholds: number;
   numberOfLocations: number;
 }) {
-  const theme = useTheme();
   return (
     <Box
       alignItems="center"
@@ -138,7 +136,10 @@ function HouseholdOverlayMarker(props: {
       sx={{ translate: '-50% -50%' }}
     >
       <Typography alignItems="center" display="flex" fontSize="14px">
-        <DoorFront fontSize="small" sx={{ color: theme.palette.grey[300] }} />
+        <DoorFront
+          fontSize="small"
+          sx={{ color: oldTheme.palette.grey[300] }}
+        />
         {props.numberOfHouseholds}
       </Typography>
       <Divider
@@ -147,7 +148,7 @@ function HouseholdOverlayMarker(props: {
         }}
       />
       <Typography alignItems="center" display="flex" fontSize="14px">
-        <Place fontSize="small" sx={{ color: theme.palette.grey[300] }} />
+        <Place fontSize="small" sx={{ color: oldTheme.palette.grey[300] }} />
 
         {props.numberOfLocations}
       </Typography>
@@ -159,8 +160,6 @@ function ProgressOverlayMarker(props: {
   successfulVisitsColorPercent: number;
   visitsColorPercent: number;
 }) {
-  const theme = useTheme();
-
   return (
     <Box
       bgcolor="white"
@@ -174,11 +173,11 @@ function ProgressOverlayMarker(props: {
       <div
         style={{
           alignItems: 'center',
-          background: `conic-gradient(${theme.palette.primary.main} ${
+          background: `conic-gradient(${oldTheme.palette.primary.main} ${
             props.successfulVisitsColorPercent
-          }%, ${lighten(theme.palette.primary.main, 0.7)} ${
+          }%, ${lighten(oldTheme.palette.primary.main, 0.7)} ${
             props.successfulVisitsColorPercent
-          }% ${props.visitsColorPercent}%, ${theme.palette.grey[400]} ${
+          }% ${props.visitsColorPercent}%, ${oldTheme.palette.grey[400]} ${
             props.visitsColorPercent
           }%)`,
           borderRadius: '2em',
@@ -194,16 +193,14 @@ function ProgressOverlayMarker(props: {
 }
 
 function NumberOverlayMarker(props: { value: number }) {
-  const theme = useTheme();
-
   return (
     <Box
       sx={{
         alignItems: 'center',
-        backgroundColor: theme.palette.primary.main,
+        backgroundColor: oldTheme.palette.primary.main,
         borderRadius: 10,
         boxShadow: '0 0 8px rgba(0,0,0,0.3)',
-        color: theme.palette.primary.contrastText,
+        color: oldTheme.palette.primary.contrastText,
         display: 'flex',
         fontWeight: 'bold',
         height: 30,
@@ -299,7 +296,6 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
   overlayStyle,
   locationStyle,
 }) => {
-  const theme = useTheme();
   const reactFGref = useRef<FeatureGroupType | null>(null);
 
   const [zoomed, setZoomed] = useState(false);
@@ -353,21 +349,21 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
 
     if (areaStyle == 'assignees') {
       return hasPeople
-        ? theme.palette.primary.main
-        : theme.palette.secondary.main;
+        ? oldTheme.palette.primary.main
+        : oldTheme.palette.secondary.main;
     }
 
     if (areaStyle == 'progress' && !hasPeople) {
-      return theme.palette.secondary.main;
+      return oldTheme.palette.secondary.main;
     }
 
     return areaStyle == 'households'
       ? //TODO: Use theme colors for these
-        `color-mix(in hsl, ${lighten(theme.palette.primary.main, 0.8)}, ${
-          theme.palette.primary.main
+        `color-mix(in hsl, ${lighten(oldTheme.palette.primary.main, 0.8)}, ${
+          oldTheme.palette.primary.main
         } ${householdColorPercent}%)`
-      : `color-mix(in hsl,  ${lighten(theme.palette.primary.main, 0.8)}, ${
-          theme.palette.primary.main
+      : `color-mix(in hsl,  ${lighten(oldTheme.palette.primary.main, 0.8)}, ${
+          oldTheme.palette.primary.main
         } ${visitsColorPercent || 1}%)`;
   };
 

--- a/src/features/canvass/components/MarkerIcon.tsx
+++ b/src/features/canvass/components/MarkerIcon.tsx
@@ -1,8 +1,8 @@
 import { FC } from 'react';
-import { useTheme } from '@mui/styles';
 import { lighten } from '@mui/system';
 
 import { VisitStats } from '../utils/getVisitPercentage';
+import oldTheme from 'theme';
 
 interface MarkerIconProps {
   percentage?: VisitStats;
@@ -15,7 +15,6 @@ const MarkerIcon: FC<MarkerIconProps> = ({
   percentage,
   selected,
 }) => {
-  const theme = useTheme();
   const totalVisitsKey = uniqueKey + '_totalVisits';
 
   return (
@@ -43,7 +42,7 @@ const MarkerIcon: FC<MarkerIconProps> = ({
       <path
         clipPath={`url(#${totalVisitsKey})`}
         d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
-        fill={lighten(theme.palette.primary.main, 0.7)}
+        fill={lighten(oldTheme.palette.primary.main, 0.7)}
       />
       <clipPath id={uniqueKey}>
         <rect
@@ -60,7 +59,7 @@ const MarkerIcon: FC<MarkerIconProps> = ({
       <path
         clipPath={`url(#${uniqueKey})`}
         d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
-        fill={theme.palette.primary.main}
+        fill={oldTheme.palette.primary.main}
       />
     </svg>
   );


### PR DESCRIPTION
## Description
This PR fixes theme errors in two places (caused by the changes in #2111).

## Screenshots
None

## Changes
* Replaces `useTheme()` with directly importing the old theme in `OrganizerMapRenderer` and `MarkerIcon`

## Notes to reviewer
Try the "Map" tab in the organizer interface for an area assignment, and also the canvasser UI. They were previously crashing, but should work with these changes.

## Related issues
Undocumented