### PR TITLE
Issue 2460: Not allowing multiple hover cards to show at once

### DIFF
--- a/src/utils/hooks/useToggleDebounce.ts
+++ b/src/utils/hooks/useToggleDebounce.ts
@@ -2,11 +2,12 @@ import { MouseEvent, useRef } from 'react';
 
 // Close will be called after a delay, which is cancelled if open is called
 // Useful to toggle poppers without closing the instant the cursor is outside the triggering element
+// Open will wait for a 'minHoverDuration' before interpretting it as intentional
 export default function useToggleDebounce(
   open: (ev: MouseEvent<HTMLElement>) => void,
   close: (ev: MouseEvent<HTMLElement>) => void,
   delay = 250,
-  minHoverDuration = 250,
+  minHoverDuration = 250
 ) {
   const targetRef = useRef<HTMLElement | null>(null);
   const timeoutId = useRef<number | undefined>();
@@ -16,7 +17,7 @@ export default function useToggleDebounce(
     clearTimeout(timeoutId.current);
 
     // We capture the currentTarget, otherwise React won't accept the delayed event
-    targetRef.current = ev.currentTarget; 
+    targetRef.current = ev.currentTarget;
 
     // Capture start-point of hovering to evaluate if the user has hovered > minHoverDuration
     hoverStartTime = Date.now();
@@ -24,8 +25,11 @@ export default function useToggleDebounce(
     window.setTimeout(() => {
       if (hoverStartTime && Date.now() - hoverStartTime > minHoverDuration) {
         hoverStartTime = null;
-        open({ ...ev, currentTarget: targetRef.current } as MouseEvent<HTMLElement>);
-      } 
+        open({
+          ...ev,
+          currentTarget: targetRef.current,
+        } as MouseEvent<HTMLElement>);
+      }
     }, minHoverDuration);
   }
 

--- a/src/utils/hooks/useToggleDebounce.ts
+++ b/src/utils/hooks/useToggleDebounce.ts
@@ -5,15 +5,32 @@ import { MouseEvent, useRef } from 'react';
 export default function useToggleDebounce(
   open: (ev: MouseEvent<HTMLElement>) => void,
   close: (ev: MouseEvent<HTMLElement>) => void,
-  delay = 250
+  delay = 250,
+  minHoverDuration = 250,
 ) {
+  const targetRef = useRef<HTMLElement | null>(null);
   const timeoutId = useRef<number | undefined>();
+  let hoverStartTime = useRef<number | null>(null);
+
   function openDebounced(ev: MouseEvent<HTMLElement>) {
     clearTimeout(timeoutId.current);
-    open(ev);
+
+    // We capture the currentTarget, otherwise React won't accept the delayed event
+    targetRef.current = ev.currentTarget; 
+
+    // Capture start-point of hovering to evaluate if the user has hovered > minHoverDuration
+    hoverStartTime = Date.now();
+
+    window.setTimeout(() => {
+      if (hoverStartTime && Date.now() - hoverStartTime > minHoverDuration) {
+        hoverStartTime = null;
+        open({ ...ev, currentTarget: targetRef.current } as MouseEvent<HTMLElement>);
+      } 
+    }, minHoverDuration);
   }
 
   function closeDebounced(ev: MouseEvent<HTMLElement>) {
+    hoverStartTime = null;
     timeoutId.current = window.setTimeout(() => {
       close(ev);
     }, delay);

--- a/src/utils/hooks/useToggleDebounce.ts
+++ b/src/utils/hooks/useToggleDebounce.ts
@@ -6,12 +6,12 @@ import { MouseEvent, useRef } from 'react';
 export default function useToggleDebounce(
   open: (ev: MouseEvent<HTMLElement>) => void,
   close: (ev: MouseEvent<HTMLElement>) => void,
-  delay = 250,
-  minHoverDuration = 250
+  delay = 50,
+  minHoverDuration = 100
 ) {
-  const targetRef = useRef<HTMLElement | null>(null);
+  const targetRef = useRef<HTMLElement | null>();
   const timeoutId = useRef<number | undefined>();
-  let hoverStartTime = useRef<number | null>(null);
+  const hoverStartTime = useRef<number | null>();
 
   function openDebounced(ev: MouseEvent<HTMLElement>) {
     clearTimeout(timeoutId.current);
@@ -20,11 +20,11 @@ export default function useToggleDebounce(
     targetRef.current = ev.currentTarget;
 
     // Capture start-point of hovering to evaluate if the user has hovered > minHoverDuration
-    hoverStartTime = Date.now();
+    hoverStartTime.current = Date.now();
 
     window.setTimeout(() => {
-      if (hoverStartTime && Date.now() - hoverStartTime > minHoverDuration) {
-        hoverStartTime = null;
+      if (hoverStartTime.current && Date.now() - hoverStartTime.current > minHoverDuration) {
+        hoverStartTime.current = null;
         open({
           ...ev,
           currentTarget: targetRef.current,
@@ -34,7 +34,7 @@ export default function useToggleDebounce(
   }
 
   function closeDebounced(ev: MouseEvent<HTMLElement>) {
-    hoverStartTime = null;
+    hoverStartTime.current = null;
     timeoutId.current = window.setTimeout(() => {
       close(ev);
     }, delay);

--- a/src/utils/hooks/useToggleDebounce.ts
+++ b/src/utils/hooks/useToggleDebounce.ts
@@ -22,8 +22,9 @@ export default function useToggleDebounce(
     // Capture start-point of hovering to evaluate if the user has hovered > minHoverDuration
     hoverStartTime.current = Date.now();
 
+    // If hoverStartTime is not null after minHoverDuration, we should trigger the Open()
     window.setTimeout(() => {
-      if (hoverStartTime.current && Date.now() - hoverStartTime.current > minHoverDuration) {
+      if (hoverStartTime.current) {
         hoverStartTime.current = null;
         open({
           ...ev,


### PR DESCRIPTION
## Description
This PR solves the issue of many hover-cards (poppers) showing at the same time, when cursor moves across many elements quickly. We solve it by delaying the opening of a new popper, until the current one has had a chance to close, combined with a minimal requirement of 100ms of hovering, before we define that as an intention to hover. 

We have been using these two cases for reproducing during the development work: 
http://localhost:3000/organize/1/people/lists/191
http://localhost:3000/organize/1/people/lists/9

## Screenshots

With rapid movements of the cursor over the orange fields:

_Before_
![image-2025-06-07-184221](https://github.com/user-attachments/assets/1c3b00b0-350a-4829-999f-f324de32196f)

_After_
<img width="717" alt="Screenshot 2025-06-07 at 18 42 17" src="https://github.com/user-attachments/assets/dfd827dd-c30d-40d1-98e7-ee639d0ed392" />

## Changes
- [X] We delay the opening, until the cards have had time to debounce and close
- [X] We evaluate if hovering has been happening for more than 100ms, to prevent showing a card on quick movements

## Notes to reviewer
- [ ] Please check as many cases you can find, where the `useToggleDebounce.ts` is being used. 


## Related issues
Resolves #2460 

Work by: @Idkirsch and @troldmand 
