### PR TITLE
fix misleading duplicates messages for de and en

### DIFF
--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -39,7 +39,7 @@ export default makeMessages('feat.duplicates', {
     dismiss: m('Dismiss'),
     noDuplicates: m('No duplicates'),
     noDuplicatesDescription: m(
-      'Yay! all your members seem to be unique individuals.'
+      'Zetkin has not found any likely duplicates in your person database. The database is scanned daily and potential duplicates will be displayed here.\n\nIf you find that the matching algorithm does not find enough duplicates, please contact Zetkin Foundation to let us know about your use case.'
     ),
     possibleDuplicates: m('Possible duplicates'),
     possibleDuplicatesDescription: m<{ numPeople: number }>(

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -662,7 +662,7 @@ feat:
     page:
       dismiss: ablehnen
       noDuplicates: keine Duplikate
-      noDuplicatesDescription: Ja! All deine Mitglieder scheinen einzelne Individuen zu sein.
+      noDuplicatesDescription: "Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.\n\nWenn Sie feststellen, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktieren Sie bitte die Zetkin Foundation, um uns über Ihren Anwendungsfall zu informieren.
       possibleDuplicates: Mögliche Duplikate
       possibleDuplicatesDescription: Diese {numPeople} Personen sehen sehr ähnlich aus.
       resolve: Beheben

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -662,7 +662,7 @@ feat:
     page:
       dismiss: ablehnen
       noDuplicates: keine Duplikate
-      noDuplicatesDescription: "Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.\n\nWenn Sie feststellen, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktieren Sie bitte die Zetkin Foundation, um uns über Ihren Anwendungsfall zu informieren."
+      noDuplicatesDescription: "Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.\n\nWenn du feststellst, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktiere bitte die Zetkin Foundation, um uns über deinen Anwendungsfall zu informieren."
       possibleDuplicates: Mögliche Duplikate
       possibleDuplicatesDescription: Diese {numPeople} Personen sehen sehr ähnlich aus.
       resolve: Beheben

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -662,7 +662,7 @@ feat:
     page:
       dismiss: ablehnen
       noDuplicates: keine Duplikate
-      noDuplicatesDescription: "Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.\n\nWenn Sie feststellen, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktieren Sie bitte die Zetkin Foundation, um uns über Ihren Anwendungsfall zu informieren.
+      noDuplicatesDescription: "Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.\n\nWenn Sie feststellen, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktieren Sie bitte die Zetkin Foundation, um uns über Ihren Anwendungsfall zu informieren."
       possibleDuplicates: Mögliche Duplikate
       possibleDuplicatesDescription: Diese {numPeople} Personen sehen sehr ähnlich aus.
       resolve: Beheben

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -405,7 +405,7 @@ feat:
     page:
       dismiss: Dismiss
       noDuplicates: No duplicates
-      noDuplicatesDescription: Yay! all your members seem to be unique individuals.
+      noDuplicatesDescription: "Zetkin has not found any likely duplicates in your person database. The database is scanned daily and potential duplicates will be displayed here. \n\nIf you find that the matching algorithm does not find enough duplicates, please contact Zetkin Foundation to let us know about your use case."
       possibleDuplicates: Possible duplicates
       possibleDuplicatesDescription: These {numPeople} people look very similar
       resolve: Resolve

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -55,7 +55,15 @@ const DuplicatesPage: PageWithLayout = () => {
             {messages.page.noDuplicates()}
           </Typography>
           <Typography variant="body1">
-            {messages.page.noDuplicatesDescription()}
+            {messages.page
+              .noDuplicatesDescription()
+              .split('\n')
+              .map((line, i) => (
+                <span key={i}>
+                  {line}
+                  <br />
+                </span>
+              ))}
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
## Description
This PR replaces a misleading duplicates message. For details see https://github.com/zetkin/app.zetkin.org/issues/2867


## Changes
Swapped the text

> Yay! all your members seem to be unique individuals.

to

> Zetkin has not found any likely duplicates in your person database. The database is scanned daily and potential duplicates will be displayed here.
>
> If you find that the matching algorithm does not find enough duplicates, please contact Zetkin Foundation to let us know about your use case.

And for German:

> Zetkin hat in dem Personendatensatz keine wahrscheinlichen Duplikate gefunden. Der Datensatz wird täglich gescannt und potenzielle Duplikate werden hier angezeigt.
>
> Wenn Sie feststellen, dass der Abgleichsalgorithmus nicht genügend Duplikate findet, kontaktieren Sie bitte die Zetkin Foundation, um uns über Ihren Anwendungsfall zu informieren.

I only speak English and German, so for the other languages, someone would need to tell me translations or fix it in another issue+PR?

I also changed some of the code as it didn't display the newlines before.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2867
