### PR TITLE
fix(2753): makes questions in surveys orderable

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -191,7 +191,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
         )}
         <ZUIReorderable
           centerWidgets
-          disableClick
+          disableClick={!editable}
           disableDrag={!editable}
           items={optionsToShow.map((option, index) => ({
             hidden: index > 2 && !expand && !editable,


### PR DESCRIPTION
## Description
Makes questions in surveys sortable


## Screenshots
![image](https://github.com/user-attachments/assets/a1194469-cf89-410f-91e5-b5bceaa8276b)


## Changes
Resolves https://github.com/zetkin/app.zetkin.org/issues/2753
* made disableClick of Reordable component depending of editing state. The property otherwise disables all sort-options


## Related issues
Resolves #2753 
