### PR TITLE
adding ParticipatingInfo section to eventPage

### DIFF
--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -35,6 +35,9 @@ export default makeMessages('feat.organizations', {
     loading: m('Loading...'),
     noLocation: m('No physical location'),
     partOfProject: m<{ projectLink: ReactElement }>('Part of {projectLink}'),
+    participatingInfo: m<{ participatingCount: number }>(
+      '{participatingCount, plural, =1 {# person is} other {# persons are}} participating'
+    ),
     today: m('Today'),
   },
   gen3: {

--- a/src/features/organizations/pages/PublicEventPage.tsx
+++ b/src/features/organizations/pages/PublicEventPage.tsx
@@ -9,6 +9,7 @@ import {
   ExpandMore,
   Link as LinkIcon,
   LocationPin,
+  Person,
   Phone,
 } from '@mui/icons-material';
 import { Map, Marker } from '@vis.gl/react-maplibre';
@@ -35,6 +36,7 @@ import useMyEvents from 'features/events/hooks/useMyEvents';
 import ZUIPublicFooter from 'zui/components/ZUIPublicFooter';
 import useEvent from 'features/events/hooks/useEvent';
 import { removeOffset } from 'utils/dateUtils';
+import useMemberships from '../hooks/useMemberships';
 
 type Props = {
   eventId: number;
@@ -44,7 +46,7 @@ type Props = {
 export const PublicEventPage: FC<Props> = ({ eventId, orgId }) => {
   const isMobile = useIsMobile();
   const myEvents = useMyEvents();
-
+  const memberships = useMemberships();
   const baseEvent = useEvent(orgId, eventId)?.data;
   const baseEventWithStatus: ZetkinEventWithStatus | undefined = baseEvent
     ? { ...baseEvent, status: null }
@@ -78,6 +80,13 @@ export const PublicEventPage: FC<Props> = ({ eventId, orgId }) => {
   const isFullScreen = !isMobile;
 
   const contactPerson = event?.contact;
+  const orgMembership = memberships.data?.find(
+    (membership) => membership.organization.id == orgId
+  );
+
+  const isLoggedInAsContactPerson =
+    contactPerson != undefined && contactPerson.id == orgMembership?.profile.id;
+
   const showContactDetails =
     !event?.cancelled && event?.status == 'booked' && !!contactPerson;
 
@@ -206,6 +215,11 @@ export const PublicEventPage: FC<Props> = ({ eventId, orgId }) => {
               >
                 <SignUpSection event={event} />
                 <DateAndLocation event={event} />
+                {isLoggedInAsContactPerson && (
+                  <ParticipatingInfo
+                    participatingCount={event.num_participants_available}
+                  />
+                )}
               </Box>
             </Box>
             <ZUIPublicFooter />
@@ -383,6 +397,28 @@ const DateAndLocation: FC<{
           </Map>
         </Box>
       )}
+    </Box>
+  );
+};
+
+const ParticipatingInfo: FC<{
+  participatingCount: number;
+}> = ({ participatingCount }) => {
+  const isMobile = useIsMobile();
+
+  return (
+    <Box display="flex" flexDirection="column" gap={isMobile ? 1 : 2}>
+      <Box alignItems="center" display="flex" gap={1}>
+        <ZUIIcon icon={Person} />
+        <ZUIText>
+          <Msg
+            id={messageIds.eventPage.participatingInfo}
+            values={{
+              participatingCount: participatingCount,
+            }}
+          />
+        </ZUIText>
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR adds a new section to an event that displays participating information.

## Screenshots
<img width="638" height="514" alt="CleanShot 2025-10-25 at 13 38 31" src="https://github.com/user-attachments/assets/ac976f10-912f-4d8b-9647-fa2a90e21584" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a small section to the event that displays the information about how many people are participating. Note that this is only visible if you are signed in as the contact person of that event.


## Notes to reviewer
- login with user Angela Davis (testadmin@example.com)
- go to `/o/1/events/485`
- you should see a section that shows `x person(s) are participating`
- login with another user that is not Angela Davis
- go to `/o/1/events/485`
- you should see not see that section anymore

## Related issues
Resolves #3169
