### PR TITLE
fix: make entire project card clickable (#2701)

### DIFF
--- a/src/features/campaigns/components/CampaignCard.tsx
+++ b/src/features/campaigns/components/CampaignCard.tsx
@@ -2,14 +2,14 @@ import NextLink from 'next/link';
 import {
   Box,
   Card,
+  CardActionArea,
   CardActions,
   CardContent,
-  Link,
   Typography,
 } from '@mui/material';
 
 import messageIds from '../l10n/messageIds';
-import { Msg } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinCampaign } from 'utils/types/zetkin';
 import CampaignStatusChip from './CampaignStatusChip';
@@ -20,36 +20,45 @@ interface CampaignCardProps {
 
 const CampaignCard = ({ campaign }: CampaignCardProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();
+  const messages = useMessages(messageIds);
   const { id, title } = campaign;
 
   return (
     <Card data-testid="campaign-card">
-      <CardContent>
-        <Box
-          sx={{
-            alignItems: 'center',
-            display: 'flex',
-            gap: 1,
-            justifyContent: 'space-between',
-          }}
-        >
-          <Typography gutterBottom noWrap variant="h6">
-            {title}
-          </Typography>
-          <CampaignStatusChip campaign={campaign} />
-        </Box>
-      </CardContent>
-      <CardActions sx={{ paddingBottom: 2, paddingLeft: 2 }}>
-        <NextLink
-          href={`/organize/${orgId}/projects/${id}`}
-          legacyBehavior
-          passHref
-        >
-          <Link underline="hover" variant="button">
+      <CardActionArea
+        aria-label={messages.all.cardAriaLabel({ title })}
+        component={NextLink}
+        href={`/organize/${orgId}/projects/${id}`}
+      >
+        <CardContent>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 1,
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography gutterBottom noWrap variant="h6">
+              {title}
+            </Typography>
+            <CampaignStatusChip campaign={campaign} />
+          </Box>
+        </CardContent>
+        <CardActions sx={{ paddingBottom: 2, paddingLeft: 2 }}>
+          <Typography
+            color="primary"
+            sx={{
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            }}
+            variant="button"
+          >
             <Msg id={messageIds.all.cardCTA} />
-          </Link>
-        </NextLink>
-      </CardActions>
+          </Typography>
+        </CardActions>
+      </CardActionArea>
     </Card>
   );
 };

--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -46,6 +46,7 @@ export default makeMessages('feat.campaigns', {
   },
   all: {
     campaignFilterPlaceholder: m('Type to filter projects'),
+    cardAriaLabel: m<{ title: string }>('Open {title} project'),
     cardCTA: m('Go to project'),
     create: m('Create new project'),
     filter: {


### PR DESCRIPTION
## Description
This PR makes the full project card clickable, instead of only the CTA link text.


## Screenshots
https://app.dev.zetkin.org/organize/1/projects
<img width="447" height="325" alt="Screenshot 2026-01-18 at 12 22 36" src="https://github.com/user-attachments/assets/a35438c8-b146-4365-8ce7-50b05044c01a" />


## Changes
- Replaced Link with Typography (card itself is now the link) and removed Link from imports
- Added aria-label for screen reader context


## Notes to reviewer
None

## Related issues
Resolves #2701 