### PR TITLE
Add top-level suspense

### DIFF
--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -5,7 +5,7 @@ import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { IntlProvider } from 'react-intl';
 import { Provider as ReduxProvider } from 'react-redux';
-import { FC, ReactNode, useRef } from 'react';
+import { FC, ReactNode, Suspense, useRef } from 'react';
 import {
   StyledEngineProvider,
   Theme,
@@ -86,7 +86,7 @@ const ClientContext: FC<ClientContextProps> = ({
                         messages={messages}
                       >
                         <CssBaseline />
-                        {children}
+                        <Suspense>{children}</Suspense>
                       </IntlProvider>
                     </ZUISnackbarProvider>
                   </IntlProvider>


### PR DESCRIPTION
## Description
This PR adds a top level suspense boundary to the client context, so that the context is not re-generated because something was loaded. This happened in the canvasser UI before, where some promise was not being caught and the top-level component re-mounted, causing a new store to be created and the entire thing to reload again.

## Screenshots
None

## Changes
* Adds `Suspense` boundary to the top-level context

## Notes to reviewer
Make sure canvassing works as before.

## Related issues
Undocumented