### PR TITLE
fix: issue 3380 - do not select area if user is drawing

### DIFF
--- a/src/features/geography/components/GLGeographyMap/index.tsx
+++ b/src/features/geography/components/GLGeographyMap/index.tsx
@@ -48,8 +48,8 @@ const GLGeographyMapInner: FC<Props> = ({ areas, orgId }) => {
   const bounds = useMapBounds({ areas, map });
   const { selectedArea, setSelectedId } = useAreaSelection({
     areas,
-    map,
     isDrawing: () => drawing,
+    map,
     onSelectFromMap: () => {
       startTransition(() => {
         setIsAreasPanelOpen(false);

--- a/src/features/geography/hooks/useAreaSelection.ts
+++ b/src/features/geography/hooks/useAreaSelection.ts
@@ -6,9 +6,9 @@ import { Zetkin2Area } from 'features/areas/types';
 
 type Props = {
   areas: Zetkin2Area[];
+  isDrawing?: () => boolean;
   map: MapType | null;
   onSelectFromMap?: (id: number) => void;
-  isDrawing?: () => boolean;
 };
 
 type Return = {


### PR DESCRIPTION
## Description
Fixes issue #3380. 

If a user is drawing a new polygon in the Geography feature, selection of other areas should not be possible. Currently, if a user selects a drawing point inside another area, this other area becomes selected.  This PR makes the drawing state accessible to the `useAreaSelection` hook as an optional prop.

Because `drawing` is initialized by the `useAreaDrawing` hook, and useAreaDrawing already relies on state initialized by useAreaSelection, it is not possible to pass drawing directly. An alternate solution would be to manage the drawing state in the parent component, or the selectedArea state in the parent component. But I think it is nice if they have control of their own states.

## Screenshots
<img width="1191" height="822" alt="Screenshot 2026-01-31 at 14 49 05" src="https://github.com/user-attachments/assets/338e5ca3-0c8e-4ea4-8a7c-1935bdfe0edd" />

## Changes
- Provides a prop to `useAreaSelection` hook to check the drawing state
- Prevents the user from selecting an area if they are currently drawing a polygon.

## Related issues
Resolves #3380 
