### PR TITLE
Fix playwright integrationTesting errors

### DIFF
--- a/.babelrc.jest.json
+++ b/.babelrc.jest.json
@@ -1,3 +1,3 @@
 {
-    "presets": ["next/babel"],
+  "presets": ["next/babel"]
 }

--- a/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
@@ -57,7 +57,7 @@ test.describe('Creating a journey instance from journey instance page', () => {
     await page.locator('data-testid=AutoTextArea-textarea').type('Some info');
 
     await Promise.all([
-      page.waitForResponse((res) => res.url().includes('api')),
+      page.waitForResponse((res) => res.url().includes('createNew')),
       page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
     ]);
 

--- a/integrationTesting/tests/organize/journeys/instance-list/persists.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-list/persists.spec.ts
@@ -74,7 +74,5 @@ test.describe('Journey instance list', () => {
     expect(firstRowAfterRefresh).toContainText('Better');
     expect(secondRowAfterRefresh).toContainText('Another');
     expect(await rowsAfterRefresh.count()).toBe(3);
-
-    await page.waitForTimeout(5000);
   });
 });

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -32,7 +32,7 @@ test.describe('View detail page', () => {
       AllMembersColumns
     );
 
-    moxy.setZetkinApiMock('/orgs/1/people/views', 'post', NewView, 203);
+    moxy.setZetkinApiMock('/orgs/1/people/views', 'post', NewView, 201);
     moxy.setZetkinApiMock(
       `/orgs/1/people/views/${NewView.id}/columns`,
       'post',

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -25,7 +25,7 @@ test.describe('View detail page', () => {
 
   test('lets user remove row from view', async ({ page, appUri, moxy }) => {
     moxy.setZetkinApiMock(
-      '/v1/orgs/1/people/views/1/rows/1',
+      '/orgs/1/people/views/1/rows/1',
       'delete',
       undefined,
       204
@@ -44,7 +44,14 @@ test.describe('View detail page', () => {
     // Show modal on click remove button -> click confirm to close modal
     await page.locator(removeButton).click();
     await expect(page.locator(confirmButtonInModal)).toBeVisible();
-    await page.locator(confirmButtonInModal).click();
+
+    await Promise.all([
+      page.waitForResponse((res) =>
+        res.url().includes('/api/views/removeRows')
+      ),
+      page.locator(confirmButtonInModal).click(),
+    ]);
+
     await expect(page.locator(confirmButtonInModal)).toBeHidden();
 
     // Check for delete request

--- a/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
@@ -51,7 +51,13 @@ test.describe('View detail page', () => {
     );
 
     await page.fill('#rename-column-title-field', newTitle);
-    await page.click('button:text("Save")');
+
+    await Promise.all([
+      page.waitForResponse((res) =>
+        res.url().includes(`/views/1/columns/${AllMembersColumns[0].id}`)
+      ),
+      page.click('button:text("Save")'),
+    ]);
 
     // Check body of request
     const columnPatchRequest = moxy


### PR DESCRIPTION
## Description

Fixes integrationTesting tests that I encountered while working on the Activist Portal "My organization" tab (PR #3388)
also did a `npx prettier --write .` run for some small linting.

`integrationTesting/tests/organize/views/detail/delete-row.spec.ts`

- fix mock path double v1 and add await for next.js/ internal API route instead of zetkins endpoint

`integrationTesting/tests/organize/views/detail/delete-row.spec.ts`
- Add page.waitForResponse() to wait for the DELETE request to complete before checking the moxy logs

`integrationTesting/tests/organize/views/detail/rename-column.spec.ts`

- Add page.waitForResponse() to wait for the PATCH request to complete before checking the moxy logs. Without this, the test was checking the logs immediately after clicking "Save", but the HTTP request hadn't been made yet, resulting in undefined.

`integrationTesting/fixtures/next.ts`

- switched MOXY Port to 4000 to not run into dev server overlap.

`integrationTesting/tests/organize/journeys/instance-list/persists.spec.ts`

- removed because blocking

`integrationTesting/tests/organize/views/detail/create.spec.ts`

- 201 to 203

`integrationTesting/tests/organize/journeys/instance-list/create.spec.ts`

-  Changed the waitForResponse filter from 'api' to 'createNew' to match the second test. The issue was that res.url().includes('api') was too broad and would match any API call (like the /api/breadcrumbs calls that were erroring in the logs). This caused the Promise.all to resolve prematurely before the actual form submission POST to create the journey instance was made. Using 'createNew' specifically targets the journey instance creation endpoint.



## Images

<img width="1041" height="312" alt="image" src="https://github.com/user-attachments/assets/84bdc5fd-d140-4037-b962-3cd4523015c3" />

