### PR TITLE
Add UI for deleteing survey submissions

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -54,8 +54,11 @@ const SurveySubmissionsList = ({
     return sorted;
   }, [submissions]);
 
-  async function handleDeleteJoinForm(submissionId: number) {
-    await deleteSurveySubmission(submissionId);
+  async function handleDeleteSurveySubmission(
+    submissionId: number,
+    surveyId: number
+  ) {
+    await deleteSurveySubmission(submissionId, surveyId);
     showSnackbar('success', <Msg id={messageIds.submissions.deleteSuccess} />);
   }
 
@@ -144,8 +147,7 @@ const SurveySubmissionsList = ({
       align: 'right',
       editable: false,
       field: 'menu',
-      flex: 1,
-      headerName: 'hej',
+      headerName: '',
       renderCell: (
         params: GridRenderCellParams<
           ZetkinSurveySubmission,
@@ -160,7 +162,11 @@ const SurveySubmissionsList = ({
                 onSelect: async (ev) => {
                   ev.stopPropagation();
                   showConfirmDialog({
-                    onSubmit: () => handleDeleteJoinForm(params.row.id),
+                    onSubmit: () =>
+                      handleDeleteSurveySubmission(
+                        params.row.id,
+                        params.row.survey.id
+                      ),
                     title: messages.submissions.deleteTitle(),
                     warningText: messages.submissions.deleteWarningText(),
                   });

--- a/src/features/surveys/hooks/useSurveySubmissionMutations.ts
+++ b/src/features/surveys/hooks/useSurveySubmissionMutations.ts
@@ -1,0 +1,18 @@
+import { surveySubmissionDeleted } from '../store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+
+export default function useSurveySubmissionMutations(orgId: number) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  async function deleteSurveySubmission(submissionId: number) {
+    await apiClient.delete(
+      `/api/orgs/${orgId}/survey_submissions/${submissionId}`
+    );
+    dispatch(surveySubmissionDeleted(submissionId));
+  }
+
+  return {
+    deleteSurveySubmission,
+  };
+}

--- a/src/features/surveys/hooks/useSurveySubmissionMutations.ts
+++ b/src/features/surveys/hooks/useSurveySubmissionMutations.ts
@@ -5,11 +5,14 @@ export default function useSurveySubmissionMutations(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
 
-  async function deleteSurveySubmission(submissionId: number) {
+  async function deleteSurveySubmission(
+    submissionId: number,
+    surveyId: number
+  ) {
     await apiClient.delete(
       `/api/orgs/${orgId}/survey_submissions/${submissionId}`
     );
-    dispatch(surveySubmissionDeleted(submissionId));
+    dispatch(surveySubmissionDeleted({ submissionId, surveyId }));
   }
 
   return {

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -161,6 +161,12 @@ export default makeMessages('feat.surveys', {
   submissions: {
     anonymous: m('Anonymous'),
     dateColumn: m('Date'),
+    delete: m('Delete'),
+    deleteSuccess: m('Successfully deleted'),
+    deleteTitle: m('Delete submission'),
+    deleteWarningText: m(
+      'Are you sure you want to delete this survey submission?'
+    ),
     emailColumn: m('Email'),
     firstNameColumn: m('First name'),
     lastNameColumn: m('Last name'),

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -313,11 +313,19 @@ const surveysSlice = createSlice({
       action: PayloadAction<{ submissionId: number; surveyId: number }>
     ) => {
       const { submissionId, surveyId } = action.payload;
-      const item = state.submissionsBySurveyId[surveyId].items.find(
+
+      const itemInList = state.submissionList.items.find(
         (item) => item.id === submissionId
       );
-      if (item) {
-        item.deleted = true;
+      if (itemInList) {
+        itemInList.deleted = true;
+      }
+
+      const itemInMap = state.submissionsBySurveyId[surveyId].items.find(
+        (item) => item.id === submissionId
+      );
+      if (itemInMap) {
+        itemInMap.deleted = true;
       }
     },
     surveySubmissionUpdate: (

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -308,6 +308,15 @@ const surveysSlice = createSlice({
 
       state.elementsBySurveyId[survey.id] = remoteList(survey.elements);
     },
+    surveySubmissionDeleted: (state, action: PayloadAction<number>) => {
+      const submissionId = action.payload;
+      const item = state.submissionList.items.find(
+        (item) => item.id === submissionId
+      );
+      if (item) {
+        item.deleted = true;
+      }
+    },
     surveySubmissionUpdate: (
       state,
       action: PayloadAction<[number, string[]]>
@@ -457,6 +466,7 @@ export const {
   surveyDeleted,
   surveyLoad,
   surveyLoaded,
+  surveySubmissionDeleted,
   surveySubmissionUpdate,
   surveySubmissionUpdated,
   surveySubmissionsLoad,

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -308,9 +308,12 @@ const surveysSlice = createSlice({
 
       state.elementsBySurveyId[survey.id] = remoteList(survey.elements);
     },
-    surveySubmissionDeleted: (state, action: PayloadAction<number>) => {
-      const submissionId = action.payload;
-      const item = state.submissionList.items.find(
+    surveySubmissionDeleted: (
+      state,
+      action: PayloadAction<{ submissionId: number; surveyId: number }>
+    ) => {
+      const { submissionId, surveyId } = action.payload;
+      const item = state.submissionsBySurveyId[surveyId].items.find(
         (item) => item.id === submissionId
       );
       if (item) {


### PR DESCRIPTION
## Description
This PR adds a user interface for deleting survey submissions.



## Screenshots
![Screen Shot 2025-05-10 at 15 27 27](https://github.com/user-attachments/assets/c73ec7b4-b9f9-4cad-9bfe-e7581c562494)


## Changes

* Adds a ellipsis menu to survey submission list, where you can choose to delete a submission.


## Notes to reviewer
Known bug: Deleting a submission will not remove it from the list until refresh. I tried to fix it by setting ```state.submissionList.items``` to a list without the deleted submission, but it didn't fix it.


## Related issues
Resolves #2712 
