### PR TITLE
Replace plural_label with title in journey breadcrumbs

### DIFF
--- a/src/pages/api/breadcrumbs.ts
+++ b/src/pages/api/breadcrumbs.ts
@@ -157,7 +157,7 @@ async function fetchElements(
     return [
       {
         href: basePath + '/' + fieldValue,
-        label: journey.data.plural_label,
+        label: journey.data.title,
       },
     ];
   } else if (fieldName == 'callAssId') {


### PR DESCRIPTION
## Description
This PR fixes the string shown in the breadcrumbs when viewing the instances of a journey


## Screenshots
<img width="1882" height="1219" alt="image" src="https://github.com/user-attachments/assets/750fb58c-0532-4753-9788-21732c5bdc08" />


## Changes
* Changes the string shown in the breadcrumbs when viewing the instances of a journey from the plural_label to title.


## Notes to reviewer
None


## Related issues
Resolves #2936 
