### PR TITLE
Remove non-text survey answers from searchableStrings

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -57,7 +57,9 @@ export default class SurveyResponseColumnType
   }
 
   getSearchableStrings(cell: SurveyResponseViewCell): string[] {
-    return cell.map((response) => response.text);
+    return cell
+      .map((response) => response?.text)
+      .filter((e) => typeof e == 'string');
   }
 }
 


### PR DESCRIPTION
## Description
This PR makes sure to only search survey responses that has a text answer, eg. not unanswered questions with null answers, when searching in a list.


## Screenshots

## Changes

* Changes searchableStrings in SurveyResponseColumnType to filter out  non text (null) answers.


## Notes to reviewer

See http://localhost:3000/organize/1/people/lists/198

## Related issues
Resolves #2786 
