### PR TITLE
Issue 2715: Add ID and Submit Token to Join Form List

### DIFF
--- a/src/features/joinForms/components/JoinFormListItem.tsx
+++ b/src/features/joinForms/components/JoinFormListItem.tsx
@@ -86,7 +86,10 @@ const JoinFormListItem = ({ form, onClick }: Props) => {
         <FormatListBulleted className={classes.icon} />
         <Box>
           <Typography color={oldTheme.palette.text.primary}>
-            {form.title}
+            {form.title}{' '}
+            <Typography color={oldTheme.palette.text.disabled} component="span">
+              (#{form.id})
+            </Typography>
           </Typography>
         </Box>
       </Box>
@@ -131,6 +134,19 @@ const JoinFormListItem = ({ form, onClick }: Props) => {
                       <Msg id={messageIds.embedding.openLink} />
                     </Button>
                   </>
+                );
+              },
+            },
+            {
+              label: messages.submitToken.copySubmitToken(),
+              onSelect: async (ev) => {
+                ev.stopPropagation();
+
+                navigator.clipboard.writeText(form.submit_token);
+
+                showSnackbar(
+                  'success',
+                  <Msg id={messageIds.submitToken.submitTokenCopied} />
                 );
               },
             },

--- a/src/features/joinForms/components/JoinFormListItem.tsx
+++ b/src/features/joinForms/components/JoinFormListItem.tsx
@@ -84,13 +84,9 @@ const JoinFormListItem = ({ form, onClick }: Props) => {
     >
       <Box className={classes.left}>
         <FormatListBulleted className={classes.icon} />
-        <Box>
-          <Typography color={oldTheme.palette.text.primary}>
-            {form.title}{' '}
-            <Typography color={oldTheme.palette.text.disabled} component="span">
-              (#{form.id})
-            </Typography>
-          </Typography>
+        <Box alignItems="center" display="flex" gap={1}>
+          <Typography>{form.title}</Typography>
+          <Typography color="secondary">(#{form.id})</Typography>
         </Box>
       </Box>
       <Box>

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -53,4 +53,8 @@ export default makeMessages('feat.joinForms', {
       'Your submission has been verified and organizers in {org} will review it shortly.'
     ),
   },
+  submitToken: {
+    copySubmitToken: m('Copy submit token'),
+    submitTokenCopied: m('Submit token copied.'),
+  },
 });


### PR DESCRIPTION
## Description
This PR exposes the Join Form ID and the Join Form submit token to the user in the List view.
- The ID is shown in parentheses in a muted color next to the Join Form title
- The submit token can be copied (similar to the embed URL) from the ellipsis menu.

## Screenshots
<img width="700" alt="screen 2025-06-06 at 13 02 29" src="https://github.com/user-attachments/assets/8ac89d19-f188-4dc0-8477-9553f242b301" />
<img width="700" alt="screen 2025-06-06 at 13 02 35" src="https://github.com/user-attachments/assets/effef414-f355-4b4b-8d8c-bbad7feb91ba" />
<img width="700" alt="screen 2025-06-06 at 13 02 38" src="https://github.com/user-attachments/assets/e39e9637-792b-4b1e-9372-096e3ea6c150" />
<img width="700" alt="screen 2025-06-06 at 13 03 48" src="https://github.com/user-attachments/assets/4afda186-7bf7-4262-b51b-ae246c52459c" />

## Changes
- Extended the `JoinFormListItem` component
- Added 2 new messages under `joinForms`

## Related issues
Resolves #2715 
