### PR TITLE
Surveys: Add length check and improve types

### DIFF
--- a/src/features/call/rpc/submitSurveysAndUpdateCall.ts
+++ b/src/features/call/rpc/submitSurveysAndUpdateCall.ts
@@ -7,6 +7,7 @@ import { ZetkinCallPatchResponse } from '../types';
 const questionResponseSchema = z.union([
   z.object({ question_id: z.number(), response: z.string() }),
   z.object({ options: z.array(z.number()), question_id: z.number() }),
+  z.object({ question_id: z.number() }),
 ]);
 
 const signatureSchema = z.union([

--- a/src/features/surveys/rpc/getSurveyResponseStats.ts
+++ b/src/features/surveys/rpc/getSurveyResponseStats.ts
@@ -145,7 +145,10 @@ const collectIncrementalStats = (
         return;
       }
 
-      if (isOptionsResponse(response) || response.response.length > 0) {
+      if (
+        isOptionsResponse(response) ||
+        (isTextResponse(response) && response.response.length > 0)
+      ) {
         responseStatsCounters[response.question_id].answerCounter++;
       }
 
@@ -169,15 +172,18 @@ const collectIncrementalStats = (
         return;
       }
 
-      responseStatsCounters[response.question_id].totalSelectedOptionsCounts +=
-        response.options.length;
-      response.options.forEach((option) => {
-        responseStatsCounters[response.question_id].selectedOptions[option]
-          .count++;
-      });
-      if (response.options.length > 1) {
-        responseStatsCounters[response.question_id]
-          .multipleSelectedOptionsCount++;
+      if (isOptionsResponse(response)) {
+        responseStatsCounters[
+          response.question_id
+        ].totalSelectedOptionsCounts += response.options.length;
+        response.options.forEach((option) => {
+          responseStatsCounters[response.question_id].selectedOptions[option]
+            .count++;
+        });
+        if (response.options.length > 1) {
+          responseStatsCounters[response.question_id]
+            .multipleSelectedOptionsCount++;
+        }
       }
     });
   });

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -363,6 +363,9 @@ export type ZetkinSurveyQuestionResponse =
   | {
       options: number[];
       question_id: number;
+    }
+  | {
+      question_id: number;
     };
 
 export type ZetkinSurveySignatureType = 'email' | 'user' | 'anonymous';


### PR DESCRIPTION
## Description
This PR aligns the `ZetkinSurveyQuestionResponse` type more closely with the production data and adds a missing undefined check.

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds missing check to `isTextResponse`, making sure that `response` is defined
* Changes the `ZetkinSurveyQuestionResponse` type so it ensures that undefined `response` is handled
* Fixes resulting type errors

Logic on why this type change is necessary:

The error `TypeError: Cannot read properties of undefined (reading 'length')` from https://github.com/zetkin/app.zetkin.org/issues/3301 is from this line:
```ts
if (isOptionsResponse(response) || response.response.length > 0) {
```
Here, it was inferred that `response.response` exists and is defined, since the type `ZetkinSurveyQuestionResponse` contained either `options` or `response`, so in case `isOptionsResponse` is `false`, it would infer `response` as a text response. 

The fix is adding a case 
```ts
{
  question_id: number;
}
```
which has neither `options` nor `response`.

## Related issues
Should resolve the error in https://github.com/zetkin/app.zetkin.org/issues/3301 but doesn't add error handling yet. Resolves the issue together with https://github.com/zetkin/app.zetkin.org/pull/3310
