### PR TITLE
Transfer focus between the expand and collapse buttons in ZUIOrganizeSidebar on click

### DIFF
--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -1,7 +1,7 @@
 import makeStyles from '@mui/styles/makeStyles';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   Architecture,
   Close,
@@ -91,6 +91,8 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
   const router = useRouter();
   const { orgId } = useNumericRouteParams();
   const key = orgId ? router.pathname.split('[orgId]')[1] : 'organize';
+  const expandButton = useRef<HTMLButtonElement>(null);
+  const collapseButton = useRef<HTMLButtonElement>(null);
 
   const [checked, setChecked] = useState(false);
   const [lastOpen, setLastOpen] = useLocalStorage('orgSidebarOpen', true);
@@ -109,6 +111,12 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
     if (!open) {
       setChecked(false);
     }
+    const nextFocus = open ? expandButton : collapseButton;
+    setTimeout(() => {
+      if (nextFocus.current) {
+        nextFocus.current.focus();
+      }
+    }, 16);
     setOpen(!open);
     setLastOpen(!open);
   };
@@ -159,7 +167,7 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
               }}
             >
               {!open && hover && (
-                <IconButton onClick={handleClick}>
+                <IconButton ref={expandButton} onClick={handleClick}>
                   <KeyboardDoubleArrowRightOutlined />
                 </IconButton>
               )}
@@ -188,7 +196,10 @@ const ZUIOrganizeSidebar = (): JSX.Element => {
                               }}
                             >
                               {hover ? (
-                                <IconButton onClick={handleClick}>
+                                <IconButton
+                                  ref={collapseButton}
+                                  onClick={handleClick}
+                                >
                                   <KeyboardDoubleArrowLeftOutlined />
                                 </IconButton>
                               ) : (


### PR DESCRIPTION
Fixes https://github.com/zetkin/app.zetkin.org/issues/3255 by adding code to transfer focus between the expand and contract buttons. In the "Before" screen recording below, I have to press "Tab" after each click in order to restore focus to the button. In the "After" recording I just press the space key over and over again as focus is in the correct place already.

| Before | After |
|-|-|
| ![2025-11-22 17 12 57](https://github.com/user-attachments/assets/12942b00-1fe8-4bdc-b123-3e0b181d0d45) | ![2025-11-22 17 14 02](https://github.com/user-attachments/assets/8166d54b-dbf6-4242-a036-b503a20abaed) |