### PR TITLE
#2670 Tags/journeys: error assigning basic tags to a journey

### DIFF
--- a/src/features/areas/hooks/useAreaTagging.ts
+++ b/src/features/areas/hooks/useAreaTagging.ts
@@ -18,7 +18,7 @@ export default function useAreaTagging(
     assignTag: async (tagId, value) => {
       const tag = await apiClient.put<ZetkinAppliedTag>(
         `/beta/orgs/${orgId}/areas/${areaId}/tags/${tagId}`,
-        { value }
+        value ? { value } : undefined // don't send emty value
       );
       dispatch(tagAssigned([areaId, tag]));
     },

--- a/src/features/journeys/hooks/useJourneyInstanceMutations.ts
+++ b/src/features/journeys/hooks/useJourneyInstanceMutations.ts
@@ -103,7 +103,8 @@ export default function useJourneyInstanceMutations(
   async function assignTag(tag: Pick<ZetkinAppliedTag, 'id' | 'value'>) {
     await apiClient.put<ZetkinAppliedTag>(
       `/api/orgs/${orgId}/journey_instances/${instanceId}/tags/${tag.id}`,
-      { value: tag.value }
+      // dont send empty value
+      tag.value ? { value: tag.value } : undefined 
     );
     dispatch(invalidateJourneyInstance(instanceId));
   }

--- a/src/features/journeys/hooks/useJourneyInstanceMutations.ts
+++ b/src/features/journeys/hooks/useJourneyInstanceMutations.ts
@@ -103,8 +103,7 @@ export default function useJourneyInstanceMutations(
   async function assignTag(tag: Pick<ZetkinAppliedTag, 'id' | 'value'>) {
     await apiClient.put<ZetkinAppliedTag>(
       `/api/orgs/${orgId}/journey_instances/${instanceId}/tags/${tag.id}`,
-      // dont send empty value
-      tag.value ? { value: tag.value } : undefined 
+      tag.value ? { value: tag.value } : undefined
     );
     dispatch(invalidateJourneyInstance(instanceId));
   }


### PR DESCRIPTION
resolve issue #2670 
Client component now checks if a value is given along with the tag, and doesn't send a "value" with the put request if it's empty. 
