### PR TITLE
Issue 2521: Fix mapping empty values to tags does not succeed

### DIFF
--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -556,6 +556,47 @@ describe('prepareImportOperations()', () => {
     ]);
   });
 
+  it('includes sub-ops to tag person with empty tags', () => {
+    const sheet: Sheet = {
+      columns: [
+        { idField: 'id', kind: ColumnKind.ID_FIELD, selected: true },
+        {
+          kind: ColumnKind.TAG,
+          mapping: [
+            {
+              tags: [{ id: 1 }],
+              value: null,
+            },
+          ],
+          selected: true,
+        },
+      ],
+      firstRowIsHeaders: false,
+      rows: [
+        {
+          data: ['123', ''],
+        },
+      ],
+      title: 'My sheet',
+    };
+
+    const ops = prepareImportOperations(sheet, countryCode);
+    expect(ops).toEqual([
+      {
+        key: {
+          id: 123,
+        },
+        op: 'person.get',
+        ops: [
+          {
+            op: 'person.tag',
+            tag_id: 1,
+          },
+        ],
+      },
+    ]);
+  });
+
   it('ignores mismatching tag mappings', () => {
     const sheet: Sheet = {
       columns: [

--- a/src/features/import/utils/prepareImportOperations.ts
+++ b/src/features/import/utils/prepareImportOperations.ts
@@ -83,7 +83,10 @@ export default function prepareImportOperations(
           });
         } else if (col.kind == ColumnKind.TAG) {
           col.mapping.forEach((mapping) => {
-            if (value == mapping.value) {
+            if (
+              value == mapping.value ||
+              (value === '' && mapping.value === null)
+            ) {
               mapping.tags.forEach((tag) => {
                 subOps.push({
                   op: 'person.tag',


### PR DESCRIPTION
## Description
This PR fixes the Issue #2521 


## Changes
Fixes the mapping of an empty field to tags when importing people from a .csv file


## Notes to reviewer
Sorry, it took quite some time to actually get to this.
One note: This fix is absolutely minimal. There might be an argument to transform imported fields which are empty to `null`. This would also resolve this problem, but is more invasive.


## Related issues
Resolves #2521 
