### PR TITLE
ZUI text editor: fix list toggle

### DIFF
--- a/src/zui/ZUITextEditor/helpers.ts
+++ b/src/zui/ZUITextEditor/helpers.ts
@@ -28,6 +28,15 @@ const toggleBlock = (editor: Editor, format: string): void => {
   const isActive = isBlockActive(editor, format);
   const isList = LIST_TYPES.includes(format);
 
+  if (!isList) {
+    const newProperties: Partial<SlateElement> = {
+      // @ts-ignore
+      type: isActive ? 'paragraph' : format,
+    };
+    Transforms.setNodes<SlateElement>(editor, newProperties);
+    return;
+  }
+
   Transforms.unwrapNodes(editor, {
     match: (n) =>
       !Editor.isEditor(n) &&
@@ -36,17 +45,19 @@ const toggleBlock = (editor: Editor, format: string): void => {
     split: true,
   });
 
-  const newProperties: Partial<SlateElement> = {
-    // @ts-ignore
-    type: isActive ? 'paragraph' : isList ? 'list-item' : format,
-  };
-  Transforms.setNodes<SlateElement>(editor, newProperties);
+  Transforms.unwrapNodes(editor, {
+    match: (n) =>
+      !Editor.isEditor(n) &&
+      SlateElement.isElement(n) &&
+      n.type === 'list-item',
+  });
 
   if (!isActive && isList) {
     const block = { children: [], type: format };
 
     // @ts-ignore
     Transforms.wrapNodes(editor, block);
+    Transforms.wrapNodes(editor, { children: [], type: 'list-item' });
   }
 };
 


### PR DESCRIPTION
## Description
This PR fixes the way lists toggle on or off in the text editor. https://github.com/zetkin/app.zetkin.org/issues/1540 showed how it kept breaking on refresh. 

The problem was that the toggle button doesn't fully unwrap and wrap list items. A list item needs to have a hierarchy like bullet-list > list-item > paragraph. The old code basically removed only the bullet-list. And the markdown serializer interpreted the list item as a list. 

The new code keeps the structure alive that is already given by slate. It always wraps the element with bullet-list > list-item on toggle active. And unwraps both on toggle inactive.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1540
