### PR TITLE
Add missing useEffect dependency to trigger scroll correctly

### DIFF
--- a/src/features/surveys/pages/PublicSurveyPage.tsx
+++ b/src/features/surveys/pages/PublicSurveyPage.tsx
@@ -66,7 +66,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
     if (errorMessageRef.current) {
       errorMessageRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, []);
+  }, [errorMessageRef.current]);
 
   useEffect(() => {
     if (status == 'submitted' || status == 'error') {


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/3067 by adding `errorMessageRef.current` to the `useEffect` dependency array in order to trigger a `scrollIntoView` call when the error message appears.

## Before

https://github.com/user-attachments/assets/2d5e4ba9-ecd9-4263-bf17-2b68683a011a

## After

https://github.com/user-attachments/assets/ea4f9ecd-ccd9-414b-a00c-5e03cdae5b52

