### PR TITLE
Allow node versions 22 and above instead of locking the major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,6 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": "22.x"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Description
This PR updates the `package.json` so we don't restrict people using the specific node major version 22 on their local machines. 22 and above are allowed now. 

## Changes
* Updates only the `package.json`. 
* From what I looked at nothing else needed a change. The Dockerfile still points to a node 22 image, but I don't see that as a problem. 

## Notes to reviewer
- Tested the dev, build, test, e2e and storybook scripts on my local machine with node version 24 and not seeing any issues.

## Related issues
Raised a couple of times on the hackathon today. 
