### PR TITLE
Lists: reduce fetch calls when adding survey columns

### DIFF
--- a/src/features/surveys/hooks/useSurveyElements.ts
+++ b/src/features/surveys/hooks/useSurveyElements.ts
@@ -1,6 +1,10 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { elementsLoad, elementsLoaded } from '../store';
-import { futureToObject, IFuture } from 'core/caching/futures';
+import {
+  futureToObject,
+  IFuture,
+  PlaceholderFuture,
+} from 'core/caching/futures';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinSurveyElement, ZetkinSurveyExtended } from 'utils/types/zetkin';
 
@@ -10,14 +14,20 @@ type UseSurveyElementsReturn = IFuture<ZetkinSurveyElement[]> & {
 
 export default function useSurveyElements(
   orgId: number,
-  surveyId: number
+  surveyId: number | null
 ): UseSurveyElementsReturn {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const elemList = useAppSelector(
-    (state) => state.surveys.elementsBySurveyId[surveyId]
-  );
-  const future = loadListIfNecessary(elemList, dispatch, {
+  const elemList = useAppSelector((state) => state.surveys.elementsBySurveyId);
+
+  if (!surveyId) {
+    return {
+      ...futureToObject(new PlaceholderFuture<ZetkinSurveyElement[]>([])),
+      surveyIsEmpty: true,
+    };
+  }
+
+  const future = loadListIfNecessary(elemList[surveyId], dispatch, {
     actionOnLoad: () => elementsLoad(surveyId),
     actionOnSuccess: (elements) => elementsLoaded([surveyId, elements]),
     loader: async () => {


### PR DESCRIPTION
## Description
This PR improves performance when adding a survey response(s) column in lists. Before, we downloaded all surveys from the entire organization, making it very laggy on big organizations. Since the UI doesn't show that data, this PR doesn't download the unnecessary data. We instead fetch the surveys, and after selecting a survey, we fetch its elements.

How 2 find
- Go to /organize/1/lists
- Add a list
- Add a column
- Select "Single survey question" or "Multiple questions"

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes the `useSurveyElements` hook so that it accepts `null` surveyIds and returns a placeholder in that case.
* Changes column addition dialogues for the survey response and survey responses types. 


## Notes to reviewer
[Add instructions for testing]
It should behave exactly the same UI wise, just be way faster. You can use the network tab to see what changes. 

While creating this PR, I also thought of a way that doesn't involve changing the `useSurveyElements` hook if you want that. It would be to extract the `<Autocomplete>` into another component, and using the hook there.

