### PR TITLE
Fix some canvassing bugs

### DIFF
--- a/src/features/areaAssignments/hooks/useLocation.ts
+++ b/src/features/areaAssignments/hooks/useLocation.ts
@@ -1,0 +1,27 @@
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { ZetkinLocation } from '../types';
+import { locationLoad, locationLoaded } from '../store';
+import { loadItemIfNecessary } from 'core/caching/cacheUtils';
+
+export default function useLocation(
+  orgId: number,
+  assignmentId: number,
+  locationId: number
+) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const locationItem = useAppSelector((state) =>
+    state.areaAssignments.locationsByAssignmentId[assignmentId].items.find(
+      (item) => item.id == locationId
+    )
+  );
+
+  return loadItemIfNecessary(locationItem, dispatch, {
+    actionOnLoad: () => locationLoad([assignmentId, locationId]),
+    actionOnSuccess: (data) => locationLoaded([assignmentId, locationId, data]),
+    loader: () =>
+      apiClient.get<ZetkinLocation>(
+        `/api2/orgs/${orgId}/area_assignments/${assignmentId}/locations/${locationId}`
+      ),
+  });
+}

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -21,7 +21,11 @@ import {
 } from './types';
 import { findOrAddItem } from 'utils/storeUtils/findOrAddItem';
 import { Zetkin2Area } from 'features/areas/types';
