### PR TITLE
Add proceed button to scale5 metric

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
@@ -310,6 +310,16 @@ const LocationVisitPage: FC<Props> = ({
                           );
                         })}
                       </Box>
+                      {!stepIsLast && (
+                        <Button
+                          onClick={() => setStep((current) => current + 1)}
+                          variant="contained"
+                        >
+                          <Msg
+                            id={messageIds.visit.location.proceedButtonLabel}
+                          />
+                        </Button>
+                      )}
                     </Box>
                   </StepContent>
                 </Step>


### PR DESCRIPTION
## Description
This PR adds a proceed button on scale5 metric survey inputs allowing user to continue to next question.

## Screenshots

![zetkin-scale5-proceed](https://github.com/user-attachments/assets/cc9f110e-8760-44af-9377-59993af3f250)

## Changes

* Adds button to continue from a scale5 metric

## Notes to reviewer

Use ex. http://localhost:3000/canvass/4/map

Should there be a requirement on when the button appears?

Also, it's possible to set the values to something outside of 1-5, ex. -6 which makes the collapsed summary say you visited a negative number of households.

## Related issues
Resolves #2768
