### PR TITLE
Add geography map settings panels and fix area selection click handle…

### DIFF
--- a/src/features/geography/components/GLGeographyMap/Areas.tsx
+++ b/src/features/geography/components/GLGeographyMap/Areas.tsx
@@ -1,31 +1,14 @@
 import { Layer, Source } from '@vis.gl/react-maplibre';
 import { FC, useMemo } from 'react';
-import { useTheme } from '@mui/material';
 
 import { Zetkin2Area } from 'features/areas/types';
+import oldTheme from 'theme';
 
 type Props = {
   areas: Zetkin2Area[];
-  dashed?: boolean;
-  fillColor?: string;
-  fillOpacity?: number;
-  outlineColor?: string;
-  outlineOpacity?: number;
-  outlineWidth?: number;
-  style?: 'filled' | 'outlined' | 'hide';
 };
 
-const Areas: FC<Props> = ({
-  areas,
-  dashed = false,
-  fillColor,
-  fillOpacity = 0.6,
-  outlineOpacity = 0.6,
-  outlineColor,
-  outlineWidth = 2,
-  style = 'filled',
-}) => {
-  const theme = useTheme();
+const Areas: FC<Props> = ({ areas }) => {
   const areasGeoJson: GeoJSON.GeoJSON = useMemo(() => {
     return {
       features: areas.map((area) => ({
@@ -37,35 +20,24 @@ const Areas: FC<Props> = ({
     };
   }, [areas]);
 
-  if (style === 'hide') {
-    return null;
-  }
-
-  const strokeColor = outlineColor ?? 'black';
-  const fill = fillColor ?? theme.palette.secondary.main;
-
   return (
     <Source data={areasGeoJson} id="areas" type="geojson">
       <Layer
         id="outlines"
         paint={{
-          'line-color': strokeColor,
-          'line-dasharray': dashed ? [5, 7] : [1, 0],
-          'line-opacity': outlineOpacity,
-          'line-width': outlineWidth,
+          'line-color': oldTheme.palette.secondary.main,
+          'line-width': 2,
         }}
         type="line"
       />
-      {style === 'filled' && (
-        <Layer
-          id="areas"
-          paint={{
-            'fill-color': fill,
-            'fill-opacity': fillOpacity,
-          }}
-          type="fill"
-        />
-      )}
+      <Layer
+        id="areas"
+        paint={{
+          'fill-color': oldTheme.palette.secondary.main,
+          'fill-opacity': 0.4,
+        }}
+        type="fill"
+      />
     </Source>
   );
 };

--- a/src/features/geography/hooks/useAreaSelection.ts
+++ b/src/features/geography/hooks/useAreaSelection.ts
@@ -21,7 +21,7 @@ export default function useAreaSelection({
   onSelectFromMap,
 }: Props): Return {
   const [selectedId, setSelectedId] = useState(0);
-  const selectedArea = areas.find((area) => area.id === selectedId) || null;
+  const selectedArea = areas.find((area) => area.id == selectedId) || null;
 
   useEffect(() => {
     if (!map) {


### PR DESCRIPTION
## Description
This PR adds a settings side panel to the Geography map for selecting areas and controlling area layer styling, and fixes an issue where map click handlers could accumulate over time.

## Screenshots
<img width="986" height="516" alt="image" src="https://github.com/user-attachments/assets/777486ad-1639-4269-91fd-df14945d3047" />
<img width="1203" height="609" alt="image" src="https://github.com/user-attachments/assets/ff1709b1-94f6-46b1-92b8-fbfb30a8066b" />
<img width="1258" height="679" alt="image" src="https://github.com/user-attachments/assets/f942f99a-69c4-4764-93f9-23caf01c9144" />
<img width="1241" height="635" alt="image" src="https://github.com/user-attachments/assets/a79b0e65-7ded-4112-9920-05afdeba4b36" />
<img width="1178" height="656" alt="image" src="https://github.com/user-attachments/assets/1487a2c8-51bd-4789-ae1e-7a56de475ba9" />


## Changes
- **Adds** a right-side settings panel with:
  - Area selection (with search/filter)
  - Area layer style controls (filled/outlined/hidden)
- **Persists** chosen area layer style in local storage per org
- **Changes** area rendering to use the active MUI theme (no `oldTheme` dependency)
- **Fixes** `useAreaSelection()` to properly register/unregister the map click handler (prevents repeated listeners) and improves robustness when reading feature IDs

## Notes to reviewer
- Go to the Geography map for an org with areas.
- Click the **layers** button and switch area style (filled/outlined/hidden) and verify the map updates.
- Click the **select** button, search for an area, select it, and verify the selection/overlay.
- Click an area directly on the map and verify it opens the select panel and selects the clicked area.
- Refresh the page and verify the chosen area style persists for the org.
- **IMPORTANT**: The "Draw" button-changes are igbnored in this PR and are tackled in PR #3330

## Related issues
Resolves #2434