### PR TITLE
Stop page flash response for /my pages before redirect, if not logged in 

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,7 +23,10 @@ export async function middleware(request: NextRequest) {
     password: requiredEnvVar('SESSION_PASSWORD'),
   });
 
-  if (isProtectedRoute && !session?.tokenData) {
+  const hasTokenData = !!session?.tokenData;
+  const userIsAnonymous = !hasTokenData;
+
+  if (isProtectedRoute && userIsAnonymous) {
     return NextResponse.redirect(
       new URL('/login?redirect=' + path, request.nextUrl)
     );


### PR DESCRIPTION
## Description
In the middleware.js file (called proxy.js in newer versions if Next.js), we add a simple check for the presence of a login cookie when visiting a 'protected' route, redirecting to the login page before reaching any of the page logic (and the `redirectIfLoginNeeded` function).

Right now this is for any path beginning with `/my`, but the logic for that can be changed.

Going by the solution set out [here](https://nextjs.org/docs/pages/guides/authentication#authorization). This is the scheme for 'optimistic' authorization. Any deeper checks, if the user has access to a particular org or similar, should not be done here, because it would slow down every request by sending a session check to the API. In other words, we still need (something like) `redirectIfLoginNeeded` for those deeper checks.

## Related issues
Resolves #3210 
