### PR TITLE
Remove journey column if no journeys

### DIFF
--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -120,7 +120,7 @@ const PersonProfilePage: PageWithLayout = () => {
             )}
           </ZUIFuture>
         </Grid>
-        {journeysFuture.data?.length && (
+        {!!journeysFuture.data?.length && (
           <Grid size={{ lg: 4, xs: 12 }}>
             <PersonJourneysCard orgId={orgId} personId={personId} />
           </Grid>


### PR DESCRIPTION
## Description
This PR fixes issue #3198. For people with no journeys linked to them, a column with only `0` was displayed in the profile.  


## Screenshots
Before: see screenshot in issue #3198.
After: 
<img width="1269" height="737" alt="image" src="https://github.com/user-attachments/assets/25c99715-837d-48bc-8a1d-aad8cb279ebb" />



## Changes
* Small change in the conditional render for journey data: converting the condition into a boolean. Otherwise, the `0` will be rendered directly.


## Notes to reviewer
--

## Related issues
Resolves #3198 
