### PR TITLE
Fix missing ics event title when it should use the activity title.

### DIFF
--- a/src/features/events/utils/icsFromEvents.ts
+++ b/src/features/events/utils/icsFromEvents.ts
@@ -28,7 +28,7 @@ export default function icsFromEvents(
       vLines.push(`DTSTAMP:${timeStamp(dayjs(event.published))}`);
       vLines.push(`DTSTART:${timeStamp(dayjs(event.start_time))}`);
       vLines.push(`DTEND:${timeStamp(dayjs(event.end_time))}`);
-      if (event.title) {
+      if (event.title || event.activity?.title) {
         vLines.push(`SUMMARY:${event.title || event.activity?.title || ''}`);
       }
       if (event.info_text) {

--- a/src/features/events/utils/icsFromEvents.ts
+++ b/src/features/events/utils/icsFromEvents.ts
@@ -29,7 +29,7 @@ export default function icsFromEvents(
       vLines.push(`DTSTART:${timeStamp(dayjs(event.start_time))}`);
       vLines.push(`DTEND:${timeStamp(dayjs(event.end_time))}`);
       if (event.title) {
-        vLines.push(`SUMMARY:${event.title ?? ''}`);
+        vLines.push(`SUMMARY:${event.title || event.activity?.title || ''}`);
       }
       if (event.info_text) {
         vLines.push(`DESCRIPTION:${event.info_text ?? ''}`);


### PR DESCRIPTION
## Description
This PR makes the ics calendar feed from #2957 use a events activity title in case the event title is missing.


## Screenshots
<img width="272" height="166" alt="image" src="https://github.com/user-attachments/assets/df86450f-b7a8-4880-9504-3a4bda768d55" />
Screenshot from Thunderbird. The event on the left is a untitled event without a activity/type/category, the right one is a untitled event with the General Assembly activity.

## Changes

* Adds event.activity?.title as a fallback when event.title is falsey.

## Notes to reviewer

Import the ics feed, ex. http://localhost:3000/o/1/projects/200/events.ics and confirm that a untitled event with a activity gets a title instead of the calendar applications default.
OR download the ics feed (ex. `curl http://localhost:3000/o/1/projects/200/events.ics`) and confirm that the `SUMMARY` property is present and correct.

## Related issues
None, but I noticed that the Copenhagen Hackathon event last weekend appeared wrong and Richard suggested this solution which behaves like event titles work everywhere else, besides the final fallback being letting the client figure it out.
