### PR TITLE
fix location not focusing on edit click

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -357,8 +357,12 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
                             {...params}
                             inputRef={renderParams.ref}
                             label={messages.eventOverviewCard.location()}
-                            onFocus={() => {
+                            onFocus={(e) => {
                               setLocationDropdownOpen(true);
+                              const target = e.currentTarget;
+                              setTimeout(() => {
+                                target?.select();
+                              }, 0);
                             }}
                             sx={{
                               backgroundColor: 'white',


### PR DESCRIPTION
## Description
This PR makes the location autocomplete focus when clicking it in the event overview editor. 


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Passes ref prop down to the input
* Adds a state variable that keeps track of the autocomplete dropdown being open
* Makes the dropdown open and select input on focus

I'm personally not a big fan of the `setTimeout(() => ..., 0)` solution, but it was the only way I could get the select to work. Inlining the select call or doing `requestAnimationFrame` didn't work. 

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1224
