### PR TITLE
Events: fix event location hook dependency

### DIFF
--- a/src/features/events/components/EventOverviewCard/index.tsx
+++ b/src/features/events/components/EventOverviewCard/index.tsx
@@ -99,7 +99,7 @@ const EventOverviewCard: FC<EventOverviewCardProps> = ({ data, orgId }) => {
       return a.title.localeCompare(b.title);
     });
     return sorted;
-  }, [locations?.length]);
+  }, [locations]);
 
   const options: (
     | ZetkinLocation


### PR DESCRIPTION
## Description
This PR ensures the `useMemo` hook depending on `locations` depends on `locations`. This fixes a state mismatch bug in the event page https://github.com/zetkin/app.zetkin.org/issues/2746

## Notes to reviewer
[Add instructions for testing]
It is likely a slower render for organizations with long locations lists. The reason is that `loadListIfNecessary` constructs a new list on each render, which causes React to detect a dependency change on this hook on each render as well. There are several ways I could fix that if you want me to. Options include refactoring `loadListIfNecessary` into a pure hook or making `useEventLocations` ignore the output of `loadListIfNecessary` and use the redux state instead.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2746
