### PR TITLE
Remove timezone offset from date

### DIFF
--- a/src/features/organizations/layouts/PublicEventLayout.tsx
+++ b/src/features/organizations/layouts/PublicEventLayout.tsx
@@ -12,6 +12,7 @@ import messageIds from '../l10n/messageIds';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
 import useIsMobile from 'utils/hooks/useIsMobile';
 import useEvent from 'features/events/hooks/useEvent';
+import { removeOffset } from 'utils/dateUtils';
 
 type Props = PropsWithChildren<{
   eventId: number;
@@ -51,8 +52,8 @@ export const PublicEventLayout: FC<Props> = ({ children, eventId, orgId }) => {
                 >
                   <ZUIText>
                     <ZUITimeSpan
-                      end={new Date(event.end_time)}
-                      start={new Date(event.start_time)}
+                      end={new Date(removeOffset(event.end_time))}
+                      start={new Date(removeOffset(event.start_time))}
                     />
                   </ZUIText>
                   <ZUIText variant="bodySmRegular">

--- a/src/features/organizations/pages/PublicEventPage.tsx
+++ b/src/features/organizations/pages/PublicEventPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC, Fragment, Suspense, useState } from 'react';
+import { FC, Fragment, Suspense, useMemo, useState } from 'react';
 import { Box } from '@mui/system';
 import {
   CalendarMonth,
@@ -34,6 +34,7 @@ import ZUIButton from 'zui/components/ZUIButton';
 import useMyEvents from 'features/events/hooks/useMyEvents';
 import ZUIPublicFooter from 'zui/components/ZUIPublicFooter';
 import useEvent from 'features/events/hooks/useEvent';
+import { removeOffset } from 'utils/dateUtils';
 
 type Props = {
   eventId: number;
@@ -313,6 +314,14 @@ const DateAndLocation: FC<{
 }> = ({ event }) => {
   const env = useEnv();
   const isMobile = useIsMobile();
+  const startTime = useMemo(
+    () => new Date(removeOffset(event.start_time)),
+    [event]
+  );
+  const endTime = useMemo(
+    () => new Date(removeOffset(event.end_time)),
+    [event]
+  );
 
   return (
     <Box display="flex" flexDirection="column" gap={isMobile ? 1 : 2}>
@@ -334,10 +343,7 @@ const DateAndLocation: FC<{
       <Box alignItems="center" display="flex" gap={1}>
         <ZUIIcon icon={CalendarMonth} />
         <ZUIText>
-          <ZUITimeSpan
-            end={new Date(event.end_time)}
-            start={new Date(event.start_time)}
-          />
+          <ZUITimeSpan end={endTime} start={startTime} />
         </ZUIText>
       </Box>
       {event.url && (


### PR DESCRIPTION
## Description
This PR fixes event page displaying the incorrect time for an event.


## Screenshots
![Screen Shot 2025-06-22 at 11 11 55](https://github.com/user-attachments/assets/5be6758a-6deb-464f-b6db-a194c6c745a0)


## Changes
* Adds removeOffset to start and end times.


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #2882 
