### PR TITLE
Introduce `QuickResponseButtons` component

### DIFF
--- a/src/features/call/components/Report/steps/CouldTalk.tsx
+++ b/src/features/call/components/Report/steps/CouldTalk.tsx
@@ -1,12 +1,10 @@
-import { FC, useEffect } from 'react';
-import { LooksOneOutlined, LooksTwoOutlined } from '@mui/icons-material';
+import { FC } from 'react';
 
-import ZUIButtonGroup from 'zui/components/ZUIButtonGroup';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/call/l10n/messageIds';
 import StepBase from './StepBase';
-import useIsMobile from 'utils/hooks/useIsMobile';
 import { Report } from 'features/call/types';
+import { QuickResponseButtons } from './QuickResponseButtons';
 
 type Props = {
   firstName: string;
@@ -15,36 +13,7 @@ type Props = {
 };
 
 const CouldTalk: FC<Props> = ({ firstName, onReportUpdate, report }) => {
-  const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
-
-  useEffect(() => {
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key == '1') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            step: 'organizerAction',
-            targetCouldTalk: true,
-          });
-        }
-      } else if (ev.key == '2') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            step: 'callBack',
-            targetCouldTalk: false,
-          });
-        }
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
 
   return (
     <StepBase
@@ -56,37 +25,29 @@ const CouldTalk: FC<Props> = ({ firstName, onReportUpdate, report }) => {
         />
       }
     >
-      <ZUIButtonGroup
-        buttons={[
+      <QuickResponseButtons
+        options={[
           {
-            endIcon: !isMobile ? LooksOneOutlined : undefined,
             label: messages.report.steps.couldTalk.question.yesButton(),
-            onClick: () => {
-              if (onReportUpdate) {
-                onReportUpdate({
-                  ...report,
-                  step: 'organizerAction',
-                  targetCouldTalk: true,
-                });
-              }
+            onSelect: () => {
+              onReportUpdate({
+                ...report,
+                step: 'organizerAction',
+                targetCouldTalk: true,
+              });
             },
           },
           {
-            endIcon: !isMobile ? LooksTwoOutlined : undefined,
             label: messages.report.steps.couldTalk.question.noButton(),
-            onClick: () => {
-              if (onReportUpdate) {
-                onReportUpdate({
-                  ...report,
-                  step: 'callBack',
-                  targetCouldTalk: false,
-                });
-              }
+            onSelect: () => {
+              onReportUpdate({
+                ...report,
+                step: 'callBack',
+                targetCouldTalk: false,
+              });
             },
           },
         ]}
-        fullWidth
-        variant="secondary"
       />
     </StepBase>
   );

--- a/src/features/call/components/Report/steps/FailureReason.tsx
+++ b/src/features/call/components/Report/steps/FailureReason.tsx
@@ -1,18 +1,10 @@
-import { FC, useEffect } from 'react';
-import { Stack } from '@mui/material';
-import {
-  Looks3Outlined,
-  Looks4Outlined,
-  LooksOneOutlined,
-  LooksTwoOutlined,
-} from '@mui/icons-material';
+import { FC } from 'react';
 
-import ZUIButton from 'zui/components/ZUIButton';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/call/l10n/messageIds';
 import StepBase from './StepBase';
-import useIsMobile from 'utils/hooks/useIsMobile';
 import { Report } from 'features/call/types';
+import { Option, QuickResponseButtons } from './QuickResponseButtons';
 
 type Props = {
   nextStepIfWrongNumber: 'wrongNumber' | 'organizerLog';
@@ -25,120 +17,55 @@ const FailureReason: FC<Props> = ({
   onReportUpdate,
   report,
 }) => {
-  const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
 
-  useEffect(() => {
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key == '1') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            failureReason: 'noPickup',
-            step: 'leftMessage',
-          });
-        }
-      } else if (ev.key == '2') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            failureReason: 'wrongNumber',
-            organizerActionNeeded: true,
-            step: nextStepIfWrongNumber,
-            wrongNumber: 'phone',
-          });
-        }
-      } else if (ev.key == '3') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            failureReason: 'lineBusy',
-            step: 'organizerAction',
-          });
-        }
-      } else if (ev.key == '4') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            failureReason: 'notAvailable',
-            step: 'callBack',
-          });
-        }
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
+  const options: Option[] = [
+    {
+      label: messages.report.steps.failureReason.question.noPickup(),
+      onSelect: () =>
+        onReportUpdate({
+          ...report,
+          failureReason: 'noPickup',
+          step: 'leftMessage',
+        }),
+    },
+    {
+      label: messages.report.steps.failureReason.question.wrongNumber(),
+      onSelect: () =>
+        onReportUpdate({
+          ...report,
+          failureReason: 'wrongNumber',
+          organizerActionNeeded: true,
+          step: nextStepIfWrongNumber,
+          wrongNumber: 'phone',
+        }),
+    },
+    {
+      label: messages.report.steps.failureReason.question.lineBusy(),
+      onSelect: () =>
+        onReportUpdate({
+          ...report,
+          failureReason: 'lineBusy',
+          step: 'organizerAction',
+        }),
+    },
+    {
+      label: messages.report.steps.failureReason.question.notAvailable(),
+      onSelect: () =>
+        onReportUpdate({
+          ...report,
+          failureReason: 'notAvailable',
+          step: 'callBack',
+        }),
+    },
+  ];
 
   return (
     <StepBase
       state="active"
       title={<Msg id={messageIds.report.steps.failureReason.question.title} />}
     >
-      <Stack sx={{ alignItems: 'flex-start', gap: '0.5rem' }}>
-        <ZUIButton
-          endIcon={!isMobile ? LooksOneOutlined : undefined}
-          label={messages.report.steps.failureReason.question.noPickup()}
-          onClick={() => {
-            if (onReportUpdate) {
-              onReportUpdate({
-                ...report,
-                failureReason: 'noPickup',
-                step: 'leftMessage',
-              });
-            }
-          }}
-          variant="secondary"
-        />
-        <ZUIButton
-          endIcon={!isMobile ? LooksTwoOutlined : undefined}
-          label={messages.report.steps.failureReason.question.wrongNumber()}
-          onClick={() => {
-            if (onReportUpdate) {
-              onReportUpdate({
-                ...report,
-                failureReason: 'wrongNumber',
-                organizerActionNeeded: true,
-                step: nextStepIfWrongNumber,
-                wrongNumber: 'phone',
-              });
-            }
-          }}
-          variant="secondary"
-        />
-        <ZUIButton
-          endIcon={!isMobile ? Looks3Outlined : undefined}
-          label={messages.report.steps.failureReason.question.lineBusy()}
-          onClick={() => {
-            if (onReportUpdate) {
-              onReportUpdate({
-                ...report,
-                failureReason: 'lineBusy',
-                step: 'organizerAction',
-              });
-            }
-          }}
-          variant="secondary"
-        />
-        <ZUIButton
-          endIcon={!isMobile ? Looks4Outlined : undefined}
-          label={messages.report.steps.failureReason.question.notAvailable()}
-          onClick={() => {
-            if (onReportUpdate) {
-              onReportUpdate({
-                ...report,
-                failureReason: 'notAvailable',
-                step: 'callBack',
-              });
-            }
-          }}
-          variant="secondary"
-        />
-      </Stack>
+      <QuickResponseButtons options={options} />
     </StepBase>
   );
 };

