### PR TITLE
Add pagination to Duplicates page

### DIFF
--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -61,13 +61,9 @@ const DuplicatesPage: PageWithLayout = () => {
       )}
       {totalItems > 0 && (
         <Box
-          ref={totalPages > 1 ? containerRef : undefined}
+          ref={containerRef}
           sx={{
             p: 1.5,
-            ...(totalPages > 1 && {
-              maxHeight: '80vh',
-              overflowY: 'auto',
-            }),
           }}
         >
           <Typography
@@ -87,7 +83,7 @@ const DuplicatesPage: PageWithLayout = () => {
               count={totalPages}
               onChange={(_, value) => {
                 setPage(value);
-                containerRef.current?.scrollTo({ behavior: 'smooth', top: 0 });
+                containerRef?.current?.scrollIntoView({ behavior: 'smooth' });
               }}
               page={page}
             />


### PR DESCRIPTION
## Description
This PR adds pagination to the Duplicates page, displaying up to 100 cluster duplicates per page.


## Screenshots
<img width="1916" height="1117" alt="image" src="https://github.com/user-attachments/assets/ad7ad87e-0546-493e-b9c4-0699617de73c" />



## Changes
* Adds Pagination component and logic

## Notes to the reviewer
*  I’ve implemented the MUI Pagination component, should we consider creating a custom ZUI version instead?

## Related issues
Resolves #2934 
