### PR TITLE
Show locations from `lnglat` fields in a map on the profile page

### DIFF
--- a/src/features/areas/types.ts
+++ b/src/features/areas/types.ts
@@ -1,4 +1,4 @@
-import { Branded } from 'utils/types';
+import { Branded } from 'utils/types/branded';
 import { ZetkinTag } from 'utils/types/zetkin';
 
 export type Longitude = Branded<number, 'Longitude'>;

--- a/src/features/import/utils/problems/predictProblems.ts
+++ b/src/features/import/utils/problems/predictProblems.ts
@@ -27,6 +27,7 @@ const VALIDATORS: Record<CUSTOM_FIELD_TYPE, (value: string) => boolean> = {
   },
   enum: () => true,
   json: () => true,
+  lnglat: () => true,
   text: () => true,
   url: (value) => isURL(value),
 };

--- a/src/features/profile/components/PersonDetailsCard.tsx
+++ b/src/features/profile/components/PersonDetailsCard.tsx
@@ -78,7 +78,11 @@ const PersonDetailsCard: React.FunctionComponent<{
   });
 
   const customFieldsConfig = customFields
-    .filter((field) => field.type !== CUSTOM_FIELD_TYPE.JSON)
+    .filter(
+      (field) =>
+        field.type != CUSTOM_FIELD_TYPE.JSON &&
+        field.type != CUSTOM_FIELD_TYPE.LNGLAT
+    )
     .map((field) => {
       // Object type is filtered above
       let value: string | React.ReactNode = person[field.slug] as

--- a/src/features/profile/components/PersonLngLatMap.tsx
+++ b/src/features/profile/components/PersonLngLatMap.tsx
@@ -1,7 +1,7 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Box, BoxProps } from '@mui/material';
 import Map, { Marker } from '@vis.gl/react-maplibre';
-import { LngLatBounds } from 'maplibre-gl';
+import { LngLatBounds, Map as MapType } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 import {
@@ -13,6 +13,7 @@ import {
 } from 'utils/types/zetkin';
 import { useEnv } from 'core/hooks';
 import MarkerIcon from 'features/canvass/components/MarkerIcon';
+import ZUIMapControls from 'zui/ZUIMapControls';
 
 type Props = {
   customFields: ZetkinCustomField[];
@@ -39,6 +40,7 @@ const PersonLngLatMap: FC<Props> = ({
   width = '100%',
 }) => {
   const env = useEnv();
+  const [map, setMap] = useState<MapType | null>(null);
 
   const lngLatFields = customFields.filter(
     (field) => field.type == CUSTOM_FIELD_TYPE.LNGLAT
@@ -70,10 +72,32 @@ const PersonLngLatMap: FC<Props> = ({
     <Box
       sx={{
         height,
+        position: 'relative',
         width,
       }}
     >
+      <ZUIMapControls
+        onFitBounds={() => {
+          if (bounds) {
+            map?.fitBounds(bounds, {
+              animate: true,
+              maxZoom: 13,
+              speed: 2,
+            });
+          }
+        }}
+        onGeolocate={(lngLat) => {
+          map?.flyTo({
+            animate: true,
+            center: lngLat,
+            speed: 2,
+          });
+        }}
+        onZoomIn={() => map?.zoomIn()}
+        onZoomOut={() => map?.zoomOut()}
+      />
       <Map
+        ref={(mapRef) => setMap(mapRef?.getMap() ?? null)}
         initialViewState={{
           latitude: bounds?.getCenter().lat,
           longitude: bounds?.getCenter().lng,

--- a/src/features/profile/components/PersonLngLatMap.tsx
+++ b/src/features/profile/components/PersonLngLatMap.tsx
@@ -1,0 +1,110 @@
+import { FC } from 'react';
+import { Box, BoxProps } from '@mui/material';
+import Map, { Marker } from '@vis.gl/react-maplibre';
+import { LngLatBounds } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+import {
+  CUSTOM_FIELD_TYPE,
+  ZetkinCustomField,
+  ZetkinCustomFieldValue,
+  ZetkinLngLatFieldValue,
+  ZetkinPerson,
+} from 'utils/types/zetkin';
+import { useEnv } from 'core/hooks';
+import MarkerIcon from 'features/canvass/components/MarkerIcon';
+
+type Props = {
+  customFields: ZetkinCustomField[];
+  height?: BoxProps['height'];
+  person: ZetkinPerson;
+  width?: BoxProps['width'];
+};
+
+function isLngLatValue(
+  value: ZetkinCustomFieldValue
+): value is ZetkinLngLatFieldValue {
+  return (
+    value != null &&
+    typeof value == 'object' &&
+    typeof value['lng'] == 'number' &&
+    typeof value['lat'] == 'number'
+  );
+}
+
+const PersonLngLatMap: FC<Props> = ({
+  customFields,
+  height = '100%',
+  person,
+  width = '100%',
+}) => {
+  const env = useEnv();
+
+  const lngLatFields = customFields.filter(
+    (field) => field.type == CUSTOM_FIELD_TYPE.LNGLAT
+  );
+  const lngLatFieldsWithValues = lngLatFields.filter(
+    (field) => !!person[field.slug]
+  );
+
+  if (lngLatFieldsWithValues.length == 0) {
+    return null;
+  }
+
+  const firstField = lngLatFieldsWithValues[0];
+  const firstValue = person[firstField.slug];
+
+  const bounds = isLngLatValue(firstValue)
+    ? new LngLatBounds(firstValue, firstValue)
+    : undefined;
+  if (bounds) {
+    lngLatFieldsWithValues.forEach((field) => {
+      const value = person[field.slug];
+      if (isLngLatValue(value)) {
+        bounds.extend(value);
+      }
+    });
+  }
+
+  return (
+    <Box
+      sx={{
+        height,
+        width,
+      }}
+    >
+      <Map
+        initialViewState={{
+          latitude: bounds?.getCenter().lat,
+          longitude: bounds?.getCenter().lng,
+          zoom: 12,
+        }}
+        mapStyle={env.vars.MAPLIBRE_STYLE}
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
+        {lngLatFieldsWithValues.map((field) => {
+          const fieldValue = person[field.slug];
+
+          if (isLngLatValue(fieldValue)) {
+            return (
+              <Marker
+                anchor="bottom"
+                draggable={false}
+                latitude={fieldValue.lat}
+                longitude={fieldValue.lng}
+                offset={[0, 6]}
+              >
+                <MarkerIcon color="#000000" selected />
+              </Marker>
+            );
+          }
+        })}
+      </Map>
+    </Box>
+  );
+};
+
+export default PersonLngLatMap;

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -22,6 +22,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import { scaffold, ScaffoldedGetServerSideProps } from 'utils/next';
 import { ZetkinPerson } from 'utils/types/zetkin';
+import PersonLngLatMap from 'features/profile/components/PersonLngLatMap';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
@@ -77,6 +78,17 @@ const PersonProfilePage: PageWithLayout = () => {
         </title>
       </Head>
       <Grid container direction="row" spacing={6}>
+        <Grid size={12}>
+          <ZUIFuture future={fieldsFuture}>
+            {(fields) => (
+              <PersonLngLatMap
+                customFields={fields}
+                height="30vh"
+                person={person}
+              />
+            )}
+          </ZUIFuture>
+        </Grid>
         <Grid size={{ lg: 4, xs: 12 }}>
           <ZUIFuture future={fieldsFuture}>
             {(fields) => (

--- a/src/utils/types/branded.ts
+++ b/src/utils/types/branded.ts
@@ -1,0 +1,3 @@
+declare const brand: unique symbol;
+
+export type Branded<T, Brand extends string> = T & { [brand]: Brand };

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -29,7 +29,3 @@ export interface Breadcrumb {
  * Stolen from: https://www.emmanuelgautier.com/blog/snippets/typescript-required-properties
  */
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-
-declare const brand: unique symbol;
-
-export type Branded<T, Brand extends string> = T & { [brand]: Brand };

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -12,6 +12,7 @@ import {
   ZetkinViewColumn,
   ZetkinViewRow,
 } from '../../features/views/components/types';
+import { Latitude, Longitude } from 'features/areas/types';
 
 export interface ZetkinCampaign {
   color: string;
@@ -179,8 +180,16 @@ export interface ZetkinPersonNativeFields {
   phone: string | null;
 }
 
+export type ZetkinCustomFieldValue =
+  | string
+  | number
+  | boolean
+  | ZetkinLngLatFieldValue
+  | Record<string, unknown>
+  | null;
+
 export type ZetkinPerson = ZetkinPersonNativeFields &
-  Record<string, string | number | boolean | Record<string, unknown> | null>;
+  Record<string, ZetkinCustomFieldValue>;
 
 export interface EnumChoice {
   key: string;
@@ -448,7 +457,13 @@ export enum CUSTOM_FIELD_TYPE {
   TEXT = 'text',
   JSON = 'json',
   ENUM = 'enum',
+  LNGLAT = 'lnglat',
 }
+
+export type ZetkinLngLatFieldValue = {
+  lat: Latitude;
+  lng: Longitude;
+};
 
 export interface ZetkinJourney {
   id: number;


### PR DESCRIPTION
## Description
This PR adds a map to profile pages, to display positions stored in `lnglat` fields on the person. The map is only displayed if there are `lnglat` fields in the organization, and if the person has values stored in those fields.

## Screenshots
<img width="1636" height="1293" alt="image" src="https://github.com/user-attachments/assets/65534dc5-1867-4a0a-a8e6-f5b61ec942bd" />

## Changes
* Extends types, enums and existing logic to accommodate the new `lnglat` custom field type
* Adds new `PersonLngLatMap` component and renders it on the profile page

## Notes to reviewer
To fully test this, make sure there is a `lnglat` field and that the person you're looking at has a value.

### Creating a `lnglat` field
Make sure one doesn't exist already. Then make a `POST` request to `/api/orgs/1/people/fields` with the following data:

```js
{
  title: 'Home location',
  slug: 'home_location',
  type: 'lnglat',
}
```

### Adding a value to a person
After creating the field (with the `home_location` slug), make a PATCH to any person in the organization, e.g. `/api/orgs/1/people/5` with the following data:

```js
{
  home_location: {
    lng: 55,
    lat: 13,
  }
}
```

## Related issues
Undocumented
