### PR TITLE
Fix bug when household visit is string instead of number

### DIFF
--- a/src/features/canvass/types.ts
+++ b/src/features/canvass/types.ts
@@ -46,7 +46,7 @@ export type YesNoMetricResponse = {
 
 export type Scale5MetricResponse = {
   metric_id: number;
-  response: 1 | 2 | 3 | 4 | 5;
+  response: 1 | 2 | 3 | 4 | 5 | string;
 };
 
 export type MetricResponse = YesNoMetricResponse | Scale5MetricResponse;

--- a/src/features/canvass/utils/summarizeMetrics.spec.ts
+++ b/src/features/canvass/utils/summarizeMetrics.spec.ts
@@ -102,4 +102,30 @@ describe('summarizeMetrics()', () => {
       num_households_visited: 2,
     });
   });
+
+  it('summarizes scale5 metrics when incorrectly typed as string', () => {
+    const output = summarizeMetrics([
+      {
+        household_id: 1,
+        metrics: [
+          { metric_id: 1, response: '1' },
+          { metric_id: 2, response: '3' },
+        ],
+      },
+    ]);
+
+    expect(output).toEqual({
+      metrics: [
+        {
+          metric_id: 1,
+          num_values: [1, 0, 0, 0, 0],
+        },
+        {
+          metric_id: 2,
+          num_values: [0, 0, 1, 0, 0],
+        },
+      ],
+      num_households_visited: 1,
+    });
+  });
 });

--- a/src/features/canvass/utils/summarizeMetrics.ts
+++ b/src/features/canvass/utils/summarizeMetrics.ts
@@ -19,7 +19,8 @@ export default function summarizeMetrics(
 
   return {
     metrics: Object.values(responsesByMetricId).map((responses) => {
-      const isBool = typeof responses[0].response == 'string';
+      const firstResp = responses[0].response;
+      const isBool = firstResp == 'yes' || firstResp == 'no';
 
       if (isBool) {
         return {


### PR DESCRIPTION
## Description
This PR adds logic to handle a case where a household visit response comes out as a string (e.g. `"3"`) instead of a number (e.g. `3`). Previously, this lead to the response being interpreted as a yes/no response, and submitted incorrectly.

## Screenshots
None

## Changes
* Changes typing of `Scale5MetricResponse` to reflect that it can sometimes be a string (even though that is not intended)
* Changes logic of `summarizeMetrics()` to correctly handle `"3"` etc.
* Updates tests to verify this logic

## Notes to reviewer
None

## Related issues
Undocumented