### PR TITLE
fixed the bug of "unselecting organization filter for certain organizations not working"

### DIFF
--- a/src/features/home/components/AllEventsList.tsx
+++ b/src/features/home/components/AllEventsList.tsx
@@ -376,7 +376,7 @@ const AllEventsList: FC = () => {
               </Box>
               <Switch
                 checked={orgIdsToFilterBy.includes(org.id)}
-                onChange={(checked) => {
+                onChange={(_event, checked) => {
                   if (checked) {
                     setOrgIdsToFilterBy([...orgIdsToFilterBy, org.id]);
                   } else {


### PR DESCRIPTION
## Description
This PR solves the bug of  unselecting organization filter for certain organization within my feed page is not working.

For more information of the bug look into #2833

## Changes

* Fix of the described bug


## Notes to reviewer

* Go to https://app.dev.zetkin.org/my/feed
* Note that the "Organizations" filter only shows up if there are only events in one single organization
* open the modal for selecting organizations to filter by by pressing the organizations filter
* select at least one organization to filter by via the toggles in the modal
* unselect one of the applied filters


## Related issues
Resolves  #2833
