### PR TITLE
Issue 3046/keep housholds visible while validation

### DIFF
--- a/src/core/hooks/usePromiseCache.ts
+++ b/src/core/hooks/usePromiseCache.ts
@@ -1,5 +1,7 @@
 type UsePromiseCacheReturn = {
   cache: (promise: Promise<unknown>) => void;
+  getOldPromise: () => Promise<unknown> | undefined;
+  oldPromise: Promise<unknown> | undefined;
 };
 
 // TODO: Store this in context?
@@ -10,12 +12,12 @@ export default function usePromiseCache(
 ): UsePromiseCacheReturn {
   const oldPromise = promises[cacheKey];
 
-  if (oldPromise) {
-    throw oldPromise;
-  }
-
   return {
     cache(promise) {
+      if (oldPromise) {
+        throw oldPromise;
+      }
+
       promises[cacheKey] = promise;
 
       promise.then(() => {
@@ -26,5 +28,7 @@ export default function usePromiseCache(
         delete promises[cacheKey];
       });
     },
+    getOldPromise: () => promises[cacheKey],
+    oldPromise,
   };
 }

--- a/src/core/hooks/useRemoteItem.ts
+++ b/src/core/hooks/useRemoteItem.ts
@@ -1,9 +1,7 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
-import shouldLoad from 'core/caching/shouldLoad';
 import { RemoteItem } from 'utils/storeUtils';
-import { useAppDispatch } from '.';
-import usePromiseCache from './usePromiseCache';
+import useRemoteObject from './useRemoteObject';
 
 export default function useRemoteItem<
   DataType,
@@ -20,34 +18,7 @@ export default function useRemoteItem<
     loader: () => Promise<DataType>;
   }
 ): DataType {
-  const dispatch = useAppDispatch();
-  const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteItem);
-
-  const promiseKey = hooks.cacheKey || hooks.loader.toString();
-  const { cache } = usePromiseCache(promiseKey);
-
-  if (loadIsNecessary) {
-    dispatch(hooks.actionOnLoad());
-
-    const promise = hooks
-      .loader()
-      .then((data) => {
-        dispatch(hooks.actionOnSuccess(data));
-      })
-      .catch((err) => {
-        if (hooks.actionOnError) {
-          dispatch(hooks.actionOnError(err));
-        }
-      });
-
-    cache(promise);
-
-    if (remoteItem?.data) {
-      return remoteItem.data;
-    } else {
-      throw promise;
-    }
-  }
+  useRemoteObject(remoteItem, hooks);
 
   if (!remoteItem?.data) {
     throw new Error('Item not loading or loaded');

--- a/src/core/hooks/useRemoteObject.ts
+++ b/src/core/hooks/useRemoteObject.ts
@@ -1,0 +1,124 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { useEffect } from 'react';
+
+import { useAppDispatch } from './index';
+import shouldLoad from '../caching/shouldLoad';
+import usePromiseCache from './usePromiseCache';
+import { RemoteItem, RemoteList } from '../../utils/storeUtils';
+import { AppDispatch } from 'core/store';
+
+export type Hooks<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType
+> = {
+  actionOnError?: (err: unknown) => PayloadAction<unknown>;
+  actionOnLoad: () => PayloadAction<OnLoadPayload>;
+  actionOnSuccess:
+    | ((item: DataType) => PayloadAction<OnSuccessPayload>)
+    | ((items: DataType[]) => PayloadAction<OnSuccessPayload>);
+  cacheKey?: string;
+  isNecessary?: () => boolean;
+  loader: (() => Promise<DataType>) | (() => Promise<DataType[]>);
+};
+
+async function makePromise<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType
+>(
+  dispatch: AppDispatch,
+  hooks: Hooks<DataType, OnLoadPayload, OnSuccessPayload>
+): Promise<DataType | DataType[] | null> {
+  try {
+    await Promise.resolve();
+    dispatch(hooks.actionOnLoad());
+    const val = await hooks.loader();
+    dispatch(hooks.actionOnSuccess(val as never));
+    return val;
+  } catch (err) {
+    {
+      if (hooks.actionOnError) {
+        dispatch(hooks.actionOnError(err));
+        return null;
+      } else {
+        throw err;
+      }
+    }
+  }
+}
+
+function useRemoteObject<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType
+>(
+  remoteObject: RemoteItem<DataType> | RemoteList<DataType> | undefined | null,
+  hooks: Hooks<DataType, OnLoadPayload, OnSuccessPayload>
+) {
+  const dispatch = useAppDispatch();
+  const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteObject);
+
+  const promiseKey = hooks.cacheKey || hooks.loader.toString();
+
+  const stateHasLoadedOnce =
+    remoteObject &&
+    (remoteObject.isLoading ||
+      remoteObject.error ||
+      remoteObject.loaded ||
+      'data' in remoteObject ||
+      ('items' in remoteObject && remoteObject.items.length > 0) ||
+      ('isStale' in remoteObject && remoteObject.isStale) ||
+      ('mutating' in remoteObject &&
+        (remoteObject.mutating as string[]).length > 0));
+
+  // initial load, suspense based data loading
+  {
+    const { cache, getOldPromise } = usePromiseCache(
+      'suspense_based_' + promiseKey
+    );
+    const oldPromise = getOldPromise();
+    if (oldPromise) {
+      throw oldPromise; // throws cached promise, so second component won't call API
+    }
+
+    if (loadIsNecessary && !stateHasLoadedOnce) {
+      const promise = makePromise<DataType, OnLoadPayload, OnSuccessPayload>(
+        dispatch,
+        hooks
+      );
+
+      // cache the promise, so other components using the same hook don't also call the API
+      cache(promise);
+
+      throw promise;
+    }
+  }
+
+  // consecutive loads, hook based loading (keeps stale data until update arrives)
+  {
+    const { cache, getOldPromise } = usePromiseCache(
+      'hook_based_' + promiseKey
+    );
+
+    useEffect(() => {
+      if (!loadIsNecessary || !stateHasLoadedOnce || getOldPromise()) {
+        return;
+      }
+
+      const promise = makePromise(dispatch, hooks);
+
+      // cache the promise, so other components using the same hook don't also call the API
+      cache(promise);
+    }, [
+      loadIsNecessary,
+      stateHasLoadedOnce,
+      dispatch,
+      cache,
+      getOldPromise,
+      // intentionally omitting hooks as they are often not wrapped in useMemo or useCallback in Zetkin...
+    ]);
+  }
+}
+
+export default useRemoteObject;

