### PR TITLE
Issue 2868: on single Event Page show "You are the contact person", if you are the contact person

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ tsconfig.tsbuildinfo
 # generated docs
 public/docs
 public/storybook
-package.json

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ tsconfig.tsbuildinfo
 # generated docs
 public/docs
 public/storybook
+package.json

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -29,6 +29,7 @@ export default makeMessages('feat.organizations', {
     cancelledParagraph: m(
       'You can no longer sign up for it and if you were signed up, you are no longer expected to attend.'
     ),
+    contactPersonThemself: m('You are the contact person'),
     contactPerson: m<{ name: string }>('{name} is the contact person'),
     defaultTitle: m('Untitled event'),
     loading: m('Loading...'),

--- a/src/features/organizations/pages/PublicEventPage.tsx
+++ b/src/features/organizations/pages/PublicEventPage.tsx
@@ -34,6 +34,7 @@ import ZUIButton from 'zui/components/ZUIButton';
 import useMyEvents from 'features/events/hooks/useMyEvents';
 import ZUIPublicFooter from 'zui/components/ZUIPublicFooter';
 import useEvent from 'features/events/hooks/useEvent';
+import useUser from 'core/hooks/useUser';
 
 type Props = {
   eventId: number;
@@ -219,7 +220,14 @@ const ContactPersonSection: FC<{
   contactPerson: { email?: string; id: number; name: string; phone?: string };
 }> = ({ contactPerson }) => {
   const [expandContactMethods, setExpandContactMethods] = useState(false);
-
+  const user = useUser()
+  if (user?.id===contactPerson.id){
+    return (
+      <Box bgcolor="white" borderRadius={2} padding={2}>
+        <Msg id={messageIds.eventPage.contactPersonThemself} />
+      </Box>
+    )
+  }
   const hasContactMethods =
     'email' in contactPerson || 'phone' in contactPerson;
 


### PR DESCRIPTION
## Description
This PR solves issue https://github.com/zetkin/app.zetkin.org/issues/2868 by getting the User's ID and comparing it with the contactPerson's ID:


## Screenshots
![image](https://github.com/user-attachments/assets/2220d688-7551-4c2a-9a25-9d84bae880b2)



## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds conditional early return of string in White Box



## Notes to reviewer
Translation needed.


## Related issues
Resolves #2868 
