### PR TITLE
Smart search filter to find everyone in a sub-organization

### DIFF
--- a/src/features/smartSearch/components/SmartSearchDialog/FilterEditor.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterEditor.tsx
@@ -1,3 +1,4 @@
+import AllInSuborg from '../filters/AllInSubOrg';
 import CallBlocked from '../filters/CallBlocked';
 import CallHistory from '../filters/CallHistory';
 import CampaignParticipation from '../filters/CampaignParticipation';
@@ -41,6 +42,13 @@ const FilterEditor = ({
 }: FilterEditorProps): JSX.Element => {
   return (
     <>
+      {filter.type == FILTER_TYPE.ALL && (
+        <AllInSuborg
+          filter={filter}
+          onCancel={onCancelSubmitFilter}
+          onSubmit={onSubmitFilter}
+        />
+      )}
       {filter.type === FILTER_TYPE.CALL_BLOCKED && (
         <CallBlocked
           filter={filter}

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/FilterGalleryCard.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/FilterGalleryCard.tsx
@@ -8,7 +8,7 @@ import { Msg } from 'core/i18n';
 
 interface FilterGalleryCardProps {
   colors: { pale: string; strong: string };
-  filter: Exclude<FILTER_TYPE, 'all' | 'call_blocked' | 'most_active'>;
+  filter: Exclude<FILTER_TYPE, 'call_blocked' | 'most_active'>;
   onAddFilter: () => void;
 }
 

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/filterGalleryPattern.ts
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/filterGalleryPattern.ts
@@ -119,6 +119,8 @@ export default function filterGalleryPattern(
     pattern = PATTERN_TEMPLATES.pattern14;
   } else if (slug === FILTER_TYPE.JOURNEY) {
     pattern = PATTERN_TEMPLATES.pattern16;
+  } else if (slug == FILTER_TYPE.ALL) {
+    pattern = PATTERN_TEMPLATES.pattern13;
   } else {
     pattern = PATTERN_TEMPLATES.pattern15;
   }

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/groupedFilters.ts
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/groupedFilters.ts
@@ -15,7 +15,6 @@ export const GROUPED_FILTERS: {
       strong: filterCategoryColors.lightBlue.strong,
     },
     filters: [
-      FILTER_TYPE.ALL,
       FILTER_TYPE.PERSON_DATA,
       FILTER_TYPE.PERSON_FIELD,
       FILTER_TYPE.PERSON_TAGS,
@@ -83,6 +82,11 @@ export const GROUPED_FILTERS: {
       pale: filterCategoryColors.red.pale,
       strong: filterCategoryColors.red.strong,
     },
-    filters: [FILTER_TYPE.JOINFORM, FILTER_TYPE.RANDOM, FILTER_TYPE.USER],
+    filters: [
+      FILTER_TYPE.ALL,
+      FILTER_TYPE.JOINFORM,
+      FILTER_TYPE.RANDOM,
+      FILTER_TYPE.USER,
+    ],
   },
 };

--- a/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/groupedFilters.ts
+++ b/src/features/smartSearch/components/SmartSearchDialog/FilterGallery/groupedFilters.ts
@@ -6,7 +6,7 @@ const filterCategoryColors = oldTheme.palette.filterCategoryColors;
 export const GROUPED_FILTERS: {
   [key in FILTER_CATEGORY]: {
     colors: { pale: string; strong: string };
-    filters: Exclude<FILTER_TYPE, 'all' | 'call_blocked' | 'most_active'>[];
+    filters: Exclude<FILTER_TYPE, 'call_blocked' | 'most_active'>[];
   };
 } = {
   [FILTER_CATEGORY.BASIC]: {
@@ -15,6 +15,7 @@ export const GROUPED_FILTERS: {
       strong: filterCategoryColors.lightBlue.strong,
     },
     filters: [
+      FILTER_TYPE.ALL,
       FILTER_TYPE.PERSON_DATA,
       FILTER_TYPE.PERSON_FIELD,
       FILTER_TYPE.PERSON_TAGS,

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/QueryOverviewFilterListItem.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/QueryOverviewFilterListItem.tsx
@@ -7,6 +7,7 @@ import QueryOverviewListItem from './QueryOverviewListItem';
 import { SmartSearchSankeyFilterSegment } from '../../sankeyDiagram';
 import {
   AnyFilterConfig,
+  FILTER_TYPE,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
 
@@ -53,7 +54,7 @@ const QueryOverviewFilterListItem: FC<QueryOverviewFilterListItemProps> = ({
         onClickDelete={() => onDeleteFilter(filter)}
         onClickEdit={() => onEditFilter(filter)}
         organizations={
-          'organizations' in filter.config
+          filter.type != FILTER_TYPE.ALL && 'organizations' in filter.config
             ? filter.config.organizations
             : undefined
         }

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
@@ -11,6 +11,7 @@ import {
   Event,
   ExploreOutlined,
   FilterAlt,
+  GroupWorkOutlined,
   LocalOfferOutlined,
   MarkEmailReadOutlined,
   PersonAddAlt,
@@ -20,7 +21,6 @@ import {
   Search,
   ShuffleOutlined,
   SpeakerNotesOutlined,
-  Surfing,
   ViewListOutlined,
 } from '@mui/icons-material';
 
@@ -241,7 +241,7 @@ export default function getFilterComponents(
         filter={filter as SmartSearchFilterWithId<AllInSuborgFilterConfig>}
       />
     );
-    filterTypeIcon = <Surfing color="secondary" fontSize="small" />;
+    filterTypeIcon = <GroupWorkOutlined color="secondary" fontSize="small" />;
   }
 
   return {

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/getFilterComponents.tsx
@@ -20,6 +20,7 @@ import {
   Search,
   ShuffleOutlined,
   SpeakerNotesOutlined,
+  Surfing,
   ViewListOutlined,
 } from '@mui/icons-material';
 
@@ -43,6 +44,7 @@ import DisplaySurveySubmission from '../../filters/SurveySubmission/DisplaySurve
 import DisplayTask from '../../filters/Task/DisplayTask';
 import DisplayUser from '../../filters/User/DisplayUser';
 import {
+  AllInSuborgFilterConfig,
   AnyFilterConfig,
   CallBlockedFilterConfig,
   CallHistoryFilterConfig,
@@ -69,6 +71,7 @@ import {
   UserFilterConfig,
 } from 'features/smartSearch/components/types';
 import DisplayJoinForm from '../../filters/JoinForm/DisplayJoinForm';
+import DisplayAllInSuborg from '../../filters/AllInSubOrg/DisplayAllInSuborg';
 
 export default function getFilterComponents(
   filter: SmartSearchFilterWithId<AnyFilterConfig>
@@ -229,6 +232,16 @@ export default function getFilterComponents(
       />
     );
     filterTypeIcon = <DoorFrontOutlined color="secondary" fontSize="small" />;
+  } else if (
+    filter.type == FILTER_TYPE.ALL &&
+    'organizations' in filter.config
+  ) {
+    displayFilter = (
+      <DisplayAllInSuborg
+        filter={filter as SmartSearchFilterWithId<AllInSuborgFilterConfig>}
+      />
+    );
+    filterTypeIcon = <Surfing color="secondary" fontSize="small" />;
   }
 
   return {

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
@@ -63,7 +63,7 @@ const QueryOverview = ({
     .filter(
       (f) =>
         f.type !== FILTER_TYPE.ALL ||
-        (f.type == FILTER_TYPE.ALL && 'organizations' in f.config)
+        (f.type == FILTER_TYPE.ALL && f.config && 'organizations' in f.config)
     )
     .map((filter, index) => ({
       id: filter.id,

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/index.tsx
@@ -60,7 +60,11 @@ const QueryOverview = ({
   const resultCount = stats?.length ? stats[stats.length - 1].result : 0;
 
   const reorderableItems = filters
-    .filter((f) => f.type !== FILTER_TYPE.ALL)
+    .filter(
+      (f) =>
+        f.type !== FILTER_TYPE.ALL ||
+        (f.type == FILTER_TYPE.ALL && 'organizations' in f.config)
+    )
     .map((filter, index) => ({
       id: filter.id,
       renderContent: () => {

--- a/src/features/smartSearch/components/filters/AllInSubOrg/DisplayAllInSuborg.tsx
+++ b/src/features/smartSearch/components/filters/AllInSubOrg/DisplayAllInSuborg.tsx
@@ -1,0 +1,109 @@
+import { FC } from 'react';
+import { useMediaQuery } from '@mui/system';
+import { Box, Chip } from '@mui/material';
+
+import {
+  AllInSuborgFilterConfig,
+  OPERATION,
+  SmartSearchFilterWithId,
+} from '../../types';
+import { Msg } from 'core/i18n';
+import messageIds from 'features/smartSearch/l10n/messageIds';
+import UnderlinedMsg from '../../UnderlinedMsg';
+import UnderlinedText from '../../UnderlinedText';
+import useSubOrganizations from 'features/organizations/hooks/useSubOrganizations';
+import { useNumericRouteParams } from 'core/hooks';
+
+type Props = {
+  filter: SmartSearchFilterWithId<AllInSuborgFilterConfig>;
+};
+
+const DisplayAllInSuborg: FC<Props> = ({ filter }) => {
+  const { orgId } = useNumericRouteParams();
+  const isDesktop = useMediaQuery('(min-width:600px');
+  const suborgs = useSubOrganizations(orgId).data || [];
+  const activeSuborgs = suborgs.filter((org) => org.is_active);
+
+  const op = filter.op || OPERATION.ADD;
+
+  if (filter.config.organizations == 'suborgs') {
+    return (
+      <Msg
+        id={messageIds.filters.allInSuborg.inputString.any}
+        values={{
+          addRemoveSelect: <UnderlinedMsg id={messageIds.operators[op]} />,
+          suborgScopeSelect: (
+            <UnderlinedMsg
+              id={messageIds.filters.allInSuborg.suborgScopeSelect.any}
+            />
+          ),
+        }}
+      />
+    );
+  } else if (
+    Array.isArray(filter.config.organizations) &&
+    filter.config.organizations.length == 1
+  ) {
+    const selectedSuborg = activeSuborgs.find(
+      (suborg) => suborg.id == filter.config.organizations[0]
+    );
+    return (
+      <Msg
+        id={messageIds.filters.allInSuborg.inputString.single}
+        values={{
+          addRemoveSelect: <UnderlinedMsg id={messageIds.operators[op]} />,
+          singleSuborgSelect: <UnderlinedText text={selectedSuborg?.title} />,
+          suborgScopeSelect: (
+            <UnderlinedMsg
+              id={messageIds.filters.allInSuborg.suborgScopeSelect.single}
+            />
+          ),
+        }}
+      />
+    );
+  } else if (
+    Array.isArray(filter.config.organizations) &&
+    filter.config.organizations.length > 1
+  ) {
+    const orgIds = filter.config.organizations;
+    const selectedSuborgs = activeSuborgs.filter((suborg) =>
+      orgIds.includes(suborg.id)
+    );
+
+    return (
+      <Msg
+        id={messageIds.filters.allInSuborg.inputString.multiple}
+        values={{
+          addRemoveSelect: <UnderlinedMsg id={messageIds.operators[op]} />,
+          multipleSuborgsSelect: (
+            <Box
+              alignItems="start"
+              display="inline-flex"
+              sx={{ marginTop: isDesktop ? '10px' : null }}
+            >
+              {selectedSuborgs.map((suborg) => (
+                <Chip
+                  key={suborg.id}
+                  label={suborg.title}
+                  size="small"
+                  sx={{ margin: '2px' }}
+                  variant="outlined"
+                />
+              ))}
+            </Box>
+          ),
+          suborgScopeSelect: (
+            <UnderlinedMsg
+              id={messageIds.filters.allInSuborg.suborgScopeSelect.multiple}
+            />
+          ),
+        }}
+      />
+    );
+  } else {
+    //If filter.config.organizations for some reason has the value "all"
+    return null;
+  }
+};
+
+export default DisplayAllInSuborg;

--- a/src/features/smartSearch/components/filters/AllInSubOrg/index.tsx
+++ b/src/features/smartSearch/components/filters/AllInSubOrg/index.tsx
@@ -1,0 +1,223 @@
+import { FC, useEffect, useState } from 'react';
+import { Chip, MenuItem } from '@mui/material';
+
+import FilterForm from '../../FilterForm';
+import {
+  AllInSuborgFilterConfig,
+  NewSmartSearchFilter,
+  OPERATION,
+  SmartSearchFilterWithId,
+  ZetkinSmartSearchFilter,
+} from '../../types';
+import StyledSelect from '../../inputs/StyledSelect';
+import { Msg } from 'core/i18n';
+import messageIds from 'features/smartSearch/l10n/messageIds';
+import useSubOrganizations from 'features/organizations/hooks/useSubOrganizations';
+import { useNumericRouteParams } from 'core/hooks';
+import useSmartSearchFilter from 'features/smartSearch/hooks/useSmartSearchFilter';
+import StyledItemSelect from '../../inputs/StyledItemSelect';
+
+type Props = {
+  filter:
+    | SmartSearchFilterWithId<AllInSuborgFilterConfig>
+    | NewSmartSearchFilter;
+  onCancel: () => void;
+  onSubmit: (
+    filter:
+      | SmartSearchFilterWithId<AllInSuborgFilterConfig>
+      | ZetkinSmartSearchFilter<AllInSuborgFilterConfig>
+  ) => void;
+};
+
+const AllInSuborg: FC<Props> = ({
+  filter: initialFilter,
+  onSubmit,
+  onCancel,
+}) => {
+  const { orgId } = useNumericRouteParams();
+  const suborgs = useSubOrganizations(orgId).data || [];
+  const [scope, setScope] = useState<'any' | 'single' | 'multiple'>('any');
+  const [selectedSuborgIds, setSelectedSuborgIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    setSelectedSuborgIds([]);
+  }, [scope]);
+
+  const { filter, setConfig, setOp } =
+    useSmartSearchFilter<AllInSuborgFilterConfig>(initialFilter, {
+      organizations: 'suborgs',
+    });
+
+  const activeSuborgs = suborgs
+    .filter((suborg) => suborg.id != orgId)
+    .filter((suborg) => suborg.is_active)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  const addRemoveSelect = (
+    <StyledSelect
+      onChange={(e) => setOp(e.target.value as OPERATION)}
+      value={filter.op}
+    >
+      {Object.values(OPERATION).map((o) => (
+        <MenuItem key={o} value={o}>
+          <Msg id={messageIds.operators[o]} />
+        </MenuItem>
+      ))}
+    </StyledSelect>
+  );
+
+  const suborgScopeSelect = (
+    <StyledSelect
+      onChange={(e) => {
+        const newValue = e.target.value as 'any' | 'single' | 'multiple';
+        setScope(newValue);
+
+        if (newValue == 'any') {
+          setConfig({
+            ...filter.config,
+            organizations: 'suborgs',
+          });
+        }
+      }}
+      value={scope}
+    >
+      <MenuItem value="any">
+        <Msg id={messageIds.filters.allInSuborg.suborgScopeSelect.any} />
+      </MenuItem>
+      <MenuItem value="single">
+        <Msg id={messageIds.filters.allInSuborg.suborgScopeSelect.single} />
+      </MenuItem>
+      <MenuItem value="multiple">
+        <Msg id={messageIds.filters.allInSuborg.suborgScopeSelect.multiple} />
+      </MenuItem>
+    </StyledSelect>
+  );
+
+  const singleSuborgSelect = (
+    <StyledSelect
+      onChange={(ev) => {
+        const selectedSuborgId = parseInt(ev.target.value);
+        setSelectedSuborgIds([selectedSuborgId]);
+        setConfig({
+          ...filter.config,
+          organizations: [selectedSuborgId],
+        });
+      }}
+    >
+      {activeSuborgs.map((suborg) => (
+        <MenuItem
+          key={suborg.id}
+          disabled={selectedSuborgIds.includes(suborg.id)}
+          value={suborg.id}
+        >
+          {suborg.title}
+        </MenuItem>
+      ))}
+    </StyledSelect>
+  );
+
+  const selectedSuborgs = activeSuborgs.filter((suborg) =>
+    selectedSuborgIds.includes(suborg.id)
+  );
+
+  const multipleSuborgsSelect = (
+    <>
+      {selectedSuborgs.map((suborg) => {
+        return (
+          <Chip
+            key={suborg.id}
+            label={suborg.title}
+            onDelete={() => {
+              setSelectedSuborgIds(
+                selectedSuborgIds.filter((id) => id != suborg.id)
+              );
+              setConfig({
+                ...filter.config,
+                organizations: selectedSuborgIds.filter(
+                  (id) => id != suborg.id
+                ),
+              });
+            }}
+            style={{ margin: '3px' }}
+            variant="outlined"
+          />
+        );
+      })}
+      {selectedSuborgIds.length < activeSuborgs.length && (
+        <StyledItemSelect
+          getOptionDisabled={(item) =>
+            selectedSuborgIds.some((id) => id == item.id) || false
+          }
+          onChange={(_, items) => {
+            const ids = items.map((item) => item.id);
+            setSelectedSuborgIds(ids);
+            setConfig({
+              ...filter.config,
+              organizations: ids,
+            });
+          }}
+          options={activeSuborgs.map((org) => ({
+            id: org.id,
+            title: org.title,
+          }))}
+          value={selectedSuborgs}
+        />
+      )}
+    </>
+  );
+
+  return (
+    <FilterForm
+      onCancel={() => onCancel()}
+      onSubmit={(ev) => {
+        ev.preventDefault();
+        onSubmit(filter);
+      }}
+      renderExamples={() => (
+        <>
+          <Msg id={messageIds.filters.allInSuborg.examples.one} />
+          <br />
+          <Msg id={messageIds.filters.allInSuborg.examples.two} />
+        </>
+      )}
+      renderSentence={() => {
+        if (scope == 'any') {
+          return (
+            <Msg
+              id={messageIds.filters.allInSuborg.inputString.any}
+              values={{
+                addRemoveSelect,
+                suborgScopeSelect,
+              }}
+            />
+          );
+        } else if (scope == 'single') {
+          return (
+            <Msg
+              id={messageIds.filters.allInSuborg.inputString.single}
+              values={{
+                addRemoveSelect,
+                singleSuborgSelect,
+                suborgScopeSelect,
+              }}
+            />
+          );
+        } else {
+          //Scope must be "multiple"
+          return (
+            <Msg
+              id={messageIds.filters.allInSuborg.inputString.multiple}
+              values={{
+                addRemoveSelect,
+                multipleSuborgsSelect,
+                suborgScopeSelect,
+              }}
+            />
+          );
+        }
+      }}
+    />
+  );
+};
+
+export default AllInSuborg;

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyProvider.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeyProvider.tsx
@@ -5,6 +5,7 @@ import oldTheme from 'theme';
 import useSmartSearchStats from 'features/smartSearch/hooks/useSmartSearchStats';
 import { ZetkinSmartSearchFilter } from '../types';
 import { SankeyConfig, SankeySegment } from './types';
+import { useNumericRouteParams } from 'core/hooks';
 
 type SmartSearchSankeyProviderProps = {
   arrowDepth?: number;
@@ -34,8 +35,9 @@ const SmartSearchSankeyProvider: FC<SmartSearchSankeyProviderProps> = ({
   margin = 30,
   filters,
 }) => {
+  const { orgId } = useNumericRouteParams();
   const stats = useSmartSearchStats(filters);
-  const segments = stats ? makeSankeySegments(stats) : [];
+  const segments = stats ? makeSankeySegments(stats, orgId) : [];
   const config: SankeyConfig = {
     arrowDepth,
     arrowWidth,

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.spec.ts
@@ -6,7 +6,7 @@ import { SankeySegment, SEGMENT_KIND, SEGMENT_STYLE } from './types';
 
 describe('makeSankeySegments()', () => {
   it('returns entry and exit for empty list', () => {
-    const result = makeSankeySegments([]);
+    const result = makeSankeySegments([], 1);
     expect(result).toEqual(<SankeySegment[]>[
       {
         kind: SEGMENT_KIND.EMPTY,
@@ -18,18 +18,21 @@ describe('makeSankeySegments()', () => {
   });
 
   it('treats non-all as empty start', () => {
-    const result = makeSankeySegments([
-      {
-        change: 200,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.CALL_BLOCKED,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 200,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.CALL_BLOCKED,
+          },
+          matches: 200,
+          result: 200,
         },
-        matches: 200,
-        result: 200,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -59,18 +62,21 @@ describe('makeSankeySegments()', () => {
   });
 
   it('treats all as non-empty entry', () => {
-    const result = makeSankeySegments([
-      {
-        change: 200,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 200,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 200,
+          result: 200,
         },
-        matches: 200,
-        result: 200,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -94,28 +100,31 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles a sub after an entry', () => {
-    const result = makeSankeySegments([
-      {
-        change: 200,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 200,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 200,
+          result: 200,
         },
-        matches: 200,
-        result: 200,
-      },
-      {
-        change: -50,
-        filter: {
-          config: {},
-          op: OPERATION.SUB,
-          type: FILTER_TYPE.PERSON_DATA,
+        {
+          change: -50,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.PERSON_DATA,
+          },
+          matches: 100,
+          result: 150,
         },
-        matches: 100,
-        result: 150,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -156,48 +165,51 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles adding to already full stream', () => {
-    const result = makeSankeySegments([
-      {
-        change: 100,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 100,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-      {
-        change: -20,
-        filter: {
-          config: {},
-          op: OPERATION.SUB,
-          type: FILTER_TYPE.PERSON_TAGS,
+        {
+          change: -20,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.PERSON_TAGS,
+          },
+          matches: 20,
+          result: 80,
         },
-        matches: 20,
-        result: 80,
-      },
-      {
-        change: 0,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        {
+          change: 0,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+          },
+          matches: 5,
+          result: 80,
         },
-        matches: 5,
-        result: 80,
-      },
-      {
-        change: 0,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.CALL_HISTORY,
+        {
+          change: 0,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.CALL_HISTORY,
+          },
+          matches: 10,
+          result: 80,
         },
-        matches: 10,
-        result: 80,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -272,38 +284,41 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles pseudo-removing', () => {
-    const result = makeSankeySegments([
-      {
-        change: 100,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 100,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-      {
-        change: -20,
-        filter: {
-          config: {},
-          op: OPERATION.SUB,
-          type: FILTER_TYPE.PERSON_TAGS,
+        {
+          change: -20,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.PERSON_TAGS,
+          },
+          matches: 20,
+          result: 80,
         },
-        matches: 20,
-        result: 80,
-      },
-      {
-        change: 0,
-        filter: {
-          config: {},
-          op: OPERATION.SUB,
-          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        {
+          change: 0,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+          },
+          matches: 5,
+          result: 80,
         },
-        matches: 5,
-        result: 80,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -361,28 +376,31 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles when first filter is a sub', () => {
-    const result = makeSankeySegments([
-      {
-        change: -100,
-        filter: {
-          config: {},
-          op: OPERATION.SUB,
-          type: FILTER_TYPE.RANDOM,
+    const result = makeSankeySegments(
+      [
+        {
+          change: -100,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.RANDOM,
+          },
+          matches: 100,
+          result: 0,
         },
-        matches: 100,
-        result: 0,
-      },
-      {
-        change: 100,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.RANDOM,
+        {
+          change: 100,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.RANDOM,
+          },
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -415,28 +433,31 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles a limit like a sub', () => {
-    const result = makeSankeySegments([
-      {
-        change: 100,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 100,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-      {
-        change: -40,
-        filter: {
-          config: {},
-          op: OPERATION.LIMIT,
-          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        {
+          change: -40,
+          filter: {
+            config: {},
+            op: OPERATION.LIMIT,
+            type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+          },
+          matches: 40,
+          result: 60,
         },
-        matches: 40,
-        result: 60,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -477,28 +498,31 @@ describe('makeSankeySegments()', () => {
   });
 
   it('imposes a minimum width of 5% to main when limited', () => {
-    const result = makeSankeySegments([
-      {
-        change: 100,
-        filter: {
-          config: {},
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.ALL,
+    const result = makeSankeySegments(
+      [
+        {
+          change: 100,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-      {
-        change: -99,
-        filter: {
-          config: {},
-          op: OPERATION.LIMIT,
-          type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+        {
+          change: -99,
+          filter: {
+            config: {},
+            op: OPERATION.LIMIT,
+            type: FILTER_TYPE.CAMPAIGN_PARTICIPATION,
+          },
+          matches: 99,
+          result: 1,
         },
-        matches: 99,
-        result: 1,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -539,38 +563,41 @@ describe('makeSankeySegments()', () => {
   });
 
   it('handles adding nothing to empty stream', () => {
-    const result = makeSankeySegments([
-      {
-        change: 0,
-        filter: {
-          config: {
-            fields: {
-              first_name: 'aaaaaaaaaaa',
+    const result = makeSankeySegments(
+      [
+        {
+          change: 0,
+          filter: {
+            config: {
+              fields: {
+                first_name: 'aaaaaaaaaaa',
+              },
+              organizations: [1],
             },
-            organizations: [1],
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.PERSON_DATA,
           },
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.PERSON_DATA,
+          matches: 0,
+          result: 0,
         },
-        matches: 0,
-        result: 0,
-      },
-      {
-        change: 100,
-        filter: {
-          config: {
-            fields: {
-              first_name: 'a',
+        {
+          change: 100,
+          filter: {
+            config: {
+              fields: {
+                first_name: 'a',
+              },
+              organizations: [1],
             },
-            organizations: [1],
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.PERSON_DATA,
           },
-          op: OPERATION.ADD,
-          type: FILTER_TYPE.PERSON_DATA,
+          matches: 100,
+          result: 100,
         },
-        matches: 100,
-        result: 100,
-      },
-    ]);
+      ],
+      1
+    );
 
     expect(result).toEqual(<SankeySegment[]>[
       {
@@ -612,6 +639,219 @@ describe('makeSankeySegments()', () => {
         output: 100,
         style: SEGMENT_STYLE.FILL,
         width: 1,
+      },
+    ]);
+  });
+
+  it('handles an ALL filter that adds from other orgs than the current, being first after starting from empty', () => {
+    const result = makeSankeySegments(
+      [
+        {
+          change: 100,
+          filter: {
+            config: {
+              organizations: [3],
+            },
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 100,
+        },
+      ],
+      1
+    );
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.EMPTY,
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: null,
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 1,
+        },
+        stats: {
+          change: 100,
+          input: 0,
+          matches: 100,
+          output: 100,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 100,
+        style: SEGMENT_STYLE.FILL,
+        width: 1,
+      },
+    ]);
+  });
+
+  it('handles an ALL filter that adds from other orgs than the current, being first after starting from all in the org', () => {
+    const result = makeSankeySegments(
+      [
+        {
+          change: 200,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 200,
+          result: 200,
+        },
+        {
+          change: 0,
+          filter: {
+            config: {
+              organizations: [3],
+            },
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 200,
+        },
+      ],
+      1
+    );
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.ENTRY,
+        stats: {
+          change: 200,
+          input: 0,
+          matches: 200,
+          output: 200,
+        },
+        style: SEGMENT_STYLE.FILL,
+        width: 1,
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 1,
+        },
+        side: {
+          style: SEGMENT_STYLE.STROKE,
+          width: 1,
+        },
+        stats: {
+          change: 0,
+          input: 200,
+          matches: 100,
+          output: 200,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 200,
+        style: SEGMENT_STYLE.FILL,
+        width: 1,
+      },
+    ]);
+  });
+
+  it('handles an ALL filter being in the middle of the filters', () => {
+    const result = makeSankeySegments(
+      [
+        {
+          change: 200,
+          filter: {
+            config: {},
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.CALL_BLOCKED,
+          },
+          matches: 200,
+          result: 200,
+        },
+        {
+          change: 50,
+          filter: {
+            config: {
+              organizations: [3],
+            },
+            op: OPERATION.ADD,
+            type: FILTER_TYPE.ALL,
+          },
+          matches: 100,
+          result: 250,
+        },
+        {
+          change: -100,
+          filter: {
+            config: {},
+            op: OPERATION.SUB,
+            type: FILTER_TYPE.RANDOM,
+          },
+          matches: 100,
+          result: 150,
+        },
+      ],
+      1
+    );
+
+    expect(result).toEqual(<SankeySegment[]>[
+      {
+        kind: SEGMENT_KIND.EMPTY,
+      },
+      {
+        kind: SEGMENT_KIND.PSEUDO_ADD,
+        main: null,
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.8,
+        },
+        stats: {
+          change: 200,
+          input: 0,
+          matches: 200,
+          output: 200,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.ADD,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.8,
+        },
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.2,
+        },
+        stats: {
+          change: 50,
+          input: 200,
+          matches: 100,
+          output: 250,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.SUB,
+        main: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.6,
+        },
+        side: {
+          style: SEGMENT_STYLE.FILL,
+          width: 0.4,
+        },
+        stats: {
+          change: -100,
+          input: 250,
+          matches: 100,
+          output: 150,
+        },
+      },
+      {
+        kind: SEGMENT_KIND.EXIT,
+        output: 150,
+        style: SEGMENT_STYLE.FILL,
+        width: 0.6,
       },
     ]);
   });

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -265,6 +265,10 @@ export interface UserFilterConfig {
 
 export type FilterConfigOrgOptions = number[] | 'all' | 'suborgs';
 
+export type AllInSuborgFilterConfig = {
+  organizations: FilterConfigOrgOptions;
+};
+
 export interface CampaignParticipationConfig {
   state: 'booked' | 'signed_up';
   status?: 'attended' | 'cancelled' | 'noshow';

--- a/src/features/smartSearch/hooks/useSmartSearch.ts
+++ b/src/features/smartSearch/hooks/useSmartSearch.ts
@@ -26,7 +26,8 @@ const useSmartSearch = (
   // correctly configure legacy queries to only have the All filter in the first position with op: 'add'
   const indexOfAllFilter = initialFilters.findLastIndex(
     (filter) =>
-      filter.type == FILTER_TYPE.ALL && !('organizations' in filter.config)
+      filter.type == FILTER_TYPE.ALL &&
+      (!('config' in filter) || !('organizations' in filter.config))
   );
 
   const normalizedFiltersWithIds = initialFilters
@@ -76,10 +77,16 @@ const useSmartSearch = (
     };
   });
 
+  const firstFilter = filtersWithIds[0];
+  const firstFilterHasConfig = firstFilter && 'config' in firstFilter;
+
+  const firstFilterHasOrgConfig =
+    firstFilterHasConfig && 'organizations' in firstFilter.config;
+
   const startsWithAll =
-    filtersWithIds[0] &&
-    filtersWithIds[0].type === FILTER_TYPE.ALL &&
-    !('organizations' in filtersWithIds[0].config);
+    firstFilter &&
+    firstFilter.type === FILTER_TYPE.ALL &&
+    (!firstFilterHasConfig || !firstFilterHasOrgConfig);
 
   const setStartsWithAll = (shouldStartWithAll: boolean) => {
     if (startsWithAll && !shouldStartWithAll) {

--- a/src/features/smartSearch/hooks/useSmartSearch.ts
+++ b/src/features/smartSearch/hooks/useSmartSearch.ts
@@ -84,7 +84,7 @@ const useSmartSearch = (
     firstFilterHasConfig && 'organizations' in firstFilter.config;
 
   const startsWithAll =
-    firstFilter &&
+    !!firstFilter &&
     firstFilter.type === FILTER_TYPE.ALL &&
     (!firstFilterHasConfig || !firstFilterHasOrgConfig);
 

--- a/src/features/smartSearch/hooks/useSmartSearch.ts
+++ b/src/features/smartSearch/hooks/useSmartSearch.ts
@@ -24,9 +24,11 @@ const useSmartSearch = (
   initialFilters: InitialFilters = []
 ): UseSmartSearch => {
   // correctly configure legacy queries to only have the All filter in the first position with op: 'add'
-  const indexOfAllFilter = initialFilters
-    .map((f) => f.type)
-    .lastIndexOf(FILTER_TYPE.ALL);
+  const indexOfAllFilter = initialFilters.findLastIndex(
+    (filter) =>
+      filter.type == FILTER_TYPE.ALL && !('organizations' in filter.config)
+  );
+
   const normalizedFiltersWithIds = initialFilters
     .filter(
       (filter, index) =>
@@ -74,7 +76,10 @@ const useSmartSearch = (
     };
   });
 
-  const startsWithAll = filtersWithIds[0]?.type === FILTER_TYPE.ALL;
+  const startsWithAll =
+    filtersWithIds[0] &&
+    filtersWithIds[0].type === FILTER_TYPE.ALL &&
+    !('organizations' in filtersWithIds[0].config);
 
   const setStartsWithAll = (shouldStartWithAll: boolean) => {
     if (startsWithAll && !shouldStartWithAll) {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -172,7 +172,7 @@ export default makeMessages('feat.smartSearch', {
         any: m<{
           addRemoveSelect: ReactElement;
           suborgScopeSelect: ReactElement;
-        }>('{addRemoveSelect} people in {suborgScopeSelect}.'),
+        }>('{addRemoveSelect} everyone who is in {suborgScopeSelect}.'),
         multiple: m<{
           addRemoveSelect: ReactElement;
           multipleSuborgsSelect: ReactElement;

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -54,8 +54,10 @@ export default makeMessages('feat.smartSearch', {
     },
     filters: {
       all: {
-        description: m('Testing the new filter'),
-        title: m('All in a sub-organization'),
+        description: m(
+          'Find people based on what sub-organization they are in.'
+        ),
+        title: m('Everyone in a sub-org'),
       },
       call_history: {
         description: m('Find people who were called, reached or tried.'),

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -53,6 +53,10 @@ export default makeMessages('feat.smartSearch', {
       },
     },
     filters: {
+      all: {
+        description: m('Testing the new filter'),
+        title: m('All in a sub-organization'),
+      },
       call_history: {
         description: m('Find people who were called, reached or tried.'),
         title: m('Call history'),
@@ -153,6 +157,39 @@ export default makeMessages('feat.smartSearch', {
       startWithSelect: {
         false: m('an empty list'),
         true: m('a list of all the people in the organization'),
+      },
+    },
+    allInSuborg: {
+      examples: {
+        one: m(
+          'Add people in the specific sub-organization My Third Organization.'
+        ),
+        two: m('Remove people in any sub-organization.'),
+      },
+      inputString: {
+        any: m<{
+          addRemoveSelect: ReactElement;
+          suborgScopeSelect: ReactElement;
+        }>('{addRemoveSelect} people in {suborgScopeSelect}.'),
+        multiple: m<{
+          addRemoveSelect: ReactElement;
+          multipleSuborgsSelect: ReactElement;
+          suborgScopeSelect: ReactElement;
+        }>(
+          '{addRemoveSelect} people in {suborgScopeSelect} {multipleSuborgsSelect}'
+        ),
+        single: m<{
+          addRemoveSelect: ReactElement;
+          singleSuborgSelect: ReactElement;
+          suborgScopeSelect: ReactElement;
+        }>(
+          '{addRemoveSelect} people in {suborgScopeSelect} {singleSuborgSelect}'
+        ),
+      },
+      suborgScopeSelect: {
+        any: m('any sub-organization'),
+        multiple: m('any of the following sub-organizations'),
+        single: m('the specific sub-organization'),
       },
     },
     callBlocked: {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -55,9 +55,9 @@ export default makeMessages('feat.smartSearch', {
     filters: {
       all: {
         description: m(
-          'Find people based on what sub-organization they are in.'
+          'Find people based on what sub-organizations they are in.'
         ),
-        title: m('Everyone in a sub-org'),
+        title: m('Everyone in a sub-organization'),
       },
       call_history: {
         description: m('Find people who were called, reached or tried.'),
@@ -164,7 +164,7 @@ export default makeMessages('feat.smartSearch', {
     allInSuborg: {
       examples: {
         one: m(
-          'Add everyone who is in the specific sub-organization My Third Organization.'
+          'Add everyone who is in the specific sub-organization Littleton Local Branch'
         ),
         two: m('Remove everyone who is in any sub-organization.'),
       },

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -162,9 +162,9 @@ export default makeMessages('feat.smartSearch', {
     allInSuborg: {
       examples: {
         one: m(
-          'Add people in the specific sub-organization My Third Organization.'
+          'Add everyone who is in the specific sub-organization My Third Organization.'
         ),
-        two: m('Remove people in any sub-organization.'),
+        two: m('Remove everyone who is in any sub-organization.'),
       },
       inputString: {
         any: m<{
@@ -176,14 +176,14 @@ export default makeMessages('feat.smartSearch', {
           multipleSuborgsSelect: ReactElement;
           suborgScopeSelect: ReactElement;
         }>(
-          '{addRemoveSelect} people in {suborgScopeSelect} {multipleSuborgsSelect}'
+          '{addRemoveSelect} everyone who is in {suborgScopeSelect}: {multipleSuborgsSelect}'
         ),
         single: m<{
           addRemoveSelect: ReactElement;
           singleSuborgSelect: ReactElement;
           suborgScopeSelect: ReactElement;
         }>(
-          '{addRemoveSelect} people in {suborgScopeSelect} {singleSuborgSelect}'
+          '{addRemoveSelect} everyone who is in {suborgScopeSelect} {singleSuborgSelect}'
         ),
       },
       suborgScopeSelect: {


### PR DESCRIPTION
## Description
This PR adds UI for a Smart search filter to find everyone in a specific sub-organization. 

## Screenshots
<img width="1386" height="772" alt="bild" src="https://github.com/user-attachments/assets/e42da3b0-a9ce-43a4-8004-cb7c3741a9a6" />


## Changes
- Adds UI to find the new filter in the filter gallery, to configure it and display it in the filter overview. 
- Updates the `makeSankeySegments` function with slightly modified logic and a few new tests, to make the `ALL` filter work in the middle of the normal filters and not just as the first filter. 

## Notes to reviewer
Please try your best to break the sankey segment overview! 

## Related issues
none
