### PR TITLE
Undocumented/automations UI schedule

### DIFF
--- a/src/features/automations/components/AutomationCard.tsx
+++ b/src/features/automations/components/AutomationCard.tsx
@@ -64,7 +64,7 @@ const AutomationCard: FC<Props> = ({ automation }) => {
           <AutomationStatusChip automation={automation} />
           <Typography color="secondary" variant="body2">
             {automation.active && (
-              <AutomationInterval seconds={automation.interval} />
+              <AutomationInterval seconds={automation.schedule.interval} />
             )}
             {!automation.active && (
               <Msg id={messageIds.labels.schedule.notScheduled} />

--- a/src/features/automations/components/SchedulingButton.tsx
+++ b/src/features/automations/components/SchedulingButton.tsx
@@ -31,7 +31,7 @@ const SchedulingButton: FC<Props> = ({ automation }) => {
   );
 
   const { value, seconds, setUnit, setValue, unit, unitOptions } =
-    useAutomationInterval(automation.interval);
+    useAutomationInterval(automation.schedule.interval);
 
   return (
     <>
@@ -109,7 +109,9 @@ const SchedulingButton: FC<Props> = ({ automation }) => {
                     setAnchorEl(null);
                     updateAutomation({
                       active: true,
-                      interval: seconds,
+                      schedule: {
+                        interval: seconds,
+                      },
                     });
                   }}
                   variant="contained"

--- a/src/features/automations/layout/AutomationLayout.tsx
+++ b/src/features/automations/layout/AutomationLayout.tsx
@@ -38,7 +38,7 @@ const AutomationLayout: FC<Props> = ({ children }) => {
             <>
               <Divider orientation="vertical" sx={{ height: '1rem' }} />
               <Typography variant="body1">
-                <AutomationInterval seconds={automation.interval} />
+                <AutomationInterval seconds={automation.schedule.interval} />
               </Typography>
             </>
           )}

--- a/src/features/automations/layout/AutomationListLayout.tsx
+++ b/src/features/automations/layout/AutomationListLayout.tsx
@@ -33,7 +33,9 @@ const AutomationListLayout: FC<Props> = ({ children }) => {
             const newAutomation = await createAutomation({
               bulk_ops: [],
               description: '',
-              interval: 60 * 60 * 24,
+              schedule: {
+                interval: 60 * 60 * 24,
+              },
               title: messages.defaultTitle(),
             });
 

--- a/src/features/automations/types/api.ts
+++ b/src/features/automations/types/api.ts
@@ -7,20 +7,22 @@ export type ZetkinBulkAutomation = {
   created_by_user_id: number;
   description: string;
   id: number;
-  interval: number;
   last_run: string | null;
   organization_id: number;
   query_id: number;
+  schedule: {
+    interval: number;
+  };
   title: string;
 };
 
 export type ZetkinBulkAutomationPostBody = Partial<
-  Pick<ZetkinBulkAutomation, 'bulk_ops' | 'description' | 'interval' | 'title'>
+  Pick<ZetkinBulkAutomation, 'bulk_ops' | 'description' | 'schedule' | 'title'>
 >;
 
 export type ZetkinBulkAutomationPatchBody = Partial<
   Pick<
     ZetkinBulkAutomation,
-    'active' | 'bulk_ops' | 'description' | 'interval' | 'title'
+    'active' | 'bulk_ops' | 'description' | 'schedule' | 'title'
   >
 >;


### PR DESCRIPTION
## Description
This PR replaces interval with schedule in the API patch request in automations UI.


## Changes
* Changes schema of post and patch for automations to use the `schedule` paramter instead of the `interval` parameter previously used. At this point, `interval` is the only type of scheduling supported, but this may change in the future.


## Notes to reviewer
Requires backend PRs related to schedule to work
