### PR TITLE
Canvass: Fix blank page clicking back from HouseholdsPage after reporting household visits in bulk

### DIFF
--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -243,7 +243,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
                 await reportHouseholdVisits(selectedHouseholdIds, responses);
                 setShowSparkle(true);
                 setSelectedHouseholdIds([]);
-                goto('households');
+                back();
               }}
               selectedHouseholsdIds={selectedHouseholdIds}
             />


### PR DESCRIPTION
## Description
This PR fixes a navigation bug where clicking Back from the `HouseholdsPage` (after coming from reportingHouseholdVisits in `BulkHouseholdVisitsPage`). Clicking back would return to `BulkHouseholdVisitsPage` with no selected households, causing a blank page. The fix prevents this invalid navigation state.

## Screenshots
Before:

https://github.com/user-attachments/assets/8498b81c-5169-4cd9-97f8-498a67d54985


After:

https://github.com/user-attachments/assets/2e55c52c-ee63-454e-b58e-e6e7f8756502



## Changes
* Changes goto() to back()


## Notes to reviewer
None


## Related issues
None
