### PR TITLE
Add button to copy ICS urls for project/org pages

### DIFF
--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -23,6 +23,7 @@ import { oldThemeWithLocale } from '../../theme';
 import { UserProvider } from './UserContext';
 import { ZetkinUser } from 'utils/types/zetkin';
 import BackendApiClient from 'core/api/client/BackendApiClient';
+import { ZUISnackbarProvider } from 'zui/ZUISnackbarContext';
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -73,8 +74,16 @@ const ClientContext: FC<ClientContextProps> = ({
                     locale={lang}
                     messages={messages}
                   >
-                    <CssBaseline />
-                    {children}
+                    <ZUISnackbarProvider>
+                      <IntlProvider
+                        defaultLocale="en"
+                        locale={lang}
+                        messages={messages}
+                      >
+                        <CssBaseline />
+                        {children}
+                      </IntlProvider>
+                    </ZUISnackbarProvider>
                   </IntlProvider>
                 </LocalizationProvider>
               </UserProvider>

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -161,6 +161,8 @@ export default makeMessages('feat.campaigns', {
   },
   noManager: m('No Project Manager'),
   publicProjectPage: {
+    calendarLinkCopied: m('Successfully copied calendar link'),
+    copyIcsUrl: m('Copy calendar subscription URL'),
     eventList: {
       emptyList: {
         message: m('Could not find any events'),

--- a/src/features/campaigns/layout/PublicProjectLayout.tsx
+++ b/src/features/campaigns/layout/PublicProjectLayout.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Box } from '@mui/material';
-import { FC, ReactNode } from 'react';
+import { FC, ReactNode, useContext } from 'react';
 import NextLink from 'next/link';
+import { CalendarMonth } from '@mui/icons-material';
 
 import { ZetkinCampaign } from 'utils/types/zetkin';
 import ZUIText from 'zui/components/ZUIText';
@@ -12,6 +13,10 @@ import ActivistPortalHeader from 'features/organizations/components/ActivistPort
 import EventMapLayout from 'features/organizations/layouts/EventMapLayout';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 import { filtersUpdated } from '../store';
+import { Msg, useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
+import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
+import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 
 type Props = {
   campaign: ZetkinCampaign;
@@ -20,6 +25,8 @@ type Props = {
 
 const PublicProjectLayout: FC<Props> = ({ children, campaign }) => {
   const dispatch = useAppDispatch();
+  const messages = useMessages(messageIds);
+  const { showSnackbar } = useContext(ZUISnackbarContext);
 
   const { allEvents, filteredEvents } = useFilteredCampaignEvents(
     campaign.organization.id,
@@ -37,12 +44,32 @@ const PublicProjectLayout: FC<Props> = ({ children, campaign }) => {
       })
     );
   };
+  function copyUrlToClipboard() {
+    const url = `${location.protocol}//${location.host}/o/${campaign.organization.id}/projects/${campaign.id}/events.ics`;
+    navigator.clipboard.writeText(url);
+    showSnackbar(
+      'success',
+      <Msg id={messageIds.publicProjectPage.calendarLinkCopied} />
+    );
+  }
 
   return (
     <EventMapLayout
       events={filteredEvents}
       header={
         <ActivistPortalHeader
+          button={
+            <ZUIEllipsisMenu
+              items={[
+                {
+                  id: 'copy-ics-url',
+                  label: messages.publicProjectPage.copyIcsUrl(),
+                  onSelect: () => copyUrlToClipboard(),
+                  startIcon: <CalendarMonth />,
+                },
+              ]}
+            />
+          }
           subtitle={campaign.info_text}
           title={campaign.title}
           topLeftComponent={

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -49,7 +49,9 @@ export default makeMessages('feat.organizations', {
       privacyPolicy: m('Privacy policy'),
     },
     header: {
+      calendarLinkCopied: m('Successfully copied calendar link'),
       connect: m('Connect'),
+      copyIcsUrl: m('Copy calendar subscription URL'),
       follow: m('Follow'),
       login: m('Login & connect'),
       unfollow: m('Unfollow'),


### PR DESCRIPTION
## Description
This PR add buttons for copying ICS calendar urls for importing into external calendar applications.
I added a snackbar notification to show that something happened when when the button was pressed, but if that is too much (payload wise?) for the activist pages I can remove it.


## Screenshots
https://github.com/user-attachments/assets/e1010736-3512-4e70-b331-4b4a0e4402a3



## Changes
* Adds buttons to public org and project layouts for copying ICS url.
* Enables snackbar notifications for public pages


## Notes to reviewer


## Related issues
Resolves #3014 
