### PR TITLE
Issue 1681/week view multi day event display

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -90,17 +90,41 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         gridTemplateColumns={`${HOUR_COLUMN_WIDTH} repeat(7, 1fr)`}
         gridTemplateRows={'1fr'}
         marginBottom={dstChange === undefined ? 2 : 0}
+        position="relative"
       >
         {/* Empty */}
         <HeaderWeekNumber weekNr={dayjs(dayDates[0]).isoWeek()} />
         {dayDates.map((weekdayDate: Date, weekday: number) => {
           return (
-            <DayHeader
-              key={`weekday-${weekday}`}
-              date={weekdayDate}
-              focused={new Date().toDateString() == weekdayDate.toDateString()}
-              onClick={() => onClickDay(weekdayDate)}
-            />
+            <Box key={`weekday-${weekday}`} position="relative">
+              <DayHeader
+                date={weekdayDate}
+                focused={
+                  new Date().toDateString() == weekdayDate.toDateString()
+                }
+                onClick={() => onClickDay(weekdayDate)}
+              />
+              <Box
+                sx={{
+                  bottom: 0,
+                  left: 0,
+                  position: 'absolute',
+                  right: 0,
+                  translate: '0 calc(100% + 4px)',
+                  zIndex: 10,
+                }}
+              >
+                {eventsByDate[weekday].multidayEvents.flatMap((lane) => {
+                  return lane.map((cluster) => {
+                    return (
+                      <Box key={`fulldaylane-${cluster.events[0].id}`}>
+                        <EventCluster cluster={cluster} height={30} />
+                      </Box>
+                    );
+                  });
+                })}
+              </Box>
+            </Box>
           );
         })}
       </Box>

--- a/src/features/calendar/hooks/useWeekCalendarEvents.ts
+++ b/src/features/calendar/hooks/useWeekCalendarEvents.ts
@@ -1,13 +1,12 @@
 import { isSameDate } from 'utils/dateUtils';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
-import { useNumericRouteParams } from 'core/hooks';
 import clusterEventsForWeekCalender, {
   AnyClusteredEvent,
 } from '../utils/clusterEventsForWeekCalender';
 
 type UseWeekCalendarEventsParams = {
-  campaignId?: number;
+  campaignId: number;
   dates: Date[];
   orgId: number;
 };
@@ -18,14 +17,15 @@ type UseWeekCalendarEventsReturn = {
 }[];
 
 export default function useWeekCalendarEvents({
+  campaignId,
   dates,
+  orgId,
 }: UseWeekCalendarEventsParams): UseWeekCalendarEventsReturn {
-  const { campId, orgId } = useNumericRouteParams();
   const eventActivities = useEventsFromDateRange(
     dates[0],
     dates[dates.length - 1],
     orgId,
-    campId
+    campaignId
   );
   const filteredActivities = useFilteredEventActivities(eventActivities);
 


### PR DESCRIPTION
## Description
This PR changes so that events spanning multiple days are shown in the header of the week, to show that the event spans the entire day, for multiple days. This way we can see that the event spans a chunk of time without having to display it over the entire day

An improvement would be to connect the event displays between the day tracks, but that would require changes on how to place the event markers.


## Screenshots
https://github.com/user-attachments/assets/6e5c6bc1-e2df-4bfe-a057-717db1ec72dc

For a lot of events it looks like this:
![Screen Shot 2025-06-07 at 16 26 20](https://github.com/user-attachments/assets/6354c22a-f775-4432-a393-696662ab45cb)
It is a bit messy but that's difficult to avoid with that amount of events.

## Changes
* Adds events spanning multiple days to week day header, so that they will be visible even when scrolling


## Related issues
Resolves #1681 
