### PR TITLE
Issue-2789: Add Multiple Persons to Events based on lists

### DIFF
--- a/src/features/callAssignments/hooks/useCallers.ts
+++ b/src/features/callAssignments/hooks/useCallers.ts
@@ -16,12 +16,12 @@ import {
 } from '../store';
 import { IFuture, PromiseFuture, ResolvedFuture } from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-import { ZetkinPerson, ZetkinTag } from 'utils/types/zetkin';
+import { ZetkinTag } from 'utils/types/zetkin';
 
 interface UseCallersReturn {
   addCaller: (callerId: number) => PromiseFuture<CallAssignmentCaller>;
   filteredCallersFuture: IFuture<CallAssignmentCaller[]>;
-  isCaller: (person: ZetkinPerson) => boolean;
+  isCaller: (personId: number) => boolean;
   removeCaller: (callerId: number) => void;
   searchString: string;
   selectedCaller: CallAssignmentCaller | null;
@@ -126,8 +126,8 @@ export default function useCallers(
       });
   };
 
-  const isCaller = (person: ZetkinPerson) =>
-    !!filteredCallersFuture.data?.find((caller) => caller.id == person.id);
+  const isCaller = (personId: number) =>
+    !!allCallersFuture.data?.find((caller) => caller.id == personId);
 
   return {
     addCaller,

--- a/src/features/events/components/AddPersonButton.tsx
+++ b/src/features/events/components/AddPersonButton.tsx
@@ -110,6 +110,10 @@ const AddPersonButton = ({ orgId, eventId }: AddPersonButtonProps) => {
 
               return (
                 <ZUIPersonSelect
+                  createPersonLabels={{
+                    submitLabel: zuiMessages.createPerson.submitLabel.add(),
+                    title: zuiMessages.createPerson.title.participant(),
+                  }}
                   getOptionDisabled={(option) =>
                     participants.some(
                       (participant) => participant.id == option.id
@@ -124,8 +128,6 @@ const AddPersonButton = ({ orgId, eventId }: AddPersonButtonProps) => {
                   }}
                   placeholder={messages.addPerson.addPlaceholder()}
                   selectedPerson={null}
-                  submitLabel={zuiMessages.createPerson.submitLabel.add()}
-                  title={zuiMessages.createPerson.title.participant()}
                   variant="outlined"
                 />
               );

--- a/src/features/events/components/EventContactCard.tsx
+++ b/src/features/events/components/EventContactCard.tsx
@@ -90,11 +90,13 @@ const ContactSelect: FC<ContactSelectProps> = ({ orgId, eventId }) => {
   return (
     <Box m={1} mb={5} mt={3}>
       <ZUIPersonSelect
+        createPersonLabels={{
+          submitLabel: zuiMessages.createPerson.submitLabel.assign(),
+          title: zuiMessages.createPerson.title.contact(),
+        }}
         onChange={(person) => handleSelectedPerson(person.id)}
         placeholder={messages.eventContactCard.selectPlaceholder()}
         selectedPerson={null}
-        submitLabel={zuiMessages.createPerson.submitLabel.assign()}
-        title={zuiMessages.createPerson.title.contact()}
         variant="outlined"
       />
     </Box>

--- a/src/features/journeys/components/JourneyInstanceSidebar.tsx
+++ b/src/features/journeys/components/JourneyInstanceSidebar.tsx
@@ -86,6 +86,12 @@ const JourneyInstanceSidebar = ({
             <ClickAwayListener onClickAway={() => setAddingAssignee(false)}>
               <div>
                 <PersonSelect
+                  createPersonLabels={{
+                    submitLabel: zuiMessages.createPerson.submitLabel.assign(),
+                    title: zuiMessages.createPerson.title.assignToJourney({
+                      journey: journeyInstance.journey.singular_label,
+                    }),
+                  }}
                   data-testid="PersonSelect-add-assignee"
                   getOptionDisabled={(option) => {
                     return journeyInstance.assignees
@@ -100,10 +106,6 @@ const JourneyInstanceSidebar = ({
                   }}
                   selectedPerson={null}
                   size="small"
-                  submitLabel={zuiMessages.createPerson.submitLabel.assign()}
-                  title={zuiMessages.createPerson.title.assignToJourney({
-                    journey: journeyInstance.journey.singular_label,
-                  })}
                 />
               </div>
             </ClickAwayListener>
@@ -138,6 +140,12 @@ const JourneyInstanceSidebar = ({
             <ClickAwayListener onClickAway={() => setAddingSubject(false)}>
               <div>
                 <PersonSelect
+                  createPersonLabels={{
+                    submitLabel: zuiMessages.createPerson.submitLabel.add(),
+                    title: zuiMessages.createPerson.title.addToList({
+                      list: journeyInstance.journey.singular_label,
+                    }),
+                  }}
                   getOptionDisabled={(option) => {
                     return journeyInstance.subjects
                       .map((s) => s.id)
@@ -151,10 +159,6 @@ const JourneyInstanceSidebar = ({
                   }}
                   selectedPerson={null}
                   size="small"
-                  submitLabel={zuiMessages.createPerson.submitLabel.add()}
-                  title={zuiMessages.createPerson.title.addToJourney({
-                    journey: journeyInstance.journey.singular_label,
-                  })}
                 />
               </div>
             </ClickAwayListener>

--- a/src/features/views/components/EmptyView.tsx
+++ b/src/features/views/components/EmptyView.tsx
@@ -45,16 +45,18 @@ const EmptyView: FunctionComponent<EmptyViewProps> = ({ orgId, view }) => {
               </Typography>
               <Box marginTop={2}>
                 <PersonSelect
+                  createPersonLabels={{
+                    submitLabel: messages.createPerson.submitLabel.add(),
+                    title: messages.createPerson.title.addToList({
+                      list: view.title,
+                    }),
+                  }}
                   name="person"
                   onChange={async (person) => {
                     await deleteContentQuery();
                     await addPerson(person.id);
                   }}
                   selectedPerson={null}
-                  submitLabel={messages.createPerson.submitLabel.add()}
-                  title={messages.createPerson.title.addToList({
-                    list: view.title,
-                  })}
                   variant="outlined"
                 />
               </Box>

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,7 +1,7 @@
 import { makeStyles } from '@mui/styles';
 import NextLink from 'next/link';
 import { CircularProgress, Link, Theme } from '@mui/material';
-import { FC, useContext } from 'react';
+import { FC, MouseEvent, useContext } from 'react';
 
 import BrowserDraggableItem from './BrowserDragableItem';
 import { Msg } from 'core/i18n';
@@ -14,6 +14,7 @@ import messageIds from 'features/views/l10n/messageIds';
 interface BrowserItemProps {
   basePath: string;
   item: ViewBrowserItem;
+  onClick: (ev: MouseEvent) => void;
 }
 
 const useStyles = makeStyles<Theme, BrowserRowDropProps>({
@@ -27,7 +28,7 @@ const useStyles = makeStyles<Theme, BrowserRowDropProps>({
   },
 });
 
-const BrowserItem: FC<BrowserItemProps> = ({ basePath, item }) => {
+const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, onClick }) => {
   const dropProps = useContext(BrowserRowContext);
   const styles = useStyles(dropProps);
   const { orgId } = useNumericRouteParams();
@@ -38,7 +39,7 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item }) => {
 
     return (
       <NextLink href={`${basePath}/${subPath}`} legacyBehavior passHref>
-        <Link className={styles.itemLink}>
+        <Link className={styles.itemLink} onClick={(ev) => onClick(ev)}>
           {item.title ? (
             <Msg
               id={
@@ -64,7 +65,9 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item }) => {
     return (
       <BrowserDraggableItem item={item}>
         <NextLink href={`${basePath}/${item.id}`} legacyBehavior passHref>
-          <Link className={styles.itemLink}>{item.title}</Link>
+          <Link className={styles.itemLink} onClick={(ev) => onClick(ev)}>
+            {item.title}
+          </Link>
         </NextLink>
         {itemIsRenaming(item.type, item.data.id) && (
           <CircularProgress size={20} />

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -32,11 +32,10 @@ import MoveViewDialog from '../MoveViewDialog';
 
 interface ViewBrowserProps {
   basePath: string;
+  enableDragAndDrop?: boolean;
+  enableEllipsisMenu?: boolean;
   folderId?: number | null;
   onSelect?: (item: ViewBrowserItem, ev: MouseEvent) => void;
-  // TODO #2789: Better to separate out into
-  // `enableDragAndDrop` and `enableEllipsisMenu`?
-  readOnly?: boolean;
 }
 
 const TYPE_SORT_ORDER = ['back', 'folder', 'view'];
@@ -49,9 +48,10 @@ function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
 
 const ViewBrowser: FC<ViewBrowserProps> = ({
   basePath,
+  enableDragAndDrop = true,
+  enableEllipsisMenu = true,
   folderId = null,
   onSelect,
-  readOnly,
 }) => {
   const { orgId } = useNumericRouteParams();
 
@@ -157,7 +157,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
       },
     });
 
-    if (!readOnly) {
+    if (enableEllipsisMenu) {
       colDefs.push({
         field: 'menu',
         headerName: '',
@@ -263,7 +263,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
 
         return (
           <>
-            {!readOnly && <BrowserDragLayer />}
+            {enableDragAndDrop && <BrowserDragLayer />}
             <DataGridPro
               apiRef={gridApiRef}
               autoHeight

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -6,7 +6,7 @@ import {
   GridSortModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import { FC, useContext, useEffect, useState } from 'react';
+import { FC, MouseEvent, useContext, useEffect, useState } from 'react';
 import { Link, Theme, useMediaQuery } from '@mui/material';
 
 import BrowserDraggableItem from './BrowserDragableItem';
@@ -33,6 +33,7 @@ import MoveViewDialog from '../MoveViewDialog';
 interface ViewBrowserProps {
   basePath: string;
   folderId?: number | null;
+  onSelect?: (item: ViewBrowserItem, ev: MouseEvent) => void;
 }
 
 const TYPE_SORT_ORDER = ['back', 'folder', 'view'];
@@ -43,7 +44,11 @@ function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
   return index0 - index1;
 }
 
-const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
+const ViewBrowser: FC<ViewBrowserProps> = ({
+  basePath,
+  folderId = null,
+  onSelect,
+}) => {
   const { orgId } = useNumericRouteParams();
 
   const messages = useMessages(messageIds);
@@ -87,7 +92,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
         if (item.type == 'back') {
           return (
             <NextLink href={`${basePath}/${subPath}`} legacyBehavior passHref>
-              <Link color="inherit">
+              <Link color="inherit" onClick={(ev) => onSelect?.(item, ev)}>
                 <BrowserItemIcon item={params.row} />
               </Link>
             </NextLink>
@@ -95,7 +100,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
         } else {
           return (
             <NextLink href={`${basePath}/${item.id}`} legacyBehavior passHref>
-              <Link color="inherit">
+              <Link color="inherit" onClick={(ev) => onSelect?.(item, ev)}>
                 <BrowserDraggableItem item={params.row}>
                   <BrowserItemIcon item={params.row} />
                 </BrowserDraggableItem>
@@ -114,7 +119,16 @@ const ViewBrowser: FC<ViewBrowserProps> = ({ basePath, folderId = null }) => {
       flex: 2,
       headerName: messages.viewsList.columns.title(),
       renderCell: (params) => {
-        return <BrowserItem basePath={basePath} item={params.row} />;
+        const item = params.row;
+        return (
+          <BrowserItem
+            basePath={basePath}
+            item={params.row}
+            onClick={(ev) => {
+              onSelect?.(item, ev);
+            }}
+          />
+        );
       },
     },
   ];

--- a/src/features/views/components/ViewDataTable/ViewDataTableFooter.tsx
+++ b/src/features/views/components/ViewDataTable/ViewDataTableFooter.tsx
@@ -30,6 +30,12 @@ const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({
   return (
     <Box p={1}>
       <ZUIPersonSelect
+        createPersonLabels={{
+          submitLabel: zuiMessages.createPerson.submitLabel.add(),
+          title: zuiMessages.createPerson.title.addToList({
+            list: viewTitle,
+          }),
+        }}
         getOptionDisabled={(option) => rows.some((row) => row.id == option.id)}
         getOptionExtraLabel={(option) => {
           return rows.some((row) => row.id == option.id)
@@ -48,10 +54,6 @@ const ViewDataTableFooter: FunctionComponent<ViewDataTableFooterProps> = ({
         }}
         placeholder={messages.footer.addPlaceholder()}
         selectedPerson={null}
-        submitLabel={zuiMessages.createPerson.submitLabel.add()}
-        title={zuiMessages.createPerson.title.addToList({
-          list: viewTitle,
-        })}
         variant="outlined"
       />
     </Box>

--- a/src/features/views/components/ViewDataTable/ViewDataTableToolbar.tsx
+++ b/src/features/views/components/ViewDataTable/ViewDataTableToolbar.tsx
@@ -15,6 +15,7 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/views/l10n/messageIds';
 
 export interface ViewDataTableToolbarProps {
+  disableBulkActions?: boolean;
   disableConfigure?: boolean;
   disabled: boolean;
   gridColumns: GridColDef[];
@@ -32,6 +33,7 @@ export interface ViewDataTableToolbarProps {
 const ViewDataTableToolbar: React.FunctionComponent<
   ViewDataTableToolbarProps
 > = ({
+  disableBulkActions,
   disableConfigure,
   disabled,
   gridColumns,
@@ -57,33 +59,41 @@ const ViewDataTableToolbar: React.FunctionComponent<
   };
   return (
     <Box role="toolbar">
-      <Slide direction="left" in={!!selection.length} timeout={150}>
-        <Button
-          data-testid="ViewDataTableToolbar-createFromSelection"
-          disabled={disabled || isLoading}
-          onClick={onViewCreate}
-          startIcon={isLoading ? <CircularProgress size={25} /> : <Launch />}
-        >
-          <Msg id={messageIds.toolbar.createFromSelection} />
-        </Button>
-      </Slide>
-      <Slide direction="left" in={!!selection.length} timeout={100}>
-        <Tooltip title={isSmartSearch ? messages.toolbar.removeTooltip() : ''}>
-          <span>
+      {!disableBulkActions && (
+        <>
+          <Slide direction="left" in={!!selection.length} timeout={150}>
             <Button
-              data-testid="ViewDataTableToolbar-removeFromSelection"
-              disabled={isSmartSearch || disabled}
-              onClick={onClickRemoveRows}
-              startIcon={<RemoveCircleOutline />}
+              data-testid="ViewDataTableToolbar-createFromSelection"
+              disabled={disabled || isLoading}
+              onClick={onViewCreate}
+              startIcon={
+                isLoading ? <CircularProgress size={25} /> : <Launch />
+              }
             >
-              <Msg
-                id={messageIds.toolbar.removeFromSelection}
-                values={{ numSelected: selection.length }}
-              />
+              <Msg id={messageIds.toolbar.createFromSelection} />
             </Button>
-          </span>
-        </Tooltip>
-      </Slide>
+          </Slide>
+          <Slide direction="left" in={!!selection.length} timeout={100}>
+            <Tooltip
+              title={isSmartSearch ? messages.toolbar.removeTooltip() : ''}
+            >
+              <span>
+                <Button
+                  data-testid="ViewDataTableToolbar-removeFromSelection"
+                  disabled={isSmartSearch || disabled}
+                  onClick={onClickRemoveRows}
+                  startIcon={<RemoveCircleOutline />}
+                >
+                  <Msg
+                    id={messageIds.toolbar.removeFromSelection}
+                    values={{ numSelected: selection.length }}
+                  />
+                </Button>
+              </span>
+            </Tooltip>
+          </Slide>
+        </>
+      )}
       <GridToolbarFilterButton
         componentsProps={{
           button: { color: 'secondary', size: 'medium' },

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -126,22 +126,21 @@ interface ViewDataTableProps {
   columns: ZetkinViewColumn[];
   disableAdd?: boolean;
   disableConfigure?: boolean;
-  // TODO #2789: Nest selection props?
-  onSelectionChange?: (selectedIds: number[]) => void;
   rows: ZetkinViewRow[];
-  selectedIds?: number[];
-  selectionMode?: 'select' | 'selectWithBulkActions';
+  rowSelection?: {
+    mode: 'select' | 'selectWithBulkActions';
+    onSelectionChange?: (selectedIds: number[]) => void;
+    selectedIds?: number[];
+  };
   view: ZetkinView;
 }
 
 const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   columns,
   disableAdd = false,
-  selectionMode,
   disableConfigure,
-  onSelectionChange,
   rows,
-  selectedIds,
+  rowSelection: selectionModel,
   view,
 }) => {
   const theme = useTheme();
@@ -156,13 +155,15 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const [columnToRename, setColumnToRename] = useState<ZetkinViewColumn | null>(
     null
   );
-  const [selection, setSelection] = useState<number[]>(selectedIds ?? []);
+  const [selection, setSelection] = useState<number[]>(
+    selectionModel?.selectedIds ?? []
+  );
   useEffect(() => {
     if (
-      onSelectionChange &&
-      JSON.stringify(selection) !== JSON.stringify(selectedIds)
+      selectionModel?.onSelectionChange &&
+      JSON.stringify(selection) !== JSON.stringify(selectionModel.selectedIds)
     ) {
-      -onSelectionChange(selection);
+      selectionModel.onSelectionChange(selection);
     }
   }, [selection]);
   const [waiting, setWaiting] = useState(false);
@@ -458,7 +459,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       },
     },
     toolbar: {
-      disableBulkActions: selectionMode !== 'selectWithBulkActions',
+      disableBulkActions: selectionModel?.mode !== 'selectWithBulkActions',
       disableConfigure,
       disabled: waiting,
       gridColumns,
@@ -487,7 +488,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       <DataGridPro
         apiRef={gridApiRef}
         autoHeight={empty}
-        checkboxSelection={!!selectionMode}
+        checkboxSelection={!!selectionModel?.mode}
         columns={gridColumns}
         disableRowSelectionOnClick={true}
         getRowClassName={(params) =>

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -124,6 +124,7 @@ const getFilterOperators = (col: Omit<GridColDef, 'field'>) => {
 
 interface ViewDataTableProps {
   columns: ZetkinViewColumn[];
+  disableAdd?: boolean;
   disableBulkActions?: boolean;
   disableConfigure?: boolean;
   rows: ZetkinViewRow[];
@@ -132,6 +133,7 @@ interface ViewDataTableProps {
 
 const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   columns,
+  disableAdd = false,
   disableBulkActions = false,
   disableConfigure,
   rows,
@@ -477,7 +479,9 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         getRowClassName={(params) =>
           params.id == addedId ? classes.addedRow : ''
         }
-        hideFooter={empty || contentSource == VIEW_CONTENT_SOURCE.DYNAMIC}
+        hideFooter={
+          disableAdd || empty || contentSource == VIEW_CONTENT_SOURCE.DYNAMIC
+        }
         localeText={{
           ...theme.components?.MuiDataGrid?.defaultProps?.localeText,
           noRowsLabel: messages.empty.notice[contentSource](),

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -497,8 +497,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         hideFooter={
           disableAdd || empty || contentSource == VIEW_CONTENT_SOURCE.DYNAMIC
         }
-        // TODO #2789: Decide how to do this:
-        // isCellEditable={() => false}
         localeText={{
           ...theme.components?.MuiDataGrid?.defaultProps?.localeText,
           noRowsLabel: messages.empty.notice[contentSource](),
@@ -565,6 +563,20 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         }}
         style={{
           border: 'none',
+        }}
+        sx={{
+          ...(accessLevel === 'readonly' && {
+            '& .MuiDataGrid-cell:focus': {
+              outline: 'none',
+            },
+            '& .MuiDataGrid-cell:focus-within': {
+              outline: 'none',
+            },
+            '& .MuiDataGrid-cell:hover': {
+              backgroundColor: 'transparent',
+              cursor: 'default',
+            },
+          }),
         }}
         {...modelGridProps}
       />

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -102,7 +102,12 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
 
           <AccessLevelProvider>
             {!columnsFuture.isLoading || !!columnsFuture.data?.length ? (
-              <ViewDataTable columns={cols} rows={rows} view={view} />
+              <ViewDataTable
+                columns={cols}
+                rows={rows}
+                selectionMode="selectWithBulkActions"
+                view={view}
+              />
             ) : null}
           </AccessLevelProvider>
         </>

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -105,7 +105,9 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
               <ViewDataTable
                 columns={cols}
                 rows={rows}
-                selectionMode="selectWithBulkActions"
+                rowSelection={{
+                  mode: 'selectWithBulkActions',
+                }}
                 view={view}
               />
             ) : null}

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -122,7 +122,6 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
             {!columnsFuture.isLoading ? (
               <ViewDataTable
                 columns={cols}
-                disableBulkActions
                 disableConfigure={!canConfigure}
                 rows={rows}
                 view={view}

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
@@ -108,6 +108,23 @@ const CallersPage: PageWithLayout = () => {
         </Paper>
         <Box marginTop={2}>
           <MUIOnlyPersonSelect
+            bulkSelection={{
+              onSelectMultiple: (ids) => {
+                // TODO #2789: Optimize this, e.g. using RPC
+                ids.forEach((id) => {
+                  if (!isCaller(id)) {
+                    addCaller(id);
+                  }
+                });
+              },
+              title: zuiMessages.personSelect.bulkAdd.title({
+                entityToAddTo: callAssignment?.title,
+              }),
+            }}
+            createPersonLabels={{
+              submitLabel: zuiMessages.createPerson.submitLabel.add(),
+              title: zuiMessages.createPerson.title.caller(),
+            }}
             getOptionDisabled={(person) => isCaller(person.id)}
             getOptionExtraLabel={(person) =>
               isCaller(person.id) ? messages.callers.add.alreadyAdded() : ''
@@ -121,18 +138,8 @@ const CallersPage: PageWithLayout = () => {
               selectInputRef?.current?.blur();
               selectInputRef?.current?.focus();
             }}
-            onSelectMultiple={(ids) => {
-              // TODO: Optimize this, e.g. using RPC
-              ids.forEach((id) => {
-                if (!isCaller(id)) {
-                  addCaller(id);
-                }
-              });
-            }}
             placeholder={messages.callers.add.placeholder()}
             selectedPerson={null}
-            submitLabel={zuiMessages.createPerson.submitLabel.add()}
-            title={zuiMessages.createPerson.title.caller()}
           />
         </Box>
         <CallerConfigDialog

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
@@ -108,9 +108,9 @@ const CallersPage: PageWithLayout = () => {
         </Paper>
         <Box marginTop={2}>
           <MUIOnlyPersonSelect
-            getOptionDisabled={isCaller}
+            getOptionDisabled={(person) => isCaller(person.id)}
             getOptionExtraLabel={(person) =>
-              isCaller(person) ? messages.callers.add.alreadyAdded() : ''
+              isCaller(person.id) ? messages.callers.add.alreadyAdded() : ''
             }
             inputRef={selectInputRef}
             onChange={(person) => {

--- a/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/callassignments/[callAssId]/callers.tsx
@@ -121,6 +121,14 @@ const CallersPage: PageWithLayout = () => {
               selectInputRef?.current?.blur();
               selectInputRef?.current?.focus();
             }}
+            onSelectMultiple={(ids) => {
+              // TODO: Optimize this, e.g. using RPC
+              ids.forEach((id) => {
+                if (!isCaller(id)) {
+                  addCaller(id);
+                }
+              });
+            }}
             placeholder={messages.callers.add.placeholder()}
             selectedPerson={null}
             submitLabel={zuiMessages.createPerson.submitLabel.add()}

--- a/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
@@ -1,0 +1,59 @@
+import { Box, Button, Divider } from '@mui/material';
+import { FC, useState } from 'react';
+
+import ViewBrowser from 'features/views/components/ViewBrowser';
+import messageIds from 'zui/l10n/messageIds';
+import { Msg } from 'core/i18n';
+
+type Props = {
+  onClose: () => void;
+  onViewSelect: (viewId: number) => void;
+};
+
+const BrowserStep: FC<Props> = ({ onClose, onViewSelect }) => {
+  const [folderId, setFolderId] = useState<number | null>(null);
+  return (
+    <Box>
+      <ViewBrowser
+        basePath=""
+        folderId={folderId}
+        onSelect={(item, ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          if (item.type == 'folder') {
+            setFolderId(item.data.id);
+          } else if (item.type == 'back') {
+            setFolderId(item.folderId);
+          } else if (item.type == 'view') {
+            onViewSelect(item.data.id);
+          }
+        }}
+      />
+      <Box>
+        <Divider />
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            gap: 2,
+            justifyContent: 'flex-end',
+            mt: 2,
+          }}
+        >
+          <Box>
+            <Button
+              onClick={() => {
+                onClose();
+              }}
+              variant="text"
+            >
+              <Msg id={messageIds.personSelect.bulkAdd.cancelButton} />
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default BrowserStep;

--- a/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, DialogTitle, Divider } from '@mui/material';
+import { Box, Button, Divider } from '@mui/material';
 import { FC } from 'react';
 
 import ViewBrowser from 'features/views/components/ViewBrowser';
@@ -20,12 +20,10 @@ const BrowserStep: FC<Props> = ({
 }) => {
   return (
     <Box>
-      {/* TODO #2789: Add more specific headline / decide whether to have a single headline across both steps */}
-      <DialogTitle sx={{ paddingLeft: 1 }} variant="h4">
-        Select people to add
-      </DialogTitle>
       <ViewBrowser
         basePath=""
+        enableDragAndDrop={false}
+        enableEllipsisMenu={false}
         folderId={folderId}
         onSelect={(item, ev) => {
           ev.preventDefault();
@@ -38,7 +36,6 @@ const BrowserStep: FC<Props> = ({
             onViewSelect(item.data.id);
           }
         }}
-        readOnly={true}
       />
       <Box>
         <Divider />

--- a/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
@@ -1,17 +1,23 @@
 import { Box, Button, Divider } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC } from 'react';
 
 import ViewBrowser from 'features/views/components/ViewBrowser';
 import messageIds from 'zui/l10n/messageIds';
 import { Msg } from 'core/i18n';
 
 type Props = {
+  folderId: number | null;
   onClose: () => void;
+  onFolderSelect: (folderId: number | null) => void;
   onViewSelect: (viewId: number) => void;
 };
 
-const BrowserStep: FC<Props> = ({ onClose, onViewSelect }) => {
-  const [folderId, setFolderId] = useState<number | null>(null);
+const BrowserStep: FC<Props> = ({
+  folderId,
+  onClose,
+  onFolderSelect,
+  onViewSelect,
+}) => {
   return (
     <Box>
       <ViewBrowser
@@ -21,9 +27,9 @@ const BrowserStep: FC<Props> = ({ onClose, onViewSelect }) => {
           ev.preventDefault();
           ev.stopPropagation();
           if (item.type == 'folder') {
-            setFolderId(item.data.id);
+            onFolderSelect(item.data.id);
           } else if (item.type == 'back') {
-            setFolderId(item.folderId);
+            onFolderSelect(item.folderId);
           } else if (item.type == 'view') {
             onViewSelect(item.data.id);
           }

--- a/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider } from '@mui/material';
+import { Box, Button, DialogTitle, Divider } from '@mui/material';
 import { FC } from 'react';
 
 import ViewBrowser from 'features/views/components/ViewBrowser';
@@ -20,6 +20,10 @@ const BrowserStep: FC<Props> = ({
 }) => {
   return (
     <Box>
+      {/* TODO #2789: Add more specific headline / decide whether to have a single headline across both steps */}
+      <DialogTitle sx={{ paddingLeft: 1 }} variant="h4">
+        Select people to add
+      </DialogTitle>
       <ViewBrowser
         basePath=""
         folderId={folderId}
@@ -34,6 +38,7 @@ const BrowserStep: FC<Props> = ({
             onViewSelect(item.data.id);
           }
         }}
+        readOnly={true}
       />
       <Box>
         <Divider />

--- a/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Typography } from '@mui/material';
+import { Box, Button, Divider } from '@mui/material';
 import { FC } from 'react';
 
 import useView from 'features/views/hooks/useView';
@@ -6,6 +6,7 @@ import messageIds from 'zui/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import useViewGrid from 'features/views/hooks/useViewGrid';
 import ZUIFutures from 'zui/ZUIFutures';
+import ViewDataTable from 'features/views/components/ViewDataTable';
 
 type Props = {
   onBack: () => void;
@@ -16,50 +17,56 @@ type Props = {
 
 const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
   const viewFuture = useView(orgId, viewId);
-  const { rowsFuture } = useViewGrid(orgId, viewId);
+  const { columnsFuture, rowsFuture } = useViewGrid(orgId, viewId);
 
   return (
     <Box>
-      <ZUIFutures futures={{ rows: rowsFuture, view: viewFuture }}>
-        {({ data: { rows, view } }) => {
+      <ZUIFutures
+        futures={{ columns: columnsFuture, rows: rowsFuture, view: viewFuture }}
+      >
+        {({ data: { columns, rows, view } }) => {
           return (
-            <>
-              <Typography>{view.title}</Typography>
-              <Typography variant="body2">{rows.length}</Typography>
-              <Box>
-                <Divider />
-                <Box
-                  sx={{
-                    alignItems: 'center',
-                    display: 'flex',
-                    gap: 2,
-                    justifyContent: 'flex-end',
-                    mt: 2,
-                  }}
-                >
-                  <Box>
-                    <Button
-                      onClick={() => {
-                        onBack();
-                      }}
-                      sx={{ mr: 2 }}
-                      variant="text"
-                    >
-                      <Msg id={messageIds.personSelect.bulkAdd.backButton} />
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        onSubmit(rows.map((row) => row.id));
-                      }}
-                      sx={{ mr: 2 }}
-                      variant="contained"
-                    >
-                      <Msg id={messageIds.personSelect.bulkAdd.submitButton} />
-                    </Button>
-                  </Box>
+            <Box>
+              <ViewDataTable
+                columns={columns}
+                disableAdd
+                disableBulkActions
+                disableConfigure
+                rows={rows}
+                view={view}
+              />
+              <Divider />
+              <Box
+                sx={{
+                  alignItems: 'center',
+                  display: 'flex',
+                  gap: 2,
+                  justifyContent: 'flex-end',
+                  mt: 2,
+                }}
+              >
+                <Box>
+                  <Button
+                    onClick={() => {
+                      onBack();
+                    }}
+                    sx={{ mr: 2 }}
+                    variant="text"
+                  >
+                    <Msg id={messageIds.personSelect.bulkAdd.backButton} />
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      onSubmit(rows.map((row) => row.id));
+                    }}
+                    sx={{ mr: 2 }}
+                    variant="contained"
+                  >
+                    <Msg id={messageIds.personSelect.bulkAdd.submitButton} />
+                  </Button>
                 </Box>
               </Box>
-            </>
+            </Box>
           );
         }}
       </ZUIFutures>

--- a/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
@@ -1,0 +1,70 @@
+import { Box, Button, Divider, Typography } from '@mui/material';
+import { FC } from 'react';
+
+import useView from 'features/views/hooks/useView';
+import messageIds from 'zui/l10n/messageIds';
+import { Msg } from 'core/i18n';
+import useViewGrid from 'features/views/hooks/useViewGrid';
+import ZUIFutures from 'zui/ZUIFutures';
+
+type Props = {
+  onBack: () => void;
+  onSubmit: (ids: number[]) => void;
+  orgId: number;
+  viewId: number;
+};
+
+const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
+  const viewFuture = useView(orgId, viewId);
+  const { rowsFuture } = useViewGrid(orgId, viewId);
+
+  return (
+    <Box>
+      <ZUIFutures futures={{ rows: rowsFuture, view: viewFuture }}>
+        {({ data: { rows, view } }) => {
+          return (
+            <>
+              <Typography>{view.title}</Typography>
+              <Typography variant="body2">{rows.length}</Typography>
+              <Box>
+                <Divider />
+                <Box
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    gap: 2,
+                    justifyContent: 'flex-end',
+                    mt: 2,
+                  }}
+                >
+                  <Box>
+                    <Button
+                      onClick={() => {
+                        onBack();
+                      }}
+                      sx={{ mr: 2 }}
+                      variant="text"
+                    >
+                      <Msg id={messageIds.personSelect.bulkAdd.backButton} />
+                    </Button>
+                    <Button
+                      onClick={() => {
+                        onSubmit(rows.map((row) => row.id));
+                      }}
+                      sx={{ mr: 2 }}
+                      variant="contained"
+                    >
+                      <Msg id={messageIds.personSelect.bulkAdd.submitButton} />
+                    </Button>
+                  </Box>
+                </Box>
+              </Box>
+            </>
+          );
+        }}
+      </ZUIFutures>
+    </Box>
+  );
+};
+
+export default ViewStep;

--- a/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
@@ -32,10 +32,12 @@ const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
                 columns={columns}
                 disableAdd
                 disableConfigure
-                onSelectionChange={setSelectedPersonIds}
                 rows={rows}
-                selectedIds={selectedPersonIds}
-                selectionMode="select"
+                rowSelection={{
+                  mode: 'select',
+                  onSelectionChange: setSelectedPersonIds,
+                  selectedIds: selectedPersonIds,
+                }}
                 view={view}
               />
               <Divider />

--- a/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
@@ -7,6 +7,7 @@ import { Msg } from 'core/i18n';
 import useViewGrid from 'features/views/hooks/useViewGrid';
 import ZUIFutures from 'zui/ZUIFutures';
 import ViewDataTable from 'features/views/components/ViewDataTable';
+import { AccessLevelProvider } from 'features/views/hooks/useAccessLevel';
 
 type Props = {
   onBack: () => void;
@@ -28,18 +29,20 @@ const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
         {({ data: { columns, rows, view } }) => {
           return (
             <Box>
-              <ViewDataTable
-                columns={columns}
-                disableAdd
-                disableConfigure
-                rows={rows}
-                rowSelection={{
-                  mode: 'select',
-                  onSelectionChange: setSelectedPersonIds,
-                  selectedIds: selectedPersonIds,
-                }}
-                view={view}
-              />
+              <AccessLevelProvider accessLevel="readonly" isRestricted={true}>
+                <ViewDataTable
+                  columns={columns}
+                  disableAdd
+                  disableConfigure
+                  rows={rows}
+                  rowSelection={{
+                    mode: 'select',
+                    onSelectionChange: setSelectedPersonIds,
+                    selectedIds: selectedPersonIds,
+                  }}
+                  view={view}
+                />
+              </AccessLevelProvider>
               <Divider />
               <Box
                 sx={{

--- a/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/ViewStep.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Divider } from '@mui/material';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import useView from 'features/views/hooks/useView';
 import messageIds from 'zui/l10n/messageIds';
@@ -18,6 +18,7 @@ type Props = {
 const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
   const viewFuture = useView(orgId, viewId);
   const { columnsFuture, rowsFuture } = useViewGrid(orgId, viewId);
+  const [selectedPersonIds, setSelectedPersonIds] = useState<number[]>([]);
 
   return (
     <Box>
@@ -30,9 +31,11 @@ const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
               <ViewDataTable
                 columns={columns}
                 disableAdd
-                disableBulkActions
                 disableConfigure
+                onSelectionChange={setSelectedPersonIds}
                 rows={rows}
+                selectedIds={selectedPersonIds}
+                selectionMode="select"
                 view={view}
               />
               <Divider />
@@ -56,13 +59,17 @@ const ViewStep: FC<Props> = ({ onBack, onSubmit, orgId, viewId }) => {
                     <Msg id={messageIds.personSelect.bulkAdd.backButton} />
                   </Button>
                   <Button
+                    disabled={selectedPersonIds.length === 0}
                     onClick={() => {
-                      onSubmit(rows.map((row) => row.id));
+                      onSubmit(selectedPersonIds);
                     }}
                     sx={{ mr: 2 }}
                     variant="contained"
                   >
-                    <Msg id={messageIds.personSelect.bulkAdd.submitButton} />
+                    <Msg
+                      id={messageIds.personSelect.bulkAdd.submitButton}
+                      values={{ numSelected: selectedPersonIds.length }}
+                    />
                   </Button>
                 </Box>
               </Box>

--- a/src/zui/ZUIBulkPersonSelect/index.tsx
+++ b/src/zui/ZUIBulkPersonSelect/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Dialog, useMediaQuery, useTheme } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import BrowserStep from './BrowserStep';
 import ViewStep from './ViewStep';
@@ -19,7 +19,15 @@ const ZUIBulkPersonSelect: FC<ZUICreatePersonProps> = ({
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const [folderId, setFolderId] = useState<number | null>(null);
   const [viewId, setViewId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setFolderId(null);
+      setViewId(null);
+    }
+  }, [open]);
 
   return (
     <Dialog
@@ -42,7 +50,9 @@ const ZUIBulkPersonSelect: FC<ZUICreatePersonProps> = ({
         )}
         {!viewId && (
           <BrowserStep
+            folderId={folderId}
             onClose={onClose}
+            onFolderSelect={(id) => setFolderId(id)}
             onViewSelect={(viewId) => setViewId(viewId)}
           />
         )}

--- a/src/zui/ZUIBulkPersonSelect/index.tsx
+++ b/src/zui/ZUIBulkPersonSelect/index.tsx
@@ -1,0 +1,54 @@
+import { Box, Dialog, useMediaQuery, useTheme } from '@mui/material';
+import { FC, useState } from 'react';
+
+import BrowserStep from './BrowserStep';
+import ViewStep from './ViewStep';
+import { useNumericRouteParams } from 'core/hooks';
+
+interface ZUICreatePersonProps {
+  onClose: () => void;
+  onSubmit: (ids: number[]) => void;
+  open: boolean;
+}
+
+const ZUIBulkPersonSelect: FC<ZUICreatePersonProps> = ({
+  open,
+  onClose,
+  onSubmit,
+}) => {
+  const theme = useTheme();
+  const { orgId } = useNumericRouteParams();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
+  const [viewId, setViewId] = useState<number | null>(null);
+
+  return (
+    <Dialog
+      fullScreen={fullScreen}
+      fullWidth
+      maxWidth="xl"
+      onClose={() => {
+        onClose();
+      }}
+      open={open}
+    >
+      <Box sx={{ p: 2 }}>
+        {!!viewId && (
+          <ViewStep
+            onBack={() => setViewId(null)}
+            onSubmit={(ids) => onSubmit(ids)}
+            orgId={orgId}
+            viewId={viewId}
+          />
+        )}
+        {!viewId && (
+          <BrowserStep
+            onClose={onClose}
+            onViewSelect={(viewId) => setViewId(viewId)}
+          />
+        )}
+      </Box>
+    </Dialog>
+  );
+};
+
+export default ZUIBulkPersonSelect;

--- a/src/zui/ZUIBulkPersonSelect/index.tsx
+++ b/src/zui/ZUIBulkPersonSelect/index.tsx
@@ -1,4 +1,10 @@
-import { Box, Dialog, useMediaQuery, useTheme } from '@mui/material';
+import {
+  Box,
+  Dialog,
+  DialogTitle,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { FC, useEffect, useState } from 'react';
 
 import BrowserStep from './BrowserStep';
@@ -9,12 +15,14 @@ interface ZUICreatePersonProps {
   onClose: () => void;
   onSubmit: (ids: number[]) => void;
   open: boolean;
+  title: string;
 }
 
 const ZUIBulkPersonSelect: FC<ZUICreatePersonProps> = ({
   open,
   onClose,
   onSubmit,
+  title,
 }) => {
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
@@ -40,6 +48,9 @@ const ZUIBulkPersonSelect: FC<ZUICreatePersonProps> = ({
       open={open}
     >
       <Box sx={{ p: 2 }}>
+        <DialogTitle sx={{ paddingLeft: 1 }} variant="h4">
+          {title}
+        </DialogTitle>
         {!!viewId && (
           <ViewStep
             onBack={() => setViewId(null)}

--- a/src/zui/ZUICreatePerson/index.tsx
+++ b/src/zui/ZUICreatePerson/index.tsx
@@ -20,6 +20,8 @@ import useCustomFields from 'features/profile/hooks/useCustomFields';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinCreatePerson, ZetkinPerson } from 'utils/types/zetkin';
 import useOrganization from '../../features/organizations/hooks/useOrganization';
+import zuiMessages from 'zui/l10n/messageIds';
+import { useMessages } from 'core/i18n';
 
 interface ZUICreatePersonProps {
   onClose: () => void;
@@ -46,6 +48,7 @@ const ZUICreatePerson: FC<ZUICreatePersonProps> = ({
   const [tags, setTags] = useState<number[]>([]);
 
   const [personalInfo, setPersonalInfo] = useState<ZetkinCreatePerson>({});
+  const messages = useMessages(zuiMessages);
 
   return (
     <Dialog
@@ -61,7 +64,7 @@ const ZUICreatePerson: FC<ZUICreatePersonProps> = ({
       <Box sx={{ padding: '40px 0 40px 40px' }}>
         <Box display="flex">
           <Typography sx={{ ml: 0.5 }} variant="h5">
-            {title}
+            {title ?? messages.createPerson.title.default()}
           </Typography>
         </Box>
         {!customFields ? (

--- a/src/zui/ZUIPersonSelect.tsx
+++ b/src/zui/ZUIPersonSelect.tsx
@@ -68,11 +68,16 @@ interface UsePersonSelectReturn {
 type UsePersonSelect = (props: UsePersonSelectProps) => UsePersonSelectReturn;
 
 type ZUIPersonSelectProps = UsePersonSelectProps & {
+  bulkSelection?: {
+    onSelectMultiple: (ids: number[]) => void;
+    title: string;
+  };
+  createPersonLabels?: {
+    submitLabel?: string;
+    title?: string;
+  };
   disabled?: boolean;
-  onSelectMultiple?: (ids: number[]) => void;
   size?: 'small' | 'medium';
-  submitLabel?: string;
-  title?: string;
   variant?: 'filled' | 'outlined' | 'standard';
 };
 
@@ -186,13 +191,12 @@ const MUIOnlyPersonSelect: FunctionComponent<ZUIPersonSelectProps> = (
   props
 ) => {
   const {
+    bulkSelection,
+    createPersonLabels,
     disabled,
     label,
-    onSelectMultiple,
     size,
     variant,
-    submitLabel,
-    title,
     ...restComponentProps
   } = props;
   const { autoCompleteProps } = usePersonSelect(restComponentProps);
@@ -214,7 +218,7 @@ const MUIOnlyPersonSelect: FunctionComponent<ZUIPersonSelectProps> = (
     }
   }, [autoCompleteProps.isLoading]);
 
-  const showBulkButton = !!onSelectMultiple;
+  const showBulkButton = !!bulkSelection;
   const showAddButton = !disabled && wasLoading;
   const showButtonBar = showBulkButton || showAddButton;
 
@@ -300,17 +304,18 @@ const MUIOnlyPersonSelect: FunctionComponent<ZUIPersonSelectProps> = (
         onClose={() => setCreatePersonOpen(false)}
         onSubmit={(e, person) => onChange(e, person)}
         open={createPersonOpen}
-        submitLabel={submitLabel}
-        title={title}
+        submitLabel={createPersonLabels?.submitLabel}
+        title={createPersonLabels?.title}
       />
       {showBulkButton && (
         <ZUIBulkPersonSelect
           onClose={() => setBulkDialogOpen(false)}
           onSubmit={(ids) => {
-            onSelectMultiple?.(ids);
+            bulkSelection.onSelectMultiple(ids);
             setBulkDialogOpen(false);
           }}
           open={bulkDialogOpen}
+          title={bulkSelection.title}
         />
       )}
     </>

--- a/src/zui/ZUIPersonSelect.tsx
+++ b/src/zui/ZUIPersonSelect.tsx
@@ -303,14 +303,16 @@ const MUIOnlyPersonSelect: FunctionComponent<ZUIPersonSelectProps> = (
         submitLabel={submitLabel}
         title={title}
       />
-      <ZUIBulkPersonSelect
-        onClose={() => setBulkDialogOpen(false)}
-        onSubmit={(ids) => {
-          onSelectMultiple?.(ids);
-          setBulkDialogOpen(false);
-        }}
-        open={bulkDialogOpen}
-      />
+      {showBulkButton && (
+        <ZUIBulkPersonSelect
+          onClose={() => setBulkDialogOpen(false)}
+          onSubmit={(ids) => {
+            onSelectMultiple?.(ids);
+            setBulkDialogOpen(false);
+          }}
+          open={bulkDialogOpen}
+        />
+      )}
     </>
   );
 };

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -199,6 +199,9 @@ export default makeMessages('zui', {
       submitButton: m<{ numSelected: number }>(
         '{numSelected, plural, =0 {Select} =1 {Select 1 person} other {Select # people}}'
       ),
+      title: m<{ entityToAddTo?: string }>(
+        '{entityToAddTo, select, undefined {Select people to add} other {Select people to add to {entityToAddTo}}}'
+      ),
     },
     keepTyping: m('Keep typing to start searching'),
     noResult: m('No matching person found'),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -192,6 +192,12 @@ export default makeMessages('zui', {
     searchResults: m('Search results'),
   },
   personSelect: {
+    bulkAdd: {
+      backButton: m('Back'),
+      cancelButton: m('Cancel'),
+      openButton: m('Bulk add'),
+      submitButton: m('Select'),
+    },
     keepTyping: m('Keep typing to start searching'),
     noResult: m('No matching person found'),
     search: m('Type to start searching'),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -196,7 +196,9 @@ export default makeMessages('zui', {
       backButton: m('Back'),
       cancelButton: m('Cancel'),
       openButton: m('Bulk add'),
-      submitButton: m('Select'),
+      submitButton: m<{ numSelected: number }>(
+        '{numSelected, plural, =0 {Select} =1 {Select 1 person} other {Select # people}}'
+      ),
     },
     keepTyping: m('Keep typing to start searching'),
     noResult: m('No matching person found'),


### PR DESCRIPTION
## Description
Adds a "Bulk Add" button to select multiple people to be added as callers to a call assignment. 

## Screenshots

https://github.com/user-attachments/assets/bae58f9e-616b-46cc-b5d2-4b7f11aeba48

## Changes
- Add optional "Bulk Add' button to `MUIOnlyPersonSelect`
- Extend `ViewBrowser` to make the ellipsis menu and drag behavior optional
- Allow disabling adding elements in a view
- Allow row selection in a `ViewDataTable` without bulk actions
- Disable visual focus states on read-only `ViewDataTable`

## Notes to reviewer

Sorry my individual commits are not as isolated as they should be in this one. 

### Out of scope
- Load animation for the `ViewBrowser` and `ViewDataTable`
- Existing issue with readonly views: Tags in a tag column show a remove button and can actually be removed if the user has necessary permissions

## Related issues
Resolves #2789 
