### PR TITLE
Ensure avatar does not stretch

### DIFF
--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -22,6 +22,7 @@ interface StyleProps {
 
 const useStyles = makeStyles<Theme, StyleProps>(() => ({
   avatar: {
+    aspectRatio: 1,
     height: 65,
     marginRight: 20,
     width: 'auto',


### PR DESCRIPTION
## Description
This PR might fix the issue described in #2589. We know that avatars should always be square, so we can set the `aspect-ratio` CSS property to ensure they are rendered as such.

## Notes to reviewer
Just like @kerry-space in #2589, I couldn't manage to sign in to the local deserver with Safari. I did make the change in the Safari devtools manually though and am hence pretty sure that it should work.

## Related issues
Resolves #2589
