### PR TITLE
issue 3363 - Notify participants from Event popper

### DIFF
--- a/src/features/events/components/RemindAllButton.tsx
+++ b/src/features/events/components/RemindAllButton.tsx
@@ -1,6 +1,12 @@
 import { FC } from 'react';
 import { Check, PriorityHigh } from '@mui/icons-material';
-import { Box, Button, CircularProgress, Tooltip } from '@mui/material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 
 import { Msg, useMessages } from 'core/i18n';
 import { useAppSelector } from 'core/hooks';
@@ -12,6 +18,8 @@ interface RemindAllButtonProps {
   eventId: number;
   orgId: number;
   sendReminders: (eventId: number) => void;
+  dense?: boolean;
+  bold?: boolean;
 }
 
 const RemindAllButton: FC<RemindAllButtonProps> = ({
@@ -19,6 +27,8 @@ const RemindAllButton: FC<RemindAllButtonProps> = ({
   eventId,
   orgId,
   sendReminders,
+  dense = false,
+  bold = false,
 }) => {
   const isRemindingParticipants = useAppSelector(
     (state) => state.events.remindingByEventId[eventId]
@@ -28,7 +38,6 @@ const RemindAllButton: FC<RemindAllButtonProps> = ({
     useEventParticipants(orgId, eventId);
 
   const messages = useMessages(messageIds);
-
   return (
     <Tooltip
       arrow
@@ -46,12 +55,15 @@ const RemindAllButton: FC<RemindAllButtonProps> = ({
             isRemindingParticipants ||
             numRemindedParticipants >= numAvailParticipants
           }
+          loading={isRemindingParticipants}
           onClick={() => {
             sendReminders(eventId);
           }}
           size="small"
           startIcon={
-            contactPerson ? (
+            dense ? (
+              ''
+            ) : contactPerson ? (
               isRemindingParticipants ? (
                 <CircularProgress size={20} />
               ) : (
@@ -62,11 +74,13 @@ const RemindAllButton: FC<RemindAllButtonProps> = ({
             )
           }
           sx={{
-            marginLeft: 2,
+            marginLeft: dense ? 0 : 2,
           }}
-          variant="outlined"
+          variant={dense ? 'text' : 'outlined'}
         >
-          <Msg id={messageIds.participantSummaryCard.remindButton} />
+          <Typography variant={bold ? 'labelSmSemiBold' : 'labelMdRegular'}>
+            <Msg id={messageIds.participantSummaryCard.remindButton} />
+          </Typography>
         </Button>
       </Box>
     </Tooltip>


### PR DESCRIPTION
## Description
This PR allow notifying event participants directly from the event popper


## Screenshots
<img width="2554" height="1220" alt="image" src="https://github.com/user-attachments/assets/84c10866-60bd-46fd-aec5-39db46a4557e" />


## Changes
- The `RemindAllButton.tsx` was extended, to include an optional `bold` and `dense ` prop to influence how it is rendered. Both are false by default, to also not influence existing uses of this component

- The `singleEvent.tsx` was extended, to conditionally render a RemindAllButton component, when notifications can be sent to participants

## Notes to reviewer
1. Verify that you have an event where participants can be notified (i.e has a valid contact person)
2. Try notifying them directly from the Event popper and reload the event page to verify the reminder was sent correctly


## Related issues
Resolves #3363 
