### PR TITLE
Deduplicate selected households

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/HouseholdsPage2.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdsPage2.tsx
@@ -119,7 +119,7 @@ const HouseholdsPage2: FC<Props> = ({
               }}
               onSelectHousehold={onSelectHousehold}
               onUpdateSelection={(selectedIds) =>
-                onSelectHouseholds(selectedIds)
+                onSelectHouseholds([...new Set(selectedIds)])
               }
               selectedHouseholdIds={selectedHouseholdIds}
             />


### PR DESCRIPTION
This fixes https://github.com/zetkin/app.zetkin.org/issues/3345

First I thought about changing `selectedHouseholdIds` type to `Set` to get rid of duplicates but ultimately decided against it because it would involve a bunch of type conversion when it comes to using `filter` (not present in set). Maybe its still better, im not sure.

If I would do that I would also think about making its type more strict and only allowing Set and not null.
The editing could be represented by a separate boolean state I think.

This ended up being a minimal fix only deduping ids after multiple households are selected and should not change other logic.