### PR TITLE
Fix the ZUIOrgLogoAvatar to load properly within surveys

### DIFF
--- a/src/zui/components/ZUIOrgLogoAvatar/index.tsx
+++ b/src/zui/components/ZUIOrgLogoAvatar/index.tsx
@@ -1,19 +1,12 @@
 import { FC } from 'react';
-import Image from 'next/image';
 
-import { avatarSizes } from '../ZUIPersonAvatar';
-import { ZUISize } from '../types';
+import ZUIAvatar from 'zui/ZUIAvatar';
 
 type ZUIOrgLogoAvatarProps = {
   /**
    * The id of the organization
    */
-  orgId: number;
-
-  /**
-   * The size of the avatar
-   */
-  size?: ZUISize;
+  orgId?: number;
 
   /**
    * If there is need to send in a custom url base to fetch the avatar,
@@ -26,17 +19,9 @@ type ZUIOrgLogoAvatarProps = {
 
 const ZUIOrgLogoAvatar: FC<ZUIOrgLogoAvatarProps> = ({
   orgId,
-  size = 'medium',
   urlBase = '/api',
 }) => {
-  return (
-    <Image
-      alt="icon"
-      height={avatarSizes[size]}
-      src={`${urlBase}/orgs/${orgId}/avatar`}
-      width={avatarSizes[size]}
-    />
-  );
+  return <ZUIAvatar size="md" url={`${urlBase}/orgs/${orgId}/avatar`} />;
 };
 
 export default ZUIOrgLogoAvatar;


### PR DESCRIPTION
## Description
This PR fixes #2739, loading the org logo image correctly when a survey is opened. 

## Screenshots
![CleanShot 2025-05-13 at 17 14 51@2x](https://github.com/user-attachments/assets/f5d7d41f-10ff-451b-92ac-129e5bdd7a1c)

## Changes
- Removes Next Image (there were some optimisation issues) as the base for the component.
- Uses the ZUIAvatar component as a base instead, much as in the ZUIPersonAvatar component. 

## Related issues
Resolves #2739 
