### PR TITLE
Remove unused, unknown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "eslint-config-next": "^14.1.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-next": "^0.0.0",
     "eslint-plugin-no-only-tests": "^3.3.0",
     "eslint-plugin-no-switch-statements": "^1.0.0",
     "eslint-plugin-react": "^7.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,11 +8026,6 @@ eslint-plugin-jsx-a11y@^6.7.1:
     object.entries "^1.1.7"
     object.fromentries "^2.0.7"
 
-eslint-plugin-next@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-next/-/eslint-plugin-next-0.0.0.tgz#f9ef680e8f68763c716ab44697c4b3cc3e0b2069"
-  integrity sha512-IldNDVb6WNduggwRbYzSGZhaskUwVecJ6fhmqwX01+S1aohwAWNzU4me6y47DDzpD/g0fdayNBGxEdt9vKkUtg==
-
 eslint-plugin-no-only-tests@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.3.0.tgz#d9d42ccd4b5d099b4872fb5046cf95441188cfb5"


### PR DESCRIPTION
## Description
This PR removes a dependency that was introduced already in #559, but unnecessarily because it never did anything. As @WULCAN recently pointed out, it's a security risk to keep around unused, untrusted packages like this, because it could be hijacked.

I think the real, proper dependency is `@next/eslint-plugin-next`, which is an indirect dependency (I believe, via NEXT.js).

## Screenshots
None

## Changes
* Removes `eslint-plugin-next` dependency

## Notes to reviewer
None

## Related issues
Undocumented