### PR TITLE
Canvass: Add Undo button in visit stepper

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
@@ -147,7 +147,7 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
                     >
                       {metric.question}
                     </Typography>
-                    {!stepIsCurrent && completed && <Undo />}
+                    {!stepIsCurrent && index < step && <Undo />}
                   </Box>
 
                   {completed && step != index && (


### PR DESCRIPTION
## Description
This PR adds and Undo button to show the user that they can edit their responses. It also adds some small style fixes in the stepper.


## Screenshots
<img width="464" height="955" alt="image" src="https://github.com/user-attachments/assets/a9a31f2b-79db-4307-b6b5-ce42e692d45a" />



## Changes
* Adds `Undo` icon
* Adds logic to reset future responses when navigating to a previous step
* Aligns stepper icon to be always inline with the first line of text


## Notes to reviewer
None


## Related issues
Resolves #2548 
