### PR TITLE
Add wrapping to email display & harmonized padding

### DIFF
--- a/src/features/surveys/components/SurveyLinkDialog.tsx
+++ b/src/features/surveys/components/SurveyLinkDialog.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward } from '@mui/icons-material';
+import { ArrowDownward } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -54,21 +54,26 @@ const SurveyLinkDialog = ({
             </Typography>
           </Box>
 
-          <Box alignItems="center" display="flex" mb={2}>
+          <Box
+            mb={2}
+            sx={{
+              alignItems: 'start',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
             {email}
-            <Box alignItems="center" display="flex" ml={2} mr={2}>
-              <ArrowForward
-                color="secondary"
-                sx={{
-                  opacity: '50%',
-                }}
-              />
-            </Box>
+            <ArrowDownward
+              color="secondary"
+              sx={{
+                opacity: '50%',
+              }}
+            />
             {person.email}
           </Box>
           {messages.surveyDialogDifferentEmail.description()}
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ padding: '20px 24px' }}>
           <Button onClick={onClose}>
             {messages.surveyDialogDifferentEmail.keep()}
           </Button>
@@ -91,24 +96,40 @@ const SurveyLinkDialog = ({
       <DialogTitle>{messages.surveyDialog.title()}</DialogTitle>
       <Divider />
       <DialogContent>
-        <Box alignItems="center" display="flex" mb={2}>
+        <Box
+          mb={2}
+          sx={{
+            alignItems: 'start',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           {email}
-          <Box alignItems="center" display="flex" ml={2} mr={2}>
-            <ArrowForward
-              color="secondary"
-              sx={{
-                opacity: '50%',
-              }}
+          <ArrowDownward
+            color="secondary"
+            sx={{
+              opacity: '50%',
+            }}
+          />
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+            }}
+          >
+            <ZUIPersonAvatar
+              orgId={orgId}
+              personId={person?.id ?? 0}
+              size="sm"
             />
+            <Typography ml={2} variant="h6">
+              {person?.first_name} {person?.last_name}
+            </Typography>
           </Box>
-          <ZUIPersonAvatar orgId={orgId} personId={person?.id ?? 0} size="sm" />
-          <Typography ml={2} variant="h6">
-            {person?.first_name} {person?.last_name}
-          </Typography>
         </Box>
         {messages.surveyDialog.description()}
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ padding: '20px 24px' }}>
         <Button onClick={onClose} variant="outlined">
           {messages.surveyDialog.cancel()}
         </Button>


### PR DESCRIPTION
## Description
This PR changes the layout of the linking dialog to be vertical instead of horizontal, to handle long email addresses better.

## Screenshots

<img width="959" height="576" alt="Screenshot_2026-03-03_19-34-54" src="https://github.com/user-attachments/assets/840bb676-5bf2-4f33-a1bd-75c2c80245f0" />

<img width="955" height="511" alt="Screenshot_2026-03-03_20-07-27" src="https://github.com/user-attachments/assets/2f225d1d-b8ca-4477-8a36-9ceb9f9c8705" />

## Changes

* Layout email linking dialog vertically
* Adds padding to align with rest of dialog


## Related issues
Resolves #3375 
