### PR TITLE
Removed dismissed duplicates from ui

### DIFF
--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -54,9 +54,11 @@ const DuplicatesPage: PageWithLayout = () => {
           >
             {messages.page.possibleDuplicates()}
           </Typography>
-          {list.data.map((cluster) => (
-            <DuplicateCard key={cluster.id} cluster={cluster} />
-          ))}
+          {list.data
+            .filter((cluster) => cluster.status === 'pending')
+            .map((cluster) => (
+              <DuplicateCard key={cluster.id} cluster={cluster} />
+            ))}
         </Box>
       )}
     </>


### PR DESCRIPTION
## Description

Makes it visible in the UI when a potential duplicate group has been dismissed.

## Screenshots

![zetkin-dismiss](https://github.com/user-attachments/assets/4481b3be-12fd-4ce2-bd6f-366781075563)

## Changes

* Changes the `duplicateUpdated` store function to remove items instead of updating them 

## Notes to reviewer

Click dismiss on ex. http://localhost:3000/organize/1/people/duplicates

## Related issues
Resolves #2750 
