### PR TITLE
Update lint script to handle shell interpretation of wildcard characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",
     "lint:translations": "ts-node src/tools/lint-translations",
-    "lint": "run-p lint:*",
+    "lint": "run-p 'lint:*'",
     "check-types": "tsc --noEmit",
     "test": "jest",
     "suite:0-checks": "run-p lint:* check-types",


### PR DESCRIPTION

## Description
This PR updates the lint script to handle shell interpretation of wildcard characters.

The yarn lint command was failing with the error `No matches found: "lint:*"`. This issue occurred because the shell (e.g., `zsh`) was interpreting the * wildcard instead of passing it as-is to the run-p command. The fix involved wrapping the `lint:*` pattern in single quotes to ensure it is correctly passed to run-p.
