### PR TITLE
Do not crash when importing one row CSV file

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/index.tsx
@@ -15,6 +15,7 @@ import useImportConfigState from 'features/import/hooks/useUIDataColumns';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
+import useRowCountValidation from '../../../hooks/useRowCountValidation';
 
 interface ConfigureProps {
   onClose: () => void;
@@ -29,6 +30,7 @@ const Configure: FC<ConfigureProps> = ({ onClose, onRestart, onValidate }) => {
   >(null);
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
+  const { hasData } = useRowCountValidation();
   const { configIsIncomplete, numColumns, numRows } = useImportConfigState();
   const getPreflightStats = useConfigure(orgId);
   const [loading, setLoading] = useState(false);
@@ -98,7 +100,13 @@ const Configure: FC<ConfigureProps> = ({ onClose, onRestart, onValidate }) => {
               )}
             </Box>
           </Box>
-          <Preview />
+          {hasData ? (
+            <Preview />
+          ) : (
+            <ZUIEmptyState
+              message={messages.configuration.mapping.notEnoughRows()}
+            />
+          )}
           <ImportFooter
             onClickPrimary={async () => {
               setLoading(true);

--- a/src/features/import/hooks/useRowCountValidation.ts
+++ b/src/features/import/hooks/useRowCountValidation.ts
@@ -1,0 +1,11 @@
+import { useAppSelector } from '../../../core/hooks';
+
+export default function useRowCountValidation() {
+  const pendingFile = useAppSelector((state) => state.import.pendingFile);
+
+  const sheet = pendingFile.sheets[pendingFile.selectedSheetIndex];
+  const rows = sheet.rows;
+  const firstRowIsHeaders = sheet.firstRowIsHeaders;
+  const hasData = rows.length >= (firstRowIsHeaders ? 2 : 1);
+  return { hasData };
+}

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -186,6 +186,9 @@ export default makeMessages('feat.import', {
           secondValue: string | number;
         }>('{firstValue} and {secondValue}.'),
       },
+      notEnoughRows: m(
+        'Your file does not contain enough rows to import any data'
+      ),
       organization: m('Organization'),
       selectZetkinField: m('Import as...'),
       tags: m('Tags'),


### PR DESCRIPTION
## Description
This PR shows a warning when user tries to import a CSV file with only one row and with the option `first row as headers` selected.


## Changes
Adds a new hook to be consistent with how this is done for other validations.

## Notes to reviewer
I felt it made most sense to never let the code get to the currently failing lines in `createPreviewData` to begin with by just not showing the `Preview` when it did not make sense. 

I'm not sure about the `ZUIEmptyState` that I am displaying now, it's pretty big..


## Related issues
Resolves #2949
