### PR TITLE
Issue 2935/map hover text reset fix

### DIFF
--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -129,10 +129,9 @@ const AreaOverlay: FC<Props> = ({
                 );
               }}
               renderInput={(props) => (
-                <TextField
-                  fullWidth
-                  inputProps={props}
-                  onBlur={() => {
+                <form
+                  onSubmit={(ev) => {
+                    ev.preventDefault();
                     if (fieldEditing === 'title') {
                       setFieldEditing(null);
                       updateArea({
@@ -140,10 +139,24 @@ const AreaOverlay: FC<Props> = ({
                       });
                     }
                   }}
-                  onChange={(ev) => setTitle(ev.target.value)}
-                  sx={{ marginBottom: 2 }}
-                  value={title}
-                />
+                >
+                  <TextField
+                    fullWidth
+                    inputProps={props}
+                    onBlur={() => {
+                      if (fieldEditing === 'title') {
+                        setFieldEditing(null);
+                        updateArea({
+                          title:
+                            title?.trim() || messages.areas.default.title(),
+                        });
+                      }
+                    }}
+                    onChange={(ev) => setTitle(ev.target.value)}
+                    sx={{ marginBottom: 2 }}
+                    value={title}
+                  />
+                </form>
               )}
               renderPreview={() => (
                 <Typography variant="h5">

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -45,6 +45,7 @@ const AreaOverlay: FC<Props> = ({
 }) => {
   const messages = useMessages(messageIds);
   const [title, setTitle] = useState(area.title);
+  const areaId = useRef(area.id);
   const [description, setDescription] = useState(area.description);
   const [fieldEditing, setFieldEditing] = useState<
     'title' | 'description' | null
@@ -77,8 +78,11 @@ const AreaOverlay: FC<Props> = ({
   );
 
   useEffect(() => {
-    setTitle(area.title);
-    setDescription(area.description);
+    if (area.id !== areaId.current) {
+      setTitle(area.title);
+      setDescription(area.description);
+      areaId.current = area.id;
+    }
   }, [area]);
 
   return (


### PR DESCRIPTION
## Description
This PR fixes issue where area name/description text input fields would reset when hovering over the map


## Screenshots
https://github.com/user-attachments/assets/36365b9f-a6fd-43be-b7ee-8317eaed428c

## Changes
* Adds a check to only re-set title and description if the area has actually changed
* Puts the title input in a form so that the enter key will work to save it


## Notes to reviewer


## Related issues
Resolves #2935 
