### PR TITLE
Canvass: Add indicator of user location on map 

### DIFF
--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -434,40 +434,40 @@ const GLCanvassMap: FC<Props> = ({ areas, assignment }) => {
         </Source>
         {geoMarker && (
           <Source
-            id="geolocation-marker"
-            type="geojson"
             data={{
-              type: 'FeatureCollection',
               features: [
                 {
-                  type: 'Feature',
                   geometry: {
-                    type: 'Point',
                     coordinates: geoMarker,
+                    type: 'Point',
                   },
                   properties: {},
+                  type: 'Feature',
                 },
               ],
+              type: 'FeatureCollection',
             }}
+            id="geolocation-marker"
+            type="geojson"
           >
             <Layer
               id="geolocation-marker-halo"
-              type="circle"
               paint={{
-                'circle-radius': 12,
                 'circle-color': alpha(theme.palette.primary.dark, 0.4),
+                'circle-radius': 12,
               }}
+              type="circle"
             />
             <Layer
               id="geolocation-marker-layer"
-              type="circle"
               paint={{
+                'circle-color': theme.palette.primary.main,
                 'circle-radius': 6,
                 'circle-stroke-color': theme.palette.primary.light,
                 'circle-stroke-width': 1,
-                'circle-color': theme.palette.primary.main,
               }}
               source="point"
+              type="circle"
             />
           </Source>
         )}


### PR DESCRIPTION
## Description
This PR adds an indicator point of the user location in the canvassing map


## Screenshots
<img width="450" height="947" alt="image" src="https://github.com/user-attachments/assets/4383e3c8-301b-466d-8938-643ecf11ed19" />



## Changes
* Adds `geoMarker` variable to the state
* Adds a `<Source>` component and two `<Layers>` in `<Map>` to complete the point that represents the user location


## Notes to reviewer
No design was provided, so we should check this with the design team.


## Related issues
Resolves #2384
