### PR TITLE
fix curPath calculation

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -51,6 +51,7 @@ const breadcrumbs = async (
         elements.forEach((elem) => breadcrumbs.push(elem));
         curPath.push(fieldValue);
       } else {
+        curPath.push(field);
         if (
           field == 'callassignments' ||
           field == 'folders' ||
@@ -62,7 +63,6 @@ const breadcrumbs = async (
           // and shouldn't link to anything.
           continue;
         }
-        curPath.push(field);
         breadcrumbs.push({
           href: '/' + curPath.join('/'),
           labelMsg: field,


### PR DESCRIPTION
fix https://github.com/zetkin/app.zetkin.org/issues/2694

## Description
This PR fixes some breadcrumb links resolving to 404. It was a miscalculation in the api. Since the previous code continues for call assignments, folders, lists and surveys, the path element gets omitted and consecutive paths resolve to invalid urls.

## Changes

* Moved the line `curPath.push(field);` above the if clause so it will get append to the path for surveys & co as well.


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2694
