### PR TITLE
Geography: Use secondary color for inactive areas

### DIFF
--- a/src/features/geography/components/GLGeographyMap/Areas.tsx
+++ b/src/features/geography/components/GLGeographyMap/Areas.tsx
@@ -25,7 +25,7 @@ const Areas: FC<Props> = ({ areas }) => {
       <Layer
         id="outlines"
         paint={{
-          'line-color': oldTheme.palette.primary.main,
+          'line-color': oldTheme.palette.secondary.main,
           'line-width': 2,
         }}
         type="line"
@@ -33,7 +33,7 @@ const Areas: FC<Props> = ({ areas }) => {
       <Layer
         id="areas"
         paint={{
-          'fill-color': oldTheme.palette.primary.main,
+          'fill-color': oldTheme.palette.secondary.main,
           'fill-opacity': 0.4,
         }}
         type="fill"


### PR DESCRIPTION
## Description
This PR changes the inactive areas color for a shade of black (secondary color). When an area is selected or draw the color will be red (main color).


## Screenshots
<img width="1074" height="1114" alt="image" src="https://github.com/user-attachments/assets/91a99670-991f-448c-8222-bd0159c9c882" />

<img width="1071" height="1038" alt="image" src="https://github.com/user-attachments/assets/4a937e29-5568-407f-ac81-9f520f460876" />


## Changes
* Changes `main` color for `secondary` color in `Areas` file


## Notes to reviewer
None

## Related issues
Resolves #2930 
