### PR TITLE
Changed item id to be composite key from user id & area id

### DIFF
--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -37,7 +37,7 @@ export interface AreaAssignmentsStoreSlice {
   areasByAssignmentId: Record<string, RemoteList<Zetkin2Area>>;
   assigneesByAssignmentId: Record<
     number,
-    RemoteList<ZetkinAreaAssignee & { id: number }>
+    RemoteList<ZetkinAreaAssignee & { id: string }>
   >;
   locationsByAssignmentId: Record<number, RemoteList<ZetkinLocation>>;
   locationsByAssignmentIdAndAreaId: Record<string, RemoteList<ZetkinLocation>>;
@@ -156,7 +156,7 @@ const areaAssignmentSlice = createSlice({
 
       remoteItemUpdated(state.assigneesByAssignmentId[assignee.assignment_id], {
         ...assignee,
-        id: assignee.user_id,
+        id: `${assignee.user_id}/${assignee.area_id}`,
       });
 
       const hasStatsItem = !!state.areaStatsByAssignmentId[
@@ -198,7 +198,10 @@ const areaAssignmentSlice = createSlice({
       const [assignmentId, sessions] = action.payload;
 
       state.assigneesByAssignmentId[assignmentId] = remoteListLoaded(
-        sessions.map((session) => ({ ...session, id: session.user_id }))
+        sessions.map((session) => ({
+          ...session,
+          id: `${session.user_id}/${session.area_id}`,
+        }))
       );
     },
     assignmentAreasLoad: (state, action: PayloadAction<number>) => {


### PR DESCRIPTION
## Description
This PR fixes the issue where it would look like you moved a user if you assigned the same one to multiple areas
The cause was that the id for the item in `assigneesByAssignmentId` was only user id, and since a user could be assigned to multiple areas in a single assignment, it would overwrite the object since it only considered user id.



## Changes

* Changes id for item in assigneesByAssignmentId to the user_id/area_id


## Notes to reviewer


## Related issues
Resolves #3019 
