### PR TITLE
Fix report editor in Area Assignment to be editable as draft event

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -188,7 +188,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                 </Typography>
                               </Box>
                             )}
-                            {unlocked && (
+                            {isReportEditable && (
                               <IconButton
                                 color="secondary"
                                 onClick={() => setMetricBeingEdited(metric)}
@@ -196,7 +196,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                 <Edit />
                               </IconButton>
                             )}
-                            {unlocked &&
+                            {isReportEditable &&
                               (metric.kind === 'scale5' ||
                                 (metric.kind === 'boolean' &&
                                   assignment.metrics.filter(
@@ -233,7 +233,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                   <Delete />
                                 </IconButton>
                               )}
-                            {unlocked &&
+                            {isReportEditable &&
                               assignment.metrics.filter(
                                 (metric) => metric.kind === 'boolean'
                               ).length <= 1 &&
@@ -470,7 +470,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                 <InputLabel>{messages.report.card.definesSuccess()}</InputLabel>
                 <Select
                   disabled={
-                    !unlocked ||
+                    !isReportEditable ||
                     assignment.metrics.filter(
                       (metric) => metric.kind === 'boolean'
                     ).length <= 1
@@ -541,7 +541,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                     justifyContent="space-between"
                   >
                     <FormControlLabel
-                      control={<Radio disabled={!unlocked} />}
+                      control={<Radio disabled={!isReportEditable} />}
                       label={messages.report.dataCard.household()}
                       sx={{ ml: 1 }}
                       value="household"
@@ -561,7 +561,7 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                     justifyContent="space-between"
                   >
                     <FormControlLabel
-                      control={<Radio disabled={!unlocked} />}
+                      control={<Radio disabled={!isReportEditable} />}
                       label={messages.report.dataCard.location()}
                       sx={{ ml: 1 }}
                       value="location"


### PR DESCRIPTION
## Description
This PR fixes a bug and makes the report editor accessible when drafting Area Assignment events.


## Screenshots

https://github.com/user-attachments/assets/a329d734-3e15-4cd2-9bbd-579a1860bd06


## Changes

* Change condition in conditional rendering of editor elements.


## Notes to reviewer
1. Go to [https://app.dev.zetkin.org/organize/1](https://app.dev.zetkin.org/organize/1)
2. Go to any project or create a new one
3. Create a new Area assignment from the Create menu in the top right
4. Go to the metrics tab
5. Questions should be editable when event is in draft form.
7. Start the event, the editor should be locked and the unlock switch should appear
8. Click the unlock switch, editor should be editable again

## Related issues
Resolves #2653 
