### PR TITLE
Add button to event popper that allows booking participants

### DIFF
--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -14,6 +14,8 @@ import {
 import { Box, Button, Link, Typography } from '@mui/material';
 import React, { FC, useContext, useState } from 'react';
 import router from 'next/router';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { useMessages } from 'core/i18n';
 import { eventsDeselected } from 'features/events/store';
@@ -40,6 +42,7 @@ import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import ZUITimeSpan from 'zui/ZUITimeSpan';
 import useEventState, { EventState } from 'features/events/hooks/useEventState';
 import ChangeCampaignDialog from '../../../campaigns/components/ChangeCampaignDialog';
+import AddPersonButton from '../AddPersonButton';
 
 interface SingleEventProps {
   event: ZetkinEvent | MultiDayEvent;
@@ -260,6 +263,9 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
             participants={availableParticipants}
           />
         )}
+        <DndProvider backend={HTML5Backend}>
+          <AddPersonButton eventId={event.id} orgId={event.organization.id} />
+        </DndProvider>
         <Box alignItems="center" display="flex" justifyContent="space-between">
           <Box alignItems="center" display="flex">
             <ZUIIconLabel


### PR DESCRIPTION
## Description
This PR adds the button to add participants to the event popper on the projects page.


## Screenshots
[Peek 2026-01-18 13-53.webm](https://github.com/user-attachments/assets/4004132a-d93d-4e43-965b-7ac7f6dc605d)


## Changes

* Changes the popper in <Single Event /> to include a button for adding people to events.


## Notes to reviewer

1. Make a event visible on the projects page by changing its that date to today on ex. http://localhost:3000/organize/1/projects/403/events/562/participants
2. Go to ex. http://localhost:3000/organize/1/projects and look for it in the pane with events starting today/tomorrow
3. Click, and use the button

Note that the bulk add function does not work here, but since it also does not work on the actual event page I suspect that it's not related to this PR.

The `<DndProvider />` component was added because the one from the root appears to be unavailable here, which breaks the bulk add function who uses `<ViewBrowser />`.

## Related issues
Resolves #3346 
