### PR TITLE
fix: activist portal link overflowing (#3296)

### DIFF
--- a/src/features/organizations/pages/PublicEventPage.tsx
+++ b/src/features/organizations/pages/PublicEventPage.tsx
@@ -375,7 +375,7 @@ const DateAndLocation: FC<{
       {event.url && (
         <Box alignItems="center" display="flex" gap={1}>
           <ZUIIcon icon={LinkIcon} />
-          <Box sx={{ overflowWrap: 'anywhere', minWidth: 0 }}>
+          <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
             <ZUILink href={event.url} openInNewTab text={event.url} />
           </Box>
         </Box>


### PR DESCRIPTION
## Description
This PR wraps the URL for the activist portal event link with "overflowWrap: anywhere" to stop long links making the UI width wider than intended.


## Screenshots
https://app.dev.zetkin.org/o/1/events/534
Original:
<img width="396" height="144" alt="Screenshot 2026-01-18 at 13 20 23" src="https://github.com/user-attachments/assets/00800ef5-5153-4b6f-96e3-633fddc0a6e1" />
New: 
<img width="365" height="168" alt="Screenshot 2026-01-18 at 13 20 43" src="https://github.com/user-attachments/assets/8f817bea-88fa-4f99-9700-e35859b3c497" />


## Changes
Wrapped link in a Box, with "overflowWrap: anywhere"


## Notes to reviewer
The original issue suggested either wrapping or replacing the overflow with an elipsis. I suggest wrapping over multiple lines so users can still see the URL, and more easily identify anything they might want to change in it - for example spelling mistakes or confusing text.


## Related issues
Resolves #3296