### PR TITLE
Consolidate German translations for `link`

### DIFF
--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -2441,7 +2441,7 @@ feat:
     submissionPane:
       anonymous: Anonym
       hidden: Verborgen
-      linked: verlinkt
+      linked: Verknüpft
       subtitle: '{person} {date}'
     submissions:
       anonymous: Anonym
@@ -2455,7 +2455,7 @@ feat:
       emailColumn: Email
       firstNameColumn: Vorname
       lastNameColumn: Nachname
-      link: Verbinden
+      link: Verknüpfen
       personRecordColumn: Befragte*r
       suggestedPeople: Vorgeschlagene Personen
       unlink: Link entfernen


### PR DESCRIPTION
Someone recently noted in our Telegram Zetkin support group, that the German locations for linking submissions use different words which might cause confusion. This PR consolidates them all to `verknüpfen`.

State before:

<img width="2978" height="2610" alt="CleanShot 2025-09-21 at 13 57 09@2x" src="https://github.com/user-attachments/assets/a847f1db-4224-4ef7-a98b-6db597e052f0" />
<img width="2976" height="2592" alt="CleanShot 2025-09-21 at 13 57 45@2x" src="https://github.com/user-attachments/assets/5eb292bb-f812-48ef-80e4-a48332754006" />
