### PR TITLE
Set map cursor to crosshair if currently drawing points

### DIFF
--- a/src/features/geography/components/GLGeographyMap/index.tsx
+++ b/src/features/geography/components/GLGeographyMap/index.tsx
@@ -275,6 +275,7 @@ const GLGeographyMapInner: FC<Props> = ({ areas, orgId }) => {
         )}
         <Map
           ref={(map) => setMap(map?.getMap() ?? null)}
+          cursor={drawingPoints ? 'crosshair' : undefined}
           initialViewState={{ bounds }}
           mapStyle={env.vars.MAPLIBRE_STYLE}
           RTLTextPlugin="/mapbox-gl-rtl-text-0.3.0.js"


### PR DESCRIPTION
## Description
This PR changes the cursor to a crosshair if the user is editing a map area.


## Screenshots

[Peek 2026-01-31 12-30.webm](https://github.com/user-attachments/assets/aac98128-ef88-410d-a8eb-69a402d2e87f)

## Changes

* Changes the map to reflect if we are drawing something using the cursor.


## Notes to reviewer

Go to the Geography tab and draw drawing something. I did no attempt at changing the cursor when the user drags the map while drawing since I feel this is fine.

## Related issues
Resolves #3383 
