### PR TITLE
fix: load avatars, while also allowing for filtering, in LocalPerson

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -57,7 +57,15 @@ export default class LocalPersonColumnType
         return makeName(v1).localeCompare(makeName(v2));
       },
       valueGetter: (params) => {
-        return params.value ? makeName(params.value) : '';
+        // we add a `toString`-method, which will be used when filtering for LocalPersons
+        return params.value
+          ? {
+              ...params.value,
+              toString() {
+                return makeName(this);
+              },
+            }
+          : undefined;
       },
     };
   }


### PR DESCRIPTION
## Description
Before these changes, avatars would not load properly in LocalPerson, because when we added the valueGetter to make filtering work, the properties that the other functions relied on disappeared. In an ideal world, this would be caught by the Typescript types, but I wasn't able to get them to work. Instead, this commit alters the valueGetter so that it keeps all existing properties, and adds a toString-method, which works with the filter functionality.


## Screenshots
Both filter and avatar works:
<img width="849" alt="image" src="https://github.com/user-attachments/assets/81a8f9b0-900c-4bd5-9f41-e2d28de6d121" />



## Changes
* Modify the `valueGetter` to add a `toString`-method rather than overwrite the entire value.


## Notes to reviewer


## Related issues
Resolves #2631
Relates to #2581 
