### PR TITLE
Add URL card to events

### DIFF
--- a/src/features/events/components/EventURLCard.tsx
+++ b/src/features/events/components/EventURLCard.tsx
@@ -1,0 +1,78 @@
+import { OpenInNew } from '@mui/icons-material';
+import { useMemo } from 'react';
+import { Box, Link, useTheme } from '@mui/material';
+
+import ZUICard from 'zui/ZUICard';
+import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
+import { Msg, useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+import useEvent from '../hooks/useEvent';
+
+interface EventURLCardProps {
+  isOpen: boolean;
+  orgId: number;
+  eventId: number;
+}
+
+const EventURLCard = ({
+  isOpen,
+  orgId,
+  eventId: eventId,
+}: EventURLCardProps) => {
+  const event = useEvent(orgId, eventId);
+  const messages = useMessages(messageIds);
+  const theme = useTheme();
+  const eventUrl = useMemo(
+    () =>
+      event != null && event.data
+        ? `${location.protocol}//${location.host}/o/${event.data.organization.id}/events/${eventId}`
+        : '',
+    [event?.data, eventId]
+  );
+
+  return (
+    <Box mt={2}>
+      <ZUICard
+        header={isOpen ? messages.urlCard.open() : messages.urlCard.preview()}
+        status={
+          <Box
+            sx={{
+              backgroundColor: isOpen
+                ? theme.palette.success.main
+                : theme.palette.grey['500'],
+              borderRadius: 5,
+              height: 20,
+              width: 20,
+            }}
+          />
+        }
+        subheader={
+          isOpen
+            ? messages.urlCard.nowAccepting()
+            : messages.urlCard.willAccept()
+        }
+      >
+        <Box display="flex" paddingBottom={2}>
+          <ZUITextfieldToClipboard copyText={eventUrl}>
+            {eventUrl}
+          </ZUITextfieldToClipboard>
+        </Box>
+        <Link
+          display="flex"
+          href={`/o/${orgId}/events/${eventId}`}
+          sx={{ alignItems: 'center', gap: 1 }}
+          target="_blank"
+        >
+          <OpenInNew fontSize="inherit" />
+          {isOpen ? (
+            <Msg id={messageIds.urlCard.visitPortal} />
+          ) : (
+            <Msg id={messageIds.urlCard.previewPortal} />
+          )}
+        </Link>
+      </ZUICard>
+    </Box>
+  );
+};
+
+export default EventURLCard;

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -292,4 +292,12 @@ export default makeMessages('feat.events', {
     tooltip: m('Click to change type'),
     uncategorized: m('Uncategorized'),
   },
+  urlCard: {
+    nowAccepting: m('Now accepting sign-ups at this link'),
+    open: m('Open for sign-ups'),
+    preview: m('Preview event'),
+    previewPortal: m('Preview event in activist portal'),
+    visitPortal: m('Visit event in activist portal'),
+    willAccept: m('Will accept sign-ups at this link'),
+  },
 });

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -8,6 +8,7 @@ import EventLayout from 'features/events/layout/EventLayout';
 import EventOverviewCard from 'features/events/components/EventOverviewCard';
 import EventParticipantsCard from 'features/events/components/EventParticipantsCard';
 import EventRelatedCard from 'features/events/components/EventRelatedCard';
+import EventURLCard from 'features/events/components/EventURLCard';
 import useEvent from 'features/events/hooks/useEvent';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUIFuture from 'zui/ZUIFuture';
@@ -68,6 +69,11 @@ const EventPage: PageWithLayout<EventPageProps> = ({ orgId, eventId }) => {
                 orgId={parseInt(orgId)}
               />
               <EventRelatedCard data={data} orgId={parseInt(orgId)} />
+              <EventURLCard
+                eventId={parseInt(eventId)}
+                isOpen={data.published != null}
+                orgId={parseInt(orgId)}
+              />
             </Grid>
           </Grid>
         );


### PR DESCRIPTION
## Description
This PR adds a box with the public URL for a event signup page.


## Screenshots

![image](https://github.com/user-attachments/assets/af3679a2-d938-4229-9deb-0b236ab3a861)


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds way to visit and copy URL to event page, based on the `<SurveyURLCart />` component.

## Notes to reviewer

Visit ex. http://localhost:3000/organize/1/projects/93/events/312 which should now have the URL card.

Questions:

* Does it make sense to mark it as open if `event.published != null`?
* Would it make sense to create a generalized `<URLCard />` that can be used both here, in surveys and on orgs (#2880)? I think it would require adding eventUrl and messageIds props to the component.

## Related issues
Resolves #2514 
