### PR TITLE
Replace some instances of deprecated makeStyles

### DIFF
--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -1,39 +1,18 @@
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
-import { Theme } from '@mui/material/styles';
-import { Breadcrumbs, Link, Typography, useMediaQuery } from '@mui/material';
+import {
+  Box,
+  Breadcrumbs,
+  Link,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 
 import { Breadcrumb } from 'utils/types';
 import { Msg } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import useBreadcrumbElements from '../hooks/useBreadcrumbs';
 import oldTheme from 'theme';
-
-const useStyles = makeStyles<Theme, { highlight?: boolean }>(() =>
-  createStyles({
-    breadcrumb: {
-      display: 'block',
-      maxWidth: '200px',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      transition: 'font-size 0.2s ease',
-      whiteSpace: 'nowrap',
-    },
-    root: {
-      '& > * + *': {
-        marginTop: oldTheme.spacing(2),
-      },
-      [oldTheme.breakpoints.down('sm')]: {
-        width: '100%',
-      },
-    },
-    viewTitle: {
-      fontWeight: ({ highlight }) => (highlight ? 'bolder' : 'inherit'),
-    },
-  })
-);
 
 function validMessageId(
   idStr: string
@@ -50,9 +29,9 @@ const BreadcrumbTrail = ({
 }: {
   highlight?: boolean;
 }): JSX.Element | null => {
-  const classes = useStyles({ highlight });
   const breadcrumbs = useBreadcrumbElements();
   const smallScreen = useMediaQuery('(max-width:700px)');
+
   const mediumScreen = useMediaQuery('(max-width:960px)');
   const largeScreen = useMediaQuery('(max-width:1200px)');
 
@@ -68,7 +47,13 @@ const BreadcrumbTrail = ({
   };
 
   return (
-    <div className={classes.root}>
+    <Box
+      sx={{
+        [oldTheme.breakpoints.down('sm')]: {
+          width: '100%',
+        },
+      }}
+    >
       <Breadcrumbs
         aria-label="breadcrumb"
         itemsAfterCollapse={smallScreen ? 1 : mediumScreen ? 2 : 3}
@@ -86,8 +71,15 @@ const BreadcrumbTrail = ({
                 passHref
               >
                 <Link
-                  className={classes.breadcrumb}
                   color="inherit"
+                  sx={{
+                    display: 'block',
+                    maxWidth: '200px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    transition: 'font-size 0.2s ease',
+                    whiteSpace: 'nowrap',
+                  }}
                   underline="hover"
                 >
                   {getLabel(crumb)}
@@ -98,7 +90,11 @@ const BreadcrumbTrail = ({
             return (
               <Typography
                 key={crumb.href}
-                classes={{ root: classes.viewTitle }}
+                sx={{
+                  p: {
+                    fontWeight: highlight ? 'bolder' : 'inherit',
+                  },
+                }}
               >
                 {getLabel(crumb)}
               </Typography>
@@ -106,7 +102,7 @@ const BreadcrumbTrail = ({
           }
         })}
       </Breadcrumbs>
-    </div>
+    </Box>
   );
 };
 

--- a/src/features/calendar/components/EventCluster/Event.tsx
+++ b/src/features/calendar/components/EventCluster/Event.tsx
@@ -1,6 +1,5 @@
-import makeStyles from '@mui/styles/makeStyles';
 import { useState } from 'react';
-import { Box, Theme, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import EventSelectionCheckBox from 'features/events/components/EventSelectionCheckBox';
 import Field from './Field';
@@ -9,73 +8,6 @@ import { useAppSelector } from 'core/hooks';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { allCollapsedPresentableFields, availableHeightByEvent } from './utils';
 import oldTheme from 'theme';
-
-interface StyleProps {
-  cancelled: boolean;
-  draft: boolean;
-  collapsed: boolean;
-  hasTopBadge: boolean;
-  height: number;
-  width: string;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  collapsedContainer: {
-    alignItems: 'center',
-    borderBottomLeftRadius: 4,
-    borderBottomRightRadius: 4,
-    borderTopLeftRadius: ({ hasTopBadge }) => (hasTopBadge ? '0px' : '4px'),
-    borderTopRightRadius: 4,
-    display: 'flex',
-    height: '100%',
-    justifyContent: 'space-between',
-    padding: '0 4px 0 8px',
-    width: '100%',
-  },
-  container: {
-    alignItems: ({ collapsed }) => (collapsed ? 'center' : ''),
-    background: ({ cancelled, draft }) =>
-      `linear-gradient(to right, ${
-        cancelled || draft
-          ? oldTheme.palette.secondary.main
-          : oldTheme.palette.primary.main
-      } 4px, white 4px)`,
-    border: `1px solid ${oldTheme.palette.grey[300]}`,
-    borderBottomLeftRadius: 4,
-    borderBottomRightRadius: 4,
-    borderTopLeftRadius: ({ hasTopBadge }) => (hasTopBadge ? '0px' : '4px'),
-    borderTopRightRadius: 4,
-    display: 'flex',
-    flexDirection: ({ collapsed }) => (collapsed ? 'row' : 'column'),
-    fontSize: 12,
-    gap: '4px 0',
-    height: ({ height }) => height,
-    justifyContent: 'space-between',
-    minHeihgt: '20px',
-    position: 'relative',
-    width: ({ width }) => width,
-  },
-  fieldGroupContainer: {
-    borderTop: `1px solid ${oldTheme.palette.grey[300]}`,
-  },
-  fieldGroups: {
-    display: 'flex',
-    flexFlow: 'column',
-    overflowY: 'hidden',
-  },
-  title: {
-    fontSize: '14px',
-    minHeight: '20px',
-    overflow: 'hidden',
-    textDecoration: ({ cancelled }) => (cancelled ? 'line-through' : ''),
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  titleContainer: {
-    borderTopLeftRadius: ({ hasTopBadge }) => (hasTopBadge ? '0px' : '4px'),
-    borderTopRightRadius: 4,
-  },
-}));
 
 interface Participants {
   kind: 'Participants';
@@ -163,33 +95,67 @@ const Event = ({
     fieldGroups.length
   );
 
-  const classes = useStyles({
-    cancelled,
-    collapsed,
-    draft,
-    hasTopBadge: !!topBadge,
-    height,
-    width,
-  });
-
   const selectedEvents = useAppSelector(
     (state) => state.events.selectedEventIds
   );
 
+  const titleStyle = {
+    fontSize: '14px',
+    minHeight: '20px',
+    overflow: 'hidden',
+    textDecoration: cancelled ? 'line-through' : '',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+
   return (
     <Box
-      className={classes.container}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      sx={{
+        alignItems: collapsed ? 'center' : '',
+        background: `linear-gradient(to right, ${
+          cancelled || draft
+            ? oldTheme.palette.secondary.main
+            : oldTheme.palette.primary.main
+        } 4px, white 4px)`,
+        border: `1px solid ${oldTheme.palette.grey[300]}`,
+        borderBottomLeftRadius: 4,
+        borderBottomRightRadius: 4,
+        borderTopLeftRadius: topBadge ? '0px' : '4px',
+        borderTopRightRadius: 4,
+        display: 'flex',
+        flexDirection: collapsed ? 'row' : 'column',
+        fontSize: 12,
+        gap: '4px 0',
+        height: height,
+        justifyContent: 'space-between',
+        minHeihgt: '20px',
+        position: 'relative',
+        width: width,
+      }}
     >
       {topBadge}
       {collapsed && (
-        <Box className={classes.collapsedContainer}>
-          <Box className={classes.title} display="flex">
+        <Box
+          sx={{
+            alignItems: 'center',
+            borderBottomLeftRadius: 4,
+            borderBottomRightRadius: 4,
+            borderTopLeftRadius: topBadge ? '0px' : '4px',
+            borderTopRightRadius: 4,
+            display: 'flex',
+            height: '100%',
+            justifyContent: 'space-between',
+            padding: '0 4px 0 8px',
+            width: '100%',
+          }}
+        >
+          <Box display="flex" sx={titleStyle}>
             {(isHovered || selectedEvents.length > 0) && (
               <EventSelectionCheckBox events={events} />
             )}
-            <Typography className={classes.title}>{title}</Typography>
+            <Typography sx={titleStyle}>{title}</Typography>
           </Box>
           <Box display="flex">
             {allCollapsedPresentableFields(fieldGroups).map((field, index) => {
@@ -207,19 +173,33 @@ const Event = ({
       )}
       {!collapsed && (
         <Box height="100%">
-          <Box className={classes.titleContainer}>
+          <Box
+            sx={{
+              borderTopLeftRadius: topBadge ? '0px' : '4px',
+              borderTopRightRadius: 4,
+            }}
+          >
             <Box alignItems="center" display="flex" sx={{ pl: 1 }}>
               {(isHovered || selectedEvents.length > 0) && (
                 <EventSelectionCheckBox events={events} />
               )}
-              <Typography className={classes.title}>{title}</Typography>
+              <Typography sx={titleStyle}>{title}</Typography>
             </Box>
           </Box>
-          <Box className={classes.fieldGroups}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexFlow: 'column',
+              overflowY: 'hidden',
+            }}
+          >
             {fieldGroups.map((fields, index) => (
               <Box
                 key={`fieldGroup-${index}`}
-                className={index > 0 ? classes.fieldGroupContainer : ''}
+                sx={{
+                  borderTop:
+                    index > 0 ? `1px solid ${oldTheme.palette.grey[300]}` : '',
+                }}
               >
                 <FieldGroup
                   fields={fields}

--- a/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
+++ b/src/features/campaigns/components/ActivitiesOverview/items/OverviewListItem.tsx
@@ -1,7 +1,6 @@
-import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
-import { Box, SvgIconTypeMap, Theme, Tooltip, Typography } from '@mui/material';
+import { Box, SvgIconTypeMap, Tooltip, Typography } from '@mui/material';
 
 import { CampaignActivity } from 'features/campaigns/types';
 import getStatusDotLabel from 'features/events/utils/getStatusDotLabel';
@@ -12,47 +11,6 @@ import ZUIRelativeTime from 'zui/ZUIRelativeTime';
 import ZUISuffixedNumber from 'zui/ZUISuffixedNumber';
 import ZUIIconLabel, { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
 import oldTheme from 'theme';
-
-interface StyleProps {
-  color: STATUS_COLORS;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  container: {
-    alignItems: 'center',
-    display: 'flex',
-    padding: '1em',
-  },
-  dot: {
-    backgroundColor: ({ color }) => oldTheme.palette.statusColors[color],
-    borderRadius: '100%',
-    height: '10px',
-    marginLeft: 'auto',
-    marginRight: 'auto',
-    width: '10px',
-  },
-  endNumber: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'flex-start',
-  },
-  left: {
-    alignItems: 'center',
-    display: 'flex',
-  },
-  primaryIcon: {
-    color: oldTheme.palette.grey[500],
-    fontSize: '28px',
-  },
-  right: {
-    alignItems: 'center',
-    display: 'flex',
-  },
-  secondaryIcon: {
-    color: oldTheme.palette.grey[700],
-    margin: '0 0.5em',
-  },
-}));
 
 export enum STATUS_COLORS {
   BLUE = 'blue',
@@ -100,8 +58,6 @@ const OverviewListItem = ({
   subtitle,
 }: OverviewListItemProps) => {
   //const color = getStatusColor(startDate, endDate);
-  const classes = useStyles({ color });
-
   const now = new Date();
   let label: JSX.Element | null = null;
 
@@ -175,7 +131,12 @@ const OverviewListItem = ({
           justifyContent="space-between"
         >
           <Box flex="0 0" width={30}>
-            <PrimaryIcon className={classes.primaryIcon} />
+            <PrimaryIcon
+              sx={{
+                color: oldTheme.palette.grey[500],
+                fontSize: '28px',
+              }}
+            />
           </Box>
           <Box
             sx={{
@@ -215,7 +176,16 @@ const OverviewListItem = ({
         <Box alignItems="center" display="flex" justifyContent="space-between">
           <Box width={30}>
             <Tooltip title={getStatusDotLabel({ color })}>
-              <Box className={classes.dot} />
+              <Box
+                sx={{
+                  backgroundColor: oldTheme.palette.statusColors[color],
+                  borderRadius: '100%',
+                  height: '10px',
+                  marginLeft: 'auto',
+                  marginRight: 'auto',
+                  width: '10px',
+                }}
+              />
             </Tooltip>
           </Box>
           <Box width="calc(100% - 30px - 80px - 20px)">

--- a/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
+++ b/src/features/campaigns/components/ActivityList/items/ActivityListItem.tsx
@@ -1,61 +1,10 @@
-import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
-import { Box, SvgIconTypeMap, Theme, Tooltip, Typography } from '@mui/material';
+import { Box, SvgIconTypeMap, Tooltip, Typography } from '@mui/material';
 
 import getStatusDotLabel from 'features/events/utils/getStatusDotLabel';
 import oldTheme from 'theme';
 import ZUIIconLabel, { ZUIIconLabelProps } from 'zui/ZUIIconLabel';
-
-interface StyleProps {
-  color: STATUS_COLORS;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  container: {
-    alignItems: 'center',
-    cursor: 'pointer',
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: '1.0em 0.5em',
-  },
-  dot: {
-    backgroundColor: ({ color }) => oldTheme.palette.statusColors[color],
-    borderRadius: '100%',
-    flexShrink: 0,
-    height: '10px',
-    marginLeft: '0.5em',
-    marginRight: '0.5em',
-    width: '10px',
-  },
-  endNumber: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'flex-start',
-    width: '7em',
-  },
-  left: {
-    alignItems: 'center',
-    display: 'flex',
-    flex: '1 0',
-    gap: '1em',
-  },
-  meta: {
-    width: '8em',
-  },
-  primaryIcon: {
-    color: oldTheme.palette.grey[500],
-    fontSize: '28px',
-  },
-  right: {
-    alignItems: 'center',
-    display: 'flex',
-  },
-  secondaryIcon: {
-    color: oldTheme.palette.grey[700],
-    margin: '0 0.5em',
-  },
-}));
 
 export enum STATUS_COLORS {
   BLUE = 'blue',
@@ -94,24 +43,50 @@ const ActivityListItem = ({
   endNumber,
   endNumberColor = 'secondary',
 }: AcitivityListItemProps) => {
-  const classes = useStyles({ color });
-
   return (
     <NextLink href={href} passHref style={{ textDecoration: 'none' }}>
       <Box
-        className={classes.container}
         onClick={(evt) => {
           if (onEventItemClick) {
             evt.preventDefault();
             onEventItemClick(evt.clientX, evt.clientY);
           }
         }}
+        sx={{
+          alignItems: 'center',
+          cursor: 'pointer',
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: '1.0em 0.5em',
+        }}
       >
-        <Box className={classes.left}>
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            flex: '1 0',
+            gap: '1em',
+          }}
+        >
           <Tooltip title={getStatusDotLabel({ color })}>
-            <Box className={classes.dot} />
+            <Box
+              sx={{
+                backgroundColor: oldTheme.palette.statusColors[color],
+                borderRadius: '100%',
+                flexShrink: 0,
+                height: '10px',
+                marginLeft: '0.5em',
+                marginRight: '0.5em',
+                width: '10px',
+              }}
+            />
           </Tooltip>
-          <PrimaryIcon className={classes.primaryIcon} />
+          <PrimaryIcon
+            sx={{
+              color: oldTheme.palette.grey[500],
+              fontSize: '28px',
+            }}
+          />
           <Box>
             <Typography color={oldTheme.palette.text.primary}>
               {title}
@@ -123,9 +98,22 @@ const ActivityListItem = ({
             )}
           </Box>
         </Box>
-        <Box className={classes.meta}>{meta}</Box>
+        <Box
+          sx={{
+            width: '8em',
+          }}
+        >
+          {meta}
+        </Box>
         <Box>
-          <Box className={classes.endNumber}>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              justifyContent: 'flex-start',
+              width: '7em',
+            }}
+          >
             <ZUIIconLabel
               color={endNumberColor}
               icon={<SecondaryIcon color={endNumberColor} />}

--- a/src/features/joinForms/components/JoinFormListItem.tsx
+++ b/src/features/joinForms/components/JoinFormListItem.tsx
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
 import { FormatListBulleted, OpenInNew } from '@mui/icons-material';
-import makeStyles from '@mui/styles/makeStyles';
 import { Box, Button, Typography } from '@mui/material';
 
 import oldTheme from 'theme';
@@ -13,36 +12,6 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
 import useJoinFormMutations from '../hooks/useJoinFormMutations';
-
-const useStyles = makeStyles({
-  container: {
-    alignItems: 'center',
-    cursor: 'pointer',
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: '1.0em 0.5em',
-  },
-  endNumber: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'flex-start',
-    width: '7em',
-  },
-  icon: {
-    color: oldTheme.palette.grey[500],
-    fontSize: '28px',
-  },
-  left: {
-    alignItems: 'center',
-    display: 'flex',
-    flex: '1 0',
-    gap: '1em',
-  },
-  right: {
-    alignItems: 'center',
-    display: 'flex',
-  },
-});
 
 export enum STATUS_COLORS {
   BLUE = 'blue',
@@ -58,7 +27,6 @@ type Props = {
 };
 
 const JoinFormListItem = ({ form, onClick }: Props) => {
-  const classes = useStyles();
   const apiClient = useApiClient();
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -77,20 +45,45 @@ const JoinFormListItem = ({ form, onClick }: Props) => {
 
   return (
     <Box
-      className={classes.container}
       onClick={() => {
         onClick();
       }}
+      sx={{
+        alignItems: 'center',
+        cursor: 'pointer',
+        display: 'flex',
+        justifyContent: 'space-between',
+        padding: '1.0em 0.5em',
+      }}
     >
-      <Box className={classes.left}>
-        <FormatListBulleted className={classes.icon} />
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          flex: '1 0',
+          gap: '1em',
+        }}
+      >
+        <FormatListBulleted
+          sx={{
+            color: oldTheme.palette.grey[500],
+            fontSize: '28px',
+          }}
+        />
         <Box alignItems="center" display="flex" gap={1}>
           <Typography>{form.title}</Typography>
           <Typography color="secondary">(#{form.id})</Typography>
         </Box>
       </Box>
       <Box>
-        <Box className={classes.endNumber}>
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'flex-start',
+            width: '7em',
+          }}
+        >
           {/* TODO: Add stats
             <ZUIIconLabel
               icon={<SecondaryIcon color={endNumberColor} />}

--- a/src/features/journeys/components/JourneyInstanceCreateFab.tsx
+++ b/src/features/journeys/components/JourneyInstanceCreateFab.tsx
@@ -2,20 +2,10 @@ import { Add } from '@mui/icons-material';
 import { Fab } from '@mui/material';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import makeStyles from '@mui/styles/makeStyles';
 
 import oldTheme from 'theme';
 
-const useStyles = makeStyles(() => ({
-  fab: {
-    bottom: oldTheme.spacing(10),
-    position: 'fixed',
-    right: oldTheme.spacing(4),
-  },
-}));
-
 const JourneyInstanceCreateFab: React.FunctionComponent = () => {
-  const classes = useStyles();
   const { orgId, journeyId } = useRouter().query;
 
   return (
@@ -25,9 +15,13 @@ const JourneyInstanceCreateFab: React.FunctionComponent = () => {
       passHref
     >
       <Fab
-        className={classes.fab}
         color="primary"
         data-testid="JourneyInstanceOverviewPage-addFab"
+        sx={{
+          bottom: oldTheme.spacing(10),
+          position: 'fixed',
+          right: oldTheme.spacing(4),
+        }}
       >
         <Add />
       </Fab>

--- a/src/features/journeys/components/JourneyStatusChip.tsx
+++ b/src/features/journeys/components/JourneyStatusChip.tsx
@@ -1,23 +1,9 @@
 import { Chip } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 
 import { useMessages } from 'core/i18n';
 import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 import messageIds from '../l10n/messageIds';
 import oldTheme from 'theme';
-
-const useStyles = makeStyles(() => ({
-  closedChip: {
-    backgroundColor: oldTheme.palette.error.main,
-    color: 'white',
-    fontWeight: 'bold',
-  },
-  openChip: {
-    backgroundColor: oldTheme.palette.success.main,
-    color: 'white',
-    fontWeight: 'bold',
-  },
-}));
 
 interface JourneyStatusChipProps {
   instance: Pick<ZetkinJourneyInstance, 'closed'>;
@@ -25,18 +11,21 @@ interface JourneyStatusChipProps {
 
 const JourneyStatusChip: React.FC<JourneyStatusChipProps> = ({ instance }) => {
   const messages = useMessages(messageIds);
-  const classes = useStyles();
-  return !instance.closed ? (
+  return (
     <Chip
-      className={classes.openChip}
       data-testid="journey-status"
-      label={messages.journeys.statusOpen()}
-    />
-  ) : (
-    <Chip
-      className={classes.closedChip}
-      data-testid="journey-status"
-      label={messages.journeys.statusClosed()}
+      label={
+        instance.closed
+          ? messages.journeys.statusClosed()
+          : messages.journeys.statusOpen()
+      }
+      sx={{
+        backgroundColor: instance.closed
+          ? oldTheme.palette.error.main
+          : oldTheme.palette.success.main,
+        color: 'white',
+        fontWeight: 'bold',
+      }}
     />
   );
 };

--- a/src/features/profile/components/PersonCard.tsx
+++ b/src/features/profile/components/PersonCard.tsx
@@ -1,4 +1,3 @@
-import makeStyles from '@mui/styles/makeStyles';
 import {
   Card,
   List,
@@ -15,29 +14,12 @@ import ZUISection from 'zui/ZUISection';
 import messageIds from '../l10n/messageIds';
 import oldTheme from 'theme';
 
-const useStyles = makeStyles(() => ({
-  divider: {
-    marginLeft: 72,
-  },
-  editButton: {
-    '& span': {
-      fontWeight: 'bold',
-    },
-    color: oldTheme.palette.primary.main,
-    textTransform: 'uppercase',
-  },
-  title: {
-    marginBottom: oldTheme.spacing(1),
-  },
-}));
-
 const PersonCard: React.FunctionComponent<{
   children: React.ReactNode;
   onClickEdit?: ReactEventHandler;
   title: string;
 }> = ({ onClickEdit, title, children }) => {
   const [editable, setEditable] = useState<boolean>();
-  const classes = useStyles();
   const messages = useMessages(messageIds);
 
   const onToggleEdit = (evt: SyntheticEvent) => {
@@ -63,12 +45,18 @@ const PersonCard: React.FunctionComponent<{
                   )}
                 </ListItemIcon>
                 <ListItemText
-                  className={classes.editButton}
                   primary={
                     editable
                       ? messages.editButtonClose({ title })
                       : messages.editButton({ title })
                   }
+                  sx={{
+                    color: oldTheme.palette.primary.main,
+                    span: {
+                      fontWeight: 'bold',
+                    },
+                    textTransform: 'uppercase',
+                  }}
                 />
               </ListItemButton>
             </ListItem>

--- a/src/features/profile/components/PersonOrganizationsCard/OrganizationsTree.tsx
+++ b/src/features/profile/components/PersonOrganizationsCard/OrganizationsTree.tsx
@@ -13,7 +13,6 @@ import {
   ListItemSecondaryAction,
   ListItemText,
 } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 
 import globalMessageIds from 'core/i18n/messageIds';
 import { useMessages } from 'core/i18n';
@@ -27,18 +26,6 @@ type OrganizationProps = {
   organizationTree: PersonOrganization;
 };
 
-const useStyles = makeStyles({
-  divider: {
-    marginLeft: 72,
-  },
-  inactive: {
-    opacity: 0.3,
-  },
-  listItemText: {
-    marginLeft: ({ level }: { level: number }) => level * 10,
-  },
-});
-
 export const OrganizationsTree: React.FunctionComponent<OrganizationProps> = ({
   editable,
   level = 0,
@@ -49,7 +36,6 @@ export const OrganizationsTree: React.FunctionComponent<OrganizationProps> = ({
   const globalMessages = useMessages(globalMessageIds);
   const messages = useMessages(messageIds);
   const hasChildren = !!sub_orgs?.length;
-  const classes = useStyles({ level });
   const getIcon = () => {
     if (level === 0) {
       return <AccountTree />;
@@ -64,14 +50,20 @@ export const OrganizationsTree: React.FunctionComponent<OrganizationProps> = ({
 
   return (
     <Collapse appear in>
-      <ListItem className={is_active ? undefined : classes.inactive}>
+      <ListItem
+        sx={{
+          opacity: is_active ? undefined : 0.3,
+        }}
+      >
         <ListItemIcon>{getIcon()}</ListItemIcon>
         <ListItemText
-          className={classes.listItemText}
           primary={title}
           secondary={
             role ? globalMessages.roles[role]() : messages.role.noRole()
           }
+          sx={{
+            marginLeft: `${level * 10}px`,
+          }}
         />
         <ListItemSecondaryAction>
           <IconButton edge="end" onClick={() => onClickRemove(id)} size="large">
@@ -79,7 +71,11 @@ export const OrganizationsTree: React.FunctionComponent<OrganizationProps> = ({
           </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
-      <Divider className={classes.divider} />
+      <Divider
+        sx={{
+          marginLeft: '72px',
+        }}
+      />
       {hasChildren &&
         sub_orgs.map((org) => (
           <OrganizationsTree

--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -1,84 +1,12 @@
 import { Clear } from '@mui/icons-material';
 import { useState } from 'react';
-import { Box, IconButton, lighten, Theme, Tooltip } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { Box, IconButton, lighten, Tooltip } from '@mui/material';
 
 import { DEFAULT_TAG_COLOR } from '../utils';
 import { getContrastColor } from 'utils/colorUtils';
 import { ZetkinAppliedTag, ZetkinTag } from 'utils/types/zetkin';
 
 type TagChipSize = 'small' | 'medium' | 'large';
-
-interface StyleProps {
-  clickable: boolean;
-  deletable: boolean;
-  disabled: boolean;
-  hover: boolean;
-  size: TagChipSize;
-  tag: ZetkinTag;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  chip: {
-    borderRadius: '1em',
-    cursor: ({ clickable, disabled }) =>
-      clickable && !disabled ? 'pointer' : 'default',
-    display: 'flex',
-    fontSize: ({ size }) =>
-      ({
-        large: '1.2em',
-        medium: '1.0em',
-        small: '0.8em',
-      }[size]),
-    lineHeight: 'normal',
-    marginRight: '0.1em',
-    opacity: ({ disabled }) => (disabled ? 0.5 : 1.0),
-    overflow: 'hidden',
-  },
-  deleteButton: {
-    fontSize: '1.1rem',
-    padding: '3px',
-    position: 'absolute',
-    right: '0.12em',
-    transform: ({ deletable, hover }) =>
-      deletable && hover ? 'translate(0,0)' : 'translate(2rem, 0)',
-    transition: ({ deletable, hover }) =>
-      deletable && hover ? 'transform 0.1s 0.1s' : 'transform 0.1s',
-  },
-  deleteContainer: {
-    padding: ({ deletable, hover }) => {
-      if (deletable) {
-        return hover ? '0.2em 1.5em 0.2em 0.7em' : '0.2em 1em';
-      } else {
-        return '0.2em 0.6em';
-      }
-    },
-    position: 'relative',
-    transition: 'padding 0.1s',
-  },
-  deleteIcon: {
-    color: ({ tag }) =>
-      tag.value_type
-        ? 'black'
-        : getContrastColor(tag.color || DEFAULT_TAG_COLOR),
-  },
-  label: {
-    backgroundColor: ({ tag }) => tag.color || DEFAULT_TAG_COLOR,
-    color: ({ tag }) => getContrastColor(tag.color || DEFAULT_TAG_COLOR),
-    maxWidth: '100%',
-    overflow: 'hidden',
-    padding: '0.2em 0.4em 0.2em 1em',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  value: {
-    backgroundColor: ({ tag }) => lighten(tag.color || DEFAULT_TAG_COLOR, 0.7),
-    maxWidth: '10em',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-}));
 
 const TagToolTip: React.FunctionComponent<{
   children: JSX.Element;
@@ -113,20 +41,31 @@ const TagChip: React.FunctionComponent<{
   tag: ZetkinTag | ZetkinAppliedTag;
 }> = ({ disabled = false, onClick, onDelete, size = 'medium', tag }) => {
   const [hover, setHover] = useState(false);
-  const classes = useStyles({
-    clickable: !!onClick,
-    deletable: !!onDelete,
-    disabled,
-    hover,
-    size,
-    tag,
-  });
-
+  const clickable = !!onClick;
+  const deletable = !!onDelete;
   const hasValue = isValueTag(tag);
+
+  const labelStyle = {
+    backgroundColor: tag.color || DEFAULT_TAG_COLOR,
+    color: getContrastColor(tag.color || DEFAULT_TAG_COLOR),
+    maxWidth: '100%',
+    overflow: 'hidden',
+    padding: '0.2em 0.4em 0.2em 1em',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  };
+  const deleteContainerStyle = {
+    padding: deletable
+      ? hover
+        ? '0.2em 1.5em 0.2em 0.7em'
+        : '0.2em 1em'
+      : '0.2em 0.6em',
+    position: 'relative',
+    transition: 'padding 0.1s',
+  };
 
   const deleteButton = onDelete ? (
     <IconButton
-      className={classes.deleteButton}
       data-testid="TagChip-deleteButton"
       onClick={(ev) => {
         // Stop propagation to prevent regular onClick() from being invoked
@@ -134,28 +73,66 @@ const TagChip: React.FunctionComponent<{
         onDelete(tag as ZetkinAppliedTag);
       }}
       size="large"
+      sx={{
+        fontSize: '1.1rem',
+        padding: '3px',
+        position: 'absolute',
+        right: '0.12em',
+        transform: deletable && hover ? 'translate(0,0)' : 'translate(2rem, 0)',
+        transition:
+          deletable && hover ? 'transform 0.1s 0.1s' : 'transform 0.1s',
+      }}
       tabIndex={-1}
     >
-      <Clear className={classes.deleteIcon} fontSize="inherit" />
+      <Clear
+        fontSize="inherit"
+        sx={{
+          color: tag.value_type
+            ? 'black'
+            : getContrastColor(tag.color || DEFAULT_TAG_COLOR),
+        }}
+      />
     </IconButton>
   ) : null;
 
   return (
     <Box
-      className={classes.chip}
       onClick={() => !disabled && onClick && onClick(tag)}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      sx={{
+        borderRadius: '1em',
+        cursor: clickable && !disabled ? 'pointer' : 'default',
+        display: 'flex',
+        fontSize: {
+          large: '1.2em',
+          medium: '1.0em',
+          small: '0.8em',
+        }[size],
+        lineHeight: 'normal',
+        marginRight: '0.1em',
+        opacity: disabled ? 0.5 : 1.0,
+        overflow: 'hidden',
+      }}
     >
       {hasValue && (
         <>
           <TagToolTip tag={tag}>
-            <Box className={classes.label}>{tag.title}</Box>
+            <Box sx={labelStyle}>{tag.title}</Box>
           </TagToolTip>
           <Tooltip arrow title={tag.value || ''}>
             <Box
-              className={classes.value + ' ' + classes.deleteContainer}
               data-testid="TagChip-value"
+              sx={[
+                {
+                  backgroundColor: lighten(tag.color || DEFAULT_TAG_COLOR, 0.7),
+                  maxWidth: '10em',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                },
+                deleteContainerStyle,
+              ]}
             >
               {tag.value}
               {deleteButton}
@@ -165,7 +142,7 @@ const TagChip: React.FunctionComponent<{
       )}
       {!hasValue && (
         <TagToolTip tag={tag}>
-          <Box className={classes.label + ' ' + classes.deleteContainer}>
+          <Box sx={[labelStyle, deleteContainerStyle]}>
             {tag.title}
             {deleteButton}
           </Box>

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -1,4 +1,3 @@
-import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import NProgress from 'nprogress';
 import {
@@ -101,20 +100,6 @@ declare module '@mui/x-data-grid-pro' {
   }
 }
 
-const useStyles = makeStyles(() => ({
-  '@keyframes addedRowAnimation': {
-    '0%': {
-      backgroundColor: oldTheme.palette.success.main,
-    },
-    '100%': {
-      backgroundColor: 'transparent',
-    },
-  },
-  addedRow: {
-    animation: '$addedRowAnimation 2s',
-  },
-}));
-
 const getFilterOperators = (col: Omit<GridColDef, 'field'>) => {
   const stringOperators = getGridStringOperators().filter(
     (op) => op.value !== 'isAnyOf'
@@ -176,7 +161,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 }) => {
   const theme = useTheme();
   const messages = useMessages(messageIds);
-  const classes = useStyles();
   const gridApiRef = useGridApiRef();
   const [addedId, setAddedId] = useState(0);
   const [columnToCreate, setColumnToCreate] =
@@ -584,8 +568,8 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   const getRowClassName = useCallback(
     (params: GridRowClassNameParams): string =>
-      params.id == addedId ? classes.addedRow : '',
-    [addedId, classes.addedRow]
+      params.id == addedId ? 'addedRow' : '',
+    [addedId]
   );
 
   const localeText = useMemo(
@@ -732,7 +716,22 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         slotProps={componentsProps}
         slots={slots}
         style={style}
-        sx={mainSx}
+        sx={[
+          mainSx,
+          {
+            '.addedRow': {
+              '@keyframes addedRowAnimation': {
+                from: {
+                  backgroundColor: oldTheme.palette.success.main,
+                },
+                to: {
+                  backgroundColor: 'transparent',
+                },
+              },
+              animation: 'addedRowAnimation 2s',
+            },
+          },
+        ]}
         {...modelGridProps}
       />
 

--- a/src/features/views/layout/SharedViewLayout.tsx
+++ b/src/features/views/layout/SharedViewLayout.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
 import { Box, Typography } from '@mui/material';
 import { Group, ViewColumnOutlined } from '@mui/icons-material';
 
@@ -13,28 +12,6 @@ import ZUIIconLabelRow from 'zui/ZUIIconLabelRow';
 import messageIds from '../l10n/messageIds';
 import oldTheme from 'theme';
 
-const useStyles = makeStyles(() => ({
-  main: {
-    overflowX: 'hidden',
-  },
-  title: {
-    marginBottom: '8px',
-    transition: 'all 0.3s ease',
-  },
-  titleGrid: {
-    alignItems: 'center',
-    display: 'grid',
-    gap: '1rem',
-    gridTemplateColumns: '1fr auto',
-    gridTemplateRows: 'auto',
-    transition: 'font-size 0.2s ease',
-    width: '100%',
-    [oldTheme.breakpoints.down('md')]: {
-      gridTemplateColumns: '1fr',
-    },
-  },
-}));
-
 interface SharedViewLayoutProps {
   children?: React.ReactNode;
 }
@@ -43,7 +20,6 @@ const SharedViewLayout: FunctionComponent<SharedViewLayoutProps> = ({
   children,
 }) => {
   const { orgId, viewId } = useNumericRouteParams();
-  const classes = useStyles();
 
   const { columnsFuture, rowsFuture } = useViewGrid(orgId, viewId);
   const viewFuture = useView(orgId, viewId);
@@ -98,7 +74,21 @@ const SharedViewLayout: FunctionComponent<SharedViewLayoutProps> = ({
       width={1}
     >
       <Box component="header" flexGrow={0} flexShrink={0} paddingLeft={2}>
-        <Box className={classes.titleGrid} mt={2}>
+        <Box
+          mt={2}
+          sx={{
+            alignItems: 'center',
+            display: 'grid',
+            gap: '1rem',
+            gridTemplateColumns: '1fr auto',
+            gridTemplateRows: 'auto',
+            transition: 'font-size 0.2s ease',
+            width: '100%',
+            [oldTheme.breakpoints.down('md')]: {
+              gridTemplateColumns: '1fr',
+            },
+          }}
+        >
           <Box
             alignItems="center"
             display="flex"
@@ -107,11 +97,14 @@ const SharedViewLayout: FunctionComponent<SharedViewLayoutProps> = ({
           >
             <Box>
               <Typography
-                className={classes.title}
                 component="div"
                 data-testid="page-title"
                 noWrap
-                style={{ display: 'flex' }}
+                sx={{
+                  display: 'flex',
+                  marginBottom: '8px',
+                  transition: 'all 0.3s ease',
+                }}
                 variant="h3"
               >
                 {title}
@@ -124,11 +117,13 @@ const SharedViewLayout: FunctionComponent<SharedViewLayoutProps> = ({
         </Box>
       </Box>
       <Box
-        className={classes.main}
         component="main"
         flexGrow={1}
         minHeight={0}
         position="relative"
+        sx={{
+          overflowX: 'hidden',
+        }}
       >
         {children}
       </Box>

--- a/src/features/views/layout/SingleViewLayout.tsx
+++ b/src/features/views/layout/SingleViewLayout.tsx
@@ -1,6 +1,5 @@
-import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
-import { Box, Button, Theme } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { FunctionComponent, useContext, useState } from 'react';
 import NProgress from 'nprogress';
 import { Group, Share, ViewColumnOutlined } from '@mui/icons-material';
@@ -26,15 +25,6 @@ import messageIds from '../l10n/messageIds';
 import SimpleLayout from 'utils/layout/SimpleLayout';
 import useView from '../hooks/useView';
 
-const useStyles = makeStyles<Theme, { deactivated: boolean }>(() => ({
-  deactivateWrapper: {
-    filter: (props) =>
-      props.deactivated ? 'grayscale(1) opacity(0.5)' : 'none',
-    pointerEvents: (props) => (props.deactivated ? 'none' : 'all'),
-    transition: 'filter 0.3s ease',
-  },
-}));
-
 interface SingleViewLayoutProps {
   children: React.ReactNode;
 }
@@ -46,7 +36,6 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   const { orgId, viewId } = useNumericRouteParams();
 
   const [deactivated, setDeactivated] = useState(false);
-  const classes = useStyles({ deactivated });
   const messages = useMessages(messageIds);
   const [queryDialogOpen, setQueryDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
@@ -167,7 +156,14 @@ const SingleViewLayout: FunctionComponent<SingleViewLayoutProps> = ({
   });
 
   return (
-    <Box key={`${viewId}`} className={classes.deactivateWrapper}>
+    <Box
+      key={`${viewId}`}
+      sx={{
+        filter: deactivated ? 'grayscale(1) opacity(0.5)' : 'none',
+        pointerEvents: deactivated ? 'none' : 'all',
+        transition: 'filter 0.3s ease',
+      }}
+    >
       <SimpleLayout
         actionButtons={
           <Button

--- a/src/utils/layout/DefaultLayout.tsx
+++ b/src/utils/layout/DefaultLayout.tsx
@@ -1,23 +1,9 @@
 import { Box } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { FunctionComponent, useState } from 'react';
 
 import { PageContainerContext } from 'utils/panes/PageContainerContext';
 import ZUIOrganizeSidebar from 'zui/ZUIOrganizeSidebar';
 import oldTheme from 'theme';
-
-const useStyles = makeStyles(() => ({
-  breadcrumbs: {
-    [oldTheme.breakpoints.down('sm')]: {
-      width: '100%',
-    },
-  },
-  root: {
-    [oldTheme.breakpoints.down('sm')]: {
-      paddingTop: '3.5rem',
-    },
-  },
-}));
 
 interface DefaultLayoutProps {
   children: React.ReactNode;
@@ -28,11 +14,18 @@ const DefaultLayout: FunctionComponent<DefaultLayoutProps> = ({
   children,
   onScroll,
 }) => {
-  const classes = useStyles();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
   return (
-    <Box className={classes.root} display="flex" height="100vh">
+    <Box
+      display="flex"
+      height="100vh"
+      sx={{
+        [oldTheme.breakpoints.down('sm')]: {
+          paddingTop: '3.5rem',
+        },
+      }}
+    >
       <ZUIOrganizeSidebar />
       <Box
         ref={(div: HTMLDivElement) => setContainer(div)}

--- a/src/utils/layout/SimpleLayout.tsx
+++ b/src/utils/layout/SimpleLayout.tsx
@@ -1,22 +1,10 @@
-import makeStyles from '@mui/styles/makeStyles';
-import { Box, Theme } from '@mui/material';
+import { Box } from '@mui/material';
 import { FunctionComponent, ReactElement, useState } from 'react';
 
 import DefaultLayout from './DefaultLayout';
 import Header from '../../zui/ZUIHeader';
 import { PaneProvider } from 'utils/panes';
 import { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
-
-interface StyleProps {
-  noPad?: boolean;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  main: {
-    overflowX: 'hidden',
-    padding: ({ noPad }) => (noPad ? 0 : undefined),
-  },
-}));
 
 interface SimpleLayoutProps {
   actionButtons?: React.ReactElement | React.ReactElement[];
@@ -42,7 +30,6 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
   title,
 }) => {
   const [collapsed, setCollapsed] = useState(false);
-  const classes = useStyles({ noPad });
 
   const onToggleCollapsed = fixedHeight
     ? (value: boolean) => setCollapsed(value)
@@ -67,12 +54,15 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
         />
         {/* Page Content */}
         <Box
-          className={classes.main}
           component="main"
           flexGrow={1}
           minHeight={0}
           p={fixedHeight ? 0 : 3}
           position="relative"
+          sx={{
+            overflowX: 'hidden',
+            padding: noPad ? 0 : undefined,
+          }}
         >
           <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
         </Box>

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -1,4 +1,3 @@
-import makeStyles from '@mui/styles/makeStyles';
 import { useRouter } from 'next/router';
 import {
   Alert,
@@ -10,7 +9,6 @@ import {
   Tab,
   TabProps,
   Tabs,
-  Theme,
 } from '@mui/material';
 import { FunctionComponent, ReactElement, useState } from 'react';
 
@@ -18,17 +16,6 @@ import DefaultLayout from './DefaultLayout';
 import Header from '../../zui/ZUIHeader';
 import { PaneProvider } from 'utils/panes';
 import { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
-
-interface StyleProps {
-  noPad?: boolean;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  main: {
-    overflow: 'hidden',
-    padding: ({ noPad }) => (noPad ? 0 : undefined),
-  },
-}));
 
 interface TabbedLayoutProps {
   actionButtons?: React.ReactElement | React.ReactElement[];
@@ -71,7 +58,6 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
   title,
 }) => {
   const [collapsed, setCollapsed] = useState(false);
-  const classes = useStyles({ noPad });
   const router = useRouter();
 
   const currentTab =
@@ -170,13 +156,16 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
         </Collapse>
         {/* Page Content */}
         <Box
-          className={classes.main}
           component="main"
           flexGrow={1}
           minHeight={0}
           p={fixedHeight ? 0 : 3}
           position="relative"
           role="tabpanel"
+          sx={{
+            overflow: 'hidden',
+            padding: noPad ? 0 : undefined,
+          }}
         >
           <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
         </Box>

--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -1,57 +1,9 @@
-import { lighten, useTheme } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
-import { FormControl, InputBase, Theme, Tooltip } from '@mui/material';
+import { Box, lighten, useTheme } from '@mui/material';
+import { FormControl, InputBase, Tooltip } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 
 import messageIds from 'zui/l10n/messageIds';
 import { useMessages } from 'core/i18n';
-
-interface StyleProps {
-  showBorder: boolean | undefined;
-  readonly: boolean | undefined;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => {
-  const theme = useTheme();
-  return {
-    input: {
-      '&:focus, &:hover': {
-        borderColor: ({ readonly }) =>
-          !readonly ? lighten(theme.palette.primary.main, 0.65) : '',
-        paddingLeft: ({ readonly }) => (!readonly ? 10 : 0),
-        paddingRight: 0,
-      },
-      border: '2px dotted transparent',
-      borderColor: ({ showBorder }) =>
-        showBorder ? lighten(theme.palette.primary.main, 0.65) : '',
-      borderRadius: 10,
-      paddingLeft: ({ showBorder }) => (showBorder ? 10 : 0),
-      paddingRight: ({ showBorder }) => (showBorder ? 0 : 10),
-      transition: 'all 0.2s ease',
-    },
-    inputRoot: {
-      cursor: 'pointer',
-      fontFamily: 'inherit',
-      fontSize: 'inherit !important',
-      fontWeight: 'inherit',
-    },
-    span: {
-      // Same styles as input
-      '&:focus, &:hover': {
-        borderColor: lighten(theme.palette.primary.main, 0.65),
-        paddingLeft: 10,
-        paddingRight: 0,
-      },
-      border: '2px dotted transparent',
-      borderRadius: 10,
-      paddingRight: 10,
-
-      // But invisible and positioned absolutely to not affect flow
-      position: 'absolute',
-      visibility: 'hidden',
-    },
-  };
-});
 
 export interface ZUIEditTextinPlaceProps {
   allowEmpty?: boolean;
@@ -81,10 +33,10 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
   const [editing, setEditing] = useState<boolean>(false);
   const [text, setText] = useState<string>(value);
 
-  const classes = useStyles({ readonly, showBorder });
   const inputRef = useRef<HTMLInputElement>(null);
   const spanRef = useRef<HTMLSpanElement>(null);
   const messages = useMessages(messageIds);
+  const theme = useTheme();
 
   useEffect(() => {
     // If the value prop changes, set the text
@@ -190,14 +142,28 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
       title={tooltipText()}
     >
       <FormControl style={{ overflow: 'hidden' }} variant="standard">
-        <span ref={spanRef} className={classes.span}>
-          {text || placeholder}
-        </span>
-        <InputBase
-          classes={{
-            input: classes.input,
-            root: classes.inputRoot,
+        <Box
+          ref={spanRef}
+          component="span"
+          sx={{
+            // Same styles as input
+            '&:focus, &:hover': {
+              borderColor: lighten(theme.palette.primary.main, 0.65),
+              paddingLeft: '10px',
+              paddingRight: 0,
+            },
+            border: '2px dotted transparent',
+            borderRadius: '10px',
+            paddingRight: '10px',
+
+            // But invisible and positioned absolutely to not affect flow
+            position: 'absolute',
+            visibility: 'hidden',
           }}
+        >
+          {text || placeholder}
+        </Box>
+        <InputBase
           disabled={disabled}
           inputRef={inputRef}
           onBlur={handleBlur}
@@ -206,6 +172,33 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
           onKeyDown={onKeyDown}
           placeholder={placeholder}
           readOnly={!editing}
+          sx={[
+            {
+              '.MuiInputBase-input': {
+                '&:focus, &:hover': {
+                  borderColor: `${
+                    !readonly ? lighten(theme.palette.primary.main, 0.65) : ''
+                  } !important`,
+                  paddingLeft: `${!readonly ? 10 : 0}px`,
+                  paddingRight: 0,
+                },
+                border: '2px dotted transparent',
+                borderColor: showBorder
+                  ? lighten(theme.palette.primary.main, 0.65)
+                  : '',
+                borderRadius: '10px',
+                paddingLeft: `${showBorder ? 10 : 0}px`,
+                paddingRight: `${showBorder ? 0 : 10}px`,
+                transition: 'all 0.2s ease',
+              },
+            },
+            {
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              fontSize: 'inherit !important',
+              fontWeight: 'inherit',
+            },
+          ]}
           value={editing ? text : text || placeholder || ''}
         />
       </FormControl>

--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -1,56 +1,12 @@
 import { ArrowUpward } from '@mui/icons-material';
-import makeStyles from '@mui/styles/makeStyles';
 import { ReactElement } from 'react';
-import {
-  Avatar,
-  Box,
-  Button,
-  Collapse,
-  Theme,
-  Typography,
-} from '@mui/material';
+import { Avatar, Box, Button, Collapse, Typography } from '@mui/material';
 
 import BreadcrumbTrail from 'features/breadcrumbs/components/BreadcrumbTrail';
 import { Msg } from 'core/i18n';
 import ZUIEllipsisMenu, { ZUIEllipsisMenuProps } from 'zui/ZUIEllipsisMenu';
 import messageIds from './l10n/messageIds';
 import oldTheme from 'theme';
-
-interface StyleProps {
-  collapsed: boolean;
-}
-
-const useStyles = makeStyles<Theme, StyleProps>(() => ({
-  avatar: {
-    aspectRatio: 1,
-    height: 65,
-    marginRight: 20,
-    width: 'auto',
-  },
-  collapseButton: {
-    '& svg': {
-      transform: ({ collapsed }) => (collapsed ? 'rotate(180deg)' : 'none'),
-      transition: 'transform 0.2s ease',
-    },
-    gridColumnEnd: 'none',
-  },
-  title: {
-    marginBottom: '8px',
-    transition: 'margin 0.3s ease',
-  },
-  titleGrid: {
-    alignItems: 'center',
-    display: 'grid',
-    gap: '1rem',
-    gridTemplateColumns: '1fr auto',
-    gridTemplateRows: 'auto',
-    transition: 'font-size 0.2s ease',
-    width: '100%',
-    [oldTheme.breakpoints.down('md')]: {
-      gridTemplateColumns: '1fr',
-    },
-  },
-}));
 
 interface HeaderProps {
   actionButtons?: ReactElement | ReactElement[];
@@ -73,8 +29,6 @@ const Header: React.FC<HeaderProps> = ({
   subtitle,
   title,
 }) => {
-  const classes = useStyles({ collapsed });
-
   const toggleCollapsed = () => {
     if (onToggleCollapsed) {
       onToggleCollapsed(!collapsed);
@@ -89,7 +43,15 @@ const Header: React.FC<HeaderProps> = ({
           {/* Search and collapse buttons */}
           <Box display="flex" flexDirection="row">
             {!!onToggleCollapsed && (
-              <Box className={classes.collapseButton}>
+              <Box
+                sx={{
+                  '& svg': {
+                    transform: collapsed ? 'rotate(180deg)' : 'none',
+                    transition: 'transform 0.2s ease',
+                  },
+                  gridColumnEnd: 'none',
+                }}
+              >
                 <Button
                   color="inherit"
                   onClick={toggleCollapsed}
@@ -109,21 +71,48 @@ const Header: React.FC<HeaderProps> = ({
         </Box>
         {/* Title, subtitle, and action buttons */}
         <Collapse in={!collapsed}>
-          <Box className={classes.titleGrid} mt={2}>
+          <Box
+            mt={2}
+            sx={{
+              alignItems: 'center',
+              display: 'grid',
+              gap: '1rem',
+              gridTemplateColumns: '1fr auto',
+              gridTemplateRows: 'auto',
+              transition: 'font-size 0.2s ease',
+              width: '100%',
+              [oldTheme.breakpoints.down('md')]: {
+                gridTemplateColumns: '1fr',
+              },
+            }}
+          >
             <Box
               alignItems="center"
               display="flex"
               flexDirection="row"
               overflow="hidden"
             >
-              {avatar && <Avatar className={classes.avatar} src={avatar} />}
+              {avatar && (
+                <Avatar
+                  src={avatar}
+                  sx={{
+                    aspectRatio: 1,
+                    height: '65px',
+                    marginRight: '20px',
+                    width: 'auto',
+                  }}
+                />
+              )}
               <Box>
                 <Typography
-                  className={classes.title}
                   component="div"
                   data-testid="page-title"
                   noWrap
                   style={{ display: 'flex' }}
+                  sx={{
+                    marginBottom: '8px',
+                    transition: 'margin 0.3s ease',
+                  }}
                   variant="h3"
                 >
                   {title}

--- a/src/zui/ZUILogo/index.tsx
+++ b/src/zui/ZUILogo/index.tsx
@@ -1,4 +1,3 @@
-import makeStyles from '@mui/styles/makeStyles';
 import SvgIcon from '@mui/material/SvgIcon';
 import { Box, Typography } from '@mui/material';
 
@@ -11,36 +10,21 @@ interface ZUILogoProps {
   beta?: boolean;
 }
 
-const useStyles = makeStyles(() => ({
-  beta: {
-    backgroundColor: oldTheme.palette.secondary.main,
-    borderRadius: oldTheme.spacing(0.25),
-    bottom: oldTheme.spacing(0.0),
-    color: oldTheme.palette.background.paper,
-    fontSize: '0.5rem',
-    fontWeight: 900,
-    lineHeight: 1,
-    padding: oldTheme.spacing(0.25),
-    position: 'absolute',
-    right: oldTheme.spacing(-0.5),
-  },
-  logoContainer: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'center',
-    position: 'relative',
-  },
-}));
-
 const ZUILogo = ({
   size,
   color,
   htmlColor,
   beta,
 }: ZUILogoProps): JSX.Element => {
-  const classes = useStyles();
   return (
-    <Box className={classes.logoContainer}>
+    <Box
+      sx={{
+        alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        position: 'relative',
+      }}
+    >
       <SvgIcon
         color={color}
         htmlColor={htmlColor}
@@ -98,7 +82,21 @@ const ZUILogo = ({
         />
       </SvgIcon>
       {beta && (
-        <Typography className={classes.beta} variant="overline">
+        <Typography
+          sx={{
+            backgroundColor: oldTheme.palette.secondary.main,
+            borderRadius: oldTheme.spacing(0.25),
+            bottom: oldTheme.spacing(0.0),
+            color: oldTheme.palette.background.paper,
+            fontSize: '0.5rem',
+            fontWeight: 900,
+            lineHeight: 1,
+            padding: oldTheme.spacing(0.25),
+            position: 'absolute',
+            right: oldTheme.spacing(-0.5),
+          }}
+          variant="overline"
+        >
           Beta
         </Typography>
       )}

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -1,4 +1,3 @@
-import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
@@ -28,6 +27,8 @@ import {
   TextField,
   Tooltip,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import Link from 'next/link';
 
@@ -49,44 +50,9 @@ import oldTheme from 'theme';
 
 const drawerWidth = 300;
 
-const useStyles = makeStyles(() => ({
-  drawer: {
-    flexShrink: 0,
-    transition: oldTheme.transitions.create('width', {
-      duration: oldTheme.transitions.duration.enteringScreen,
-      easing: oldTheme.transitions.easing.sharp,
-    }),
-    whiteSpace: 'nowrap',
-    width: drawerWidth,
-  },
-  drawerPaper: {
-    display: 'none',
-    [oldTheme.breakpoints.up('sm')]: {
-      display: 'block',
-    },
-    overflowX: 'hidden',
-    transition: oldTheme.transitions.create('width', {
-      duration: oldTheme.transitions.duration.enteringScreen,
-      easing: oldTheme.transitions.easing.sharp,
-    }),
-    width: drawerWidth,
-  },
-  toggleDrawerPaper: {
-    [oldTheme.breakpoints.up('sm')]: {
-      width: `calc(${oldTheme.spacing(8)} + 1px)`,
-    },
-    transition: oldTheme.transitions.create('width', {
-      duration: oldTheme.transitions.duration.leavingScreen,
-      easing: oldTheme.transitions.easing.sharp,
-    }),
-    width: `calc(${oldTheme.spacing(7)} + 1px)`,
-  },
-}));
-
 const ZUIOrganizeSidebar = (): JSX.Element => {
   const [hover, setHover] = useState(false);
   const messages = useMessages(messageIds);
-  const classes = useStyles();
   const user = useCurrentUser();
   const router = useRouter();
   const { orgId } = useNumericRouteParams();
@@ -128,22 +94,36 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
 
   const showOrgSwitcher = checked && open;
 
+  const theme = useTheme();
+  const isSmall = useMediaQuery(theme.breakpoints.up('sm'));
+  const width = open
+    ? `${drawerWidth}px`
+    : `calc(${oldTheme.spacing(isSmall ? 8 : 7)} + 1px)`;
   return (
     <Box data-testid="organize-sidebar">
       <Drawer
-        classes={{
-          paper:
-            classes.drawerPaper +
-            (!open ? ` ${classes.toggleDrawerPaper}` : ''),
-        }}
-        className={
-          classes.drawer + (!open ? ` ${classes.toggleDrawerPaper}` : '')
-        }
         onMouseLeave={() => {
           setHover(false);
         }}
         onMouseOver={() => {
           setHover(true);
+        }}
+        sx={{
+          '.MuiDrawer-paper': {
+            [oldTheme.breakpoints.up('sm')]: {
+              display: 'block',
+            },
+            display: 'none',
+            overflowX: 'hidden',
+            width,
+          },
+          flexShrink: 0,
+          transition: oldTheme.transitions.create('width', {
+            duration: oldTheme.transitions.duration.enteringScreen,
+            easing: oldTheme.transitions.easing.sharp,
+          }),
+          whiteSpace: 'nowrap',
+          width,
         }}
         variant="permanent"
       >

--- a/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineNoteAdded.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@mui/material';
 import { Edit } from '@mui/icons-material';
-import makeStyles from '@mui/styles/makeStyles';
 import { useState } from 'react';
 
 import EmailLoader from './elements/EmailLoader';
@@ -21,22 +20,7 @@ interface Props {
   update: ZetkinUpdateJourneyInstanceAddNote;
 }
 
-const useStyles = makeStyles(() => {
-  return {
-    note: {
-      '& p:first-child': {
-        marginTop: 0,
-      },
-      '& p:last-child': {
-        marginBottom: 0,
-      },
-    },
-  };
-});
-
 const TimelineNoteAdded: React.FC<Props> = ({ onEditNote, update }) => {
-  const classes = useStyles();
-
   const [editing, setEditing] = useState(false);
   const [noteText, setNoteText] = useState(update.details.note.text);
 
@@ -98,8 +82,15 @@ const TimelineNoteAdded: React.FC<Props> = ({ onEditNote, update }) => {
         <>
           <ZUIMarkdown
             BoxProps={{
-              className: classes.note,
               component: 'div',
+              sx: {
+                '& p:first-child': {
+                  marginTop: 0,
+                },
+                '& p:last-child': {
+                  marginBottom: 0,
+                },
+              },
             }}
             markdown={update.details.note.text}
           />

--- a/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
+++ b/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
@@ -1,12 +1,10 @@
 import Link from 'next/link';
-import makeStyles from '@mui/styles/makeStyles';
 import {
   Box,
   Chip,
   CircularProgress,
   Grid,
   Stack,
-  Theme,
   Typography,
 } from '@mui/material';
 import { LetterparserNode, parse } from 'letterparser';
@@ -53,28 +51,11 @@ const PrettyEmail: React.FC<PrettyEmailProps> = ({ emailStr }) => {
   }
 };
 
-const useBodyStyles = makeStyles<Theme, { plain: boolean }>(() => ({
-  body: {
-    '& blockquote': {
-      borderColor: oldTheme.palette.text.disabled,
-      borderLeftWidth: 4,
-      borderStyle: 'solid',
-      borderWidth: 0,
-      marginLeft: 2,
-      opacity: 0.8,
-      paddingLeft: 10,
-    },
-    fontFamily: 'sans-serif',
-    whiteSpace: ({ plain }) => (plain ? 'pre' : 'normal'),
-  },
-}));
-
 const EmailBody: React.FC<{
   body: LetterparserNode['body'];
   forcePlain?: boolean;
 }> = ({ body, forcePlain = false }) => {
   const plain = forcePlain || typeof body == 'string';
-  const classes = useBodyStyles({ plain });
 
   if (Array.isArray(body)) {
     let bodyToRender = body.find(
@@ -92,11 +73,23 @@ const EmailBody: React.FC<{
     return (
       <ZUICleanHtml
         BoxProps={{
-          className: classes.body,
           component: 'div',
           style: {
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-word',
+          },
+          sx: {
+            '& blockquote': {
+              borderColor: oldTheme.palette.text.disabled,
+              borderLeftWidth: 4,
+              borderStyle: 'solid',
+              borderWidth: 0,
+              marginLeft: 2,
+              opacity: 0.8,
+              paddingLeft: 10,
+            },
+            fontFamily: 'sans-serif',
+            whiteSpace: plain ? 'pre' : 'normal',
           },
         }}
         dirtyHtml={content}


### PR DESCRIPTION
## Description
This PR replaces some instances of deprecated `makeStyles` with `sx`

## Changes

* Replaces a lot of instances of makeStyles with sx
* Replace `inputProps` with `slotProps={{ htmlInput: {...} }}`


## Notes to reviewer
The way I handled the animation in ViewDataTable might raise some eyebrows, I'm not sure if using a css module is allowed.
I had to work around the fact that it uses an external component, DataGridPro, that hasn't got the sx attribute. The way the animation worked was that it would add a class containing an animation, which isn't possible with sx. So instead I used a css module containing the animation.
Maybe there's a better way?

## Related issues
Contributes to #3176 