--- a/src/features/call/components/Report/steps/LeftMessage.tsx
+++ b/src/features/call/components/Report/steps/LeftMessage.tsx
@@ -1,12 +1,10 @@
-import { FC, useEffect } from 'react';
-import { LooksOneOutlined, LooksTwoOutlined } from '@mui/icons-material';
+import { FC } from 'react';
 
-import ZUIButtonGroup from 'zui/components/ZUIButtonGroup';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/call/l10n/messageIds';
 import StepBase from './StepBase';
-import useIsMobile from 'utils/hooks/useIsMobile';
 import { Report } from 'features/call/types';
+import { QuickResponseButtons } from './QuickResponseButtons';
 
 type Props = {
   onReportUpdate: (updatedReport: Report) => void;
@@ -14,44 +12,18 @@ type Props = {
 };
 
 const LeftMessage: FC<Props> = ({ onReportUpdate, report }) => {
-  const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
-
-  useEffect(() => {
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key == '1') {
-        onReportUpdate({
-          ...report,
-          leftMessage: true,
-          step: 'organizerAction',
-        });
-      } else if (ev.key == '2') {
-        onReportUpdate({
-          ...report,
-          leftMessage: false,
-          step: 'organizerAction',
-        });
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
 
   return (
     <StepBase
       state="active"
       title={<Msg id={messageIds.report.steps.leftMessage.question.title} />}
     >
-      <ZUIButtonGroup
-        buttons={[
+      <QuickResponseButtons
+        options={[
           {
-            endIcon: !isMobile ? LooksOneOutlined : undefined,
             label: messages.report.steps.leftMessage.question.yesButton(),
-            onClick: () =>
+            onSelect: () =>
               onReportUpdate({
                 ...report,
                 leftMessage: true,
@@ -59,9 +31,8 @@ const LeftMessage: FC<Props> = ({ onReportUpdate, report }) => {
               }),
           },
           {
-            endIcon: !isMobile ? LooksTwoOutlined : undefined,
             label: messages.report.steps.leftMessage.question.noButton(),
-            onClick: () =>
+            onSelect: () =>
               onReportUpdate({
                 ...report,
                 leftMessage: false,
@@ -69,8 +40,6 @@ const LeftMessage: FC<Props> = ({ onReportUpdate, report }) => {
               }),
           },
         ]}
-        fullWidth
-        variant="secondary"
       />
     </StepBase>
   );

--- a/src/features/call/components/Report/steps/OrganizerAction.tsx
+++ b/src/features/call/components/Report/steps/OrganizerAction.tsx
@@ -1,12 +1,10 @@
-import { FC, useEffect } from 'react';
-import { LooksOneOutlined, LooksTwoOutlined } from '@mui/icons-material';
+import { FC } from 'react';
 
-import ZUIButtonGroup from 'zui/components/ZUIButtonGroup';
 import messageIds from 'features/call/l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
 import StepBase from './StepBase';
-import useIsMobile from 'utils/hooks/useIsMobile';
 import { Report } from 'features/call/types';
+import { QuickResponseButtons } from './QuickResponseButtons';
 
 type Props = {
   disableCallerNotes: boolean;
@@ -21,38 +19,7 @@ const OrganizerAction: FC<Props> = ({
   onReportUpdate,
   report,
 }) => {
-  const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
-
-  useEffect(() => {
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key == '1') {
-        onReportUpdate({
-          ...report,
-          organizerActionNeeded: true,
-          step: 'organizerLog',
-        });
-      } else if (ev.key == '2') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            organizerActionNeeded: false,
-            step: 'callerLog',
-          });
-
-          if (onReportFinished) {
-            onReportFinished();
-          }
-        }
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
 
   return (
     <StepBase
@@ -61,12 +28,11 @@ const OrganizerAction: FC<Props> = ({
         <Msg id={messageIds.report.steps.organizerAction.question.title} />
       }
     >
-      <ZUIButtonGroup
-        buttons={[
+      <QuickResponseButtons
+        options={[
           {
-            endIcon: !isMobile ? LooksOneOutlined : undefined,
             label: messages.report.steps.organizerAction.question.yesButton(),
-            onClick: () =>
+            onSelect: () =>
               onReportUpdate({
                 ...report,
                 organizerActionNeeded: true,
@@ -74,9 +40,8 @@ const OrganizerAction: FC<Props> = ({
               }),
           },
           {
-            endIcon: !isMobile ? LooksTwoOutlined : undefined,
             label: messages.report.steps.organizerAction.question.noButton(),
-            onClick: () => {
+            onSelect: () => {
               onReportUpdate({
                 ...report,
                 completed: disableCallerNotes ? true : false,
@@ -89,8 +54,6 @@ const OrganizerAction: FC<Props> = ({
             },
           },
         ]}
-        fullWidth
-        variant="secondary"
       />
     </StepBase>
   );

--- a/src/features/call/components/Report/steps/QuickResponseButtons.tsx
+++ b/src/features/call/components/Report/steps/QuickResponseButtons.tsx
@@ -1,0 +1,76 @@
+import {
+  Looks3Outlined,
+  Looks4Outlined,
+  LooksOneOutlined,
+  LooksTwoOutlined,
+} from '@mui/icons-material';
+import { FC, useEffect } from 'react';
+import { Stack } from '@mui/system';
+
+import ZUIButtonGroup from '../../../../../zui/components/ZUIButtonGroup';
+import useIsMobile from '../../../../../utils/hooks/useIsMobile';
+import ZUIButton from '../../../../../zui/components/ZUIButton';
+
+type QuickResponseProps = {
+  options: Option[];
+};
+
+export interface Option {
+  onSelect: () => void | Promise<void>;
+  label: string;
+}
+
+export const QuickResponseButtons: FC<QuickResponseProps> = ({ options }) => {
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    const optionCount = options.length;
+    const onKeyDown = (ev: KeyboardEvent) => {
+      const pressedNumber = Number.parseInt(ev.key);
+      if (!Number.isNaN(pressedNumber) && pressedNumber <= optionCount) {
+        options[pressedNumber - 1].onSelect();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const numberButtons = [
+    LooksOneOutlined,
+    LooksTwoOutlined,
+    Looks3Outlined,
+    Looks4Outlined,
+  ];
+
+  if (options.length === 2) {
+    return (
+      <ZUIButtonGroup
+        buttons={options.map((option, index) => ({
+          endIcon: !isMobile ? numberButtons[index] : undefined,
+          label: option.label,
+          onClick: option.onSelect,
+        }))}
+        fullWidth
+        variant="secondary"
+      />
+    );
+  }
+
+  return (
+    <Stack sx={{ alignItems: 'flex-start', gap: '0.5rem' }}>
+      {options.map((option, index) => (
+        <ZUIButton
+          key={option.label}
+          endIcon={!isMobile ? numberButtons[index] : undefined}
+          label={option.label}
+          onClick={option.onSelect}
+          variant="secondary"
+        />
+      ))}
+    </Stack>
+  );
+};

--- a/src/features/call/components/Report/steps/SuccessOrFailure.tsx
+++ b/src/features/call/components/Report/steps/SuccessOrFailure.tsx
@@ -1,12 +1,10 @@
-import { FC, useEffect } from 'react';
-import { LooksOneOutlined, LooksTwoOutlined } from '@mui/icons-material';
+import { FC } from 'react';
 
-import ZUIButtonGroup from 'zui/components/ZUIButtonGroup';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/call/l10n/messageIds';
 import StepBase from './StepBase';
-import useIsMobile from 'utils/hooks/useIsMobile';
 import { Report } from 'features/call/types';
+import { QuickResponseButtons } from './QuickResponseButtons';
 
 type Props = {
   firstName: string;
@@ -15,36 +13,7 @@ type Props = {
 };
 
 const SuccessOrFailure: FC<Props> = ({ firstName, onReportUpdate, report }) => {
-  const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
-
-  useEffect(() => {
-    const onKeyDown = (ev: KeyboardEvent) => {
-      if (ev.key == '1') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            step: 'couldTalk',
-            success: true,
-          });
-        }
-      } else if (ev.key == '2') {
-        if (onReportUpdate) {
-          onReportUpdate({
-            ...report,
-            step: 'failureReason',
-            success: false,
-          });
-        }
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-    };
-  }, []);
 
   return (
     <StepBase
@@ -58,37 +27,29 @@ const SuccessOrFailure: FC<Props> = ({ firstName, onReportUpdate, report }) => {
         />
       }
     >
-      <ZUIButtonGroup
-        buttons={[
+      <QuickResponseButtons
+        options={[
           {
-            endIcon: !isMobile ? LooksOneOutlined : undefined,
             label: messages.report.steps.successOrFailure.question.yesButton(),
-            onClick: () => {
-              if (onReportUpdate) {
-                onReportUpdate({
-                  ...report,
-                  step: 'couldTalk',
-                  success: true,
-                });
-              }
+            onSelect: () => {
+              onReportUpdate({
+                ...report,
+                step: 'couldTalk',
+                success: true,
+              });
             },
           },
           {
-            endIcon: !isMobile ? LooksTwoOutlined : undefined,
             label: messages.report.steps.successOrFailure.question.noButton(),
-            onClick: () => {
-              if (onReportUpdate) {
-                onReportUpdate({
-                  ...report,
-                  step: 'failureReason',
-                  success: false,
-                });
-              }
+            onSelect: () => {
+              onReportUpdate({
+                ...report,
+                step: 'failureReason',
+                success: false,
+              });
             },
           },
         ]}
-        fullWidth
-        variant="secondary"
       />
     </StepBase>
   );


### PR DESCRIPTION
## Description
This PR introduces a new component that can be used in the new call interface to build the buttons that are also intractable via numbers on the keyboard.


## Screenshots
Looks just like it did before.


## Changes
In the current version, the callbacks are defined for the `keydown` event and for the buttons themselves. We also have to set up (and clean up) the event listener in each file. This change introduces the new `QuickResposneButtosn` component that can be used to remove some of that duplication.


## Notes to reviewer
I think the behavior of `src/features/call/components/Report/steps/OrganizerAction.tsx` changed slightly since that was actually using different callbacks depending on if you interacted via keyboard or mouse (probably not intended?).
