### PR TITLE
2720: disable add value tag button when value is empty

### DIFF
--- a/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -48,7 +48,7 @@ const ValueTagForm: React.FC<{
       </Box>
       <ZUISubmitCancelButtons
         onCancel={onCancel}
-        submitDisabled={!inputValue || inputValue.trim().length == 0}
+        submitDisabled={inputValue.trim().length == 0}
       />
     </form>
   );


### PR DESCRIPTION
## Description
This PR prohibits the creation of value tags with null / empty / blank values.


## Screenshots
<img width="1432" height="638" alt="image" src="https://github.com/user-attachments/assets/eee71774-52f2-4421-b524-4f0da96bc9d7" />


## Changes
* submit button in ValueTagForm checks now for undefined / null / trim().length == 0

## Notes to reviewer
* create or use an existing value tag
* go to e.g. http://localhost:3000/organize/1/journeys/1/1 - in tag area add the created or already existing value tag and try to use a blank value - submit button is disabled now
