### PR TITLE
Replace @mui/style in `AssignmentStatusChip`

### DIFF
--- a/src/features/areaAssignments/components/AssignmentStatusChip.tsx
+++ b/src/features/areaAssignments/components/AssignmentStatusChip.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { Box } from '@mui/material';
-import { makeStyles } from '@mui/styles';
 
 import { AreaAssignmentState } from '../hooks/useAreaAssignmentStatus';
 import oldTheme from 'theme';
@@ -13,45 +12,28 @@ const capitalizeFirstLetter = (str: string): string => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 
-const useStyles = makeStyles(() => ({
-  chip: {
-    alignItems: 'center',
-    borderRadius: '2em',
-    color: 'white',
-    display: 'inline-flex',
-    fontSize: 14,
-    fontWeight: 'bold',
-    padding: '0.5em 0.7em',
-  },
-  closed: {
-    backgroundColor: oldTheme.palette.error.main,
-  },
-  draft: {
-    backgroundColor: oldTheme.palette.grey[500],
-  },
-  open: {
-    backgroundColor: oldTheme.palette.success.main,
-  },
-  scheduled: {
-    backgroundColor: oldTheme.palette.statusColors.blue,
-  },
-}));
-
 const AssignmentStatusChip: FC<AssigmentStatusChipProps> = ({ state }) => {
-  const classes = useStyles();
-
-  const classMap: Record<AreaAssignmentState, string> = {
-    [AreaAssignmentState.CLOSED]: classes.closed,
-    [AreaAssignmentState.OPEN]: classes.open,
-    [AreaAssignmentState.SCHEDULED]: classes.scheduled,
-    [AreaAssignmentState.UNKNOWN]: classes.draft,
-    [AreaAssignmentState.DRAFT]: classes.draft,
+  const bgColorMap: Record<AreaAssignmentState, string> = {
+    [AreaAssignmentState.CLOSED]: oldTheme.palette.error.main,
+    [AreaAssignmentState.DRAFT]: oldTheme.palette.grey[500],
+    [AreaAssignmentState.OPEN]: oldTheme.palette.success.main,
+    [AreaAssignmentState.SCHEDULED]: oldTheme.palette.statusColors.blue,
+    [AreaAssignmentState.UNKNOWN]: oldTheme.palette.grey[500],
   };
 
-  const colorClassName = classMap[state];
-
   return (
-    <Box className={`${colorClassName} ${classes.chip}`}>
+    <Box
+      sx={{
+        alignItems: 'center',
+        backgroundColor: bgColorMap[state],
+        borderRadius: '2em',
+        color: 'white',
+        display: 'inline-flex',
+        fontSize: 14,
+        fontWeight: 'bold',
+        padding: '0.5em 0.7em',
+      }}
+    >
       {capitalizeFirstLetter(state)}
     </Box>
   );


### PR DESCRIPTION
## Description
This PR replaces one usage of @mui/styles with the inline `sx` prop. It does so since we need to get rid of @mui/styles since it has been [deprecated](https://v6.mui.com/system/styles/basics/) ([migration instructions](https://v6.mui.com/material-ui/migration/migrating-from-jss/)) and is currently blocking the migration to npm which is tracked in #2909 since npm more strictly checks peer dependencies. If you agree that it makes sense to continue down this path, I'll create a separate issue to replace @mui/styles everywhere and will link to this issue as an example for how one might tackle this.

There should be no visual changes with these code changes.