### PR TITLE
fix issue 2767

### DIFF
--- a/src/features/areaAssignments/layouts/AreaAssignmentLayout.tsx
+++ b/src/features/areaAssignments/layouts/AreaAssignmentLayout.tsx
@@ -139,7 +139,6 @@ const AreaAssignmentLayout: FC<AreaAssignmentLayoutProps> = ({
       tabs={[
         { href: '/', label: messages.layout.tabs.overview() },
         { href: '/map', label: messages.layout.tabs.map() },
-        { href: '/assignees', label: messages.layout.tabs.assignees() },
         { href: '/report', label: messages.layout.tabs.report() },
         { href: '/instructions', label: messages.layout.tabs.instructions() },
       ]}


### PR DESCRIPTION
remove assignee tab as sugested in prposed solution of issue

## Description
This PR removes the assignee's tab as suggested in proposed solution of bug


## Changes
changed file AreaAssignmentLayout.tsx