### PR TITLE
Add check for event being active or not to use with conditional render.

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/questions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/questions.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useState } from 'react';
 import { Grid, useMediaQuery, useTheme } from '@mui/material';
+import dayjs from 'dayjs';
 
 import EditWarningCard from 'features/surveys/components/EditWarningCard';
 import { PageWithLayout } from 'utils/types';
@@ -49,6 +50,16 @@ const QuestionsPage: PageWithLayout<QuestionsPageProps> = ({
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const isShared = campId === 'shared';
 
+  const now = dayjs();
+  const today = now.format('YYYY-MM-DD');
+  const surveyStart = dayjs(surveyFuture.data?.published).format('YYYY-MM-DD');
+  const surveyEnd = dayjs(surveyFuture.data?.expires).format('YYYY-MM-DD');
+
+  const isActive =
+    surveyEnd && surveyStart
+      ? surveyStart <= today && today <= surveyEnd
+      : false;
+
   return (
     <>
       <Head>
@@ -57,6 +68,7 @@ const QuestionsPage: PageWithLayout<QuestionsPageProps> = ({
       <ZUIFuture future={statsFuture}>
         {(stats) => {
           const receivingSubmissions = stats.submissionCount > 0;
+          const isEditingLocked = receivingSubmissions || isActive;
           return (
             <Grid
               container
@@ -66,14 +78,12 @@ const QuestionsPage: PageWithLayout<QuestionsPageProps> = ({
               <Grid size={{ md: 8, xs: 12 }}>
                 <SurveyEditor
                   orgId={parseInt(orgId)}
-                  readOnly={
-                    (receivingSubmissions && !forceEditable) || isShared
-                  }
+                  readOnly={(isEditingLocked && !forceEditable) || isShared}
                   surveyId={parseInt(surveyId)}
                 />
               </Grid>
               <Grid size={{ md: 4, xs: 12 }}>
-                {receivingSubmissions && !isShared && (
+                {isEditingLocked && !isShared && (
                   <EditWarningCard
                     editing={forceEditable}
                     onToggle={(newValue) => setForceEditable(newValue)}


### PR DESCRIPTION
## Description
This PR fixes a bug where the contents of a survey is not locked when published.


## Screenshots

https://github.com/user-attachments/assets/737abc30-7b2a-4648-89e0-c668b3509c50



## Changes

* Adds a check for wether a survey is active or not and uses that to determine wether the editor should be locked or not.


## Notes to reviewer
1. Go to https://app.dev.zetkin.org/organize/1/projects
2. Create a project or pick an existing one at random
3. Create a Survey
4. Click CREATE QUESTIONS. Event should be draft and publish button should be greyed out
5. Click OPEN QUESTION
6. Type anyhing as title
7. Click PUBLISH SURVEY, the lock card should appear and the editor should lock.
8. The card should stay visible and editor should remain locked when you click unpublish.


## Related issues
Resolves #2597 
