### PR TITLE
Proxy avatar images server-side in dev environment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,7 @@ module.exports = {
   images: {
     domains: [
       `files.${process.env.ZETKIN_API_DOMAIN}`,
+      `avatars.${process.env.ZETKIN_API_DOMAIN}`,
 
       // localhost added for playwright testing
       'localhost',

--- a/src/zui/components/ZUIOrgLogoAvatar/index.tsx
+++ b/src/zui/components/ZUIOrgLogoAvatar/index.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import Image from 'next/image';
 
 import { avatarSizes } from '../ZUIPersonAvatar';
 import { ZUISize } from '../types';
@@ -29,10 +30,7 @@ const ZUIOrgLogoAvatar: FC<ZUIOrgLogoAvatarProps> = ({
   urlBase = '/api',
 }) => {
   return (
-    /*TODO: Use Next.JS Image component here if we figure out 
-    how to handle it properly */
-    /* eslint-disable @next/next/no-img-element*/
-    <img
+    <Image
       alt="icon"
       height={avatarSizes[size]}
       src={`${urlBase}/orgs/${orgId}/avatar`}


### PR DESCRIPTION
## Description

Proxy avatar images server-side in the dev environment and use Next.js Image component for organization avatars. The first one is a requirement for the latter. 

## Screenshots



## Changes

* Adds proxy for images in dev for HTTPS-only mode
* Add Next's Image component for avatars.


## Notes to reviewer
* Take a look and evaluate if the proxy may be causing more problems further on. But IMO this has to be done because of the "using a real HTTPS backend in dev" approach.


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/2678

