### PR TITLE
Add ext_id that was missing in test, but needed after merge

### DIFF
--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -236,6 +236,7 @@ describe('prepareImportOperations()', () => {
           {
             data: {
               email: 'clara@example.com',
+              ext_id: '123',
             },
             op: 'person.setfields',
           },


### PR DESCRIPTION
## Description
Two separate PRs recently caused a logical merge conflict causing tests to fail on main.

* #2472 modifies the importer UI to use new backend features, and in a late addition the logic was changed to include `ext_id` in `person.setfields` so that the external ID is not just used for keying, but also saved on the person.
* #2659 branched off the former, but before the `ext_id` change was made, so it included tests that did not take that change into account.

## Screenshots
None

## Changes
* Adds `ext_id` to the `person.setfields` op in one test where it was missing

## Notes to reviewer
None

## Related issues
Undocumented