### PR TITLE
Refactor area coordinate handling to improve consistency

### DIFF
--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -70,10 +70,11 @@ const AreaSelect: FC<Props> = ({
 
   const locationsInSelectedArea: ZetkinLocation[] = [];
   if (selectedArea) {
+    const points = selectedArea.boundary.coordinates[0] || [];
     locations.map((location) => {
       const isInsideArea = isPointInsidePolygon(
         locToLatLng(location),
-        selectedArea.points.map((point) => ({ lat: point[0], lng: point[1] }))
+        points.map((point) => ({ lat: point[0], lng: point[1] }))
       );
       if (isInsideArea) {
         locationsInSelectedArea.push(location);

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -158,14 +158,16 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
             if (map) {
               if (areas.length) {
                 // Start with first area
+                const boundary = areas[0].boundary.coordinates[0] || [];
                 const totalBounds = latLngBounds(
-                  areas[0].points.map((p) => objToLatLng(p))
+                  boundary.map((p) => objToLatLng(p))
                 );
 
                 // Extend with all areas
                 areas.forEach((area) => {
+                  const areaPoints = area.boundary.coordinates[0] || [];
                   const areaBounds = latLngBounds(
-                    area.points.map((p) => objToLatLng(p))
+                    areaPoints.map((p) => objToLatLng(p))
                   );
                   totalBounds.extend(areaBounds);
                 });

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -315,7 +315,8 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
           (area) => area.id === navigateToAreaId
         );
         if (areaToNavigate) {
-          map.fitBounds(areaToNavigate.points);
+          const boundary = areaToNavigate.boundary.coordinates[0] || [];
+          map.fitBounds(boundary);
           setZoomed(true);
         }
       } else {
@@ -365,9 +366,10 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
     locationsByAreaId[area.id] = [];
 
     locations.forEach((location) => {
+      const points = area.boundary.coordinates[0] || [];
       const isInsideArea = isPointInsidePolygon(
         locToLatLng(location),
-        area.points.map((point) => ({
+        points.map((point) => ({
           lat: point[0],
           lng: point[1],
         }))
@@ -474,6 +476,8 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
               ? (stats.num_visited_households / stats.num_households) * 100
               : 0;
 
+            const points = area.boundary.coordinates[0] || [];
+
             return (
               <Polygon
                 key={key}
@@ -491,7 +495,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                 )}
                 fillOpacity={1}
                 interactive={areaStyle != 'hide'}
-                positions={area.points}
+                positions={points}
                 weight={selected ? 5 : 2}
               />
             );
@@ -503,9 +507,10 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
             //Find ids of area/s that the location is in
             const areaIds: number[] = [];
             areas.forEach((area) => {
+              const points = area.boundary.coordinates[0] || [];
               const isInsideArea = isPointInsidePolygon(
                 locToLatLng(location),
-                area.points.map((point) => ({
+                points.map((point) => ({
                   lat: point[0],
                   lng: point[1],
                 }))
@@ -568,9 +573,10 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
       )}
       <FeatureGroup>
         {filteredAreas.map((area) => {
+          const points = area.boundary.coordinates[0] || [];
           const mid: [number, number] = [0, 0];
-          if (area.points.length) {
-            area.points
+          if (points.length) {
+            points
               .map((input) => {
                 if ('lat' in input && 'lng' in input) {
                   return [input.lat as number, input.lng as number];
@@ -583,8 +589,8 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                 mid[1] += point[1];
               });
 
-            mid[0] /= area.points.length;
-            mid[1] /= area.points.length;
+            mid[0] /= points.length;
+            mid[1] /= points.length;
           }
 
           const detailed = zoom >= 15;

--- a/src/features/areaAssignments/hooks/useAssignmentAreas.ts
+++ b/src/features/areaAssignments/hooks/useAssignmentAreas.ts
@@ -1,20 +1,23 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
 import { assignmentAreasLoad, assignmentAreasLoaded } from '../store';
-import { Zetkin2Area } from 'features/areas/types';
+import { ZetkinArea } from 'features/areas/types';
 import useRemoteList from 'core/hooks/useRemoteList';
 
-export default function useAssignmentAreas(orgId: number, areaAssId: number) {
+export default function useAssignmentAreas(
+  orgId: number,
+  areaAssignmentId: number
+) {
   const apiClient = useApiClient();
   const list = useAppSelector(
-    (state) => state.areaAssignments.areasByAssignmentId[areaAssId]
+    (state) => state.areaAssignments.areasByAssignmentId[areaAssignmentId]
   );
 
   return useRemoteList(list, {
-    actionOnLoad: () => assignmentAreasLoad(areaAssId),
-    actionOnSuccess: (data) => assignmentAreasLoaded([areaAssId, data]),
+    actionOnLoad: () => assignmentAreasLoad(areaAssignmentId),
+    actionOnSuccess: (data) => assignmentAreasLoaded([areaAssignmentId, data]),
     loader: () =>
-      apiClient.get<Zetkin2Area[]>(
-        `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas`
+      apiClient.get<ZetkinArea[]>(
+        `/api2/orgs/${orgId}/area_assignments/${areaAssignmentId}/areas`
       ),
   });
 }

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -23,7 +23,7 @@ import {
   SessionDeletedPayload,
   ZetkinMetric,
 } from './types';
-import { Zetkin2Area } from 'features/areas/types';
+import { ZetkinArea } from 'features/areas/types';
 import { ZetkinHouseholdVisit } from 'features/canvass/types';
 
 export interface AreaAssignmentsStoreSlice {
@@ -36,7 +36,7 @@ export interface AreaAssignmentsStoreSlice {
     RemoteItem<ZetkinAssignmentAreaStats & { id: number }>
   >;
   areaAssignmentList: RemoteList<ZetkinAreaAssignment>;
-  areasByAssignmentId: Record<string, RemoteList<Zetkin2Area>>;
+  areasByAssignmentId: Record<string, RemoteList<ZetkinArea>>;
   assigneesByAssignmentId: Record<
     number,
     RemoteList<ZetkinAreaAssignee & { id: number }>
@@ -211,7 +211,7 @@ const areaAssignmentSlice = createSlice({
     },
     assignmentAreasLoaded: (
       state,
-      action: PayloadAction<[number, Zetkin2Area[]]>
+      action: PayloadAction<[number, ZetkinArea[]]>
     ) => {
       const [assignmentId, areas] = action.payload;
       state.areasByAssignmentId[assignmentId] = remoteListLoaded(areas);

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -1,11 +1,3 @@
-import {
-  FC,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
 import { Close } from '@mui/icons-material';
 import {
   Box,
@@ -16,17 +8,25 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { ZetkinArea } from '../../types';
-import useAreaMutations from '../../hooks/useAreaMutations';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import { ZUIExpandableText } from 'zui/ZUIExpandableText';
 import ZUIPreviewableInput, {
   ZUIPreviewableMode,
 } from 'zui/ZUIPreviewableInput';
-import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
-import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import { Msg, useMessages } from 'core/i18n';
-import messageIds from 'features/areas/l10n/messageIds';
-import { ZUIExpandableText } from 'zui/ZUIExpandableText';
+import messageIds from '../../l10n/messageIds';
+import useAreaMutations from '../../hooks/useAreaMutations';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 
 type Props = {
   area: ZetkinArea;
@@ -44,18 +44,20 @@ const AreaOverlay: FC<Props> = ({
   onClose,
 }) => {
   const messages = useMessages(messageIds);
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+  const { deleteArea, updateArea } = useAreaMutations(
+    area.organization_id,
+    area.id
+  );
+
   const [title, setTitle] = useState(area.title);
   const [description, setDescription] = useState(area.description);
   const [fieldEditing, setFieldEditing] = useState<
     'title' | 'description' | null
   >(null);
-  const { deleteArea, updateArea } = useAreaMutations(
-    area.organization_id,
-    area.id
-  );
-  const tagsElement = useRef<HTMLElement>();
-  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+
   const enteredEditableMode = useRef(false);
+  const tagsElement = useRef<HTMLElement>();
 
   const handleDescriptionTextAreaRef = useCallback(
     (el: HTMLTextAreaElement | null) => {
@@ -224,7 +226,7 @@ const AreaOverlay: FC<Props> = ({
               onClick={() => {
                 updateArea({
                   boundary: {
-                    coordinates: [area.points],
+                    coordinates: [area.boundary.coordinates[0]],
                     type: 'Polygon',
                   },
                 });

--- a/src/features/areas/models.ts
+++ b/src/features/areas/models.ts
@@ -3,17 +3,17 @@ import mongoose from 'mongoose';
 import { ZetkinArea } from './types';
 
 type ZetkinAreaModelType = {
+  boundary: ZetkinArea['boundary'];
   description: string;
   orgId: number;
-  points: ZetkinArea['points'];
   tags: { id: number; value?: string }[];
   title: string;
 };
 
 const areaSchema = new mongoose.Schema<ZetkinAreaModelType>({
+  boundary: Object,
   description: String,
   orgId: { required: true, type: Number },
-  points: Array,
   tags: Array,
   title: String,
 });

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,31 +1,22 @@
 import { ZetkinTag } from 'utils/types/zetkin';
 
+// Backend format: [lng, lat]
 export type PointData = [number, number];
 
+export type ZetkinAreaLine = PointData[];
+
 export type ZetkinArea = {
-  description: string;
-  id: number;
-  organization_id: number;
-  points: PointData[];
-  tags: ZetkinTag[];
-  title: string;
-};
-
-export type ZetkinAreaPostBody = Partial<Omit<ZetkinArea, 'id'>>;
-
-export type Zetkin2AreaLine = PointData[];
-
-export type Zetkin2Area = {
   boundary: {
-    coordinates: Zetkin2AreaLine[];
+    coordinates: ZetkinAreaLine[];
     type: 'Polygon';
   };
   description: string;
   id: number;
   organization_id: number;
+  tags: ZetkinTag[];
   title: string;
 };
 
-export type Zetkin2AreaPostBody = Partial<
-  Omit<Zetkin2Area, 'id' | 'organization_id'>
+export type ZetkinAreaPostBody = Partial<
+  Omit<ZetkinArea, 'id' | 'organization_id'>
 >;

--- a/src/features/areas/utils/coordinateConversion.ts
+++ b/src/features/areas/utils/coordinateConversion.ts
@@ -1,0 +1,59 @@
+import { PointData, ZetkinArea } from '../types';
+
+/**
+ * Convert coordinates from backend format [lng, lat] to display format [lat, lng]
+ */
+export function backendToDisplay(point: PointData): PointData {
+  return [point[1], point[0]]; // [lng, lat] -> [lat, lng]
+}
+
+/**
+ * Convert coordinates from display format [lat, lng] to backend format [lng, lat]
+ */
+export function displayToBackend(point: PointData): PointData {
+  return [point[1], point[0]]; // [lat, lng] -> [lng, lat]
+}
+
+/**
+ * Convert array of coordinates from backend format to display format
+ */
+export function backendToDisplayArray(points: PointData[]): PointData[] {
+  return points.map(backendToDisplay);
+}
+
+/**
+ * Convert array of coordinates from display format to backend format
+ */
+export function displayToBackendArray(points: PointData[]): PointData[] {
+  return points.map(displayToBackend);
+}
+
+/**
+ * Extract the first polygon's coordinates from an area's boundary
+ * For backward compatibility with components expecting a points array
+ */
+export function getAreaPoints(area: ZetkinArea): PointData[] {
+  return area.boundary.coordinates[0] || [];
+}
+
+/**
+ * Extract the first polygon's coordinates in display format [lat, lng]
+ * For backward compatibility with components expecting a points array
+ */
+export function getAreaDisplayPoints(area: ZetkinArea): PointData[] {
+  return backendToDisplayArray(getAreaPoints(area));
+}
+
+/**
+ * Create a boundary structure from a points array
+ * For converting from old points format to new boundary format
+ */
+export function createBoundaryFromPoints(points: PointData[]): {
+  coordinates: PointData[][];
+  type: 'Polygon';
+} {
+  return {
+    coordinates: [points],
+    type: 'Polygon',
+  };
+}

--- a/src/features/canvass/utils/getBoundSize.ts
+++ b/src/features/canvass/utils/getBoundSize.ts
@@ -4,7 +4,9 @@ import { ZetkinArea } from '../../areas/types';
 import objToLatLng from '../../areas/utils/objToLatLng';
 
 export const getBoundSize = (area: ZetkinArea): number => {
-  const bounds0 = latLngBounds(area.points.map(objToLatLng));
+  const coordinates = area.boundary.coordinates[0] || [];
+
+  const bounds0 = latLngBounds(coordinates.map(objToLatLng));
   const dx = bounds0.getEast() - bounds0.getWest();
   const dy = bounds0.getNorth() - bounds0.getSouth();
   return dx * dy;

--- a/src/features/geography/components/GeographyMap/MapRenderer.tsx
+++ b/src/features/geography/components/GeographyMap/MapRenderer.tsx
@@ -108,11 +108,11 @@ const MapRenderer: FC<Props> = ({
           <Polygon
             key={'editing'}
             color={theme.palette.primary.main}
-            positions={editingArea.points}
+            positions={editingArea.boundary.coordinates[0] || []}
             weight={5}
           />
         )}
-        {editingArea?.points?.map((point, index) => {
+        {editingArea?.boundary.coordinates[0]?.map((point, index) => {
           return (
             <DivIconMarker
               key={index}
@@ -121,11 +121,18 @@ const MapRenderer: FC<Props> = ({
                 dragend: (evt) => {
                   const latLng = evt.target.getLatLng();
                   const movedPoint: PointData = [latLng.lat, latLng.lng];
+                  const currentPoints =
+                    editingArea.boundary.coordinates[0] || [];
                   onChangeArea({
                     ...editingArea,
-                    points: editingArea.points.map((oldPoint, oldIndex) =>
-                      oldIndex == index ? movedPoint : oldPoint
-                    ),
+                    boundary: {
+                      ...editingArea.boundary,
+                      coordinates: [
+                        currentPoints.map((oldPoint, oldIndex) =>
+                          oldIndex == index ? movedPoint : oldPoint
+                        ),
+                      ],
+                    },
                   });
                 },
               }}
@@ -169,7 +176,7 @@ const MapRenderer: FC<Props> = ({
                     }
                   },
                 }}
-                positions={area.points}
+                positions={area.boundary.coordinates[0] || []}
                 weight={2}
               />
             );
@@ -183,7 +190,7 @@ const MapRenderer: FC<Props> = ({
                 onSelectArea(null);
               },
             }}
-            positions={selectedArea.points}
+            positions={selectedArea.boundary.coordinates[0] || []}
             weight={5}
           />
         )}

--- a/src/features/geography/components/GeographyMap/index.tsx
+++ b/src/features/geography/components/GeographyMap/index.tsx
@@ -51,8 +51,8 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     const map = mapRef.current;
 
     if (selectedArea && map) {
-      const points = selectedArea.points.map((p) => objToLatLng(p));
-      const areaBounds = latLngBounds(points);
+      const points = selectedArea.boundary.coordinates[0] || [];
+      const areaBounds = latLngBounds(points.map((p) => objToLatLng(p)));
       const topRightOnMap = areaBounds.getNorthEast();
       const container = map.getContainer();
 
@@ -114,14 +114,12 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     const map = mapRef.current;
     if (map) {
       if (areas.length) {
-        const totalBounds = latLngBounds(
-          areas[0].points.map((p) => objToLatLng(p))
-        );
+        const boundary = areas[0].boundary.coordinates[0] || [];
+        const totalBounds = latLngBounds(boundary.map((p) => objToLatLng(p)));
 
         areas.forEach((area) => {
-          const areaBounds = latLngBounds(
-            area.points.map((p) => objToLatLng(p))
-          );
+          const boundary = area.boundary.coordinates[0] || [];
+          const areaBounds = latLngBounds(boundary.map((p) => objToLatLng(p)));
           totalBounds.extend(areaBounds);
         });
 
@@ -253,7 +251,9 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
               areas={filteredAreas}
               drawingPoints={drawingPoints}
               editingArea={editingArea}
-              onChangeArea={(area) => setEditingArea(area)}
+              onChangeArea={(area) => {
+                setEditingArea(area);
+              }}
               onChangeDrawingPoints={(points) => setDrawingPoints(points)}
               onFinishDrawing={() => finishDrawing()}
               onSelectArea={(area) => setSelectedId(area?.id ?? 0)}


### PR DESCRIPTION

## Description
This PR refactors coordinate handling in the areas feature to improve consistency and reduce confusion. The changes move coordinate conversion logic to happen at the data layer (when fetching/posting) rather than in individual components, and consolidate area data types into a single, cleaner structure.

## Screenshots
[Add screenshots here]


## Changes
* Consolidates area data types: Removes the confusing Zetkin2Area datatype and uses a single ZetkinArea type
* Centralizes coordinate conversion: Converts coordinates from backend format [lng, lat] to display format [lat, lng] at the data fetching layer instead of in individual components
* Adds coordinate conversion utilities: Creates a new coordinateConversion.ts utility module with helper functions for converting between backend and display coordinate formats
* Updates area hooks: Modifies useAreas, useAreaMutations, and useCreateArea to handle coordinate conversion automatically
* Simplifies component logic: Removes coordinate conversion logic from map components (OrganizerMap, OrganizerMapRenderer, AreaOverlay, GeographyMap) since conversion now happens at the data layer


## Notes to reviewer
`GLCanvassMap` was not updated because I couldn't get this to work either with or without the changes made. Hopefully you can make the necessary changes if you think this is a good approach.


## Related issues
Resolves #[id]
