### PR TITLE
Activist portal map tab improvements

### DIFF
--- a/src/features/campaigns/layout/PublicProjectLayout.tsx
+++ b/src/features/campaigns/layout/PublicProjectLayout.tsx
@@ -28,7 +28,7 @@ const PublicProjectLayout: FC<Props> = ({ children, campaign }) => {
   const messages = useMessages(messageIds);
   const { showSnackbar } = useContext(ZUISnackbarContext);
 
-  const { allEvents, filteredEvents } = useFilteredCampaignEvents(
+  const { filteredEvents } = useFilteredCampaignEvents(
     campaign.organization.id,
     campaign.id
   );

--- a/src/features/organizations/layouts/PublicOrgLayout.tsx
+++ b/src/features/organizations/layouts/PublicOrgLayout.tsx
@@ -11,6 +11,7 @@ import {
   Public,
 } from '@mui/icons-material';
 import NextLink from 'next/link';
+import { useIntl } from 'react-intl';
 
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
@@ -27,9 +28,8 @@ import { useAppDispatch, useAppSelector } from 'core/hooks';
 import { filtersUpdated } from '../store';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ZUISnackbarContext from 'zui/ZUISnackbarContext';
-import ZUIIconLabel from '../../../zui/ZUIIconLabel';
-import ZUILink from '../../../zui/components/ZUILink';
-import { useIntl } from 'react-intl';
+import ZUIIconLabel from 'zui/ZUIIconLabel';
+import ZUILink from 'zui/components/ZUILink';
 
 type Props = {
   children: ReactNode;
@@ -54,7 +54,8 @@ const PublicOrgLayout: FC<Props> = ({ children, org }) => {
   const getCountryName = useCallback(
     (code: string) => {
       try {
-        return regionNames.of(code);
+        const regionName = regionNames.of(code);
+        return regionName ?? code;
       } catch (_) {
         return code;
       }
@@ -160,7 +161,14 @@ const PublicOrgLayout: FC<Props> = ({ children, org }) => {
                       })}
                     />
                   }
-                  label={org.phone}
+                  label={
+                    <ZUILink
+                      hoverUnderline={true}
+                      href={`tel:${org.phone}`}
+                      text={org.phone}
+                      variant={'secondary'}
+                    />
+                  }
                   size={'sm'}
                 />
               ) : null}

--- a/src/zui/components/ZUILink/index.tsx
+++ b/src/zui/components/ZUILink/index.tsx
@@ -6,6 +6,11 @@ import { ZUIMedium, ZUISmall } from '../types';
 
 type ZUILinkProps = {
   /**
+   * If true, only show underline when hovering
+   */
+  hoverUnderline?: boolean;
+
+  /**
    * The href to link to.
    */
   href: string;
@@ -28,6 +33,11 @@ type ZUILinkProps = {
    * The text that will show as the link.
    */
   text: string;
+
+  /**
+   * Switch color (default: primary)
+   */
+  variant?: 'primary' | 'secondary';
 };
 
 const ZUILink: FC<ZUILinkProps> = ({
@@ -35,6 +45,8 @@ const ZUILink: FC<ZUILinkProps> = ({
   text,
   openInNewTab = false,
   size,
+  variant = 'primary',
+  hoverUnderline,
 }) => {
   const linkVariants = {
     medium: 'linkMd',
@@ -45,12 +57,15 @@ const ZUILink: FC<ZUILinkProps> = ({
     <Link
       component={NextLink}
       href={href}
-      rel={openInNewTab ? 'noopener' : ''}
+      rel={openInNewTab ? 'noopener noreferrer nofollow' : ''}
       sx={(theme) => ({
         '&:hover': {
-          textDecorationColor: theme.palette.text.primary,
+          textDecoration: 'underline',
+          textDecorationColor: theme.palette.text[variant],
         },
-        textDecorationColor: theme.palette.text.primary,
+        color: theme.palette.text[variant],
+        textDecoration: hoverUnderline ? 'none' : 'underline',
+        textDecorationColor: theme.palette.text[variant],
       })}
       target={openInNewTab ? '_blank' : ''}
       variant={size ? linkVariants[size] : undefined}


### PR DESCRIPTION
## Description
This PR adds some information to the organizations page and removes the map view disabe in some cases. I found it hurts UX a bit when the map view animates away when opening the "explore"/suborgs tab, or when a project page doesn't have any events.  Also, info like the email, phone and country can easily be added as the data is already loaded there.


## Screenshots
[Add screenshots here]
<img width="960" height="752" alt="map-view-improvements" src="https://github.com/user-attachments/assets/86aef9a0-4333-4aea-a244-3d10b0f8be82" />
<img width="960" height="752" alt="map-view-improvements-2" src="https://github.com/user-attachments/assets/87ec2111-815e-4a4d-b9c6-97ef63c8b4e2" />




## Changes
[Add a list of features added/changed, bugs fixed etc]

- Adds phone number, email and country name to organization page/suborgs
- Disables map disable on explore page, and empty events in projects page


## Notes to reviewer
[Add instructions for testing]
- I have no idea how to test the phone display feature as there is no organization on the dev instance that has a phone number defined and I can't find any settings for that.
- Borrowed `ZUILink` from https://github.com/zetkin/app.zetkin.org/pull/3122

