### PR TITLE
Fix buggy width in public survey page

### DIFF
--- a/src/features/surveys/layouts/PublicSurveyLayout.tsx
+++ b/src/features/surveys/layouts/PublicSurveyLayout.tsx
@@ -30,7 +30,7 @@ const PublicSurveyLayout: FC<Props> = ({ children, survey }) => {
           sx={{
             flex: 1,
             gap: '1rem',
-            maxWidth: 'sm',
+            maxWidth: '37.5rem',
             padding: 2,
             width: '100%',
           }}

--- a/src/features/surveys/pages/PublicSurveyPage.tsx
+++ b/src/features/surveys/pages/PublicSurveyPage.tsx
@@ -83,7 +83,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
     <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
       <Box
         sx={{
-          maxWidth: 'sm',
+          maxWidth: '37.5rem',
         }}
       >
         {showErrorAlert && (


### PR DESCRIPTION
## Description
This PR fixes the bug with strange width of surveys on the public survey page.


## Screenshots
Chrome
![bild](https://github.com/user-attachments/assets/c6347526-2d69-4ab3-bc39-c8ef17717876)

Firefox
![bild](https://github.com/user-attachments/assets/a382288a-a1f6-44b2-b556-824417a3c7c2)


## Changes
- Changes `maxWidth` property from `sm` to `37.5rem` (<- aka 600px)


## Notes to reviewer



## Related issues
none
