### PR TITLE
Break overflowing text inside select box into multiple lines

### DIFF
--- a/src/features/surveys/components/SurveyForm/OptionsQuestion.tsx
+++ b/src/features/surveys/components/SurveyForm/OptionsQuestion.tsx
@@ -143,9 +143,13 @@ const OptionsQuestion: FC<OptionsQuestionProps> = ({
                 value={dropdownValue}
               >
                 {options.map((option: ZetkinSurveyOption) => (
-                  <MenuItem key={option.id} value={option.id}>
+                  <MenuItem
+                    key={option.id}
+                    sx={{ whiteSpace: 'normal' }}
+                    value={option.id}
+                  >
                     <Typography
-                      noWrap
+                      flex="wrap"
                       sx={(theme) => ({
                         fontFamily: theme.typography.fontFamily,
                         fontSize: '1rem',


### PR DESCRIPTION
## Description
This PR ensures that overflowing text in survey dropdown options wraps into multiple lines.


## Screenshots
<img width="764" height="1508" alt="Screenshot 2025-10-15 142651" src="https://github.com/user-attachments/assets/cf803d25-a4ff-484f-9431-66d87db0d3fe" />
<img width="753" height="1500" alt="Screenshot 2025-10-15 142710" src="https://github.com/user-attachments/assets/9447fc64-9299-4165-8af5-25e1210b0c9f" />


## Related issues
Resolves #3025 
