### PR TITLE
Issue 3263 - Display name of person signed up to event in call screen

### DIFF
--- a/src/features/call/components/EventCard.tsx
+++ b/src/features/call/components/EventCard.tsx
@@ -60,7 +60,9 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
                 {event.num_participants_available <
                   event.num_participants_required &&
                   !isSignedUp && <ZUISignUpChip status="needed" />}
-                {isSignedUp && <ZUISignUpChip status="signedUp" />}
+                {isSignedUp && (
+                  <ZUISignUpChip name={target.first_name} status="signedUp" />
+                )}
               </>,
             ]
       }

--- a/src/zui/components/ZUISignUpChip/index.tsx
+++ b/src/zui/components/ZUISignUpChip/index.tsx
@@ -6,10 +6,11 @@ import messageIds from 'zui/l10n/messageIds';
 import ZUILabel from '../ZUILabel';
 
 type ZUISignUpChipProps = {
+  name?: string;
   status: 'needed' | 'signedUp' | 'booked';
 };
 
-const ZUISignUpChip: FC<ZUISignUpChipProps> = ({ status }) => {
+const ZUISignUpChip: FC<ZUISignUpChipProps> = ({ name, status }) => {
   const theme = useTheme();
 
   const getColors = () => {
@@ -39,7 +40,11 @@ const ZUISignUpChip: FC<ZUISignUpChipProps> = ({ status }) => {
       }}
     >
       <ZUILabel color="inherit">
-        <Msg id={messageIds.signUpChip[status]} />
+        {name && status == 'signedUp' ? (
+          <Msg id={messageIds.signUpChip.callSignUp} values={{ name }} />
+        ) : (
+          <Msg id={messageIds.signUpChip[status]} />
+        )}
       </ZUILabel>
     </Box>
   );

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -233,6 +233,7 @@ export default makeMessages('zui', {
   },
   signUpChip: {
     booked: m('You are booked'),
+    callSignUp: m<{ name: string }>('{name} has signed up'),
     needed: m('You are needed'),
     signedUp: m('You have signed up'),
   },


### PR DESCRIPTION
When signing up a person in the call screen it now displays "{name} has signed up" instead of "You have signed up"

## Description
This PR adds a new message string which takes in the first name of the person being called, and displays that in the ZUISignUpChip in the call screen.

## Screenshots
<img width="1906" height="719" alt="image" src="https://github.com/user-attachments/assets/6ac0f94c-622f-4168-86e8-c19004668577" />

## Changes

* Adds a message for the signUpChip which takes in a name parameter
* Changes the ZUISignUpChip to have an optional name parameter and use the new message if name is valid and the status is signedUp


## Notes to reviewer
Start a call assignment and try to sign up the called person to an event. It should now display that "{name} has signed up"

## Related issues
Resolves #3263 
