### PR TITLE
Load and cache different orgs separately

### DIFF
--- a/src/features/organizations/hooks/useOrganization.ts
+++ b/src/features/organizations/hooks/useOrganization.ts
@@ -7,10 +7,12 @@ import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 const useOrganization = (orgId: number): IFuture<ZetkinOrganization> => {
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
-  const organizationState = useAppSelector((state) => state.organizations);
+  const orgItem = useAppSelector((state) =>
+    state.organizations.orgList.items.find((item) => item.id == orgId)
+  );
 
-  return loadItemIfNecessary(organizationState.orgData, dispatch, {
-    actionOnLoad: () => organizationLoad(),
+  return loadItemIfNecessary(orgItem, dispatch, {
+    actionOnLoad: () => organizationLoad(orgId),
     actionOnSuccess: (data) => organizationLoaded(data),
     loader: () => apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`),
   });

--- a/src/features/organizations/store.ts
+++ b/src/features/organizations/store.ts
@@ -11,6 +11,7 @@ import {
 import {
   remoteItem,
   RemoteItem,
+  remoteItemUpdated,
   remoteList,
   RemoteList,
 } from 'utils/storeUtils';
@@ -20,6 +21,7 @@ import {
   ZetkinOrganization,
   ZetkinSubOrganization,
 } from 'utils/types/zetkin';
+import { findOrAddItem } from 'utils/storeUtils/findOrAddItem';
 
 type OrgEventFilters = {
   customDatesToFilterBy: DateRange<Dayjs>;
@@ -32,7 +34,7 @@ type OrgEventFilters = {
 export interface OrganizationsStoreSlice {
   eventsByOrgId: Record<number, RemoteList<ZetkinEvent>>;
   filters: OrgEventFilters;
-  orgData: RemoteItem<ZetkinOrganization>;
+  orgList: RemoteList<ZetkinOrganization>;
   subOrgsByOrgId: Record<number, RemoteList<ZetkinSubOrganization>>;
   suborgsWithStats: RemoteList<SuborgResult>;
   statsBySuborgId: Record<
@@ -52,7 +54,7 @@ const initialState: OrganizationsStoreSlice = {
     geojsonToFilterBy: [],
     orgIdsToFilterBy: [],
   },
-  orgData: remoteItem(0),
+  orgList: remoteList(),
   statsBySuborgId: {},
   subOrgsByOrgId: {},
   suborgsWithStats: remoteList(),
@@ -120,15 +122,14 @@ const OrganizationsSlice = createSlice({
         membershipToUpdate.loaded = new Date().toISOString();
       }
     },
-    organizationLoad: (state) => {
-      state.orgData.isLoading = true;
+    organizationLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      const item = findOrAddItem(state.orgList, orgId);
+      item.isLoading = true;
     },
     organizationLoaded: (state, action: PayloadAction<ZetkinOrganization>) => {
       const org = action.payload;
-
-      state.orgData.data = org;
-      state.orgData.loaded = new Date().toISOString();
-      state.orgData.isLoading = false;
+      remoteItemUpdated(state.orgList, org);
     },
     subOrgsLoad: (state, action: PayloadAction<number>) => {
       const orgId = action.payload;

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -123,7 +123,7 @@ export default function mockState(overrides?: RootState) {
         geojsonToFilterBy: [],
         orgIdsToFilterBy: [],
       },
-      orgData: remoteItem(0),
+      orgList: remoteList(),
       statsBySuborgId: {},
       subOrgsByOrgId: {},
       suborgsWithStats: remoteList(),


### PR DESCRIPTION
## Description
This PR fixes a bug that was causing the same organization to be used for all area assignments in the "my activities" list.

## Screenshots
<img width="1274" height="953" alt="image" src="https://github.com/user-attachments/assets/f52f92a0-70f3-42ea-a700-306e6a69a101" />

## Changes
* Changes the store to allow for storing multiple organizations
* Changes `useOrganization()` hook and the reducers to add each org to a list instead of storing just one

## Notes to reviewer
None

## Related issues
Resolves #3385