### PR TITLE
Issue 2675 / Add title to reports and instructions tab

### DIFF
--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/instructions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/instructions.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import { useContext, useState } from 'react';
 import { Box, Button, Link, Paper, Typography } from '@mui/material';
+import Head from 'next/head';
 
 import { AREAS } from 'utils/featureFlags';
 import { PageWithLayout } from 'utils/types';
@@ -11,6 +12,7 @@ import AreaAssignmentLayout from 'features/areaAssignments/layouts/AreaAssignmen
 import useAreaAssignmentInstructions from 'features/areaAssignments/hooks/useCanvassInstructions';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areaAssignments/l10n/messageIds';
+import useAreaAssignment from 'features/areaAssignments/hooks/useAreaAssignment';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -34,6 +36,7 @@ const AreaAssignmentInstructionsPage: PageWithLayout<
 > = ({ orgId, areaAssId }) => {
   const messages = useMessages(messageIds);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+  const areaAssignmentFuture = useAreaAssignment(parseInt(orgId), areaAssId);
 
   const {
     hasNewText,
@@ -48,97 +51,102 @@ const AreaAssignmentInstructionsPage: PageWithLayout<
   const [key, setKey] = useState(1);
 
   return (
-    <Box width="70%">
-      <Paper
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <Box
+    <>
+      <Head>
+        <title>{areaAssignmentFuture.data?.title}</title>
+      </Head>
+      <Box width="70%">
+        <Paper
           sx={{
             display: 'flex',
             flexDirection: 'column',
-            maxHeight: 'calc(max(35ch, 100vh - 300px))',
-            minHeight: 0,
-            padding: 2,
           }}
         >
-          <Typography variant="h4">
-            <Msg id={messageIds.instructions.title} />
-          </Typography>
-          <form
-            onSubmit={(evt) => {
-              evt.preventDefault();
-              save();
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              maxHeight: 'calc(max(35ch, 100vh - 300px))',
+              minHeight: 0,
+              padding: 2,
             }}
-            style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
           >
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                marginBottom: 2,
-                marginTop: 4,
-                minHeight: 0,
+            <Typography variant="h4">
+              <Msg id={messageIds.instructions.title} />
+            </Typography>
+            <form
+              onSubmit={(evt) => {
+                evt.preventDefault();
+                save();
               }}
+              style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
             >
-              <ZUITextEditor
-                key={key}
-                initialValue={instructions}
-                onChange={(markdown) => setInstructions(markdown)}
-                placeholder={messages.instructions.editor.editorPlaceholder()}
-              />
-            </Box>
-            <Box alignItems="center" display="flex" justifyContent="flex-end">
-              <Box marginRight={2}>
-                {isSaved && (
-                  <Typography>
-                    <Msg id={messageIds.instructions.editor.savedMessage} />
-                  </Typography>
-                )}
-                {isUnsaved && (
-                  <Typography component="span">
-                    <Msg id={messageIds.instructions.editor.unsavedMessage} />
-                    <Link
-                      color="textPrimary"
-                      component="span"
-                      onClick={() => {
-                        showConfirmDialog({
-                          onSubmit: () => {
-                            revert();
-                            //Force Slate to re-mount
-                            setKey((current) => current + 1);
-                          },
-                          warningText: messages.instructions.editor.confirm(),
-                        });
-                      }}
-                      style={{ cursor: 'pointer', fontFamily: 'inherit' }}
-                    >
-                      <Msg id={messageIds.instructions.editor.revertLink} />
-                    </Link>
-                  </Typography>
-                )}
-              </Box>
-              <Button
-                color="primary"
-                disabled={!hasNewText}
-                type="submit"
-                variant="contained"
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  marginBottom: 2,
+                  marginTop: 4,
+                  minHeight: 0,
+                }}
               >
-                <Msg
-                  id={
-                    isSaving
-                      ? messageIds.instructions.editor.savingButton
-                      : messageIds.instructions.editor.saveButton
-                  }
+                <ZUITextEditor
+                  key={key}
+                  initialValue={instructions}
+                  onChange={(markdown) => setInstructions(markdown)}
+                  placeholder={messages.instructions.editor.editorPlaceholder()}
                 />
-              </Button>
-            </Box>
-          </form>
-        </Box>
-      </Paper>
-    </Box>
+              </Box>
+              <Box alignItems="center" display="flex" justifyContent="flex-end">
+                <Box marginRight={2}>
+                  {isSaved && (
+                    <Typography>
+                      <Msg id={messageIds.instructions.editor.savedMessage} />
+                    </Typography>
+                  )}
+                  {isUnsaved && (
+                    <Typography component="span">
+                      <Msg id={messageIds.instructions.editor.unsavedMessage} />
+                      <Link
+                        color="textPrimary"
+                        component="span"
+                        onClick={() => {
+                          showConfirmDialog({
+                            onSubmit: () => {
+                              revert();
+                              //Force Slate to re-mount
+                              setKey((current) => current + 1);
+                            },
+                            warningText: messages.instructions.editor.confirm(),
+                          });
+                        }}
+                        style={{ cursor: 'pointer', fontFamily: 'inherit' }}
+                      >
+                        <Msg id={messageIds.instructions.editor.revertLink} />
+                      </Link>
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  color="primary"
+                  disabled={!hasNewText}
+                  type="submit"
+                  variant="contained"
+                >
+                  <Msg
+                    id={
+                      isSaving
+                        ? messageIds.instructions.editor.savingButton
+                        : messageIds.instructions.editor.saveButton
+                    }
+                  />
+                </Button>
+              </Box>
+            </form>
+          </Box>
+        </Paper>
+      </Box>
+    </>
   );
 };
 

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -194,7 +194,9 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                 >
                                   <Typography px={1}>
                                     <Msg
-                                      id={messagesIds.report.card.definesSuccess}
+                                      id={
+                                        messagesIds.report.card.definesSuccess
+                                      }
                                     />
                                   </Typography>
                                 </Box>
@@ -249,7 +251,9 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                                   (metric) => metric.kind === 'boolean'
                                 ).length <= 1 &&
                                 metric.kind == 'boolean' && (
-                                  <Tooltip title={messages.report.card.tooltip()}>
+                                  <Tooltip
+                                    title={messages.report.card.tooltip()}
+                                  >
                                     <Delete color="disabled" sx={{ mx: 1 }} />
                                   </Tooltip>
                                 )}
