### PR TITLE
Render links as `a`-links in survey questions

### DIFF
--- a/src/features/surveys/components/SurveyForm/LinkifiedText.tsx
+++ b/src/features/surveys/components/SurveyForm/LinkifiedText.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@mui/material';
+import { FC } from 'react';
+
+type LinkifiedTextProps = {
+  text: string;
+};
+
+const LinkifiedText: FC<LinkifiedTextProps> = ({ text }) => {
+  const LINK_REGEX = /(https:\/\/[^\s]+)/g;
+  const parts = text.split(LINK_REGEX);
+
+  return (
+    <>
+      {parts.map((part, idx) => {
+        if (part.startsWith('https://')) {
+          return (
+            <Link
+              key={`link-${idx}`}
+              href={part}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {part}
+            </Link>
+          );
+        }
+        return part;
+      })}
+    </>
+  );
+};
+
+export default LinkifiedText;

--- a/src/features/surveys/components/SurveyForm/OptionsQuestion.tsx
+++ b/src/features/surveys/components/SurveyForm/OptionsQuestion.tsx
@@ -21,6 +21,7 @@ import {
 import ZUIText from 'zui/components/ZUIText';
 import ZUIPublicSurveyOption from '../../../../zui/components/ZUIPublicSurveyOption';
 import messageIds from 'features/surveys/l10n/messageIds';
+import LinkifiedText from './LinkifiedText';
 
 export type OptionsQuestionProps = {
   element: ZetkinSurveyOptionsQuestionElement;
@@ -80,7 +81,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({
             </FormLabel>
             {question.description && (
               <ZUIText id={`description-${element.id}`}>
-                {question.description}
+                <LinkifiedText text={question.description} />
               </ZUIText>
             )}
           </Box>
@@ -116,7 +117,7 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({
               </FormLabel>
               {question.description && (
                 <ZUIText id={`description-${element.id}`}>
-                  {question.description}
+                  <LinkifiedText text={question.description} />
                 </ZUIText>
               )}
             </Box>

--- a/src/features/surveys/components/SurveyForm/TextQuestion.tsx
+++ b/src/features/surveys/components/SurveyForm/TextQuestion.tsx
@@ -6,6 +6,7 @@ import { ZetkinSurveyTextQuestionElement } from 'utils/types/zetkin';
 import ZUIText from 'zui/components/ZUIText';
 import ZUITextField from 'zui/components/ZUITextField';
 import messageIds from 'features/surveys/l10n/messageIds';
+import LinkifiedText from './LinkifiedText';
 
 export type SurveyTextQuestionProps = {
   element: ZetkinSurveyTextQuestionElement;
@@ -36,7 +37,7 @@ const TextQuestion: FC<SurveyTextQuestionProps> = ({
           </FormLabel>
           {element.question.description && (
             <ZUIText id={`description-${element.id}`}>
-              {element.question.description}
+              <LinkifiedText text={element.question.description} />
             </ZUIText>
           )}
         </Box>

--- a/src/features/surveys/components/SurveyForm/index.tsx
+++ b/src/features/surveys/components/SurveyForm/index.tsx
@@ -10,6 +10,7 @@ import ZUIText from '../../../../zui/components/ZUIText';
 import TextQuestion from './TextQuestion';
 import OptionsQuestion from './OptionsQuestion';
 import useServerSide from 'core/useServerSide';
+import LinkifiedText from './LinkifiedText';
 
 type SurveyFormProps = {
   initialValues?: Record<string, string | string[]>;
@@ -64,7 +65,9 @@ const SurveyForm: FC<SurveyFormProps> = ({
                   <ZUIText variant="headingMd">
                     {element.text_block.header}
                   </ZUIText>
-                  <ZUIText>{element.text_block.content}</ZUIText>
+                  <ZUIText>
+                    <LinkifiedText text={element.text_block.content} />
+                  </ZUIText>
                 </Box>
               )}
               {isTextQuestion && (


### PR DESCRIPTION
## Description
This PR renders all text that starts with `https://` as links in survey questions descriptions.

## Screenshots
<img width="1402" height="2104" alt="CleanShot 2025-10-13 at 16 43 37@2x" src="https://github.com/user-attachments/assets/b23a4025-ee54-4cd8-a9df-ce7ba1152479" />

## Changes
* Adds a new `LinkifiedText` component that can be used where `https://` strings should be turned into links.


## Notes to reviewer
@richardolsson proposed using `ZUIMarkdown` an an alternative but this seemed so trivial to implement that for now I chose to create a new dedicated component. Happy to discuss alternatives though.


## Related issues
Resolves #3117
