### PR TITLE
Issue #2886 / Surveys: Warn when signature name/email mismatches with linked

### DIFF
--- a/src/features/surveys/components/SurveyLinkDialog.tsx
+++ b/src/features/surveys/components/SurveyLinkDialog.tsx
@@ -32,6 +32,60 @@ const SurveyLinkDialog = ({
   const { orgId } = useNumericRouteParams();
   const { updatePerson } = usePersonMutations(orgId, person.id);
 
+  if (person.email && email !== person.email) {
+    return (
+      <Dialog open={open}>
+        <DialogTitle>{messages.surveyDialogDifferentEmail.title()}</DialogTitle>
+        <Divider />
+        <DialogContent>
+          <Box
+            alignItems="center"
+            display="flex"
+            flexDirection="row"
+            paddingBottom="5px"
+          >
+            <ZUIPersonAvatar
+              orgId={orgId}
+              personId={person?.id ?? 0}
+              size="sm"
+            />
+            <Typography ml={2} variant="h6">
+              {person?.first_name} {person?.last_name}
+            </Typography>
+          </Box>
+
+          <Box alignItems="center" display="flex" mb={2}>
+            {email}
+            <Box alignItems="center" display="flex" ml={2} mr={2}>
+              <ArrowForward
+                color="secondary"
+                sx={{
+                  opacity: '50%',
+                }}
+              />
+            </Box>
+            {person.email}
+          </Box>
+          {messages.surveyDialogDifferentEmail.description()}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>
+            {messages.surveyDialogDifferentEmail.keep()}
+          </Button>
+          <Button
+            onClick={() => {
+              updatePerson({ email });
+              onClose();
+            }}
+            variant="contained"
+          >
+            {messages.surveyDialogDifferentEmail.update()}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog open={open}>
       <DialogTitle>{messages.surveyDialog.title()}</DialogTitle>

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -266,7 +266,11 @@ const SurveySubmissionsList = ({
       const respondentEmail = row.respondent?.email;
       if (person) {
         const personHasNoEmail = person.email == null || person.email == '';
-        if (personHasNoEmail && respondentEmail != undefined) {
+        const personHasDifferentEmail = person.email !== respondentEmail;
+        if (
+          (personHasNoEmail && respondentEmail != undefined) ||
+          (personHasDifferentEmail && respondentEmail != undefined)
+        ) {
           setDialogEmail(respondentEmail);
           setDialogPerson(person);
         }

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -195,6 +195,14 @@ export default makeMessages('feat.surveys', {
     ),
     title: m('Add email address'),
   },
+  surveyDialogDifferentEmail: {
+    description: m(
+      'The person you are about to link has a different email to the one in the survey response. Would you like to set the survey response email to be the new email for this person?'
+    ),
+    keep: m('No, keep old email'),
+    title: m('Update email address'),
+    update: m('Yes, update email'),
+  },
   surveyDuplicated: {
     error: m('Error: Could not duplicate survey'),
     success: m('Your survey has been duplicated.'),


### PR DESCRIPTION
## Description
This PR adds a new dialog option for when a person is about to be linked to a survey response and when that survey response has a different email from the person it is being linked to. It gives two options: to keep the old email or to update the person's email with the email from the survey response. 

The solution is a bit different from what the issue requested, but during a discussion with @richardolsson I explained that the original request might not be implementable because the API returns only the latest email associated with the survey response. There is no person.email to compare it to, so we settled on another way to solve this issue. 


## Screenshots
<img width="769" height="605" alt="Screenshot From 2025-11-23 10-33-29" src="https://github.com/user-attachments/assets/aebe8c35-17e8-4571-beb8-b1128817d7b1" />



## Changes

* Adds a new dialogue for updating the email address
* Adds new messages for the new dialogue
* Changes the condtitions required to trigger the new dialogue


## Notes to reviewer
- Some tests fail in the suite, but it seems to me none are connected to the changes made in this PR.
- There is a lack of a "cancel" option in both the old and the new dialogue. I have tried to make one in the new dialogue, but whatever is done, the dialogue will make *some* action, whether update the email or keep the old one. There is no scenario in which I have managed to cancel the dialog itself. I have noticed the same issue in the old dialogue too. I've talked to Richard about that as well, and he advised me to push this PR without addressing it first. 

## Related issues
Resolves #2886 
