### PR TITLE
Copy list before sorting to avoid readonly mutation bug

### DIFF
--- a/src/features/canvass/hooks/useVisitReporting.ts
+++ b/src/features/canvass/hooks/useVisitReporting.ts
@@ -73,7 +73,8 @@ export default function useVisitReporting(
     };
 
     Object.entries(visitsByHouseholdId).forEach(([id, list]) => {
-      const sortedItems = list.items.sort(
+      const itemsCopy = list.items.concat();
+      const sortedItems = itemsCopy.sort(
         (a, b) =>
           new Date(b.data?.created ?? 0).getTime() -
           new Date(a.data?.created ?? 0).getTime()


### PR DESCRIPTION
## Description
This PR hopefully fixes a problem that I've been able to reproduce, but affected some users when reporting visits in the canvasser UI. It seems from reading call stacks that an exception was thrown when trying to sort an array, because the array is immutable for some reason, maybe because it's part of the redux state. 

## Screenshots
None

## Changes
* Creates a copy of the list of households before sorting it

## Notes to reviewer
I will merge this without review (if CI passes) because I would like this in today's release. Please review even though it's already been merged, and we can revisit if any issues are found.

## Related issues
Undocumented