### PR TITLE
Wrap filters on desktop instead of clipping them

### DIFF
--- a/src/features/organizations/pages/PublicOrgPage.tsx
+++ b/src/features/organizations/pages/PublicOrgPage.tsx
@@ -36,12 +36,14 @@ import useFilteredOrgEvents from '../hooks/useFilteredOrgEvents';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 import { filtersUpdated } from '../store';
 import useOrganization from '../hooks/useOrganization';
+import useIsMobile from 'utils/hooks/useIsMobile';
 
 type Props = {
   orgId: number;
 };
 
 const PublicOrgPage: FC<Props> = ({ orgId }) => {
+  const isMobile = useIsMobile();
   const intl = useIntl();
   const messages = useMessages(messageIds);
   const nextDelay = useIncrementalDelay();
@@ -280,7 +282,9 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
           gap={1}
           maxWidth="100%"
           padding={1}
-          sx={{ overflowX: 'auto' }}
+          sx={{
+            ...(isMobile ? { overflowX: 'auto' } : { flexWrap: 'wrap' }),
+          }}
         >
           {isFiltered && (
             <ZUIFilterButton


### PR DESCRIPTION
## Description
This PR makes in the activists portal the filter row on mobile horizontally scrollable, while on desktop the filters overflowing the section are wrapped to the next row.

## Screenshots

### Desktop
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f711c2c4-c0ea-4bf8-850e-7c7e146b6f7a" />

### Mobile

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2c482283-bed4-4ec3-b644-822d5ed41bc8" />

## Changes

* If the site is used on mobile, the filter row gets the CSS property `overflow-x ` set to `auto` like previously. Otherwise the property `flexWrap: wrap` is set. 

## Related issues
Resolves #3076 
