### PR TITLE
wait for patch request

### DIFF
--- a/src/features/home/components/AppPreferences.tsx
+++ b/src/features/home/components/AppPreferences.tsx
@@ -75,8 +75,8 @@ const AppPreferences: FC<Props> = ({ user }) => {
               <ZUIButton
                 disabled={selectedLanguage == user.lang}
                 label={messages.settings.appPreferences.lang.saveButton()}
-                onClick={() => {
-                  updateUser({ lang: selectedLanguage });
+                onClick={async () => {
+                  await updateUser({ lang: selectedLanguage });
                   location.reload();
                 }}
                 size="large"


### PR DESCRIPTION
## Description
This PR
* Fixes issue that the user language does not update


## Screenshots
[Add screenshots here]


## Changes

* Changes
  * Await request to update user settings before reloading page  

## Notes to reviewer
* http://localhost:3000/my/home
* Go to settings and pick a language
* Check the language is persisted


## Related issues
Resolves #2612 
