### PR TITLE
Remove last remaining imports of useTheme from mui/styles

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMapFilters/index.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapFilters/index.tsx
@@ -1,7 +1,6 @@
 import { Close } from '@mui/icons-material';
 import { FC, useContext, useEffect, useMemo, useState } from 'react';
-import { Box, Checkbox, IconButton, Typography } from '@mui/material';
-import { useTheme } from '@mui/styles';
+import { Box, Checkbox, IconButton, Typography, useTheme } from '@mui/material';
 
 import { ZetkinArea } from 'features/areas/types';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';

--- a/src/features/areas/components/AreaFilters/index.tsx
+++ b/src/features/areas/components/AreaFilters/index.tsx
@@ -1,6 +1,5 @@
 import { FC, useContext, useEffect, useMemo, useState } from 'react';
-import { Box, Checkbox, Typography } from '@mui/material';
-import { useTheme } from '@mui/styles';
+import { Box, Checkbox, Typography, useTheme } from '@mui/material';
 
 import { ZetkinArea } from 'features/areas/types';
 import { ZetkinTag, ZetkinTagGroup } from 'utils/types/zetkin';

--- a/src/features/views/components/MoveViewDialog.tsx
+++ b/src/features/views/components/MoveViewDialog.tsx
@@ -11,9 +11,9 @@ import {
   List,
   ListItem,
   useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import { Box } from '@mui/system';
-import { useTheme } from '@mui/styles';
 
 import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';


### PR DESCRIPTION
## Description
This PR removes the last remaining imports of useTheme from mui/styles, which is pretty much deprecated in version and 7 of mui.


## Screenshots
none


## Changes
* Imports useTheme from mui/material instead of mui/styles

## Notes to reviewer
[Add instructions for testing]


## Related issues
none
