### PR TITLE
Calendar: Fix local storage state handling

### DIFF
--- a/src/features/calendar/hooks/useTimeScale.ts
+++ b/src/features/calendar/hooks/useTimeScale.ts
@@ -8,7 +8,7 @@ function getTimeScale(timeScaleQueryParam: string | string[] | undefined) {
   ) {
     return timeScaleQueryParam as TimeScale;
   }
-  return TimeScale.MONTH;
+  return undefined;
 }
 
 export default function useTimeScale(
@@ -17,8 +17,8 @@ export default function useTimeScale(
   const [localStorageTimeScale, setLocalStorageTimeScale] =
     useLocalStorage<TimeScale>(
       'calendarTimeScale',
-      getTimeScale(timeScaleQueryParam),
-      true
+      TimeScale.MONTH,
+      getTimeScale(timeScaleQueryParam)
     );
 
   return {

--- a/src/zui/hooks/useLocalStorage.ts
+++ b/src/zui/hooks/useLocalStorage.ts
@@ -1,32 +1,28 @@
-import { useCallback, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useLocalStorage<T>(
   key: string,
   defaultValue: T,
-  useDefaultValueAsInitialValue?: boolean
+  initialValue?: T
 ): [T, (newValue: T) => void] {
   const [value, setValue] = useState<T>(() =>
-    getLocalStorageValue(key, defaultValue, useDefaultValueAsInitialValue)
+    getLocalStorageValue(key, defaultValue, initialValue)
   );
 
-  const updateValue = useCallback(
-    (newValue: T) => {
-      localStorage.setItem(key, JSON.stringify(newValue));
-      setValue(newValue);
-    },
-    [setValue, key]
-  );
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [value, key]);
 
-  return [value, updateValue] as const;
+  return [value, setValue] as const;
 }
 
 function getLocalStorageValue<T>(
   key: string,
   defaultValue: T,
-  useDefaultValueAsInitialValue?: boolean
+  initialValue?: T
 ): T {
-  if (useDefaultValueAsInitialValue) {
-    return defaultValue;
+  if (initialValue) {
+    return initialValue;
   }
 
   const isBrowser = typeof window !== 'undefined';


### PR DESCRIPTION
## Description
This PR makes adjustments to the `useLocalStorage` hook so state flip flops like https://github.com/zetkin/app.zetkin.org/issues/3288 don't happen. 

I defined these behaviours:

For the calendar time scale:
- If the `timeScale` query param is set, this is the initial state. 
- Whenever the time scale state changes, it should be stored in `localStorage`
- If `timeScale` is not set, we use the value from `localStorage`. If that doesn't exist, we fall back to MONTH.

For the `useLocalStorage` hook:
- On initial render, we `getLocalStorageValue` retrieves our initial state
- When updating the value, we update the local storage

With this, I came to the conclusion, `useLocalStorage` needs an initial state and a default (fallback) state. The initial state is the time scale query parameter. And the default state is MONTH. Using this, we can kick out one of the effects and solve the flip flop.

## Notes to reviewer
[Add instructions for testing]
The `useLocalStorage` hook is used in a lot of places. I tested the ones I know about and it changed nothing obvious. I identified two differences to the previous version:
- Before this PR, `localStorage` would not get update just from rendering the page. This PR will make the page update `localStorage` on initial render. 
- Before this PR, we fetch the `localStorage` value on each render and output it to the user component. This means, when another tab or another component updates the `localStorage` and the component rerenders, it will output that new value. This branch fully removes this behaviour. And if we deserve a behaviour like that, we should subscribe to 'storage' events to update the local state cleanly.

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3288
