### PR TITLE
Design for ZUIDisplayDate component

### DIFF
--- a/src/zui/ZUIDateDisplay/index.stories.tsx
+++ b/src/zui/ZUIDateDisplay/index.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta, StoryFn } from '@storybook/react';
+
+import ZUIDateDisplay from '.';
+
+export default {
+  component: ZUIDateDisplay,
+  title: 'Other/ZUIDateDisplay',
+} as Meta<typeof ZUIDateDisplay>;
+
+const Template: StoryFn<typeof ZUIDateDisplay> = (args) => (
+  <ZUIDateDisplay
+    displayFormat={args.displayFormat}
+    endTimestamp={args.endTimestamp}
+    showRelative={args.showRelative}
+    timestamp={args.timestamp}
+  />
+);
+
+// slicing away the "Z" at the end of the ISO-string, because
+// that's how dates are formatted coming from the backend.
+export const full = Template.bind({});
+full.args = {
+  displayFormat: 'full',
+  timestamp: new Date().toISOString().slice(0, -1),
+};
+
+export const short = Template.bind({});
+short.args = {
+  displayFormat: 'short',
+  timestamp: new Date().toISOString().slice(0, -1),
+};
+export const log = Template.bind({});
+log.args = {
+  displayFormat: 'log',
+  timestamp: new Date().toISOString().slice(0, -1),
+};
+export const time = Template.bind({});
+time.args = {
+  displayFormat: 'time',
+  timestamp: new Date().toISOString().slice(0, -1),
+};
+export const range = Template.bind({});
+const now = new Date();
+const threeDaysLater = new Date(now);
+threeDaysLater.setDate(threeDaysLater.getDate() + 3);
+const sixDaysLater = new Date(now);
+sixDaysLater.setDate(sixDaysLater.getDate() + 6);
+range.args = {
+  displayFormat: 'range',
+  endTimestamp: sixDaysLater.toISOString().slice(0, -1),
+  timestamp: threeDaysLater.toISOString().slice(0, -1),
+};
+
+export const todayRange = Template.bind({});
+const threeHoursLater = new Date(now);
+threeHoursLater.setHours(threeHoursLater.getHours() + 3);
+todayRange.args = {
+  displayFormat: 'range',
+  endTimestamp: threeHoursLater.toISOString().slice(0, -1),
+  showRelative: true,
+  timestamp: now.toISOString().slice(0, -1),
+};
+
+export const tomorrowRange = Template.bind({});
+const tomorrow = new Date(now);
+tomorrow.setDate(tomorrow.getDate() + 1);
+tomorrowRange.args = {
+  displayFormat: 'range',
+  endTimestamp: threeDaysLater.toISOString().slice(0, -1),
+  showRelative: true,
+  timestamp: tomorrow.toISOString().slice(0, -1),
+};

