### PR TITLE
Canvasser : Ensure selected location stays on top of the others

### DIFF
--- a/src/features/canvass/components/CanvassMap.tsx
+++ b/src/features/canvass/components/CanvassMap.tsx
@@ -334,7 +334,8 @@ const CanvassMap: FC<CanvassMapProps> = ({ areas, assignment }) => {
             const percentage = getVisitPercentage(
               assignment.id,
               location.households,
-              assignment.metrics.find((metric) => metric.definesDone)?.id || null
+              assignment.metrics.find((metric) => metric.definesDone)?.id ||
+                null
             );
             return (
               <DivIconMarker

--- a/src/features/canvass/components/CanvassMap.tsx
+++ b/src/features/canvass/components/CanvassMap.tsx
@@ -317,36 +317,47 @@ const CanvassMap: FC<CanvassMapProps> = ({ areas, assignment }) => {
             />
           ))}
         </FeatureGroup>
-        {locations.map((location) => {
-          const selected = location.id == selectedLocationId;
-          const key = `marker-${location.id}-${selected.toString()}`;
-          const percentage = getVisitPercentage(
-            assignment.id,
-            location.households,
-            assignment.metrics.find((metric) => metric.definesDone)?.id || null
-          );
-          return (
-            <DivIconMarker
-              key={key}
-              eventHandlers={{
-                click: (evt) => {
-                  panTo(evt.latlng);
-                },
-              }}
-              iconAnchor={[11, 33]}
-              position={{
-                lat: location.position.lat,
-                lng: location.position.lng,
-              }}
-            >
-              <MarkerIcon
-                percentage={percentage}
-                selected={selected}
-                uniqueKey={key}
-              />
-            </DivIconMarker>
-          );
-        })}
+        {locations
+          // sort the selectedLocation on top of the others
+          .sort((a0, a1) => {
+            if (a0.id == selectedLocationId) {
+              return 1;
+            }
+            if (a1.id == selectedLocationId) {
+              return -1;
+            }
+            return 0;
+          })
+          .map((location) => {
+            const selected = location.id == selectedLocationId;
+            const key = `marker-${location.id}-${selected.toString()}`;
+            const percentage = getVisitPercentage(
+              assignment.id,
+              location.households,
+              assignment.metrics.find((metric) => metric.definesDone)?.id || null
+            );
+            return (
+              <DivIconMarker
+                key={key}
+                eventHandlers={{
+                  click: (evt) => {
+                    panTo(evt.latlng);
+                  },
+                }}
+                iconAnchor={[11, 33]}
+                position={{
+                  lat: location.position.lat,
+                  lng: location.position.lng,
+                }}
+              >
+                <MarkerIcon
+                  percentage={percentage}
+                  selected={selected}
+                  uniqueKey={key}
+                />
+              </DivIconMarker>
+            );
+          })}
       </MapContainer>
       <CanvassMapOverlays
         assignment={assignment}


### PR DESCRIPTION
## Description
This PR fixes issue https://github.com/zetkin/app.zetkin.org/issues/2687 where selected location was sometimes rendered behind other close locations preventing from seeing the progress indicator for the location.

## Screenshots
![image](https://github.com/user-attachments/assets/ef4cee47-a4d8-478f-b982-f049b198ab7d)


## Changes
I used the sort function to render the location which has the same id as the selected location id above the others.


## Related issues
Resolves #2687 
