### PR TITLE
fix lists survey response filters & sorting

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyOptionsColumnType.tsx
@@ -25,9 +25,10 @@ export type SurveyOptionsViewCell =
     }[]
   | null;
 
-const surveyOptionsColumnSortRank = (str: string) => {
-  const split = str.split('|');
-  return -split[split.length - 1].length;
+const surveyOptionsColumnSortRank = (allOptionsJoined: string) => {
+  const options = allOptionsJoined.split('|');
+  const lastOption = options[options.length - 1];
+  return -lastOption.length;
 };
 
 export default class SurveyOptionsColumnType
@@ -54,12 +55,16 @@ export default class SurveyOptionsColumnType
           return '';
         }
 
-        const sorted = cell.concat().sort((sub0, sub1) => {
+        const sortedSubmissions = cell.concat().sort((sub0, sub1) => {
           const d0 = new Date(sub0.submitted);
           const d1 = new Date(sub1.submitted);
           return d1.getTime() - d0.getTime();
         });
-        return sorted[0].selected.map((s) => s.text).join('|');
+        const mostRecentSubmission = sortedSubmissions[0];
+        const selectedOptions = mostRecentSubmission.selected.map(
+          (s) => s.text
+        );
+        return selectedOptions.join('|');
       },
     };
   }

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -43,13 +43,14 @@ export default class SurveyResponseColumnType
           return '';
         }
 
-        const sorted = cell.concat().sort((sub0, sub1) => {
+        const sortedSubmissions = cell.concat().sort((sub0, sub1) => {
           const d0 = new Date(sub0.submitted);
           const d1 = new Date(sub1.submitted);
           return d1.getTime() - d0.getTime();
         });
+        const mostRecentSubmission = sortedSubmissions[0];
 
-        return sorted[0].text || '';
+        return mostRecentSubmission.text || '';
       },
       width: 250,
     };


### PR DESCRIPTION
## Description
This PR fixes survey response filters in the lists feature of Zetkin. It harmonizes the way sorting works with the displayed values as well.


## Screenshots
[Add screenshots here]
<img width="1672" height="955" alt="filterfix" src="https://github.com/user-attachments/assets/a967d515-9083-4a5d-b879-528089450cd7" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Makes `SurveyOptionsColumnType` and `SurveyResponseColumnType` return strings in `valueGetter`
* Changes `sortComparator` to be basic string compare instead of comparing lists


## Notes to reviewer
[Add instructions for testing]
I think the data grid didn't really support returning arrays there? Idk.. it fixes the problem. And `valueGetter` is only used by filtering and sorting, since we override rendering with renderCell according to [the docs](https://mui.com/x/react-data-grid/column-definition/#value-getter)

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2885
