### PR TITLE
Surveys: Fix survey saving fail for options

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -16,17 +16,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import {
-  createRef,
-  FC,
-  RefObject,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { FC, useContext, useEffect, useRef, useState } from 'react';
 
 import DeleteHideButtons from '../DeleteHideButtons';
 import DropdownIcon from 'zui/icons/DropDown';


### PR DESCRIPTION
## Description
This PR fixes a bug when creating surveys. This is a bug several organizers mentioned to me.

Steps to reproduce:
- Create a new survey
- Go to Questions
- Add an options question
- Add an option text
- Click away
- Before this PR: The option text will not be saved
- After this PR: The option text will be saved


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Save survey state fully when clicking away from the inputs