--- a/src/zui/ZUIDateDisplay/index.tsx
+++ b/src/zui/ZUIDateDisplay/index.tsx
@@ -1,0 +1,154 @@
+import { FormattedDate, FormattedTime } from 'react-intl';
+import { format as dateFormat, isSameDay, isToday, isTomorrow } from 'date-fns';
+import React from 'react';
+
+type ZUIDateDisplayFormats =
+  | 'full'
+  | 'time'
+  | 'short'
+  | 'range'
+  | 'log'
+  | undefined;
+
+interface ZUIDateDisplayProps {
+  displayFormat?: ZUIDateDisplayFormats;
+  timestamp: string;
+  endTimestamp?: string;
+  showRelative?: boolean;
+}
+
+const ZUIDateDisplay: React.FunctionComponent<ZUIDateDisplayProps> = ({
+  endTimestamp,
+  showRelative,
+  timestamp,
+  displayFormat,
+}) => {
+  const endDate = endTimestamp ? new Date(endTimestamp) : null;
+  const startDate = new Date(timestamp);
+
+  const endsOnSameDay = endDate ? isSameDay(startDate, endDate) : false;
+
+  const getRelativeTag = () => {
+    if (!showRelative) {
+      return '';
+    }
+    if (isToday(startDate)) {
+      return 'Today ';
+    }
+    if (isTomorrow(startDate)) {
+      return 'Tomorrow ';
+    }
+    return '';
+  };
+
+  const relativeTag = getRelativeTag();
+
+  return (
+    <>
+      {displayFormat === 'full' && (
+        <>
+          {relativeTag}
+          <FormattedDate
+            day="numeric"
+            month="long"
+            value={timestamp}
+            weekday="long"
+            year="numeric"
+          />
+        </>
+      )}
+      {displayFormat === 'time' && (
+        <>
+          {relativeTag}
+          <FormattedDate
+            day="numeric"
+            month="long"
+            value={timestamp}
+            weekday="long"
+            year="numeric"
+          />
+          {' - '}
+          <FormattedTime
+            hour="2-digit"
+            hourCycle="h24"
+            minute="2-digit"
+            value={timestamp}
+          />
+        </>
+      )}
+      {displayFormat === 'short' && (
+        <FormattedDate
+          day="2-digit"
+          month="2-digit"
+          value={timestamp}
+          year="2-digit"
+        />
+      )}
+      {displayFormat === 'range' &&
+        (endsOnSameDay ? (
+          <>
+            {relativeTag}
+            <FormattedDate
+              day="numeric"
+              month="long"
+              value={timestamp}
+              weekday="long"
+              year="numeric"
+            />
+            {' | '}
+            <FormattedTime
+              hour="2-digit"
+              hourCycle="h24"
+              minute="2-digit"
+              value={timestamp}
+            />
+            {' - '}
+            <FormattedTime
+              hour="2-digit"
+              hourCycle="h24"
+              minute="2-digit"
+              value={endTimestamp}
+            />
+          </>
+        ) : (
+          <>
+            {relativeTag}
+            <FormattedDate
+              day="numeric"
+              month="long"
+              value={timestamp}
+              weekday="long"
+              year="numeric"
+            />
+            {', '}
+            <FormattedTime
+              hour="2-digit"
+              hourCycle="h24"
+              minute="2-digit"
+              value={timestamp}
+            />
+            {' - '}
+            <FormattedDate
+              day="numeric"
+              month="long"
+              value={endTimestamp}
+              weekday="long"
+              year="numeric"
+            />
+            {', '}
+            <FormattedTime
+              hour="2-digit"
+              hourCycle="h24"
+              minute="2-digit"
+              value={endTimestamp}
+            />
+          </>
+        ))}
+      {displayFormat === 'log' && (
+        <>{dateFormat(startDate, 'dd-MM-yyyy - HH:mm:ss')}</>
+      )}
+    </>
+  );
+};
+
+export default ZUIDateDisplay;


### PR DESCRIPTION
## Description
This PR introduces a component to display date. It is meant to wrap different ways of displaying date into a singular one so the different ways of displaying dates and time across the webapp become uniform. 

___

I have come across existing components solving parts of what was mentioned in the issue linked to this PR. 

This function is used to format dates in components used for Event.
https://github.com/zetkin/app.zetkin.org/blob/8a681c61cdb7988ed5cde6d60896ad2f2153dd10/src/zui/utils/timeSpanString.ts#L7


And these components are already present to present date using `<FormattedDate>`and `<FormattedTime>` from `react-intl`

https://github.com/zetkin/app.zetkin.org/blob/7d3b29b8a9cbf1e9c3b18148286a7fbdfc512a83/src/zui/ZUIDate/index.tsx#L7

https://github.com/zetkin/app.zetkin.org/blob/8c258e27ca7c5730e2876c301bd10aab5488c7dd/src/zui/ZUIDateTime/index.tsx#L10

___


I think I can refactor this a bit more to reduce the duplication of some code and perhaps try to weave in some of the already existing components and logic. But for now I would be happy to hear your thoughts in how this looks and what I could change. 

## Notes to reviewer

1. Start a local storybook server using `yarn storybook` 
2. Scroll down to ZUIDateDisplay under the `Other` section
3. View the different variants of the component.


## Related issues
Resolves #2821 
