### PR TITLE
Add rtl plugin to maps

### DIFF
--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -359,6 +359,7 @@ const GLCanvassMap: FC<Props> = ({ areas, assignment, selectedArea }) => {
         }}
         onMove={() => updateSelection()}
         onMoveEnd={() => saveBounds()}
+        RTLTextPlugin="https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js"
         style={{ height: '100%', width: '100%' }}
       >
         <Source data={areasGeoJson} id="areas" type="geojson">

--- a/src/features/geography/components/GLGeographyMap/index.tsx
+++ b/src/features/geography/components/GLGeographyMap/index.tsx
@@ -128,6 +128,7 @@ const GLGeographyMap: FC<Props> = ({ areas, orgId }) => {
             ref={(map) => setMap(map?.getMap() ?? null)}
             initialViewState={{ bounds }}
             mapStyle={env.vars.MAPLIBRE_STYLE}
+            RTLTextPlugin="https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js"
           >
             <Areas areas={areasExceptSelected} />
             {!!drawingPoints && <DrawingArea drawingPoints={drawingPoints} />}

--- a/src/features/organizations/pages/PublicEventPage.tsx
+++ b/src/features/organizations/pages/PublicEventPage.tsx
@@ -368,6 +368,7 @@ const DateAndLocation: FC<{
             onClick={(ev) => {
               ev.target.panTo(ev.lngLat, { animate: true });
             }}
+            RTLTextPlugin="https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js"
             style={{ height: 200, width: '100%' }}
           >
             <Marker


### PR DESCRIPTION
## Description
This PR fixes names of places in languages read right to left, like hebrew and arabic by adding a plugin.
The plugin is lazy-loaded, so it's only loaded when it needs RTL support.

The plugin needs a url to be able to handle the lazy loading, so in all of the examples it gets it from either `https://api.mapbox.com/` or `https://unpkg.com`. 

I tried to load it locally, but couldn't find a way of importing a script as a url.
Another possibility is to simply copy the file to the public folder and add it that way, but I didn't want to add the entire script to this commit.
 
## Screenshots
<img width="745" height="842" alt="Screenshot_2025-09-28_11-21-03" src="https://github.com/user-attachments/assets/61399ed6-554f-4325-9224-877a22509a24" />


## Changes
* Adds RTLTextPlugin to three different maps.


## Notes to reviewer
Is it okay to fetch the script from a CDN or does it have to be handled in a different way?

## Related issues
Resolves #3042 
