### PR TITLE
Use slotProps for StyledNumberInput

### DIFF
--- a/src/features/smartSearch/components/filters/CallHistory/index.tsx
+++ b/src/features/smartSearch/components/filters/CallHistory/index.tsx
@@ -192,13 +192,13 @@ const CallHistory = ({
                     input: (
                       <StyledNumberInput
                         defaultValue={filter.config.minTimes || 1}
-                        inputProps={{ min: '1' }}
                         onChange={(e) => {
                           setConfig({
                             ...filter.config,
                             minTimes: +e.target.value,
                           });
                         }}
+                        slotProps={{ htmlInput: { min: '1' } }}
                       />
                     ),
                     minTimes: filter.config.minTimes || 1,

--- a/src/features/smartSearch/components/filters/Journey/index.tsx
+++ b/src/features/smartSearch/components/filters/Journey/index.tsx
@@ -186,10 +186,6 @@ const Journey: FC<JourneyProps> = ({
                 {conditionSelect}
                 {selected === JOURNEY_CONDITION_OP.SOME && (
                   <StyledNumberInput
-                    inputProps={{
-                      max: filter.config.tags!.ids.length,
-                      min: '1',
-                    }}
                     onChange={(e) =>
                       setConfig({
                         ...filter.config,
@@ -200,6 +196,12 @@ const Journey: FC<JourneyProps> = ({
                         },
                       })
                     }
+                    slotProps={{
+                      htmlInput: {
+                        max: filter.config.tags!.ids.length,
+                        min: '1',
+                      },
+                    }}
                     sx={{ ml: '0.5rem' }}
                     value={filter.config.tags?.min_matching}
                   />

--- a/src/features/smartSearch/components/filters/MostActive/index.tsx
+++ b/src/features/smartSearch/components/filters/MostActive/index.tsx
@@ -93,13 +93,13 @@ const MostActive = ({
             numPeopleSelect: (
               <StyledNumberInput
                 defaultValue={filter.config?.size}
-                inputProps={{ min: '1' }}
                 onChange={(e) => {
                   setConfig({
                     ...filter.config,
                     size: +e.target.value,
                   });
                 }}
+                slotProps={{ htmlInput: { min: '1' } }}
               />
             ),
             timeFrame: (

--- a/src/features/smartSearch/components/filters/PersonTags/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonTags/index.tsx
@@ -155,10 +155,6 @@ const PersonTags = ({
                     conditionSelect,
                     minMatchingInput: (
                       <StyledNumberInput
-                        inputProps={{
-                          max: selectedTags.length,
-                          min: '1',
-                        }}
                         onChange={(e) =>
                           setConfig({
                             ...filter.config,
@@ -166,6 +162,12 @@ const PersonTags = ({
                             min_matching: +e.target.value || undefined,
                           })
                         }
+                        slotProps={{
+                          htmlInput: {
+                            max: selectedTags.length,
+                            min: '1',
+                          },
+                        }}
                         value={filter.config.min_matching}
                       />
                     ),

--- a/src/features/smartSearch/components/filters/Random/index.tsx
+++ b/src/features/smartSearch/components/filters/Random/index.tsx
@@ -119,12 +119,6 @@ const Random = ({
                 values={{
                   numInput: (
                     <StyledNumberInput
-                      inputProps={{
-                        min: '1',
-                        ...(selected === QUANTITY.PERCENT && {
-                          max: '99',
-                        }),
-                      }}
                       onChange={(e) => {
                         if (
                           selected === QUANTITY.PERCENT &&
@@ -133,6 +127,14 @@ const Random = ({
                           return;
                         }
                         setQuantityDisplay(+e.target.value);
+                      }}
+                      slotProps={{
+                        htmlInput: {
+                          min: '1',
+                          ...(selected === QUANTITY.PERCENT && {
+                            max: '99',
+                          }),
+                        },
                       }}
                       value={quantityDisplay}
                     />

--- a/src/features/smartSearch/components/filters/TimeFrame.tsx
+++ b/src/features/smartSearch/components/filters/TimeFrame.tsx
@@ -154,8 +154,8 @@ const TimeFrame = ({
             days: numDays,
             daysInput: (
               <StyledNumberInput
-                inputProps={{ min: '1' }}
                 onChange={(e) => setNumDays(+e.target.value)}
+                slotProps={{ htmlInput: { min: '1' } }}
                 value={numDays}
               />
             ),

--- a/src/features/smartSearch/components/inputs/StyledNumberInput.tsx
+++ b/src/features/smartSearch/components/inputs/StyledNumberInput.tsx
@@ -1,8 +1,22 @@
 import { TextField, TextFieldProps } from '@mui/material';
+import { merge } from 'lodash';
 
 import oldTheme from 'theme';
 
 const StyledNumberInput: React.FC<TextFieldProps> = (props): JSX.Element => {
+  const slotProps = merge<typeof props.slotProps, typeof props.slotProps>(
+    {
+      htmlInput: {
+        sx: {
+          fontSize: oldTheme.typography.h4.fontSize,
+          padding: 0,
+          textAlign: 'center',
+          width: '5rem',
+        },
+      },
+    },
+    props.slotProps
+  );
   return (
     <TextField
       sx={{
@@ -11,17 +25,7 @@ const StyledNumberInput: React.FC<TextFieldProps> = (props): JSX.Element => {
       }}
       type="number"
       {...props}
-      slotProps={{
-        htmlInput: {
-          ...props.inputProps,
-          sx: {
-            fontSize: oldTheme.typography.h4.fontSize,
-            padding: 0,
-            textAlign: 'center',
-            width: '5rem',
-          },
-        },
-      }}
+      slotProps={slotProps}
       variant="standard"
     />
   );


### PR DESCRIPTION
## Description
This PR replaces inputProps with slotProps for StyledNumberInput

StyledNumberInput had already replaces inputProp with slotProps internally but this PR changes uses of the component to use slotProps, to make it less confusing which property it's using.


## Changes
* Replaces inputProps for slotProps for uses of \<StyledNumbedInput\>


## Related issues
Contributes to #3322 
