### PR TITLE
fix dev mode activist portal link

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org
+ZETKIN_APP_DOMAIN=http://localhost:3000
 ZETKIN_GEN2_ORGANIZE_URL=http://organize.dev.zetkin.org
 ZETKIN_GEN2_CALL_URL=http://call.dev.zetkin.org
 

--- a/src/features/organizations/components/OrganizationsList.tsx
+++ b/src/features/organizations/components/OrganizationsList.tsx
@@ -36,7 +36,11 @@ const OrganizationsList = () => {
               </Typography>
               <Typography my={1}>
                 <NextLink
-                  href={env.vars.ZETKIN_APP_DOMAIN || ''}
+                  href={
+                    env.vars.ZETKIN_APP_DOMAIN
+                      ? `${env.vars.ZETKIN_APP_DOMAIN}/my/`
+                      : ''
+                  }
                   legacyBehavior
                   passHref
                 >


### PR DESCRIPTION
## Description
This PR enables new devs to actually get to the activist portal. 

It changes the link 'Go to activist portal' that appears when the user doesn't have access to the admin UI. 

Before, it was 'http://www.dev.zetkin.org', which was neither the activist portal nor on the dev instance. Now, it links to 'localhost:3000/my/'. 

This provides new devs that want to edit the activist portal with a clear flow. Login with the user account => click on link => you're in the activist portal.