### PR TITLE
Remove unnecessary (and incorrect) awaits that were causing flakiness

### DIFF
--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -520,11 +520,6 @@ test.describe('User submitting a survey', () => {
       }
     );
 
-    // Wait for the select input to be visible to ensure page is loaded
-    await page
-      .locator('[id="mui-component-select-3.options"]')
-      .waitFor({ state: 'visible' });
-
     await page.click('input[name="sig"][value="anonymous"]');
     await page.click('data-testid=Survey-acceptTerms');
     await Promise.all([


### PR DESCRIPTION
## Description
This PR applies the fix that was discovered by @laurablum in #2745.

## Screenshots
None

## Changes
* Removes `await` from all `page.click()` actions where `Promise.all()` is used

## Notes to reviewer
If the test succeeds, lets consider this done!

## Related issues
Undocumented