### PR TITLE
fix closed surveys not showing 404

### DIFF
--- a/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
@@ -3,11 +3,13 @@
 import { headers } from 'next/headers';
 import { Metadata } from 'next';
 import { FC, ReactElement, ReactNode } from 'react';
+import { notFound } from 'next/navigation';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import { ZetkinSurveyExtended } from 'utils/types/zetkin';
 import HomeThemeProvider from 'features/home/components/HomeThemeProvider';
 import PublicSurveyLayout from 'features/surveys/layouts/PublicSurveyLayout';
+import { ZetkinSurveyExtended } from 'utils/types/zetkin';
+import { ApiClientError } from 'core/api/errors';
 
 type Props = {
   children: ReactNode;
@@ -20,9 +22,20 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { orgId, surveyId } = params;
   const apiClient = new BackendApiClient({});
-  const survey = await apiClient.get<ZetkinSurveyExtended>(
-    `/api/orgs/${orgId}/surveys/${surveyId}`
-  );
+
+  let survey: ZetkinSurveyExtended;
+  try {
+    survey = await apiClient.get<ZetkinSurveyExtended>(
+      `/api/orgs/${orgId}/surveys/${surveyId}`
+    );
+  } catch (e) {
+    if (e instanceof ApiClientError && e.status === 404) {
+      notFound();
+    } else {
+      throw e;
+    }
+  }
+
   return {
     description: survey.info_text,
     openGraph: {
@@ -44,9 +57,19 @@ const SurveyLayout: FC<Props> = async ({
   const apiClient = new BackendApiClient(headersObject);
 
   const { orgId, surveyId } = params;
-  const survey = await apiClient.get<ZetkinSurveyExtended>(
-    `/api/orgs/${orgId}/surveys/${surveyId}`
-  );
+
+  let survey: ZetkinSurveyExtended;
+  try {
+    survey = await apiClient.get<ZetkinSurveyExtended>(
+      `/api/orgs/${orgId}/surveys/${surveyId}`
+    );
+  } catch (e) {
+    if (e instanceof ApiClientError && e.status === 404) {
+      notFound();
+    } else {
+      throw e;
+    }
+  }
 
   return (
     <HomeThemeProvider>

--- a/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
@@ -2,10 +2,12 @@
 
 import { FC } from 'react';
 import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 
 import PublicSurveyPage from 'features/surveys/pages/PublicSurveyPage';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinSurveyExtended, ZetkinUser } from 'utils/types/zetkin';
+import { ApiClientError } from 'core/api/errors';
 
 type Props = {
   params: {
@@ -22,9 +24,19 @@ const Page: FC<Props> = async ({ params }) => {
   const apiClient = new BackendApiClient(headersObject);
 
   const { orgId, surveyId } = params;
-  const survey = await apiClient.get<ZetkinSurveyExtended>(
-    `/api/orgs/${orgId}/surveys/${surveyId}`
-  );
+
+  let survey: ZetkinSurveyExtended;
+  try {
+    survey = await apiClient.get<ZetkinSurveyExtended>(
+      `/api/orgs/${orgId}/surveys/${surveyId}`
+    );
+  } catch (e) {
+    if (e instanceof ApiClientError && e.status === 404) {
+      notFound();
+    } else {
+      throw e;
+    }
+  }
 
   let user: ZetkinUser | null;
   try {


### PR DESCRIPTION
## Description
Makes sure closed (unpublished) surveys show 404 instead of 500. The issue was the handling of the API request. It failed with 404, which threw an error in the frontend, leading to the 500 response code.

## Changes

* Add a function `surveyFetch` that fetches the survey. I put it in `utils/fetching`, let me know if that makes sense to you.
* Update fetching methods in `layout.tsx` and `page.tsx`, where the survey is fetched from the API.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2850
