### PR TITLE
Use user avatar instead of person avatar on organizer map

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -43,7 +43,6 @@ type OrganizerMapProps = {
   areas: ZetkinArea[];
   locations: ZetkinLocation[];
   onAddAssigneeToArea: (area: ZetkinArea, user: ZetkinOrgUser) => void;
-  orgId: number;
   sessions: ZetkinAreaAssignee[];
 };
 
@@ -60,7 +59,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
   areaStats,
   areaAssId,
   onAddAssigneeToArea,
-  orgId,
   locations,
   sessions,
 }) => {
@@ -368,7 +366,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
                 setSettingsOpen('select');
               }
             }}
-            orgId={orgId}
             overlayStyle={mapStyle.overlay}
             selectedId={selectedId}
             sessions={sessions}

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -110,7 +110,6 @@ type OrganizerMapRendererProps = {
   locations: ZetkinLocation[];
   navigateToAreaId?: number;
   onSelectedIdChange: (newId: number) => void;
-  orgId: number;
   overlayStyle: 'assignees' | 'households' | 'progress' | 'hide';
   selectedId: number;
   sessions: ZetkinAreaAssignee[];
@@ -213,12 +212,10 @@ function NumberOverlayMarker(props: { value: number }) {
 }
 
 function AssigneeOverlayMarker({
-  organizationID,
-  people,
+  userIds,
   zoom,
 }: {
-  organizationID: number;
-  people: number[];
+  userIds: number[];
   zoom: number;
 }) {
   return (
@@ -234,13 +231,13 @@ function AssigneeOverlayMarker({
       }}
       width={zoom >= 16 ? '95px' : '65px'}
     >
-      {people.map((personId, index) => {
+      {userIds.map((userId, index) => {
         if (index <= 4) {
           return (
             <Box
               //TODO: only use person id once we have logic preventing
               //assigning the same person to an area more than once
-              key={`${personId}-${index}`}
+              key={`${userId}-${index}`}
               sx={{
                 borderRadius: '50%',
                 boxShadow: '0 0 8px rgba(0,0,0,0.3)',
@@ -248,7 +245,7 @@ function AssigneeOverlayMarker({
             >
               <ZUIAvatar
                 size={zoom >= 16 ? 'sm' : 'xs'}
-                url={`/api/orgs/${organizationID}/people/${personId}/avatar`}
+                url={`/api/users/${userId}/avatar`}
               />
             </Box>
           );
@@ -268,7 +265,7 @@ function AssigneeOverlayMarker({
               <Typography
                 color="secondary"
                 fontSize={zoom >= 16 ? 14 : 11}
-              >{`+${people.length - 5}`}</Typography>
+              >{`+${userIds.length - 5}`}</Typography>
             </Box>
           );
         } else {
@@ -288,7 +285,6 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
   sessions,
   navigateToAreaId,
   onSelectedIdChange,
-  orgId,
   overlayStyle,
   locationStyle,
 }) => {
@@ -593,7 +589,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
 
           const detailed = zoom >= 15;
 
-          const people = sessions
+          const userIds = sessions
             .filter((session) => session.area_id == area.id)
             .map((session) => session.user_id);
 
@@ -636,15 +632,9 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
             }
             if (overlayStyle === 'assignees' && area.hasPeople) {
               if (detailed) {
-                return (
-                  <AssigneeOverlayMarker
-                    organizationID={orgId}
-                    people={people}
-                    zoom={zoom}
-                  />
-                );
+                return <AssigneeOverlayMarker userIds={userIds} zoom={zoom} />;
               }
-              return <NumberOverlayMarker value={people.length} />;
+              return <NumberOverlayMarker value={userIds.length} />;
             }
             return null;
           };

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
@@ -86,7 +86,6 @@ const OrganizerMapPage: PageWithLayout<OrganizerMapPageProps> = ({
                   onAddAssigneeToArea={(area, user) => {
                     assignUserToArea(user.id, area.id);
                   }}
-                  orgId={parseInt(orgId)}
                   sessions={sessions}
                 />
               </AssigneeFilterProvider>


### PR DESCRIPTION
## Description
This PR replaces the avatars on the organizer map in area assignments, so that it renders user avatars instead of person avatars. It was incorrectly using the user ID as if it was a person ID, which happened to be fine on the development servers where users and persons have parallel IDs, but does not render correctly in production.

## Screenshots
![image](https://github.com/user-attachments/assets/6e3a7473-abe0-4fad-a1f6-7890718ccfe6)

## Changes
* Replaces `/orgs/ID/people/ID/avatar` with `/users/ID/avatar` in the organizer map
* Removes the `orgId` property, which cascades upwards to several other components that no longer need it

## Notes to reviewer
None

## Related issues
Undocumented