### PR TITLE
Fixing issues with embedded join form

### DIFF
--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -93,7 +93,7 @@ export default async function Page({ params, searchParams }: PageProps) {
               margin-bottom: 1rem;
             }
 
-            .zetkin-joinform__field input[type="text"], .zetkin-joinform__field select {
+            .zetkin-joinform__field input.zetkin-joinform__text-input, .zetkin-joinform__field select {
               width: 100%;
               max-width: 600px;
               padding: 0.3rem;

--- a/src/features/joinForms/components/EmbeddedJoinForm.tsx
+++ b/src/features/joinForms/components/EmbeddedJoinForm.tsx
@@ -95,6 +95,7 @@ const EmbeddedJoinForm: FC<Props> = ({ encrypted, fields, messages }) => {
                     <div>
                       {field.s != 'gender' && (
                         <input
+                          className="zetkin-joinform__text-input"
                           name={field.s}
                           required={
                             field.s == 'first_name' || field.s == 'last_name'


### PR DESCRIPTION
## Description
This PR cuts down js size of embedded join forms by moving message resolution to server rendering. It also fixes a hydration issue.

https://github.com/zetkin/app.zetkin.org/issues/2718 documented how the js size is too large. I analyzed which modules cause this for me. It was formatjs, which is imported by useMessages -> useIntl (react-intl) -> formatjs. I moved the message resolution to the server render and passed resolved messages to the client instead of the client needing to load those formatting libraries. In dev mode, it cut my page.js size by around 80%. 

The joinform page also kind of twitched for me when I reload the page. It's because of a weird hydration issue I found in the console: 
```
Warning: Text content did not match. Server: 
...
.zetkin-joinform__field input[type=&quot;text&quot;], .zetkin-joinform__field select
...
" Client: "
...
.zetkin-joinform__field input[type="text"], .zetkin-joinform__field select {
```

I guess next and react render quotes differently. So I added a class to text fields and used that as the selector. And that stopped that "twiching" I saw. 

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Moves message resolution to server side for joinforms
* Changes css selection method from type to class selector

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2718
