### PR TITLE
Clear allEvents cache on follow/unfollow organizations

### DIFF
--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -105,6 +105,9 @@ const eventsSlice = createSlice({
       state.allEventsList = remoteList(action.payload);
       state.allEventsList.loaded = new Date().toISOString();
     },
+    allEventsUnload: (state) => {
+      state.allEventsList = remoteList();
+    },
     campaignEventsLoad: (state, action: PayloadAction<number>) => {
       const id = action.payload;
       state.eventsByCampaignId[id] = remoteList<ZetkinEvent>();
@@ -733,6 +736,7 @@ export default eventsSlice;
 export const {
   allEventsLoad,
   allEventsLoaded,
+  allEventsUnload,
   campaignEventsLoad,
   campaignEventsLoaded,
   eventCreate,

--- a/src/features/organizations/hooks/useFollowOrgMutations.ts
+++ b/src/features/organizations/hooks/useFollowOrgMutations.ts
@@ -1,6 +1,7 @@
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import { orgFollowed, orgUnfollowed } from '../store';
 import { ZetkinMembership } from 'utils/types/zetkin';
+import { allEventsUnload } from '../../events/store';
 
 export default function useFollowOrgMutations(orgId: number) {
   const apiClient = useApiClient();
@@ -11,11 +12,13 @@ export default function useFollowOrgMutations(orgId: number) {
       follow: true,
     });
     dispatch(orgFollowed(membership));
+    dispatch(allEventsUnload());
   };
 
   const unfollowOrg = async () => {
     await apiClient.delete(`/api/users/me/following/${orgId}`);
     dispatch(orgUnfollowed(orgId));
+    dispatch(allEventsUnload());
   };
 
   return { followOrg, unfollowOrg };


### PR DESCRIPTION
## Description
This PR unloads the `allEventsList` in the redux state when the user follows or unfollows an organizations through `useFollowOrgMutations`. This way, /my/feed/ is updated after the user follows an organization. Before, when following an organization and going back to the feed, it would not show the new events, because it uses the cached list. This issue became apparent after I added the /my/organizations page I will link in an upcoming PR.
