### PR TITLE
ZUI Previewable Input: improve focus code

### DIFF
--- a/src/zui/ZUIPreviewableInput/index.tsx
+++ b/src/zui/ZUIPreviewableInput/index.tsx
@@ -38,7 +38,11 @@ function ZUIPreviewableInput<
         {renderInput({
           ref: (elem) => {
             if (focusingRef.current) {
-              elem?.focus();
+              if (elem) {
+                elem.focus();
+                elem.setSelectionRange(elem.value.length, elem.value.length);
+                elem.scrollTop = elem.scrollHeight;
+              }
               focusingRef.current = false;
             }
           },


### PR DESCRIPTION
## Description
This PR puts the caret of the input at the end when starting to edit a field using `ZUIPreviewableInput` according to https://github.com/zetkin/app.zetkin.org/issues/1231


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/1231
