### PR TITLE
Fix move event without project error

### DIFF
--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -85,8 +85,11 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
     showSnackbar(
       'success',
       messages.eventChangeCampaignDialog.success({
-        campaignTitle: updatedEvent.campaign?.title || '?',
-        eventTitle: updatedEvent.title || event.title || '?',
+        campaignTitle: updatedEvent.campaign?.title || '',
+        eventTitle:
+          updatedEvent.title ||
+          updatedEvent.activity?.title ||
+          messages.common.noTitle(),
       })
     );
   };


### PR DESCRIPTION
## Description
Fix Bug 3060 and prevent error message.


## Changes
Use updatedEvent to access data.

## Notes to reviewer

1. Create Event in Organization Calendar Week View without Project
2. Move Event to Project
3. No error message anymore


## Related issues
Resolves #3060 
