### PR TITLE
Dev performance: Enable turbopack

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,8 +15,7 @@ module.exports = {
   allowedDevOrigins: [],
 
   experimental: {
-    esmExternals: "loose",
-    serverComponentsExternalPackages: ["mjml", "mongoose"],
+    serverComponentsExternalPackages: ['mjml', 'mongoose'],
   },
   images: {
     domains: [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "analyze": "ANALYZE=true next build",
     "build": "next build",
     "start": "next start -p 80",
-    "devserver": "cross-env NODE_OPTIONS='--inspect' next dev -p 3000",
+    "devserver": "cross-env NODE_OPTIONS='--inspect' next dev -p 3000 --turbo",
     "docs:build": "storybook build -o public/storybook",
     "lint:eslint": "eslint src integrationTesting",
     "lint:prettier": "prettier --check src integrationTesting",

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -53,7 +53,7 @@ async function loadMessages(): Promise<MessageDB> {
       const dotPath = pathElems.join('.');
       const lang = fileName.replace('.yml', '');
 
-      const content = await fs.readFile(fullPath, 'utf8');
+      const content = await fs.readFile(fullPath || '', 'utf8');
       const data = yaml.parse(content);
       const flattened = flattenObject(data, dotPath);
 


### PR DESCRIPTION
## Description
This PR enables [turbopack](https://nextjs.org/docs/app/api-reference/turbopack). This should make compile speed during development faster and smoother. 

I needed to add a script that runs before compile that generates a json file from the existing yml translation files. This was necessary, because the existing approach to load these files used `fs.readFile`, which threw warnings that it is dynamic. Using `import` instead, this can be fixed. But `import` will only work with `json`.

## Screenshots

Before:

https://github.com/user-attachments/assets/54a61b1b-8c52-4818-9052-9dbe0d662523


After:

https://github.com/user-attachments/assets/9e8c361c-3da2-4065-988b-36f3b7da1872

sry about the grayscalyness

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Enables turbopack on `devserver` script
* Removes `esmExternals: "loose",` from `next.config.js` as turbopack doesn't support it
* Adds a script `lyra-to-json` that finds all yml translation files and converts it into a single json file.
* Imports the generated json file in `utils/locale.ts` to use for translations
* Adds `lyra-to-json` as a yarn script and adds it to all scripts that require the translation module as a pre-build step


## Notes to reviewer
[Add instructions for testing]
Click around the app. The compile speed should be faster compared to main. Especially when switching tabs in the same feature. It's kind of subtle at times I think since loading in general is slow on dev right now.

I did compare a few compile speed numbers. Initial compile is roughly the same speed, but maybe a bit faster. Switching to "Calendar" for the first time is a lot faster than on main for me. 
