### PR TITLE
Canvasser map reporting improvements

### DIFF
--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -231,6 +231,14 @@ const areaAssignmentSlice = createSlice({
         remoteItemUpdated(list, location);
       });
     },
+    locationLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinLocation]>
+    ) => {
+      const [assignmentId, location] = action.payload;
+
+      remoteItemUpdated(state.locationsByAssignmentId[assignmentId], location);
+    },
     locationUpdated: (state, action: PayloadAction<ZetkinLocation>) => {
       const location = action.payload;
 
@@ -328,6 +336,7 @@ export const {
   assignmentAreasLoaded,
   householdVisitCreated,
   locationCreated,
+  locationLoaded,
   locationsInvalidated,
   locationsLoad,
   locationsLoaded,

--- a/src/features/canvass/components/GLCanvassMap/MarkerImageRenderer.ts
+++ b/src/features/canvass/components/GLCanvassMap/MarkerImageRenderer.ts
@@ -15,8 +15,8 @@ export default class MarkerImageRenderer implements StyleImageInterface {
     selected: boolean,
     color: string
   ) {
-    this.width = 21;
-    this.height = 30;
+    this.width = 23;
+    this.height = 32;
     this.data = new Uint8ClampedArray(this.width * this.height * 4);
 
     this._color = color;
@@ -51,11 +51,15 @@ export default class MarkerImageRenderer implements StyleImageInterface {
     }
 
     const pinOutlinePath = new Path2D(
-      'M10.5 0C4.695 0 0 4.695 0 10.5C0 18.375 10.5 30 10.5 30C10.5 30 21 18.375 21 10.5C21 4.695 16.305 0 10.5 0Z'
+      'M11.5 1C5.695 1 1 5.695 1 11.5C1 19.375 11.5 31 11.5 31C11.5 31 22 19.375 22 11.5C21 5.695 17.305 1 11.5 1Z'
     );
     const pinInteriorPath = new Path2D(
-      'M10.5 3C6 3 3 6.5 3 10.5C3 16 10.5 27 10.5 27C10.5 27 18 16 18 10.5C18 6.5 15 3 10.5 3Z'
+      'M11.5 4C7 4 4 7.5 4 11.5C4 17 11.5 28 11.5 28C11.5 28 19 17 19 11.5C19 7.5 16 4 11.5 4Z'
     );
+
+    context.strokeStyle = 'rgba(0,0,0,0.15)';
+    context.lineWidth = 2;
+    context.stroke(pinOutlinePath);
 
     context.fillStyle = this._selected ? this._color : '#ffffff';
     context.fill(pinOutlinePath);

--- a/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
@@ -190,7 +190,7 @@ const LocationVisitPage: FC<Props> = ({
                         <IntInput
                           label={messages.visit.location.yesInputLabel()}
                           labelPlacement="horizontal"
-                          min={1}
+                          min={0}
                           onChange={(value) => {
                             setValuesByMetricId((current) => ({
                               ...current,
@@ -202,7 +202,7 @@ const LocationVisitPage: FC<Props> = ({
                         <IntInput
                           label={messages.visit.location.noInputLabel()}
                           labelPlacement="horizontal"
-                          min={1}
+                          min={0}
                           onChange={(value) => {
                             setValuesByMetricId((current) => ({
                               ...current,
@@ -295,6 +295,7 @@ const LocationVisitPage: FC<Props> = ({
                               key={ratingValue}
                               label={ratingValue.toString()}
                               labelPlacement="horizontal"
+                              min={0}
                               onChange={(newValue) => {
                                 setValuesByMetricId((current) => ({
                                   ...current,


### PR DESCRIPTION
## Description
This PR fixes two problems with the canvasser map.

## Screenshots
![image](https://github.com/user-attachments/assets/75071978-2680-4d1f-954b-8e39dc522c1e)

![image](https://github.com/user-attachments/assets/1ee932b4-7e66-4afe-b6a1-3c2a562f35f7)

## Changes
* Adds a slight stroke around the pin markers, as a simpler version of the shadow that existed in the DOM-based map, so that individual markers are more easily distinguished when close to each other
* Reloads location stats after submitting a visit, which was solved (but never merged) in #2803, but in a way that was incompatible with how the map works now
* Fixes bugs with the lower bounds when bulk reporting ("Quick report")
  * There was no lower bound on scale questions
  * The lower bound on yes/no questions was 1 (for some reason) which meant that once you had pressed plus once, you could not go back to zero by pressing minus

## Notes to reviewer
None

## Related issues
Undocumented