### PR TITLE
Fix bug preventing releases to build

### DIFF
--- a/src/app/api2/[...path]/route.ts
+++ b/src/app/api2/[...path]/route.ts
@@ -12,12 +12,6 @@ type Context = {
   };
 };
 
-const clientId = requiredEnvVar('ZETKIN_CLIENT_ID');
-const clientSecret = requiredEnvVar('ZETKIN_CLIENT_SECRET');
-const host = requiredEnvVar('ZETKIN_API_HOST');
-const port = process.env.ZETKIN_API_PORT;
-const ssl = stringToBool(process.env.ZETKIN_USE_TLS);
-
 export const GET = proxy;
 export const POST = proxy;
 export const PATCH = proxy;
@@ -28,6 +22,12 @@ async function proxy(
   request: Request,
   context: Context
 ): Promise<NextResponse> {
+  const clientId = requiredEnvVar('ZETKIN_CLIENT_ID');
+  const clientSecret = requiredEnvVar('ZETKIN_CLIENT_SECRET');
+  const host = requiredEnvVar('ZETKIN_API_HOST');
+  const port = process.env.ZETKIN_API_PORT;
+  const ssl = stringToBool(process.env.ZETKIN_USE_TLS);
+
   const path = context.params.path;
   const pathStr = path.join('/');
 


### PR DESCRIPTION
## Description
This PR changes how environment variables are read in the APIv2 proxy. Before this PR, some environment variables need to be present as the proxy router module is imported, which happens when NEXT.js builds, and at that time the environment variables are not known. This PR moves the loading to when the route is executed, which only happens at runtime.

## Screenshots
None

## Changes
* Move env var loading from module scope to inside the route handler


## Notes to reviewer
If you want to verify this, make sure you don't have a `.env.production` and then try to run `yarn build`, first on `main` (expected to fail) and then on this branch (should succeed).

## Related issues
Undocumented