### PR TITLE
Issue 2674/ Journeys hiding columns do not persist

### DIFF
--- a/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/index.tsx
@@ -35,19 +35,9 @@ const JourneyInstancesDataTable: FunctionComponent<JourneysDataTableProps> = ({
     useConfigurableDataGridColumns(storageKey, rawColumns);
 
   // Set column state to persist on page reload
-  function visibilityModelFromColumns() {
-    const defaultVisibilityModel: { [key: string]: boolean } = {};
-    const columnFields = rawColumns.map((col) => col.field);
-
-    columnFields.forEach((field) => {
-      defaultVisibilityModel[field] = true;
-    });
-    return defaultVisibilityModel;
-  }
-
   const [visibleColumns, setVisibleColumns] = useLocalStorage(
     'visibleColumns',
-    visibilityModelFromColumns()
+    {}
   );
 
   // Add localised header titles


### PR DESCRIPTION
## Description
This PR fixes the issue of hidden columns in Journeys not persisting after page reload by saving a snapshot of the DataGrid to local storage. 

## Screenshots
After page reload:

![Screenshot From 2025-06-07 12-39-41](https://github.com/user-attachments/assets/50ea6e83-0103-4f7b-9778-2eca3232c0d1)

## Changes
Added code to save DataGrid state snapshot to localStorage. 

## Notes to reviewer
Some Playwright test were skipped, everything else passes.


## Related issues
Resolves #2674 
