### PR TITLE
Canvass: Generate markers correctly

### DIFF
--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -121,8 +121,11 @@ const GLCanvassMap: FC<Props> = ({ areas, assignment }) => {
             successRatio = successfulVisits / totalVisits;
           }
 
-          const visitPercentage = Math.round(visitRatio * 10) * 10;
-          const successPercentage = Math.round(successRatio * 10) * 10;
+          const roundToPercentage = (value: number) =>
+            Math.min(100, Math.round(value / 10) * 10);
+
+          const visitPercentage = roundToPercentage(visitRatio * 100);
+          const successPercentage = roundToPercentage(successRatio * 100);
           const icon =
             `marker-${successPercentage}-${visitPercentage}` +
             (selected ? '-selected' : '');


### PR DESCRIPTION
## Description
This PR fixes marker warnings in the console and prevents location markers from disappearing by rounding visitPercentage and successPercentage. This ensures the generated marker icon IDs always match the pre-registered images.


## Screenshots
Before:
<img width="436" height="909" alt="image" src="https://github.com/user-attachments/assets/141d24cd-8f0d-4c65-80c8-985389102562" />

After:
<img width="433" height="916" alt="image" src="https://github.com/user-attachments/assets/37a4a9ae-8177-4e36-8597-098f5d20cf52" />




## Changes
* Adds `roundToPercentatge()` function to calculate `visitPercentatge` and `successPercentage`.



## Notes to reviewer
None


## Related issues
Resolves #2980 
