### PR TITLE
Inform the user if the shared list link they are using doesn't exist or is not shared

### DIFF
--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -42,9 +42,14 @@ async function getAccessLevel(
     return 'configure';
   }
 
-  const accessList = await apiClient.get<ZetkinObjectAccess[]>(
-    `/api/orgs/${orgId}/people/views/${viewId}/access`
-  );
+  let accessList: ZetkinObjectAccess[] = [];
+  try {
+    accessList = await apiClient.get<ZetkinObjectAccess[]>(
+      `/api/orgs/${orgId}/people/views/${viewId}/access`
+    );
+  } catch (e) {
+    return null;
+  }
   const accessObject = accessList.find(
     (obj) => obj.person.id == myMembership.profile.id
   );
@@ -63,23 +68,30 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
     parseInt(viewId as string)
   );
 
+  if (accessLevel == null) {
+    return {
+      notFound: true,
+    };
+  }
+
   try {
     await apiClient.get<ZetkinView>(
       `/api/orgs/${orgId}/people/views/${viewId}`
     );
-
-    return {
-      props: {
-        accessLevel,
-        orgId,
-        viewId,
-      },
-    };
   } catch (err) {
     return {
       notFound: true,
     };
   }
+
+
+  return {
+    props: {
+      accessLevel,
+      orgId,
+      viewId,
+    },
+  };
 }, scaffoldOptions);
 
 type SharedViewPageProps = {

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -84,7 +84,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
     };
   }
 
-
   return {
     props: {
       accessLevel,


### PR DESCRIPTION

## Description
This PR attempts to show the user a useful error message if they cant view a shared list.

Parts of the code violates the lint rule regarding rules of hooks (conditionally running hooks), but given that the access level cannot change without reloading the entire page, it should not become a problem. I'm not sure what the best way to fix this without ignoring rules is.

## Screenshots

![image](https://github.com/user-attachments/assets/4638964a-40cd-4080-9e57-d327988ac45a)


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes the view shared list page to detect disallowed access or access to non-existing list.

## Notes to reviewer

A list that exists but is not shared, ex. http://localhost:3000/organize/1/people/lists/199/shared without being logged in or logged in as a user that does not have access, and access a list that does not exist. Both should give the user a similar message.

## Related issues
Resolves #2708
