### PR TITLE
Wrap the call pages in the new theme

### DIFF
--- a/src/app/call/[callAssId]/layout.tsx
+++ b/src/app/call/[callAssId]/layout.tsx
@@ -7,6 +7,7 @@ import CallLayout from 'features/call/layouts/CallLayout';
 import redirectIfLoginNeeded from 'core/utils/redirectIfLoginNeeded';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import { CALL, hasFeature } from 'utils/featureFlags';
+import HomeThemeProvider from 'features/home/components/HomeThemeProvider';
 
 type Props = {
   children?: ReactNode;
@@ -32,7 +33,11 @@ const CallPageLayout = async ({ children, params }: Props) => {
   const { callAssId } = params;
 
   if (hasFeature(CALL, assignment.organization.id, process.env)) {
-    return <CallLayout callAssId={callAssId}>{children}</CallLayout>;
+    return (
+      <HomeThemeProvider>
+        <CallLayout callAssId={callAssId}>{children}</CallLayout>;
+      </HomeThemeProvider>
+    );
   } else {
     const callUrl = process.env.ZETKIN_GEN2_CALL_URL;
     const assignmentUrl = `${callUrl}/assignments/${params.callAssId}/call`;


### PR DESCRIPTION
## Description
This PR wraps the gen 3 call pages in the new theme! :D 


## Screenshots
![bild](https://github.com/user-attachments/assets/2010cb25-ebd8-410c-839d-98ad8e49e5c4)


## Changes
* Adds `HomeThemeProvider` around the `CallLayout`

## Notes to reviewer
Click around and see that there are no weird errors popping up?

## Related issues
none
