### PR TITLE
Fix heading levels in ZUIHeader

### DIFF
--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -105,7 +105,6 @@ const Header: React.FC<HeaderProps> = ({
               )}
               <Box>
                 <Typography
-                  className={classes.title}
                   component="h1"
                   data-testid="page-title"
                   noWrap


### PR DESCRIPTION
Resolves https://github.com/zetkin/app.zetkin.org/issues/3259 by changing the `title` of ZUIHeader from `<div>` to `<h1>` and the `subtitle` from `<h2>` to `<div>`.

| Before | After |
|-|-|
| ![headings](https://github.com/user-attachments/assets/76e99ebe-01a0-4413-a81a-4942c8957300) | ![after](https://github.com/user-attachments/assets/27e95b69-baa4-4f92-88d1-75f6ea784014) |
