### PR TITLE
Remove offset of local date

### DIFF
--- a/src/features/calendar/hooks/useWeekCalendarEvents.ts
+++ b/src/features/calendar/hooks/useWeekCalendarEvents.ts
@@ -1,6 +1,11 @@
 import { partition } from 'lodash';
 
-import { dateIsAfter, isSameDate, dateIsBefore } from 'utils/dateUtils';
+import {
+  dateIsAfter,
+  dateIsBefore,
+  isSameDate,
+  removeOffset,
+} from 'utils/dateUtils';
 import useEventsFromDateRange from 'features/events/hooks/useEventsFromDateRange';
 import useFilteredEventActivities from 'features/events/hooks/useFilteredEventActivities';
 import clusterEventsForWeekCalender, {
@@ -35,8 +40,8 @@ export default function useWeekCalendarEvents({
   return dates.map((date) => {
     const relevantActivities = filteredActivities
       .filter((activity) => {
-        const start = new Date(activity.data.start_time);
-        const end = new Date(activity.data.end_time);
+        const start = new Date(removeOffset(activity.data.start_time));
+        const end = new Date(removeOffset(activity.data.end_time));
         return (
           isSameDate(start, date) ||
           isSameDate(end, date) ||
@@ -46,8 +51,8 @@ export default function useWeekCalendarEvents({
       .map((activity) => ({
         activity,
         isMultipleDays: !isSameDate(
-          new Date(activity.data.start_time),
-          new Date(activity.data.end_time)
+          new Date(removeOffset(activity.data.start_time)),
+          new Date(removeOffset(activity.data.end_time))
         ),
       }));
 


### PR DESCRIPTION
## Description
This PR fixes the issue where an event scheduled to 22:00 would count as a multi day event in UTC+2.


## Screenshots
<img width="992" height="1307" alt="multiday" src="https://github.com/user-attachments/assets/4bcc7105-4dba-4e06-ae4a-bcf6440be035" />

## Changes
* Removes offset from date so that it will correctly parse it as a local date instead of UTC+0.


## Related issues
Resolves #2982 
