### PR TITLE
Fix for issue #1982: Better responsiveness with `min-height` instead of `height` to prevent scrollbar

### DIFF
--- a/src/utils/panes/index.tsx
+++ b/src/utils/panes/index.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles({
     zIndex: 999,
   },
   paper: {
-    height: '100%',
+    minHeight: '100%',
   },
 });
 


### PR DESCRIPTION
By @Idkirsch and @troldmand 


## Description
This PR solves an issue where an internal scrollbar have been showing under very special edge-case circumstances. 

The reason was, that the pane had `height: 100%`. This maximises height on it's first render, but then if the window later is resized, it can cause the layout to shift (for example with linebreaks in the title), making the previous height insufficient. 

Instead of `height: 100%`  for panes, it should be `min-height: 100%`, then if window is resized and title has a line-break, the pane container will resize and not show the internal scrollbar.

## Screenshots
Before: 
<img width="286" alt="Screenshot 2025-06-06 at 15 43 34" src="https://github.com/user-attachments/assets/8501e79b-e860-46fc-ae64-e29beb34826f" />

After: 
<img width="302" alt="Screenshot 2025-06-06 at 15 42 17" src="https://github.com/user-attachments/assets/95da7cf3-9d43-49a6-9057-fb25cd21fd63" />

## Changes
* The `panes`, from `util/panes/index.ts`'s height is now `min-height: 100%` instead of `height: 100%`


## Notes to reviewer

- [x] Consider if `min-height` instead of `height` can have bad consequences for other cases. 

## Related issues
* Fixes issue #1982 
