### PR TITLE
rephrase move button to reschedule

### DIFF
--- a/src/features/calendar/l10n/messageIds.ts
+++ b/src/features/calendar/l10n/messageIds.ts
@@ -103,12 +103,12 @@ export default makeMessages('feat.calendar', {
       ),
       createShift: m('After each event (create shift)'),
       duplicate: m('Same time and date (duplicate)'),
-      move: m('Move'),
-      moveMenuHeader: m<{ numberOfEvents: number }>(
-        'Move {numberOfEvents} events to'
-      ),
       nextDay: m<{ dates: ReactElement }>('Next day {dates}'),
       nextWeek: m<{ dates: ReactElement }>('Next week {dates}'),
+      reschedule: m('Reschedule'),
+      rescheduleMenuHeader: m<{ numberOfEvents: number }>(
+        'Reschedule {numberOfEvents} events to'
+      ),
     },
   },
   shortWeek: m<{ weekNumber: number }>('w {weekNumber}'),

--- a/src/features/events/components/SelectionBar/MoveCopyButtons.tsx
+++ b/src/features/events/components/SelectionBar/MoveCopyButtons.tsx
@@ -36,7 +36,7 @@ const MoveCopyButtons: FC = () => {
         }}
         variant="outlined"
       >
-        <Msg id={messageIds.selectionBar.moveCopyButtons.move} />
+        <Msg id={messageIds.selectionBar.moveCopyButtons.reschedule} />
       </Button>
       <Menu
         anchorEl={moveMenuAnchorEl}
@@ -56,7 +56,7 @@ const MoveCopyButtons: FC = () => {
         <Box sx={{ cursor: 'default', paddingLeft: 2 }}>
           <Typography fontWeight="medium" variant="body2">
             <Msg
-              id={messageIds.selectionBar.moveCopyButtons.moveMenuHeader}
+              id={messageIds.selectionBar.moveCopyButtons.rescheduleMenuHeader}
               values={{ numberOfEvents: selectedEvents.length }}
             />
           </Typography>


### PR DESCRIPTION
## Description
This PR renames the "Move" button in the calendar UI to "Reschedule" to avoid confusion with the "Move" action that moves events between projects. The calendar "Move" button is used for bulk rescheduling events to different dates, which is a different action than moving events between projects.

## Screenshots
<img width="226" height="183" alt="image" src="https://github.com/user-attachments/assets/e685e16e-06d3-47af-a95b-8292956945e0" />

## Changes
* Renames the "Move" button to "Reschedule" in the calendar selection bar for bulk event rescheduling
* Updates message IDs from `move`/`moveMenuHeader` to `reschedule`/`rescheduleMenuHeader` in the calendar feature
* Updates translations in all 5 supported languages (de, en, nl, nn, sv) with appropriate "Reschedule" translations
* Keeps the "Move" action unchanged for moving events between projects (in EventActionButtons)

## Notes to reviewer
To test:
1. Go to the calendar view (`/organize/[orgId]/projects/calendar`)
2. Select multiple events using their checkboxes
3. Verify the bottom action tray shows a "Reschedule" button (instead of "Move")
4. Click "Reschedule" and verify it opens a menu for rescheduling to different dates
5. Go to an individual event page (`/organize/[orgId]/projects/[projectId]/events/[eventId]`)
6. Open the event's ellipsis menu (⠇)
7. Verify the "Move" menu item is still present and moves the event between projects (not rescheduling)

## Related issues
Resolves #3227