### PR TITLE
Add white background to and alter structure of MarkerIcon

### DIFF
--- a/src/features/canvass/components/MarkerIcon.tsx
+++ b/src/features/canvass/components/MarkerIcon.tsx
@@ -15,7 +15,11 @@ const MarkerIcon: FC<MarkerIconProps> = ({
   percentage,
   selected,
 }) => {
-  const totalVisitsKey = uniqueKey + '_totalVisits';
+  const pinInteriorKey = uniqueKey + '_pinInterior';
+  const pinOutlinePath =
+    'M10.5 0C4.695 0 0 4.695 0 10.5C0 18.375 10.5 30 10.5 30C10.5 30 21 18.375 21 10.5C21 4.695 16.305 0 10.5 0Z';
+  const pinInteriorPath =
+    'M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z';
 
   return (
     <svg
@@ -27,39 +31,41 @@ const MarkerIcon: FC<MarkerIconProps> = ({
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
-        d="M10.5 0C4.695 0 0 4.695 0 10.5C0 18.375 10.5 30 10.5 30C10.5 30 21 18.375 21 10.5C21 4.695 16.305 0 10.5 0Z"
-        fill={selected ? '#ED1C55' : 'white'}
+        d={pinOutlinePath}
+        fill={selected ? oldTheme.palette.primary.main : 'white'}
       />
 
-      <clipPath id={totalVisitsKey}>
-        <rect
-          height="30"
-          width="21"
-          x="0"
-          y={percentage ? `${30 - (percentage.totalVisits / 100) * 30}` : '0'}
-        />
+      <clipPath id={pinInteriorKey}>
+        <path d={pinInteriorPath} />
       </clipPath>
-      <path
-        clipPath={`url(#${totalVisitsKey})`}
-        d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
-        fill={lighten(oldTheme.palette.primary.main, 0.7)}
+
+      <rect
+        clipPath={`url(#${pinInteriorKey})`}
+        fill="white"
+        height="30"
+        width="21"
+        x="0"
+        y="0"
       />
-      <clipPath id={uniqueKey}>
-        <rect
-          height="30"
-          width="21"
-          x="0"
-          y={
-            percentage
-              ? `${30 - (percentage.totalSuccessfulVisits / 100) * 30}`
-              : '0'
-          }
-        />
-      </clipPath>
-      <path
-        clipPath={`url(#${uniqueKey})`}
-        d="M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z"
+      <rect
+        clipPath={`url(#${pinInteriorKey})`}
+        fill={lighten(oldTheme.palette.primary.main, 0.7)}
+        height="30"
+        width="21"
+        x="0"
+        y={percentage ? `${30 - (percentage.totalVisits / 100) * 30}` : '0'}
+      />
+      <rect
+        clipPath={`url(#${pinInteriorKey})`}
         fill={oldTheme.palette.primary.main}
+        height="30"
+        width="21"
+        x="0"
+        y={
+          percentage
+            ? `${30 - (percentage.totalSuccessfulVisits / 100) * 30}`
+            : '0'
+        }
       />
     </svg>
   );


### PR DESCRIPTION
## Description
This PR adds a white rectangle background behind the visit stats visualisation inside a marker pin. This fixes the issue where the colour of a selected marker pin would show through as the background of the interior.

It also simplifies the structure of the `MarkerIcon` `<svg>`, using just one clipping path for the pin interior. It also converts a hard-coded colour code to use the (old)theme colour.


## Screenshots
### Previous behaviour
![image](https://github.com/user-attachments/assets/debfac00-105a-445e-a3b2-57be7d62d88b)

### Corrected behaviour
![image](https://github.com/user-attachments/assets/a3045eb3-bfad-40ee-a62e-71cf67ca78fc)


## Changes
* Adds a white rectangle background behind the visit stats visualisation inside a marker pin
* Changes structure of visit stats visualisation to use three rectangles clipped to the same interior path
* Converts a hard-coded colour code to use the (old)theme colour


## Notes to reviewer
Credit to @Herover who also worked on fixing this issue!


## Related issues
Resolves #2595 
