### PR TITLE
Add specific event to campaign participation filter

### DIFF
--- a/src/features/smartSearch/components/filters/CampaignParticipation/DisplayCampaignParticipation.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/DisplayCampaignParticipation.tsx
@@ -9,6 +9,7 @@ import {
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedActivityTitle from './UnderlinedActivityTitle';
 import UnderlinedCampaignTitle from './UnderlinedCampaignTitle';
+import UnderlinedEventTitle from './UnderlinedEventTitle';
 import UnderlinedLocationTitle from './UnderlinedLocationTitle';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import { useNumericRouteParams } from 'core/hooks';
@@ -31,6 +32,7 @@ const DisplayCampaignParticipation = ({
     campaign: campId,
     activity: activityId,
     location: locationId,
+    event: eventId,
   } = config;
   const op = filter.op || OPERATION.ADD;
   const timeFrame = getTimeFrameWithConfig({
@@ -55,6 +57,11 @@ const DisplayCampaignParticipation = ({
           <UnderlinedCampaignTitle campId={campId} orgId={orgId} />
         ) : (
           <UnderlinedMsg id={localMessageIds.campaignSelect.any} />
+        ),
+        eventSelect: eventId ? (
+          <UnderlinedEventTitle eventId={eventId} orgId={orgId} />
+        ) : (
+          <UnderlinedMsg id={localMessageIds.eventSelect.any} />
         ),
         haveSelect: <Msg id={localMessageIds.haveSelect[operator]} />,
         locationSelect: locationId ? (

--- a/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedEventTitle.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/UnderlinedEventTitle.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+
+import messageIds from 'features/smartSearch/l10n/messageIds';
+import eventsMessageIds from 'features/events/l10n/messageIds';
+import UnderlinedMsg from '../../UnderlinedMsg';
+import UnderlinedText from '../../UnderlinedText';
+import useEvent from 'features/events/hooks/useEvent';
+import { useMessages } from 'core/i18n';
+
+const localMessageIds = messageIds.filters.campaignParticipation;
+const eventsLocalMessageIds = eventsMessageIds.common;
+
+interface UnderlinedEventTitleProps {
+  eventId: number;
+  orgId: number;
+}
+
+const UnderlinedEventTitle: FC<UnderlinedEventTitleProps> = ({
+  eventId,
+  orgId,
+}) => {
+  const eventFuture = useEvent(orgId, eventId);
+  const eventsMessages = useMessages(eventsLocalMessageIds);
+
+  if (!eventFuture?.data) {
+    return null;
+  }
+
+  const event = eventFuture.data;
+
+  return (
+    <UnderlinedMsg
+      id={localMessageIds.eventSelect.event}
+      values={{
+        event: (
+          <UnderlinedText text={event.title || eventsMessages.noTitle()} />
+        ),
+      }}
+    />
+  );
+};
+
+export default UnderlinedEventTitle;

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -277,6 +277,7 @@ export interface CampaignParticipationConfig {
   campaign?: number;
   activity?: number;
   location?: number;
+  event?: number;
   after?: string;
   before?: string;
 }

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -252,6 +252,10 @@ export default makeMessages('feat.smartSearch', {
           'project "{campaign}"'
         ),
       },
+      eventSelect: {
+        any: m('any event'),
+        event: m<{ event: ReactElement | string }>('event "{event}"'),
+      },
       examples: {
         one: m(
           "Add people who have signed up and showed up for events in any project of any type at location 'Dorfplatz' at any point in time"
@@ -269,12 +273,13 @@ export default makeMessages('feat.smartSearch', {
         addRemoveSelect: ReactElement;
         bookedSelect: ReactElement;
         campaignSelect: ReactElement;
+        eventSelect: ReactElement;
         haveSelect: ReactElement;
         locationSelect: ReactElement;
         statusSelect: ReactElement;
         timeFrame: ReactElement;
       }>(
-        '{addRemoveSelect} people who {haveSelect} {bookedSelect} {statusSelect} for events in {campaignSelect} of {activitySelect} at {locationSelect} {timeFrame}'
+        '{addRemoveSelect} people who {haveSelect} {bookedSelect} {statusSelect} for {eventSelect} in {campaignSelect} of {activitySelect} at {locationSelect} {timeFrame}'
       ),
       locationSelect: {
         any: m('any location'),


### PR DESCRIPTION
## Description
This PR adds specific event to the campaign participation filter.

## Screenshots
<img width="1847" height="670" alt="image" src="https://github.com/user-attachments/assets/c2f388e9-45e9-4613-9568-3974779bbf13" />
<img width="1849" height="667" alt="image" src="https://github.com/user-attachments/assets/2ccd7781-07c5-4224-aab7-87c2a7a5c0f5" />

## Changes
* Changes the campaign participation filter to have a event selection box as well.
