### PR TITLE
Canvass: filter out areas if the canvasser is not assigned

### DIFF
--- a/src/features/canvass/components/CanvassPage.tsx
+++ b/src/features/canvass/components/CanvassPage.tsx
@@ -19,16 +19,10 @@ const Page: FC<{ assignment: ZetkinAreaAssignment }> = ({ assignment }) => {
   const areas = useAssignmentAreas(assignment.organization_id, assignment.id);
   const orgFuture = useOrganization(assignment.organization_id);
   const user = useCurrentUser();
-  const areaAssignees = useAreaAssignees(
-    assignment.organization_id,
-    assignment.id
-  );
-
-  const visibleAreas = areas.filter((area) =>
-    areaAssignees.data?.some(
-      (assignee) => assignee.area_id == area.id && assignee.user_id == user?.id
-    )
-  );
+  const areaAssignees =
+    useAreaAssignees(assignment.organization_id, assignment.id).data ?? [];
+  const areasData = areas ?? [];
+  const currentUserId = user?.id;
 
   const isServer = useServerSide();
   const [showMenu, setShowMenu] = useState(false);
@@ -36,6 +30,16 @@ const Page: FC<{ assignment: ZetkinAreaAssignment }> = ({ assignment }) => {
   if (isServer) {
     return null;
   }
+
+  const visibleAreas = currentUserId
+    ? areasData.filter((area) =>
+        areaAssignees.some(
+          (assignee) =>
+            assignee.area_id == area.id && assignee.user_id == currentUserId
+        )
+      )
+    : [];
+
   return (
     <ZUIFutures futures={{ org: orgFuture }}>
       {({ data: { org } }) => (


### PR DESCRIPTION
## Description
This PR filters out areas to which the current user is not assigned, ensuring they only see the areas they are assigned to.

## Screenshots
Before Angela Davis (Admin) can see areas that she is not assigned too:
<img width="397" height="677" alt="image" src="https://github.com/user-attachments/assets/5db5f55f-29c1-45ab-9fe2-213a672b98da" />


After (area is not visible):
<img width="404" height="687" alt="image" src="https://github.com/user-attachments/assets/2d31944c-1929-4d4a-a5f8-20d848718631" />


## Changes
* Adds a filter to only get the `visibleAreas` for the current user



## Notes to reviewer
None


## Related issues
None
