### PR TITLE
Fix flaky unit test

### DIFF
--- a/src/features/canvass/hooks/useVisitReporting.spec.ts
+++ b/src/features/canvass/hooks/useVisitReporting.spec.ts
@@ -144,7 +144,10 @@ describe('useVisitReporting()', () => {
       const dateStr =
         result.current.lastVisitByHouseholdId[HOUSEHOLD_ID].created;
       const date = new Date(dateStr);
-      expect(date.getTime() / 1000).toBeCloseTo(new Date().getTime() / 1000, 1);
+      expect(date.getTime() / 10000).toBeCloseTo(
+        new Date().getTime() / 10000,
+        1
+      );
     });
 
     it('triggers a refresh of the location stats', async () => {
@@ -443,7 +446,10 @@ describe('useVisitReporting()', () => {
       const dateStr =
         result.current.lastVisitByHouseholdId[HOUSEHOLD_ID].created;
       const date = new Date(dateStr);
-      expect(date.getTime() / 1000).toBeCloseTo(new Date().getTime() / 1000, 1);
+      expect(date.getTime() / 10000).toBeCloseTo(
+        new Date().getTime() / 10000,
+        1
+      );
 
       const stateAfterAction = store.getState();
       expect(
@@ -546,7 +552,10 @@ describe('useVisitReporting()', () => {
       const dateStr =
         result.current.lastVisitByHouseholdId[HOUSEHOLD_ID].created;
       const date = new Date(dateStr);
-      expect(date.getTime() / 1000).toBeCloseTo(new Date().getTime() / 1000, 1);
+      expect(date.getTime() / 10000).toBeCloseTo(
+        new Date().getTime() / 10000,
+        1
+      );
 
       const stateAfterAction = store.getState();
       expect(


### PR DESCRIPTION
## Description
This PR fixes a flaky unit test that would sometimes fail if it didn't run fast enough.

## Screenshots
None

## Changes
* Changes  useVisitReporting() unit tests to compare timestamps less precisely

## Notes to reviewer
None

## Related issues
Undocumented