### PR TITLE
Surveys: Fix word cloud umlaut handling

### DIFF
--- a/src/features/surveys/rpc/getSurveyResponseStats.ts
+++ b/src/features/surveys/rpc/getSurveyResponseStats.ts
@@ -152,7 +152,7 @@ const collectIncrementalStats = (
       if (isTextResponse(response)) {
         const wordList = response.response
           .toLowerCase()
-          .replace(/[^a-z0-9]+/gi, ' ')
+          .replace(/[^\p{L}\p{N}]+/giu, ' ')
           .split(/\s+/)
           .filter(Boolean);
         responseStatsCounters[response.question_id].totalWordCounts +=

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["es6", "dom", "dom.iterable", "esnext"],
     "downlevelIteration": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Description
This PR fixes the way word clouds handle umlauts (äöü etc). 


## Screenshots
[Add screenshots here]
<img width="1521" height="400" alt="open question(10)" src="https://github.com/user-attachments/assets/592daa65-9a25-4bce-a55f-9bb027612b0e" />



## Changes
[Add a list of features added/changed, bugs fixed etc]

* Makes the regex in `getSurveyResponseStats` use `\p` to match any number or letter.
* Changes `tsconfig` to use es6. This is necessary to do `\p`



## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3295
