### PR TITLE
Add project page to activist portal

### DIFF
--- a/src/app/o/[orgId]/projects/[projId]/layout.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/layout.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode } from 'react';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 
 import HomeThemeProvider from 'features/home/components/HomeThemeProvider';
 import ProjHomeLayout from 'features/campaigns/layout/ProjHomeLayout';
@@ -38,21 +39,25 @@ const MyHomeLayout: FC<Props> = async ({ children, params }) => {
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
 
-  const org = await apiClient.get<ZetkinOrganization>(
-    `/api/orgs/${params.orgId}`
-  );
+  try {
+    const org = await apiClient.get<ZetkinOrganization>(
+      `/api/orgs/${params.orgId}`
+    );
 
-  const proj = await apiClient.get<ZetkinCampaign>(
-    `/api/orgs/${params.orgId}/campaigns/${params.projId}`
-  );
+    const proj = await apiClient.get<ZetkinCampaign>(
+      `/api/orgs/${params.orgId}/campaigns/${params.projId}`
+    );
 
-  return (
-    <HomeThemeProvider>
-      <ProjHomeLayout org={org} proj={proj}>
-        {children}
-      </ProjHomeLayout>
-    </HomeThemeProvider>
-  );
+    return (
+      <HomeThemeProvider>
+        <ProjHomeLayout org={org} proj={proj}>
+          {children}
+        </ProjHomeLayout>
+      </HomeThemeProvider>
+    );
+  } catch (err) {
+    return notFound();
+  }
 };
 
 export default MyHomeLayout;

--- a/src/app/o/[orgId]/projects/[projId]/layout.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/layout.tsx
@@ -1,0 +1,58 @@
+import { FC, ReactNode } from 'react';
+import { Metadata } from 'next';
+import { headers } from 'next/headers';
+
+import HomeThemeProvider from 'features/home/components/HomeThemeProvider';
+import ProjHomeLayout from 'features/campaigns/layout/ProjHomeLayout';
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinCampaign, ZetkinOrganization } from 'utils/types/zetkin';
+
+type Props = {
+  children: ReactNode;
+  params: {
+    orgId: number;
+    projId: number;
+  };
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+
+  const proj = await apiClient.get<ZetkinCampaign>(
+    `/api/orgs/${params.orgId}/campaigns/${params.projId}`
+  );
+
+  return {
+    icons: [{ url: '/logo-zetkin.png' }],
+    title: proj.title,
+  };
+}
+
+// @ts-expect-error https://nextjs.org/docs/app/building-your-application/configuring/typescript#async-server-component-typescript-error
+const MyHomeLayout: FC<Props> = async ({ children, params }) => {
+  const headersList = headers();
+  const headersEntries = headersList.entries();
+  const headersObject = Object.fromEntries(headersEntries);
+  const apiClient = new BackendApiClient(headersObject);
+
+  const org = await apiClient.get<ZetkinOrganization>(
+    `/api/orgs/${params.orgId}`
+  );
+
+  const proj = await apiClient.get<ZetkinCampaign>(
+    `/api/orgs/${params.orgId}/campaigns/${params.projId}`
+  );
+
+  return (
+    <HomeThemeProvider>
+      <ProjHomeLayout org={org} proj={proj}>
+        {children}
+      </ProjHomeLayout>
+    </HomeThemeProvider>
+  );
+};
+
+export default MyHomeLayout;

--- a/src/app/o/[orgId]/projects/[projId]/page.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/page.tsx
@@ -1,12 +1,17 @@
-import { redirect } from 'next/navigation';
+'use server';
 
-export default function Page({
-  params,
-}: {
-  params: { orgId: string; projId: string };
-}) {
-  const { orgId, projId } = params;
-  redirect(
-    `http://${process.env.ZETKIN_API_DOMAIN}/o/${orgId}/campaigns/${projId}`
-  );
-}
+import { FC } from 'react';
+
+import PublicProjPage from 'features/organizations/pages/PublicProjPage';
+
+type Props = {
+  params: {
+    orgId: number;
+  };
+};
+
+const Page: FC<Props> = ({ params }) => {
+  return <PublicProjPage orgId={params.orgId} />;
+};
+
+export default Page;

--- a/src/app/o/[orgId]/projects/[projId]/page.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/page.tsx
@@ -2,16 +2,17 @@
 
 import { FC } from 'react';
 
