### PR TITLE
enable language setting support for app router

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,9 +11,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const lang = getBrowserLanguage(headers().get('accept-language') || '');
-  const messages = await getMessages(lang);
-
   const headersList = headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
@@ -25,6 +22,10 @@ export default async function RootLayout({
   } catch (e) {
     user = null;
   }
+
+  const lang =
+    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+  const messages = await getMessages(lang);
 
   return (
     <html lang="en">


### PR DESCRIPTION
## Description
This PR changes how the language of the activist portal is set and harmonizes it with how `scaffold` does it. Before, when you change the language in `/my/settings`, the activist portal would be still in english (or your default browser language), and the organizer portal would be in the newly set language.
