### PR TITLE
Issue 2706: Added routing to lists view when creating a new folder on join forms tab

### DIFF
--- a/src/features/views/components/PeopleActionButton.tsx
+++ b/src/features/views/components/PeopleActionButton.tsx
@@ -56,6 +56,7 @@ const PeopleActionButton: FC<PeopleActionButtonProps> = ({
             label: messages.actions.createFolder(),
             onClick: () => {
               createFolder(messages.newFolderTitle(), folderId || undefined);
+              router.push(`/organize/${orgId}/people`);
             },
           },
           {


### PR DESCRIPTION
## Description
This PR adds routing to the Create Forms button that takes the user to the "lists view" when creating a folder while on the "Join Forms" tab.


## Screenshots
https://github.com/user-attachments/assets/10863291-15ca-448e-8fb0-06f0dcf586c5


## Changes
Added a routing to the the default list view to the Create Folder button.


## Notes to reviewer
Go to https://app.dev.zetkin.org/organize/2/people/joinforms
Click on Create
Click on Create Folder
See that view changes to lists view.


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2706
