### PR TITLE
fix: issue 3397/shared with us card not clickable

### DIFF
--- a/src/features/campaigns/components/SharedCard.tsx
+++ b/src/features/campaigns/components/SharedCard.tsx
@@ -17,7 +17,6 @@ import { useNumericRouteParams } from 'core/hooks';
 const SharedCard = (): JSX.Element => {
   const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
-  const title = messages.shared.title();
 
   return (
     <Card
@@ -25,7 +24,7 @@ const SharedCard = (): JSX.Element => {
       sx={{ border: `2px solid ${oldTheme.palette.primary.main}` }}
     >
       <CardActionArea
-        aria-label={messages.all.cardAriaLabel({ title })}
+        aria-label={messages.shared.cta()}
         component={NextLink}
         href={`/organize/${orgId}/projects/shared`}
       >


### PR DESCRIPTION
## Description
This PR makes the 'shared' project card clickable


## Screenshots
http://localhost:3000/organize/2/projects
<img width="685" height="341" alt="Screenshot 2026-01-31 at 10 43 30" src="https://github.com/user-attachments/assets/8087a0c7-4b86-4207-a205-9f5ee51b3f0c" />


## Changes
Uses same solution as #3351 for the other campaign cards:
* Wraps whole card's content in `CardActionArea`
* Replaced Link with Typography (card itself is now the link) and removed Link from imports
* Added aria-label for screen reader context

## Notes to reviewer
One of three very small but distinct issues on this same component, alongside #3396 and #3399. I'm submitting them as three separate PRs but if you would prefer me to do them as one, I'm happy to do that.

Note that the red border in the screenshot is removed by #3408 

## Related issues
Resolves #3397 
