### PR TITLE
invert activiy sorting order

### DIFF
--- a/src/features/campaigns/hooks/useClusteredActivities.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.ts
@@ -157,12 +157,12 @@ export default function useClusteredActivities(
     if (!aStart && !bStart) {
       return 0;
     } else if (!aStart) {
-      return -1;
-    } else if (!bStart) {
       return 1;
+    } else if (!bStart) {
+      return -1;
     }
 
-    return aStart.getTime() - bStart.getTime();
+    return bStart.getTime() - aStart.getTime();
   });
 }
 


### PR DESCRIPTION
fixes https://github.com/zetkin/app.zetkin.org/issues/2679

## Description
This PR inverts the current sorting order of activities in the `useClusteredActivities` hook. This solves the issue https://github.com/zetkin/app.zetkin.org/issues/2679 where the activities tab of the projects view.

The issue mentioned considering different dates. Since the current implementation already handles different dates, I didn't touch this.

I am a new contributor and since this is my first PR in this project, someone with more experience in this project should review this. From what I can see, `useClusteredActivities` is used in different places. I checked out all of the places I think would be hit and they all looked normal.


## Screenshots

![image](https://github.com/user-attachments/assets/bbbe230f-8536-4093-836c-8b943f06b438)


## Changes

* Invert the sorting order of `useClusteredActivities`

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2679