-import { ZetkinHouseholdVisit } from 'features/canvass/types';
+import {
+  ZetkinHouseholdVisit,
+  ZetkinLocationVisit,
+} from 'features/canvass/types';
+import { visitCreated } from 'features/canvass/store';
 
 export interface AreaAssignmentsStoreSlice {
   areaGraphByAssignmentId: Record<
@@ -60,6 +64,19 @@ const initialState: AreaAssignmentsStoreSlice = {
 };
 
 const areaAssignmentSlice = createSlice({
+  extraReducers: (builder) =>
+    builder.addCase(
+      visitCreated,
+      (state, action: PayloadAction<ZetkinLocationVisit>) => {
+        const visit = action.payload;
+        state.locationsByAssignmentId[visit.assignment_id] ||= remoteList();
+        const item = findOrAddItem(
+          state.locationsByAssignmentId[visit.assignment_id],
+          visit.location_id
+        );
+        item.isStale = true;
+      }
+    ),
   initialState: initialState,
   name: 'areaAssignments',
   reducers: {

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -241,6 +241,31 @@ const areaAssignmentSlice = createSlice({
         remoteItemUpdated(list, location);
       });
     },
+    locationLoad: (state, action: PayloadAction<[number, number]>) => {
+      const [assignmentId, locationId] = action.payload;
+      state.locationsByAssignmentId[assignmentId] ||= remoteList();
+      const item = findOrAddItem(
+        state.locationsByAssignmentId[assignmentId],
+        locationId
+      );
+      item.isLoading = true;
+    },
+    locationLoaded: (
+      state,
+      action: PayloadAction<[number, number, ZetkinLocation]>
+    ) => {
+      const timestamp = new Date().toISOString();
+      const [assignmentId, locationId, location] = action.payload;
+      state.locationsByAssignmentId[assignmentId] ||= remoteList();
+      const item = findOrAddItem(
+        state.locationsByAssignmentId[assignmentId],
+        locationId
+      );
+      item.isLoading = false;
+      item.data = location;
+      item.loaded = timestamp;
+      item.isStale = false;
+    },
     locationUpdated: (state, action: PayloadAction<ZetkinLocation>) => {
       const location = action.payload;
 
@@ -356,6 +381,8 @@ export const {
   assignmentAreasLoaded,
   householdVisitCreated,
   locationCreated,
+  locationLoad,
+  locationLoaded,
   locationsInvalidated,
   locationsLoad,
   locationsLoaded,

--- a/src/features/canvass/components/CanvassMap.tsx
+++ b/src/features/canvass/components/CanvassMap.tsx
@@ -35,6 +35,7 @@ import { Zetkin2Area } from '../../areas/types';
 import { ZetkinAreaAssignment } from 'features/areaAssignments/types';
 import locToLatLng from 'features/geography/utils/locToLatLng';
 import { useAutoResizeMap } from 'features/map/hooks/useResizeMap';
+import LocationMarkerIcon from './LocationMarkerIcon';
 
 const useStyles = makeStyles(() => ({
   '@keyframes ghostMarkerBounce': {
@@ -349,19 +350,11 @@ const CanvassMap: FC<Props> = ({ areas, assignment }) => {
                 iconAnchor={[11, 33]}
                 position={locToLatLng(location)}
               >
-                <MarkerIcon
+                <LocationMarkerIcon
+                  assignmentId={assignment.id}
+                  locationId={location.id}
+                  orgId={assignment.organization_id}
                   selected={selected}
-                  successfulVisits={
-                    location.num_households_successful ||
-                    location.num_successful_visits
-                  }
-                  totalHouseholds={Math.max(
-                    location.num_estimated_households,
-                    location.num_known_households
-                  )}
-                  totalVisits={
-                    location.num_households_visited || location.num_visits
-                  }
                   uniqueKey={key}
                 />
               </DivIconMarker>

--- a/src/features/canvass/components/CanvassSidebar/index.tsx
+++ b/src/features/canvass/components/CanvassSidebar/index.tsx
@@ -53,7 +53,19 @@ const CanvassSidebar: FC<Props> = ({ assignment }) => {
             />
             <Divider sx={(theme) => ({ bgcolor: theme.palette.grey[100] })} />
             <Typography sx={{ pb: 2, pt: 2 }} variant="body2">
-              <ZUIMarkdown markdown={assignment.instructions} />
+              <ZUIMarkdown
+                BoxProps={{
+                  ref: (elem: HTMLElement) => {
+                    if (elem) {
+                      const aNodes = elem.querySelectorAll('a');
+                      aNodes.forEach((node) => {
+                        node.setAttribute('target', '_blank');
+                      });
+                    }
+                  },
+                }}
+                markdown={assignment.instructions}
+              />
             </Typography>
             <Divider sx={(theme) => ({ bgcolor: theme.palette.grey[100] })} />
           </ListItem>

--- a/src/features/canvass/components/LocationMarkerIcon.tsx
+++ b/src/features/canvass/components/LocationMarkerIcon.tsx
@@ -1,0 +1,44 @@
+import { FC } from 'react';
+
+import useLocation from 'features/areaAssignments/hooks/useLocation';
+import MarkerIcon from './MarkerIcon';
+
+type Props = {
+  assignmentId: number;
+  locationId: number;
+  orgId: number;
+  selected: boolean;
+  uniqueKey?: string;
+};
+
+const LocationMarkerIcon: FC<Props> = ({
+  assignmentId,
+  locationId,
+  orgId,
+  selected,
+  uniqueKey,
+}) => {
+  const locationFuture = useLocation(orgId, assignmentId, locationId);
+  const location = locationFuture.data;
+
+  return (
+    <MarkerIcon
+      selected={selected}
+      successfulVisits={
+        location?.num_households_successful ||
+        location?.num_successful_visits ||
+        0
+      }
+      totalHouseholds={Math.max(
+        location?.num_estimated_households ?? 0,
+        location?.num_known_households ?? 0
+      )}
+      totalVisits={
+        location?.num_households_visited || location?.num_visits || 0
+      }
+      uniqueKey={uniqueKey}
+    />
+  );
+};
+
+export default LocationMarkerIcon;

--- a/src/features/canvass/components/MarkerIcon.tsx
+++ b/src/features/canvass/components/MarkerIcon.tsx
@@ -34,6 +34,11 @@ const MarkerIcon: FC<MarkerIconProps> = ({
     const successRatio = successfulVisits / totalHouseholds;
     successBandHeight = 0.8 * successRatio * totalHeight;
     visitsBandHeight = 0.8 * visitRatio * totalHeight;
+  } else if (totalVisits > 0) {
+    const visitRatio = 1;
+    const successRatio = successfulVisits / totalVisits;
+    successBandHeight = 0.8 * successRatio * totalHeight;
+    visitsBandHeight = 0.8 * visitRatio * totalHeight;
   }
 
   return (


### PR DESCRIPTION
## Description
This PR fixes a number of undocumented canvassing bugs, that I discovered (and wanted fixed) when I was preparing for my masterclass today.

## Screenshots
None

## Changes
* Fixes a bug that was causing map UI to not update after a visit was reported. This is fixed by marking as stale and re-fetching the location data using a new `useLocation()` hook
* Updates markers so that they reflect the number of visits instead of households, when household data is not available
* Modifies the instructions in the sidebar so that links open in new tab

## Notes to reviewer
None

## Related issues
Undocumented