### PR TITLE
Add notification regarding invalid organization country code on import

### DIFF
--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/ImportMessageItem.tsx
@@ -114,6 +114,18 @@ const ImportMessageItem: FC<Props> = ({ onCheck, onClickBack, problem }) => {
         title={messages.preflight.messages.unknownPerson.title()}
       />
     );
+  } else if (problem.kind == ImportProblemKind.INVALID_ORG_COUNTRY) {
+    return (
+      <ImportMessage
+        description={messages.preflight.messages.invalidOrgCountry.description()}
+        onCheck={onCheck}
+        onClickBack={onClickBack}
+        status="info"
+        title={messages.preflight.messages.invalidOrgCountry.title({
+          code: problem.code,
+        })}
+      />
+    );
   } else if (problem.kind == ImportProblemKind.UNKNOWN_ERROR) {
     return (
       <ImportMessage

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
@@ -1,16 +1,10 @@
 import { Stack } from '@mui/material';
-import { getCountries } from 'libphonenumber-js';
 import { FC, useEffect, useState } from 'react';
 
 import ImportMessage from './ImportMessage';
 import ImportMessageItem from './ImportMessageItem';
-import {
-  ImportFieldProblem,
-  ImportProblem,
-  ImportProblemKind,
-} from 'features/import/utils/problems/types';
+import { ImportProblem } from 'features/import/utils/problems/types';
 import { levelForProblem } from 'features/import/utils/problems';
-import { store } from 'core/store';
 
 type Props = {
   defaultDescription?: string;
@@ -36,24 +30,6 @@ const ImportMessageList: FC<Props> = ({
 
     onAllChecked(numChecked == warningCount);
   }, [numChecked]);
-
-  const formatProblemIndex = problems.findIndex(
-    (problem) => problem.kind == ImportProblemKind.INVALID_FORMAT
-  );
-  if (formatProblemIndex != -1) {
-    const problem = problems[formatProblemIndex] as ImportFieldProblem;
-    if (
-      problem.field == 'phone' &&
-      getCountries().findIndex(
-        (iso) => store.getState().organizations.orgData.data?.country == iso
-      ) == -1
-    ) {
-      problems.push({
-        code: store.getState().organizations.orgData.data?.country ?? '',
-        kind: ImportProblemKind.INVALID_ORG_COUNTRY,
-      });
-    }
-  }
 
   return (
     <Stack spacing={2}>

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
@@ -1,10 +1,16 @@
 import { Stack } from '@mui/material';
+import { getCountries } from 'libphonenumber-js';
 import { FC, useEffect, useState } from 'react';
 
 import ImportMessage from './ImportMessage';
 import ImportMessageItem from './ImportMessageItem';
-import { ImportProblem } from 'features/import/utils/problems/types';
+import {
+  ImportFieldProblem,
+  ImportProblem,
+  ImportProblemKind,
+} from 'features/import/utils/problems/types';
 import { levelForProblem } from 'features/import/utils/problems';
+import { store } from 'core/store';
 
 type Props = {
   defaultDescription?: string;
@@ -30,6 +36,24 @@ const ImportMessageList: FC<Props> = ({
 
     onAllChecked(numChecked == warningCount);
   }, [numChecked]);
+
+  const formatProblemIndex = problems.findIndex(
+    (problem) => problem.kind == ImportProblemKind.INVALID_FORMAT
+  );
+  if (formatProblemIndex != -1) {
+    const problem = problems[formatProblemIndex] as ImportFieldProblem;
+    if (
+      problem.field == 'phone' &&
+      getCountries().findIndex(
+        (iso) => store.getState().organizations.orgData.data?.country == iso
+      ) == -1
+    ) {
+      problems.push({
+        code: store.getState().organizations.orgData.data?.country ?? '',
+        kind: ImportProblemKind.INVALID_ORG_COUNTRY,
+      });
+    }
+  }
 
   return (
     <Stack spacing={2}>

--- a/src/features/import/hooks/useConfigure.ts
+++ b/src/features/import/hooks/useConfigure.ts
@@ -24,7 +24,7 @@ export default function useConfigure(orgId: number) {
   if (!organization) {
     return;
   }
-  const countryCode = organization.country.toUpperCase() as CountryCode;
+  const countryCode = organization.country as CountryCode;
 
   const emptyStats = {
     person: {

--- a/src/features/import/hooks/usePreflight.ts
+++ b/src/features/import/hooks/usePreflight.ts
@@ -47,7 +47,7 @@ export default function usePreflight(orgId: number) {
 
   const problems = predictProblems(
     sheet,
-    organization.country.toUpperCase() as CountryCode,
+    organization.country as CountryCode,
     fields
   );
 

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -325,6 +325,14 @@ export default makeMessages('feat.import', {
       invalidFormat: {
         title: m<{ field: string }>('Wrong format for field: {field}'),
       },
+      invalidOrgCountry: {
+        description: m(
+          'This makes it impossible to guess ex. phone number country codes. Contact support to fix this.'
+        ),
+        title: m<{ code: string }>(
+          'Possible invalid organization country code: {code}'
+        ),
+      },
       majorChange: {
         description: m(
           'This warning is shown when more than 30% of imported people are affected. Make sure you have configured the columns correctly'

--- a/src/features/import/utils/problems/index.ts
+++ b/src/features/import/utils/problems/index.ts
@@ -2,6 +2,7 @@ import { ImportProblem, ImportProblemKind } from './types';
 
 const LEVEL_BY_PROBLEM_KIND: Record<ImportProblemKind, 'warning' | 'error'> = {
   INVALID_FORMAT: 'error',
+  INVALID_ORG_COUNTRY: 'warning',
   MAJOR_CHANGE: 'warning',
   MISSING_ID_AND_NAME: 'error',
   NO_IMPACT: 'error',

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -575,11 +575,14 @@ describe('predictProblem()', () => {
       rows: [
         // Valid values
         {
-          data: [2, '+46701234567'],
+          data: [1, '+46701234567'],
         },
         // Invalid values
         {
-          data: [1, '701234567'],
+          data: [2, '701234567'],
+        },
+        {
+          data: [3, '701234567'],
         },
       ],
     });
@@ -594,7 +597,7 @@ describe('predictProblem()', () => {
       },
       {
         field: 'phone',
-        indices: [1],
+        indices: [1, 2],
         kind: ImportProblemKind.INVALID_FORMAT,
       },
     ]);

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -1,3 +1,5 @@
+import { CountryCode } from 'libphonenumber-js';
+
 import { ImportProblemKind } from './types';
 import { predictProblems } from './predictProblems';
 import { ColumnKind, Sheet } from '../types';
@@ -554,5 +556,47 @@ describe('predictProblem()', () => {
     });
     const result = predictProblems(sheet, 'SE', customFields);
     expect(result).toEqual([]);
+  });
+
+  it('detects invalid country code when a phone number is without country code', () => {
+    const sheet = makeFullSheet({
+      columns: [
+        {
+          idField: 'id',
+          kind: ColumnKind.ID_FIELD,
+          selected: true,
+        },
+        {
+          field: 'phone',
+          kind: ColumnKind.FIELD,
+          selected: true,
+        },
+      ],
+      rows: [
+        // Valid values
+        {
+          data: [2, '+46701234567'],
+        },
+        // Invalid values
+        {
+          data: [1, '701234567'],
+        },
+      ],
+    });
+
+    const countryCode = 'not_a_country_code' as CountryCode;
+
+    const problems = predictProblems(sheet, countryCode, customFields);
+    expect(problems).toEqual([
+      {
+        code: countryCode,
+        kind: ImportProblemKind.INVALID_ORG_COUNTRY,
+      },
+      {
+        field: 'phone',
+        indices: [1],
+        kind: ImportProblemKind.INVALID_FORMAT,
+      },
+    ]);
   });
 });

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -1,6 +1,10 @@
 import isURL from 'validator/lib/isURL';
 import { z } from 'zod';
-import { CountryCode, isValidPhoneNumber } from 'libphonenumber-js';
+import {
+  CountryCode,
+  isValidPhoneNumber,
+  getCountries,
+} from 'libphonenumber-js';
 
 import { ColumnKind, Sheet } from '../types';
 import { CUSTOM_FIELD_TYPE, ZetkinCustomField } from 'utils/types/zetkin';
@@ -116,6 +120,15 @@ export function predictProblems(
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
               if (!isValidPhoneNumber(cleanPhoneNumber(value), country)) {
                 accumulateFieldProblem(column.field, rowIndex);
+
+                const countryIsUnknown =
+                  getCountries().findIndex((iso) => country == iso) == -1;
+                if (countryIsUnknown) {
+                  problems.push({
+                    code: country,
+                    kind: ImportProblemKind.INVALID_ORG_COUNTRY,
+                  });
+                }
               }
             } else if (column.field == 'gender') {
               if (!['m', 'f', 'o', ''].includes(value.toString())) {

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -68,12 +68,14 @@ export function predictProblems(
     const existing = problemByField[field];
     if (existing) {
       existing.indices.push(row);
+      return true;
     } else {
       problemByField[field] = {
         field: field,
         indices: [row],
         kind: ImportProblemKind.INVALID_FORMAT,
       };
+      return false;
     }
   }
 
@@ -119,15 +121,20 @@ export function predictProblems(
               accumulateFieldProblem(column.field, rowIndex);
             } else if (column.field == 'phone' || column.field == 'alt_phone') {
               if (!isValidPhoneNumber(cleanPhoneNumber(value), country)) {
-                accumulateFieldProblem(column.field, rowIndex);
+                const isKnownProblem = accumulateFieldProblem(
+                  column.field,
+                  rowIndex
+                );
 
-                const countryIsUnknown =
-                  getCountries().findIndex((iso) => country == iso) == -1;
-                if (countryIsUnknown) {
-                  problems.push({
-                    code: country,
-                    kind: ImportProblemKind.INVALID_ORG_COUNTRY,
-                  });
+                if (!isKnownProblem) {
+                  const countryIsUnknown =
+                    getCountries().findIndex((iso) => country == iso) == -1;
+                  if (countryIsUnknown) {
+                    problems.push({
+                      code: country,
+                      kind: ImportProblemKind.INVALID_ORG_COUNTRY,
+                    });
+                  }
                 }
               }
             } else if (column.field == 'gender') {

--- a/src/features/import/utils/problems/types.ts
+++ b/src/features/import/utils/problems/types.ts
@@ -8,6 +8,7 @@ export enum ImportProblemKind {
   UNKNOWN_PERSON = 'UNKNOWN_PERSON',
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
   MAJOR_CHANGE = 'MAJOR_CHANGE',
+  INVALID_ORG_COUNTRY = 'INVALID_ORG_COUNTRY',
 }
 
 export type ImportFieldProblem = {
@@ -38,6 +39,11 @@ export type ImportSheetProblem = {
     | ImportProblemKind.UNCONFIGURED_ID_AND_NAME;
 };
 
+export type ImportOrgProblem = {
+  code: string;
+  kind: ImportProblemKind.INVALID_ORG_COUNTRY;
+};
+
 export type ImportUnexpectedProblem = {
   kind: ImportProblemKind.UNEXPECTED_ERROR;
 };
@@ -45,6 +51,7 @@ export type ImportUnexpectedProblem = {
 export type ImportProblem =
   | ImportFieldProblem
   | ImportFieldMetaProblem
+  | ImportOrgProblem
   | ImportRowProblem
   | ImportSheetProblem
   | ImportUnexpectedProblem;


### PR DESCRIPTION
## Description
This adds a info box on imports with invalid phone numbers if the organization has a invalid country code, since this may be the cause of the phone number error.

## Screenshots

![image](https://github.com/user-attachments/assets/7a559249-b7f0-4421-9e14-b24bf063b20a)

## Changes

* Adds a invalid organization organization country code error kind
* Adds a problem displayed as a "info" problem when relevant which instructs the reader to contact support


## Notes to reviewer

Organization "My Fourth Organization" with ID 4 has a invalid country code set, use this and follow the instructions on the issue.

## Related issues
Resolves #2723 
