### PR TITLE
Add custom person fields to merge duplicates dialog

### DIFF
--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -8,13 +8,13 @@ import {
 } from '@mui/material';
 import { FC, useState } from 'react';
 
-import globalMessageIds from 'core/i18n/messageIds';
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
-import { Msg, useMessages } from 'core/i18n';
+import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
+import useFieldTitle from 'utils/hooks/useFieldTitle';
 
 interface FieldSettingsRowProps {
   duplicates: ZetkinPerson[];
@@ -33,6 +33,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
   const messages = useMessages(messageIds);
   const [selectedValue, setSelectedValue] = useState(values[0]);
   const { orgId } = useNumericRouteParams();
+  const getFieldTitle = useFieldTitle(orgId);
 
   const getLabel = (value: string) => {
     if (field === NATIVE_PERSON_FIELDS.GENDER) {
@@ -94,9 +95,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
           padding={1}
           sx={{ borderRadius: 2 }}
         >
-          <Typography>
-            <Msg id={globalMessageIds.personFields[field]} />
-          </Typography>
+          <Typography>{getFieldTitle(field)}</Typography>
         </Box>
       </Box>
       <Box

--- a/src/features/duplicates/hooks/useFieldSettings.ts
+++ b/src/features/duplicates/hooks/useFieldSettings.ts
@@ -1,9 +1,14 @@
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import sortValuesByFrequency from '../utils/sortValuesByFrequency';
 import { ZetkinPerson } from 'utils/types/zetkin';
+import useCustomFields from 'features/profile/hooks/useCustomFields';
+import { useNumericRouteParams } from 'core/hooks';
 
 export default function useFieldSettings(duplicates: ZetkinPerson[]) {
-  const sortedNativePersonFields: NATIVE_PERSON_FIELDS[] = [
+  const { orgId } = useNumericRouteParams();
+  const customFields = useCustomFields(orgId).data ?? [];
+
+  const sortedPersonFields: string[] = [
     NATIVE_PERSON_FIELDS.FIRST_NAME,
     NATIVE_PERSON_FIELDS.LAST_NAME,
     NATIVE_PERSON_FIELDS.EMAIL,
@@ -16,11 +21,12 @@ export default function useFieldSettings(duplicates: ZetkinPerson[]) {
     NATIVE_PERSON_FIELDS.CITY,
     NATIVE_PERSON_FIELDS.COUNTRY,
     NATIVE_PERSON_FIELDS.EXT_ID,
+    ...customFields.map((item) => item.slug),
   ];
 
   const fieldValues: Record<string, string[]> = {};
 
-  sortedNativePersonFields.forEach((field) => {
+  sortedPersonFields.forEach((field) => {
     const values = duplicates.map((person) => {
       const value = person[field];
       return value ? value.toString() : '';


### PR DESCRIPTION
## Description
This PR adds custom person fields to merge duplicates dialog.


## Screenshots

<img width="1848" height="1011" alt="Bildschirmfoto vom 2025-10-05 18-16-57" src="https://github.com/user-attachments/assets/86429289-96d1-4993-a4bb-b666d96ac36e" />

## Changes

* adds all custom fields that are configured for the organization to the merge dialog
* the title of the fields is fetched with `useFieldTitle` from `utils/hooks/useFieldTitle` instead of `globalMessageIds` from `core/i18n/messageIds`

## Related issues
Resolves #3051 
