### PR TITLE
Update url query param when pagination changes page in duplicates page

### DIFF
--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
-import { useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
 import { Box, CircularProgress, Pagination, Typography } from '@mui/material';
 
 import DuplicateCard from 'features/duplicates/components/DuplicateCard';
@@ -24,9 +25,19 @@ const DuplicatesPage: PageWithLayout = () => {
   const { orgId } = useNumericRouteParams();
   const list = useDuplicates(orgId);
   const messages = useMessages(messageIds);
-  const [page, setPage] = useState(1);
+  const router = useRouter();
+  const [page, setPage] = useState(
+    router.query.page !== undefined ? Number(router.query.page) : 1
+  );
   const pageSize = 100;
   const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const url = `${window.location.protocol}//${window.location.host}${
+      router.asPath.split('?')[0]
+    }?page=${page}`;
+    window.history.replaceState({}, '', url);
+  }, [page]);
 
   if (onServer) {
     return null;


### PR DESCRIPTION
## Description
This PR implements updating the query parameters in the url when changing page for duplicates.

## Changes

* Sets page from router.query.page
* Adds a useEffect which calls window.history.replaceState with an url containing the page as a query param


## Notes to reviewer
I decided to use window.history.replaceState to not toggle a slow router page change. I tried to use pushState and then listen to url changes, but it didn't seem possible in next. If it's important to use back/forward buttons to change pagination, I could change this MR to use hte nextjs router to change the page, but when testing that it felt sluggish.

## Related issues
Resolves #2958 
