### PR TITLE
Org Page: make useMemberships not filter

### DIFF
--- a/src/features/organizations/components/OrganizationsList.tsx
+++ b/src/features/organizations/components/OrganizationsList.tsx
@@ -25,7 +25,9 @@ const OrganizationsList = () => {
   return (
     <ZUIFuture future={organizations} ignoreDataWhileLoading>
       {(data) => {
-        if (organizations.data && organizations.data.length == 0) {
+        const orgs = data.filter((m) => m.role != null);
+
+        if (orgs && orgs.length == 0) {
           return (
             <Alert icon={<Key />} severity="error">
               <AlertTitle>

--- a/src/features/organizations/hooks/useMemberships.ts
+++ b/src/features/organizations/hooks/useMemberships.ts
@@ -15,8 +15,6 @@ export default function useMemberships(): IFuture<ZetkinMembership[]> {
     actionOnLoad: () => dispatch(userMembershipsLoad()),
     actionOnSuccess: (data) => dispatch(userMembershipsLoaded(data)),
     loader: () =>
-      apiClient
-        .get<ZetkinMembership[]>(`/api/users/me/memberships`)
-        .then((response) => response.filter((m) => m.role != null)),
+      apiClient.get<ZetkinMembership[]>(`/api/users/me/memberships`),
   });
 }

--- a/src/features/settings/components/OfficialList.tsx
+++ b/src/features/settings/components/OfficialList.tsx
@@ -88,7 +88,8 @@ const OfficialList: FC<OfficialListProps> = ({ orgId, officialList }) => {
       minWidth: 300,
       renderCell: (params) => {
         const matchingMembership = userMemberships.data?.find(
-          (membership) => membership.organization.id === orgId
+          (membership) =>
+            membership.role !== null && membership.organization.id === orgId
         );
         if (params.row.profile.id === matchingMembership?.profile.id) {
           return <Typography>{messages.officials.you()}</Typography>;


### PR DESCRIPTION
## Description
This PR fixes https://github.com/zetkin/app.zetkin.org/issues/3379

The problem was that `useMemberships` and `useMembership` use the same redux state but `useMemberships` filters out all organizations where `role` is `null`. `useMemberships` seems to have been called before `useMembership`, so `useMembership` didn't get any organization where the user isn't already an organizer. That's also the reason why the issue only happened with `testuser` and not `testadmin` for example. 

I made `useMemberships` not filter before pushing into the redux store and made sure. Since the user components of `useMemberships` mostly already have additional filters, I didn't have to change too much. 


## Screenshots
[Add scre
<img width="807" height="412" alt="fix_follow_button" src="https://github.com/user-attachments/assets/9aafd8d8-6a76-4ff8-b4fa-7b291d6a5896" />
enshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
* Changes…


## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3379
