### PR TITLE
add subquery email targets

### DIFF
--- a/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/DisplaySubQuery.tsx
@@ -1,6 +1,7 @@
 import { ZetkinQuery } from 'utils/types/zetkin';
 import {
   OPERATION,
+  QUERY_TYPE,
   SmartSearchFilterWithId,
   SubQueryFilterConfig,
 } from 'features/smartSearch/components/types';
@@ -11,6 +12,8 @@ import UnderlinedText from '../../UnderlinedText';
 import useCallAssignments from 'features/callAssignments/hooks/useCallAssignments';
 import { useNumericRouteParams } from 'core/hooks';
 import useSmartSearchQueries from 'features/smartSearch/hooks/useSmartSearchQueries';
+import useEmails from 'features/emails/hooks/useEmails';
+
 const localMessageIds = messageIds.filters.subQuery;
 
 interface DisplaySubQueryProps {
@@ -36,6 +39,15 @@ const DisplaySubQuery = ({ filter }: DisplaySubQueryProps): JSX.Element => {
     title: a.title,
   }));
 
+  const emailsFuture = useEmails(orgId);
+  const emails = emailsFuture.data || [];
+
+  const emailTargetQueriesWithTitles: ZetkinQuery[] = emails.map((e) => ({
+    ...e.target,
+    title: e.title || undefined,
+    type: QUERY_TYPE.EMAIL_TARGET,
+  }));
+
   const { query_id } = config;
 
   const op = filter.op || OPERATION.ADD;
@@ -43,7 +55,8 @@ const DisplaySubQuery = ({ filter }: DisplaySubQueryProps): JSX.Element => {
   const query =
     standaloneQueries.find((q) => q.id === query_id) ||
     targetGroupQueriesWithTitles.find((q) => q.id === query_id) ||
-    purposeGroupQueriesWithTitles.find((q) => q.id === query_id);
+    purposeGroupQueriesWithTitles.find((q) => q.id === query_id) ||
+    emailTargetQueriesWithTitles.find((q) => q.id === query_id);
 
   return (
     <Msg

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -20,6 +20,7 @@ import {
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
 import messageIds from 'features/smartSearch/l10n/messageIds';
+import useEmails from 'features/emails/hooks/useEmails';
 
 const localMessageIds = messageIds.filters.subQuery;
 
@@ -58,10 +59,20 @@ const SubQuery = ({
     title: a.title,
   }));
 
+  const emailsFuture = useEmails(orgId);
+  const emails = emailsFuture.data || [];
+
+  const emailTargetQueriesWithTitles: ZetkinQuery[] = emails.map((e) => ({
+    ...e.target,
+    title: e.title || undefined,
+    type: QUERY_TYPE.EMAIL_TARGET,
+  }));
+
   const queries = [
     ...standaloneQueries,
     ...targetGroupQueriesWithTitles,
     ...purposeGroupQueriesWithTitles,
+    ...emailTargetQueriesWithTitles,
   ];
 
   const { filter, setOp } =
@@ -252,6 +263,18 @@ const SubQuery = ({
                               id={
                                 localMessageIds.query.selectOptions
                                   .callassignment_goal
+                              }
+                            />
+                          </MenuItem>
+                        )}
+                        {emailTargetQueriesWithTitles.length > 0 && (
+                          <MenuItem
+                            key={QUERY_TYPE.EMAIL_TARGET}
+                            value={QUERY_TYPE.EMAIL_TARGET}
+                          >
+                            <Msg
+                              id={
+                                localMessageIds.query.selectOptions.email_target
                               }
                             />
                           </MenuItem>

--- a/src/features/smartSearch/components/types.ts
+++ b/src/features/smartSearch/components/types.ts
@@ -399,6 +399,7 @@ export enum QUERY_TYPE {
   STANDALONE = 'standalone',
   PURPOSE = 'callassignment_goal',
   TARGET = 'callassignment_target',
+  EMAIL_TARGET = 'email_target',
 }
 
 export interface ZetkinQuery {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -625,6 +625,10 @@ export default makeMessages('feat.smartSearch', {
             querySelect: ReactElement;
             titleSelect: ReactElement;
           }>('{querySelect} of call assignment "{titleSelect}"'),
+          email_target: m<{
+            querySelect: ReactElement;
+            titleSelect: ReactElement;
+          }>('{querySelect} of email "{titleSelect}"'),
           none: m<{ querySelect: ReactElement; titleSelect: ReactElement }>(
             '{querySelect}'
           ),
@@ -640,6 +644,9 @@ export default makeMessages('feat.smartSearch', {
           callassignment_target: m<{ queryTitle: ReactElement | string }>(
             'the target group of call assignment "{queryTitle}"'
           ),
+          email_target: m<{
+            queryTitle: ReactElement | string;
+          }>('the target group of email "{queryTitle}"'),
           none: m<{ queryTitle: ReactElement | string }>('{queryTitle}'),
           standalone: m<{ queryTitle: ReactElement | string }>(
             'Smart Search query "{queryTitle}"'
@@ -648,12 +655,14 @@ export default makeMessages('feat.smartSearch', {
         selectLabel: {
           callassignment_goal: m('the purpose group'),
           callassignment_target: m('the target group'),
+          email_target: m('the target group'),
           none: m('a Smart Search query'),
           standalone: m('Smart Search query'),
         },
         selectOptions: {
           callassignment_goal: m('the purpose group of a call assignment'),
           callassignment_target: m('the target group of a call assignment'),
+          email_target: m('the target group of an email'),
           none: m(
             "This organization doesn't have any call assignments or Smart Search queries yet."
           ),


### PR DESCRIPTION
## Description
This PR adds email targets to subqueries in smart search.


## Screenshots
[Add screenshots here]
<img width="1230" height="963" alt="email-target-preview" src="https://github.com/user-attachments/assets/93c9d958-cfe5-4c25-851a-988487ddd350" />
<img width="1232" height="965" alt="email-target-main" src="https://github.com/user-attachments/assets/832e9d07-c060-4511-90cd-554320f57453" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds EMAIL_TARGET to enum QUERY_TYPE and implements preview and edit view for the new subquery type


## Notes to reviewer
[Add instructions for testing]
Go to a list like http://localhost:3000/organize/1/people/lists/164 and edit the email target filter

Emails can only be selected by title currently. I copied it from the call assignments in subquery. 


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1713
