### PR TITLE
Set z-index of pin depending on visited status

### DIFF
--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -128,7 +128,10 @@ const GLCanvassMap: FC<Props> = ({ areas, assignment, selectedArea }) => {
             `marker-${successPercentage}-${visitPercentage}` +
             (selected ? '-selected' : '');
 
-          const renderOnTop = selected;
+          let z = visitRatio === 1.0 ? 1 : 2;
+          if (selected) {
+            z = 3;
+          }
 
           return {
             geometry: {
@@ -139,7 +142,7 @@ const GLCanvassMap: FC<Props> = ({ areas, assignment, selectedArea }) => {
               icon,
               successPercentage,
               visitPercentage,
-              z: renderOnTop ? 1 : 0,
+              z,
             },
             type: 'Feature',
           };


### PR DESCRIPTION
## Description
This PR puts pins of unvisited households on top of visited ones.


## Screenshots
<img width="1027" height="806" alt="Screenshot_2025-09-13_11-19-15" src="https://github.com/user-attachments/assets/4034d672-1221-47ee-b5be-6d0144808400" />


## Changes
* Sets marker z-index depending on whether the location is 100% visited. If it's selected it should be on top.

## Notes to reviewer


## Related issues
Resolves #3028 
