### PR TITLE
issue-2655 | Feed includes events from all orgs

### DIFF
--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -20,9 +20,11 @@ export const getAllEventsDef = {
 export default makeRPCDef<Params, Result>(getAllEventsDef.name);
 
 async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
-  const memberships = await apiClient.get<ZetkinMembership[]>(
-    '/api/users/me/memberships'
-  );
+  const memberships = await apiClient
+    .get<ZetkinMembership[]>('/api/users/me/memberships')
+    .then((memberships) =>
+      memberships.filter((membership) => membership.follow)
+    );
 
   const now = new Date().toISOString();
 


### PR DESCRIPTION
## Description
This PR solves issue #2655 which is described quite thoroughly. Also it changes 


## Screenshots
<img width="587" alt="image" src="https://github.com/user-attachments/assets/3c0c46ee-ee54-4f59-babf-1e8ca6f11fc4" />


## Changes
* When navigating to [My Feed](https://app.dev.zetkin.org/my/feed) instead of showing the events from all the users organizations, events are only shown if the user follows the organization 
* While loading the events, they are now requested asynchronously grouped by organization 

## Notes to reviewer
A few thoughts here:
* I dont know how the backend is looking, I checked for documentation/a swagger but could not find one (tbh I didnt look very through). It might be sensible to use other endpoints or query parameters (or implement them e.g. GET /api/users/me/memberships?follow=true)
* In regular use cases it should not cause any issues to call GET /api/orgs/{id}/actions async. In most cases it should also not provide huge benfits, but... I like to do it :) Feel free to drop the second commit if you do not like it.

## Related issues
Resolves #2655 
