### PR TITLE
Enable cancel when linking person to survey

### DIFF
--- a/src/features/surveys/components/SurveyLinkDialog.tsx
+++ b/src/features/surveys/components/SurveyLinkDialog.tsx
@@ -13,28 +13,30 @@ import {
 import messageIds from '../l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import { useMessages } from 'core/i18n';
-import usePersonMutations from 'features/profile/hooks/usePersonMutations';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
 
 const SurveyLinkDialog = ({
   email,
   onClose,
+  onKeepEmail,
+  onUpdateEmail,
   open,
   person,
 }: {
   email: string;
   onClose: () => void;
+  onKeepEmail: () => void;
+  onUpdateEmail: (email: string) => void;
   open: boolean;
   person: ZetkinPerson;
 }) => {
   const messages = useMessages(messageIds);
   const { orgId } = useNumericRouteParams();
-  const { updatePerson } = usePersonMutations(orgId, person.id);
 
   if (person.email && email !== person.email) {
     return (
-      <Dialog open={open}>
+      <Dialog onClose={onClose} open={open}>
         <DialogTitle>{messages.surveyDialogDifferentEmail.title()}</DialogTitle>
         <Divider />
         <DialogContent>
@@ -69,12 +71,26 @@ const SurveyLinkDialog = ({
           {messages.surveyDialogDifferentEmail.description()}
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>
+          <Box sx={{ display: 'flex', flexGrow: 1 }}>
+            <Button
+              onClick={() => {
+                onClose();
+              }}
+            >
+              {messages.surveyDialog.cancelLinking()}
+            </Button>
+          </Box>
+          <Button
+            onClick={() => {
+              onKeepEmail();
+              onClose();
+            }}
+          >
             {messages.surveyDialogDifferentEmail.keep()}
           </Button>
           <Button
             onClick={() => {
-              updatePerson({ email });
+              onUpdateEmail(email);
               onClose();
             }}
             variant="contained"
@@ -87,7 +103,7 @@ const SurveyLinkDialog = ({
   }
 
   return (
-    <Dialog open={open}>
+    <Dialog onClose={onClose} open={open}>
       <DialogTitle>{messages.surveyDialog.title()}</DialogTitle>
       <Divider />
       <DialogContent>
@@ -110,11 +126,11 @@ const SurveyLinkDialog = ({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} variant="outlined">
-          {messages.surveyDialog.cancel()}
+          {messages.surveyDialog.doNotAdd()}
         </Button>
         <Button
           onClick={() => {
-            updatePerson({ email });
+            onUpdateEmail(email);
             onClose();
           }}
           variant="contained"

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -225,10 +225,11 @@ export default makeMessages('feat.surveys', {
   },
   surveyDialog: {
     add: m('Add'),
-    cancel: m("Don't add"),
+    cancelLinking: m('Cancel'),
     description: m(
       'The person you are about to link does not have an email address while the survey response does. Would you like to add it the person?'
     ),
+    doNotAdd: m("Don't add"),
     title: m('Add email address'),
   },
   surveyDialogDifferentEmail: {


### PR DESCRIPTION
## Description
This PR makes it so that you can change your mind after opening the link dialog and cancel without any changes happening.


## Screenshots
https://github.com/user-attachments/assets/c5f10397-c758-45df-bd48-b4ce9bed8461


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Moved mutation logic out from SurveyLinkDialog so that the outside component can decide whether to commit changes or not
* Adds close listener to dialog to enable clicking outside the dialog or pressing escape.


## Related issues
Resolves #3374
