### PR TITLE
Households v2: fix households sorting

### DIFF
--- a/src/features/canvass/components/LocationDialog/FloorMatrix/index.tsx
+++ b/src/features/canvass/components/LocationDialog/FloorMatrix/index.tsx
@@ -15,6 +15,8 @@ import FloorEditor from './FloorEditor';
 import { EditedFloor } from './types';
 import AddFloorButton from './AddFloorButton';
 
+const naturalCmp = new Intl.Collator(undefined, { numeric: true }).compare;
+
 type Props = {
   assignment: ZetkinAreaAssignment;
   draftFloors: EditedFloor[] | null;
@@ -56,7 +58,7 @@ const FloorMatrix: FC<Props> = ({
     const floor1 = h1.level ?? Infinity;
 
     if (floor0 == floor1) {
-      return h0.title.localeCompare(h1.title);
+      return naturalCmp(h0.title, h1.title);
     }
 
     return floor0 - floor1;


### PR DESCRIPTION
## Description
This PR tries to fix sorting in the canvass households v2 app. Before, it was using alphabetical sorting. And that will be confusing for semi-numeric arrays like households are. I used natural sort order instead. So now `"Household 2" < "Household 10"`


## Screenshots
[Add screenshots here]
Before:
<img width="1853" height="767" alt="canvass-before" src="https://github.com/user-attachments/assets/3bb9bb0b-4890-435c-8b31-c67daaf37a07" />

After:
<img width="1905" height="750" alt="canvass-after" src="https://github.com/user-attachments/assets/d4e71069-82c6-4403-a888-51faf135a97d" />

## Notes to reviewer
[Add instructions for testing]
Contra point would probably be that the sorting changes and that might confuse people in the collapsed view.
