### PR TITLE
Issue 2728/display added to sub org

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
@@ -7,7 +7,10 @@ import { ZetkinOrganization } from 'utils/types/zetkin';
 
 interface AddedOrgsProps {
   numPeopleWithOrgsAdded: number;
-  orgsWithNewPeople: Pick<ZetkinOrganization, 'title' | 'id'>[];
+  orgsWithNewPeople: {
+    adding: number;
+    org: Pick<ZetkinOrganization, 'title' | 'id'>;
+  }[];
   tense: 'past' | 'future';
 }
 
@@ -64,8 +67,8 @@ const AddedOrgs: FC<AddedOrgsProps> = ({
       </Typography>
       <Box display="flex" flexWrap="wrap" gap={0.5}>
         {orgsWithNewPeople.map((org, index) => (
-          <Typography key={org.id} color="secondary">
-            {org.title}
+          <Typography key={org.org.id} color="secondary">
+            {org.org.title} ({org.adding})
             {orgsWithNewPeople.length === 1 ||
             orgsWithNewPeople.length - 1 === index
               ? ''

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
@@ -68,10 +68,13 @@ const AddedOrgs: FC<AddedOrgsProps> = ({
       <Box display="flex" flexWrap="wrap" gap={0.5}>
         {orgsWithNewPeople.map((org, index) => (
           <Typography key={org.org.id} color="secondary">
-            <Msg id={messageIds.impactSummary.peopleToSubOrg} values={{
-              num: org.adding,
-              orgName: org.org.title,
-            }} />
+            <Msg
+              id={messageIds.impactSummary.peopleToSubOrg}
+              values={{
+                num: org.adding,
+                orgName: org.org.title,
+              }}
+            />
             {orgsWithNewPeople.length === 1 ||
             orgsWithNewPeople.length - 1 === index
               ? ''

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/AddedOrgs.tsx
@@ -68,7 +68,10 @@ const AddedOrgs: FC<AddedOrgsProps> = ({
       <Box display="flex" flexWrap="wrap" gap={0.5}>
         {orgsWithNewPeople.map((org, index) => (
           <Typography key={org.org.id} color="secondary">
-            {org.org.title} ({org.adding})
+            <Msg id={messageIds.impactSummary.peopleToSubOrg} values={{
+              num: org.adding,
+              orgName: org.org.title,
+            }} />
             {orgsWithNewPeople.length === 1 ||
             orgsWithNewPeople.length - 1 === index
               ? ''

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
@@ -25,10 +25,16 @@ const ImpactSummary: FC<Props> = ({ orgId, summary, tense }) => {
     Object.keys(tagged.byTag).includes(tag.id.toString())
   );
 
-  const orgsWithNewPeople = subOrgs.filter(
-    (org) =>
-      Object.keys(addedToOrg.byOrg).includes(org.id.toString()) && org.is_active
-  );
+  const orgsWithNewPeople = subOrgs
+    .filter(
+      (org) =>
+        Object.keys(addedToOrg.byOrg).includes(org.id.toString()) &&
+        org.is_active
+    )
+    .map((org) => ({
+      org,
+      adding: summary.addedToOrg.byOrg[org.id],
+    }));
 
   return (
     <>

--- a/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImpactSummary/index.tsx
@@ -32,8 +32,8 @@ const ImpactSummary: FC<Props> = ({ orgId, summary, tense }) => {
         org.is_active
     )
     .map((org) => ({
-      org,
       adding: summary.addedToOrg.byOrg[org.id],
+      org,
     }));
 
   return (

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -284,9 +284,7 @@ export default makeMessages('feat.import', {
     people: m<{ numPeople: number; number: ReactElement }>(
       '{number} {numPeople, plural, =1 {person} other {people}}'
     ),
-    peopleToSubOrg: m<{ num: number, orgName: string }>(
-      '{orgName} ({num})'
-    ),
+    peopleToSubOrg: m<{ num: number; orgName: string }>('{orgName} ({num})'),
   },
   importStatus: {
     completed: {

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -284,6 +284,9 @@ export default makeMessages('feat.import', {
     people: m<{ numPeople: number; number: ReactElement }>(
       '{number} {numPeople, plural, =1 {person} other {people}}'
     ),
+    peopleToSubOrg: m<{ num: number, orgName: string }>(
+      '{orgName} ({num})'
+    ),
   },
   importStatus: {
     completed: {


### PR DESCRIPTION
## Description
This PR makes it visible which sub organizations imported people are added to.


## Screenshots

![image](https://github.com/user-attachments/assets/4898d14d-4768-4396-a128-f4fba9ca095b)


## Changes

* Adds a number next to the organization people are added to.


## Notes to reviewer

Follow the instructions on the issue for when testing.

## Related issues
Resolves #2728 
