### PR TITLE
Fix Survey Submission UI State reset

### DIFF
--- a/src/core/caching/cacheUtils.ts
+++ b/src/core/caching/cacheUtils.ts
@@ -77,7 +77,11 @@ export function loadListIfNecessary<
   const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteList);
 
   if (!remoteList || loadIsNecessary) {
-    return loadList(dispatch, hooks);
+    return loadList(
+      dispatch,
+      hooks,
+      remoteList?.items.map((item) => item.data).filter((item) => item != null)
+    );
   }
 
   return new RemoteListFuture({
@@ -97,7 +101,8 @@ export function loadList<
     actionOnLoad: () => PayloadAction<OnLoadPayload>;
     actionOnSuccess: (items: DataType[]) => PayloadAction<OnSuccessPayload>;
     loader: () => Promise<DataType[]>;
-  }
+  },
+  existingData?: DataType[]
 ): IFuture<DataType[]> {
   dispatch(hooks.actionOnLoad());
   const promise = hooks
@@ -115,7 +120,7 @@ export function loadList<
       }
     });
 
-  return new PromiseFuture(promise);
+  return new PromiseFuture(promise, existingData);
 }
 
 /**

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -399,7 +399,8 @@ const surveysSlice = createSlice({
     },
     /* eslint-disable-next-line */
     surveySubmissionsLoad: (state, action: PayloadAction<number>) => {
-      state.submissionsBySurveyId[action.payload] = remoteList();
+      state.submissionsBySurveyId[action.payload] =
+        state.submissionsBySurveyId[action.payload] || remoteList();
       state.submissionsBySurveyId[action.payload].isLoading = true;
       state.submissionList.isLoading = true;
     },

--- a/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/surveys/[surveyId]/submissions.tsx
@@ -64,7 +64,7 @@ const SubmissionsPage: PageWithLayout<SubmissionsPageProps> = ({
       </Head>
       <Grid container spacing={2}>
         <Grid size={{ md: isShared ? 12 : 8, sm: 12, xs: 12 }}>
-          <ZUIFuture future={submissionsFuture} ignoreDataWhileLoading>
+          <ZUIFuture future={submissionsFuture}>
             {(data) => {
               let submissions = data;
               if (showUnlinkedOnly) {


### PR DESCRIPTION
## Description

This PR fixes the bug that the UI State (e.g. scrolling) resets when the survey submission data is refetched from the server.

This behaviour always happens when the future passed to `ZUIFuture` (in this case, the `submissionsFuture`) has no data. It leads the `ZUIFuture` to only show the Skeleton (a loading indicator) and thus resets the UI state.

## Changes

This bug has three individual causes:
1. The `ignoreDataWhileLoading` flag was passed to `ZUIFuture`. This makes `ZUIFuture` to always show the Skeleton when loading data from the server. Other views using the `ZUIFuture`, like the Events Participants view, do not use this flag.
2. When loading data, the `/src/core/caching/cacheUtils.ts` returns a `PromiseFuture`. This happens both for the working Events Participants view and the Survey Submissions view. The difference is that for the Events Participants view `existingData` is passed to the `PromiseFuture` (via the function `loadItemIfNecessary`) which allows falling back to existing data as long as the new data fetches. For the Survey Submission data, just no `existingData` is passed (in the function `loadList`).
3. In the survey's `store.ts`, the submissions data is always reset when new data is about to be fetched. This prevents inline update and leads to a full reset, including first no data and then inserting the same data again. For other kinds of data, we just update the `isLoading` flag. This seems also the right way in this case.


## Notes to reviewer
It is beyond my skills to foresee all the consequences of the changes made with this PR 🙃 

## Related issues
Resolves #3300