### PR TITLE
Center progress indicator

### DIFF
--- a/src/zui/ZUINavStack/index.tsx
+++ b/src/zui/ZUINavStack/index.tsx
@@ -41,7 +41,20 @@ const ZUINavStack: FC<Props> = ({ bgcolor, children, currentPage }) => {
                 zIndex: index,
               }}
             >
-              <Suspense fallback={<CircularProgress />}>{child}</Suspense>
+              <Suspense
+                fallback={
+                  <Box
+                    alignItems="center"
+                    display="flex"
+                    height="100%"
+                    justifyContent="center"
+                  >
+                    <CircularProgress />
+                  </Box>
+                }
+              >
+                {child}
+              </Suspense>
             </Box>
           </Slide>
         );


### PR DESCRIPTION
## Description
This PR adjusts the placement of the progress indicator when loading an individual household from a list of households, from a location in a Canvass event.


## Screenshots
https://github.com/user-attachments/assets/b3383fda-709c-4d21-b1b1-6f7e1ff7b7e5


## Changes
* Center the progress indicator horizontally and vertically.
