### PR TITLE
When creating a folder, do not redirect to root folders if we're inside a folder

### DIFF
--- a/src/features/views/components/PeopleActionButton.tsx
+++ b/src/features/views/components/PeopleActionButton.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { FC, useState } from 'react';
 import {
   FolderOutlined,
@@ -30,6 +30,7 @@ const PeopleActionButton: FC<PeopleActionButtonProps> = ({
   orgId,
 }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const joinFormMessages = useMessages(joinFormMessageIds);
   const messages = useMessages(messageIds);
   const zuiMessages = useMessages(zuiMessageIds);
@@ -56,7 +57,9 @@ const PeopleActionButton: FC<PeopleActionButtonProps> = ({
             label: messages.actions.createFolder(),
             onClick: () => {
               createFolder(messages.newFolderTitle(), folderId || undefined);
-              router.push(`/organize/${orgId}/people`);
+              if (!pathname?.includes('folders')) {
+                router.push(`/organize/${orgId}/people`);
+              }
             },
           },
           {


### PR DESCRIPTION
## Description
This fixes #3059 which was caused by #2706. When a folder is created it would redirect to the list of folders, which worked for the case where you created a folder from another tab, but not when you were inside a folder.


## Changes

* Add check if we're not inside a folder before doing a router.push


## Notes to reviewer


## Related issues
Resolves #3059 
