### PR TITLE
fix: ESC key not cancelling drawing

### DIFF
--- a/src/features/geography/components/GLGeographyMap/index.tsx
+++ b/src/features/geography/components/GLGeographyMap/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mui/material';
 import { Pentagon } from '@mui/icons-material';
 import Map from '@vis.gl/react-maplibre';
-import { FC, startTransition, useMemo, useState } from 'react';
+import { FC, startTransition, useEffect, useMemo, useState } from 'react';
 import { Map as MapType } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import Fuse from 'fuse.js';
@@ -110,6 +110,20 @@ const GLGeographyMapInner: FC<Props> = ({ areas, orgId }) => {
       });
     }
   };
+
+  const handleEscapeKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cancelDrawing();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscapeKeydown);
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKeydown);
+    };
+  });
 
   return (
     <Box


### PR DESCRIPTION
## Description
This PR fixes the bug that when a user presses Escape in Drawing mode in the Geography tab it won't cancel drawing like it does when clicking the "Cancel" button.


## Screenshots
-

## Changes
* Changes GLGeographyMap such that it listens to the "Escape" keydown event and cancels drawing just like the Cancel button.


## Notes to reviewer
Follow steps to reproduce and press Escape.


## Related issues
Resolves #3381

(Collectively contributed by all people that participated at the Hackathon in Vienna [KPÖ])