### PR TITLE
Trigger onClickAway on mouseDown or touchStart

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -151,8 +151,8 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
   return (
     <ClickAwayListener
       mouseEvent="onMouseDown"
-      touchEvent="onTouchStart"
       onClickAway={clickAwayProps.onClickAway}
+      touchEvent="onTouchStart"
     >
       <Box {...containerProps}>
         <PreviewableSurveyInput

--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -84,8 +84,8 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
   return (
     <ClickAwayListener
       mouseEvent="onMouseDown"
-      touchEvent="onTouchStart"
       onClickAway={clickAwayProps.onClickAway}
+      touchEvent="onTouchStart"
     >
       <Box {...containerProps}>
         <PreviewableSurveyInput

--- a/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/TextBlock.tsx
@@ -53,8 +53,8 @@ const TextBlock: FC<TextBlockProps> = ({
   return (
     <ClickAwayListener
       mouseEvent="onMouseDown"
-      touchEvent="onTouchStart"
       onClickAway={clickAwayProps.onClickAway}
+      touchEvent="onTouchStart"
     >
       <Box {...containerProps}>
         <PreviewableSurveyInput


### PR DESCRIPTION
## Description
This PR makes sure that `onClickAway` is fired not only when the user clicks outside of the element, but also onto another element. Previously, we never reached `save()`, because the `onClick` of the next question was fired first. 

Now, `onClickAway` is triggered already at `mouseDown` or `touchStart`, before the `idOfBlockInEditMode` is updated to the new question.

## Screenshots
See before in issue #3158 
After: 

https://github.com/user-attachments/assets/f42dc3e8-177b-489f-b7ea-c79378ea3ea2



## Changes
* Adding `mouseEvent` and `touchEvent` to the props for the `ClickAwayListener`.

## Notes to reviewer
Steps to reproduce: 
- Change text in a survey question
- Click directly onto another question
- refresh
=> the changes are now persisted.

## Related issues
Resolves #3158 
