### PR TITLE
Inverses LocalBoolColumnType sorting order

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -26,7 +26,7 @@ export default class LocalBoolColumnType implements IColumnType {
 
   getColDef(column: LocalBoolViewColumn): Omit<GridColDef, 'field'> {
     return {
-      headerAlign: 'left',
+      headerAlign: 'center',
       renderCell: (params: GridRenderCellParams<ZetkinViewRow, boolean>) => {
         return (
           <Cell cell={params.value} column={column} personId={params.row.id} />


### PR DESCRIPTION
## Description
This PR inverses sorting order of bools in DataTable columns so that true gets sorted to the top first. This is relevant when sorting lists as having unchecked boxes (false) getting sorted to the top first does not make intuitive sense.

## Screenshots
<img width="1070" height="511" alt="image" src="https://github.com/user-attachments/assets/7fe8a0c1-d871-4694-8ce4-2f4016c6c811" />

## Changes
* Adds a sorting order for LocalBoolColumnType with descending as the first sorting type.
* Changes the LocalBoolColumnType header to be left aligned to prevent the text from bouncing to the left when hovering.

## Notes to reviewer
Go to any populated list and add a Toggle column. Check the toggle boxes of some random people, and sort the list by the toggle column. The list should now sort the checked boxes to the top.

