### PR TITLE
Fix size of loaded image for ZUIItemCard

### DIFF
--- a/src/zui/components/ZUIItemCard/index.tsx
+++ b/src/zui/components/ZUIItemCard/index.tsx
@@ -144,10 +144,10 @@ const ZUIItemCard: FC<ItemCard> = (props) => {
           {hasImageSrc && (
             <Image
               alt={props.title}
-              height={100}
+              height={480}
               src={props.src}
               style={{ height: '100%', objectFit: 'cover', width: '100%' }}
-              width={100}
+              width={960}
             />
           )}
           {hasImageElement && props.imageElement}


### PR DESCRIPTION
## Description
This PR fixes #2685, which I believe was due to a misunderstanding about the `width` and `height` properties of the NEXTjs `Image` component.


## Screenshots
![image](https://github.com/user-attachments/assets/26d1ef8f-5fb1-420f-8f3e-1da5910251d5)

## Changes
* Changes `width` and `height` to use 960 and 480 pixels respectively, so that sufficiently large images are loaded

## Notes to reviewer
See issue for instructions on how to reproduce

## Related issues
Resolves #2685 