### PR TITLE
#3375: handle long email in email-change survey dialog

### DIFF
--- a/src/features/surveys/components/SurveyLinkDialog.tsx
+++ b/src/features/surveys/components/SurveyLinkDialog.tsx
@@ -58,9 +58,9 @@ const SurveyLinkDialog = ({
           <Box alignItems="center" display="flex" flexDirection="column" mb={2}>
             <TextField
               aria-readonly
+              style={{ marginTop: '5px', width: '100%' }}
               value={email}
               variant="outlined"
-              style={{ width: '100%', marginTop: '5px' }}
             />
             <Box alignItems="center" display="flex" ml={2} mr={2}>
               <ArrowDownward
@@ -72,9 +72,9 @@ const SurveyLinkDialog = ({
             </Box>
             <TextField
               aria-readonly
+              style={{ marginTop: '5px', width: '100%' }}
               value={person.email}
               variant="outlined"
-              style={{ width: '100%', marginTop: '5px' }}
             />
           </Box>
           {messages.surveyDialogDifferentEmail.description()}


### PR DESCRIPTION
## Description
Switches the layout for display old and new email from row to column layout and put the email in a read-only textfield to avoid breaking the dialog.


## Screenshots
<img width="1432" height="673" alt="image" src="https://github.com/user-attachments/assets/28f04ce0-415d-4ba8-b5ea-199efac38795" />

## Changes
* flex to flex-direction=column
* email to read-only textfield

## Notes to reviewer
* create new user with a very long email joerghasregisteredandisnowwaitingbutwas@left.over
* go to http://localhost:3000/organize/1/projects/1/surveys/1/submissions
* click on an existing entry with an other person already assigned (and search for the new user with the long email)
