### PR TITLE
Issue 2932/ics feed

### DIFF
--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -29,7 +29,7 @@ export async function GET(
     .slice(0, 10);
 
   const events = await apiClient.get<ZetkinEvent[]>(
-    `/api/orgs/${orgId}/actions?recursive&ilter=start_time>=${startTime}`
+    `/api/orgs/${orgId}/actions?recursive&filter=start_time>=${startTime}`
   );
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);

--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -15,10 +15,10 @@ export async function GET(
   const { orgId } = await params;
 
   // Convert ReadonlyHeaders to IncomingHttpHeaders
-  const apiHeaders: IncomingHttpHeaders = headerList.keys().reduce((hs, h) => {
-    hs[h] = headerList.get(h) as string;
-    return hs;
-  }, {} as IncomingHttpHeaders);
+  const apiHeaders: IncomingHttpHeaders = {};
+  for (const h in headerList.keys()) {
+    apiHeaders[h] = headerList.get(h) as string;
+  }
 
   const apiClient = new BackendApiClient(apiHeaders);
 

--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -29,7 +29,7 @@ export async function GET(
     .slice(0, 10);
 
   const events = await apiClient.get<ZetkinEvent[]>(
-    `/api/orgs/${orgId}/actions?frecursive&ilter=start_time>=${startTime}`
+    `/api/orgs/${orgId}/actions?recursive&ilter=start_time>=${startTime}`
   );
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);

--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -34,7 +34,7 @@ export async function GET(
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
-  return new Response(icsFromEvents(events, org), {
+  return new Response(icsFromEvents(org.title, events, org), {
     headers: { 'Content-Type': 'text/calendar' },
   });
 }

--- a/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
@@ -8,11 +8,11 @@ import icsFromEvents from 'features/events/utils/icsFromEvents';
 
 export async function GET(
   _req: Request,
-  { params }: { params: Promise<{ orgId: string }> }
+  { params }: { params: Promise<{ orgId: string; projId: string }> }
 ) {
   const headerList = await headers();
 
-  const { orgId } = await params;
+  const { orgId, projId } = await params;
 
   // Convert ReadonlyHeaders to IncomingHttpHeaders
   const apiHeaders: IncomingHttpHeaders = headerList.keys().reduce((hs, h) => {
@@ -29,7 +29,7 @@ export async function GET(
     .slice(0, 10);
 
   const events = await apiClient.get<ZetkinEvent[]>(
-    `/api/orgs/${orgId}/actions?frecursive&ilter=start_time>=${startTime}`
+    `/api/orgs/${orgId}/campaigns/${projId}/actions?filter=start_time>=${startTime}`
   );
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);

--- a/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
@@ -15,10 +15,10 @@ export async function GET(
   const { orgId, projId } = await params;
 
   // Convert ReadonlyHeaders to IncomingHttpHeaders
-  const apiHeaders: IncomingHttpHeaders = headerList.keys().reduce((hs, h) => {
-    hs[h] = headerList.get(h) as string;
-    return hs;
-  }, {} as IncomingHttpHeaders);
+  const apiHeaders: IncomingHttpHeaders = {};
+  for (const h in headerList.keys()) {
+    apiHeaders[h] = headerList.get(h) as string;
+  }
 
   const apiClient = new BackendApiClient(apiHeaders);
 

--- a/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
@@ -3,7 +3,11 @@ import dayjs from 'dayjs';
 import { headers } from 'next/headers';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import { ZetkinEvent, ZetkinOrganization } from 'utils/types/zetkin';
+import {
+  ZetkinCampaign,
+  ZetkinEvent,
+  ZetkinOrganization,
+} from 'utils/types/zetkin';
 import icsFromEvents from 'features/events/utils/icsFromEvents';
 
 export async function GET(
@@ -33,8 +37,11 @@ export async function GET(
   );
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
+  const campaign = await apiClient.get<ZetkinCampaign>(
+    `/api/orgs/${orgId}/campaigns/${projId}`
+  );
 
-  return new Response(icsFromEvents(events, org), {
+  return new Response(icsFromEvents(campaign.title, events, org), {
     headers: { 'Content-Type': 'text/calendar' },
   });
 }

--- a/src/features/events/utils/icsFromEvents.ts
+++ b/src/features/events/utils/icsFromEvents.ts
@@ -1,0 +1,63 @@
+import dayjs, { Dayjs } from 'dayjs';
+
+import { ZetkinEvent, ZetkinOrganization } from 'utils/types/zetkin';
+
+const timeStamp = (t: Dayjs): string => t.format('YYYYMMDDTHHmmss');
+const formatString = (str: string): string =>
+  str
+    .replaceAll('\n', '\\n')
+    .match(/.{1,74}/g)
+    ?.join('\r\n\t') ?? '';
+
+export default function icsFromEvents(
+  events: ZetkinEvent[],
+  org: ZetkinOrganization
+): string {
+  const vLines: string[] = [];
+  events
+    .filter((event) => !event.cancelled && event.published)
+    .forEach((event) => {
+      vLines.push(`BEGIN:VEVENT`);
+      vLines.push(`UID:${event.id}@${process.env.ZETKIN_APP_HOST}`);
+      vLines.push(
+        `ORGANIZER;CN=${event.organization.title.replace('\n', ' ')}:MAILTO:${
+          org.email ?? 'noreply@zetkin.org'
+        }`
+      );
+      vLines.push(`DTSTAMP:${timeStamp(dayjs(event.published))}`);
+      vLines.push(`DTSTART:${timeStamp(dayjs(event.start_time))}`);
+      vLines.push(`DTEND:${timeStamp(dayjs(event.end_time))}`);
+      if (event.title) {
+        vLines.push(`SUMMARY:${event.title ?? ''}`);
+      }
+      if (event.info_text) {
+        vLines.push(`DESCRIPTION:${event.info_text ?? ''}`);
+      }
+      vLines.push(
+        `URL:${process.env.ZETKIN_APP_HOST}/o/${org.id}/events/${event.id}`
+      );
+      if (event.location) {
+        vLines.push(`GEO:${event.location.lat};${event.location.lng}`);
+        vLines.push(`LOCATION:${event.location.title}`);
+      }
+
+      if (event.cover_file?.url) {
+        vLines.push(
+          `IMAGE;VALUE=URI;DISPLAY=BADGE;FMTTYPE=${event.cover_file.mime_type}:${event.cover_file.url}`
+        );
+      }
+
+      vLines.push('END:VEVENT');
+    });
+
+  const eventsStr = vLines.map((s) => formatString(s)).join('\r\n');
+  const body = `BEGIN:VCALENDAR\r
+VERSION:2.0\r
+PRODID:-//Zetkin Foundation//Zetkin App//EN\r
+NAME:My Calendar Name\r
+X-WR-CALNAME:My Calendar Name\r
+${eventsStr}\r
+END:VCALENDAR`;
+
+  return body;
+}

--- a/src/features/events/utils/icsFromEvents.ts
+++ b/src/features/events/utils/icsFromEvents.ts
@@ -10,10 +10,11 @@ const formatString = (str: string): string =>
     ?.join('\r\n\t') ?? '';
 
 export default function icsFromEvents(
+  name: string,
   events: ZetkinEvent[],
   org: ZetkinOrganization
 ): string {
-  const vLines: string[] = [];
+  const vLines: string[] = ['NAME:' + name, 'X-WR-CALNAME:' + name];
   events
     .filter((event) => !event.cancelled && event.published)
     .forEach((event) => {
@@ -54,8 +55,6 @@ export default function icsFromEvents(
   const body = `BEGIN:VCALENDAR\r
 VERSION:2.0\r
 PRODID:-//Zetkin Foundation//Zetkin App//EN\r
-NAME:My Calendar Name\r
-X-WR-CALNAME:My Calendar Name\r
 ${eventsStr}\r
 END:VCALENDAR`;
 

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -63,10 +63,6 @@ export default async function handle(
 
   res
     .setHeader('Content-Type', 'text/calendar')
-    .setHeader(
-      'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=59'
-    )
     .status(200).send(`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Zetkin Foundation//Zetkin App//EN

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -4,7 +4,9 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinEvent } from 'utils/types/zetkin';
 
-const timeStamp = (t: Dayjs) => t.format('YYYYMMDDTHHmmss');
+const timeStamp = (t: Dayjs): string => t.format('YYYYMMDDTHHmmss');
+const formatString = (str: string): string =>
+  str.match(/.{1,75}/g)?.join('\n\t') ?? '';
 
 export default async function handle(
   req: NextApiRequest,
@@ -15,37 +17,49 @@ export default async function handle(
   const apiClient = new BackendApiClient(req.headers);
 
   const startTime = dayjs()
-    .subtract(1, 'month')
+    .subtract(2, 'month')
     .toDate()
     .toISOString()
     .slice(0, 10);
 
   const events = await apiClient.get<ZetkinEvent[]>(
-    `/api/orgs/${orgId}/actions?filter=start_time>${startTime}`
+    `/api/orgs/${orgId}/actions?frecursive&ilter=start_time>=${startTime}`
   );
 
-  const vEvents = events
+  const vEvents: string[] = [];
+  events
     .filter((event) => !event.cancelled && event.published)
-    .map((event) => {
-      let str = `BEGIN:VEVENT
-UID:${event.id}@zetkin.org
-ORGANIZER;CN=${event.organization.title.replace(
-        '\n',
-        ' '
-      )}:MAILTO:noreply@zetkin.org
-DTSTAMP:${timeStamp(dayjs(event.published))}
-DTSTART:${timeStamp(dayjs(event.start_time))}
-DTEND:${timeStamp(dayjs(event.end_time))}
-SUMMARY:${event.title?.replace('\n', ' ') ?? ''}
-`;
+    .forEach((event) => {
+      vEvents.push(`BEGIN:VEVENT`);
+      vEvents.push(`UID:${event.id}@zetkin.org`);
+      vEvents.push(
+        `ORGANIZER;CN=${event.organization.title.replace(
+          '\n',
+          ' '
+        )}:MAILTO:noreply@zetkin.org`
+      );
+      vEvents.push(`DTSTAMP:${timeStamp(dayjs(event.published))}`);
+      vEvents.push(`DTSTART:${timeStamp(dayjs(event.start_time))}`);
+      vEvents.push(`DTEND:${timeStamp(dayjs(event.end_time))}`);
+      vEvents.push(`SUMMARY:${event.title?.replace('\n', ' ') ?? ''}`);
+      vEvents.push(
+        `URL:${process.env.ZETKIN_APP_HOST}/o/${orgId}/events/${event.id}`
+      );
       if (event.location) {
-        str += `GEO:${event.location.lat};${event.location.lng}\n`;
-        str += `LOCATION:${event.location.title}\n`;
+        vEvents.push(`GEO:${event.location.lat};${event.location.lng}`);
+        vEvents.push(`LOCATION:${event.location.title}`);
       }
-      str += 'END:VEVENT';
 
-      return str;
+      if (event.cover_file?.url) {
+        vEvents.push(
+          `IMAGE;VALUE=URI;DISPLAY=BADGE;FMTTYPE=${event.cover_file.mime_type}:${event.cover_file.url}`
+        );
+      }
+
+      vEvents.push('END:VEVENT');
     });
+
+  const eventsStr = vEvents.map((s) => formatString(s)).join('\n');
 
   res
     .setHeader('Content-Type', 'text/calendar')
@@ -56,6 +70,6 @@ SUMMARY:${event.title?.replace('\n', ' ') ?? ''}
     .status(200).send(`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Zetkin Foundation//Zetkin App//EN
-${vEvents.join('\n')}
+${eventsStr}
 END:VCALENDAR`);
 }

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -6,7 +6,10 @@ import { ZetkinEvent } from 'utils/types/zetkin';
 
 const timeStamp = (t: Dayjs): string => t.format('YYYYMMDDTHHmmss');
 const formatString = (str: string): string =>
-  str.match(/.{1,75}/g)?.join('\n\t') ?? '';
+  str
+    .replaceAll('\n', '\\n')
+    .match(/.{1,75}/g)
+    ?.join('\n\t') ?? '';
 
 export default async function handle(
   req: NextApiRequest,
@@ -41,7 +44,8 @@ export default async function handle(
       vEvents.push(`DTSTAMP:${timeStamp(dayjs(event.published))}`);
       vEvents.push(`DTSTART:${timeStamp(dayjs(event.start_time))}`);
       vEvents.push(`DTEND:${timeStamp(dayjs(event.end_time))}`);
-      vEvents.push(`SUMMARY:${event.title?.replace('\n', ' ') ?? ''}`);
+      vEvents.push(`SUMMARY:${event.title ?? ''}`);
+      vEvents.push(`DESCRIPTION:${event.info_text ?? ''}`);
       vEvents.push(
         `URL:${process.env.ZETKIN_APP_HOST}/o/${orgId}/events/${event.id}`
       );

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -1,0 +1,61 @@
+import dayjs, { Dayjs } from 'dayjs';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZetkinEvent } from 'utils/types/zetkin';
+
+const timeStamp = (t: Dayjs) => t.format('YYYYMMDDTHHmmss');
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const { orgId } = req.query;
+
+  const apiClient = new BackendApiClient(req.headers);
+
+  const startTime = dayjs()
+    .subtract(1, 'month')
+    .toDate()
+    .toISOString()
+    .slice(0, 10);
+
+  const events = await apiClient.get<ZetkinEvent[]>(
+    `/api/orgs/${orgId}/actions?filter=start_time>${startTime}`
+  );
+
+  const vEvents = events
+    .filter((event) => !event.cancelled && event.published)
+    .map((event) => {
+      let str = `BEGIN:VEVENT
+UID:${event.id}@zetkin.org
+ORGANIZER;CN=${event.organization.title.replace(
+        '\n',
+        ' '
+      )}:MAILTO:noreply@zetkin.org
+DTSTAMP:${timeStamp(dayjs(event.published))}
+DTSTART:${timeStamp(dayjs(event.start_time))}
+DTEND:${timeStamp(dayjs(event.end_time))}
+SUMMARY:${event.title?.replace('\n', ' ') ?? ''}
+`;
+      if (event.location) {
+        str += `GEO:${event.location.lat};${event.location.lng}\n`;
+        str += `LOCATION:${event.location.title}\n`;
+      }
+      str += 'END:VEVENT';
+
+      return str;
+    });
+
+  res
+    .setHeader('Content-Type', 'text/calendar')
+    .setHeader(
+      'Cache-Control',
+      'public, s-maxage=10, stale-while-revalidate=59'
+    )
+    .status(200).send(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Zetkin Foundation//Zetkin App//EN
+${vEvents.join('\n')}
+END:VCALENDAR`);
+}

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -61,9 +61,8 @@ export default async function handle(
 
   const eventsStr = vEvents.map((s) => formatString(s)).join('\n');
 
-  res
-    .setHeader('Content-Type', 'text/calendar')
-    .status(200).send(`BEGIN:VCALENDAR
+  res.setHeader('Content-Type', 'text/calendar').status(200)
+    .send(`BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Zetkin Foundation//Zetkin App//EN
 ${eventsStr}

--- a/src/pages/api/orgs/[orgId]/events.ics/index.ts
+++ b/src/pages/api/orgs/[orgId]/events.ics/index.ts
@@ -8,8 +8,8 @@ const timeStamp = (t: Dayjs): string => t.format('YYYYMMDDTHHmmss');
 const formatString = (str: string): string =>
   str
     .replaceAll('\n', '\\n')
-    .match(/.{1,75}/g)
-    ?.join('\n\t') ?? '';
+    .match(/.{1,74}/g)
+    ?.join('\r\n\t') ?? '';
 
 export default async function handle(
   req: NextApiRequest,
@@ -63,12 +63,12 @@ export default async function handle(
       vEvents.push('END:VEVENT');
     });
 
-  const eventsStr = vEvents.map((s) => formatString(s)).join('\n');
+  const eventsStr = vEvents.map((s) => formatString(s)).join('\r\n');
 
   res.setHeader('Content-Type', 'text/calendar').status(200)
-    .send(`BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//Zetkin Foundation//Zetkin App//EN
-${eventsStr}
+    .send(`BEGIN:VCALENDAR\r
+VERSION:2.0\r
+PRODID:-//Zetkin Foundation//Zetkin App//EN\r
+${eventsStr}\r
 END:VCALENDAR`);
 }


### PR DESCRIPTION
## Description
This PR adds a ICS calendar feed.


## Screenshots
<img width="1175" height="846" alt="image" src="https://github.com/user-attachments/assets/b9ad59c6-bb2b-46a1-8788-b1d5cc0c3374" />
(Thunderbird calendar view)

## Changes

* Adds endpoint for ics calendar on ex. http://localhost:3000/api/orgs/1/events.ics

## Notes to reviewer

The feed can be imported using a local client, ex. Thunderbird as seen in the screenshot.

I changed the url because I could not get urls outside of `/api/` to not add html tags, scripts etc. The specification requires a email or other form of contact on the ORGANIZATION property, I put noreply@zetkin.org on it since there doesn't seem to be contact information on the public event.

Resources used (more features to implement!)

* Quick overview https://en.wikipedia.org/wiki/ICalendar
* Specification https://datatracker.ietf.org/doc/html/rfc5545
* Extension https://www.rfc-editor.org/rfc/rfc7986.html
* Validator https://icalendar.org/validator.html

Also note that timestamps are without timezone as they are not included (or set to +00:00) in API responses, meaning remote events might have wrong time if the reader is in a different timezone than the creator.

I did not add any link to it because I wasn't sure what makes sense. I tried something like below on the organization calendar page, but I couldn't figure out how to make the browser not download the ics file, which makes it kind of hard to get the actual url. Maybe a read-only input field or text with the url somewhere would make more sense?
<img width="228" height="150" alt="image" src="https://github.com/user-attachments/assets/612af095-5c3a-406d-99ce-0b6378e823dd" />
(Also, wrapping the MUI SVG icon in a `a` tag seems to be a bit wonky)

## Related issues
Resolves #2932
