### PR TITLE
Issue 2806/allow target blank zui markdown

### DIFF
--- a/src/features/call/components/InstructionsSection.tsx
+++ b/src/features/call/components/InstructionsSection.tsx
@@ -14,7 +14,7 @@ const InstructionsSection: FC<Props> = ({ instructions }) => {
       renderContent={() => (
         <ZUIText>
           {instructions ? (
-            <ZUIMarkdown markdown={instructions} />
+            <ZUIMarkdown forceTargetBlank={true} markdown={instructions} />
           ) : (
             "This assignment doesn't have instructions."
           )}

--- a/src/features/canvass/components/CanvassInstructionsPage.tsx
+++ b/src/features/canvass/components/CanvassInstructionsPage.tsx
@@ -68,7 +68,10 @@ const Page: FC<{
                     mx: 1,
                   }}
                 >
-                  <ZUIMarkdown markdown={assignment.instructions} />
+                  <ZUIMarkdown
+                    forceTargetBlank={true}
+                    markdown={assignment.instructions}
+                  />
                 </Box>
               </Card>
             ) : (

--- a/src/features/canvass/components/CanvassSidebar/index.tsx
+++ b/src/features/canvass/components/CanvassSidebar/index.tsx
@@ -53,7 +53,10 @@ const CanvassSidebar: FC<Props> = ({ assignment }) => {
             />
             <Divider sx={(theme) => ({ bgcolor: theme.palette.grey[100] })} />
             <Typography sx={{ pb: 2, pt: 2 }} variant="body2">
-              <ZUIMarkdown markdown={assignment.instructions} />
+              <ZUIMarkdown
+                forceTargetBlank={true}
+                markdown={assignment.instructions}
+              />
             </Typography>
             <Divider sx={(theme) => ({ bgcolor: theme.palette.grey[100] })} />
           </ListItem>

--- a/src/features/journeys/components/JourneyInstanceSummary.tsx
+++ b/src/features/journeys/components/JourneyInstanceSummary.tsx
@@ -97,6 +97,7 @@ const JourneyInstanceSummary = ({
                 overflowWrap: 'anywhere',
               },
             }}
+            forceTargetBlank={true}
             markdown={journeyInstance.summary}
           />
         </ZUICollapse>

--- a/src/features/tasks/components/TaskPreviewSection.tsx
+++ b/src/features/tasks/components/TaskPreviewSection.tsx
@@ -53,6 +53,7 @@ const TaskPreviewSection: React.FC<TaskPreviewSectionProps> = ({ task }) => {
           )}
           <ZUIMarkdown
             BoxProps={{ component: 'div' }}
+            forceTargetBlank={true}
             markdown={task.instructions}
           />
         </Box>

--- a/src/zui/ZUICleanHtml.tsx
+++ b/src/zui/ZUICleanHtml.tsx
@@ -4,15 +4,23 @@ import { Box, BoxProps } from '@mui/material';
 import { useMemo } from 'react';
 
 interface ZUICleanHtmlProps {
-  dirtyHtml: string;
+  allowTargetBlank?: boolean;
   BoxProps?: BoxProps;
+  dirtyHtml: string;
 }
 
 const ZUICleanHtml = ({
+  allowTargetBlank = false,
   BoxProps,
   dirtyHtml,
 }: ZUICleanHtmlProps): JSX.Element => {
-  const cleanHtml = useMemo(() => DOMPurify.sanitize(dirtyHtml), [dirtyHtml]);
+  const cleanHtml = useMemo(
+    () =>
+      DOMPurify.sanitize(dirtyHtml, {
+        ADD_ATTR: allowTargetBlank ? ['target', 'rel'] : [],
+      }),
+    [dirtyHtml]
+  );
   return <Box dangerouslySetInnerHTML={{ __html: cleanHtml }} {...BoxProps} />;
 };
 

--- a/src/zui/ZUIMarkdown.tsx
+++ b/src/zui/ZUIMarkdown.tsx
@@ -6,10 +6,33 @@ import ZUICleanHtml from './ZUICleanHtml';
 interface ZUIMarkdownProps {
   BoxProps?: BoxProps;
   markdown: string;
+  forceTargetBlank?: boolean;
 }
 
-const ZUIMarkdown: React.FC<ZUIMarkdownProps> = ({ BoxProps, markdown }) => {
+const ZUIMarkdown: React.FC<ZUIMarkdownProps> = ({
+  BoxProps,
+  markdown,
+  forceTargetBlank,
+}) => {
   const dirtyHtml = marked(markdown, { breaks: true });
+  if (forceTargetBlank) {
+    const parser = new DOMParser();
+    const parsedHtml = parser.parseFromString(dirtyHtml, 'text/html');
+    const aNodes = parsedHtml.querySelectorAll('a');
+    aNodes.forEach((a) => {
+      a.setAttribute('target', '_blank');
+      a.setAttribute('rel', 'noopener noreferrer');
+    });
+    const serializer = new XMLSerializer();
+    const dirtyNewTabHtml = serializer.serializeToString(parsedHtml);
+    return (
+      <ZUICleanHtml
+        allowTargetBlank={true}
+        BoxProps={BoxProps}
+        dirtyHtml={dirtyNewTabHtml}
+      />
+    );
+  }
   return <ZUICleanHtml BoxProps={BoxProps} dirtyHtml={dirtyHtml} />;
 };
 

--- a/src/zui/ZUITimeline/updates/TimelineJourneyStart.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyStart.tsx
@@ -29,6 +29,7 @@ const TimelineJourneyStart: React.FC<TimelineJourneyStartProps> = ({
       />
       <ZUIMarkdown
         BoxProps={{ margin: '1rem 0' }}
+        forceTargetBlank={true}
         markdown={update.details.data.opening_note}
       />
     </UpdateContainer>

--- a/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
@@ -101,6 +101,7 @@ const TimelineNoteAdded: React.FC<Props> = ({ onEditNote, update }) => {
               className: classes.note,
               component: 'div',
             }}
+            forceTargetBlank={true}
             markdown={update.details.note.text}
           />
           {!!miscFiles.length && (


### PR DESCRIPTION
## Description
The issue was that ZUIMarkdown wouldn't open a-links in a new tab
## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* added forceTargetBlank property to the ZUIMarkdownProps interface 
* added allowTargetBlank? property to the ZUICleanHtmlProps interface
* made allowTargetBlank = 'true' everywhere ZUICleanHtml is used


## Notes to reviewer
go anywhere the user needs to get details or instructions and see if the embedded link opens in a new tab


## Related issues
Resolves #2806
https://github.com/zetkin/app.zetkin.org/issues/2806
