### PR TITLE
Geography: fetch all areas & refactor 

### DIFF
--- a/src/features/areas/hooks/useAreas.ts
+++ b/src/features/areas/hooks/useAreas.ts
@@ -2,6 +2,7 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { areasLoad, areasLoaded } from '../store';
 import { Zetkin2Area } from '../types';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useAreas(orgId: number) {
   const apiClient = useApiClient();
@@ -11,6 +12,10 @@ export default function useAreas(orgId: number) {
   return loadListIfNecessary(list, dispatch, {
     actionOnLoad: () => areasLoad(),
     actionOnSuccess: (data) => areasLoaded(data),
-    loader: () => apiClient.get<Zetkin2Area[]>(`/api2/orgs/${orgId}/areas`),
+    loader: async () => {
+      return await fetchAllPaginated<Zetkin2Area>((page) =>
+        apiClient.get(`/api2/orgs/${orgId}/areas?size=100&page=${page}`)
+      );
+    },
   });
 }

--- a/src/features/events/rpc/loadEventLocations.ts
+++ b/src/features/events/rpc/loadEventLocations.ts
@@ -4,6 +4,7 @@ import IApiClient from 'core/api/client/IApiClient';
 import { makeRPCDef } from 'core/rpc/types';
 import { ZetkinLocation as ZetkinEventLocation } from 'utils/types/zetkin';
 import { ZetkinLocation } from 'features/areaAssignments/types';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 const paramsSchema = z.object({
   orgId: z.number(),
@@ -22,23 +23,9 @@ export default makeRPCDef<Params, Result>(loadEventLocationsDef.name);
 
 async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
   const { orgId } = params;
-  const listOfLocations: ZetkinLocation[] = [];
-
-  const BATCH_SIZE = 100;
-
-  async function loadNextBatch(page: number = 1) {
-    const batchLocations = await apiClient.get<ZetkinLocation[]>(
-      `/api2/orgs/${orgId}/locations?size=${BATCH_SIZE}&page=${page}`
-    );
-
-    listOfLocations.push(...batchLocations);
-
-    if (batchLocations.length >= BATCH_SIZE) {
-      await loadNextBatch(page + 1);
-    }
-  }
-
-  await loadNextBatch();
+  const listOfLocations = await fetchAllPaginated<ZetkinLocation>((page) =>
+    apiClient.get(`/api2/orgs/${orgId}/locations?size=100&page=${page}`)
+  );
 
   const locations = listOfLocations
     .filter(excludeLocationsCreatedWhileCanvassing)

--- a/src/utils/fetchAllPaginated.ts
+++ b/src/utils/fetchAllPaginated.ts
@@ -1,0 +1,18 @@
+export async function fetchAllPaginated<T>(
+  fetchPage: (page: number) => Promise<T[]>,
+  batchSize: number = 100
+): Promise<T[]> {
+  const result: T[] = [];
+
+  async function loadNextBatch(page: number = 1) {
+    const batch = await fetchPage(page);
+    result.push(...batch);
+
+    if (batch.length >= batchSize) {
+      await loadNextBatch(page + 1);
+    }
+  }
+
+  await loadNextBatch();
+  return result;
+}


### PR DESCRIPTION
## Description
This PR ensures that all areas are fetched in the Geography feature, rather than only the first 50. It introduces a reusable utility function, `fetchAllPaginated()`, and it refactors existing API calls that require loading full datasets (e.g., areas, users, locations).


## Screenshots
None


## Changes
* Adds `fetchAllPaginated()` utility function
* Implements `fetchAllPaginated()` in `useAreas()` hook loader
* Refactors `loadEventLocations()` hook to implement `fetchAllPaginated()`
* Refactors `useOrgUsers()` hook to implement `fetchAllPaginated()`

## Notes to reviewer
None


## Related issues
None
