### PR TITLE
Lists: make survey response texts nullable

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveyResponseColumnType.tsx
@@ -20,14 +20,14 @@ import useToggleDebounce from 'utils/hooks/useToggleDebounce';
 export type SurveyResponseViewCell = {
   submission_id: number;
   submitted: string;
-  text: string;
+  text: string | null;
 }[];
 
 export default class SurveyResponseColumnType
   implements IColumnType<SurveyResponseViewColumn, SurveyResponseViewCell>
 {
   cellToString(cell: SurveyResponseViewCell): string {
-    return cell?.length ? cell[0].text : '';
+    return cell?.length && cell[0].text ? cell[0].text : '';
   }
 
   getColDef(): Omit<GridColDef<SurveyResponseViewCell>, 'field'> {
@@ -50,7 +50,7 @@ export default class SurveyResponseColumnType
       },
       valueGetter: (params: GridValueGetterParams) => {
         const cell: SurveyResponseViewCell = params.row[params.field];
-        return cell?.map((response) => response.text) || [];
+        return cell?.map((response) => response.text || '') || [];
       },
       width: 250,
     };
@@ -129,7 +129,7 @@ const Cell: FC<{ cell: SurveyResponseViewCell | undefined }> = ({ cell }) => {
           submissions={cell.map((sub, index) => ({
             id: sub.submission_id,
             matchingContent:
-              index == 0 ? getEllipsedString(sub.text, 300) : null,
+              index == 0 && sub.text ? getEllipsedString(sub.text, 300) : null,
             submitted: sub.submitted,
           }))}
         />


### PR DESCRIPTION
## Description
This PR makes survey response texts nullable in the type, since they can be null https://github.com/zetkin/app.zetkin.org/issues/3199 . And it adds type checks to make it not crash.

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes type of `text` to also include `null`
* Adds type checks to make it not crash


## Notes to reviewer
[Add instructions for testing]
Since the UI doesn't provide a way to make a null text, I used network override to set a null value to the survey response text for testing. 

It overlaps with https://github.com/zetkin/app.zetkin.org/pull/3189 in the `valueGetter`. A merged version should check for null and then join to string.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3199
