### PR TITLE
Only copy rows if the list does not have a query/is not a smart list

### DIFF
--- a/src/features/views/rpc/copy/server.ts
+++ b/src/features/views/rpc/copy/server.ts
@@ -51,28 +51,28 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
     );
   }
 
-  // Copy filters
   if (
     oldView.content_query != null &&
     oldView.content_query.filter_spec.length != 0
   ) {
+    // Copy filters
     apiClient.patch<ZetkinQuery[], Pick<ZetkinQuery, 'filter_spec'>>(
       `/api/orgs/${orgId}/people/views/${newView.id}/content_query`,
       {
         filter_spec: oldView.content_query?.filter_spec,
       }
     );
-  }
-
-  // Copy manually added rows
-  const rows = await apiClient.get<ZetkinViewRow[]>(
-    `/api/orgs/${orgId}/people/views/${oldView.id}/rows`
-  );
-  if (rows.length != 0) {
-    for await (const person of rows) {
-      await apiClient.put(
-        `/api/orgs/${orgId}/people/views/${newView.id}/rows/${person.id}`
-      );
+  } else {
+    // Copy manually added rows
+    const rows = await apiClient.get<ZetkinViewRow[]>(
+      `/api/orgs/${orgId}/people/views/${oldView.id}/rows`
+    );
+    if (rows.length != 0) {
+      for await (const person of rows) {
+        await apiClient.put(
+          `/api/orgs/${orgId}/people/views/${newView.id}/rows/${person.id}`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes copying smart-lists with a lot of rows.


## Screenshots

## Changes

* Changes the copy rpc to only work on either smart lists or manual lists, instead of always copying rows.

## Notes to reviewer

Create a smart list with a lot of people, use the duplicate button to create a copy. The call should not time out.

This will not change that lists that actually has a lot of rows will still time out, see comment on the issue.

## Related issues
Resolves #2941
