### PR TITLE
Issue 3091/remove event type name formatting

### DIFF
--- a/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
+++ b/src/features/campaigns/hooks/useFilteredCampaignEvents.ts
@@ -47,8 +47,8 @@ export default function useFilteredCampaignEvents(
 
   const dispatch = useAppDispatch();
   const eventTypeFilter = useEventTypeFilter(allEvents, {
-    eventTypesToFilterBy,
-    setEventTypesToFilterBy: (newArray) =>
+    eventTypeLabelsToFilterBy: eventTypesToFilterBy,
+    setEventTypeLabelsToFilterBy: (newArray) =>
       dispatch(filtersUpdated({ eventTypesToFilterBy: newArray })),
   });
 

--- a/src/features/campaigns/pages/PublicProjPage.tsx
+++ b/src/features/campaigns/pages/PublicProjPage.tsx
@@ -250,7 +250,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
                     geojsonToFilterBy: [],
                   })
                 );
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
               }}
             />
           )}
@@ -290,7 +290,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
                     dateFilterState: null,
                   })
                 );
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
               }}
               variant="secondary"
             />
@@ -394,20 +394,15 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
         open={drawerContent == 'eventTypes'}
       >
         <List>
-          {eventTypeFilter.eventTypes.map((eventType) => (
-            <ListItem
-              key={eventTypeFilter.getLabelFromEventType(eventType)}
-              sx={{ justifyContent: 'space-between' }}
-            >
+          {eventTypeFilter.eventTypeLabels.map((eventType) => (
+            <ListItem key={eventType} sx={{ justifyContent: 'space-between' }}>
               <Box alignItems="center" display="flex">
-                <ZUIText>
-                  {eventTypeFilter.getLabelFromEventType(eventType)}
-                </ZUIText>
+                <ZUIText>{eventType}</ZUIText>
               </Box>
               <Switch
-                checked={eventTypeFilter.getIsCheckedEventType(eventType)}
+                checked={eventTypeFilter.getIsCheckedEventTypeLabel(eventType)}
                 onChange={() => {
-                  eventTypeFilter.toggleEventType(eventType);
+                  eventTypeFilter.toggleEventTypeLabel(eventType);
                 }}
               />
             </ListItem>

--- a/src/features/campaigns/store.ts
+++ b/src/features/campaigns/store.ts
@@ -8,7 +8,7 @@ import { remoteItem, RemoteList, remoteList } from 'utils/storeUtils';
 type CampaignEventFilters = {
   customDatesToFilterBy: DateRange<Dayjs>;
   dateFilterState: 'today' | 'tomorrow' | 'thisWeek' | 'custom' | null;
-  eventTypesToFilterBy: (string | null)[];
+  eventTypesToFilterBy: string[];
   geojsonToFilterBy: GeoJSON.Feature[];
 };
 

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -7,7 +7,6 @@ import { FC, useContext, useEffect, useRef, useState } from 'react';
 
 import messageIds from '../l10n/messageIds';
 import oldTheme from 'theme';
-import { toSentenceCase } from 'utils/stringUtils';
 import useCreateType from '../hooks/useCreateType';
 import { useMessages } from 'core/i18n';
 import useDeleteType from '../hooks/useDeleteType';
@@ -145,9 +144,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
         disableClearable
         filterOptions={(options, { inputValue }) => {
           const searchedResults = fuse.search(inputValue);
-          const inputStartWithCapital = inputValue
-            ? toSentenceCase(inputValue)
-            : '';
+          const sanitized = inputValue.trim();
 
           const filteredResult: EventTypeOption[] = [
             ...searchedResults.map((result) => {
@@ -170,7 +167,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
 
           filteredResult.push({
             id: 'CREATE',
-            title: inputStartWithCapital,
+            title: sanitized,
           });
           return inputValue ? filteredResult : options;
         }}

--- a/src/features/home/components/AllEventsList.tsx
+++ b/src/features/home/components/AllEventsList.tsx
@@ -31,8 +31,6 @@ import ZUIText from 'zui/components/ZUIText';
 import ZUIDrawerModal from 'zui/components/ZUIDrawerModal';
 import { useEventTypeFilter } from 'features/events/hooks/useEventTypeFilter';
 
-const initializeEventTypesToFilterBy = () => [] as (string | null)[];
-
 const AllEventsList: FC = () => {
   const intl = useIntl();
   const messages = useMessages(messageIds);
@@ -43,8 +41,8 @@ const AllEventsList: FC = () => {
     'orgs' | 'calendar' | 'eventTypes' | null
   >(null);
   const [orgIdsToFilterBy, setOrgIdsToFilterBy] = useState<number[]>([]);
-  const [eventTypesToFilterBy, setEventTypesToFilterBy] = useState(
-    initializeEventTypesToFilterBy()
+  const [eventTypesToFilterBy, setEventTypesToFilterBy] = useState<string[]>(
+    []
   );
   const [customDatesToFilterBy, setCustomDatesToFilterBy] = useState<
     DateRange<Dayjs>
@@ -54,8 +52,8 @@ const AllEventsList: FC = () => {
   >(null);
 
   const eventTypeFilter = useEventTypeFilter(allEvents, {
-    eventTypesToFilterBy,
-    setEventTypesToFilterBy,
+    eventTypeLabelsToFilterBy: eventTypesToFilterBy,
+    setEventTypeLabelsToFilterBy: setEventTypesToFilterBy,
   });
 
   const orgs = [
@@ -266,7 +264,7 @@ const AllEventsList: FC = () => {
                 setDateFilterState(null);
                 setCustomDatesToFilterBy([null, null]);
                 setOrgIdsToFilterBy([]);
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
               }}
             />
           )}
@@ -300,7 +298,7 @@ const AllEventsList: FC = () => {
               onClick={() => {
                 setCustomDatesToFilterBy([null, null]);
                 setOrgIdsToFilterBy([]);
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
                 setDateFilterState(null);
               }}
               variant="secondary"
@@ -424,20 +422,15 @@ const AllEventsList: FC = () => {
         open={drawerContent == 'eventTypes'}
       >
         <List>
-          {eventTypeFilter.eventTypes.map((eventType) => (
-            <ListItem
-              key={eventTypeFilter.getLabelFromEventType(eventType)}
-              sx={{ justifyContent: 'space-between' }}
-            >
+          {eventTypeFilter.eventTypeLabels.map((eventType) => (
+            <ListItem key={eventType} sx={{ justifyContent: 'space-between' }}>
               <Box alignItems="center" display="flex">
-                <ZUIText>
-                  {eventTypeFilter.getLabelFromEventType(eventType)}
-                </ZUIText>
+                <ZUIText>{eventType}</ZUIText>
               </Box>
               <Switch
-                checked={eventTypeFilter.getIsCheckedEventType(eventType)}
+                checked={eventTypeFilter.getIsCheckedEventTypeLabel(eventType)}
                 onChange={() => {
-                  eventTypeFilter.toggleEventType(eventType);
+                  eventTypeFilter.toggleEventTypeLabel(eventType);
                 }}
               />
             </ListItem>

--- a/src/features/organizations/hooks/useFilteredOrgEvents.ts
+++ b/src/features/organizations/hooks/useFilteredOrgEvents.ts
@@ -45,8 +45,8 @@ export default function useFilteredOrgEvents(orgId: number) {
 
   const dispatch = useAppDispatch();
   const eventTypeFilter = useEventTypeFilter(allEvents, {
-    eventTypesToFilterBy,
-    setEventTypesToFilterBy: (newArray) =>
+    eventTypeLabelsToFilterBy: eventTypesToFilterBy,
+    setEventTypeLabelsToFilterBy: (newArray) =>
       dispatch(filtersUpdated({ eventTypesToFilterBy: newArray })),
   });
 

--- a/src/features/organizations/pages/PublicOrgPage.tsx
+++ b/src/features/organizations/pages/PublicOrgPage.tsx
@@ -300,7 +300,7 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
                     orgIdsToFilterBy: [],
                   })
                 );
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
               }}
             />
           )}
@@ -339,7 +339,7 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
                     orgIdsToFilterBy: [],
                   })
                 );
-                eventTypeFilter.clearEventTypes();
+                eventTypeFilter.clearEventTypeFilter();
               }}
               variant="secondary"
             />
@@ -499,20 +499,15 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
         open={drawerContent == 'eventTypes'}
       >
         <List>
-          {eventTypeFilter.eventTypes.map((eventType) => (
-            <ListItem
-              key={eventTypeFilter.getLabelFromEventType(eventType)}
-              sx={{ justifyContent: 'space-between' }}
-            >
+          {eventTypeFilter.eventTypeLabels.map((eventType) => (
+            <ListItem key={eventType} sx={{ justifyContent: 'space-between' }}>
               <Box alignItems="center" display="flex">
-                <ZUIText>
-                  {eventTypeFilter.getLabelFromEventType(eventType)}
-                </ZUIText>
+                <ZUIText>{eventType}</ZUIText>
               </Box>
               <Switch
-                checked={eventTypeFilter.getIsCheckedEventType(eventType)}
+                checked={eventTypeFilter.getIsCheckedEventTypeLabel(eventType)}
                 onChange={() => {
-                  eventTypeFilter.toggleEventType(eventType);
+                  eventTypeFilter.toggleEventTypeLabel(eventType);
                 }}
               />
             </ListItem>

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -19,7 +19,7 @@ import {
 type OrgEventFilters = {
   customDatesToFilterBy: DateRange<Dayjs>;
   dateFilterState: 'today' | 'tomorrow' | 'thisWeek' | 'custom' | null;
-  eventTypesToFilterBy: (string | null)[];
+  eventTypesToFilterBy: string[];
   geojsonToFilterBy: GeoJSON.Feature[];
   orgIdsToFilterBy: number[];
 };

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -46,8 +46,4 @@ const truncateOnMiddle = (str: string, maxLength: number) => {
 export const isInteger = (str: string): boolean =>
   Number.isInteger(parseFloat(str));
 
-const toSentenceCase = (str: string): string => {
-  return str ? `${str[0].toUpperCase()}${str.substring(1).toLowerCase()}` : str;
-};
-
-export { getEllipsedString, stringToBool, truncateOnMiddle, toSentenceCase };
+export { getEllipsedString, stringToBool, truncateOnMiddle };


### PR DESCRIPTION
## Description
This PR removes the enforced event type name formatting in the autocomplete input and the event type filter UI.

## Screenshots

<img width="1202" height="945" alt="screen 2025-10-11 at 14 05 57" src="https://github.com/user-attachments/assets/45928423-3b2d-42bf-a564-eee09c3d8582" />
<img width="1205" height="572" alt="screen 2025-10-11 at 14 04 35" src="https://github.com/user-attachments/assets/eeb6e396-54bc-4e8a-aca3-4207cd9db100" />
<img width="1205" height="572" alt="screen 2025-10-11 at 14 04 21" src="https://github.com/user-attachments/assets/8b1ea296-f03b-478a-b745-fd8e88e738ff" />


## Changes

* Removes string utility `toSentenceCase`
* Changes normalizing event type filter labels by first occurrence, considering lowercased strings to be equal
* Simplifies the interface of `useEventTypeFilter` slightly: only exposing labels and no internal representation.


## Notes to reviewer
- I set up a test case for deduplication of event type names accross organizations 'CANVAS' and 'Canvas', if you want to check that. In /my/feed you'll only see one of them, as expected. 
<img width="1202" height="1145" alt="screen 2025-10-11 at 14 11 20" src="https://github.com/user-attachments/assets/969b43b0-fac8-41c9-b47c-07f2b9152e7d" />


## Related issues
#3091 
