### PR TITLE
Issue 2274: Calendar day view message and style fixes

### DIFF
--- a/src/features/calendar/components/CalendarDayView/Day/DateLabel.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/DateLabel.tsx
@@ -8,27 +8,32 @@ const DateLabel = ({ date }: { date: Date }) => {
   const isToday = dayjs(date).isSame(dayjs(), 'day');
   const isThePast = dayjs(date).isBefore(dayjs(), 'day');
   return (
-    <Box
-      alignItems="center"
-      display="flex"
-      gap={1}
-      sx={{
-        backgroundColor: isToday ? oldTheme.palette.primary.main : undefined,
-        borderRadius: '20%/50%',
-        color: isToday
-          ? // White colour if today
-            'white'
-          : isThePast
-          ? // Grey if it's the past
-            oldTheme.palette.secondary.main
-          : // Default colour if it's the future
-            'inherit',
-        padding: '8px 12px',
-      }}
-    >
-      <Typography fontSize="1.4em" variant="h4">
-        <FormattedDate day="numeric" value={date} />
-      </Typography>
+    <Box alignItems="center" display="flex" gap={1}>
+      <Box
+        alignItems="center"
+        display="inline-flex"
+        justifyContent="center"
+        sx={{
+          aspectRatio: '1',
+          backgroundColor: isToday ? oldTheme.palette.primary.main : undefined,
+          borderRadius: '50%',
+          color: isToday
+            ? // White colour if today
+              'white'
+            : isThePast
+            ? // Grey if it's the past
+              oldTheme.palette.secondary.main
+            : // Default colour if it's the future
+              'inherit',
+          minHeight: '40px',
+          minWidth: '40px',
+          padding: '8px',
+        }}
+      >
+        <Typography fontSize="1.4em" variant="h4">
+          <FormattedDate day="numeric" value={date} />
+        </Typography>
+      </Box>
       <Typography variant="body1">
         <FormattedDate month="long" value={date} />
         ,&nbsp;

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -91,7 +91,7 @@ feat:
         none: Inga
       type: Skriv för att filtrera innehåll
     lastDayWithEvents: Den senaste dagen med aktiviteter ägde {numEvents, plural,
-      one {ett} other {numEvents}} event rum
+      one {ett} other {#}} event rum
     loadMore: Ladda mer
     moreEvents: '{numEvents, plural, one {# event till} other {# fler event}}'
     next: NÄSTA


### PR DESCRIPTION
## Description
This PR fixes two small issues in the calendar _Day_ view.

1. Updates the `feat.calendar.lastDayWithEvents` to render the passed number of events instead of the variable name in the Swedish language version. The ICU syntax was a bit confusing to me here at first. This [online editor](https://format-message.github.io/icu-message-format-for-translators/editor.html) was useful to debug.
    - I updated the `src/locale/sv.yml` manually. Not sure if that was correct.
    - I also submitted an update via https://translate.zetkin.org/projects/3/sv

2. Improves the highlighting of today's day.
    - This is intended for 1- or 2-digit numbers only, so the styling could have been done with `minHeight` and `minWidth` only. But I thought it would be nice to have a more flexible approach with `aspectRatio` and `padding` in case someone wants to use this as an example to make a circle around text with more dynamic lengths.
    - Is the gap between non-highlighted day and rest of the date a bit wide? Also happy to remove the circle and highlight today differently.

## Screenshots
For 1: 
<img width="1584" alt="screen 2025-04-12 at 14 19 05" src="https://github.com/user-attachments/assets/1c4fec24-23a9-4a26-a725-0a352dc65c57" />


For 2: 


<img width="946" alt="screen 2025-04-12 at 13 23 34" src="https://github.com/user-attachments/assets/b646fb6d-eba9-405a-b603-aec7ee575f8f" />
<img width="946" alt="screen 2025-04-12 at 13 23 18" src="https://github.com/user-attachments/assets/99e76fcf-84c2-42a2-b7a6-fd97fc385922" />
<img width="1196" alt="screen 2025-04-12 at 14 47 52" src="https://github.com/user-attachments/assets/8acad132-eab5-44f0-ac60-f6fc1c76c96b" />

## Related issues
Resolves #2274 
