### PR TITLE
Add inner white area in marker while selected

### DIFF
--- a/src/features/canvass/components/MarkerIcon.tsx
+++ b/src/features/canvass/components/MarkerIcon.tsx
@@ -17,6 +17,7 @@ const MarkerIcon: FC<MarkerIconProps> = ({
 }) => {
   const theme = useTheme();
   const totalVisitsKey = uniqueKey + '_totalVisits';
+  const innerPath = "M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
 
   return (
     <svg
@@ -31,6 +32,10 @@ const MarkerIcon: FC<MarkerIconProps> = ({
         d="M10.5 0C4.695 0 0 4.695 0 10.5C0 18.375 10.5 30 10.5 30C10.5 30 21 18.375 21 10.5C21 4.695 16.305 0 10.5 0Z"
         fill={selected ? '#ED1C55' : 'white'}
       />
+      <path
+        d={innerPath}
+        fill="white"
+      />
 
       <clipPath id={totalVisitsKey}>
         <rect
@@ -42,7 +47,7 @@ const MarkerIcon: FC<MarkerIconProps> = ({
       </clipPath>
       <path
         clipPath={`url(#${totalVisitsKey})`}
-        d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
+        d={innerPath}
         fill={lighten(theme.palette.primary.main, 0.7)}
       />
       <clipPath id={uniqueKey}>
@@ -59,7 +64,7 @@ const MarkerIcon: FC<MarkerIconProps> = ({
       </clipPath>
       <path
         clipPath={`url(#${uniqueKey})`}
-        d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
+        d={innerPath}
         fill={theme.palette.primary.main}
       />
     </svg>


### PR DESCRIPTION
## Description
This PR makes it clearer how much of a MarkerIcon is "filled" while it is selected.

## Screenshots

No screenshots because themes seems broken atm, but it looks like requested in #2595 

## Changes

* Adds inner white area in pin above outer line.


## Notes to reviewer

When a pin is not selected and not under the center cursor it should have a white background. When selected it should get a red outline.

## Related issues
Resolves #2595 
