### PR TITLE
Issue 2730: Fixes the breadcrumb path of subpages in call assignments and surveys

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -51,12 +51,10 @@ const breadcrumbs = async (
         elements.forEach((elem) => breadcrumbs.push(elem));
         curPath.push(fieldValue);
       } else {
-        if (
-          field == 'callassignments' ||
-          field == 'folders' ||
-          field == 'lists' ||
-          field == 'surveys'
-        ) {
+        if (field == 'callassignments' || field == 'surveys') {
+          curPath.push(field);
+          continue;
+        } else if (field == 'folders' || field == 'lists') {
           // Ignore "views" and "folders" which are only there
           // for technical reasons, but do not represent any page
           // and shouldn't link to anything.


### PR DESCRIPTION
## Description
This PR fixes the breadcrumb path so that clicking on the call assignment or survey breadcrumb it takes you to the Overview page instead of a 404.


## Screenshots
![image](https://github.com/user-attachments/assets/8193c8f5-fc51-45bc-8e2a-abeb6b5f3312)


## Changes

* Changes the breadcrumbs.ts so that call assignments and surveys still add to the current path as opposed to being ignored like folders and lists.


## Notes to reviewer
Go to a call assignment or survey. Click on one of the subpage headers, such as Questions or Submissions for surveys. Click on the breadcrumb for the survey or call assignment. Without these changes it should take you to a 404, and with these changes it should take you to the Overview page.


## Related issues
Resolves #2730 
