### PR TITLE
View browser data virtualization

### DIFF
--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -48,7 +48,7 @@ function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
 }
 
 const ViewBrowser: FC<ViewBrowserProps> = ({
-  autoHeight = true,
+  autoHeight = false,
   basePath,
   enableDragAndDrop = true,
   enableEllipsisMenu = true,

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -50,7 +50,7 @@ const PeopleViewsPage: PageWithLayout<PeopleViewsPageProps> = ({ orgId }) => {
       <Head>
         <title>{messages.browserLayout.title()}</title>
       </Head>
-      <ViewBrowser autoHeight={false} basePath={`/organize/${orgId}/people`} />
+      <ViewBrowser basePath={`/organize/${orgId}/people`} />
     </>
   );
 };


### PR DESCRIPTION
## Description
This PR makes the mui data grid in /people and /people/folders/[folderId] use [data virtualization](https://mui.com/x/react-data-grid/virtualization/). It was disabled by autoHeight being true and fixedHeight being undefined on those pages. 


## Screenshots
[Add screenshots here]

https://github.com/user-attachments/assets/cd4985b2-9dd4-4691-87c2-c941a31f40f3




## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1553 because the lag was mostly caused by re-rendering lots of components that were not visible anyway. With virtualization, it only re-renders the visible (plus some small buffer) components.
