### PR TITLE
fixed reference to logicOperator for filters with multiple criteria

### DIFF
--- a/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts
@@ -122,7 +122,7 @@ function parseFilterModelFromQuery(query: ParsedUrlQuery): GridFilterModel {
   return {
     items,
     ...(!!items.length && {
-      linkOperator:
+      logicOperator:
         query.filterOperator == 'or'
           ? GridLogicOperator.Or
           : GridLogicOperator.And,


### PR DESCRIPTION
## Description
This PR fixes using 'OR' between multiple criteria in a list filter, by correcting the reference to the logicOperator property


## Screenshots
<img width="1903" height="1218" alt="Screenshot From 2025-09-13 16-20-24" src="https://github.com/user-attachments/assets/58efff40-ca00-4398-b877-d2240c00f7d2" />


## Changes
* Changes property to correct identifier logicOperator (was linkOperator) in parseFilterModelFromQuery function


## Notes to reviewer
None


## Related issues
Resolves #2937 
