### PR TITLE
Fix links in search modal

### DIFF
--- a/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CallAssignmentListItem.tsx
@@ -20,12 +20,9 @@ const CallassigmentListItem: React.FunctionComponent<{
   const { orgId } = router.query as { orgId: string };
   return (
     <Link
-      key={callAssignment.id}
       href={`/organize/${orgId}/projects/${
         callAssignment.campaign?.id ?? 'standalone'
       }/callassignments/${callAssignment.id}`}
-      legacyBehavior
-      passHref
     >
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>

--- a/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/CampaignListItem.tsx
@@ -19,12 +19,7 @@ const CampaignListItem: React.FunctionComponent<{
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
   return (
-    <Link
-      key={campaign.id}
-      href={`/organize/${orgId}/projects/${campaign.id}`}
-      legacyBehavior
-      passHref
-    >
+    <Link key={campaign.id} href={`/organize/${orgId}/projects/${campaign.id}`}>
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>
           <ListItemAvatar>

--- a/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/JourneyInstanceListItem.tsx
@@ -20,8 +20,6 @@ const JourneyInstanceListItem: React.FunctionComponent<{
   return (
     <Link
       href={`/organize/${orgId}/journeys/${journeyInstance.journey.id}/${journeyInstance.id}`}
-      legacyBehavior
-      passHref
     >
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>

--- a/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/PersonListItem.tsx
@@ -18,12 +18,7 @@ const PersonListItem: React.FunctionComponent<{ person: ZetkinPerson }> = ({
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
   return (
-    <Link
-      key={person.id}
-      href={`/organize/${orgId}/people/${person.id}`}
-      legacyBehavior
-      passHref
-    >
+    <Link href={`/organize/${orgId}/people/${person.id}`}>
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>
           <ListItemAvatar>

--- a/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/SurveyListItem.tsx
@@ -20,12 +20,7 @@ const SurveyListItem: React.FunctionComponent<{
   const router = useRouter();
   const { orgId } = router.query as { orgId: string };
   return (
-    <Link
-      key={survey.id}
-      href={getSurveyUrl(survey, parseInt(orgId))}
-      legacyBehavior
-      passHref
-    >
+    <Link href={getSurveyUrl(survey, parseInt(orgId))}>
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>
           <ListItemAvatar>

--- a/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/TaskListItem.tsx
@@ -28,10 +28,7 @@ const TaskListItem: React.FunctionComponent<{ task: ZetkinTask }> = ({
 
   return (
     <Link
-      key={task.id}
       href={`/organize/${orgId}/projects/${task.campaign.id}/calendar/tasks/${task.id}`}
-      legacyBehavior
-      passHref
     >
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>

--- a/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
@@ -27,11 +27,7 @@ const ViewListItem: React.FunctionComponent<{ view: ZetkinView }> = ({
   elements.push(messages.results.view());
 
   return (
-    <Link
-      href={`/organize/${orgId}/people/views/${view.id}`}
-      legacyBehavior
-      passHref
-    >
+    <Link href={`/organize/${orgId}/people/views/${view.id}`}>
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>
           <ListItemAvatar>

--- a/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
+++ b/src/features/search/components/SearchDialog/ResultsList/ViewListItem.tsx
@@ -27,7 +27,7 @@ const ViewListItem: React.FunctionComponent<{ view: ZetkinView }> = ({
   elements.push(messages.results.view());
 
   return (
-    <Link href={`/organize/${orgId}/people/views/${view.id}`}>
+    <Link href={`/organize/${orgId}/people/lists/${view.id}`}>
       <ListItem data-testid="SearchDialog-resultsListItem">
         <ListItemButton>
           <ListItemAvatar>

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,3 +42,8 @@ blockquote {
 #nprogress #nprogress .bar {
   position: absolute;
 }
+
+a {
+  text-decoration: inherit;
+  color: inherit;
+}


### PR DESCRIPTION
## Description
This PR fixes an undocumented issue with the links in the search modal. The links were not using basic `<a>` elements, so they didn't behave as normal links in the browser.

## Screenshots
None

## Changes
* Switches links in the search modal to not use the legacy behavior anymore (which means that they will now render `<a>` elements)
* Changes the base CSS stylesheet so that all links inherit their style by default
* Updates the URL used in `ViewListItem` (unrelated to the intent of this PR)

## Notes to reviewer
Please check to see if you find any unrelated links that have been inadvertently changed because of the CSS change.

## Related issues
Undocumented