### PR TITLE
fix: issue-3399 - shared card CTA text

### DIFF
--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -209,7 +209,7 @@ export default makeMessages('feat.campaigns', {
     },
   },
   shared: {
-    cta: m('Go to project'),
+    cta: m('View shared activities'),
     noActivities: m(
       'All ongoing activities shared with your organization will appear here.'
     ),

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -794,7 +794,6 @@ feat:
         viewInListButton: In Liste anzeigen
         viewInMapButton: Auf Karte anzeigen
     shared:
-      cta: Gehe zum Projekt
       noActivities: Aktuelle Aktivitäten, die mit deiner Organisation geteilt wurden,
         erscheinen hier.
       noArchives: Abgelaufene Aktivitäten, die mit deiner Organisation geteilt wurden,

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -345,7 +345,6 @@ feat:
       heading: Mobilization and outreach (none configured)
     noManager: No Project Manager
     shared:
-      cta: Go to project
       noActivities: All ongoing activities shared with your organization will appear here.
       noArchives: All expired activities that have been shared with your organization
         will appear here.

--- a/src/locale/nl.yml
+++ b/src/locale/nl.yml
@@ -371,7 +371,6 @@ feat:
       heading: Mobilisering en outreach (niet geconfigureerd)
     noManager: Geen project manager
     shared:
-      cta: Ga naar project
       noActivities: Alle lopende activiteiten die met je organisatie worden gedeeld,
         worden hier weergegeven.
       noArchives: Alle verlopen activiteiten die met je organisatie worden gedeeld,

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -773,7 +773,6 @@ feat:
         viewInListButton: Vis i liste
         viewInMapButton: Vis i kart
     shared:
-      cta: Gå til prosjekt
       noActivities: Alle pågående aktiviteter som er delt med organisasjonen din vil
         vises her.
       noArchives: Alle tidligere aktiviteter som har blitt delt med organisasjonen din

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -689,7 +689,6 @@ feat:
         viewInListButton: Visa i lista
         viewInMapButton: Visa på karta
     shared:
-      cta: Gå till projekt
       noActivities: Alla pågående aktiviteter som delas med din organisation kommer
         synas här.
       noArchives: Alla utgångna aktiviteter som delas med din organisation kommer


### PR DESCRIPTION
## Description
This PR replaces the CTA on shared project cards ("Go to project") with "View shared activities"


## Screenshots
http://localhost:3000/organize/2/projects
<img width="397" height="293" alt="Screenshot 2026-01-31 at 13 28 59" src="https://github.com/user-attachments/assets/9dd07bac-97ad-4f94-b20a-2d47a1c519d5" />


## Changes
* Changes the `shared.cta` text
* Removes `shared.cta` from all the localisation yaml files so it can be correctly translated (except in Danish where that entry doesn't seem to exist)


## Notes to reviewer
The final of three very small but distinct issues on this same component, alongside #3396 and #3397. I'm submitting them as three separate PRs but if you would prefer me to do them as one, I'm happy to do that.


## Related issues
Resolves #3399 
