### PR TITLE
Households v2: Expand floor matrix for desktop users

### DIFF
--- a/src/features/canvass/components/LocationDialog/FloorMatrix/index.tsx
+++ b/src/features/canvass/components/LocationDialog/FloorMatrix/index.tsx
@@ -14,6 +14,7 @@ import {
 import FloorEditor from './FloorEditor';
 import { EditedFloor } from './types';
 import AddFloorButton from './AddFloorButton';
+import useIsMobile from 'utils/hooks/useIsMobile';
 
 type Props = {
   assignment: ZetkinAreaAssignment;
@@ -39,6 +40,7 @@ const FloorMatrix: FC<Props> = ({
   selectedHouseholdIds,
 }) => {
   const households = useHouseholds(location.organization_id, location.id);
+  const isMobile = useIsMobile();
 
   const metrics = useAreaAssignmentMetrics(
     location.organization_id,
@@ -93,7 +95,7 @@ const FloorMatrix: FC<Props> = ({
   const unlikelyToBeSingleFloorInRealLife = households.length > 8;
   const householdsLikelyCreatedWithoutFloors =
     hasOnlyLevelZero && unlikelyToBeSingleFloorInRealLife;
-  const shouldStartExpanded = householdsLikelyCreatedWithoutFloors;
+  const shouldStartExpanded = householdsLikelyCreatedWithoutFloors || !isMobile;
 
   return (
     <Box


### PR DESCRIPTION
## Description
This PR expands the households for each floor by default for desktop users. That way, they don't need to scroll horizontally.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3235
