### PR TITLE
fix described bug

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -38,7 +38,7 @@ export default class SurveyResponseColumnType
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
-        return cell.map((response) => response.text);
+        return cell?.map((response) => response.text) || [];
       },
       width: 250,
     };


### PR DESCRIPTION
Fix issue #2713

`cell` in  `valueGetter` of `SurveyResponseColumnType.tsx` is undefined when adding multiple survey columns. This results in a runtime exception when map is called on `undefined`.

## Changes
* in the corresponding valueGetter function handled the case that cell is undefined, by returning an empty array instead of running map
