### PR TITLE
Allow log out from activist portal pages

### DIFF
--- a/src/features/organizations/components/ActivistPortlHeader/index.tsx
+++ b/src/features/organizations/components/ActivistPortlHeader/index.tsx
@@ -1,13 +1,16 @@
-import { Box } from '@mui/material';
-import { FC } from 'react';
-import NextLink from 'next/link';
+import { Box, Button } from '@mui/material';
+import { FC, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 
+import messageIds from 'features/organizations/l10n/messageIds';
 import ZUIText from 'zui/components/ZUIText';
 import ZUITabbedNavBar, {
   ZUITabbedNavBarProps,
 } from 'zui/components/ZUITabbedNavBar';
 import ZUIPersonAvatar from 'zui/components/ZUIPersonAvatar';
 import useUser from 'core/hooks/useUser';
+import { useMessages } from 'core/i18n';
+import ZUIMenu, { MenuItem } from 'zui/components/ZUIMenu';
 
 type Props = {
   button?: JSX.Element;
@@ -27,8 +30,27 @@ const ActivistPortalHeader: FC<Props> = ({
   topLeftComponent,
 }) => {
   const user = useUser();
+  const messages = useMessages(messageIds);
 
   const hasNavBar = selectedTab && tabs;
+  const [logoutMenuAnchorEl, setLogoutMenuAnchorEl] =
+    useState<HTMLButtonElement | null>(null);
+  const router = useRouter();
+  const path = usePathname();
+
+  const menuItems: MenuItem[] = [
+    {
+      label: messages.home.menu.logout(),
+      onClick: () => router.push('/logout'),
+    },
+  ];
+  if (!path?.startsWith('/my')) {
+    menuItems.unshift({
+      divider: true,
+      label: process.env.HOME_TITLE || messages.home.menu.myZetkin(),
+      onClick: () => router.push('/my'),
+    });
+  }
 
   return (
     <Box
@@ -56,14 +78,23 @@ const ActivistPortalHeader: FC<Props> = ({
         >
           {topLeftComponent}
           {user && (
-            <NextLink href="/my">
-              <ZUIPersonAvatar
-                firstName={user.first_name}
-                id={user.id}
-                isUser
-                lastName={user.last_name}
+            <>
+              <Button
+                onClick={(event) => setLogoutMenuAnchorEl(event.currentTarget)}
+              >
+                <ZUIPersonAvatar
+                  firstName={user.first_name}
+                  id={user.id}
+                  isUser
+                  lastName={user.last_name}
+                />
+              </Button>
+              <ZUIMenu
+                anchorEl={logoutMenuAnchorEl}
+                menuItems={menuItems}
+                onClose={() => setLogoutMenuAnchorEl(null)}
               />
-            </NextLink>
+            </>
           )}
         </Box>
         <Box

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -57,6 +57,10 @@ export default makeMessages('feat.organizations', {
       viewInList: m('View in list'),
       viewInMap: m('View in map'),
     },
+    menu: {
+      logout: m('Logout'),
+      myZetkin: m('My Zetkin'),
+    },
     tabs: {
       calendar: m('Calendar'),
       suborgs: m('Explore'),


### PR DESCRIPTION
## Description
This PR adds a logout button that opens in a context menu on click of the's profile in the activist portal pages.

## Screenshots

<img width="1738" height="1078" alt="CleanShot 2025-09-01 at 07 58 44@2x" src="https://github.com/user-attachments/assets/be19abcf-90ea-47c3-8945-1c652eb50b27" />


## Notes to reviewer
I'm not sure if the `NextLink` should be switched out or styled differently in the menu.

The `Menu`s that I found in the code base usually come with a lot more props. I wasn't sure which ones were actually needed and hence did not want to just copy all of them to avoid cargo culting. Happy to learn which ones should actually be there. 

## Related issues
Resolves #2893
