### PR TITLE
Issue 1578/invalidate dependent lists

### DIFF
--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -1,5 +1,6 @@
 import createStyles from '@mui/styles/createStyles';
 import makeStyles from '@mui/styles/makeStyles';
+import NextLink from 'next/link';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import { Theme } from '@mui/material/styles';
 import { Breadcrumbs, Link, Typography, useMediaQuery } from '@mui/material';
@@ -75,19 +76,39 @@ const BreadcrumbTrail = ({
         maxItems={smallScreen ? 2 : mediumScreen ? 4 : largeScreen ? 6 : 10}
         separator={<NavigateNextIcon fontSize="small" />}
       >
-        {breadcrumbs.map((crumb, index) => {
+        {breadcrumbs.map((crumb: Breadcrumb, index: number) => {
+          const isOrganizeRegex = new RegExp('/organize/[0-9]+(?!/)');
           if (index < breadcrumbs.length - 1) {
-            return (
-              <Link
-                key={crumb.href}
-                className={classes.breadcrumb}
-                color="inherit"
-                href={crumb.href}
-                underline="hover"
-              >
-                {getLabel(crumb)}
-              </Link>
-            );
+            if (isOrganizeRegex.test(crumb.href)) {
+              return (
+                <Link
+                  key={crumb.href}
+                  className={classes.breadcrumb}
+                  color="inherit"
+                  href={crumb.href}
+                  underline="hover"
+                >
+                  {getLabel(crumb)}
+                </Link>
+              );
+            } else {
+              return (
+                <NextLink
+                  key={crumb.href}
+                  href={crumb.href}
+                  legacyBehavior
+                  passHref
+                >
+                  <Link
+                    className={classes.breadcrumb}
+                    color="inherit"
+                    underline="hover"
+                  >
+                    {getLabel(crumb)}
+                  </Link>
+                </NextLink>
+              );
+            }
           } else {
             return (
               <Typography

--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -77,38 +77,23 @@ const BreadcrumbTrail = ({
         separator={<NavigateNextIcon fontSize="small" />}
       >
         {breadcrumbs.map((crumb: Breadcrumb, index: number) => {
-          const isOrganizeRegex = new RegExp('/organize/[0-9]+(?!/)');
           if (index < breadcrumbs.length - 1) {
-            if (isOrganizeRegex.test(crumb.href)) {
-              return (
+            return (
+              <NextLink
+                key={crumb.href}
+                href={crumb.href}
+                legacyBehavior
+                passHref
+              >
                 <Link
-                  key={crumb.href}
                   className={classes.breadcrumb}
                   color="inherit"
-                  href={crumb.href}
                   underline="hover"
                 >
                   {getLabel(crumb)}
                 </Link>
-              );
-            } else {
-              return (
-                <NextLink
-                  key={crumb.href}
-                  href={crumb.href}
-                  legacyBehavior
-                  passHref
-                >
-                  <Link
-                    className={classes.breadcrumb}
-                    color="inherit"
-                    underline="hover"
-                  >
-                    {getLabel(crumb)}
-                  </Link>
-                </NextLink>
-              );
-            }
+              </NextLink>
+            );
           } else {
             return (
               <Typography

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -542,34 +542,39 @@ interface Dependency {
 }
 
 function invalidateDependentViews(
-  viewUpdatedId: number | undefined,
+  updatedViewId: number | undefined,
   state: ViewsStoreSlice
 ) {
   const dependencies = getViewDependencies(state);
-  const viewsVisited = [];
+  const viewsCheckedForDependencies = [];
   const viewsQueue = [];
 
-  while (dependencies.length > 0 && viewUpdatedId) {
-    viewsVisited.push(viewUpdatedId);
+  while (dependencies.length > 0 && updatedViewId) {
+    viewsCheckedForDependencies.push(updatedViewId);
 
     for (let i = 0; i < dependencies.length; i++) {
-      if (dependencies[i].to == viewUpdatedId) {
-        if (!viewsVisited.includes(dependencies[i].from)) {
-          viewsQueue.push(dependencies[i].from);
+
+      const dependency = dependencies[i];
+      const isDependentOnUpdatedView = dependency.to == updatedViewId
+
+      if (isDependentOnUpdatedView) {
+        const alreadyChecked = viewsCheckedForDependencies.includes(dependency.from)
+
+        if (!alreadyChecked) {
+          viewsQueue.push(dependency.from);
         }
 
-        const updatedViewRows = state.rowsByViewId[dependencies[i].from];
-
-        if (updatedViewRows) {
-          updatedViewRows.items = [];
-          updatedViewRows.isStale = true;
+        const viewRowsToInvalidate = state.rowsByViewId[dependency.from];
+        if (viewRowsToInvalidate) {
+          viewRowsToInvalidate.items = [];
+          viewRowsToInvalidate.isStale = true;
         }
 
         dependencies.splice(i, 1);
         i--;
       }
     }
-    viewUpdatedId = viewsQueue.pop();
+    updatedViewId = viewsQueue.pop();
   }
 }
 

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -542,18 +542,18 @@ interface Dependency {
 }
 
 function invalidateDependentViews(
-  viewUpdated: number | undefined,
+  viewUpdatedId: number | undefined,
   state: ViewsStoreSlice
 ) {
   const dependencies = getViewDependencies(state);
   const viewsVisited = [];
   const viewsQueue = [];
 
-  while (dependencies.length > 0 && viewUpdated) {
-    viewsVisited.push(viewUpdated);
+  while (dependencies.length > 0 && viewUpdatedId) {
+    viewsVisited.push(viewUpdatedId);
 
     for (let i = 0; i < dependencies.length; i++) {
-      if (dependencies[i].to == viewUpdated) {
+      if (dependencies[i].to == viewUpdatedId) {
         if (!viewsVisited.includes(dependencies[i].from)) {
           viewsQueue.push(dependencies[i].from);
         }
@@ -569,7 +569,7 @@ function invalidateDependentViews(
         i--;
       }
     }
-    viewUpdated = viewsQueue.pop();
+    viewUpdatedId = viewsQueue.pop();
   }
 }
 

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -553,12 +553,13 @@ function invalidateDependentViews(
     viewsCheckedForDependencies.push(updatedViewId);
 
     for (let i = 0; i < dependencies.length; i++) {
-
       const dependency = dependencies[i];
-      const isDependentOnUpdatedView = dependency.to == updatedViewId
+      const isDependentOnUpdatedView = dependency.to == updatedViewId;
 
       if (isDependentOnUpdatedView) {
-        const alreadyChecked = viewsCheckedForDependencies.includes(dependency.from)
+        const alreadyChecked = viewsCheckedForDependencies.includes(
+          dependency.from
+        );
 
         if (!alreadyChecked) {
           viewsQueue.push(dependency.from);

--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -86,7 +86,7 @@ async function fetchElements(
     const org = await apiFetch(`/orgs/${orgId}`).then((res) => res.json());
     return [
       {
-        href: basePath + '/' + fieldValue,
+        href: basePath + '/' + fieldValue + '/projects',
         label: org.data.title,
       },
     ];


### PR DESCRIPTION
## Description
Context:

- The original bug is like this: We have one _list_ that in turn is getting people from another _list_ . When updating the root/source _list_ , and navigating to the _list_ dependent on the root/source, we wouldn't see the changes. This is because the cache is invalid, but it hasn't been marked as invalid. Refreshing the page works, as we then fetch data from backend again. 
- However, this issue is not currently reproducible, because pressing the breadcrumbs links forces a refresh as well.
- Breadcrumb link refresh was enabled in #2637 because of a bug. However, the bug is only for the organization breadcrumb, not all other types of breadcrumbs. 
- This PR changes the BreadCrumbTrail.tsx file to avoid refreshing the entire page 
- To fix the bug from #2637, we redirect the organize/[org_id] page to the /projects page. Which is already done elsewhere in the project.  
- After doing this change, it was possible to trigger the issue from #1578 and I've implemented a fix in the store to invalidate dependent _lists_. 
- The functionality is implemented to work with multiple levels of dependencies. Circular dependencies are not allowed in backend, which will cause other issues, but this change still supports it without being caught in infinite loops. 
- I've tried to limit performance impact.

## Screenshots
![image](https://github.com/user-attachments/assets/ecf622bc-16e2-4465-94e9-5ca161411ed4)

![image](https://github.com/user-attachments/assets/f41318fe-0333-4941-9ea1-9efd493e0f72)


## Notes to reviewer
You can use the second organization test data, from the image above: https://app.dev.zetkin.org/organize/2/people/folders/55

1. Create a _list_ dependent on another _list_ (which might be dependent on another _list_ in turn). Use the cross reference option in the smart search
2. Update the source/root _list_ 
3. Click the breadcrumbs to navigate back to the folder/people page

Expected: The whole page does not refresh

4. Click a _list_ dependent on the changed _list_ 

Expected: The changes in the source/root _list_ are reflected in the changed _list_ 


## Related issues
Resolves #1578 
