### PR TITLE
Make avatar behave as link

### DIFF
--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -14,7 +14,7 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import { FunctionComponent, useContext, useState } from 'react';
-import { Link, useTheme } from '@mui/material';
+import { Box, Link, useTheme } from '@mui/material';
 
 import columnTypes from './columnTypes';
 import EmptyView from 'features/views/components/EmptyView';
@@ -306,17 +306,17 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
             passHref
           >
             <Link
-              alt="Avatar"
-              component="img"
               onClick={(evt) => evt.stopPropagation()}
-              src={url}
-              style={{
-                cursor: 'pointer',
-                maxHeight: '100%',
-                maxWidth: '100%',
-              }}
+              style={{ cursor: 'pointer' }}
               underline="hover"
-            />
+            >
+              <Box
+                alt={'Avatar'}
+                component="img"
+                src={url}
+                sx={{ maxHeight: '100%', maxWidth: '100%' }}
+              />
+            </Link>
           </NextLink>
         </ZUIPersonHoverCard>
       );


### PR DESCRIPTION
## Description
This PR makes the individual avatars in a list clickable as links. The user can click the avatar to navigate to a person's profile page, or right-click the avatar to open the profile page in a new tab.


## Screenshots
![list-avatar-link](https://github.com/user-attachments/assets/605a264a-9f3e-4867-9006-49f68ef3375e)


## Changes
* Adds a Box component as a child to the existing Link component, to hold the avatar img, instead of using the Link as a self-closing img component.


## Notes to reviewer
None


## Related issues
Resolves #2671 

