### PR TITLE
Disabled submit button when no value has been added to tag

### DIFF
--- a/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -46,7 +46,14 @@ const ValueTagForm: React.FC<{
           <TagChip tag={{ ...tag, value: inputValue }} />
         </Box>
       </Box>
-      <ZUISubmitCancelButtons onCancel={onCancel} />
+      <ZUISubmitCancelButtons 
+      onCancel={onCancel} 
+      submitDisabled={
+        inputValue === ''
+        ? true
+        : false
+      }
+        />
     </form>
   );
 };


### PR DESCRIPTION
## Description
This PR sets submit button as disabled while no value is added for chosen tag.


## Screenshots
<img width="202" alt="Screenshot 2025-05-10 at 14 41 01" src="https://github.com/user-attachments/assets/d47e6bbb-ac6d-4806-9b9c-41b281bdd9be" />



## Changes
Added logic that that sets submit button to disabled when no input value is present.


## Notes to reviewer
Go to https://app.dev.zetkin.org/organize/1/journeys/1/2
Click on "Add tag" down to the right
In the menu that opens, select a value tag
In the little dialog to input a value to the value tag - see if 
submit button is disabled when value is empty, and enabled when value is present.

## Related issues
Resolves #[[2720](https://github.com/zetkin/app.zetkin.org/issues/2720)]
