### PR TITLE
Suggested fix to make event description field show newlines

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -506,7 +506,9 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                     >
                       {messages.eventOverviewCard.description().toUpperCase()}
                     </Typography>
-                    <Typography variant="body1">{data.info_text}</Typography>
+                    <Typography sx={{ whiteSpace: 'pre-line' }} variant="body1">
+                      {data.info_text}
+                    </Typography>
                   </Box>
                 ),
               })}


### PR DESCRIPTION
## Description
This PR makes event descriptions show newlines after editing. 


## Screenshots
<img width="1272" height="937" alt="zetkin-event-description-newlines" src="https://github.com/user-attachments/assets/ddb1d28c-bd9c-4c00-8252-6893fafbb0c0" />



## Changes

* Adds `whiteSpace: 'pre-line'` to the given `Typography` element, so it shows newlines.


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1746