-import PublicProjPage from 'features/organizations/pages/PublicProjPage';
+import PublicProjPage from 'features/campaigns/pages/PublicProjPage';
 
 type Props = {
   params: {
     orgId: number;
+    projId: number;
   };
 };
 
 const Page: FC<Props> = ({ params }) => {
-  return <PublicProjPage orgId={params.orgId} />;
+  return <PublicProjPage orgId={params.orgId} projId={params.projId} />;
 };
 
 export default Page;

--- a/src/features/campaigns/hooks/useCampaignAllEvents.ts
+++ b/src/features/campaigns/hooks/useCampaignAllEvents.ts
@@ -1,0 +1,33 @@
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+import { ZetkinEvent } from 'utils/types/zetkin';
+import {
+  campaignEventsLoad,
+  campaignEventsLoaded,
+} from 'features/events/store';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+
+export default function useCampaignEvents(
+  orgId: number,
+  campId: number
+): ZetkinEvent[] {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const eventsByCampaignId = useAppSelector(
+    (state) => state.events.eventsByCampaignId
+  );
+
+  const campaignEventsFuture = loadListIfNecessary(
+    eventsByCampaignId[campId],
+    dispatch,
+    {
+      actionOnLoad: () => campaignEventsLoad(campId),
+      actionOnSuccess: (data) => campaignEventsLoaded([campId, data]),
+      loader: () =>
+        apiClient.get<ZetkinEvent[]>(
+          `/api/orgs/${orgId}/campaigns/${campId}/actions`
+        ),
+    }
+  );
+
+  return campaignEventsFuture.data || [];
+}

--- a/src/features/campaigns/layout/ProjHomeLayout.tsx
+++ b/src/features/campaigns/layout/ProjHomeLayout.tsx
@@ -102,7 +102,7 @@ const ProjHomeLayout: FC<Props> = ({ children, org, proj }) => {
         >
           <Box sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
             <ZUIText variant="headingLg">{proj.title}</ZUIText>
-            <ZUIText>{proj.info_text}</ZUIText>
+            {proj.info_text ? <ZUIText>{proj.info_text}</ZUIText> : null}
           </Box>
         </Box>
       </Box>

--- a/src/features/campaigns/layout/ProjHomeLayout.tsx
+++ b/src/features/campaigns/layout/ProjHomeLayout.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { FC, ReactNode, Suspense } from 'react';
+import NextLink from 'next/link';
+import { NorthWest } from '@mui/icons-material';
+
+import { useMessages } from 'core/i18n';
+import messageIds from '../../organizations/l10n/messageIds';
+import useUser from 'core/hooks/useUser';
+import ZUILogo from 'zui/ZUILogo';
+import { useEnv } from 'core/hooks';
+import { ZetkinCampaign, ZetkinOrganization } from 'utils/types/zetkin';
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+import ZUIButton from 'zui/components/ZUIButton';
+import ZUIOldAvatar from 'zui/ZUIAvatar';
+import ZUIPersonAvatar from 'zui/components/ZUIPersonAvatar';
+import ZUIText from 'zui/components/ZUIText';
+import ZUILink from 'zui/components/ZUILink';
+import useMembership from '../../organizations/hooks/useMembership';
+import useConnectOrg from '../../organizations/hooks/useConnectOrg';
+
+type Props = {
+  children: ReactNode;
+  org: ZetkinOrganization;
+  proj: ZetkinCampaign;
+};
+
+const ProjHomeLayout: FC<Props> = ({ children, org, proj }) => {
+  const messages = useMessages(messageIds);
+  const env = useEnv();
+
+  const user = useUser();
+  const membership = useMembership(org.id).data;
+
+  const { connectOrg } = useConnectOrg(org.id);
+
+  return (
+    <Box
+      sx={{
+        marginX: 'auto',
+        maxWidth: 960,
+      }}
+    >
+      <Box
+        sx={(theme) => ({
+          bgcolor: theme.palette.grey[100],
+          display: 'flex',
+          flexDirection: 'column',
+        })}
+      >
+        <Box sx={{ mb: 6, minHeight: 40, mt: 2, mx: 2, opacity: 0.7 }}>
+          {org.parent && (
+            <NextLink href={`/o/${org.parent.id}`} passHref>
+              <ZUIButton label={org.parent.title} startIcon={NorthWest} />
+            </NextLink>
+          )}
+        </Box>
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'space-between',
+            mx: 2,
+          }}
+        >
+          <Box sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
+            <ZUIOldAvatar size="md" url={`/api/orgs/${org.id}/avatar`} />
+            <ZUIText variant="headingLg">{org.title}</ZUIText>
+
+            {user && !membership && (
+              <ZUIButton
+                label={messages.home.header.connect()}
+                onClick={() => connectOrg()}
+              />
+            )}
+            {!user && (
+              <ZUIButton
+                href={`/login?redirect=${encodeURIComponent(`/o/${org.id}`)}`}
+                label={messages.home.header.login()}
+              />
+            )}
+          </Box>
+          {user && (
+            <NextLink href="/my">
+              <ZUIPersonAvatar
+                firstName={user.first_name}
+                id={user.id}
+                lastName={user.last_name}
+              />
+            </NextLink>
+          )}
+        </Box>
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'space-between',
+            mx: 2,
+            my: 1,
+          }}
+        >
+          <Box sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
+            <ZUIText variant="headingLg">{proj.title}</ZUIText>
+            <ZUIText>{proj.info_text}</ZUIText>
+          </Box>
+        </Box>
+      </Box>
+      <Suspense
+        fallback={
+          <Box
+            alignItems="center"
+            display="flex"
+            flexDirection="column"
+            height="90dvh"
+            justifyContent="center"
+          >
+            <ZUILogoLoadingIndicator />
+          </Box>
+        }
+      >
+        <Box minHeight="90dvh">{children}</Box>
+      </Suspense>
+      <Box
+        alignItems="center"
+        component="footer"
+        display="flex"
+        flexDirection="column"
+        mx={1}
+        my={2}
+        sx={{ opacity: 0.75 }}
+      >
+        <ZUILogo />
+        <ZUIText variant="bodySmRegular">Zetkin</ZUIText>
+        <ZUILink
+          href={
+            env.vars.ZETKIN_PRIVACY_POLICY_LINK ||
+            'https://www.zetkin.org/privacy'
+          }
+          size="small"
+          text={messages.home.footer.privacyPolicy()}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default ProjHomeLayout;

