### PR TITLE
Draft: Add button to create person from link menu in survey list

### DIFF
--- a/src/zui/ZUIPersonGridEditCell.tsx
+++ b/src/zui/ZUIPersonGridEditCell.tsx
@@ -1,4 +1,4 @@
-import { Close } from '@mui/icons-material';
+import { Close, PersonAdd } from '@mui/icons-material';
 import { makeStyles } from '@mui/styles';
 import { useRouter } from 'next/router';
 import {
@@ -18,11 +18,12 @@ import {
 } from '@mui/material';
 import { FC, HTMLAttributes, useEffect, useRef, useState } from 'react';
 
-import { useMessages } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
 import { usePersonSelect } from './ZUIPersonSelect';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
 import messageIds from './l10n/messageIds';
+import ZUICreatePerson from 'zui/ZUICreatePerson';
 
 const ZUIPersonGridEditCell: FC<{
   cell?: (Partial<Omit<ZetkinPerson, 'id'>> & { id: number | null }) | null;
@@ -45,6 +46,7 @@ const ZUIPersonGridEditCell: FC<{
   const styles = useStyles({ isRestrictedMode });
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [searching, setSearching] = useState(false);
+  const [createPersonOpen, setCreatePersonOpen] = useState(false);
 
   const orgId = parseInt(query.orgId as string);
 
@@ -303,6 +305,25 @@ const ZUIPersonGridEditCell: FC<{
                             />
                           );
                         })}
+
+                        {autoComplete.inputValue.length >= 3 &&
+                          !personSelect.autoCompleteProps.isLoading &&
+                          searchResults.length === 0 && (
+                            <Button
+                              color="primary"
+                              onClick={() => {
+                                setCreatePersonOpen(true);
+                              }}
+                              startIcon={<PersonAdd />}
+                              sx={{
+                                justifyContent: 'flex-start',
+                                m: 2,
+                              }}
+                              variant="outlined"
+                            >
+                              <Msg id={messageIds.createPerson.createBtn} />
+                            </Button>
+                          )}
                       </List>
                     )}
                   </List>
@@ -312,6 +333,13 @@ const ZUIPersonGridEditCell: FC<{
           </Paper>
         </Popper>
       ) : null}
+
+      <ZUICreatePerson
+        onClose={() => setCreatePersonOpen(false)}
+        open={createPersonOpen}
+        submitLabel={messages.createPerson.submitLabel.default()}
+        title={messages.createPerson.defaultitle()}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Description
Enables you to create a person from the survey submission person link menu.

## Screenshots
![20250412_14h23m37s_grim](https://github.com/user-attachments/assets/f0560cbc-5c71-4314-864e-5cd18bb31612)

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a create person button to the person link menu in the survey submission list.


## Notes to reviewer
Test by going to the person link menu in a survey submission list of your choice and create a person with the new button.


## Related issues
Resolves #2368.
