### PR TITLE
Issue 2760: Allow adding newlines in text cell input

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -107,15 +107,9 @@ const EditTextarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
 
   const handleKeyDown = useCallback<NonNullable<InputBaseProps['onKeyDown']>>(
     (event) => {
-      if (
-        event.key === 'Escape' ||
-        (event.key === 'Enter' &&
-          !event.shiftKey &&
-          !event.ctrlKey &&
-          !event.metaKey)
-      ) {
-        const params = apiRef.current.getCellParams(id, field);
-        apiRef.current.publishEvent('cellKeyDown', params, event);
+      // allow adding newlines without submission
+      if (event.key === 'Enter' && event.shiftKey) {
+        event.stopPropagation();
       }
     },
     [apiRef, id, field]


### PR DESCRIPTION
This only handles enter+shift to add newline. Can be expanded or changed to enter+alt if that is preferred.

It was not clear to me what the ESC and other ENTER key handling would do. The `onChange` event handler seems to do all the internal work. Enter still submits, ESC still dismisses.

Resolves #2760
