### PR TITLE
Only render ZUIEllipsisMenu when the menu trigger button will be visible

### DIFF
--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -373,33 +373,35 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                       justifyContent: 'flex-end',
                     }}
                   >
-                    <ZUIEllipsisMenu
-                      anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
-                      items={[
-                        {
-                          href: '/my',
-                          label:
-                            messages.organizeSidebar.myPagesMenuItemLabel(),
-                        },
-                        {
-                          divider: true,
-                          href: '/my/settings',
-                          label:
-                            messages.organizeSidebar.mySettingsMenuItemLabel(),
-                        },
-                        {
-                          label: messages.organizeSidebar.signOut(),
-                          onSelect: () => {
-                            logOut();
+                    {open && (
+                      <ZUIEllipsisMenu
+                        anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+                        items={[
+                          {
+                            href: '/my',
+                            label:
+                              messages.organizeSidebar.myPagesMenuItemLabel(),
                           },
-                          startIcon: <Logout />,
-                        },
-                      ]}
-                      transformOrigin={{
-                        horizontal: 'right',
-                        vertical: 'bottom',
-                      }}
-                    />
+                          {
+                            divider: true,
+                            href: '/my/settings',
+                            label:
+                              messages.organizeSidebar.mySettingsMenuItemLabel(),
+                          },
+                          {
+                            label: messages.organizeSidebar.signOut(),
+                            onSelect: () => {
+                              logOut();
+                            },
+                            startIcon: <Logout />,
+                          },
+                        ]}
+                        transformOrigin={{
+                          horizontal: 'right',
+                          vertical: 'bottom',
+                        }}
+                      />
+                    )}
                   </Box>
                 </>
               )}


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/3253 by conditionally rendering ZUIEllipsisMenu based on the value of `open`. The menu's not visible unless `open` is true so it's best not to render it at all unless `open` is true so that we avoid this accessibility issue.

If you watch very very closely in this slow motion before and after, you can see that in the after shot the ellipsis menu trigger now disappears in the same frame as the menu item label text instead of sliding left with the close animation.

| Before | After |
|-|-|
| ![2025-11-22 16 48 11](https://github.com/user-attachments/assets/47d64d80-86d1-444f-b91c-0a709367ee78) | ![2025-11-22 16 47 48](https://github.com/user-attachments/assets/4b40e7cf-d7fa-41db-803d-27a7e28f242d) |

> [!NOTE]
> Use GItHub's `?w=1` flag on this one so that you see the two lines that actually change without the noise of the 26 indentation changes.
> https://github.com/zetkin/app.zetkin.org/pull/3254/files?w=1