### PR TITLE
Issue 2889/Events: Sign-ups show "notified" even though they're not

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -229,6 +229,32 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       sortingOrder: ['asc', 'desc', null],
     },
     {
+      disableColumnMenu: true,
+      field: type == 'signups' ? 'signups' : 'notified',
+      flex: 1,
+      headerName:
+        type == 'signups'
+          ? messages.eventParticipantsList.columnSignedUp()
+          : messages.eventParticipantsList.columnNotified(),
+      renderCell: (params) => {
+        if (params.row.person) {
+          return <ZUIRelativeTime datetime={params.row.response_date} />;
+        } else {
+          return <ZUIRelativeTime datetime={params.row.reminder_sent} />;
+        }
+      },
+      resizable: false,
+      sortingOrder: ['asc', 'desc', null],
+      type: 'date',
+      valueGetter: (params) => {
+        if (params.row.person) {
+          return new Date(params.row.response_date);
+        } else {
+          return new Date(params.row.reminder_sent);
+        }
+      },
+    },
+    {
       align: 'right',
       disableColumnMenu: true,
       field: 'cancel',
@@ -361,58 +387,6 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       },
     },
   ];
-
-  if (type == 'signups') {
-    columns.splice(4, 0, {
-      disableColumnMenu: true,
-      field: 'signed up',
-      flex: 1,
-      headerName: messages.addPerson.status.signedUp(),
-      renderCell: (params) => {
-        if (params.row.person) {
-          return <ZUIRelativeTime datetime={params.row.response_date} />;
-        } else {
-          return;
-        }
-      },
-      resizable: false,
-      sortingOrder: ['asc', 'desc', null],
-      type: 'date',
-      valueGetter: (params) => {
-        if (params.row.person) {
-          return new Date(params.row.response_date);
-        } else {
-          return;
-        }
-      },
-    });
-  }
-
-  if (type == 'booked' || type == 'cancelled') {
-    columns.splice(4, 0, {
-      disableColumnMenu: true,
-      field: 'notified',
-      flex: 1,
-      headerName: messages.eventParticipantsList.columnNotified(),
-      renderCell: (params) => {
-        if (params.row.person) {
-          return <ZUIRelativeTime datetime={params.row.response_date} />;
-        } else {
-          return <ZUIRelativeTime datetime={params.row.reminder_sent} />;
-        }
-      },
-      resizable: false,
-      sortingOrder: ['asc', 'desc', null],
-      type: 'date',
-      valueGetter: (params) => {
-        if (params.row.person) {
-          return new Date(params.row.response_date);
-        } else {
-          return new Date(params.row.reminder_sent);
-        }
-      },
-    });
-  }
 
   return (
     <>

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -85,6 +85,7 @@ export default makeMessages('feat.events', {
     columnName: m('Name'),
     columnNotified: m('Notified'),
     columnPhone: m('Phone'),
+    columnSignedUp: m('Signed up'),
     contactTooltip: m('Contact Person'),
     descriptionBooked: m(
       'These are the people you have booked and are counting on for the event. To cancel their participation they have to contact you and you can cancel them manually.'


### PR DESCRIPTION
## Description
This PR solves the above mentioned issue by creating the Signed Up column and conditionally rendering either the "Signed up" or the "Notified" columns.


## Screenshots
![Screenshot From 2025-06-28 16-44-29](https://github.com/user-attachments/assets/3a56ce68-bb61-4653-9992-3bb327c23cdf)


## Changes

* Adds a new "Signed up" column to the event participants page.
* Conditionally renders either the "Signed up" or the "Notified" column depending whether the event participant's type is "signups", "booked" or "cancelled".


## Notes to reviewer
All tests pass except two, although I am not completely sure what that has to do with the changes made in this PR. Please let me know if anything could be improved regarding that from my side.
 
From regular tests:
"useVisitReporting() › Household-level assignment › reportHouseholdVisit() creates household visit at correct URL"
From Playwright: 
"1) tests/organize/campaigns/detail/delete.spec.ts:23:3 › Campaign detail page › allows users to delete a campaign"

## Related issues
Resolves #2889 
