### PR TITLE
Fix disable on TagChip and localBool columnType

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -8,6 +8,7 @@ import {
 
 import { IColumnType } from '.';
 import { useNumericRouteParams } from 'core/hooks';
+import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import { ZetkinObjectAccess } from 'core/api/types';
 import {
   LocalBoolViewColumn,
@@ -75,6 +76,7 @@ const Cell: FC<{
   );
 
   const checked = !!cell;
+  const [isRestricted] = useAccessLevel();
 
   return (
     <Box
@@ -88,6 +90,7 @@ const Cell: FC<{
       <Checkbox
         checked={checked}
         color="success"
+        disabled={isRestricted}
         onChange={onChange}
         tabIndex={-1}
       />

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
@@ -14,7 +14,6 @@ import { DEFAULT_TAG_COLOR } from 'features/tags/components/TagManager/utils';
 import IApiClient from 'core/api/client/IApiClient';
 import { IColumnType } from '../';
 import { loadItemIfNecessary } from 'core/caching/cacheUtils';
-import TagChip from 'features/tags/components/TagManager/components/TagChip';
 import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import useTag from 'features/tags/hooks/useTag';
 import useTagging from 'features/tags/hooks/useTagging';
@@ -27,6 +26,7 @@ import { AppDispatch } from 'core/store';
 import { PersonTagViewColumn, ZetkinViewRow } from '../../../types';
 import { tagLoad, tagLoaded } from 'features/tags/store';
 import { RemoteList } from 'utils/storeUtils';
+import ZUITagChip from 'zui/components/ZUITagChip';
 
 type PersonTagViewCell = null | {
   value?: string;
@@ -229,7 +229,8 @@ const BasicTagCell: FC<{
 
   if (cell) {
     return (
-      <TagChip
+      <ZUITagChip
+        disabled={isRestricted}
         onDelete={() => {
           removeFromPerson(personId, tagId);
         }}
@@ -262,7 +263,7 @@ const BasicTagCell: FC<{
                   pointerEvents: 'none',
                 }}
               >
-                <TagChip tag={tag} />
+                <ZUITagChip tag={tag} />
               </Box>
             </Box>
           )}


### PR DESCRIPTION
## Description
This PR fix the problem that even if a view was readonly it could send data to the server. 
Now the components are disabled when necessary.


## Screenshots
<img width="669" height="385" alt="image" src="https://github.com/user-attachments/assets/127f11b7-f2f1-463c-a356-58dfa24bbfbe" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
* Changes…


## Notes to reviewer
Make a new list share the list with someone as read only. 
Change account and go to the shared link.
The checkbox (boolean) and the tag should be disabled. 


## Related issues
Resolves #2844 