### PR TITLE
Issue 2759/search-rework

### DIFF
--- a/src/features/views/components/ViewDataTable/utils.spec.ts
+++ b/src/features/views/components/ViewDataTable/utils.spec.ts
@@ -37,7 +37,7 @@ describe('viewQuickSearch', () => {
 
   const rows = [
     mockViewRow({
-      content: ['Angela', 'Davis', mockSurveyResponseCell('Response text Ab')],
+      content: ['Angela', 'Davis', mockSurveyResponseCell('Response text AA')],
     }),
     mockViewRow({
       content: ['Clara', 'Zetkin', mockSurveyResponseCell('Response text B')],
@@ -56,15 +56,15 @@ describe('viewQuickSearch', () => {
     expect(matchedRows.length).toEqual(1);
   });
   it('Correctly returns rows when searching for an object field', () => {
-    const matchedRows = viewQuickSearch(rows, columns, 'text ab');
+    const matchedRows = viewQuickSearch(rows, columns, 'text aa');
     const matchedNotes = matchedRows[0].content[2] as SurveyResponseViewCell;
 
     expect(matchedRows.length).toEqual(1);
     expect(matchedNotes).toHaveLength(1);
-    expect(matchedNotes[0].text).toEqual('Response text Ab');
+    expect(matchedNotes[0].text).toEqual('Response text AA');
   });
   it('Returns an empty array if no rows match the search', () => {
-    const matchedRows = viewQuickSearch(rows, columns, 'text cal');
+    const matchedRows = viewQuickSearch(rows, columns, 'text ca');
 
     expect(matchedRows).toEqual([]);
   });

--- a/src/features/views/components/ViewDataTable/utils.spec.ts
+++ b/src/features/views/components/ViewDataTable/utils.spec.ts
@@ -37,7 +37,7 @@ describe('viewQuickSearch', () => {
 
   const rows = [
     mockViewRow({
-      content: ['Angela', 'Davis', mockSurveyResponseCell('Response text A')],
+      content: ['Angela', 'Davis', mockSurveyResponseCell('Response text Ab')],
     }),
     mockViewRow({
       content: ['Clara', 'Zetkin', mockSurveyResponseCell('Response text B')],
@@ -56,15 +56,15 @@ describe('viewQuickSearch', () => {
     expect(matchedRows.length).toEqual(1);
   });
   it('Correctly returns rows when searching for an object field', () => {
-    const matchedRows = viewQuickSearch(rows, columns, 'text a');
+    const matchedRows = viewQuickSearch(rows, columns, 'text ab');
     const matchedNotes = matchedRows[0].content[2] as SurveyResponseViewCell;
 
     expect(matchedRows.length).toEqual(1);
     expect(matchedNotes).toHaveLength(1);
-    expect(matchedNotes[0].text).toEqual('Response text A');
+    expect(matchedNotes[0].text).toEqual('Response text Ab');
   });
   it('Returns an empty array if no rows match the search', () => {
-    const matchedRows = viewQuickSearch(rows, columns, 'text c');
+    const matchedRows = viewQuickSearch(rows, columns, 'text cal');
 
     expect(matchedRows).toEqual([]);
   });

--- a/src/features/views/components/ViewDataTable/utils.tsx
+++ b/src/features/views/components/ViewDataTable/utils.tsx
@@ -20,14 +20,24 @@ export const viewQuickSearch = (
     return rows;
   }
 
-  return rows.filter((row) => {
-    const searchStrings = columns.flatMap((col, idx) => {
-      return columnTypes[col.type].getSearchableStrings(row.content[idx], col);
-    });
+  const searchTerms = quickSearch
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term.length > 0);
 
-    const lowerCaseQuickSearch = quickSearch.toLowerCase();
-    return searchStrings.some((str) =>
-      str.toLowerCase().includes(lowerCaseQuickSearch)
+  return rows.filter((row) => {
+    const columnsText = columns
+      .flatMap((col, idx) => {
+        return columnTypes[col.type].getSearchableStrings(
+          row.content[idx],
+          col
+        );
+      })
+      .map((str) => str.toLowerCase());
+
+    // All search terms must be found somewhere in the searchable strings
+    return searchTerms.every((term) =>
+      columnsText.some((personCol) => personCol.includes(term))
     );
   });
 };


### PR DESCRIPTION
## Description
Reworked the quicksearch function in "utils.tsx" to not match the full string with each column value. Instead splits the search string by spaces and checks if every substring matches for any of column of the provided columns. (such that a search input as `clara zet` matches, which it does not right now)

## Changes

* changed the  quick search function as described
* changed the corresponding unit test, as it does not work as intended (see comment on issue: https://github.com/zetkin/app.zetkin.org/issues/2759#issuecomment-2907749056)

