### PR TITLE
Issue 2860/expired survey still renders

### DIFF
--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -124,6 +124,7 @@ export default makeMessages('feat.surveys', {
     },
     unknownTitle: m('Untitled survey'),
   },
+
   optionCollapse: {
     collapse: m('Collapse'),
     more: m<{ numOfOptions: number }>(
@@ -139,6 +140,10 @@ export default makeMessages('feat.surveys', {
       button: m('Create questions'),
       title: m('There are no questions in this survey yet'),
     },
+  },
+
+  publicSurvey: {
+    surveyExpired: m('This survey is expired and can no longer be filled out.'),
   },
   shareSuborgsCard: {
     caption: m(

--- a/src/features/surveys/layouts/PublicSurveyLayout.tsx
+++ b/src/features/surveys/layouts/PublicSurveyLayout.tsx
@@ -4,6 +4,8 @@ import { Box } from '@mui/material';
 import { FC, ReactNode } from 'react';
 import { useSearchParams } from 'next/navigation';
 
+import { Msg } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
 import { ZetkinSurveyExtended } from 'utils/types/zetkin';
 import ZUIOrgLogoAvatar from 'zui/components/ZUIOrgLogoAvatar';
 import ZUIText from 'zui/components/ZUIText';
@@ -17,6 +19,7 @@ type Props = {
 const PublicSurveyLayout: FC<Props> = ({ children, survey }) => {
   const searchParams = useSearchParams();
   const showOrganization = searchParams?.get('hideOrganization') != 'true';
+  const isExpired = survey.access === 'expired';
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100dvh' }}>
@@ -48,14 +51,26 @@ const PublicSurveyLayout: FC<Props> = ({ children, survey }) => {
           )}
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <ZUIText variant="headingLg">{survey.title}</ZUIText>
-            {survey.info_text && (
-              <ZUIText color="secondary">{survey.info_text}</ZUIText>
+            {isExpired ? (
+              <ZUIText color="secondary">
+                <Msg id={messageIds.publicSurvey.surveyExpired} />
+              </ZUIText>
+            ) : (
+              survey.info_text && (
+                <ZUIText color="secondary">{survey.info_text}</ZUIText>
+              )
             )}
           </Box>
         </Box>
       </Box>
-      <Box sx={{ flexGrow: 1 }}>{children}</Box>
-      <ZUIPublicFooter />
+
+      {/* Render children and footer only if not expired */}
+      {!isExpired && (
+        <>
+          <Box sx={{ flexGrow: 1 }}>{children}</Box>
+          <ZUIPublicFooter />
+        </>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Description
Solves Issue 2860. 

## Changes

* displays the name of the survey and an expired message, when a survey is flagged as 'expired'.
* adds exception handling to layout.tsx, as sometimes metadata could not be loaded resulting in 404 errors, not showing the survey at all. (This seems to be a backend error, as the second request loading the survey itself works in those cases...) 


## Notes to reviewer
* When unpublishing the survey (and deleting browser cache data or opening in inkognito mode) The survey is not loaded at all, as the metadata request results in a 404 error. This seems to be backend related...
* So far all surveys have the access variable set to 'open'. Therefore without changing the value manually the new behaviour is not visible. 

## Related issues
Resolves #2860