### PR TITLE
Issue 2446/area assignment status colour

### DIFF
--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -91,9 +91,9 @@ const Activities = ({ activities, orgId }: ActivitiesProps) => {
               index={index}
             >
               <AreaAssignmentListItem
+                activity={activity}
                 caId={activity.data.id}
                 orgId={orgId}
-                activity={activity}
               />
             </LazyActivitiesBox>
           );

--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -90,7 +90,11 @@ const Activities = ({ activities, orgId }: ActivitiesProps) => {
               key={`areaassignment-${activity.data.id}`}
               index={index}
             >
-              <AreaAssignmentListItem caId={activity.data.id} orgId={orgId} />
+              <AreaAssignmentListItem
+                caId={activity.data.id}
+                orgId={orgId}
+                activity={activity}
+              />
             </LazyActivitiesBox>
           );
         } else if (isEventCluster(activity)) {

--- a/src/features/campaigns/components/ActivityList/items/AreaAssignmentListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/AreaAssignmentListItem.tsx
@@ -1,17 +1,20 @@
 import { FC } from 'react';
 import { Map, Person } from '@mui/icons-material';
 
+import { AreaAssignmentActivity } from 'features/campaigns/types';
 import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
 import useAreaAssignment from 'features/areaAssignments/hooks/useAreaAssignment';
 import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
 import getAreaAssignees from 'features/areaAssignments/utils/getAreaAssignees';
+import getStatusColor from 'features/campaigns/utils/getStatusColor';
 
 type Props = {
   caId: number;
   orgId: number;
+  activity: AreaAssignmentActivity;
 };
 
-const AreaAssignmentListItem: FC<Props> = ({ caId, orgId }) => {
+const AreaAssignmentListItem: FC<Props> = ({ caId, orgId, activity }) => {
   const { data: assignment } = useAreaAssignment(orgId, caId);
 
   const allSessions = useAreaAssignees(orgId, caId).data || [];
@@ -24,7 +27,7 @@ const AreaAssignmentListItem: FC<Props> = ({ caId, orgId }) => {
   }
 
   const areaAssignees = getAreaAssignees(sessions);
-  const color = STATUS_COLORS.GREY;
+  const color = getStatusColor(activity.visibleFrom, activity.visibleUntil);
 
   return (
     <ActivityListItem

--- a/src/features/campaigns/components/ActivityList/items/AreaAssignmentListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/AreaAssignmentListItem.tsx
@@ -2,16 +2,16 @@ import { FC } from 'react';
 import { Map, Person } from '@mui/icons-material';
 
 import { AreaAssignmentActivity } from 'features/campaigns/types';
-import ActivityListItem, { STATUS_COLORS } from './ActivityListItem';
+import ActivityListItem from './ActivityListItem';
 import useAreaAssignment from 'features/areaAssignments/hooks/useAreaAssignment';
 import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
 import getAreaAssignees from 'features/areaAssignments/utils/getAreaAssignees';
 import getStatusColor from 'features/campaigns/utils/getStatusColor';
 
 type Props = {
+  activity: AreaAssignmentActivity;
   caId: number;
   orgId: number;
-  activity: AreaAssignmentActivity;
 };
 
 const AreaAssignmentListItem: FC<Props> = ({ caId, orgId, activity }) => {


### PR DESCRIPTION
## Description

This PR adds the correct method for selecting the status colour for an area assignment in the project activity list.

## Screenshots

![Screenshot From 2025-06-08 11-06-51](https://github.com/user-attachments/assets/421c4373-5006-4bb8-80ee-01717ac5d68b)
![Screenshot From 2025-06-08 11-07-08](https://github.com/user-attachments/assets/2869b522-2020-4dd0-b783-a32331b0c03f)


## Changes

* Adds the correct method for selecting the status colour (replacing hard coded grey value)

## Notes to reviewer

(none)

## Related issues

Resolves #2446 
