### PR TITLE
Render Settings page/menu option if organization has Officials flag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default async function RootLayout({
           <ClientContext
             envVars={{
               FEAT_AREAS: process.env.FEAT_AREAS,
+              FEAT_SETTINGS: process.env.FEAT_SETTINGS,
               FEAT_TASKS: process.env.FEAT_TASKS,
               INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
               INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default async function RootLayout({
           <ClientContext
             envVars={{
               FEAT_AREAS: process.env.FEAT_AREAS,
-              FEAT_SETTINGS: process.env.FEAT_SETTINGS,
+              FEAT_OFFICIALS: process.env.FEAT_OFFICIALS,
               FEAT_TASKS: process.env.FEAT_TASKS,
               INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
               INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -21,7 +21,7 @@ import IApiClient from 'core/api/client/IApiClient';
  */
 export type EnvVars = {
   FEAT_AREAS?: string;
-  FEAT_SETTINGS?: string;
+  FEAT_OFFICIALS?: string;
   FEAT_TASKS?: string;
   INSTANCE_OWNER_HREF?: string;
   INSTANCE_OWNER_NAME?: string;

--- a/src/core/env/Environment.ts
+++ b/src/core/env/Environment.ts
@@ -21,6 +21,7 @@ import IApiClient from 'core/api/client/IApiClient';
  */
 export type EnvVars = {
   FEAT_AREAS?: string;
+  FEAT_SETTINGS?: string;
   FEAT_TASKS?: string;
   INSTANCE_OWNER_HREF?: string;
   INSTANCE_OWNER_NAME?: string;

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -15,7 +15,7 @@ import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
-import { SETTINGS } from 'utils/featureFlags';
+import { OFFICIALS } from 'utils/featureFlags';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    featuresRequired: [SETTINGS],
+    featuresRequired: [OFFICIALS],
   }
 );
 

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -15,7 +15,6 @@ import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
-import { OFFICIALS } from 'utils/featureFlags';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -25,7 +24,6 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    featuresRequired: [OFFICIALS],
   }
 );
 

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -15,6 +15,7 @@ import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
+import { SETTINGS } from 'utils/featureFlags';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -24,6 +25,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    featuresRequired: [SETTINGS],
   }
 );
 

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -2,5 +2,5 @@ export { default as hasFeature } from './hasFeature';
 
 export const AREAS = 'FEAT_AREAS';
 export const CALL = 'FEAT_CALL';
-export const SETTINGS = 'FEAT_SETTINGS';
+export const OFFICIALS = 'FEAT_OFFICIALS';
 export const TASKS = 'FEAT_TASKS';

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -2,4 +2,5 @@ export { default as hasFeature } from './hasFeature';
 
 export const AREAS = 'FEAT_AREAS';
 export const CALL = 'FEAT_CALL';
+export const SETTINGS = 'FEAT_SETTINGS';
 export const TASKS = 'FEAT_TASKS';

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -207,7 +207,7 @@ export const scaffold =
         ...result.props,
         envVars: omitUndefined({
           FEAT_AREAS: process.env.FEAT_AREAS,
-          FEAT_SETTINGS: process.env.FEAT_SETTINGS,
+          FEAT_OFFICIALS: process.env.FEAT_OFFICIALS,
           FEAT_TASKS: process.env.FEAT_TASKS,
           INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
           INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -207,6 +207,7 @@ export const scaffold =
         ...result.props,
         envVars: omitUndefined({
           FEAT_AREAS: process.env.FEAT_AREAS,
+          FEAT_SETTINGS: process.env.FEAT_SETTINGS,
           FEAT_TASKS: process.env.FEAT_TASKS,
           INSTANCE_OWNER_HREF: process.env.INSTANCE_OWNER_HREF,
           INSTANCE_OWNER_NAME: process.env.INSTANCE_OWNER_NAME,

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -43,7 +43,7 @@ import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIUserAvatar from 'zui/ZUIUserAvatar';
 import useFeature from 'utils/featureFlags/useFeature';
-import { AREAS } from 'utils/featureFlags';
+import { AREAS, SETTINGS } from 'utils/featureFlags';
 import oldTheme from 'theme';
 
 const drawerWidth = 300;
@@ -97,6 +97,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const [searchString, setSearchString] = useState('');
   const organizationFuture = useOrganization(orgId);
   const hasAreas = useFeature(AREAS, orgId);
+  const hasSettings = useFeature(SETTINGS, orgId);
 
   const handleExpansion = () => {
     setChecked(!checked);
@@ -288,6 +289,9 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
               />
               {menuItemsMap.map(({ name, icon }) => {
                 if (name == 'geography' && !hasAreas) {
+                  return null;
+                }
+                if (name == 'settings' && !hasSettings) {
                   return null;
                 }
 

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -43,7 +43,7 @@ import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFuture from 'zui/ZUIFuture';
 import ZUIUserAvatar from 'zui/ZUIUserAvatar';
 import useFeature from 'utils/featureFlags/useFeature';
-import { AREAS, SETTINGS } from 'utils/featureFlags';
+import { AREAS, OFFICIALS } from 'utils/featureFlags';
 import oldTheme from 'theme';
 
 const drawerWidth = 300;
@@ -97,7 +97,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const [searchString, setSearchString] = useState('');
   const organizationFuture = useOrganization(orgId);
   const hasAreas = useFeature(AREAS, orgId);
-  const hasSettings = useFeature(SETTINGS, orgId);
+  const hasSettings = useFeature(OFFICIALS, orgId);
 
   const handleExpansion = () => {
     setChecked(!checked);


### PR DESCRIPTION
## Description
This PR adds the Officials flag feature to only show the Settings page (and option in the menu) to organizations that have the flag active. 


## Screenshots
<img width="1093" height="1041" alt="image" src="https://github.com/user-attachments/assets/cf04994b-540d-4f8a-9ec3-7fa54236dd2c" />



## Changes
* Adds `OFFICIALS` flag in the environment
* Require `Officials` flag in settings page, otherwise returns 404
* Checks if officials flag exists to render Settings in `ZUIOrganizeSideBar` component


## Notes to reviewer
Add/remove in `.env.local` file the flag `FEAT_OFFICIALS=* `


## Related issues
Resolves #2911 
