### PR TITLE
Fix UserAutocomplete filtering, duplicates, and hover states

### DIFF
--- a/src/features/user/components/UserAutocomplete.tsx
+++ b/src/features/user/components/UserAutocomplete.tsx
@@ -8,6 +8,7 @@ import {
   ListItemText,
   TextField,
 } from '@mui/material';
+import Fuse from 'fuse.js';
 
 import useOrgUsers from '../hooks/useOrgUsers';
 import { ZetkinOrgUser } from '../types';
@@ -24,25 +25,18 @@ const UserAutocomplete: FC<Props> = ({ onSelect, orgId }) => {
     options: ZetkinOrgUser[],
     state: FilterOptionsState<ZetkinOrgUser>
   ): ZetkinOrgUser[] => {
-    const inputValue = state.inputValue.trim().toLowerCase();
+    const inputValue = state.inputValue.trim();
 
     if (inputValue.length === 0) {
       return options;
     }
 
-    return options.filter((user) => {
-      const firstName = user.first_name.toLowerCase();
-      const lastName = user.last_name.toLowerCase();
-      const email = user.email?.toLowerCase() || '';
-      const fullName = `${firstName} ${lastName}`;
-
-      return (
-        firstName.includes(inputValue) ||
-        lastName.includes(inputValue) ||
-        fullName.includes(inputValue) ||
-        email.includes(inputValue)
-      );
+    const fuse = new Fuse(options, {
+      keys: ['first_name', 'last_name', 'email'],
+      threshold: 0.4,
     });
+
+    return fuse.search(inputValue).map((result) => result.item);
   };
 
   return (


### PR DESCRIPTION
## Description
This PR fixes three bugs in the UserAutocomplete component used for assigning people to areas in area assignments:

1. **False matches in filtering**: The default Material-UI Autocomplete filtering was showing incorrect results when searching for names
2. **Duplicate results**: The same user could appear multiple times in the filtered results
3. **Incorrect hover states**: Hovering over one result would highlight a different result element

## Screenshots
<img width="403" height="451" alt="image" src="https://github.com/user-attachments/assets/b825d606-fd5e-4c6e-80e5-107cd3f55e9c" />

<img width="390" height="337" alt="image" src="https://github.com/user-attachments/assets/515441dd-c555-4888-9615-181da34333a9" />

<img width="422" height="263" alt="image" src="https://github.com/user-attachments/assets/95ab7b0c-ea2c-4cfd-8a0a-36dbbdc3a07d" />


## Changes
* Adds custom `filterOptions` function that properly filters users by first name, last name, full name, and email address
* Adds `isOptionEqualToValue` prop to prevent duplicate results by comparing users based on their unique ID
* Adds `getOptionKey` prop for better performance and proper React key handling
* Fixes `renderOption` to extract and handle the `key` prop separately, ensuring correct hover state behavior

## Notes to reviewer
To test these fixes:

1. Navigate to an area assignment map page (e.g., `/organize/1/projects/341/areaassignments/59/map`)
2. Select any area in the Areas map side pane
3. Click the "Add assignee" autocomplete dropdown
4. Type "Angela" as a filter term
5. Verify:
   - Only users matching "Angela" are shown (check first name, last name, and email)
   - No duplicate entries appear
   - Hovering over a result highlights the correct element

## Related issues
Resolves #3244