### PR TITLE
add timestamp property to items in local storage via useLocalStorage …

### DIFF
--- a/src/zui/hooks/useLocalStorage.ts
+++ b/src/zui/hooks/useLocalStorage.ts
@@ -34,7 +34,7 @@ function getLocalStorageValue<T>(key: string, defaultValue: T): StoredValue<T> {
     const newItem: StoredValue<T> = {
       timestamp: Date.now(),
       value: defaultValue,
-    }
+    };
     if (isBrowser) {
       localStorage.setItem(key, JSON.stringify(newItem));
     }


### PR DESCRIPTION
…hook

## Description
This PR adds timestamp property to items in local storage via the useLocalStorage hook.


## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a timestamp property to the items stored in local storage, having created an interface for that.
* Changes…


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #2873
