### PR TITLE
Issue 2907/Organization Page: Organizations under "Explore" should be sorted

### DIFF
--- a/src/features/organizations/pages/SubOrgsPage.tsx
+++ b/src/features/organizations/pages/SubOrgsPage.tsx
@@ -15,11 +15,15 @@ type Props = {
 
 const SubOrgsPage: FC<Props> = ({ orgId }) => {
   const allSubOrgs = usePublicSubOrgs(orgId);
-  const subOrgs = allSubOrgs.filter((org) => org.parent?.id == orgId);
+  const subOrgsSorted = allSubOrgs
+    .filter((org) => org.parent?.id == orgId)
+    .sort((so1, so2) => {
+      return so1.title.localeCompare(so2.title);
+    });
 
   return (
     <List>
-      {subOrgs.map((org) => {
+      {subOrgsSorted.map((org) => {
         const hasSubOrgs = !!allSubOrgs.find(
           (subOrg) => subOrg.parent?.id == org.id
         );


### PR DESCRIPTION
## Description
This PR fixes the sorting of listed sub-organizations.

## Screenshots
<img width="1912" height="930" alt="Screenshot From 2025-08-16 11-54-57" src="https://github.com/user-attachments/assets/39e3fd0f-c320-4cb9-9d13-d823d2d75df3" />

## Changes
Added the sort method to alphabetically sort sub-organizations.

## Notes to reviewer

## Related issues
Resolves #2907 