@@ -324,7 +328,12 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                   </Card>
                 )}
                 <Dialog onClose={() => setAnchorEl(null)} open={!!anchorEl}>
-                  <Box display="flex" flexDirection="column" gap={1} padding={2}>
+                  <Box
+                    display="flex"
+                    flexDirection="column"
+                    gap={1}
+                    padding={2}
+                  >
                     <Box
                       alignItems="center"
                       display="flex"
@@ -379,7 +388,8 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
                               onClick={() => {
                                 if (metricBeingDeleted?.definesDone) {
                                   const filtered = assignment.metrics.filter(
-                                    (metric) => metric.id != metricBeingDeleted.id
+                                    (metric) =>
+                                      metric.id != metricBeingDeleted.id
                                   );
                                   updateAreaAssignment({
                                     metrics: [
@@ -447,7 +457,9 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
               >
                 <Divider />
                 <FormControl fullWidth sx={{ mt: 2 }}>
-                  <InputLabel>{messages.report.card.definesSuccess()}</InputLabel>
+                  <InputLabel>
+                    {messages.report.card.definesSuccess()}
+                  </InputLabel>
                   <Select
                     disabled={
                       !isReportEditable ||

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/report.tsx
@@ -31,6 +31,7 @@ import {
   useTheme,
   Grid,
 } from '@mui/material';
+import Head from 'next/head';
 
 import { AREAS } from 'utils/featureFlags';
 import AreaAssignmentLayout from 'features/areaAssignments/layouts/AreaAssignmentLayout';
@@ -131,432 +132,437 @@ const AreaAssignmentReportPage: PageWithLayout<AreaAssignmentReportProps> = ({
   const isReportEditable = !areaAssignmentFuture.data?.start_date || unlocked;
 
   return (
-    <ZUIFuture future={areaAssignmentFuture}>
-      {(assignment: ZetkinAreaAssignment) => (
-        <Grid
-          container
-          direction={isMobile ? 'column-reverse' : 'row'}
-          spacing={2}
-        >
-          <Grid size={{ md: 8, xs: 12 }}>
-            <Box>
-              {assignment.metrics.map((metric) => (
-                <Card key={metric.id} sx={{ mb: 2 }}>
-                  <CardContent>
-                    <Box display="flex">
-                      <Box
-                        display="flex"
-                        flexDirection="column"
-                        flexGrow={1}
-                        gap={1}
-                      >
+    <>
+      <Head>
+        <title>{areaAssignmentFuture.data?.title}</title>
+      </Head>
+      <ZUIFuture future={areaAssignmentFuture}>
+        {(assignment: ZetkinAreaAssignment) => (
+          <Grid
+            container
+            direction={isMobile ? 'column-reverse' : 'row'}
+            spacing={2}
+          >
+            <Grid size={{ md: 8, xs: 12 }}>
+              <Box>
+                {assignment.metrics.map((metric) => (
+                  <Card key={metric.id} sx={{ mb: 2 }}>
+                    <CardContent>
+                      <Box display="flex">
                         <Box
-                          alignItems="flex-start"
                           display="flex"
-                          justifyContent="space-between"
+                          flexDirection="column"
+                          flexGrow={1}
+                          gap={1}
                         >
-                          <Box alignItems="center" display="flex">
-                            <Typography
-                              display="flex"
-                              gutterBottom
-                              mr={1}
-                              variant="h6"
-                            >
-                              {metric.kind == 'boolean' ? (
-                                <Typography color="secondary" mr={1}>
-                                  <SwitchLeft />
-                                </Typography>
-                              ) : (
-                                <Typography color="secondary" mr={1}>
-                                  <LinearScale />
-                                </Typography>
-                              )}
-                              {metric.question ||
-                                messages.report.card.question()}
-                            </Typography>
-                          </Box>
-                          <Box alignItems="center" display="flex">
-                            {metric.definesDone && metric.kind === 'boolean' && (
-                              <Box
-                                bgcolor={alpha(
-                                  theme.palette.success.light,
-                                  0.5
-                                )}
-                                borderRadius={2}
+                          <Box
+                            alignItems="flex-start"
+                            display="flex"
+                            justifyContent="space-between"
+                          >
+                            <Box alignItems="center" display="flex">
+                              <Typography
                                 display="flex"
+                                gutterBottom
                                 mr={1}
-                                p={0.5}
+                                variant="h6"
                               >
-                                <Typography px={1}>
-                                  <Msg
-                                    id={messagesIds.report.card.definesSuccess}
-                                  />
-                                </Typography>
-                              </Box>
-                            )}
-                            {isReportEditable && (
-                              <IconButton
-                                color="secondary"
-                                onClick={() => setMetricBeingEdited(metric)}
-                              >
-                                <Edit />
-                              </IconButton>
-                            )}
-                            {isReportEditable &&
-                              (metric.kind === 'scale5' ||
-                                (metric.kind === 'boolean' &&
-                                  assignment.metrics.filter(
-                                    (m) => m.kind === 'boolean'
-                                  ).length > 1)) && (
+                                {metric.kind == 'boolean' ? (
+                                  <Typography color="secondary" mr={1}>
+                                    <SwitchLeft />
+                                  </Typography>
+                                ) : (
+                                  <Typography color="secondary" mr={1}>
+                                    <LinearScale />
+                                  </Typography>
+                                )}
+                                {metric.question ||
+                                  messages.report.card.question()}
+                              </Typography>
+                            </Box>
+                            <Box alignItems="center" display="flex">
+                              {metric.definesDone && metric.kind === 'boolean' && (
+                                <Box
+                                  bgcolor={alpha(
+                                    theme.palette.success.light,
+                                    0.5
+                                  )}
+                                  borderRadius={2}
+                                  display="flex"
+                                  mr={1}
+                                  p={0.5}
+                                >
+                                  <Typography px={1}>
+                                    <Msg
+                                      id={messagesIds.report.card.definesSuccess}
+                                    />
+                                  </Typography>
+                                </Box>
+                              )}
+                              {isReportEditable && (
                                 <IconButton
                                   color="secondary"
-                                  onClick={(ev) => {
-                                    if (metric.definesDone) {
-                                      setMetricBeingDeleted(metric);
-                                      setAnchorEl(ev.currentTarget);
-                                    } else {
-                                      showConfirmDialog({
-                                        onCancel: () => {
-                                          setMetricBeingDeleted(null),
-                                            setAnchorEl(null);
-                                        },
-                                        onSubmit: () => {
-                                          handleDeleteMetric(metric.id);
-                                          setAnchorEl(null);
-                                          setMetricBeingDeleted(null);
-                                        },
-                                        title: `${
-                                          messages.report.card.delete() +
-                                          ' ' +
-                                          metric.question
-                                        }`,
-                                        warningText:
-                                          messages.report.delete.dialog(),
-                                      });
-                                    }
-                                  }}
+                                  onClick={() => setMetricBeingEdited(metric)}
                                 >
-                                  <Delete />
+                                  <Edit />
                                 </IconButton>
                               )}
-                            {isReportEditable &&
-                              assignment.metrics.filter(
-                                (metric) => metric.kind === 'boolean'
-                              ).length <= 1 &&
-                              metric.kind == 'boolean' && (
-                                <Tooltip title={messages.report.card.tooltip()}>
-                                  <Delete color="disabled" sx={{ mx: 1 }} />
-                                </Tooltip>
-                              )}
+                              {isReportEditable &&
+                                (metric.kind === 'scale5' ||
+                                  (metric.kind === 'boolean' &&
+                                    assignment.metrics.filter(
+                                      (m) => m.kind === 'boolean'
+                                    ).length > 1)) && (
+                                  <IconButton
+                                    color="secondary"
+                                    onClick={(ev) => {
+                                      if (metric.definesDone) {
+                                        setMetricBeingDeleted(metric);
+                                        setAnchorEl(ev.currentTarget);
+                                      } else {
+                                        showConfirmDialog({
+                                          onCancel: () => {
+                                            setMetricBeingDeleted(null),
+                                              setAnchorEl(null);
+                                          },
+                                          onSubmit: () => {
+                                            handleDeleteMetric(metric.id);
+                                            setAnchorEl(null);
+                                            setMetricBeingDeleted(null);
+                                          },
+                                          title: `${
+                                            messages.report.card.delete() +
+                                            ' ' +
+                                            metric.question
+                                          }`,
+                                          warningText:
+                                            messages.report.delete.dialog(),
+                                        });
+                                      }
+                                    }}
+                                  >
+                                    <Delete />
+                                  </IconButton>
+                                )}
+                              {isReportEditable &&
+                                assignment.metrics.filter(
+                                  (metric) => metric.kind === 'boolean'
+                                ).length <= 1 &&
+                                metric.kind == 'boolean' && (
+                                  <Tooltip title={messages.report.card.tooltip()}>
+                                    <Delete color="disabled" sx={{ mx: 1 }} />
+                                  </Tooltip>
+                                )}
+                            </Box>
                           </Box>
+                          <Typography color="secondary" ml={4}>
+                            {metric.description ||
+                              messages.report.card.description()}
+                          </Typography>
                         </Box>
-                        <Typography color="secondary" ml={4}>
-                          {metric.description ||
-                            messages.report.card.description()}
-                        </Typography>
                       </Box>
-                    </Box>
-                  </CardContent>
-                </Card>
-              ))}
-            </Box>
-            {metricBeingCreated && (
-              <Box mb={2} mt={2}>
-                <MetricCard
-                  metric={metricBeingCreated}
-                  onClose={() => setMetricBeingCreated(null)}
-                  onSave={handleSaveMetric}
-                />
+                    </CardContent>
+                  </Card>
+                ))}
               </Box>
-            )}
-            {metricBeingEdited && (
-              <Dialog
-                onClose={() => setMetricBeingEdited(null)}
-                open={metricBeingEdited ? true : false}
-                sx={{
-                  alignItems: 'center',
-                  display: 'flex',
-                  justifyContent: 'center',
-                }}
-              >
-                <MetricCard
-                  metric={metricBeingEdited}
-                  onClose={() => setMetricBeingEdited(null)}
-                  onSave={handleSaveMetric}
-                />
-              </Dialog>
-            )}
-            <Box>
-              {isReportEditable && (
-                <Card
-                  sx={{
-                    backgroundColor: theme.palette.grey[200],
-                    border: 'none',
-                    marginTop: 2,
-                    padding: 2,
-                  }}
-                >
-                  <Typography color="secondary">
-                    <Msg id={messagesIds.report.toolBar.title} />
-                  </Typography>
-                  <Box alignItems="center" display="flex" mt={2}>
-                    <Button
-                      onClick={() => handleAddNewMetric('boolean')}
-                      startIcon={<SwitchLeft />}
-                      sx={{ marginRight: 1 }}
-                      variant="outlined"
-                    >
-                      <Msg id={messagesIds.report.metricCard.choice} />
-                    </Button>
-                    <Button
-                      onClick={() => handleAddNewMetric('scale5')}
-                      startIcon={<LinearScale />}
-                      variant="outlined"
-                    >
-                      <Msg id={messagesIds.report.metricCard.scale} />
-                    </Button>
-                  </Box>
-                </Card>
-              )}
-              <Dialog onClose={() => setAnchorEl(null)} open={!!anchorEl}>
-                <Box display="flex" flexDirection="column" gap={1} padding={2}>
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    justifyContent="space-between"
-                  >
-                    <Typography variant="h6">
-                      {`${
-                        messages.report.card.delete() +
-                          ' ' +
-                          assignment.metrics.find(
-                            (metric) => metric.id === metricBeingDeleted?.id
-                          )?.question || messages.report.card.question()
-                      }`}
-                    </Typography>
-                    <IconButton
-                      onClick={() => {
-                        setMetricBeingDeleted(null);
-                        setAnchorEl(null);
-                      }}
-                    >
-                      <Close />
-                    </IconButton>
-                  </Box>
-                  <Box display="flex" flexDirection="column" gap={1}>
-                    <Typography>
-                      <Msg
-                        id={messagesIds.report.delete.deleteWarningText}
-                        values={{
-                          title:
-                            metricBeingDeleted?.question ||
-                            messages.report.card.question(),
-                        }}
-                      />
-                    </Typography>
-                    {assignment.metrics
-                      .filter(
-                        (metric) =>
-                          metric.kind == 'boolean' &&
-                          metric.id != metricBeingDeleted?.id
-                      )
-                      .map((metric) => (
-                        <Box
-                          key={metric.question}
-                          alignItems="center"
-                          display="flex"
-                          gap={1}
-                          justifyContent="space-between"
-                          width="100%"
-                        >
-                          {metric.question || messages.report.card.question()}
-                          <Button
-                            onClick={() => {
-                              if (metricBeingDeleted?.definesDone) {
-                                const filtered = assignment.metrics.filter(
-                                  (metric) => metric.id != metricBeingDeleted.id
-                                );
-                                updateAreaAssignment({
-                                  metrics: [
-                                    ...filtered.slice(
-                                      0,
-                                      filtered.indexOf(metric)
-                                    ),
-                                    {
-                                      ...metric,
-                                      definesDone: true,
-                                    },
-                                    ...filtered.slice(
-                                      filtered.indexOf(metric) + 1
-                                    ),
-                                  ],
-                                });
-                              }
-                              setAnchorEl(null);
-                              setMetricBeingDeleted(null);
-                            }}
-                            variant="outlined"
-                          >
-                            <Msg id={messagesIds.report.delete.select} />
-                          </Button>
-                        </Box>
-                      ))}
-                  </Box>
+              {metricBeingCreated && (
+                <Box mb={2} mt={2}>
+                  <MetricCard
+                    metric={metricBeingCreated}
+                    onClose={() => setMetricBeingCreated(null)}
+                    onSave={handleSaveMetric}
+                  />
                 </Box>
-              </Dialog>
-            </Box>
-          </Grid>
-          <Grid size={{ md: 4, xs: 12 }}>
-            {assignment.start_date && (
-              <ZUILockCard
-                isActive={unlocked}
-                lockedHeader={messages.report.lockCard.header()}
-                lockedSubheader={messages.report.lockCard.description()}
-                onToggle={setUnlocked}
-                tips={{
-                  safe: {
-                    bullets: [
-                      messages.report.lockCard.fix(),
-                      messages.report.lockCard.add(),
-                    ],
-                    header: messages.report.lockCard.safe(),
-                    iconType: 'check',
-                  },
-                  unsafe: {
-                    bullets: [
-                      messages.report.lockCard.rename(),
-                      messages.report.lockCard.change(),
-                    ],
-                    header: messages.report.lockCard.unsafe(),
-                    iconType: 'close',
-                  },
-                }}
-                unlockedHeader={messages.report.lockCard.headerUnlock()}
-                unlockedSubheader={messages.report.lockCard.descriptionUnlock()}
-              />
-            )}
-            <ZUICard
-              header={messages.report.successCard.header()}
-              subheader={messages.report.successCard.subheader()}
-              sx={{ mb: 2 }}
-            >
-              <Divider />
-              <FormControl fullWidth sx={{ mt: 2 }}>
-                <InputLabel>{messages.report.card.definesSuccess()}</InputLabel>
-                <Select
-                  disabled={
-                    !isReportEditable ||
-                    assignment.metrics.filter(
-                      (metric) => metric.kind === 'boolean'
-                    ).length <= 1
-                  }
-                  label={messages.report.card.definesSuccess()}
-                  onChange={(ev: SelectChangeEvent) => {
-                    const updatedMetrics =
-                      areaAssignmentFuture.data?.metrics.map(
-                        (m: ZetkinMetric) => {
-                          if (m.id === ev.target.value) {
-                            return {
-                              ...m,
-                              definesDone: true,
-                            };
-                          } else {
-                            return {
-                              ...m,
-                              definesDone: false,
-                            };
-                          }
-                        }
-                      );
-
-                    updateAreaAssignment({
-                      metrics: updatedMetrics,
-                    });
+              )}
+              {metricBeingEdited && (
+                <Dialog
+                  onClose={() => setMetricBeingEdited(null)}
+                  open={metricBeingEdited ? true : false}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'center',
                   }}
-                  value={
-                    assignment.metrics.find((metric) => metric.definesDone)
-                      ?.id || ''
-                  }
                 >
-                  {assignment.metrics.map((metric) =>
-                    metric.kind === 'boolean' ? (
-                      <MenuItem key={metric.id} value={metric.id}>
-                        {metric.question}
-                      </MenuItem>
-                    ) : null
-                  )}
-                </Select>
-              </FormControl>
-            </ZUICard>
-            <ZUICard
-              header={messages.report.dataCard.header()}
-              subheader={messages.report.dataCard.subheader()}
-              sx={{ mb: 2 }}
-            >
-              <Divider />
-              <FormControl fullWidth>
-                <RadioGroup
-                  onChange={(ev) => {
-                    const value = ev.target.value;
-                    if (value === 'household' || value === 'location') {
-                      updateAreaAssignment({
-                        reporting_level: value,
-                      });
+                  <MetricCard
+                    metric={metricBeingEdited}
+                    onClose={() => setMetricBeingEdited(null)}
+                    onSave={handleSaveMetric}
+                  />
+                </Dialog>
+              )}
+              <Box>
+                {isReportEditable && (
+                  <Card
+                    sx={{
+                      backgroundColor: theme.palette.grey[200],
+                      border: 'none',
+                      marginTop: 2,
+                      padding: 2,
+                    }}
+                  >
+                    <Typography color="secondary">
+                      <Msg id={messagesIds.report.toolBar.title} />
+                    </Typography>
+                    <Box alignItems="center" display="flex" mt={2}>
+                      <Button
+                        onClick={() => handleAddNewMetric('boolean')}
+                        startIcon={<SwitchLeft />}
+                        sx={{ marginRight: 1 }}
+                        variant="outlined"
+                      >
+                        <Msg id={messagesIds.report.metricCard.choice} />
+                      </Button>
+                      <Button
+                        onClick={() => handleAddNewMetric('scale5')}
+                        startIcon={<LinearScale />}
+                        variant="outlined"
+                      >
+                        <Msg id={messagesIds.report.metricCard.scale} />
+                      </Button>
+                    </Box>
+                  </Card>
+                )}
+                <Dialog onClose={() => setAnchorEl(null)} open={!!anchorEl}>
+                  <Box display="flex" flexDirection="column" gap={1} padding={2}>
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="space-between"
+                    >
+                      <Typography variant="h6">
+                        {`${
+                          messages.report.card.delete() +
+                            ' ' +
+                            assignment.metrics.find(
+                              (metric) => metric.id === metricBeingDeleted?.id
+                            )?.question || messages.report.card.question()
+                        }`}
+                      </Typography>
+                      <IconButton
+                        onClick={() => {
+                          setMetricBeingDeleted(null);
+                          setAnchorEl(null);
+                        }}
+                      >
+                        <Close />
+                      </IconButton>
+                    </Box>
+                    <Box display="flex" flexDirection="column" gap={1}>
+                      <Typography>
+                        <Msg
+                          id={messagesIds.report.delete.deleteWarningText}
+                          values={{
+                            title:
+                              metricBeingDeleted?.question ||
+                              messages.report.card.question(),
+                          }}
+                        />
+                      </Typography>
+                      {assignment.metrics
+                        .filter(
+                          (metric) =>
+                            metric.kind == 'boolean' &&
+                            metric.id != metricBeingDeleted?.id
+                        )
+                        .map((metric) => (
+                          <Box
+                            key={metric.question}
+                            alignItems="center"
+                            display="flex"
+                            gap={1}
+                            justifyContent="space-between"
+                            width="100%"
+                          >
+                            {metric.question || messages.report.card.question()}
+                            <Button
+                              onClick={() => {
+                                if (metricBeingDeleted?.definesDone) {
+                                  const filtered = assignment.metrics.filter(
+                                    (metric) => metric.id != metricBeingDeleted.id
+                                  );
+                                  updateAreaAssignment({
+                                    metrics: [
+                                      ...filtered.slice(
+                                        0,
+                                        filtered.indexOf(metric)
+                                      ),
+                                      {
+                                        ...metric,
+                                        definesDone: true,
+                                      },
+                                      ...filtered.slice(
+                                        filtered.indexOf(metric) + 1
+                                      ),
+                                    ],
+                                  });
+                                }
+                                setAnchorEl(null);
+                                setMetricBeingDeleted(null);
+                              }}
+                              variant="outlined"
+                            >
+                              <Msg id={messagesIds.report.delete.select} />
+                            </Button>
+                          </Box>
+                        ))}
+                    </Box>
+                  </Box>
+                </Dialog>
+              </Box>
+            </Grid>
+            <Grid size={{ md: 4, xs: 12 }}>
+              {assignment.start_date && (
+                <ZUILockCard
+                  isActive={unlocked}
+                  lockedHeader={messages.report.lockCard.header()}
+                  lockedSubheader={messages.report.lockCard.description()}
+                  onToggle={setUnlocked}
+                  tips={{
+                    safe: {
+                      bullets: [
+                        messages.report.lockCard.fix(),
+                        messages.report.lockCard.add(),
+                      ],
+                      header: messages.report.lockCard.safe(),
+                      iconType: 'check',
+                    },
+                    unsafe: {
+                      bullets: [
+                        messages.report.lockCard.rename(),
+                        messages.report.lockCard.change(),
+                      ],
+                      header: messages.report.lockCard.unsafe(),
+                      iconType: 'close',
+                    },
+                  }}
+                  unlockedHeader={messages.report.lockCard.headerUnlock()}
+                  unlockedSubheader={messages.report.lockCard.descriptionUnlock()}
+                />
+              )}
+              <ZUICard
+                header={messages.report.successCard.header()}
+                subheader={messages.report.successCard.subheader()}
+                sx={{ mb: 2 }}
+              >
+                <Divider />
+                <FormControl fullWidth sx={{ mt: 2 }}>
+                  <InputLabel>{messages.report.card.definesSuccess()}</InputLabel>
+                  <Select
+                    disabled={
+                      !isReportEditable ||
+                      assignment.metrics.filter(
+                        (metric) => metric.kind === 'boolean'
+                      ).length <= 1
                     }
-                  }}
-                  sx={{ mr: 2 }}
-                  value={assignment.reporting_level}
-                >
-                  <Typography mt={1}>
-                    <Msg id={messagesIds.report.dataCard.info} />
-                  </Typography>
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    justifyContent="space-between"
+                    label={messages.report.card.definesSuccess()}
+                    onChange={(ev: SelectChangeEvent) => {
+                      const updatedMetrics =
+                        areaAssignmentFuture.data?.metrics.map(
+                          (m: ZetkinMetric) => {
+                            if (m.id === ev.target.value) {
+                              return {
+                                ...m,
+                                definesDone: true,
+                              };
+                            } else {
+                              return {
+                                ...m,
+                                definesDone: false,
+                              };
+                            }
+                          }
+                        );
+
+                      updateAreaAssignment({
+                        metrics: updatedMetrics,
+                      });
+                    }}
+                    value={
+                      assignment.metrics.find((metric) => metric.definesDone)
+                        ?.id || ''
+                    }
                   >
-                    <FormControlLabel
-                      control={<Radio disabled={!isReportEditable} />}
-                      label={messages.report.dataCard.household()}
-                      sx={{ ml: 1 }}
-                      value="household"
-                    />
-                    {unlocked && (
-                      <Badge
-                        badgeContent={
-                          areaAssignmentStats?.num_visited_households
-                        }
-                        color="secondary"
-                      />
+                    {assignment.metrics.map((metric) =>
+                      metric.kind === 'boolean' ? (
+                        <MenuItem key={metric.id} value={metric.id}>
+                          {metric.question}
+                        </MenuItem>
+                      ) : null
                     )}
-                  </Box>
-                  <Box
-                    alignItems="center"
-                    display="flex"
-                    justifyContent="space-between"
+                  </Select>
+                </FormControl>
+              </ZUICard>
+              <ZUICard
+                header={messages.report.dataCard.header()}
+                subheader={messages.report.dataCard.subheader()}
+                sx={{ mb: 2 }}
+              >
+                <Divider />
+                <FormControl fullWidth>
+                  <RadioGroup
+                    onChange={(ev) => {
+                      const value = ev.target.value;
+                      if (value === 'household' || value === 'location') {
+                        updateAreaAssignment({
+                          reporting_level: value,
+                        });
+                      }
+                    }}
+                    sx={{ mr: 2 }}
+                    value={assignment.reporting_level}
                   >
-                    <FormControlLabel
-                      control={<Radio disabled={!isReportEditable} />}
-                      label={messages.report.dataCard.location()}
-                      sx={{ ml: 1 }}
-                      value="location"
-                    />
-                    {unlocked && (
-                      <Badge
-                        badgeContent={
-                          areaAssignmentStats?.num_visited_locations
-                        }
-                        color="secondary"
+                    <Typography mt={1}>
+                      <Msg id={messagesIds.report.dataCard.info} />
+                    </Typography>
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="space-between"
+                    >
+                      <FormControlLabel
+                        control={<Radio disabled={!isReportEditable} />}
+                        label={messages.report.dataCard.household()}
+                        sx={{ ml: 1 }}
+                        value="household"
                       />
-                    )}
-                  </Box>
-                </RadioGroup>
-              </FormControl>
-            </ZUICard>
+                      {unlocked && (
+                        <Badge
+                          badgeContent={
+                            areaAssignmentStats?.num_visited_households
+                          }
+                          color="secondary"
+                        />
+                      )}
+                    </Box>
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      justifyContent="space-between"
+                    >
+                      <FormControlLabel
+                        control={<Radio disabled={!isReportEditable} />}
+                        label={messages.report.dataCard.location()}
+                        sx={{ ml: 1 }}
+                        value="location"
+                      />
+                      {unlocked && (
+                        <Badge
+                          badgeContent={
+                            areaAssignmentStats?.num_visited_locations
+                          }
+                          color="secondary"
+                        />
+                      )}
+                    </Box>
+                  </RadioGroup>
+                </FormControl>
+              </ZUICard>
+            </Grid>
           </Grid>
-        </Grid>
-      )}
-    </ZUIFuture>
+        )}
+      </ZUIFuture>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
This PR adds the correct title in the tab sectoin to the "report" and "instructions" tab of area assigments and closes https://github.com/zetkin/app.zetkin.org/issues/2675 by that.

## Screenshots
![image](https://github.com/user-attachments/assets/7e7fbe32-8447-41b4-9cc1-e52e83e55654)

## Notes to reviewer
This is my first pull request, so please write, if I missed any step as this process is new to me :)
A lot of displayed changes is due to the formatting with the tabulator, with hiding the whitespaces, only the relevant ones are shown.
