### PR TITLE
Increase gap between buttons

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdsPage.tsx
@@ -128,7 +128,7 @@ const HouseholdsPage: FC<Props> = ({
             </Typography>
           </Box>
 
-          <Box display="flex" gap={1}>
+          <Box display="flex" gap={3}>
             <Button
               onClick={() => {
                 onBulkVisit(selectedHouseholdIds);


### PR DESCRIPTION
## Description
This PR increases the gap between 'Visit' and 'Edit' buttons on the top of the page when multiple households are selected at an location when canvassing.

@richardolsson Demoed a different version of the UI on this page that might become permanent.  Therefore I have merely pulled the buttons apart to prevent errors when clicking them to make it easier as we wait for a new version. :)


## Screenshots
![households](https://github.com/user-attachments/assets/393c72a4-1c67-4fe4-ab3c-efca8f39febc)


## Changes

- Increase flex gap to 3


## Notes to reviewer
1. Go to https://app.zetkin.org/my and sign in as [testadmin@example.com](mailto:testadmin@example.com)
2. Click on the "Canvass" filter
3. Find any area assignment and open it
4. Proceed to the map
5. Find a location or create one, and hover over it with the crosshairs
6. Press the drawer at the bottom to open the location
7. Click the "households" button to navigate to the households list
8. If there are no households, create some
9. In the households list, select at least one household using the checkboxes
10. The buttons at the top should have adequate space between to prevent pressing the wrong one

## Related issues
Resolves #3049 
