### PR TITLE
Forward all query params to /households beta endpoint

### DIFF
--- a/src/app/beta/orgs/[orgId]/locations/[locationId]/households/route.ts
+++ b/src/app/beta/orgs/[orgId]/locations/[locationId]/households/route.ts
@@ -24,7 +24,9 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
   const apiClient = new BackendApiClient(headers);
 
   const households = await apiClient.get<Zetkin2Household[]>(
-    `/api2/orgs/${params.orgId}/locations/${params.locationId}/households?size=100`
+    `/api2/orgs/${params.orgId}/locations/${
+      params.locationId
+    }/households?${request.nextUrl.searchParams.toString()}`
   );
 
   const householdsWithColor: HouseholdWithColor[] = [];


### PR DESCRIPTION
## Description
This PR ensures that all params (most notably, also the `page` param) is forwarded to the beta endpoint for the getting `households`



## Changes
- Changes the `/beta/orgs/[orgId]/locations/[locationId]/households/` route to forward all query params (the frontend currently sends `page` and `size` as fast as I could tell) instead of only hardcoding `size` and omitting `page` which breaks pagination since the frontend thinks it requests page 2 where it the middleware actually always re-requests page 1.

## Related issues
Resolves #3143

