### PR TITLE
Issue 3387-fix participants events UI

### DIFF
--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -514,9 +514,9 @@ const eventsSlice = createSlice({
       state.remindingByEventId[eventId] = false;
       state.participantsByEventId[eventId].items.map((item) => {
         if (
-            item.data &&
-            item.data?.reminder_sent == null &&
-            item.data?.cancelled == null
+          item.data &&
+          item.data?.reminder_sent == null &&
+          item.data?.cancelled == null
         ) {
           item.data = { ...item.data, reminder_sent: new Date().toISOString() };
         }


### PR DESCRIPTION
## Description
This PR fixes the Events participation UI, by not showing canceled participants as having received an event reminder.


## Screenshots
<img width="2557" height="1220" alt="Events participants" src="https://github.com/user-attachments/assets/3d8f1883-2ace-4e20-b3df-b55eb633469e" />

## Changes
The events store.ts participantsReminded action was updated to not set a reminder_sent for canceled participants


## Notes to reviewer
1. Go to http://localhost:3000/organize/1/projects
2. Create a new event and add participants
3. Make one contact and cancel one participant
4. Send reminders to all participants


## Related issues
Resolves #3387
