### PR TITLE
Delete household

### DIFF
--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -50,10 +50,8 @@ const LocationDialog: FC<LocationDialogProps> = ({
     assignment.organization_id,
     assignment.id
   );
-  const { updateHousehold, updateLocation } = useLocationMutations(
-    orgId,
-    location.id
-  );
+  const { deleteHousehold, updateHousehold, updateLocation } =
+    useLocationMutations(orgId, location.id);
   const { lastVisitByHouseholdId, reportHouseholdVisit, reportLocationVisit } =
     useVisitReporting(orgId, assignment.id, location.id);
 
@@ -148,6 +146,11 @@ const LocationDialog: FC<LocationDialogProps> = ({
               location={location}
               onBack={() => back()}
               onClose={onClose}
+              onDelete={() => {
+                deleteHousehold(selectedHouseholdId);
+                setSelectedHouseholdId(null);
+                back();
+              }}
               onEdit={() => goto('editHousehold')}
               onHouseholdVisitStart={() => {
                 goto('householdVisit');

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdPage.tsx
@@ -1,17 +1,19 @@
 import { Box, Button, Typography } from '@mui/material';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import PageBase from './PageBase';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/canvass/l10n/messageIds';
 import { ZetkinLocation } from 'features/areaAssignments/types';
 import useHousehold from 'features/canvass/hooks/useHousehold';
+import ZUIConfirmDialog from 'zui/ZUIConfirmDialog';
 
 type HouseholdPageProps = {
   householdId: number;
   location: ZetkinLocation;
   onBack: () => void;
   onClose: () => void;
+  onDelete: () => void;
   onEdit: () => void;
   onHouseholdVisitStart: () => void;
   visitedInThisAssignment: boolean;
@@ -22,11 +24,13 @@ const HouseholdPage: FC<HouseholdPageProps> = ({
   location,
   onBack,
   onClose,
+  onDelete,
   onEdit,
   onHouseholdVisitStart,
   visitedInThisAssignment,
 }) => {
   const messages = useMessages(messageIds);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const household = useHousehold(
     location.organization_id,
     location.id,
@@ -34,31 +38,44 @@ const HouseholdPage: FC<HouseholdPageProps> = ({
   );
 
   return (
-    <PageBase
-      actions={
-        <Box display="flex" flexDirection="column">
-          {visitedInThisAssignment && (
-            <Typography>
-              <Msg id={messageIds.households.single.wasVisited} />
-            </Typography>
-          )}
-          <Button onClick={onHouseholdVisitStart} variant="contained">
-            <Msg id={messageIds.households.single.logVisitButtonLabel} />
-          </Button>
-        </Box>
-      }
-      onBack={onBack}
-      onClose={onClose}
-      onEdit={onEdit}
-      subtitle={
-        household.level
-          ? messages.households.single.subtitle({
-              floorNumber: household.level,
-            })
-          : messages.default.floor()
-      }
-      title={household.title}
-    />
+    <>
+      <PageBase
+        actions={
+          <Box display="flex" flexDirection="column">
+            {visitedInThisAssignment && (
+              <Typography>
+                <Msg id={messageIds.households.single.wasVisited} />
+              </Typography>
+            )}
+            <Button onClick={onHouseholdVisitStart} variant="contained">
+              <Msg id={messageIds.households.single.logVisitButtonLabel} />
+            </Button>
+          </Box>
+        }
+        onBack={onBack}
+        onClose={onClose}
+        onDelete={() => setDeleteDialogOpen(true)}
+        onEdit={onEdit}
+        subtitle={
+          household.level
+            ? messages.households.single.subtitle({
+                floorNumber: household.level,
+              })
+            : messages.default.floor()
+        }
+        title={household.title}
+      />
+      <ZUIConfirmDialog
+        indexValue={99999}
+        onCancel={() => setDeleteDialogOpen(false)}
+        onSubmit={onDelete}
+        open={deleteDialogOpen}
+        title={messages.households.delete.title()}
+        warningText={messages.households.delete.warningText({
+          household: household.title,
+        })}
+      />
+    </>
   );
 };
 

--- a/src/features/canvass/components/LocationDialog/pages/PageBase.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/PageBase.tsx
@@ -1,4 +1,4 @@
-import { Close, Edit } from '@mui/icons-material';
+import { Close, Delete, Edit } from '@mui/icons-material';
 import { Box, Divider, IconButton } from '@mui/material';
 import { FC, ReactNode } from 'react';
 
@@ -9,6 +9,7 @@ type Props = {
   children?: ReactNode;
   onBack?: () => void;
   onClose?: () => void;
+  onDelete?: () => void;
   onEdit?: () => void;
   subtitle?: string;
   title: string;
@@ -19,6 +20,7 @@ const PageBase: FC<Props> = ({
   children,
   onBack,
   onClose,
+  onDelete,
   onEdit,
   subtitle,
   title,
@@ -40,6 +42,11 @@ const PageBase: FC<Props> = ({
               {onEdit && (
                 <IconButton onClick={onEdit}>
                   <Edit />
+                </IconButton>
+              )}
+              {onDelete && (
+                <IconButton onClick={onDelete}>
+                  <Delete />
                 </IconButton>
               )}
               {onClose && (

--- a/src/features/canvass/hooks/useLocationMutations.ts
+++ b/src/features/canvass/hooks/useLocationMutations.ts
@@ -4,7 +4,7 @@ import {
   Zetkin2Household,
   ZetkinLocationPatchBody,
 } from '../types';
-import { householdCreated, householdUpdated } from '../store';
+import { householdCreated, householdDeleted, householdUpdated } from '../store';
 import { locationUpdated } from '../../areaAssignments/store';
 import createHouseholds from '../rpc/createHouseholds/client';
 import { ZetkinLocation } from 'features/areaAssignments/types';
@@ -33,6 +33,12 @@ export default function useLocationMutations(
       });
 
       created.forEach((household) => dispatch(householdCreated(household)));
+    },
+    deleteHousehold: async (householdId: number) => {
+      await apiClient.delete(
+        `/api2/orgs/${orgId}/locations/${locationId}/households/${householdId}`
+      );
+      dispatch(householdDeleted([locationId, householdId]));
     },
     updateHousehold: async (householdId: number, data: HouseholdPatchBody) => {
       const household = await apiClient.patch<

--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -17,6 +17,12 @@ export default makeMessages('feat.canvass', {
       numberOfFloorsInput: m('Number of floors'),
       numberOfHouseholdsInput: m('Households per floor'),
     },
+    delete: {
+      title: m('Confirm deletion of household'),
+      warningText: m<{ household: string }>(
+        'Are you sure you want to delete the household {household}? It can not be undone.'
+      ),
+    },
     edit: {
       floorLabel: m('Edit floor'),
       header: m<{ title: string }>('Edit {title}'),

--- a/src/features/canvass/store.ts
+++ b/src/features/canvass/store.ts
@@ -31,6 +31,13 @@ const canvassSlice = createSlice({
         })
       );
     },
+    householdDeleted: (state, action: PayloadAction<[number, number]>) => {
+      const [locationId, householdId] = action.payload;
+      state.householdsByLocationId[locationId].items =
+        state.householdsByLocationId[locationId].items.filter(
+          (item) => item.id != householdId
+        );
+    },
     householdLoad: (state, action: PayloadAction<[number, number]>) => {
       const [locationId, householdId] = action.payload;
 
@@ -147,6 +154,7 @@ const canvassSlice = createSlice({
 export default canvassSlice;
 export const {
   householdCreated,
+  householdDeleted,
   householdLoad,
   householdLoaded,
   householdUpdated,

--- a/src/zui/ZUIConfirmDialog/index.tsx
+++ b/src/zui/ZUIConfirmDialog/index.tsx
@@ -6,6 +6,7 @@ import ZUISubmitCancelButtons from 'zui/ZUISubmitCancelButtons';
 import messageIds from 'zui/l10n/messageIds';
 
 export interface ZUIConfirmDialogProps {
+  indexValue?: number;
   open: boolean;
   onCancel: () => void;
   onSubmit: () => void;
@@ -21,10 +22,12 @@ const ZUIConfirmDialog: React.FunctionComponent<ZUIConfirmDialogProps> = ({
   title,
   warningText,
   submitDisabled,
+  indexValue,
 }) => {
   const messages = useMessages(messageIds);
   return (
     <ZUIDialog
+      indexValue={indexValue}
       onClose={() => onCancel()}
       open={open}
       title={title || messages.confirmDialog.defaultTitle()}

--- a/src/zui/ZUIDialog/index.tsx
+++ b/src/zui/ZUIDialog/index.tsx
@@ -11,6 +11,7 @@ import {
 interface ZUIDialogProps {
   children: React.ReactNode;
   contentHeight?: number | string;
+  indexValue?: number;
   open: boolean;
   onClose: () => void;
   title?: string;
@@ -24,6 +25,7 @@ const ZUIDialog: FunctionComponent<ZUIDialogProps> = ({
   open,
   onClose,
   title,
+  indexValue,
 }): JSX.Element => {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
@@ -35,6 +37,7 @@ const ZUIDialog: FunctionComponent<ZUIDialogProps> = ({
       maxWidth={maxWidth || 'sm'}
       onClose={onClose}
       open={open}
+      sx={indexValue != null ? { zIndex: indexValue } : undefined}
     >
       <Box p={2}>
         {title && <DialogTitle>{title}</DialogTitle>}


### PR DESCRIPTION
## Description
This PR adds the necessary UI and logic to be able to delete a household


## Screenshots
<img width="458" height="956" alt="image" src="https://github.com/user-attachments/assets/32906d7c-4290-4b74-a657-c79c1dec84f9" />

<img width="451" height="955" alt="image" src="https://github.com/user-attachments/assets/fb6bdc87-1c33-43ee-9e1a-57a1f754c11d" />



## Changes
* Adds `deleteHousehold()` hook
* Adds `householdDeleted()` reducer in the store
* Adds optional property `indexValue` to `ZUIConfirmDialog` and `ZUIDialog`
* Adds `Delete` button in `HouseholdPage`
* Adds `ZUIConfirmDialog` in `HouseholdPage`


## Notes to reviewer
* I’ve used the existing `ZUIConfirmDialog` here since our new design system isn’t available in this feature.
* If we’d prefer a standard MUI dialog that stays compact on mobile (rather than going full‑screen, as ZUIDialog has it set by default), I can swap it out for a custom <Dialog> implementation.)


## Related issues
Resolves #2874 
