### PR TITLE
feat(#3090): adds location create autocomplete with suggestions

### DIFF
--- a/src/features/canvass/components/CanvassInstructionsPage.tsx
+++ b/src/features/canvass/components/CanvassInstructionsPage.tsx
@@ -111,7 +111,7 @@ const Page: FC<{
                 href={
                   userMustSelectArea
                     ? `/canvass/${assignment.id}/areas`
-                    : `/canvass/${assignment.id}/areas/${areas[0].id}`
+                    : `/canvass/${assignment.id}/areas/${areas?.[0]?.id}`
                 }
                 sx={{
                   width: '50%',

--- a/src/features/canvass/components/CanvassMapOverlays.tsx
+++ b/src/features/canvass/components/CanvassMapOverlays.tsx
@@ -18,6 +18,7 @@ type Props = {
   onCreate: (title: string) => void;
   onToggleCreating: (creating: boolean) => void;
   selectedLocation: ZetkinLocation | null;
+  suggestions?: string[];
 };
 
 const useStyles = makeStyles(() => ({
@@ -39,6 +40,7 @@ const CanvassMapOverlays: FC<Props> = ({
   onCreate,
   onToggleCreating,
   selectedLocation,
+  suggestions = [],
 }) => {
   const [expanded, setExpanded] = useState(false);
   const classes = useStyles();
@@ -115,6 +117,7 @@ const CanvassMapOverlays: FC<Props> = ({
               onCreate={(title) => {
                 onCreate(title);
               }}
+              suggestions={suggestions}
             />
           </Box>
         )}

--- a/src/features/canvass/components/CreateLocationCard.tsx
+++ b/src/features/canvass/components/CreateLocationCard.tsx
@@ -1,5 +1,11 @@
-import { FC, useState } from 'react';
-import { Box, Button, FormControl, TextField } from '@mui/material';
+import { FC, useMemo, useState } from 'react';
+import {
+  Autocomplete,
+  Box,
+  Button,
+  FormControl,
+  TextField,
+} from '@mui/material';
 
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
@@ -7,14 +13,102 @@ import messageIds from '../l10n/messageIds';
 type CreateLocationCardProps = {
   onClose: () => void;
   onCreate: (title: string) => void;
+  suggestions?: string[];
 };
 
 export const CreateLocationCard: FC<CreateLocationCardProps> = ({
   onClose,
   onCreate,
+  suggestions = [],
 }) => {
   const messages = useMessages(messageIds);
   const [title, setTitle] = useState<string>('');
+
+  const titles = suggestions ?? [];
+
+  const { tokenOriginalByLower, tokenCounts, bigramCounts } = useMemo(() => {
+    const tokenOriginalByLower = new Map<string, string>();
+    const tokenCounts: Record<string, number> = {};
+    const bigramCounts: Record<string, Record<string, number>> = {};
+
+    titles.forEach((t) => {
+      const toks = t.split(/\s+/).filter(Boolean);
+      toks.forEach((tok, idx) => {
+        const lower = tok.toLowerCase();
+        if (!tokenOriginalByLower.has(lower)) {
+          tokenOriginalByLower.set(lower, tok);
+        }
+        tokenCounts[lower] = (tokenCounts[lower] || 0) + 1;
+        if (idx < toks.length - 1) {
+          const next = toks[idx + 1].toLowerCase();
+          if (!bigramCounts[lower]) {
+            bigramCounts[lower] = {};
+          }
+          bigramCounts[lower][next] = (bigramCounts[lower][next] || 0) + 1;
+        }
+      });
+    });
+
+    return { bigramCounts, tokenCounts, tokenOriginalByLower };
+  }, [titles]);
+
+  const allTokenLowers = useMemo(
+    () => Array.from(tokenOriginalByLower.keys()),
+    [tokenOriginalByLower]
+  );
+
+  const generateSuggestions = (input: string): string[] => {
+    if (!input) {
+      return [];
+    }
+
+    if (!input.trim() || input.endsWith(' ')) {
+      return [];
+    }
+
+    const parts = input.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      return [];
+    }
+
+    const partsLower = parts.map((p) => p.toLowerCase());
+
+    if (partsLower.length === 1 && /^\d+$/.test(partsLower[0])) {
+      return [];
+    }
+
+    const lastIndex = partsLower.length - 1;
+    const lastLower = partsLower[lastIndex];
+    let candidates = allTokenLowers.filter(
+      (tok) => tok !== lastLower && tok.startsWith(lastLower)
+    );
+
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    if (lastIndex > 0) {
+      const prev = partsLower[lastIndex - 1];
+      const nextCounts = bigramCounts[prev] || {};
+      candidates = candidates.filter((c) => (nextCounts[c] || 0) > 0);
+      candidates = candidates.sort((a, b) => {
+        const aScore = (nextCounts[a] || 0) * 1000 + (tokenCounts[a] || 0);
+        const bScore = (nextCounts[b] || 0) * 1000 + (tokenCounts[b] || 0);
+        return bScore - aScore;
+      });
+    } else {
+      candidates = candidates.sort(
+        (a, b) => (tokenCounts[b] || 0) - (tokenCounts[a] || 0)
+      );
+    }
+
+    const prefix = parts.slice(0, lastIndex).join(' ');
+    const suggestionList = candidates.slice(0, 6).map((cand) => {
+      const orig = tokenOriginalByLower.get(cand) || cand;
+      return prefix ? `${prefix} ${orig}` : orig;
+    });
+    return suggestionList;
+  };
 
   return (
     <form
@@ -25,11 +119,38 @@ export const CreateLocationCard: FC<CreateLocationCardProps> = ({
       }}
     >
       <FormControl fullWidth>
-        <TextField
-          fullWidth
-          onChange={(ev) => setTitle(ev.target.value)}
-          placeholder={messages.map.addLocation.inputPlaceholder()}
-          sx={{ paddingTop: 1 }}
+        <Autocomplete
+          filterOptions={(_, state) => generateSuggestions(state.inputValue)}
+          freeSolo
+          inputValue={title}
+          onChange={(_, value) => {
+            if (typeof value === 'string') {
+              const withSpace = value.endsWith(' ') ? value : `${value} `;
+              setTitle(withSpace);
+            }
+          }}
+          onInputChange={(_, value) => setTitle(value)}
+          options={titles}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              fullWidth
+              placeholder={messages.map.addLocation.inputPlaceholder()}
+              sx={{ paddingTop: 1 }}
+            />
+          )}
+          slotProps={{
+            listbox: { sx: { maxHeight: 220, overflow: 'auto' } },
+            popper: {
+              modifiers: [
+                {
+                  name: 'preventOverflow',
+                  options: { altBoundary: true, rootBoundary: 'viewport' },
+                },
+              ],
+              style: { zIndex: 14000 },
+            },
+          }}
         />
       </FormControl>
       <Box display="flex" gap={1} mt={1}>

--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -171,6 +171,11 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
     return locations.data?.find((loc) => loc.id == selectedLocationId) || null;
   }, [locations]);
 
+  const locationTitles = useMemo(() => {
+    const titles = locations.data?.map((l) => l.title) ?? [];
+    return Array.from(new Set(titles));
+  }, [locations.data]);
+
   const saveBounds = () => {
     const bounds = map?.getBounds();
 
@@ -458,6 +463,7 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
         }}
         onToggleCreating={(creating) => setIsCreating(creating)}
         selectedLocation={selectedLocation}
+        suggestions={locationTitles}
       />
     </>
   );


### PR DESCRIPTION
## Description
Implements a autocomplete in the create location card with location suggestions.


## Screenshots
<img width="1234" height="692" alt="image" src="https://github.com/user-attachments/assets/d398b7c5-9486-48aa-9797-417256953447" />
<img width="1228" height="520" alt="image" src="https://github.com/user-attachments/assets/cb208c43-0eee-4665-acea-59a41a445087" />



## Changes

* Adds an autocomplete to the location create card
* Fixes a read props of undefined issue in src/features/canvass/components/CanvassInstructionsPage.tsx

## Related issues
Resolves #3090
