### PR TITLE
Fix for 3120: align ZUICheckbox to top of label

### DIFF
--- a/src/zui/components/ZUICheckbox/index.tsx
+++ b/src/zui/components/ZUICheckbox/index.tsx
@@ -80,6 +80,12 @@ const ZUICheckbox: FC<ZUICheckboxProps> = ({
         '& .MuiTypography-root': {
           '-ms-user-select': 'none',
           '-webkit-user-select': 'none',
+          marginTop: (theme) =>
+            labelPlacement == 'start' || labelPlacement == 'end'
+              ? `calc(${parseFloat(sizes[size]) / 2}rem + (9px - ${
+                  theme.typography.labelXlMedium.lineHeight
+                } / 2))`
+              : 0,
           userSelect: 'none',
         },
         alignItems:


### PR DESCRIPTION
## Description
This PR aligns the ZUICheckbox to the top of the label where 'labelPlacement' is "start" or "end".


## Screenshots
http://localhost:6006/?path=/docs/components-zuicheckbox--docs
<img width="1041" height="322" alt="Screenshot 2026-01-21 at 18 12 24" src="https://github.com/user-attachments/assets/44046d9e-eb79-44f3-a7bc-3dba6a5165e4" />



## Changes
Checks for labelPlacement 'start' or 'end' and, if present, aligns the label to the top with flex-start


## Notes to reviewer
Easiest to check with `yarn storybook`


## Related issues
Resolves #3120
