### PR TITLE
Fix dompurify crashing dev canvass instructions page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,11 @@ module.exports = {
   allowedDevOrigins: [],
 
   experimental: {
+    turbo: {
+      resolveAlias: {
+        canvas: 'util',
+      },
+    },
     serverComponentsExternalPackages: ['mjml', 'mongoose'],
   },
   images: {


### PR DESCRIPTION
## Description
Enabling turbopack seems to have broken the canvass instructions page for dev instances. See http://localhost:3000/canvass/14 for instance. This PR fixes this. 

The issue was caused by jsdom, which is imported by isomorphic-dompurify, which is used in ZUICleanCode. It tried to import canvas even though it didn't exist. I found a fix here https://github.com/jsdom/jsdom/issues/2508 though it was for webpack. Turbopack took the fix as well though.