### PR TITLE
Remove filter() call that breaks the preview popup for blank answers

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -126,14 +126,12 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
               width: 400,
             });
           }}
-          submissions={cell
-            .filter((sub) => sub.text)
-            .map((sub, index) => ({
-              id: sub.submission_id,
-              matchingContent:
-                index == 0 ? getEllipsedString(sub.text, 300) : null,
-              submitted: sub.submitted,
-            }))}
+          submissions={cell.map((sub, index) => ({
+            id: sub.submission_id,
+            matchingContent:
+              index == 0 ? getEllipsedString(sub.text, 300) : null,
+            submitted: sub.submitted,
+          }))}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/3031 by removing a `.filter((sub) => sub.text)` call that hides any submissions whose `text` property isn't truthy.

| Before | After |
|-|-|
| ![2025-09-28 11 04 28](https://github.com/user-attachments/assets/2ac548b2-1c98-4b45-a77f-4cdd10ddfa56) | ![2025-09-28 11 04 08](https://github.com/user-attachments/assets/31f97283-b327-49f1-9b3e-acd8d8a864ea) |