### PR TITLE
Canvass: Show stats in Organizer Map

### DIFF
--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -14,17 +14,14 @@ import { ZetkinArea } from 'features/areas/types';
 import {
   ZetkinAssignmentAreaStatsItem,
   ZetkinAreaAssignee,
-  ZetkinLocation,
   ZetkinAreaAssignment,
 } from '../types';
 import ZUIAvatar from 'zui/ZUIAvatar';
-import isPointInsidePolygon from '../../canvass/utils/isPointInsidePolygon';
 import { useNumericRouteParams } from 'core/hooks';
 import { Msg, useMessages } from 'core/i18n';
 import areaAssignmentMessageIds from '../l10n/messageIds';
 import areasMessageIds from 'features/areas/l10n/messageIds';
 import { ZUIExpandableText } from 'zui/ZUIExpandableText';
-import locToLatLng from 'features/geography/utils/locToLatLng';
 import UserAutocomplete from 'features/user/components/UserAutocomplete';
 import { ZetkinOrgUser } from 'features/user/types';
 import useAreaAssignmentMutations from '../hooks/useAreaAssignmentMutations';
@@ -36,7 +33,6 @@ type Props = {
   assignment: ZetkinAreaAssignment;
   filterAreas: (areas: ZetkinArea[], matchString: string) => ZetkinArea[];
   filterText: string;
-  locations: ZetkinLocation[];
   onAddAssignee: (user: ZetkinOrgUser) => void;
   onClose: () => void;
   onFilterTextChange: (newValue: string) => void;
@@ -55,7 +51,6 @@ const AreaSelect: FC<Props> = ({
   onClose,
   onFilterTextChange,
   onSelectArea,
-  locations,
   selectedArea,
   selectedAreaStats,
   sessions,
@@ -69,19 +64,6 @@ const AreaSelect: FC<Props> = ({
   const selectedAreaAssignees = sessions
     .filter((session) => session.area_id == selectedArea?.id)
     .map((session) => session.user_id);
-
-  const locationsInSelectedArea: ZetkinLocation[] = [];
-  if (selectedArea) {
-    locations.map((location) => {
-      const isInsideArea = isPointInsidePolygon(
-        locToLatLng(location),
-        selectedArea.points.map((point) => ({ lat: point[0], lng: point[1] }))
-      );
-      if (isInsideArea) {
-        locationsInSelectedArea.push(location);
-      }
-    });
-  }
 
   return (
     <Box

--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -32,7 +32,6 @@ import UserItem from 'features/user/components/UserItem';
 import AreaStats from './AreaStats';
 
 type Props = {
-  areaAssId: number;
   areas: ZetkinArea[];
   assignment: ZetkinAreaAssignment;
   filterAreas: (areas: ZetkinArea[], matchString: string) => ZetkinArea[];
@@ -49,7 +48,6 @@ type Props = {
 
 const AreaSelect: FC<Props> = ({
   areas,
-  areaAssId,
   assignment,
   filterAreas,
   filterText,
@@ -67,7 +65,7 @@ const AreaSelect: FC<Props> = ({
   const theme = useTheme();
 
   const { orgId } = useNumericRouteParams();
-  const { unassignArea } = useAreaAssignmentMutations(orgId, areaAssId);
+  const { unassignArea } = useAreaAssignmentMutations(orgId, assignment.id);
   const selectedAreaAssignees = sessions
     .filter((session) => session.area_id == selectedArea?.id)
     .map((session) => session.user_id);

--- a/src/features/areaAssignments/components/AreaSelect.tsx
+++ b/src/features/areaAssignments/components/AreaSelect.tsx
@@ -15,6 +15,7 @@ import {
   ZetkinAssignmentAreaStatsItem,
   ZetkinAreaAssignee,
   ZetkinLocation,
+  ZetkinAreaAssignment,
 } from '../types';
 import ZUIAvatar from 'zui/ZUIAvatar';
 import isPointInsidePolygon from '../../canvass/utils/isPointInsidePolygon';
@@ -28,10 +29,12 @@ import UserAutocomplete from 'features/user/components/UserAutocomplete';
 import { ZetkinOrgUser } from 'features/user/types';
 import useAreaAssignmentMutations from '../hooks/useAreaAssignmentMutations';
 import UserItem from 'features/user/components/UserItem';
+import AreaStats from './AreaStats';
 
 type Props = {
   areaAssId: number;
   areas: ZetkinArea[];
+  assignment: ZetkinAreaAssignment;
   filterAreas: (areas: ZetkinArea[], matchString: string) => ZetkinArea[];
   filterText: string;
   locations: ZetkinLocation[];
@@ -47,6 +50,7 @@ type Props = {
 const AreaSelect: FC<Props> = ({
   areas,
   areaAssId,
+  assignment,
   filterAreas,
   filterText,
   onAddAssignee,
@@ -80,13 +84,6 @@ const AreaSelect: FC<Props> = ({
       }
     });
   }
-
-  const numberOfHouseholdsInSelectedArea = locationsInSelectedArea
-    .map(
-      (location) =>
-        location.num_known_households || location.num_estimated_households
-    )
-    .reduce((prev, curr) => prev + curr, 0);
 
   return (
     <Box
@@ -262,37 +259,7 @@ const AreaSelect: FC<Props> = ({
               </Typography>
             </Box>
           )}
-          <Box alignItems="start" display="flex" flexDirection="column" gap={1}>
-            <Box alignItems="center" display="flex">
-              <Typography
-                color="secondary"
-                sx={(theme) => ({ color: theme.palette.primary.main })}
-                variant="h5"
-              >
-                {selectedAreaStats?.num_visited_households || 0}
-              </Typography>
-              <Typography color="secondary" ml={0.5} variant="h5">
-                / {numberOfHouseholdsInSelectedArea}
-              </Typography>
-            </Box>
-            <Typography color="secondary" textAlign="center" variant="caption">
-              <Msg
-                id={areaAssignmentMessageIds.map.areaInfo.stats.households}
-                values={{ numHouseholds: numberOfHouseholdsInSelectedArea }}
-              />
-            </Typography>
-          </Box>
-          <Box alignItems="start" display="flex" flexDirection="column" gap={1}>
-            <Typography color="secondary" variant="h5">
-              {locationsInSelectedArea.length}
-            </Typography>
-            <Typography color="secondary" textAlign="center" variant="caption">
-              <Msg
-                id={areaAssignmentMessageIds.map.areaInfo.stats.locations}
-                values={{ numLocations: locationsInSelectedArea.length }}
-              />
-            </Typography>
-          </Box>
+          <AreaStats assignment={assignment} selectedArea={selectedArea.id} />
           <Divider />
           <Box mt={2}>
             <Typography variant="h6">

--- a/src/features/areaAssignments/components/AreaStats.tsx
+++ b/src/features/areaAssignments/components/AreaStats.tsx
@@ -1,0 +1,65 @@
+import { FC } from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { ZetkinAreaAssignment } from '../types';
+import useLocations from '../hooks/useLocations';
+import { Msg } from 'core/i18n';
+import areaAssignmentMessageIds from '../l10n/messageIds';
+
+type AreaStatsProps = {
+  assignment: ZetkinAreaAssignment;
+  selectedArea: number;
+};
+
+const AreaStats: FC<AreaStatsProps> = ({ assignment, selectedArea }) => {
+  const locationsInArea =
+    useLocations(assignment.organization_id, assignment.id, selectedArea)
+      .data ?? [];
+
+  const { totalVisited, totalHouseholds } = locationsInArea?.reduce(
+    (acc, location) => {
+      acc.totalHouseholds += location.num_known_households ?? 0;
+      acc.totalVisited += location.num_visits ?? 0;
+      return acc;
+    },
+    { totalHouseholds: 0, totalVisited: 0 }
+  ) ?? { totalHouseholds: 0, totalVisited: 0 };
+
+  return (
+    <>
+      <Box alignItems="start" display="flex" flexDirection="column" gap={1}>
+        <Box alignItems="center" display="flex">
+          <Typography
+            color="secondary"
+            sx={(theme) => ({ color: theme.palette.primary.main })}
+            variant="h5"
+          >
+            {totalVisited || 0}
+          </Typography>
+          <Typography color="secondary" ml={0.5} variant="h5">
+            / {totalHouseholds}
+          </Typography>
+        </Box>
+        <Typography color="secondary" textAlign="center" variant="caption">
+          <Msg
+            id={areaAssignmentMessageIds.map.areaInfo.stats.households}
+            values={{ numHouseholds: totalHouseholds }}
+          />
+        </Typography>
+      </Box>
+      <Box alignItems="start" display="flex" flexDirection="column" gap={1}>
+        <Typography color="secondary" variant="h5">
+          {locationsInArea.length}
+        </Typography>
+        <Typography color="secondary" textAlign="center" variant="caption">
+          <Msg
+            id={areaAssignmentMessageIds.map.areaInfo.stats.locations}
+            values={{ numLocations: locationsInArea.length || 0 }}
+          />
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export default AreaStats;

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -21,6 +21,7 @@ import {
   ZetkinAssignmentAreaStats,
   ZetkinAreaAssignee,
   ZetkinLocation,
+  ZetkinAreaAssignment,
 } from '../types';
 import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
 import { assigneesFilterContext } from './OrganizerMapFilters/AssigneeFilterContext';
@@ -41,6 +42,7 @@ type OrganizerMapProps = {
   areaAssId: number;
   areaStats: ZetkinAssignmentAreaStats;
   areas: ZetkinArea[];
+  assignment: ZetkinAreaAssignment;
   locations: ZetkinLocation[];
   onAddAssigneeToArea: (area: ZetkinArea, user: ZetkinOrgUser) => void;
   sessions: ZetkinAreaAssignee[];
@@ -58,6 +60,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
   areas,
   areaStats,
   areaAssId,
+  assignment,
   onAddAssigneeToArea,
   locations,
   sessions,
@@ -281,6 +284,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
                     key={selectedArea?.id}
                     areaAssId={areaAssId}
                     areas={areas}
+                    assignment={assignment}
                     filterAreas={filterAreas}
                     filterText={filterText}
                     locations={locations}

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -355,6 +355,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
             areas={filteredAreas}
             areaStats={areaStats}
             areaStyle={mapStyle.area}
+            assignment={assignment}
             locations={locations}
             locationStyle={mapStyle.location}
             onSelectedIdChange={(newId) => {

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -284,7 +284,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
                     assignment={assignment}
                     filterAreas={filterAreas}
                     filterText={filterText}
-                    locations={locations}
                     onAddAssignee={(user) => {
                       if (selectedArea) {
                         onAddAssigneeToArea(selectedArea, user);

--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -39,7 +39,6 @@ import { ZetkinOrgUser } from 'features/user/types';
 import { useAutoResizeMap } from 'features/map/hooks/useResizeMap';
 
 type OrganizerMapProps = {
-  areaAssId: number;
   areaStats: ZetkinAssignmentAreaStats;
   areas: ZetkinArea[];
   assignment: ZetkinAreaAssignment;
@@ -59,7 +58,6 @@ type SettingName = 'layers' | 'filters' | 'select';
 const OrganizerMap: FC<OrganizerMapProps> = ({
   areas,
   areaStats,
-  areaAssId,
   assignment,
   onAddAssigneeToArea,
   locations,
@@ -68,7 +66,7 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
   const messages = useMessages(messageIds);
   const theme = useTheme();
   const [mapStyle, setMapStyle] = useLocalStorage<MapStyle>(
-    `mapStyle-${areaAssId}`,
+    `mapStyle-${assignment.id}`,
     {
       area: 'assignees',
       location: 'dot',
@@ -282,7 +280,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
                 >
                   <AreaSelect
                     key={selectedArea?.id}
-                    areaAssId={areaAssId}
                     areas={areas}
                     assignment={assignment}
                     filterAreas={filterAreas}

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
@@ -74,10 +74,11 @@ const OrganizerMapPage: PageWithLayout<OrganizerMapPageProps> = ({
         <ZUIFutures
           futures={{
             areaStats: areaStatsFuture,
+            assignment: assignmentFuture,
             sessions: sessionsFuture,
           }}
         >
-          {({ data: { areaStats, sessions } }) => (
+          {({ data: { areaStats, assignment, sessions } }) => (
             <AreaFilterProvider>
               <AssigneeFilterProvider>
                 <OrganizerMap
@@ -91,6 +92,7 @@ const OrganizerMapPage: PageWithLayout<OrganizerMapPageProps> = ({
                     title: area.title,
                   }))}
                   areaStats={areaStats}
+                  assignment={assignment}
                   locations={locations}
                   onAddAssigneeToArea={(area, user) => {
                     assignUserToArea(user.id, area.id);

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/map.tsx
@@ -82,7 +82,6 @@ const OrganizerMapPage: PageWithLayout<OrganizerMapPageProps> = ({
             <AreaFilterProvider>
               <AssigneeFilterProvider>
                 <OrganizerMap
-                  areaAssId={areaAssId}
                   areas={areas.map((area) => ({
                     description: area.description,
                     id: area.id,


### PR DESCRIPTION
## Description
This PR fixes the stats (households visited / number of households and locations) in the organizer map to be shown when we select an area of the map.


## Screenshots
<img width="490" height="795" alt="image" src="https://github.com/user-attachments/assets/7b6cd118-5bbc-431d-9386-19d0a8812686" />
<img width="1456" height="1040" alt="image" src="https://github.com/user-attachments/assets/9ada568c-07ac-4d9c-95a3-e2efefa0a0c6" />
<img width="1457" height="1047" alt="image" src="https://github.com/user-attachments/assets/f71cd66e-60ca-425c-9762-8847b0bf9f3e" />



## Changes
* Adds new component `AreaStats` to render the stats.
* Removes dead code an unnecessary props (locations and areaAssId)


## Notes to reviewer
None

## Related issues
None
