### PR TITLE
Include translations for messages that have no English translation

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -67,7 +67,7 @@ async function loadMessages(): Promise<MessageDB> {
   // Fall back to English for any strings that is missing from other languages
   Object.keys(messages).forEach((lang) => {
     if (lang !== 'en') {
-      const messagesWithFallbacks: MessageList = {};
+      const messagesWithFallbacks: MessageList = { ...messages[lang] };
       Object.keys(messages.en).forEach((id) => {
         const val = messages[lang][id];
         messagesWithFallbacks[id] = val || messages.en[id];


### PR DESCRIPTION
## Description
This PR fixes a bug that was causing translations not to render, if there wasn't a matching English translation in the `en.yml` file.

The `en.yml` file has mostly existed because our old translation tool needed a YAML file for the English base strings. Since we switched to Lyra, we haven't had to use `en.yml`, so it hasn't been updated in a long time.

But unfortunately the logic to load strings from YAML would post-process the translated messages such that it only included the ones that also had English "translations", i.e. that exists in `en.yml`.

## Screenshots
None

## Changes
* Changes fallback logic to not skip non-English translations (e.g. from `nn.yml`) even if they are not represented in `en.yml`

## Notes to reviewer
Make sure that the Geography, Area assignments and/or canvassing features are properly translated to Norwegian to confirm that this is working.

## Related issues
Undocumented