### PR TITLE
Ask for confirmation before sending out reminders

### DIFF
--- a/src/features/events/components/RemindAllButton.tsx
+++ b/src/features/events/components/RemindAllButton.tsx
@@ -1,11 +1,6 @@
 import React, { FC, useState } from 'react';
 import { Check, PriorityHigh } from '@mui/icons-material';
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Tooltip,
-} from '@mui/material';
+import { Box, Button, CircularProgress, Tooltip } from '@mui/material';
 
 import { Msg, useMessages } from 'core/i18n';
 import { useAppSelector } from 'core/hooks';
@@ -87,7 +82,7 @@ const RemindAllButton: FC<RemindAllButtonProps> = ({
           open={isConfirmReminderOpen}
           title={messages.eventPopper.confirmRemindersTitle()}
           warningText={messages.eventPopper.confirmRemindersMessage({
-            numReminders: numAvailParticipants - numRemindedParticipants
+            numReminders: numAvailParticipants - numRemindedParticipants,
           })}
         />
       </Box>

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -117,7 +117,7 @@ export default makeMessages('feat.events', {
     ),
     confirmCancel: m('Are you sure you want to cancel this event?'),
     confirmDelete: m('Are you sure you want to delete this event?'),
-    confirmRemindersMessage: m<{numReminders: number}>(
+    confirmRemindersMessage: m<{ numReminders: number }>(
       'Please confirm that you want to send out a reminder to {numReminders, plural, =1 {one participant} other {# participants}}'
     ),
     confirmRemindersTitle: m('Confirm sending out reminders'),


### PR DESCRIPTION
## Description
This PR adds a confirmation dialog before sending reminders


## Screenshots
<img width="2554" height="1220" alt="image" src="https://github.com/user-attachments/assets/b828d179-6242-4c12-8867-28af67979ea3" />

## Changes
- Added 2 translations to the events feature
- Added `ZUIConfirmDialog` to `RemindAllButton.tsx`

## Notes to reviewer
1. Go any event and sens all reminders
2. Verify the confirmation dialog appears


## Related issues
Resolves #3364 
