### PR TITLE
Accessible expand/collapse button in OrganizeSidebar

### DIFF
--- a/src/zui/ZUIEllipsisMenu/index.tsx
+++ b/src/zui/ZUIEllipsisMenu/index.tsx
@@ -7,10 +7,11 @@ import {
   Typography,
 } from '@mui/material';
 import { FunctionComponent, ReactElement, useState } from 'react';
-import Link from 'next/link';
 
 import noPropagate from 'utils/noPropagate';
 import oldTheme from 'theme';
+import { useMessages } from 'core/i18n';
+import messageIds from 'zui/l10n/messageIds';
 
 type horizontalType = 'left' | 'center' | 'right';
 type verticalType = 'top' | 'center' | 'bottom';
@@ -21,7 +22,7 @@ export interface MenuItem {
   href?: string;
   id?: string;
   label: string | React.ReactNode;
-  onSelect?: (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
+  onSelect?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   startIcon?: ReactElement;
   subMenuItems?: Omit<MenuItem, 'subMenuItems'>[];
   textColor?: string;
@@ -38,6 +39,8 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
   anchorOrigin,
   transformOrigin,
 }) => {
+  const messages = useMessages(messageIds);
+
   const [menuActivator, setMenuActivator] = useState<null | HTMLElement>(null);
   const [subMenuActivator, setSubMenuActivator] = useState<null | HTMLElement>(
     null
@@ -48,6 +51,7 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
   return (
     <>
       <Button
+        aria-label={messages.ellipsisMenu.ariaLabel()}
         color="inherit"
         data-testid="ZUIEllipsisMenu-menuActivator"
         disableElevation
@@ -80,19 +84,24 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
         }
       >
         {items.map((item, idx) => {
-          const menuItem = (
+          const componentProps = item.href
+            ? ({ component: 'a', href: item.href } as const)
+            : {};
+
+          return (
             <MenuItem
               key={item.id || idx}
+              {...componentProps}
               data-testid={`ZUIEllipsisMenu-item-${item.id || idx}`}
               disabled={item.disabled}
               divider={item.divider}
-              onClick={(e) => {
+              onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (item.onSelect) {
                   item.onSelect(e);
                   setMenuActivator(null);
                 }
                 if (item.subMenuItems) {
-                  setSubMenuActivator(e.currentTarget as HTMLElement);
+                  setSubMenuActivator(e.currentTarget);
                 }
               }}
             >
@@ -134,14 +143,6 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
                 </Menu>
               )}
             </MenuItem>
-          );
-
-          return item.href ? (
-            <Link key={item.id || idx} href={item.href} passHref>
-              {menuItem}
-            </Link>
-          ) : (
-            menuItem
           );
         })}
       </Menu>

--- a/src/zui/ZUIOrganizeSidebar/index.tsx
+++ b/src/zui/ZUIOrganizeSidebar/index.tsx
@@ -409,6 +409,7 @@ const ZUIOrganizeSidebar = ({
 
                         {showOrgSwitcher && (
                           <TextField
+                            aria-label={messages.organizeSidebar.filterLabel()}
                             fullWidth
                             InputProps={{
                               endAdornment:
@@ -437,7 +438,14 @@ const ZUIOrganizeSidebar = ({
                       </Box>
 
                       <Box sx={{ display: open ? 'flex' : 'none' }}>
-                        <IconButton onClick={handleExpansion}>
+                        <IconButton
+                          aria-label={
+                            checked
+                              ? messages.organizeSidebar.organizationSwitcher.hide()
+                              : messages.organizeSidebar.organizationSwitcher.show()
+                          }
+                          onClick={handleExpansion}
+                        >
                           {checked ? <ExpandLess /> : <ExpandMore />}
                         </IconButton>
                       </Box>

--- a/src/zui/l10n/messageIds.ts
+++ b/src/zui/l10n/messageIds.ts
@@ -135,6 +135,9 @@ export default makeMessages('zui', {
   editableImage: {
     add: m('Click to add image'),
   },
+  ellipsisMenu: {
+    ariaLabel: m('More options'),
+  },
   eventWarningIcons: {
     contact: m('No contact person has been assigned'),
     reminders: m<{ numMissing: number }>(
@@ -179,6 +182,7 @@ export default makeMessages('zui', {
     collapse: m('Collapse sidebar'),
     expand: m('Expand sidebar'),
     filter: m('Type to filter'),
+    filterLabel: m('Filter organizations'),
     geography: m('Geography'),
     home: m('Home'),
     journeys: m('Journeys'),
@@ -186,6 +190,10 @@ export default makeMessages('zui', {
     myPagesMenuItemLabel: m('My pages'),
     mySettingsMenuItemLabel: m('My settings'),
     organizationAvatarAltText: m('Organization icon'),
+    organizationSwitcher: {
+      hide: m('Hide organization switcher'),
+      show: m('Show organization switcher'),
+    },
     overview: m('Overview'),
     people: m('People'),
     projects: m('Projects & Activities'),


### PR DESCRIPTION
## Description
This PR improves accessibility in the OrganizeSidebar for screen readers and keyboard users. 


## Screenshots
It's a screen recording, to better catch the screen reader interaction


https://github.com/user-attachments/assets/f4c4a4f3-8840-459f-a6bf-6ec631916d20


## Changes

* Add labels describing the buttons (instead of just saying "button")
* Make sure the expand/collapse buttons are not unmounted (only hidden) when not hovering/focusing on them
* Fix rendering of links in ZUIEllipsisMenu so that they are navigable with keyboard
* Add label to organization filter TextField, describing what it does when the placeholder is not visible


## Notes to reviewer
I am not 100% sure I handled the CSS in an idiomatic way for Zetkin/MUI, so please take an extra look on that part.

## Related issues
Resolves #3257 
