### PR TITLE
fix(2769): fixes boolcheck for vistedHoushold numbers

### DIFF
--- a/src/features/canvass/components/LocationDialog/ContractedHeader.tsx
+++ b/src/features/canvass/components/LocationDialog/ContractedHeader.tsx
@@ -31,7 +31,7 @@ const ContractedHeader: FC<Props> = ({ assignment, location }) => {
       }
       subtitle={
         <Box alignItems="center" display="flex" justifyContent="space-between">
-          {numVisitedHouseholds && (
+          {!!numVisitedHouseholds && (
             <>
               <Box
                 sx={{
@@ -49,7 +49,7 @@ const ContractedHeader: FC<Props> = ({ assignment, location }) => {
             </>
           )}
 
-          {numSuccessfulHouseholds && (
+          {!!numSuccessfulHouseholds && (
             <>
               <Box
                 sx={{


### PR DESCRIPTION
## Description
This PR fixes this issue: https://github.com/zetkin/app.zetkin.org/issues/2769


## Screenshots
<img width="1681" alt="image" src="https://github.com/user-attachments/assets/f16846d4-c12b-4048-a8cc-0e34ac1746ab" />


## Changes
[[[Add a list of features added/changed, bugs fixed etc]](https://github.com/zetkin/app.zetkin.org/issues/2769)](https://github.com/zetkin/app.zetkin.org/issues/2769)

## Notes to reviewer
fixed boolean check in ContractedHeader.tsx


## Related issues
Resolves #[i2769]
