### PR TITLE
fix: fit map to screen when menu is collapsed or window is resized

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -36,6 +36,7 @@ import { areaFilterContext } from 'features/areas/components/AreaFilters/AreaFil
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
 import messageIdsAss from '../l10n/messageIds';
+import { useAutoResizeMap } from 'features/map/hooks/useResizeMap';
 
 type OrganizerMapProps = {
   areaAssId: string;
@@ -86,6 +87,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
   const { navigateToAreaId } = router.query;
 
   const mapRef = useRef<MapType | null>(null);
+  useAutoResizeMap(mapRef.current);
 
   const selectedArea = areas.find((area) => area.id == selectedId);
 

--- a/src/features/canvass/components/CanvassMap.tsx
+++ b/src/features/canvass/components/CanvassMap.tsx
@@ -33,6 +33,7 @@ import useLocalStorage from 'zui/hooks/useLocalStorage';
 import useLocations from 'features/areaAssignments/hooks/useLocations';
 import { ZetkinArea } from '../../areas/types';
 import { ZetkinAreaAssignment } from 'features/areaAssignments/types';
+import { useAutoResizeMap } from 'features/map/hooks/useResizeMap';
 
 const useStyles = makeStyles(() => ({
   '@keyframes ghostMarkerBounce': {
@@ -79,6 +80,7 @@ const CanvassMap: FC<CanvassMapProps> = ({ areas, assignment }) => {
   >(`mapBounds-${assignment.id}`, null);
 
   const [map, setMap] = useState<Map | null>(null);
+  useAutoResizeMap(map);
   const [zoomed, setZoomed] = useState(false);
   const [selectedLocationId, setSelectedLocationId] = useState<string | null>(
     null
@@ -278,7 +280,7 @@ const CanvassMap: FC<CanvassMapProps> = ({ areas, assignment }) => {
         </Box>
       </Box>
       <MapContainer
-        ref={(map) => setMap(map)}
+        ref={setMap}
         attributionControl={false}
         minZoom={1}
         style={{ height: '100%', width: '100%' }}

--- a/src/features/geography/components/GeographyMap/index.tsx
+++ b/src/features/geography/components/GeographyMap/index.tsx
@@ -26,6 +26,7 @@ import AreaFilterButton from '../../../areas/components/AreaFilters/AreaFilterBu
 import MapControls from 'features/areaAssignments/components/MapControls';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
+import { useAutoResizeMap } from 'features/map/hooks/useResizeMap';
 
 interface MapProps {
   areas: ZetkinArea[];
@@ -45,7 +46,7 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
 
   const { orgId } = useNumericRouteParams();
   const createArea = useCreateArea(orgId);
-  const containerElm = useRef<HTMLElement | undefined>();
+  useAutoResizeMap(mapRef.current);
 
   useEffect(() => {
     const map = mapRef.current;
@@ -129,18 +130,6 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     }
   };
 
-  useEffect(() => {
-    if (containerElm.current !== undefined) {
-      const resizeObserver = new ResizeObserver(() => {
-        mapRef.current?.invalidateSize();
-      });
-      resizeObserver.observe(containerElm.current);
-      return () => {
-        resizeObserver.disconnect();
-      };
-    }
-  }, [containerElm]);
-
   return (
     <AreaFilterProvider>
       <Box
@@ -151,13 +140,7 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
           width: '100%',
         }}
       >
-        <Box
-          ref={(ref) => (containerElm.current = ref as HTMLElement)}
-          display="flex"
-          justifyContent="space-between"
-          px={2}
-          py={1}
-        >
+        <Box display="flex" justifyContent="space-between" px={2} py={1}>
           <Box alignItems="center" display="flex" gap={1}>
             <ButtonGroup variant="contained">
               {!drawingPoints && (

--- a/src/features/map/hooks/useResizeMap.ts
+++ b/src/features/map/hooks/useResizeMap.ts
@@ -1,0 +1,21 @@
+import { Map as MapType } from 'leaflet';
+import { useEffect } from 'react';
+
+/**
+ * Automatically resizes the map when its container is resized.
+ * For example, this can be triggered by a window resize or when the side-menu is opened/closed.
+ * @param mapRef - The map reference to resize.
+ */
+export const useAutoResizeMap = (mapRef: MapType | null) => {
+  const containerElement = mapRef?.getContainer();
+
+  useEffect(() => {
+    if (!containerElement) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => mapRef?.invalidateSize());
+    resizeObserver.observe(containerElement);
+    return () => resizeObserver.disconnect();
+  }, [containerElement]);
+};


### PR DESCRIPTION
## Description
This PR makes the map automatically fill the entire screen when the map's container is resized, which can happen when the window is resized or when the side menu is expanded/collapsed.


## Screenshots


## Changes

* Added a hook `useAutoResizeMap` which can be used where necessary. This hook is heavily based on the work in #2646 
* Add usage of said hook in the places where it seemed relevant (every place the leaflet map is used, except for in a modal)


## Notes to reviewer



## Related issues
Resolves #2665 
