### PR TITLE
Issue 2752: Environment variable: TILESERVER missing default value in app router

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default async function RootLayout({
     INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
     INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
     MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
-    TILESERVER: process.env.TILESERVER,
+    TILESERVER: process.env.TILESERVER || 'https://tile.openstreetmap.org',
     ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
     ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
     ZETKIN_PRIVACY_POLICY_LINK: process.env.ZETKIN_PRIVACY_POLICY_LINK,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import ClientContext from 'core/env/ClientContext';
+import { EnvVars } from 'core/env/Environment';
 import { ZetkinUser } from 'utils/types/zetkin';
 import { getBrowserLanguage, getMessages } from 'utils/locale';
 
@@ -17,6 +18,17 @@ export default async function RootLayout({
   const headersList = headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
+  const envVars: EnvVars = {
+    FEAT_AREAS: process.env.FEAT_AREAS,
+    FEAT_TASKS: process.env.FEAT_TASKS,
+    INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
+    INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
+    MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
+    TILESERVER: process.env.TILESERVER,
+    ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
+    ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
+    ZETKIN_PRIVACY_POLICY_LINK: process.env.ZETKIN_PRIVACY_POLICY_LINK,
+  };
   const apiClient = new BackendApiClient(headersObject);
 
   let user: ZetkinUser | null;
@@ -31,18 +43,7 @@ export default async function RootLayout({
       <body>
         <AppRouterCacheProvider>
           <ClientContext
-            envVars={{
-              FEAT_AREAS: process.env.FEAT_AREAS,
-              FEAT_TASKS: process.env.FEAT_TASKS,
-              INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
-              INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,
-              MUIX_LICENSE_KEY: process.env.MUIX_LICENSE_KEY,
-              TILESERVER: process.env.TILESERVER,
-              ZETKIN_APP_DOMAIN: process.env.ZETKIN_APP_DOMAIN,
-              ZETKIN_GEN2_ORGANIZE_URL: process.env.ZETKIN_GEN2_ORGANZE_URL,
-              ZETKIN_PRIVACY_POLICY_LINK:
-                process.env.ZETKIN_PRIVACY_POLICY_LINK,
-            }}
+            envVars={envVars}
             headers={headersObject}
             lang={lang}
             messages={messages}

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -205,7 +205,7 @@ export const scaffold =
     if (hasProps(result)) {
       result.props = {
         ...result.props,
-        envVars: omitUndefined({
+        envVars: <EnvVars>omitUndefined({
           FEAT_AREAS: process.env.FEAT_AREAS,
           FEAT_TASKS: process.env.FEAT_TASKS,
           INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,


### PR DESCRIPTION
One commit is just setting the default fallback, the other uses `EnvVars` to prepare for better typing. This does not yet solve the missing env var problem, however we can selectively make env vars non-optional at https://github.com/zetkin/app.zetkin.org/blob/main/src/core/env/Environment.ts#L28 Only issue here is that there are various places where the envVars are initiated with an empty object and then just passed down. So not sure if env vars may or may be valid to be unset for code down the line. Apparently not so regarding the `TILESERVER`.

Feel free to close if too trivial/wrong, I am not much into typescript to know probably better ways.

Part of #2752
