### PR TITLE
Improve draw button states: remove icons, set cancel to outlined vari…

### DIFF
--- a/src/features/geography/components/GLGeographyMap/index.tsx
+++ b/src/features/geography/components/GLGeographyMap/index.tsx
@@ -1,5 +1,4 @@
-import { Box, Button, ButtonGroup } from '@mui/material';
-import { Close, Create, Save } from '@mui/icons-material';
+import { Box, Button } from '@mui/material';
 import Map from '@vis.gl/react-maplibre';
 import { FC, useMemo, useState } from 'react';
 import { Map as MapType } from 'maplibre-gl';
@@ -60,42 +59,40 @@ const GLGeographyMap: FC<Props> = ({ areas, orgId }) => {
           width: '100%',
         }}
       >
-        <Box display="flex" justifyContent="space-between" px={2} py={1}>
+        <Box display="flex" justifyContent="flex-end" px={2} py={1}>
           <Box alignItems="center" display="flex" gap={1}>
-            <ButtonGroup variant="contained">
-              {!drawing && (
-                <Button
-                  onClick={() => {
-                    startDrawing();
-                  }}
-                  startIcon={<Create />}
-                >
-                  <Msg id={messageIds.areas.draw.startButton} />
-                </Button>
-              )}
-              {drawing && (
-                <Button
-                  disabled={creating}
-                  onClick={() => {
-                    cancelDrawing();
-                  }}
-                  startIcon={<Close />}
-                >
-                  <Msg id={messageIds.areas.draw.cancelButton} />
-                </Button>
-              )}
-              {drawing && canFinishDrawing && (
-                <Button
-                  loading={creating}
-                  onClick={() => {
-                    finishDrawing();
-                  }}
-                  startIcon={<Save />}
-                >
-                  <Msg id={messageIds.areas.draw.saveButton} />
-                </Button>
-              )}
-            </ButtonGroup>
+            {!drawing && (
+              <Button
+                onClick={() => {
+                  startDrawing();
+                }}
+                variant="contained"
+              >
+                <Msg id={messageIds.areas.draw.startButton} />
+              </Button>
+            )}
+            {drawing && (
+              <Button
+                disabled={creating}
+                onClick={() => {
+                  cancelDrawing();
+                }}
+                variant="outlined"
+              >
+                <Msg id={messageIds.areas.draw.cancelButton} />
+              </Button>
+            )}
+            {drawing && canFinishDrawing && (
+              <Button
+                loading={creating}
+                onClick={() => {
+                  finishDrawing();
+                }}
+                variant="contained"
+              >
+                <Msg id={messageIds.areas.draw.saveButton} />
+              </Button>
+            )}
           </Box>
         </Box>
         <Box sx={{ flexGrow: 1, position: 'relative' }}>


### PR DESCRIPTION
## Description
This PR improves the draw button states in the Areas section by removing icons, adjusting button variants, and adding proper spacing between buttons.

## Screenshots
<img width="647" height="351" alt="Screenshot 2026-01-06 at 12 45 47" src="https://github.com/user-attachments/assets/926fc585-a1e9-46c7-9b4d-dd2e43a0b47c" />
<img width="1028" height="503" alt="Screenshot 2026-01-06 at 12 45 42" src="https://github.com/user-attachments/assets/d9419678-e669-454a-addc-c08943776c4a" />
<img width="858" height="546" alt="Screenshot 2026-01-06 at 12 45 36" src="https://github.com/user-attachments/assets/31d132c8-c629-44b9-91e4-93fb1447120c" />


## Changes
* Removes icons from DRAW, CANCEL, and SAVE buttons
* Changes CANCEL button to outlined variant (white with red border) instead of contained
* Adds spacing between buttons by replacing ButtonGroup with Box layout using gap
* Aligns buttons to the right side of the toolbar
* Removes unused icon imports (Close, Create, Save)

## Notes to reviewer
To test:
1. Navigate to Areas section
2. Click "Draw" button - should appear as red contained button without icon, aligned to the right
3. Start drawing by clicking on the map to create anchor points
4. Verify CANCEL button appears as outlined (white with red border) without icon
5. After creating enough points, verify SAVE button appears next to CANCEL with spacing between them
6. Both CANCEL and SAVE should be aligned to the right with proper spacing

## Related issues
Resolves #2435