### PR TITLE
Minor improvements to event page

### DIFF
--- a/src/features/organizations/layouts/PublicEventLayout.tsx
+++ b/src/features/organizations/layouts/PublicEventLayout.tsx
@@ -3,7 +3,6 @@
 import { Box } from '@mui/system';
 import { FC, PropsWithChildren } from 'react';
 import NextLink from 'next/link';
-import { Typography } from '@mui/material';
 
 import ActivistPortalHeader from '../components/ActivistPortlHeader';
 import ZUIOrgLogoAvatar from 'zui/components/ZUIOrgLogoAvatar';
@@ -57,7 +56,7 @@ export const PublicEventLayout: FC<Props> = ({ children, eventId, orgId }) => {
                       start={new Date(removeOffset(event.start_time))}
                     />
                   </ZUIText>
-                  <Typography component="span">·</Typography>
+                  <ZUIText component="span">·</ZUIText>
                   <ZUIText variant="bodySmRegular">
                     {event.location?.title || (
                       <Msg id={messageIds.eventPage.noLocation} />


### PR DESCRIPTION
## Description
This PR adds two small things to the design of the event page:

1. A dot between time span and location
2. A label to the description text (the style is borrowed from the label in the project edit view in the organizer panel)


## Screenshots

<img width="1051" height="932" alt="zetkin-project-page" src="https://github.com/user-attachments/assets/c003bca3-1d77-4366-a6b5-99e18963bb2f" />


