### PR TITLE
Add file extension on lint:translations script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docs:build": "storybook build -o public/storybook",
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",
-    "lint:translations": "ts-node src/tools/lint-translations",
+    "lint:translations": "ts-node src/tools/lint-translations.ts",
     "lint": "run-p lint:*",
     "check-types": "tsc --noEmit",
     "test": "jest",


### PR DESCRIPTION
## Description
This PR adds a file extension on script that is run by the `lint:translations` package.json script. This is done because some (ex. me) are unable to run the script without errors.

## Screenshots
n/a


## Changes

* Changes the lint:translations script to include file extension.

## Notes to reviewer

#2784 also has this change + a lot more. This PR only focus on this specific issue which apparently blocks linting for some but not everyone.

## Related issues
