### PR TITLE
Add option to ignore unknown rows

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/SheetSettings/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/SheetSettings/index.tsx
@@ -40,7 +40,7 @@ const SheetSettings: FC<SheetSettingsProps> = ({ clearConfiguration }) => {
     firstRowIsHeaders,
     selectedSheetIndex,
     sheets,
-    updateFirstRowIsHeaders,
+    updateSheetSettings,
     updateSelectedSheetIndex,
   } = useSheets();
   const [settingsExpanded, setSettingsExpanded] = useState(true);
@@ -93,7 +93,9 @@ const SheetSettings: FC<SheetSettingsProps> = ({ clearConfiguration }) => {
         <Box alignItems="center" display="flex">
           <Checkbox
             checked={firstRowIsHeaders}
-            onChange={(ev, isChecked) => updateFirstRowIsHeaders(isChecked)}
+            onChange={(ev, isChecked) =>
+              updateSheetSettings({ firstRowIsHeaders: isChecked })
+            }
           />
           <Typography>
             <Msg id={messageIds.configuration.settings.firstRowIsHeaders} />

--- a/src/features/import/components/ImportDialog/Configure/SheetSettings/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/SheetSettings/index.tsx
@@ -40,6 +40,7 @@ const SheetSettings: FC<SheetSettingsProps> = ({ clearConfiguration }) => {
     firstRowIsHeaders,
     selectedSheetIndex,
     sheets,
+    skipUnknown,
     updateSheetSettings,
     updateSelectedSheetIndex,
   } = useSheets();
@@ -99,6 +100,17 @@ const SheetSettings: FC<SheetSettingsProps> = ({ clearConfiguration }) => {
           />
           <Typography>
             <Msg id={messageIds.configuration.settings.firstRowIsHeaders} />
+          </Typography>
+        </Box>
+        <Box alignItems="center" display="flex">
+          <Checkbox
+            checked={skipUnknown}
+            onChange={(ev, isChecked) =>
+              updateSheetSettings({ skipUnknown: isChecked })
+            }
+          />
+          <Typography>
+            <Msg id={messageIds.configuration.settings.skipUnknown} />
           </Typography>
         </Box>
       </AccordionDetails>

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
@@ -9,6 +9,7 @@ import {
   ImportProblem,
   ImportProblemKind,
 } from 'features/import/utils/problems/types';
+import useSheets from 'features/import/hooks/useSheets';
 
 type Props = {
   onCheck: (checked: boolean) => void;
@@ -20,6 +21,7 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
   const messages = useMessages(messageIds);
   const { orgId } = useNumericRouteParams();
   const getFieldTitle = useFieldTitle(orgId);
+  const { skipUnknown } = useSheets();
 
   if (problem.kind == ImportProblemKind.INVALID_FORMAT) {
     return (
@@ -60,7 +62,11 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
   } else if (problem.kind == ImportProblemKind.NO_IMPACT) {
     return (
       <ImportMessage
-        description={messages.preflight.messages.noImpact.description()}
+        description={
+          skipUnknown
+            ? messages.preflight.messages.noImpact.descriptionSkipped()
+            : messages.preflight.messages.noImpact.description()
+        }
         onCheck={onCheck}
         onClickBack={onClickBack}
         status="error"

--- a/src/features/import/hooks/useSheets.ts
+++ b/src/features/import/hooks/useSheets.ts
@@ -1,5 +1,6 @@
-import { setFirstRowIsHeaders, setSelectedSheetIndex } from '../store';
+import { sheetSettingsUpdated, setSelectedSheetIndex } from '../store';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
+import { SheetSettings } from '../utils/types';
 
 export default function useSheets() {
   const dispatch = useAppDispatch();
@@ -13,15 +14,15 @@ export default function useSheets() {
     dispatch(setSelectedSheetIndex(newIndex));
   };
 
-  const updateFirstRowIsHeaders = (firstRowIsHeaders: boolean) => {
-    dispatch(setFirstRowIsHeaders(firstRowIsHeaders));
+  const updateSheetSettings = (settings: Partial<SheetSettings>) => {
+    dispatch(sheetSettingsUpdated(settings));
   };
 
   return {
     firstRowIsHeaders: selectedSheet.firstRowIsHeaders,
     selectedSheetIndex: pendingFile.selectedSheetIndex,
     sheets,
-    updateFirstRowIsHeaders,
     updateSelectedSheetIndex,
+    updateSheetSettings,
   };
 }

--- a/src/features/import/hooks/useSheets.ts
+++ b/src/features/import/hooks/useSheets.ts
@@ -22,6 +22,7 @@ export default function useSheets() {
     firstRowIsHeaders: selectedSheet.firstRowIsHeaders,
     selectedSheetIndex: pendingFile.selectedSheetIndex,
     sheets,
+    skipUnknown: !!selectedSheet.skipUnknown,
     updateSelectedSheetIndex,
     updateSheetSettings,
   };

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -231,6 +231,7 @@ export default makeMessages('feat.import', {
         'Your file has multiple sheets, select which one to use.'
       ),
       sheetSelectLabel: m('Sheet'),
+      skipUnknown: m('Skip rows with unknown IDs (never create new people)'),
     },
     show: m('Show'),
     statusMessage: {

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -343,6 +343,9 @@ export default makeMessages('feat.import', {
         description: m(
           'This could be because the file contains no new data, or due to an unknown error.'
         ),
+        descriptionSkipped: m(
+          'This could be because the file contains no new data, or because all new data was skipped according to your settings. In rare occasions, it could be due to an unknown error.'
+        ),
         title: m('This import would have no effect'),
       },
       ok: {

--- a/src/features/import/store.ts
+++ b/src/features/import/store.ts
@@ -5,6 +5,7 @@ import {
   ImportedFile,
   ImportPreview,
   PersonImport,
+  SheetSettings,
 } from './utils/types';
 
 export interface ImportStoreSlice {
@@ -42,12 +43,18 @@ const importSlice = createSlice({
     importResultAdd: (state, action: PayloadAction<PersonImport>) => {
       state.importResult = action.payload;
     },
-    setFirstRowIsHeaders: (state, action: PayloadAction<boolean>) => {
-      const sheetIndex = state.pendingFile.selectedSheetIndex;
-      state.pendingFile.sheets[sheetIndex].firstRowIsHeaders = action.payload;
-    },
     setSelectedSheetIndex: (state, action: PayloadAction<number>) => {
       state.pendingFile.selectedSheetIndex = action.payload;
+    },
+    sheetSettingsUpdated: (
+      state,
+      action: PayloadAction<Partial<SheetSettings>>
+    ) => {
+      const sheetIndex = state.pendingFile.selectedSheetIndex;
+      state.pendingFile.sheets[sheetIndex] = {
+        ...state.pendingFile.sheets[sheetIndex],
+        ...action.payload,
+      };
     },
   },
 });
@@ -58,6 +65,6 @@ export const {
   columnUpdate,
   importPreviewAdd,
   importResultAdd,
-  setFirstRowIsHeaders,
+  sheetSettingsUpdated,
   setSelectedSheetIndex,
 } = importSlice.actions;

--- a/src/features/import/types.ts
+++ b/src/features/import/types.ts
@@ -22,6 +22,7 @@ type PersonCreateBulkOp = {
 };
 
 type PersonGetBulkOp = {
+  if_none?: 'create' | 'skip';
   key: { id: number } | { ext_id: string };
   op: 'person.get';
   ops: BulkSubOp[];

--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -207,6 +207,42 @@ describe('prepareImportOperations()', () => {
     ]);
   });
 
+  it('sets if_none in person.get when sheet is configured to skip unknown', () => {
+    const sheet: Sheet = {
+      columns: [
+        { idField: 'ext_id', kind: ColumnKind.ID_FIELD, selected: true },
+        { field: 'email', kind: ColumnKind.FIELD, selected: true },
+      ],
+      firstRowIsHeaders: false,
+      rows: [
+        {
+          data: ['123', 'clara@example.com'],
+        },
+      ],
+      skipUnknown: true,
+      title: 'My sheet',
+    };
+
+    const ops = prepareImportOperations(sheet, countryCode);
+    expect(ops).toEqual([
+      {
+        if_none: 'skip',
+        key: {
+          ext_id: '123',
+        },
+        op: 'person.get',
+        ops: [
+          {
+            data: {
+              email: 'clara@example.com',
+            },
+            op: 'person.setfields',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('parses and sets date field', () => {
     const sheet: Sheet = {
       columns: [

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -120,6 +120,7 @@ export default function prepareImportOperations(
 
     if (extId) {
       preparedOps.push({
+        if_none: sheet.skipUnknown ? 'skip' : undefined,
         key: {
           ext_id: extId,
         },
@@ -128,6 +129,7 @@ export default function prepareImportOperations(
       });
     } else if (zetkinId) {
       preparedOps.push({
+        if_none: sheet.skipUnknown ? 'skip' : undefined,
         key: {
           id: zetkinId,
         },

--- a/src/features/import/utils/types.ts
+++ b/src/features/import/utils/types.ts
@@ -16,6 +16,8 @@ export type Sheet = {
   title: string;
 };
 
+export type SheetSettings = Omit<Sheet, 'columns' | 'rows' | 'title'>;
+
 export type Row = {
   data: CellData[];
 };

--- a/src/features/import/utils/types.ts
+++ b/src/features/import/utils/types.ts
@@ -13,6 +13,7 @@ export type Sheet = {
   columns: Column[];
   firstRowIsHeaders: boolean;
   rows: Row[];
+  skipUnknown?: boolean;
   title: string;
 };
 


### PR DESCRIPTION
## Description
This PR augments #2472 with an additional option to skip unknown rows, i.e. rows where the ID does not match any ID in the database of people.

## Screenshots
![image](https://github.com/user-attachments/assets/7ba5e1e0-e22f-45e5-9236-1086b7cc1793)
![image](https://github.com/user-attachments/assets/6839c73f-7dd5-4c13-a72f-43ce2ecd8f81)



## Changes
* Adds `skipUnknown` option to sheets
* Implements the new `if_none: 'skip'` property on `person.get` ops
* Adds a checkbox to to toggle the option in the importer settings section
* Adds a new message to be displayed when an import has no effect while skipping unknown rows

## Notes to reviewer
What do you think about the text?

## Related issues
Undocumented