--- a/src/features/canvass/hooks/useHouseholds.ts
+++ b/src/features/canvass/hooks/useHouseholds.ts
@@ -15,6 +15,7 @@ export default function useHouseholds(
   return useRemoteList(list, {
     actionOnLoad: () => householdsLoad(locationId),
     actionOnSuccess: (data) => householdsLoaded([locationId, data]),
+    cacheKey: `households:${orgId}:${locationId}`,
     loader: async () =>
       fetchAllPaginated<HouseholdWithColor>(
         (page) =>

--- a/src/features/canvass/hooks/useLocationVisits.ts
+++ b/src/features/canvass/hooks/useLocationVisits.ts
@@ -16,6 +16,7 @@ export default function useLocationVisits(
   const visits = useRemoteList(visitList, {
     actionOnLoad: () => visitsLoad(assignmentId),
     actionOnSuccess: (items) => visitsLoaded([assignmentId, items]),
+    cacheKey: `visits:${orgId}:${assignmentId}:${locationId}`,
     loader: () =>
       apiClient.get<ZetkinLocationVisit[]>(
         `/api2/orgs/${orgId}/area_assignments/${assignmentId}/locations/${locationId}/visits`

--- a/src/features/canvass/store.ts
+++ b/src/features/canvass/store.ts
@@ -182,17 +182,21 @@ const canvassSlice = createSlice({
       state.visitsByAssignmentId[assignmentId].isStale = true;
     },
     visitsLoad: (state, action: PayloadAction<number>) => {
-      state.visitsByAssignmentId[action.payload] = remoteList();
-      state.visitsByAssignmentId[action.payload].isLoading = true;
+      const assignmentId = action.payload;
+      state.visitsByAssignmentId[assignmentId] ||= remoteList();
+      // Preserve existing items; just mark as loading
+      state.visitsByAssignmentId[assignmentId].isLoading = true;
+      // Also mark as stale while revalidating if not loaded yet handled downstream
     },
     visitsLoaded: (
       state,
       action: PayloadAction<[number, ZetkinLocationVisit[]]>
     ) => {
-      const [locationId, visits] = action.payload;
-      state.visitsByAssignmentId[locationId] = remoteList(visits);
-      state.visitsByAssignmentId[locationId].isLoading = false;
-      state.visitsByAssignmentId[locationId].loaded = new Date().toISOString();
+      const [assignmentId, visits] = action.payload;
+      state.visitsByAssignmentId[assignmentId] = remoteList(visits);
+      state.visitsByAssignmentId[assignmentId].isLoading = false;
+      state.visitsByAssignmentId[assignmentId].loaded =
+        new Date().toISOString();
     },
   },
 });


### PR DESCRIPTION
Description
This PR implements stale-while-revalidate behavior for useRemoteList and useRemoteItem hooks, ensuring that cached data remains visible during revalidation instead of showing empty states or loading spinners. It also adds proper promise deduplication across multiple components using the same data source.

## Screenshots
[Screen Recording 2025-10-24 at 13.41.32](https://github.com/user-attachments/assets/5f841c3b-1dee-488b-b25d-60b9b93eb324)

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds `getOldPromise()` getter to `usePromiseCache` to enable proper promise deduplication across render cycles
* Changes `useHouseholds` to use stable `cacheKey` (`households:${orgId}:${locationId}`) for reliable cross-component deduplication
* Changes `visitsLoad` reducer in canvass store to preserve existing items during revalidation instead of clearing the list
* Adds deduplication tests for both `useRemoteList` and `useRemoteItem` that verify the loader is called only once when two components mount simultaneously with the same `cacheKey`


## Notes to reviewer
[Add instructions for testing]

* Run the new tests with `yarn test useRemoteList.spec` and `yarn test useRemoteItem.spec` to verify deduplication works correctly
* For manual testing: temporarily reduce `DEFAULT_TTL` in `src/core/caching/shouldLoad.ts` to 10 seconds, navigate to a household list in the canvass interface, wait for TTL expiry, then return to the list - you should see the old data remain visible while revalidation happens in the background (check network tab)
* Verify that navigating between location views and household lists doesn't show empty states during revalidation

## Obsolete PRs
- [PR#3110](https://github.com/zetkin/app.zetkin.org/pull/3110)
- [PR#3146](https://github.com/zetkin/app.zetkin.org/pull/3146)

## Related issues
Resolves #3046
