### PR TITLE
Issue 2840 & 2841: Adding tabindex to ZUITabbedNavBar to improve accessibility

### DIFF
--- a/src/zui/components/ZUITabbedNavBar/index.tsx
+++ b/src/zui/components/ZUITabbedNavBar/index.tsx
@@ -127,6 +127,7 @@ const ZUITabbedNavBar: FC<ZUITabbedNavBarProps> = ({
             minWidth: '1.5rem',
             paddingY: '0.563rem',
           }}
+          tabIndex={0}
           value={tab.value}
         />
       ))}


### PR DESCRIPTION

## Description
Add `tabindex={0}` to all tabs of ZUITabbedNavBar, to enforce they all are navigable. 

## Screenshots
Before:
![Jun-08-2025 18-48-09](https://github.com/user-attachments/assets/a4ed8413-fb64-4a1b-9753-ffeb1853b253)

After:
![Jun-08-2025 18-47-54](https://github.com/user-attachments/assets/31abdbaf-6f5d-406e-af1d-ef9b72ffd8f7)

## Notes to reviewer
Go to:
http://localhost:3000/my/home
http://localhost:3000/o/1

Use `tab` and notice the sequence. Compare with: 
https://app.dev.zetkin.org/my/home
https://app.dev.zetkin.org/o/1

## Related issues
Resolves #2840, #2841
