### PR TITLE
Name ICU MessageFormat in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,8 @@ represents the structure of that part of the app, and with messages defined in t
 object. Add your own message (or sub-object of multiple messages) where each message is
 defined using the `m()` function.
 
+Messages use [ICU MessageFormat](https://unicode-org.github.io/icu/userguide/format_parse/messages) for variable interpolation and pluralization (e.g. `{orgCount, plural, =0 {No organizations} =1 {One organization} other {# organizations}}`).
+
 ### How it works
 Translations are stored in YAML files in `src/locale`. These files are not created by
 humans. The English "translations" are generated from the `messageIds`, and any other


### PR DESCRIPTION
## Description
This PR adds a link and very short explanation to ICU MessageFormat for internationalization. I hope this could be useful for newcomers and people like me who always forget the official name for that syntax and want to look up how it works (again). 

I know it's also mentioned in the linked PR. This would be just a little shortcut where you don't have to parse the extra information provided in the PR. 

## Notes to reviewer
Happy for any feedback on how to word this. 