### PR TITLE
Handle null content in survey text blocks

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -32,7 +32,7 @@ const TextBlock: FC<TextBlockProps> = ({
   const { updateElement } = useSurveyMutations(orgId, surveyId);
 
   const [header, setHeader] = useState(element.text_block.header);
-  const [content, setContent] = useState(element.text_block.content);
+  const [content, setContent] = useState(element.text_block.content || '');
 
   const { autoFocusDefault, clickAwayProps, containerProps, previewableProps } =
     useEditPreviewBlock({

--- a/src/features/surveys/components/SurveyForm/index.tsx
+++ b/src/features/surveys/components/SurveyForm/index.tsx
@@ -66,7 +66,9 @@ const SurveyForm: FC<SurveyFormProps> = ({
                     {element.text_block.header}
                   </ZUIText>
                   <ZUIText>
-                    <LinkifiedText text={element.text_block.content} />
+                    {element.text_block.content && (
+                      <LinkifiedText text={element.text_block.content} />
+                    )}
                   </ZUIText>
                 </Box>
               )}

--- a/src/features/surveys/hooks/useHydratedSurveySubmission.ts
+++ b/src/features/surveys/hooks/useHydratedSurveySubmission.ts
@@ -103,7 +103,7 @@ export default function useHydratedSurveySubmission(
       elements.push({
         header: elem.text_block.header,
         id: elem.id,
-        text: elem.text_block.content,
+        text: elem.text_block.content || '',
         type: ELEM_TYPE.TEXT_BLOCK,
       });
     } else {

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -276,7 +276,7 @@ export interface ZetkinSurveyTextElement {
   hidden: boolean;
   id: number;
   text_block: {
-    content: string;
+    content: string | null;
     header: string;
   };
   type: ELEMENT_TYPE.TEXT;


### PR DESCRIPTION
## Description
This PR fixes an undocumented bug that was causing the survey page to crash when text blocks had `null` content. It was the recently added link rendering code (#3119) that tried to split `content` without checking for `null`, because the type was incorrect.

## Screenshots
None

## Changes
* Changes the `ZetkinSurveyTextElement` type to correctly reflect the API type (where `content` can be `null`)
* Adds guards or fallbacks to all uses of `ZetkinSurveyTextElement.content`

## Notes to reviewer
None

## Related issues
Undocumented