### PR TITLE
Issue 2871: Stop breadcrumbs from updating on query string changes

### DIFF
--- a/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
+++ b/src/features/breadcrumbs/hooks/useBreadcrumbs.ts
@@ -10,21 +10,22 @@ export default function useBreadcrumbElements() {
   const dispatch = useAppDispatch();
   const router = useRouter();
   const { pathname, asPath: path } = router;
+  const pathWithoutQueryString = path.split('?')[0];
   const crumbsItem = useAppSelector(
-    (state) => state.breadcrumbs.crumbsByPath[path]
+    (state) => state.breadcrumbs.crumbsByPath[pathWithoutQueryString]
   );
 
   const query = getPathParameters(router);
 
   const future = loadItemIfNecessary(crumbsItem, dispatch, {
-    actionOnLoad: () => crumbsLoad(path),
-    actionOnSuccess: (item) => crumbsLoaded([path, item]),
+    actionOnLoad: () => crumbsLoad(pathWithoutQueryString),
+    actionOnSuccess: (item) => crumbsLoaded([pathWithoutQueryString, item]),
     loader: async () => {
       const elements = await apiClient.get<BreadcrumbElement[]>(
         `/api/breadcrumbs?pathname=${pathname}&${query}`
       );
 
-      return { elements, id: path };
+      return { elements, id: pathWithoutQueryString };
     },
   });
 


### PR DESCRIPTION
## Description
This PR separates the query string from the breadcrumbs path to stop the breadcrumbs flashing when f.e. filters are updated

## Screenshots
![firefox_4rOfTAaZ6X](https://github.com/user-attachments/assets/e46df62b-c4ff-4313-8054-97066ae77bae)


## Changes
* Changes the used path in the breadcrumbs to a split path that separates out the query strings

## Notes to reviewer
1. Go to a list with many entries.
2. Enter a filter string.
3. Compare the breadcrumbs with the changes and without.
4. Click around on the site to make sure the rest of the site works as intended.

## Related issues
Resolves #2871 
