### PR TITLE
Tasks: fix expiry date parsing

### DIFF
--- a/src/features/tasks/utils/getTaskStatus.ts
+++ b/src/features/tasks/utils/getTaskStatus.ts
@@ -14,7 +14,7 @@ const getTaskStatus = (task: ZetkinTask): TASK_STATUS => {
   const { published, expires } = task;
   const now = dayjs();
 
-  const isExpiresPassed = expires && dayjs(expires + '.000Z').isBefore(now);
+  const isExpiresPassed = expires && dayjs(expires + 'Z').isBefore(now);
 
   if (isExpiresPassed) {
     return TASK_STATUS.EXPIRED;


### PR DESCRIPTION
## Description
This PR fixes expiry date parsing. It used to return invalid dates in case the date is formatted with sub-second data like in https://github.com/zetkin/app.zetkin.org/issues/2754 . Just doing `expired + 'Z'` parses both variants correctly.


## Screenshots
[Add screenshots here]
<img width="388" height="106" alt="image" src="https://github.com/user-attachments/assets/f4c66caa-1add-4542-a672-0d38a74adc06" />


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2754
