### PR TITLE
Issue 2972/Area assignments should include organization and project titles

### DIFF
--- a/src/features/home/components/MyActivitiesList.tsx
+++ b/src/features/home/components/MyActivitiesList.tsx
@@ -117,7 +117,17 @@ const MyActivitiesList: FC = () => {
                   variant="secondary"
                 />,
               ]}
-              info={[]}
+              info={[
+                {
+                  Icon: GroupWorkOutlined,
+                  labels: activity.data.instructions
+                    ? [
+                        activity.data.instructions,
+                        activity.data.reporting_level,
+                      ]
+                    : [activity.data.reporting_level],
+                },
+              ]}
               title={
                 activity.data.title || messages.defaultTitles.areaAssignment()
               }


### PR DESCRIPTION
## Description
Let me preface this by saying that I'm not completely sure that I have solved this. The initial problem is clear: while the assignments marked as callAssignment had a filled info object, the info object for the areaAssignment was empty. That's why it showed only the title at the top. 

Now, the issue title requests the inclusion of the organization and project titles. However, the ZetkinAreaAssignment type from which that activity.data is pulled does not include any of that. Have I not managed to find it, or does it really not exist? In the meantime, I have put what I think would be the best fit for the info: instructions and reporting level. 

Please let me know if and how anything else could be added. 


## Screenshots
<img width="941" height="338" alt="Screenshot From 2025-08-20 23-23-30" src="https://github.com/user-attachments/assets/35a0956a-f21c-4ac1-be38-76afa6513341" />



## Changes

* Adds info about the area assignment to the area assignment card


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #2972 
