### PR TITLE
Remove id and gender from person info

### DIFF
--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -1,12 +1,6 @@
 import { FC } from 'react';
 import { Box } from '@mui/system';
-import {
-  Fingerprint,
-  HomeOutlined,
-  MailOutline,
-  Phone,
-  Transgender,
-} from '@mui/icons-material';
+import { HomeOutlined, MailOutline, Phone } from '@mui/icons-material';
 
 import ZUISection from 'zui/components/ZUISection';
 import ZUIText from 'zui/components/ZUIText';
@@ -18,7 +12,6 @@ import ZUIIcon from 'zui/components/ZUIIcon';
 import useIsMobile from 'utils/hooks/useIsMobile';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
-import globalMessageIds from 'core/i18n/messageIds';
 
 type AboutSectionProps = {
   call: ZetkinCall | null;
@@ -49,12 +42,6 @@ export const AboutContent = ({ call }: { call: ZetkinCall }) => {
               <ZUIText>{call.target.email}</ZUIText>
             </Box>
           )}
-          {call.target.ext_id && (
-            <Box alignItems="center" display="flex" gap={1}>
-              <ZUIIcon color="secondary" icon={Fingerprint} size="small" />
-              <ZUIText>{call.target.ext_id}</ZUIText>
-            </Box>
-          )}
         </Box>
         <Box
           display={isMobile ? 'block' : 'flex'}
@@ -64,18 +51,6 @@ export const AboutContent = ({ call }: { call: ZetkinCall }) => {
           mt={isMobile ? 1 : 0}
           paddingTop={1}
         >
-          <Box alignItems="center" display="flex" gap={1}>
-            <ZUIIcon color="secondary" icon={Transgender} size="small" />
-            <ZUIText>
-              <Msg
-                id={
-                  call.target.gender
-                    ? globalMessageIds.genderOptions[call.target.gender]
-                    : globalMessageIds.genderOptions.unspecified
-                }
-              />
-            </ZUIText>
-          </Box>
           {(call.target.co_address || call.target.street_address) && (
             <Box alignItems="center" display="block" mt={isMobile ? 1 : 0}>
               <ZUIText display="flex">


### PR DESCRIPTION
## Description
This PR removes the code for id and gender from person info on the frontend.


## Screenshots
Before:
<img width="620" height="366" alt="Screenshot 2026-01-26 at 11 42 18" src="https://github.com/user-attachments/assets/ea51642a-77fe-4928-8a3c-ab46de01edbb" />

After:
<img width="410" height="307" alt="Screenshot 2026-01-26 at 11 33 29" src="https://github.com/user-attachments/assets/1adba08d-dfcc-41ea-b0ee-e4393a3362f9" />

## Changes
* Remove id and gender from person info.

## Notes to reviewer
* Go to [/call](http://localhost:3000/call)

## Related issues
