### PR TITLE
Load all assignees, not just first page

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -2,6 +2,7 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinAreaAssignee } from '../types';
 import { assigneesLoad, assigneesLoaded } from '../store';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useAreaAssignees(orgId: number, areaAssId: number) {
   const apiClient = useApiClient();
@@ -15,8 +16,12 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
 
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
-      apiClient.get<ZetkinAreaAssignee[]>(
-        `/api2/orgs/${orgId}/area_assignments/${areaAssId}/assignees`
+      fetchAllPaginated(
+        (page) =>
+          apiClient.get<ZetkinAreaAssignee[]>(
+            `/api2/orgs/${orgId}/area_assignments/${areaAssId}/assignees?size=100&page=${page}`
+          ),
+        100
       ),
   });
 }


### PR DESCRIPTION
## Description
This PR fixes a bug causing not all assignees of an area assignment to load properly, because the API is paginated but the app only loaded the first page.

## Screenshots
None

## Changes
* Uses the `fetchAllPaginated()` utility in `useAreaAssignees()`

## Notes to reviewer
None

## Related issues
Undocumented