### PR TITLE
messageIds now import module instead of directory

### DIFF
--- a/src/core/l10n/messageIds.ts
+++ b/src/core/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('core', {
   err404: {

--- a/src/features/areaAssignments/l10n/messageIds.ts
+++ b/src/features/areaAssignments/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.areaAssignments', {
   assignees: {

--- a/src/features/areas/l10n/messageIds.ts
+++ b/src/features/areas/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.areas', {
   areas: {

--- a/src/features/breadcrumbs/l10n/messageIds.ts
+++ b/src/features/breadcrumbs/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.breadcrumbs', {
   elements: {

--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.calendar', {
   createMenu: {

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.call', {
   about: {

--- a/src/features/callAssignments/l10n/messageIds.ts
+++ b/src/features/callAssignments/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.callAssignments', {
   actions: {

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.campaigns', {
   activitiesOverview: {

--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.canvass', {
   default: {

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.duplicates', {
   modal: {

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.events', {
   addPerson: {

--- a/src/features/files/l10n/messageIds.ts
+++ b/src/features/files/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.files', {
   fileUpload: {

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.import', {
   actionButtons: {

--- a/src/features/joinForms/l10n/messageIds.ts
+++ b/src/features/joinForms/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.joinForms', {
   defaultTitle: m('Untitled form'),

--- a/src/features/journeys/l10n/messageIds.ts
+++ b/src/features/journeys/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.journeys', {
   instance: {

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.organizations', {
   allEventsList: {

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.profile', {
   delete: {

--- a/src/features/search/l10n/messageIds.ts
+++ b/src/features/search/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.search', {
   error: m('There was an error'),

--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -1,4 +1,4 @@
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.settings', {
   officials: {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.smartSearch', {
   buttonLabels: {

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.surveys', {
   addBlocks: {

--- a/src/features/tags/l10n/messageIds.ts
+++ b/src/features/tags/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.tags', {
   dialog: {

--- a/src/features/tasks/l10n/messageIds.ts
+++ b/src/features/tasks/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.tasks', {
   actions: {

--- a/src/features/views/l10n/messageIds.ts
+++ b/src/features/views/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.views', {
   actions: {

--- a/src/zui/ZUITimeline/l10n/messageIds.ts
+++ b/src/zui/ZUITimeline/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('zui.timeline', {
   addNotePlaceholder: m('Enter text to leave a note'),

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-import { m, makeMessages } from 'core/i18n';
+import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('zui', {
   accessList: {


### PR DESCRIPTION
## Description
This PR makes the `messageIds.ts` files import 'core/i18n/messages' instead of 'core/i18n'. This makes it possible to use these files in RSCs. I believe it also increases compile speed in dev mode because it reduces unnecessary module imports. 

## Notes to reviewer
[Add instructions for testing]
I found this while doing SEO, which needed a message server side. It kept crashing, because it imported the directory fully and thereby `Msg.tsx`, which imports from `react-intl`, which tried to create a context, which isn't possible in a server component. 

Test it by importing something like this in `/o/[orgId]/(home)/layout.tsx` for example:

```ts
import messageIds from 'features/organizations/l10n/messageIds';
```

Before this PR, it would crash because of this error:

```
TypeError: createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component
```

