### PR TITLE
Keep breadcrumbs trail height consistent

### DIFF
--- a/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
+++ b/src/features/breadcrumbs/components/BreadcrumbTrail.tsx
@@ -76,7 +76,7 @@ const BreadcrumbTrail = ({
         maxItems={smallScreen ? 2 : mediumScreen ? 4 : largeScreen ? 6 : 10}
         separator={<NavigateNextIcon fontSize="small" />}
         sx={{
-          height: '24px',
+          minHeight: '24px',
         }}
       >
         {breadcrumbs.map((crumb: Breadcrumb, index: number) => {


### PR DESCRIPTION
## Description
This PR fixes the height of the breadcrumbs trail so it doesn't collapse during load.


## Screenshots
[Add screenshots here]
Before:

https://github.com/user-attachments/assets/8dada7df-0072-4121-b3ef-a9327ed2ae09

After:

https://github.com/user-attachments/assets/3914c6cb-bab4-4d38-8db4-ebdab1dbb5a0

sry about the grayscalyness