### PR TITLE
Fix image size in ZUIItemCard component 

### DIFF
--- a/src/zui/components/ZUIItemCard/index.tsx
+++ b/src/zui/components/ZUIItemCard/index.tsx
@@ -156,10 +156,10 @@ const ZUIItemCard: FC<ItemCard> = (props) => {
             {hasImageSrc && (
               <Image
                 alt={props.title}
-                height={100}
+                height={480}
                 src={props.src}
                 style={{ height: '100%', objectFit: 'cover', width: '100%' }}
-                width={100}
+                width={960}
               />
             )}
             {hasImageElement && props.imageElement}


### PR DESCRIPTION
## Description
This PR changes the height and width of the Image component in `ZUIItemCard ` to render the image in a more suitable resolution.


## Screenshots
<img width="1917" height="1000" alt="image" src="https://github.com/user-attachments/assets/c77229d9-33fb-4b67-bd9d-19d9814fb14d" />
<img width="1919" height="1157" alt="image" src="https://github.com/user-attachments/assets/20c1abc5-9621-49f6-b50d-0590b6004846" />



## Changes
- Changes width and height to use `960 `and `480 `pixels respectively, so that sufficiently large images are loaded


## Notes to reviewer
Implemented same fix than here #2854 

## Related issues
Resolves #2685 
