### PR TITLE
fix: issue 3396/remove red border on sharedcard

### DIFF
--- a/src/features/campaigns/components/SharedCard.tsx
+++ b/src/features/campaigns/components/SharedCard.tsx
@@ -11,7 +11,6 @@ import {
 
 import messageIds from 'features/campaigns/l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
-import oldTheme from 'theme';
 import { useNumericRouteParams } from 'core/hooks';
 
 const SharedCard = (): JSX.Element => {
@@ -26,13 +25,15 @@ const SharedCard = (): JSX.Element => {
         href={`/organize/${orgId}/projects/shared`}
       >
         <CardContent>
-          <Box sx={{
-            alignItems: 'center',
-            display: 'flex',
-            gap: 1,
-            height: '35px',
-            justifyContent: 'space-between',
-          }}>
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              gap: 1,
+              height: '35px',
+              justifyContent: 'space-between',
+            }}
+          >
             <Typography gutterBottom noWrap variant="h6">
               <Msg id={messageIds.shared.title} />
             </Typography>


### PR DESCRIPTION
## Description
This PR removes the red border on the "Shared with us" project card, to make it look the same as the others.


## Screenshots
http://localhost:3000/organize/2/projects
<img width="940" height="646" alt="Screenshot 2026-01-31 at 10 24 48" src="https://github.com/user-attachments/assets/a1ef92c9-da9f-48d1-9d0e-a9fe23c4be02" />


## Changes
* Removes the inline styling on the SharedCard.tsx component and removes the now-redundant oldTheme import
* Sets the box height to `35px` to compensate for the `GroupWork` icons being smaller than the `CampaignStatusChip`, so the cards are the exact same height, as well as synthesing the box styling with `CampaignCard`


## Notes to reviewer
One of three very small but distinct issues on this same component, alongside #3397 and #3399. I'm submitting them as three separate PRs but if you would prefer me to do them as one, I'm happy to do that.

Also note that, without the change to the box height, you can see that the cards aren't exactly the same height:
<img width="448" height="304" alt="Screenshot 2026-01-31 at 09 41 02" src="https://github.com/user-attachments/assets/d516cad2-af7b-4bb4-aa91-64048ca62558" />

## Related issues
Resolves #3396 
