### PR TITLE
increase Padding from 20px to 200px for initialViewState in ActivistP…

### DIFF
--- a/src/features/organizations/components/ActivistPortalEventMap.tsx
+++ b/src/features/organizations/components/ActivistPortalEventMap.tsx
@@ -97,7 +97,7 @@ export const ActivistPortalEventMap: FC<
         ref={(map) => setMap(map?.getMap() ?? null)}
         initialViewState={{
           bounds,
-          fitBoundsOptions: { padding: 20 },
+          fitBoundsOptions: { padding: 200 },
         }}
         mapStyle={env.vars.MAPLIBRE_STYLE}
         onClick={(ev) => {


### PR DESCRIPTION
## Description
This PR increases the zoom Padding from 20px to 200px for initialViewState in ActivistPortalEventMap to zoom out a bit.


## Screenshots
<img width="1280" alt="New Zoom" src="https://github.com/user-attachments/assets/694302fb-b2e7-432c-bc70-915eba1cb38c" />



## Changes
* Changes:
increases the zoom Padding from 20px to 200px for initialViewState in ActivistPortalEventMap


## Related issues
Resolves #2878
