### PR TITLE
Issue 2951/Events: Avatars in participant list are not links

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -132,9 +132,11 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
       headerName: '',
       hideSortIcons: true,
       renderCell: (params) => (
-        <ZUIPersonHoverCard personId={params.row.id}>
-          <ZUIPersonAvatar orgId={orgId} personId={params.row.id} />
-        </ZUIPersonHoverCard>
+        <Link href={`/organize/${orgId}/people/${params.row.id}`}>
+          <ZUIPersonHoverCard personId={params.row.id}>
+            <ZUIPersonAvatar orgId={orgId} personId={params.row.id} />
+          </ZUIPersonHoverCard>
+        </Link>
       ),
       resizable: false,
       sortable: false,


### PR DESCRIPTION
## Description
This PR turns the avatars in Participant lists into clickable links. 


## Screenshots
Before clicking on the avatar (popover still appears but isn't captured by the screenshot, I don't know why): 
<img width="1200" height="511" alt="Screenshot From 2025-08-20 21-21-13" src="https://github.com/user-attachments/assets/fca87958-7013-4a22-8f06-cdf1787a665f" />

After clicking on the avatar: 
<img width="1200" height="511" alt="Screenshot From 2025-08-20 21-21-21" src="https://github.com/user-attachments/assets/54dd3ffe-2a9d-4488-aa3e-bff7f43241de" />




## Changes
- Wrapped the ZUIPersonHoverCard in a Link component to enable the avatar itself to become a clickable link

## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #2951 
