### PR TITLE
Exclude canvass locations

### DIFF
--- a/src/features/areaAssignments/types.ts
+++ b/src/features/areaAssignments/types.ts
@@ -56,6 +56,8 @@ export type Household = {
 };
 
 export type ZetkinLocation = {
+  created: string;
+  created_by_user_id: number | null;
   description: string;
   id: number;
   latitude: number;

--- a/src/features/canvass/hooks/useVisitReporting.spec.ts
+++ b/src/features/canvass/hooks/useVisitReporting.spec.ts
@@ -149,6 +149,8 @@ describe('useVisitReporting()', () => {
 
     it('triggers a refresh of the location stats', async () => {
       const mockLocation: ZetkinLocation = {
+        created: new Date().toISOString(),
+        created_by_user_id: 1,
         description: '',
         id: LOCATION_ID,
         latitude: 55,
@@ -333,6 +335,8 @@ describe('useVisitReporting()', () => {
 
     it('reportLocationVisit() triggers refresh of location stats', async () => {
       const mockLocation: ZetkinLocation = {
+        created: new Date().toISOString(),
+        created_by_user_id: 1,
         description: '',
         id: LOCATION_ID,
         latitude: 55,
@@ -643,6 +647,8 @@ describe('useVisitReporting()', () => {
 
     it('reportHouseholdVisit() triggers refresh of location stats', async () => {
       const mockLocation: ZetkinLocation = {
+        created: new Date().toISOString(),
+        created_by_user_id: 1,
         description: '',
         id: LOCATION_ID,
         latitude: 55,

--- a/src/features/events/hooks/useEventLocations.ts
+++ b/src/features/events/hooks/useEventLocations.ts
@@ -1,11 +1,12 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
-import { ZetkinLocation } from 'utils/types/zetkin';
+import { ZetkinLocation as ZetkinEventLocation } from 'utils/types/zetkin';
 import { locationsLoad, locationsLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { ZetkinLocation } from 'features/areaAssignments/types';
 
 export default function useEventLocations(
   orgId: number
-): ZetkinLocation[] | null {
+): ZetkinEventLocation[] | null {
   const apiClient = useApiClient();
   const locationsList = useAppSelector((state) => state.events.locationList);
   const dispatch = useAppDispatch();
@@ -13,9 +14,32 @@ export default function useEventLocations(
   const locations = loadListIfNecessary(locationsList, dispatch, {
     actionOnLoad: () => locationsLoad(),
     actionOnSuccess: (data) => locationsLoaded(data),
-    loader: () =>
-      apiClient.get<ZetkinLocation[]>(`/api/orgs/${orgId}/locations`),
+    loader: async () => {
+      const locations: ZetkinEventLocation[] = await apiClient
+        .get<ZetkinLocation[]>(`/api2/orgs/${orgId}/locations`)
+        .then((locations) =>
+          locations
+            .filter(excludeLocationsCreatedWhileCanvassing)
+            .map((location) => ({
+              id: location.id,
+              info_text: location.description,
+              lat: location.latitude,
+              lng: location.longitude,
+              title: location.title,
+            }))
+        );
+
+      return locations;
+    },
   });
 
   return locations.data;
+}
+
+function excludeLocationsCreatedWhileCanvassing(
+  location: ZetkinLocation
+): boolean {
+  const hasUserInfo = location.created_by_user_id;
+  const createdWithApiV1 = !hasUserInfo;
+  return createdWithApiV1;
 }


### PR DESCRIPTION
## Description
This PR fixes a problem temporarily, caused by our decision to use the same location model for both canvassing locations and event locations. We need to think more about how to work with this, but for now, this PR hides canvassing locations from UIs where event locations matter (like Smart Search and the event location dialog).

## Screenshots
None

## Changes
* Adds the `created` and `created_by_user_id` properties to the area assignment location type
* Changes the loading of event locations to filter out locations created in the canvasser UI, as recognized by having the `created_by_user_id` which will only be the case for area assignment locations.

## Notes to reviewer
Check the Smart Search for events (where there is a drop down for locations) and the location modal when editing an event, to make sure that locations created while canvassing are not included there.

## Related issues
Undocumented