### PR TITLE
Add store remoteList utility methods

### DIFF
--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -6,6 +6,9 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import { ZetkinArea } from './types';
 import { ZetkinAppliedTag, ZetkinTag } from 'utils/types/zetkin';
@@ -45,19 +48,16 @@ const areasSlice = createSlice({
       remoteItemUpdated(state.areaList, area);
     },
     areasLoad: (state) => {
-      state.areaList.isLoading = true;
+      state.areaList = remoteListLoad(state.areaList);
     },
     areasLoaded: (state, action: PayloadAction<ZetkinArea[]>) => {
-      const timestamp = new Date().toISOString();
       const areas = action.payload;
-      state.areaList = remoteList(areas);
-      state.areaList.loaded = timestamp;
-      state.areaList.items.forEach((item) => (item.loaded = timestamp));
+      state.areaList = remoteListLoaded(areas);
     },
     tagAssigned: (state, action: PayloadAction<[number, ZetkinTag]>) => {
       const [areaId, tag] = action.payload;
-      state.tagsByAreaId[areaId] ||= remoteList();
 
+      state.tagsByAreaId[areaId] ||= remoteListCreated();
       remoteItemUpdated(state.tagsByAreaId[areaId], tag);
 
       const areaItem = state.areaList.items.find((item) => item.id == areaId);
@@ -67,7 +67,7 @@ const areasSlice = createSlice({
     },
     tagUnassigned: (state, action: PayloadAction<[number, number]>) => {
       const [areaId, tagId] = action.payload;
-      state.tagsByAreaId[areaId] ||= remoteList();
+      state.tagsByAreaId[areaId] ||= remoteListCreated();
       state.tagsByAreaId[areaId].items = state.tagsByAreaId[
         areaId
       ].items.filter((item) => item.id != tagId);
@@ -81,16 +81,14 @@ const areasSlice = createSlice({
     },
     tagsLoad: (state, action: PayloadAction<number>) => {
       const areaId = action.payload;
-      state.tagsByAreaId[areaId] ||= remoteList();
-      state.tagsByAreaId[areaId].isLoading = true;
+      state.tagsByAreaId[areaId] = remoteListLoad(state.tagsByAreaId[areaId]);
     },
     tagsLoaded: (
       state,
       action: PayloadAction<[number, ZetkinAppliedTag[]]>
     ) => {
       const [areaId, tags] = action.payload;
-      state.tagsByAreaId[areaId] = remoteList(tags);
-      state.tagsByAreaId[areaId].loaded = new Date().toISOString();
+      state.tagsByAreaId[areaId] = remoteListLoaded(tags);
     },
   },
 });

--- a/src/features/joinForms/store.ts
+++ b/src/features/joinForms/store.ts
@@ -7,6 +7,8 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import { ZetkinJoinForm, ZetkinJoinSubmission } from './types';
 
@@ -30,10 +32,7 @@ const joinFormsSlice = createSlice({
     },
     joinFormDeleted: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
-      const item = state.formList.items.find((item) => item.id == formId);
-      if (item) {
-        item.deleted = true;
-      }
+      remoteItemDeleted(state.formList, formId);
     },
     joinFormLoad: (state, action: PayloadAction<number>) => {
       const formId = action.payload;
@@ -52,11 +51,10 @@ const joinFormsSlice = createSlice({
       remoteItemUpdated(state.formList, form);
     },
     joinFormsLoad: (state) => {
-      state.formList.isLoading = true;
+      state.formList = remoteListLoad(state.formList);
     },
     joinFormsLoaded: (state, action: PayloadAction<ZetkinJoinForm[]>) => {
-      state.formList = remoteList(action.payload);
-      state.formList.loaded = new Date().toISOString();
+      state.formList = remoteListLoaded(action.payload);
     },
     submissionDeleted: (state, action: PayloadAction<number>) => {
       const submissionId = action.payload;
@@ -79,14 +77,14 @@ const joinFormsSlice = createSlice({
       remoteItemUpdated(state.submissionList, submission);
     },
     submissionsLoad: (state) => {
-      state.submissionList.isLoading = true;
+      state.submissionList = remoteListLoad(state.submissionList);
     },
     submissionsLoaded: (
       state,
       action: PayloadAction<ZetkinJoinSubmission[]>
     ) => {
-      state.submissionList = remoteList(action.payload);
-      state.submissionList.loaded = new Date().toISOString();
+      const submissions = action.payload;
+      state.submissionList = remoteListLoaded(submissions);
     },
   },
 });

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -7,6 +7,9 @@ import {
   remoteItemUpdated,
   remoteList,
   RemoteList,
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
 import {
   ZetkinAppliedTag,
@@ -32,24 +35,18 @@ const tagsSlice = createSlice({
   reducers: {
     personTagsLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
-      if (!state.tagsByPersonId[id]) {
-        state.tagsByPersonId[id] = remoteList();
-      }
-      state.tagsByPersonId[id].isLoading = true;
+      state.tagsByPersonId[id] = remoteListLoad(state.tagsByPersonId[id]);
     },
     personTagsLoaded: (
       state,
       action: PayloadAction<[number, ZetkinAppliedTag[]]>
     ) => {
       const [id, tags] = action.payload;
-      state.tagsByPersonId[id] = remoteList(tags);
-      state.tagsByPersonId[id].loaded = new Date().toISOString();
+      state.tagsByPersonId[id] = remoteListLoaded(tags);
     },
     tagAssigned: (state, action: PayloadAction<[number, ZetkinTag]>) => {
       const [personId, tag] = action.payload;
-      if (!state.tagsByPersonId[personId]) {
-        state.tagsByPersonId[personId] = remoteList();
-      }
+      state.tagsByPersonId[personId] ||= remoteListCreated();
       remoteItemUpdated(state.tagsByPersonId[personId], tag);
     },
     tagCreate: (state) => {
@@ -78,19 +75,15 @@ const tagsSlice = createSlice({
     },
     tagGroupCreated: (state, action: PayloadAction<ZetkinTagGroup>) => {
       const tagGroup = action.payload;
-      state.tagGroupList.isLoading = false;
       remoteItemUpdated(state.tagGroupList, tagGroup);
     },
     tagGroupsLoad: (state) => {
-      state.tagGroupList.isLoading = true;
+      state.tagGroupList.isLoading = true; // Same as above comment
+      state.tagGroupList = remoteListLoad(state.tagGroupList);
     },
     tagGroupsLoaded: (state, action: PayloadAction<ZetkinTagGroup[]>) => {
       const tagGroups = action.payload;
-      const timestamp = new Date().toISOString();
-
-      state.tagGroupList = remoteList(tagGroups);
-      state.tagGroupList.loaded = timestamp;
-      state.tagGroupList.items.forEach((item) => (item.loaded = timestamp));
+      state.tagGroupList = remoteListLoaded(tagGroups);
     },
     tagLoad: (state, action: PayloadAction<number>) => {
       const tagId = action.payload;
@@ -102,9 +95,8 @@ const tagsSlice = createSlice({
     },
     tagUnassigned: (state, action: PayloadAction<[number, number]>) => {
       const [personId, tagId] = action.payload;
-      const tagsByPersonId = state.tagsByPersonId[personId];
 
-      if (!tagsByPersonId) {
+      if (!state.tagsByPersonId[personId]) {
         return;
       }
 
@@ -128,15 +120,11 @@ const tagsSlice = createSlice({
       });
     },
     tagsLoad: (state) => {
-      state.tagList.isLoading = true;
+      state.tagList = remoteListLoad(state.tagList);
     },
     tagsLoaded: (state, action: PayloadAction<ZetkinTag[]>) => {
       const tags = action.payload;
-      const timestamp = new Date().toISOString();
-
-      state.tagList = remoteList(tags);
-      state.tagList.loaded = timestamp;
-      state.tagList.items.forEach((item) => (item.loaded = timestamp));
+      state.tagList = remoteListLoaded(tags);
     },
   },
 });

--- a/src/utils/storeUtils/findOrAddItem.spec.ts
+++ b/src/utils/storeUtils/findOrAddItem.spec.ts
@@ -8,7 +8,6 @@ describe('findOrAddItem', () => {
 
   afterEach(() => {
     jest.clearAllTimers();
-    jest.clearAllMocks();
   });
 
   it('Creates a new item in list if none exist', () => {

--- a/src/utils/storeUtils/findOrAddItem.ts
+++ b/src/utils/storeUtils/findOrAddItem.ts
@@ -20,13 +20,16 @@ export function findOrAddItem<DataType extends RemoteData>(
   }
 }
 
-export function remoteItemCreated<DataType extends RemoteData>(
-  list: RemoteList<DataType>,
-  id: number | string
-): RemoteItem<DataType> {
-  return findOrAddItem(list, id);
-}
-
+/**
+ * When sending an update to backend, this method should be used to update the redux store (cache).
+ * It receives the item, creates it if needed and sets the mutating field. Returns the item.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList, a cached representation of an existing list in the database.
+ * @param id ID of a RemoteItem, which might or might not exist in cache.
+ * @param mutating THe fields on the item being updated.
+ * @returns The existing or newly created mutating RemoteItem.
+ */
 export function remoteItemUpdate<DataType extends RemoteData>(
   list: RemoteList<DataType>,
   id: number | string,
@@ -37,6 +40,15 @@ export function remoteItemUpdate<DataType extends RemoteData>(
   return item;
 }
 
+/**
+ * When starting a load from backend, this method should be used to update the redux store (cache).
+ * It receives the item, creates it if needed and sets the isLoading field. Returns the item.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList, a cached representation of an existing list in the database.
+ * @param id ID of a RemoteItem, which might or might not exist in cache.
+ * @returns The existing or newly created RemoteItem.
+ */
 export function remoteItemLoad<DataType extends RemoteData>(
   list: RemoteList<DataType>,
   id: number | string

--- a/src/utils/storeUtils/index.ts
+++ b/src/utils/storeUtils/index.ts
@@ -141,7 +141,13 @@ export function remoteList<DataType extends RemoteData>(
 }
 
 export {
-  remoteItemCreated,
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
+  remoteListInvalidated,
+} from 'utils/storeUtils/remoteListUtils';
+
+export {
   remoteItemUpdate,
   remoteItemLoad,
 } from 'utils/storeUtils/findOrAddItem';

--- a/src/utils/storeUtils/remoteItemDeleted.ts
+++ b/src/utils/storeUtils/remoteItemDeleted.ts
@@ -1,5 +1,14 @@
 import { RemoteData, RemoteList } from 'utils/storeUtils';
 
+/**
+ * When recieving response from backend that a remote item has been deleted, this method should be used to update the redux store (cache).
+ * It receives a RemoteList and a RemoteItem ID and ensures the item is deleted. Returns true if item was succesfully found and set to deleted.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList, a cached representation of an existing list in the database.
+ * @param deletedId ID of RemoteItem to be deleted.
+ * @returns true if item was found and succesfully set to deleted.
+ */
 export function remoteItemDeleted<DataType extends RemoteData>(
   list: RemoteList<DataType>,
   deletedId: number | string

--- a/src/utils/storeUtils/remoteItemUpdated.spec.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.spec.ts
@@ -16,7 +16,6 @@ describe('remoteItemUpdated', () => {
 
   afterEach(() => {
     jest.clearAllTimers();
-    jest.clearAllMocks();
   });
 
   it('Creates an item with data if none exist', () => {
@@ -78,6 +77,18 @@ describe('remoteItemUpdated', () => {
     const resultUpdated = remoteItemUpdated(list, existingUpdatedData);
 
     expect(resultUpdated.isLoading).toBeFalsy();
+  });
+
+  it('Sets isStale to false', () => {
+    const list = remoteList();
+
+    const existingItem = findOrAddItem(list, existingId);
+    existingItem.data = existingData;
+    existingItem.isStale = true;
+
+    const resultUpdated = remoteItemUpdated(list, existingUpdatedData);
+
+    expect(resultUpdated.isStale).toBeFalsy();
   });
 
   it('Returns the updated/fetched item', () => {

--- a/src/utils/storeUtils/remoteItemUpdated.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.ts
@@ -1,14 +1,24 @@
-import { RemoteData, RemoteList } from 'utils/storeUtils';
+import { RemoteData, RemoteItem, RemoteList } from 'utils/storeUtils';
 import { findOrAddItem } from './findOrAddItem';
 
+/**
+ * When recieving response from backend that a remote item has been updated, this method should be used to update the redux store (cache).
+ * It receives a RemoteList and some data and ensures the item in the list is updated.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList, a cached representation of an existing list in the database.
+ * @param updatedData Data of item being updated. Contains an ID of the item.
+ * @returns the updated or created RemoteItem
+ */
 export function remoteItemUpdated<DataType extends RemoteData>(
   list: RemoteList<DataType>,
   updatedData: DataType
-) {
+): RemoteItem<DataType> {
   const item = findOrAddItem(list, updatedData.id);
   item.data = updatedData;
   item.mutating = [];
   item.isLoading = false;
+  item.isStale = false;
   item.loaded = new Date().toISOString();
   return item;
 }

--- a/src/utils/storeUtils/remoteListUtils.spec.ts
+++ b/src/utils/storeUtils/remoteListUtils.spec.ts
@@ -1,0 +1,88 @@
+import { remoteList } from 'utils/storeUtils';
+import {
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
+  remoteListInvalidated,
+} from 'utils/storeUtils/remoteListUtils';
+
+describe('remoteListCreated', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('Sets loaded to recent time if list is created', () => {
+    const testDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(testDate);
+
+    const resultList = remoteListCreated();
+
+    expect(resultList.loaded).toBe(testDate.toISOString());
+  });
+});
+
+describe('remoteListLoad', () => {
+  it('Sets isLoading to true for an existing list', () => {
+    const existingList = remoteList();
+    existingList.isLoading = false;
+
+    const resultList = remoteListLoad(existingList);
+
+    expect(resultList.isLoading).toBe(true);
+  });
+
+  it('Sets isLoading to true for a new list', () => {
+    const resultList = remoteListLoad(null);
+
+    expect(resultList.isLoading).toBe(true);
+  });
+});
+
+describe('remoteListLoaded', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('Sets loaded to recent time for the list', () => {
+    const correctDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(correctDate);
+    const loadedData = [{ id: 'Loaded example data' }];
+
+    const resultList = remoteListLoaded(loadedData);
+
+    expect(resultList.loaded).toBe(correctDate.toISOString());
+  });
+
+  it('Sets loaded to recent time for the items in the list', () => {
+    const correctDate = new Date('2020-01-01');
+    jest.useFakeTimers().setSystemTime(correctDate);
+    const loadedData = [
+      { id: 'Loaded example data A' },
+      { id: 'Loaded example data B' },
+    ];
+
+    const resultList = remoteListLoaded(loadedData);
+
+    expect(resultList.items.length).toBe(2);
+    resultList.items.forEach((item) => {
+      expect(item.loaded).toBe(correctDate.toISOString());
+    });
+  });
+});
+
+describe('remoteListInvalidated', () => {
+  it('Sets isStale to true for an existing list', () => {
+    const existingList = remoteList();
+    existingList.isStale = false;
+
+    const resultList = remoteListInvalidated(existingList);
+
+    expect(resultList.isStale).toBe(true);
+  });
+
+  it('Sets isStale to true for a new list', () => {
+    const resultList = remoteListInvalidated(null);
+
+    expect(resultList.isStale).toBe(true);
+  });
+});

--- a/src/utils/storeUtils/remoteListUtils.ts
+++ b/src/utils/storeUtils/remoteListUtils.ts
@@ -50,7 +50,7 @@ export function remoteListLoaded<DataType extends RemoteData>(
 }
 
 /**
- * When recieving response from backend that a remote list has been invalidated, this method should be used to update the redux store (cache).
+ * When user action prompts the invalidation of a list, this method should be used to update the redux store (cache).
  * It receives a RemoteList and sets it to stale. Returns the list.
  * This is a utility method for manipulating the cache, and should only be used in this context.
  *

--- a/src/utils/storeUtils/remoteListUtils.ts
+++ b/src/utils/storeUtils/remoteListUtils.ts
@@ -1,0 +1,68 @@
+import { RemoteData, RemoteList, remoteList } from 'utils/storeUtils';
+
+/**
+ * When recieving response from backend that a remote list has been created, this method should be used to update the redux store (cache).
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @returns the created RemoteList.
+ */
+export function remoteListCreated<
+  DataType extends RemoteData
+>(): RemoteList<DataType> {
+  const list = remoteList<DataType>();
+  list.loaded = new Date().toISOString();
+  return list;
+}
+
+/**
+ * When a list is being in progress of being fetched from backend (loading), this method should be used to update the redux store (cache).
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList to set as loading.
+ * @returns the RemoteList.
+ */
+export function remoteListLoad<DataType extends RemoteData>(
+  list: RemoteList<DataType> | null
+): RemoteList<DataType> {
+  if (!list) {
+    list = remoteList();
+  }
+  list.isLoading = true;
+  return list;
+}
+
+/**
+ * When recieving response from backend that a remote list has been loaded, this method should be used to update the redux store (cache).
+ * It receives a list of items, and makes sure a list is created with the loaded items. Returns the list.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param items Loaded RemoteItem-compatible data used for populating the list.
+ * @returns the loaded RemoteList.
+ */
+export function remoteListLoaded<DataType extends RemoteData>(
+  items: DataType[]
+): RemoteList<DataType> {
+  const list = remoteList(items);
+  const timeStamp = new Date().toISOString();
+  list.loaded = timeStamp;
+  list.items.forEach((item) => (item.loaded = timeStamp));
+  return list;
+}
+
+/**
+ * When recieving response from backend that a remote list has been invalidated, this method should be used to update the redux store (cache).
+ * It receives a RemoteList and sets it to stale. Returns the list.
+ * This is a utility method for manipulating the cache, and should only be used in this context.
+ *
+ * @param list RemoteList to set as stale/invalidated.
+ * @returns Stale RemoteList.
+ */
+export function remoteListInvalidated<DataType extends RemoteData>(
+  list: RemoteList<DataType> | null
+): RemoteList<DataType> {
+  if (!list) {
+    list = remoteList();
+  }
+  list.isStale = true;
+  return list;
+}


### PR DESCRIPTION
## Description
This PR is a complement to PR #2482, which added store utility methods for items in list. This PR adds store utility methods for the lists themselves. This PR is more updated compared to PR #2601, with changes to AreaAssignments store. 

Furthermore, just like the last PR, this PR also updates four features with the new utility methods:
areas, areaAssignments, tags and joinForms. There's also one or two small fixes related to the last PR.

The purpose of the refactoring is to align how we use store methods, to avoid pitfalls and common errors. 

After this PR, there's still two data types that might be relevant to make utility methods for, namely records <string, remoteItem> and <string, remoteList>. 

## Screenshots
No changes to UI

## Changes
* Adds remoteList store utility methods: remoteListCreated, remoteListLoad, remoteListLoaded and remoteListInvalidated.
* Changes areas, areaAssignments, tags and joinForms to use the new utility methods. 

## Notes to reviewer


## Related issues
Doesn't resolve the related issue completely. 
