### PR TITLE
Event: Make type of `lat` and `lng` safer in `ZetkinEvent`

### DIFF
--- a/src/features/areas/utils/asLongitudeLatitude.ts
+++ b/src/features/areas/utils/asLongitudeLatitude.ts
@@ -1,0 +1,9 @@
+import { Latitude, Longitude } from 'features/areas/types';
+
+export function asLongitude(num: number): Longitude {
+  return num as Longitude;
+}
+
+export function asLatitude(num: number): Latitude {
+  return num as Latitude;
+}

--- a/src/features/calendar/components/EventCluster/index.stories.tsx
+++ b/src/features/calendar/components/EventCluster/index.stories.tsx
@@ -5,6 +5,10 @@ import mockEvent from 'utils/testing/mocks/mockEvent';
 import MultiLocation from './MultiLocation';
 import MultiShift from './MultiShift';
 import Single from './Single';
+import {
+  asLatitude,
+  asLongitude,
+} from 'features/areas/utils/asLongitudeLatitude';
 
 export default {
   component: Single,
@@ -60,8 +64,8 @@ singleEvent.args = {
     cancelled: '2023-01-01',
     location: {
       id: 1,
-      lat: 51.192702,
-      lng: 12.284873,
+      lat: asLatitude(51.192702),
+      lng: asLongitude(12.284873),
       title: 'Hööööör',
     },
     num_participants_available: 16,
@@ -80,8 +84,8 @@ multiLocationEvent.args = {
     mockEvent({
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -91,8 +95,8 @@ multiLocationEvent.args = {
     mockEvent({
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Malmö',
       },
       num_participants_available: 16,
@@ -113,8 +117,8 @@ multiShiftEvent.args = {
       end_time: '2022-06-16T11:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -126,8 +130,8 @@ multiShiftEvent.args = {
       end_time: '2022-06-16T13:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -139,8 +143,8 @@ multiShiftEvent.args = {
       end_time: '2022-06-16T15:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -162,8 +166,8 @@ arbitraryCluster.args = {
       end_time: '2022-06-16T11:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -175,8 +179,8 @@ arbitraryCluster.args = {
       end_time: '2022-06-16T13:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,
@@ -188,8 +192,8 @@ arbitraryCluster.args = {
       end_time: '2022-06-16T15:00:00+00:00',
       location: {
         id: 1,
-        lat: 51.192702,
-        lng: 12.284873,
+        lat: asLatitude(51.192702),
+        lng: asLongitude(12.284873),
         title: 'Hööööör',
       },
       num_participants_available: 16,

--- a/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
+++ b/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
@@ -2,6 +2,7 @@ import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
 import clusterEventsForWeekCalender from './clusterEventsForWeekCalender';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ACTIVITIES, EventActivity } from 'features/campaigns/types';
+import { asLatitude, asLongitude } from '../../areas/utils/asLongitudeLatitude';
 
 const mockEventData: ZetkinEvent = {
   activity: {
@@ -20,8 +21,8 @@ const mockEventData: ZetkinEvent = {
   info_text: '',
   location: {
     id: 1,
-    lat: 0,
-    lng: 0,
+    lat: asLatitude(0),
+    lng: asLongitude(0),
     title: 'Dorfplatz',
   },
   num_participants_available: 0,
@@ -163,49 +164,49 @@ describe('doArbitraryClustering()', () => {
       mockEvent(1, {
         // 10:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 1, lat: 0, lng: 0, title: '' },
+        location: { id: 1, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T10:00:00.000Z',
       }),
       mockEvent(2, {
         // 10:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 2, lat: 0, lng: 0, title: '' },
+        location: { id: 2, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T10:00:00.000Z',
       }),
       mockEvent(3, {
         // 11:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 3, lat: 0, lng: 0, title: '' },
+        location: { id: 3, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T11:00:00.000Z',
       }),
       mockEvent(4, {
         // 11:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 4, lat: 0, lng: 0, title: '' },
+        location: { id: 4, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T11:00:00.000Z',
       }),
       mockEvent(5, {
         // 12:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 5, lat: 0, lng: 0, title: '' },
+        location: { id: 5, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T12:00:00.000Z',
       }),
       mockEvent(6, {
         // 12:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 6, lat: 0, lng: 0, title: '' },
+        location: { id: 6, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T12:00:00.000Z',
       }),
       mockEvent(7, {
         // 13:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 7, lat: 0, lng: 0, title: '' },
+        location: { id: 7, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T13:00:00.000Z',
       }),
       mockEvent(8, {
         // 13:00 - 14:00
         end_time: '1857-07-05T14:00:00.000Z',
-        location: { id: 8, lat: 0, lng: 0, title: '' },
+        location: { id: 8, lat: asLatitude(0), lng: asLongitude(0), title: '' },
         start_time: '1857-07-05T13:00:00.000Z',
       }),
     ]);

--- a/src/features/campaigns/hooks/useClusteredActivities.spec.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.spec.ts
@@ -16,6 +16,10 @@ import {
   ZetkinEvent,
   ZetkinSurvey,
 } from 'utils/types/zetkin';
+import {
+  asLongitude,
+  asLatitude,
+} from 'features/areas/utils/asLongitudeLatitude';
 
 const mockEventData: ZetkinEvent = {
   activity: {
@@ -34,8 +38,8 @@ const mockEventData: ZetkinEvent = {
   info_text: '',
   location: {
     id: 1,
-    lat: 0,
-    lng: 0,
+    lat: asLatitude(0),
+    lng: asLongitude(0),
     title: 'Dorfplatz',
   },
   num_participants_available: 0,
@@ -129,8 +133,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T13:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T12:00:00.000Z',
@@ -139,8 +143,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T14:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T13:00:00.000Z',
@@ -149,8 +153,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T15:00:00.000Z',
           location: {
             id: 2, // <-- Different location
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T14:00:00.000Z',
@@ -175,8 +179,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T13:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T12:00:00.000Z',
@@ -201,8 +205,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T14:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T13:00:00.000Z',
@@ -228,8 +232,8 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 1,
-            lat: 12123.1,
-            lng: 12123.2,
+            lat: asLatitude(12123.1),
+            lng: asLongitude(12123.2),
             title: 'The square',
           },
         }),
@@ -240,8 +244,8 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -252,8 +256,8 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 3,
-            lat: 12987.1,
-            lng: 12987.2,
+            lat: asLatitude(12987.1),
+            lng: asLongitude(12987.2),
             title: 'The square',
           },
         }),
@@ -290,16 +294,16 @@ describe('useClusteredActivities()', () => {
         mockEvent(2, {
           location: {
             id: 1,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
         mockEvent(2, {
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -314,16 +318,16 @@ describe('useClusteredActivities()', () => {
         mockEvent(2, {
           location: {
             id: 1,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
         mockEvent(2, {
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -331,8 +335,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-03T13:00:00.000Z',
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
           start_time: '1857-07-03T12:00:00.000Z',
@@ -348,8 +352,8 @@ describe('useClusteredActivities()', () => {
         mockEvent(112, {
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -360,16 +364,16 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
         mockEvent(123, {
           location: {
             id: 2,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -384,8 +388,8 @@ describe('useClusteredActivities()', () => {
         mockEvent(112, {
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -396,8 +400,8 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -412,24 +416,24 @@ describe('useClusteredActivities()', () => {
         mockEvent(9, {
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square1',
           },
         }),
         mockEvent(10, {
           location: {
             id: 222,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square2',
           },
         }),
         mockEvent(11, {
           location: {
             id: 2222,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square3',
           },
         }),
@@ -440,8 +444,8 @@ describe('useClusteredActivities()', () => {
           },
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
         }),
@@ -449,8 +453,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T13:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T12:00:00.000Z',
@@ -459,8 +463,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T14:00:00.000Z',
           location: {
             id: 1,
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T13:00:00.000Z',
@@ -469,8 +473,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T15:00:00.000Z',
           location: {
             id: 2, // <-- Different location
-            lat: 0,
-            lng: 0,
+            lat: asLatitude(0),
+            lng: asLongitude(0),
             title: '',
           },
           start_time: '1857-07-05T14:00:00.000Z',
@@ -490,8 +494,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T13:00:00.000Z',
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
           start_time: '1857-07-05T12:00:00.000Z',
@@ -505,8 +509,8 @@ describe('useClusteredActivities()', () => {
           end_time: '1857-07-05T14:00:00.000Z',
           location: {
             id: 112,
-            lat: 12321.1,
-            lng: 12321.2,
+            lat: asLatitude(12321.1),
+            lng: asLongitude(12321.2),
             title: 'The square',
           },
           start_time: '1857-07-05T13:00:00.000Z',

--- a/src/features/organizations/components/ActivistPortalEventMap.tsx
+++ b/src/features/organizations/components/ActivistPortalEventMap.tsx
@@ -56,10 +56,7 @@ export const ActivistPortalEventMap: FC<
         events
           .map((event) => event.location)
           .filter(notEmpty)
-          .map((location) => [
-            location.lng as Longitude,
-            location.lat as Latitude,
-          ])
+          .map((location) => [location.lng, location.lat])
       ) ?? undefined,
     [events]
   );
@@ -80,7 +77,7 @@ export const ActivistPortalEventMap: FC<
             }
             acc[key].count += 1;
             return acc;
-          }, {} as Record<string, { count: number; id: number; lat: number; lng: number }>)
+          }, {} as Record<string, { count: number; id: number; lat: Latitude; lng: Longitude }>)
       ),
     [events]
   );

--- a/src/utils/testing/mocks/mockEvent.ts
+++ b/src/utils/testing/mocks/mockEvent.ts
@@ -1,6 +1,10 @@
 import { mockObject } from 'utils/testing/mocks';
 import mockOrganization from './mockOrganization';
 import { ZetkinEvent } from 'utils/types/zetkin';
+import {
+  asLatitude,
+  asLongitude,
+} from '../../../features/areas/utils/asLongitudeLatitude';
 
 const event: ZetkinEvent = {
   activity: {
@@ -19,8 +23,8 @@ const event: ZetkinEvent = {
   info_text: 'Info text is informational',
   location: {
     id: 1,
-    lat: 51.192702,
-    lng: 12.284873,
+    lat: asLatitude(51.192702),
+    lng: asLongitude(12.284873),
     title: 'Dorfplatz',
   },
   num_participants_available: 3,

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -79,8 +79,8 @@ export interface ZetkinEvent {
   info_text: string;
   location: {
     id: number;
-    lat: number;
-    lng: number;
+    lat: Latitude;
+    lng: Longitude;
     title: string;
   } | null;
   num_participants_required: number;


### PR DESCRIPTION
## Description
This PR changes the types of `lat` and `lng` to `Longitude` and `Latitude` in the type `ZetkinEvent`

## Changes

As requested,

- `lat` and `lng` properties on ZetkinEvent are typed as `Latitude` and `Longitude`, insted of `number`
- Removes the typecast that is done in `ActivistPortalEventMap`, at least the one I found. It wasn't clearly stated which one the issue refers to.

I ran `yarn check-types` and fixed all type problems that occurred.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2869