### PR TITLE
fix: prevent overlay from covering selected area by zooming out

### DIFF
--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -28,6 +28,8 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
 import { ZUIExpandableText } from 'zui/ZUIExpandableText';
 
+export const AREA_OVERLAY_WIDTH = 400;
+
 type Props = {
   area: ZetkinArea;
   editing: boolean;
@@ -87,8 +89,8 @@ const AreaOverlay: FC<Props> = ({
         bottom: '1rem',
         display: 'flex',
         flexDirection: 'column',
-        maxWidth: 400,
-        minWidth: 400,
+        maxWidth: AREA_OVERLAY_WIDTH,
+        minWidth: AREA_OVERLAY_WIDTH,
         overflow: 'auto',
         padding: 2,
         position: 'absolute',


### PR DESCRIPTION
## Description
This PR prevents the Area Overlay from covering the area after a user selects it in the Geography view.

This PR solves it with zooming rather than panning, so this might not be the preferred solution.


## Screenshots

https://github.com/user-attachments/assets/9a05b5ca-8d40-4db4-a355-e67e0ce7058a




## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a `useEffect` that triggers when the `selectedArea` changes.
  * Checks if the area would be obscured by the overlay, and if so
  * calculates new bounds and fits to them


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #2915 