--- a/src/features/campaigns/layout/ProjHomeLayout.tsx
+++ b/src/features/campaigns/layout/ProjHomeLayout.tsx
@@ -100,7 +100,14 @@ const ProjHomeLayout: FC<Props> = ({ children, org, proj }) => {
             my: 1,
           }}
         >
-          <Box sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
+          <Box
+            sx={{
+              alignItems: 'left',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+            }}
+          >
             <ZUIText variant="headingLg">{proj.title}</ZUIText>
             {proj.info_text ? <ZUIText>{proj.info_text}</ZUIText> : null}
           </Box>

--- a/src/features/organizations/pages/PublicProjPage.tsx
+++ b/src/features/organizations/pages/PublicProjPage.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import dayjs from 'dayjs';
+import { Box, Fade } from '@mui/material';
+import { FC, useMemo, useState } from 'react';
+
+import useUpcomingOrgEvents from '../hooks/useUpcomingOrgEvents';
+import EventListItem from 'features/home/components/EventListItem';
+import { ZetkinEventWithStatus } from 'features/home/types';
+import useIncrementalDelay from 'features/home/hooks/useIncrementalDelay';
+import ZUIDate from 'zui/ZUIDate';
+import SubOrgEventBlurb from '../components/SubOrgEventBlurb';
+import { ZetkinEvent } from 'utils/types/zetkin';
+import useUser from 'core/hooks/useUser';
+import { Msg, useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+import useMyEvents from 'features/events/hooks/useMyEvents';
+import NoEventsBlurb from '../components/NoEventsBlurb';
+import ZUIText from 'zui/components/ZUIText';
+import ZUIModal from 'zui/components/ZUIModal';
+import ZUIDivider from 'zui/components/ZUIDivider';
+
+type Props = {
+  orgId: number;
+};
+
+const PublicProjPage: FC<Props> = ({ orgId }) => {
+  const messages = useMessages(messageIds);
+  const [postAuthEvent, setPostAuthEvent] = useState<ZetkinEvent | null>(null);
+  const [includeSubOrgs, setIncludeSubOrgs] = useState(false);
+  const nextDelay = useIncrementalDelay();
+  const orgEvents = useUpcomingOrgEvents(orgId);
+  const myEvents = useMyEvents();
+  const user = useUser();
+
+  const allEvents = useMemo(() => {
+    return orgEvents.map<ZetkinEventWithStatus>((event) => ({
+      ...event,
+      status:
+        myEvents.find((userEvent) => userEvent.id == event.id)?.status || null,
+    }));
+  }, [orgEvents]);
+
+  const topOrgEvents = allEvents.filter(
+    (event) => event.organization.id == orgId
+  );
+
+  const events =
+    includeSubOrgs || topOrgEvents.length == 0 ? allEvents : topOrgEvents;
+
+  const eventsByDate = events.reduce<Record<string, ZetkinEventWithStatus[]>>(
+    (dates, event) => {
+      const eventDate = event.start_time.slice(0, 10);
+      const existingEvents = dates[eventDate] || [];
+
+      const firstFilterDate = dayjs().format('YYYY-MM-DD');
+
+      const dateToSortAs =
+        firstFilterDate && eventDate < firstFilterDate
+          ? firstFilterDate
+          : eventDate;
+
+      return {
+        ...dates,
+        [dateToSortAs]: [...existingEvents, event],
+      };
+    },
+    {}
+  );
+
+  const dates = Object.keys(eventsByDate).sort();
+  const indexForSubOrgsButton = Math.min(1, dates.length - 1);
+  const showSubOrgBlurb = allEvents.length > events.length;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, my: 2 }}>
+      {!dates.length && (
+        <Box key="empty">
+          <NoEventsBlurb orgId={orgId} />
+        </Box>
+      )}
+      {dates.map((date, index) => (
+        <Box key={date} paddingX={1}>
+          <Fade appear in mountOnEnter style={{ transitionDelay: nextDelay() }}>
+            <Box sx={{ mb: 2, mt: 3 }}>
+              <ZUIText variant="headingMd">
+                <ZUIDate datetime={date} />
+              </ZUIText>
+            </Box>
+          </Fade>
+          <Fade appear in mountOnEnter style={{ transitionDelay: nextDelay() }}>
+            <Box display="flex" flexDirection="column" gap={1}>
+              {eventsByDate[date].map((event) => (
+                <EventListItem
+                  key={event.id}
+                  event={event}
+                  onClickSignUp={(ev) => {
+                    if (!user) {
+                      setPostAuthEvent(event);
+                      ev.preventDefault();
+                    }
+                  }}
+                />
+              ))}
+            </Box>
+          </Fade>
+          {index == indexForSubOrgsButton && showSubOrgBlurb && (
+            <Fade
+              appear
+              in
+              mountOnEnter
+              style={{ transitionDelay: nextDelay() }}
+            >
+              <Box sx={{ my: 4 }}>
+                <ZUIDivider />
+                <SubOrgEventBlurb
+                  onClickShow={() => setIncludeSubOrgs(true)}
+                  subOrgEvents={allEvents.filter(
+                    (event) => event.organization.id != orgId
+                  )}
+                />
+                <ZUIDivider />
+              </Box>
+            </Fade>
+          )}
+        </Box>
+      ))}
+      <ZUIModal
+        onClose={() => setPostAuthEvent(null)}
+        open={!!postAuthEvent}
+        primaryButton={{
+          href: `/login?redirect=${encodeURIComponent(`/o/${orgId}`)}`,
+          label: messages.authDialog.loginButton(),
+        }}
+        secondaryButton={{
+          label: messages.authDialog.cancelButton(),
+          onClick: () => setPostAuthEvent(null),
+        }}
+        size="small"
+        title={messages.authDialog.label()}
+      >
+        <Box sx={{ paddingTop: '0.75rem' }}>
+          <ZUIText>
+            <Msg id={messageIds.authDialog.content} />
+          </ZUIText>
+        </Box>
+      </ZUIModal>
+    </Box>
+  );
+};
+
+export default PublicProjPage;


### PR DESCRIPTION
## Description
This PR adds a page for a project to the activist portal. It meets the minimum requirements specified in issue #2801. It is not yet linked from any other page in the activist portal.


## Screenshots
![Screenshot From 2025-06-06 18-15-57](https://github.com/user-attachments/assets/96720f15-1907-41a2-b2c5-81a553294de4)


## Changes
* Adds a page for a project to the activist portal (replacing previous redirect)
* Adds hook useCampaignAllEvents, returning all events for a particular project


## Notes to reviewer
The code is mostly duplicated from the organisation page, so there is still room to refactor what is common. The design of the header could still use some work (e.g. the description text is not vertically aligned with the project name). The organisation header does not link back to the organisation page.


## Related issues
Resolves #2801
