### PR TITLE
Fix mistakenly counting canceled participants towards unsent reminders

### DIFF
--- a/src/features/events/components/EventWarningIcons.tsx
+++ b/src/features/events/components/EventWarningIcons.tsx
@@ -27,7 +27,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
     verifiedParticipantsFuture,
     numSignedUpParticipants,
     numRemindedParticipants,
-    bookedParticipants,
+    numAvailParticipants,
   } = useEventParticipants(orgId, eventId);
 
   if (!event) {
@@ -38,7 +38,7 @@ const EventWarningIcons: FC<EventWarningIconsProps> = ({
     <EventWarningIconsSansModel
       compact={compact}
       hasContact={!!event.contact}
-      numParticipants={bookedParticipants.length}
+      numParticipants={numAvailParticipants}
       numRemindersSent={numRemindedParticipants}
       numSignups={numSignedUpParticipants}
       participantsLoading={!verifiedParticipantsFuture.data}


### PR DESCRIPTION
## Description
This PR fixes incorrectly counting participants, who have canceled, towards participants that have not received reminders. This caused the error icon to be show in the Events overview. Now this is not shown, if all actually booked participants have received reminders.


## Screenshots
<img width="2534" height="1215" alt="image" src="https://github.com/user-attachments/assets/ee58a8e5-ce0e-41df-b25c-da165bfb5138" />


## Changes
Changes were made to the Event Warning icons, where canceled participants were filtered out before passing them into the IconsWarningSansModel component.


## Notes to reviewer
1. Go to http://localhost:3000/organize/1/projects
2. Create a new event and add participants
3. Make one contact and cancel one participant
4. Send reminders to all participants

## Related issues
Resolves #3386 
