### PR TITLE
Flipped area coords

### DIFF
--- a/src/features/areaAssignments/components/MapControls.tsx
+++ b/src/features/areaAssignments/components/MapControls.tsx
@@ -1,6 +1,7 @@
 import { Map } from 'leaflet';
 import { FC } from 'react';
 
+import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 import ZUIMapControls from 'zui/ZUIMapControls';
 
 type MapControlsProps = {
@@ -12,8 +13,8 @@ const MapControls: FC<MapControlsProps> = ({ map, onFitBounds }) => {
   return (
     <ZUIMapControls
       onFitBounds={onFitBounds}
-      onGeolocate={(latLng) => {
-        map?.flyTo(latLng, undefined, {
+      onGeolocate={(lngLat) => {
+        map?.flyTo(flipForLeaflet(lngLat), undefined, {
           animate: true,
           duration: 0.8,
         });

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -22,7 +22,7 @@ import {
   ZetkinAreaAssignee,
   ZetkinLocation,
 } from '../types';
-import objToLatLng from 'features/areas/utils/objToLatLng';
+import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 import { assigneesFilterContext } from './OrganizerMapFilters/AssigneeFilterContext';
 import OrganizerMapFilters from './OrganizerMapFilters';
 import OrganizerMapFilterBadge from './OrganizerMapFilters/OrganizerMapFilterBadge';
@@ -159,13 +159,13 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
               if (areas.length) {
                 // Start with first area
                 const totalBounds = latLngBounds(
-                  areas[0].points.map((p) => objToLatLng(p))
+                  areas[0].points.map(flipForLeaflet)
                 );
 
                 // Extend with all areas
                 areas.forEach((area) => {
                   const areaBounds = latLngBounds(
-                    area.points.map((p) => objToLatLng(p))
+                    area.points.map(flipForLeaflet)
                   );
                   totalBounds.extend(areaBounds);
                 });

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -25,6 +25,7 @@ import { useEnv } from 'core/hooks';
 import MarkerIcon from 'features/canvass/components/MarkerIcon';
 import locToLatLng from 'features/geography/utils/locToLatLng';
 import oldTheme from 'theme';
+import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 
 const LocationMarker: FC<{
   location: ZetkinLocation;
@@ -315,7 +316,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
           (area) => area.id === navigateToAreaId
         );
         if (areaToNavigate) {
-          map.fitBounds(areaToNavigate.points);
+          map.fitBounds(areaToNavigate.points.map(flipForLeaflet));
           setZoomed(true);
         }
       } else {
@@ -491,7 +492,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                 )}
                 fillOpacity={1}
                 interactive={areaStyle != 'hide'}
-                positions={area.points}
+                positions={area.points.map(flipForLeaflet)}
                 weight={selected ? 5 : 2}
               />
             );
@@ -579,8 +580,8 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
                 }
               })
               .forEach((point) => {
-                mid[0] += point[0];
-                mid[1] += point[1];
+                mid[0] += point[1];
+                mid[1] += point[0];
               });
 
             mid[0] /= area.points.length;

--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,6 +1,10 @@
+import { Branded } from 'utils/types';
 import { ZetkinTag } from 'utils/types/zetkin';
 
-export type PointData = [number, number];
+export type Longitude = Branded<number, 'Longitude'>;
+export type Latitude = Branded<number, 'Latitude'>;
+
+export type PointData = [Longitude, Latitude];
 
 export type ZetkinArea = {
   description: string;

--- a/src/features/areas/utils/flipForLeaflet.ts
+++ b/src/features/areas/utils/flipForLeaflet.ts
@@ -1,0 +1,8 @@
+import { Latitude, Longitude } from '../types';
+
+export default function flipForLeaflet(
+  pointFromApi: [Longitude, Latitude]
+): [Latitude, Longitude] {
+  const [lng, lat] = pointFromApi;
+  return [lat, lng];
+}

--- a/src/features/geography/components/GeographyMap/MapRenderer.tsx
+++ b/src/features/geography/components/GeographyMap/MapRenderer.tsx
@@ -9,10 +9,16 @@ import {
   useMapEvents,
 } from 'react-leaflet';
 
-import { PointData, ZetkinArea } from 'features/areas/types';
+import {
+  Latitude,
+  Longitude,
+  PointData,
+  ZetkinArea,
+} from 'features/areas/types';
 import { DivIconMarker } from 'features/events/components/LocationModal/DivIconMarker';
 import { getBoundSize } from '../../../canvass/utils/getBoundSize';
 import { useEnv } from 'core/hooks';
+import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 
 type Props = {
   areas: ZetkinArea[];
@@ -43,10 +49,10 @@ const MapRenderer: FC<Props> = ({
   const map = useMapEvents({
     click: (evt) => {
       if (isDrawing) {
-        const lat = evt.latlng.lat;
-        const lng = evt.latlng.lng;
+        const lat = evt.latlng.lat as Latitude;
+        const lng = evt.latlng.lng as Longitude;
         const current = drawingPoints || [];
-        onChangeDrawingPoints([...current, [lat, lng]]);
+        onChangeDrawingPoints([...current, [lng, lat]]);
       }
     },
     zoom: () => {
@@ -85,10 +91,13 @@ const MapRenderer: FC<Props> = ({
         }}
       >
         {drawingPoints && (
-          <Polyline pathOptions={{ color: 'red' }} positions={drawingPoints} />
+          <Polyline
+            pathOptions={{ color: 'red' }}
+            positions={drawingPoints.map(flipForLeaflet)}
+          />
         )}
         {drawingPoints && drawingPoints.length > 0 && (
-          <DivIconMarker position={drawingPoints[0]}>
+          <DivIconMarker position={flipForLeaflet(drawingPoints[0])}>
             <Box
               onClick={(ev) => {
                 ev.stopPropagation();
@@ -108,7 +117,7 @@ const MapRenderer: FC<Props> = ({
           <Polygon
             key={'editing'}
             color={theme.palette.primary.main}
-            positions={editingArea.points}
+            positions={editingArea.points.map(flipForLeaflet)}
             weight={5}
           />
         )}
@@ -120,7 +129,9 @@ const MapRenderer: FC<Props> = ({
               eventHandlers={{
                 dragend: (evt) => {
                   const latLng = evt.target.getLatLng();
-                  const movedPoint: PointData = [latLng.lat, latLng.lng];
+                  const lat = latLng.lat as Latitude;
+                  const lng = latLng.lng as Longitude;
+                  const movedPoint: PointData = [lng, lat];
                   onChangeArea({
                     ...editingArea,
                     points: editingArea.points.map((oldPoint, oldIndex) =>
@@ -129,7 +140,7 @@ const MapRenderer: FC<Props> = ({
                   });
                 },
               }}
-              position={point}
+              position={flipForLeaflet(point)}
             >
               <Box
                 sx={{
@@ -169,7 +180,7 @@ const MapRenderer: FC<Props> = ({
                     }
                   },
                 }}
-                positions={area.points}
+                positions={area.points.map(flipForLeaflet)}
                 weight={2}
               />
             );
@@ -183,7 +194,7 @@ const MapRenderer: FC<Props> = ({
                 onSelectArea(null);
               },
             }}
-            positions={selectedArea.points}
+            positions={selectedArea.points.map(flipForLeaflet)}
             weight={5}
           />
         )}

--- a/src/features/geography/components/GeographyMap/index.tsx
+++ b/src/features/geography/components/GeographyMap/index.tsx
@@ -15,7 +15,7 @@ import { latLngBounds, Map as MapType } from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
 import { useNumericRouteParams } from 'core/hooks';
-import objToLatLng from 'features/areas/utils/objToLatLng';
+import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 import useCreateArea from '../../../areas/hooks/useCreateArea';
 import { PointData, ZetkinArea } from '../../../areas/types';
 import AreaFilters from '../../../areas/components/AreaFilters';
@@ -51,7 +51,7 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     const map = mapRef.current;
 
     if (selectedArea && map) {
-      const points = selectedArea.points.map((p) => objToLatLng(p));
+      const points = selectedArea.points.map(flipForLeaflet);
       const areaBounds = latLngBounds(points);
       const topRightOnMap = areaBounds.getNorthEast();
       const container = map.getContainer();
@@ -114,14 +114,10 @@ const GeographyMap: FC<MapProps> = ({ areas }) => {
     const map = mapRef.current;
     if (map) {
       if (areas.length) {
-        const totalBounds = latLngBounds(
-          areas[0].points.map((p) => objToLatLng(p))
-        );
+        const totalBounds = latLngBounds(areas[0].points.map(flipForLeaflet));
 
         areas.forEach((area) => {
-          const areaBounds = latLngBounds(
-            area.points.map((p) => objToLatLng(p))
-          );
+          const areaBounds = latLngBounds(area.points.map(flipForLeaflet));
           totalBounds.extend(areaBounds);
         });
 

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -29,3 +29,7 @@ export interface Breadcrumb {
  * Stolen from: https://www.emmanuelgautier.com/blog/snippets/typescript-required-properties
  */
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+declare const brand: unique symbol;
+
+export type Branded<T, Brand extends string> = T & { [brand]: Brand };

--- a/src/zui/ZUIMapControls.tsx
+++ b/src/zui/ZUIMapControls.tsx
@@ -3,9 +3,11 @@ import React, { useState } from 'react';
 import { Box, Button, ButtonGroup, useTheme } from '@mui/material';
 import { Add, Remove, GpsFixed, Home } from '@mui/icons-material';
 
+import { Latitude, Longitude, PointData } from 'features/areas/types';
+
 type Props = {
   onFitBounds: () => void;
-  onGeolocate: (latLng: [number, number]) => void;
+  onGeolocate: (lngLat: PointData) => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
 };
@@ -60,12 +62,10 @@ const ZUIMapControls: React.FC<Props> = ({
               (pos) => {
                 setLocating(false);
 
-                const latLng: [number, number] = [
-                  pos.coords.latitude,
-                  pos.coords.longitude,
-                ];
+                const lat = pos.coords.latitude as Latitude;
+                const lng = pos.coords.longitude as Longitude;
 
-                onGeolocate(latLng);
+                onGeolocate([lng, lat]);
               },
               () => {
                 setLocating(false);


### PR DESCRIPTION
## Description
This PR correctly starts treating the backend as using lng/lat instead of lat/lng in GeoJSON-like constructs, like areas.

## Screenshots
None

## Changes
* Adds a `Branded` utility type for "branded" types, and types the `PointData` type as `[Longitude,Latitude]` instead of just `[number,number]`
* Changes all Leaflet based maps to flip the coordinates (temporary until these maps are replaced with GL maps)
* Changes the `GLCanvassMap` component to _not flip_ (it previously had to)

## Notes to reviewer
Depending on when you look at this, the preview build of this branch may mean that all areas appear as if they are located somewhere else in the world entirely. This is not a mistake.

The mistake was before, where latitude was treated as longitude and vice versa, so all areas that have been created before are in the wrong order. Newly created areas will be created and stored correctly.

The order of existing areas need to be flipped in the database using a migration script that I will soon run on the backend.

## Related issues
Undocumented