### PR TITLE
issue-2666 | Move "Assigned" column in journey to third place by default

### DIFF
--- a/src/features/journeys/components/JourneyInstancesDataTable/getColumns.ts
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getColumns.ts
@@ -15,7 +15,7 @@ const getColumns = (
   const staticColumns = getStaticColumns(messages, journeyInstances);
   return (
     staticColumns
-      .splice(0, 2)
+      .splice(0, 3)
       .concat(getTagColumns(messages, journeyInstances, tagColumns))
       // Add/override common props
       .concat(staticColumns)

--- a/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/getStaticColumns.tsx
@@ -188,6 +188,37 @@ export const getStaticColumns = (
       },
     },
     {
+      field: 'assignees',
+      filterOperators: [
+        makeIncludesFilterOperator(
+          messages,
+          messages.instances.filters.personLabel(),
+          uniqueAssignees
+        ),
+        makeDoesNotIncludeFilterOperator(
+          messages,
+          messages.instances.filters.doesNotIncludeOperator(),
+          uniqueAssignees
+        ),
+        makeEmptyFilterOperator(messages),
+      ],
+      renderCell: (params) =>
+        (params.row.assignees as ZetkinPersonType[]).map((person) => (
+          <ZUIPersonHoverCard key={person.id} personId={person.id}>
+            <ZUIPerson
+              containerProps={{ style: { marginRight: 10 } }}
+              id={person.id}
+              link
+              name={`${person.first_name} ${person.last_name}`}
+              showText={false}
+            />
+          </ZUIPersonHoverCard>
+        )),
+      sortComparator: (value0, value1) => sortByName(value0, value1),
+      valueFormatter: (params) =>
+        getPeopleString(params.value as ZetkinPersonType[]),
+    },
+    {
       field: 'subjects',
       filterOperators: [
         makeIncludesFilterOperator(
@@ -278,37 +309,6 @@ export const getStaticColumns = (
     },
     {
       field: 'outcome',
-    },
-    {
-      field: 'assignees',
-      filterOperators: [
-        makeIncludesFilterOperator(
-          messages,
-          messages.instances.filters.personLabel(),
-          uniqueAssignees
-        ),
-        makeDoesNotIncludeFilterOperator(
-          messages,
-          messages.instances.filters.doesNotIncludeOperator(),
-          uniqueAssignees
-        ),
-        makeEmptyFilterOperator(messages),
-      ],
-      renderCell: (params) =>
-        (params.row.assignees as ZetkinPersonType[]).map((person) => (
-          <ZUIPersonHoverCard key={person.id} personId={person.id}>
-            <ZUIPerson
-              containerProps={{ style: { marginRight: 10 } }}
-              id={person.id}
-              link
-              name={`${person.first_name} ${person.last_name}`}
-              showText={false}
-            />
-          </ZUIPersonHoverCard>
-        )),
-      sortComparator: (value0, value1) => sortByName(value0, value1),
-      valueFormatter: (params) =>
-        getPeopleString(params.value as ZetkinPersonType[]),
     },
   ];
 };


### PR DESCRIPTION
## Description
This PR solves issue #2666 which is described quite thoroughly.


## Changes
* In the journey overview table the column 'Assigned' is now  in the third place by default


## Notes to reviewer
No, just thank you and happy Easter!


## Related issues
Resolves #2666 
