### PR TITLE
Sort most recent activity first in archives

### DIFF
--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -22,6 +22,7 @@ import ActivityListItem, { STATUS_COLORS } from './items/ActivityListItem';
 interface ActivitiesProps {
   activities: CampaignActivity[];
   orgId: number;
+  sortNewestFirst?: boolean;
 }
 
 interface LazyActivitiesBoxProps extends BoxProps {
@@ -72,8 +73,12 @@ const LazyActivitiesBox = ({
   );
 };
 
-const Activities = ({ activities, orgId }: ActivitiesProps) => {
-  const clustered = useClusteredActivities(activities);
+const Activities = ({
+  activities,
+  orgId,
+  sortNewestFirst,
+}: ActivitiesProps) => {
+  const clustered = useClusteredActivities(activities, sortNewestFirst);
 
   return (
     <Card>
@@ -135,6 +140,7 @@ interface ActivityListProps {
   filters: ACTIVITIES[];
   orgId: number;
   searchString: string;
+  sortNewestFirst?: boolean;
 }
 
 const ActivityList = ({
@@ -142,6 +148,7 @@ const ActivityList = ({
   filters,
   orgId,
   searchString,
+  sortNewestFirst,
 }: ActivityListProps) => {
   const messages = useMessages(messageIds);
 
@@ -163,7 +170,11 @@ const ActivityList = ({
   return (
     <>
       {searchResults.length > 0 && (
-        <Activities activities={searchResults} orgId={orgId} />
+        <Activities
+          activities={searchResults}
+          orgId={orgId}
+          sortNewestFirst={sortNewestFirst}
+        />
       )}
       {!searchResults.length && (
         <Box alignItems="center" display="flex" flexDirection="column">

--- a/src/features/campaigns/hooks/useClusteredActivities.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.ts
@@ -131,7 +131,8 @@ export function clusterEvents(
 }
 
 export default function useClusteredActivities(
-  activities: CampaignActivity[]
+  activities: CampaignActivity[],
+  newestFirst?: boolean
 ): ClusteredActivity[] {
   const eventActivities: EventActivity[] = [];
   const otherActivities: NonEventActivity[] = [];
@@ -162,7 +163,9 @@ export default function useClusteredActivities(
       return 1;
     }
 
-    return aStart.getTime() - bStart.getTime();
+    return newestFirst
+      ? bStart.getTime() - aStart.getTime()
+      : aStart.getTime() - bStart.getTime();
   });
 }
 

--- a/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/archive/index.tsx
@@ -82,6 +82,7 @@ const CampaignArchivePage: PageWithLayout = () => {
                   filters={filters}
                   orgId={orgId}
                   searchString={searchString}
+                  sortNewestFirst
                 />
               </Grid>
               <Grid size={{ sm: 4 }}>

--- a/src/pages/organize/[orgId]/projects/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/archive/index.tsx
@@ -84,6 +84,7 @@ const ActivitiesArchivePage: PageWithLayout = () => {
                   filters={filters}
                   orgId={orgId}
                   searchString={searchString}
+                  sortNewestFirst
                 />
               </Grid>
 


### PR DESCRIPTION
## Description
This PR sorts both the org archive and the project archive to have the most recent activity show up at the top.


## Screenshots
![bild](https://github.com/user-attachments/assets/bd921779-a6f8-45bd-bfc3-e94938493e06)

## Changes
* Adds property to `useClusteredActivities` to optionally sort clustered activities with most recent first
* Passes this property in through the `ActivityList` on both archive pages

## Notes to reviewer
look and see if the order looks weird somehow


## Related issues
Resolves #2679 
