### PR TITLE
Group Households on unknown level 

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
@@ -83,8 +83,8 @@ const HouseholdsPage: FC<Props> = ({
         )}
         <List sx={{ overflowY: 'visible' }}>
           {sortedHouseholds.map((household, index) => {
-            const prevFloor = sortedHouseholds[index - 1]?.level ?? null;
-            const curFloor = household.level ?? null;
+            const prevFloor = sortedHouseholds[index - 1]?.level ?? 0;
+            const curFloor = household.level ?? 0;
             const firstOnFloor = index == 0 || curFloor != prevFloor;
 
             const mostRecentVisit = lastVisitByHouseholdId[household.id];

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
@@ -84,7 +84,7 @@ const HouseholdsPage: FC<Props> = ({
         <List sx={{ overflowY: 'visible' }}>
           {sortedHouseholds.map((household, index) => {
             const prevFloor = sortedHouseholds[index - 1]?.level ?? null;
-            const curFloor = household.level || null;
+            const curFloor = household.level ?? null;
             const firstOnFloor = index == 0 || curFloor != prevFloor;
 
             const mostRecentVisit = lastVisitByHouseholdId[household.id];


### PR DESCRIPTION
## Description
This PR prevents the creation of individual headers for households with level 0, grouping them under the same header.


## Screenshots
<img width="693" height="1442" alt="image" src="https://github.com/user-attachments/assets/b2c921fc-4238-4624-8509-4c38cd164f60" />



## Changes
* Changes `||` for `??` to avoid level 0 to be treated as null
* If level is something that is not a number (undefined, null) treat it like level 0


## Notes to reviewer
No


## Related issues
Resolves #2948 
