### PR TITLE
Issue 2673: Add resizable textarea to data table in read-only mode

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -23,9 +23,21 @@ export default class LocalTextColumnType implements IColumnType {
     accessLevel: ZetkinObjectAccess['level'] | null
   ): Omit<GridColDef, 'field'> {
     return {
-      editable: accessLevel != 'readonly',
+      /* 
+        Important trade-off:
+        Our goal is to show a resizable textarea even in read-only mode.
+
+        We are going against MUI's semantics here, setting `editable` to `true`, 
+        because we want to leverage MUI's built-in user interaction handlers (and styles).
+
+        We guarantee that the accessLevel is respected, 
+        by overwriting the `isEditable` prop of the Textarea component directly.
+      */
+      editable: true,
       renderCell: (params) => <Cell cell={params.value} />,
-      renderEditCell: (params) => <EditTextarea {...params} />,
+      renderEditCell: (params) => (
+        <Textarea {...params} isEditable={accessLevel != 'readonly'} />
+      ),
       width: 250,
     };
   }
@@ -73,7 +85,7 @@ const Cell: FC<{ cell: LocalTextViewCell | undefined }> = ({ cell }) => {
   );
 };
 
-const EditTextarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
+const Textarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
   const { id, field, value, colDef } = props;
   const [valueState, setValueState] = useState(value);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
@@ -95,6 +107,9 @@ const EditTextarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
 
   const handleChange = useCallback<NonNullable<InputBaseProps['onChange']>>(
     (event) => {
+      if (!props.isEditable) {
+        return;
+      }
       const newValue = event.target.value;
       setValueState(newValue);
       apiRef.current.setEditCellValue(
@@ -141,6 +156,7 @@ const EditTextarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
               multiline
               onChange={handleChange}
               onKeyDown={handleKeyDown}
+              readOnly={!props.isEditable}
               rows={4}
               sx={{ textarea: { resize: 'both' }, width: '100%' }}
               value={valueState}


### PR DESCRIPTION
## Description
This PR ensures the data tables renders a resizable textarea when clicking on a cell also in read-only mode. 

### Context
Looking at the issue I saw two main paths of resolving the issue: 
1. First, the component assigned to `renderCell` can be extended so it behaves the same way the combination of the current `renderCell` and `renderEditCell` behaves.
    - The main benefit is that it respects the semantics of MUI.
    - The drawback is that the new component needs to implement all click and keyboard event handling and that MUI applies different styles (padding) to the parents of the `renderCell` and the `renderEditCell` that need to be overridden. Of course this is possible but will introduce potential drift from the framework. 
    - I got to an OK point with this approach, but would still need to figure out some edge cases on the user events and overriding the cell padding coming from MUI.
2. Going against  the semantics of MUI and setting the `editable` prop to always `true` to leverage the MUI's functionality. Here we need to override the `isEditable` prop in the `renderEditCell` component to enforce the correct access. The pros and cons are basically inverse of the first approach.
    - The semantics are wrong from the framework perspective. It needs a comment explaining the trade-off.
    - It's easier to maintain since we are not introducing any custom behavior or style overrides.

### Suggestion
I would propose to go for the 2. approach. When I compare both approaches side-by-side, this one reads easier and seems faster for someone else to understand even if it is semantically against the grain of the framework. Let me know if I should open a draft PR with the other changes, so you can also compare. 

## Screenshots
I was not sure how to capture this in a screenshot, since the shared view does not indicate the currently logged in user. Here's one anyway to illustrate:

<img width="1205" alt="screen 2025-05-04 at 13 35 37" src="https://github.com/user-attachments/assets/b43817c4-2ae6-4064-94d3-9059d00c973d" />


## Notes to reviewer
Writing this before the CI has run: I haven't found tests that would be affected by this change. I would be curious to write one if it is helpful enough so that it warrants someone spending some time giving me a quick intro to the test setup with playwright.


## Related issues
Resolves #2673 