### PR TITLE
Canvasser UI: showing error message when WebGL is disabled or fails to initialize

### DIFF
--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -9,6 +9,7 @@ import {
   Map as MapType,
 } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import { Alert } from '@mui/material';
 
 import { Zetkin2Area } from 'features/areas/types';
 import { ZetkinAreaAssignment } from 'features/areaAssignments/types';
@@ -22,14 +23,14 @@ import useLocalStorage from 'zui/hooks/useLocalStorage';
 import ZUIMapControls from 'zui/ZUIMapControls';
 import { useEnv } from 'core/hooks';
 import ClusterImageRenderer from './ClusterImageRenderer';
-
+import messageIds from '../../l10n/messageIds';
+import { Msg } from 'core/i18n';
 const BOUNDS_PADDING = 20;
 
 type Props = {
   assignment: ZetkinAreaAssignment;
   selectedArea: Zetkin2Area;
 };
-
 const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
   const env = useEnv();
   const locations = useLocations(
@@ -49,6 +50,7 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(
     null
   );
+  const [mapInitError, setMapInitError] = useState(false);
 
   const areasGeoJson: GeoJSON.GeoJSON = useMemo(() => {
     const earthCover = [
@@ -242,6 +244,16 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
     return null;
   }
 
+  if (mapInitError) {
+    return (
+      <Box data-testid="map-error" role="alert">
+        <Alert severity="error">
+          <Msg id={messageIds.map.initializationError} />
+        </Alert>
+      </Box>
+    );
+  }
+
   return (
     <>
       <Box sx={{ position: 'relative' }}>
@@ -311,6 +323,9 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
         mapStyle={env.vars.MAPLIBRE_STYLE}
         onClick={(ev) => {
           ev.target.panTo(ev.lngLat, { animate: true });
+        }}
+        onError={() => {
+          setMapInitError(true);
         }}
         onLoad={(ev) => {
           const map = ev.target;

--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -140,6 +140,9 @@ export default makeMessages('feat.canvass', {
       create: m('Create location'),
       inputPlaceholder: m('Give the location a name'),
     },
+    initializationError: m(
+      'There was an error initializing the map. Please check if your browser supports WebGL and it is enabled.'
+    ),
   },
   selectArea: {
     noAreas: m('No areas available'),


### PR DESCRIPTION
## Description
This PR introduces an error message within the Canvasser UI when WebGL is disabled or fails to initialize

## Screenshots

<img width="3516" height="2388" alt="CleanShot 2025-11-23 at 10 34 41@2x" src="https://github.com/user-attachments/assets/6fcfaaaa-cb88-4642-b1f5-6f54db18fe8c" />


## Changes

* Adds an error message when WebGL is disabled or fails to initialize


## Notes to reviewer

see "steps to reproduce" in #3239

## Related issues
Resolves #3239
