### PR TITLE
Add sortComparator to all three types of survey columns.

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionColumnType.tsx
@@ -36,6 +36,35 @@ export default class SurveyOptionColumnType
       renderCell: (params) => {
         return <Cell cell={params.value} />;
       },
+      sortComparator: (v1: SurveyOptionViewCell, v2: SurveyOptionViewCell) => {
+        const getPriority = (cell: SurveyOptionViewCell) => {
+          if (!cell || cell.length == 0) {
+            return 1;
+          }
+
+          const hasPickedThisOption = !!cell.filter(
+            (submission) => submission.selected
+          ).length;
+
+          if (!hasPickedThisOption) {
+            return 1;
+          }
+
+          const sorted = cell.concat().sort((sub0, sub1) => {
+            const d0 = new Date(sub0.submitted);
+            const d1 = new Date(sub1.submitted);
+            return d1.getTime() - d0.getTime();
+          });
+
+          const mostRecent = sorted[0];
+
+          return mostRecent.selected ? -1 : 0;
+        };
+
+        const result = getPriority(v1) - getPriority(v2);
+
+        return result;
+      },
       type: 'boolean',
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -38,6 +38,17 @@ export default class SurveyOptionsColumnType
       renderCell: (params: GridRenderCellParams) => {
         return <Cell cell={params.row[params.field]} />;
       },
+      sortComparator: (v1: string[][], v2: string[][]) => {
+        const getPriority = (cell: string[][]) => {
+          if (cell == null || cell.length == 0) {
+            return 0;
+          } else {
+            return -cell[cell.length - 1].length;
+          }
+        };
+
+        return getPriority(v1) - getPriority(v2);
+      },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyOptionsViewCell = params.row[params.field];
         return cell?.map((response) =>

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -36,6 +36,18 @@ export default class SurveyResponseColumnType
       renderCell: (params: GridRenderCellParams) => {
         return <Cell cell={params.row[params.field]} />;
       },
+      sortComparator: (v1: string[], v2: string[]) => {
+        const lastInV1 = v1[v1.length - 1];
+        const lastInV2 = v2[v2.length - 1];
+
+        if (v1.length == 0 || lastInV1 == '') {
+          return 1;
+        } else if (v2.length == 0 || lastInV2 == '') {
+          return -1;
+        } else {
+          return lastInV1.localeCompare(lastInV2);
+        }
+      },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
         return cell.map((response) => response.text);


### PR DESCRIPTION
## Description
This PR wraps up the work started by @Herover in #2517 


## Screenshots
![bild](https://github.com/user-attachments/assets/cd81ff5c-05af-4c52-a799-153e69524232)


## Changes
* Adds `sortComparator` functions to the three types of survey column


## Notes to reviewer
Make a list with all three kinds of columns and see that it works to sort by them.


## Related issues
Resolves #2508 
