### PR TITLE
Small bugs in canvass visit reporting

### DIFF
--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -152,6 +152,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
               onHouseholdVisitStart={() => {
                 goto('householdVisit');
               }}
+              showLogVisitButton={assignment.reporting_level == 'household'}
               visitedInThisAssignment={
                 !!lastVisitByHouseholdId[selectedHouseholdId]
               }

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdPage.tsx
@@ -14,10 +14,12 @@ type HouseholdPageProps = {
   onClose: () => void;
   onEdit: () => void;
   onHouseholdVisitStart: () => void;
+  showLogVisitButton: boolean;
   visitedInThisAssignment: boolean;
 };
 
 const HouseholdPage: FC<HouseholdPageProps> = ({
+  showLogVisitButton,
   householdId,
   location,
   onBack,
@@ -42,9 +44,11 @@ const HouseholdPage: FC<HouseholdPageProps> = ({
               <Msg id={messageIds.households.single.wasVisited} />
             </Typography>
           )}
-          <Button onClick={onHouseholdVisitStart} variant="contained">
-            <Msg id={messageIds.households.single.logVisitButtonLabel} />
-          </Button>
+          {showLogVisitButton && (
+            <Button onClick={onHouseholdVisitStart} variant="contained">
+              <Msg id={messageIds.households.single.logVisitButtonLabel} />
+            </Button>
+          )}
         </Box>
       }
       onBack={onBack}

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
@@ -91,11 +91,11 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
                   },
                 ]
               : [
-                  { label: 1, value: '1' },
-                  { label: 2, value: '2' },
-                  { label: 3, value: '3' },
-                  { label: 4, value: '4' },
-                  { label: 5, value: '5' },
+                  { label: 1, value: 1 },
+                  { label: 2, value: 2 },
+                  { label: 3, value: 3 },
+                  { label: 4, value: 4 },
+                  { label: 5, value: 5 },
                 ];
 
           const stepIsCurrent = index == step;

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
@@ -46,6 +46,7 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
   const [step, setStep] = useState(0);
 
   useEffect(() => {
+    setResponseByMetricId({});
     setStep(0);
   }, [household.id]);
 


### PR DESCRIPTION
## Description
This PR fixes 3 small bugs in canvass assignment visit reporting


## Screenshots
no button at household in location level assignment 
![bild](https://github.com/user-attachments/assets/85d7bbec-6748-499a-b85f-9060088b3ce4)


## Changes
* Only shows the "log visit" button if you're in a household level assignment
* Resets the content of the household report between households 
* Changes scale question from being reported as strings, to being numbers

## Notes to reviewer
none


## Related issues
none
