### PR TITLE
Issue 2967/filter events by type

### DIFF
--- a/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
+++ b/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
@@ -14,8 +14,15 @@ export default function useFilteredCampaignEvents(
   const events = useUpcomingCampaignEvents(campId, orgId);
   const myEvents = useMyEvents();
 
-  const { customDatesToFilterBy, dateFilterState, geojsonToFilterBy } =
-    useAppSelector((state) => state.campaigns.filters);
+  const {
+    customDatesToFilterBy,
+    dateFilterState,
+    eventTypesToFilterBy,
+    geojsonToFilterBy,
+  } = useAppSelector((state) => state.campaigns.filters);
+
+  const eventToEventType = (event: { activity: { title: string } | null }) =>
+    event.activity?.title ?? null;
 
   const getDateRange = (): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
@@ -39,35 +46,43 @@ export default function useFilteredCampaignEvents(
     }));
   }, [events]);
 
-  const filteredEvents = allEvents.filter((event) => {
-    if (
-      !dateFilterState ||
-      (dateFilterState == 'custom' && !customDatesToFilterBy[0])
-    ) {
-      return true;
-    }
+  const filteredEvents = allEvents
+    .filter((event) => {
+      if (
+        !dateFilterState ||
+        (dateFilterState == 'custom' && !customDatesToFilterBy[0])
+      ) {
+        return true;
+      }
 
-    const [start, end] = getDateRange();
-    const eventStart = dayjs(event.start_time);
-    const eventEnd = dayjs(event.end_time);
+      const [start, end] = getDateRange();
+      const eventStart = dayjs(event.start_time);
+      const eventEnd = dayjs(event.end_time);
 
-    if (!end) {
-      const isOngoing = eventStart.isBefore(start) && eventEnd.isAfter(start);
-      const startsOnSelectedDay = eventStart.isSame(start, 'day');
-      const endsOnSelectedDay = eventEnd.isSame(start, 'day');
-      return isOngoing || startsOnSelectedDay || endsOnSelectedDay;
-    } else {
-      const isOngoing =
-        eventStart.isBefore(start, 'day') && eventEnd.isAfter(end, 'day');
-      const startsInPeriod =
-        (eventStart.isSame(start, 'day') || eventStart.isAfter(start, 'day')) &&
-        (eventStart.isSame(end, 'day') || eventStart.isBefore(end, 'day'));
-      const endsInPeriod =
-        (eventEnd.isSame(start, 'day') || eventEnd.isAfter(start, 'day')) &&
-        (eventEnd.isBefore(end, 'day') || eventEnd.isSame(end, 'day'));
-      return isOngoing || startsInPeriod || endsInPeriod;
-    }
-  });
+      if (!end) {
+        const isOngoing = eventStart.isBefore(start) && eventEnd.isAfter(start);
+        const startsOnSelectedDay = eventStart.isSame(start, 'day');
+        const endsOnSelectedDay = eventEnd.isSame(start, 'day');
+        return isOngoing || startsOnSelectedDay || endsOnSelectedDay;
+      } else {
+        const isOngoing =
+          eventStart.isBefore(start, 'day') && eventEnd.isAfter(end, 'day');
+        const startsInPeriod =
+          (eventStart.isSame(start, 'day') ||
+            eventStart.isAfter(start, 'day')) &&
+          (eventStart.isSame(end, 'day') || eventStart.isBefore(end, 'day'));
+        const endsInPeriod =
+          (eventEnd.isSame(start, 'day') || eventEnd.isAfter(start, 'day')) &&
+          (eventEnd.isBefore(end, 'day') || eventEnd.isSame(end, 'day'));
+        return isOngoing || startsInPeriod || endsInPeriod;
+      }
+    })
+    .filter((event) => {
+      if (eventTypesToFilterBy.length === 0) {
+        return true;
+      }
+      return eventTypesToFilterBy.includes(eventToEventType(event));
+    });
 
   const locationEvents = filteredEvents.filter((event) => {
     if (geojsonToFilterBy.length === 0) {

--- a/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
+++ b/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
@@ -6,6 +6,7 @@ import useMyEvents from 'features/events/hooks/useMyEvents';
 import useUpcomingCampaignEvents from './useUpcomingCampaignEvents';
 import { ZetkinEventWithStatus } from 'features/home/types';
 import { getGeoJSONFeaturesAtLocations } from 'features/map/utils/locationFiltering';
+import { getShouldShowEvent } from 'features/events/hooks/useEventTypeFilter';
 
 export default function useFilteredCampaignEvents(
   campId: number,
@@ -20,9 +21,6 @@ export default function useFilteredCampaignEvents(
     eventTypesToFilterBy,
     geojsonToFilterBy,
   } = useAppSelector((state) => state.campaigns.filters);
-
-  const eventToEventType = (event: { activity: { title: string } | null }) =>
-    event.activity?.title ?? null;
 
   const getDateRange = (): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
@@ -77,12 +75,7 @@ export default function useFilteredCampaignEvents(
         return isOngoing || startsInPeriod || endsInPeriod;
       }
     })
-    .filter((event) => {
-      if (eventTypesToFilterBy.length === 0) {
-        return true;
-      }
-      return eventTypesToFilterBy.includes(eventToEventType(event));
-    });
+    .filter((event) => getShouldShowEvent(event, eventTypesToFilterBy));
 
   const locationEvents = filteredEvents.filter((event) => {
     if (geojsonToFilterBy.length === 0) {

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -167,6 +167,9 @@ export default makeMessages('feat.campaigns', {
         removeFiltersButton: m('Clear filters'),
       },
       filterButtonLabels: {
+        eventTypes: m<{ numEventTypes: number }>(
+          '{numEventTypes, plural,=0 {Event types} =1 {1 event type} other {# event types}}'
+        ),
         locations: m<{ count: number }>('{count} locations'),
         thisWeek: m('This week'),
         today: m('Today'),

--- a/src/features/campaigns/store.ts
+++ b/src/features/campaigns/store.ts
@@ -8,6 +8,7 @@ import { remoteItem, RemoteList, remoteList } from 'utils/storeUtils';
 type CampaignEventFilters = {
   customDatesToFilterBy: DateRange<Dayjs>;
   dateFilterState: 'today' | 'tomorrow' | 'thisWeek' | 'custom' | null;
+  eventTypesToFilterBy: (string | null)[];
   geojsonToFilterBy: GeoJSON.Feature[];
 };
 
@@ -24,6 +25,7 @@ const initialCampaignsState: CampaignsStoreSlice = {
   filters: {
     customDatesToFilterBy: [null, null],
     dateFilterState: null,
+    eventTypesToFilterBy: [],
     geojsonToFilterBy: [],
   },
   recentlyCreatedCampaign: null,

--- a/src/features/events/hooks/useEventTypeFilter.ts
+++ b/src/features/events/hooks/useEventTypeFilter.ts
@@ -1,0 +1,76 @@
+import { useMemo, useCallback } from 'react';
+
+interface EventWithActivity {
+  activity: { title: string } | null;
+}
+
+const getLabelFromEventType = (eventType: string | null) => {
+  return eventType === null ? 'Uncategorized' : eventType;
+};
+
+const getEventTypeFromEvent = (event: EventWithActivity) =>
+  event.activity?.title ?? null;
+
+/**
+ * @param events - Array of events with activity titles to extract types from
+ * @param state - External state management object containing the current filter selection and setter function (can be useState or Redux store)
+ */
+export const useEventTypeFilter = (
+  events: EventWithActivity[],
+  state: {
+    eventTypesToFilterBy: (string | null)[];
+    setEventTypesToFilterBy: (eventTypes: (string | null)[]) => void;
+  }
+) => {
+  const eventTypes = useMemo(() => {
+    const uniqueTypes = new Set(events.map(getEventTypeFromEvent));
+    return Array.from(uniqueTypes).sort((a, b) => {
+      if (a === null) {
+        return 1;
+      }
+      if (b === null) {
+        return -1;
+      }
+      return a.localeCompare(b);
+    });
+  }, [events, getEventTypeFromEvent]);
+
+  const toggleEventType = useCallback(
+    (eventType: string | null) => {
+      const newArray = state.eventTypesToFilterBy.includes(eventType)
+        ? state.eventTypesToFilterBy.filter((t) => t !== eventType)
+        : [...state.eventTypesToFilterBy, eventType];
+      state.setEventTypesToFilterBy(newArray);
+    },
+    [state]
+  );
+
+  const clearEventTypes = useCallback(() => {
+    state.setEventTypesToFilterBy([]);
+  }, [state.setEventTypesToFilterBy]);
+
+  return {
+    clearEventTypes,
+    eventTypes,
+    filterCount: state.eventTypesToFilterBy.length,
+    getLabelFromEventType,
+    isFiltered: state.eventTypesToFilterBy.length > 0,
+    shouldShowFilter: eventTypes.length > 1,
+    toggleEventType,
+  };
+};
+
+/*  
+  Filter logic for a single event.
+  We need to export this for reuse in the redux stores
+  where the return of the hook is not available 
+*/
+export const getShouldShowEvent = (
+  event: EventWithActivity,
+  eventTypesToFilterBy: (string | null)[]
+) => {
+  if (eventTypesToFilterBy.length === 0) {
+    return true;
+  }
+  return eventTypesToFilterBy.includes(getEventTypeFromEvent(event));
+};

--- a/src/features/home/l10n/messageIds.ts
+++ b/src/features/home/l10n/messageIds.ts
@@ -31,6 +31,9 @@ export default makeMessages('feat.home', {
       removeFiltersButton: m('Clear filters'),
     },
     filterButtonLabels: {
+      eventTypes: m<{ numEventTypes: number }>(
+        '{numEventTypes, plural,=0 {Event types} =1 {1 event type} other {# event types}}'
+      ),
       organizations: m<{ numOrgs: number }>(
         '{numOrgs, plural,=0 {Organizations} =1 {1 organization} other {# organizations}}'
       ),

--- a/src/features/organizations/hooks/useFilteredOrgEvents.ts
+++ b/src/features/organizations/hooks/useFilteredOrgEvents.ts
@@ -6,6 +6,7 @@ import useUpcomingOrgEvents from './useUpcomingOrgEvents';
 import useMyEvents from 'features/events/hooks/useMyEvents';
 import { useAppSelector } from 'core/hooks';
 import { getGeoJSONFeaturesAtLocations } from '../../map/utils/locationFiltering';
+import { getShouldShowEvent } from 'features/events/hooks/useEventTypeFilter';
 
 export default function useFilteredOrgEvents(orgId: number) {
   const orgEvents = useUpcomingOrgEvents(orgId);
@@ -18,9 +19,6 @@ export default function useFilteredOrgEvents(orgId: number) {
     geojsonToFilterBy,
     orgIdsToFilterBy,
   } = useAppSelector((state) => state.organizations.filters);
-
-  const eventToEventType = (event: { activity: { title: string } | null }) =>
-    event.activity?.title ?? null;
 
   const getDateRange = (): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
@@ -81,12 +79,7 @@ export default function useFilteredOrgEvents(orgId: number) {
         return isOngoing || startsInPeriod || endsInPeriod;
       }
     })
-    .filter((event) => {
-      if (eventTypesToFilterBy.length === 0) {
-        return true;
-      }
-      return eventTypesToFilterBy.includes(eventToEventType(event));
-    });
+    .filter((event) => getShouldShowEvent(event, eventTypesToFilterBy));
 
   const locationEvents = filteredEvents.filter((event) => {
     if (geojsonToFilterBy.length === 0) {

--- a/src/features/organizations/hooks/useFilteredOrgEvents.ts
+++ b/src/features/organizations/hooks/useFilteredOrgEvents.ts
@@ -14,9 +14,13 @@ export default function useFilteredOrgEvents(orgId: number) {
   const {
     customDatesToFilterBy,
     dateFilterState,
+    eventTypesToFilterBy,
     geojsonToFilterBy,
     orgIdsToFilterBy,
   } = useAppSelector((state) => state.organizations.filters);
+
+  const eventToEventType = (event: { activity: { title: string } | null }) =>
+    event.activity?.title ?? null;
 
   const getDateRange = (): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
@@ -76,6 +80,12 @@ export default function useFilteredOrgEvents(orgId: number) {
           (eventEnd.isBefore(end, 'day') || eventEnd.isSame(end, 'day'));
         return isOngoing || startsInPeriod || endsInPeriod;
       }
+    })
+    .filter((event) => {
+      if (eventTypesToFilterBy.length === 0) {
+        return true;
+      }
+      return eventTypesToFilterBy.includes(eventToEventType(event));
     });
 
   const locationEvents = filteredEvents.filter((event) => {

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -9,6 +9,9 @@ export default makeMessages('feat.organizations', {
       removeFiltersButton: m('Clear filters'),
     },
     filterButtonLabels: {
+      eventTypes: m<{ numEventTypes: number }>(
+        '{numEventTypes, plural,=0 {Event types} =1 {1 event type} other {# event types}}'
+      ),
       locations: m<{ count: number }>('{count} locations'),
       organizations: m<{ numOrgs: number }>(
         '{numOrgs, plural,=0 {Organizations} =1 {1 organization} other {# organizations}}'

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -19,6 +19,7 @@ import {
 type OrgEventFilters = {
   customDatesToFilterBy: DateRange<Dayjs>;
   dateFilterState: 'today' | 'tomorrow' | 'thisWeek' | 'custom' | null;
+  eventTypesToFilterBy: (string | null)[];
   geojsonToFilterBy: GeoJSON.Feature[];
   orgIdsToFilterBy: number[];
 };
@@ -37,6 +38,7 @@ const initialState: OrganizationsStoreSlice = {
   filters: {
     customDatesToFilterBy: [null, null],
     dateFilterState: null,
+    eventTypesToFilterBy: [],
     geojsonToFilterBy: [],
     orgIdsToFilterBy: [],
   },

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -114,6 +114,7 @@ export default function mockState(overrides?: RootState) {
       filters: {
         customDatesToFilterBy: [null, null],
         dateFilterState: null,
+        eventTypesToFilterBy: [],
         geojsonToFilterBy: [],
         orgIdsToFilterBy: [],
       },

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -44,6 +44,7 @@ export default function mockState(overrides?: RootState) {
       filters: {
         customDatesToFilterBy: [null, null],
         dateFilterState: null,
+        eventTypesToFilterBy: [],
         geojsonToFilterBy: [],
       },
       recentlyCreatedCampaign: null,


### PR DESCRIPTION
## Description
This PR introduces a event type filter for events on these pages
My page: http://localhost:3000/my/feed
Organization page: http://localhost:3000/o/1
Project page: http://localhost:3000/o/1/projects/168

## Screenshots
<img width="377" height="674" alt="screen 2025-08-31 at 17 35 17" src="https://github.com/user-attachments/assets/517266ee-31f1-4185-b743-0ca6403ee9f1" />

<img width="392" height="845" alt="screen 2025-08-31 at 17 36 58" src="https://github.com/user-attachments/assets/68d291ea-80a8-4a5c-bbf7-bb9b8d0bfb38" />

Note that we are cutting of the filter buttons and horizontal scroll is necessary. Not sure if we want to do something about that.


## Changes
- Add a new `useEventTypeFilter` hook that does not keep track of the filter state itself but allows for interop between local and redux state management.
   - Wanted to keep it a bit more reusable. But if the abstraction is not useful, we can drop the last commit and only add the functionality based on the patterns for the other filters manually without any sharing code.
- No changes on the existing filters


## Notes to reviewer
- Check the three different event pages (replace localhost with the preview deploy link)
- Test for a event type with the same title across multiple orgs
- Validate clearing the filters work ('X' button and 'Clear filters')


## Related issues
Resolves #2967 
