### PR TITLE
Allow configuring to open links from markdown-based HTML in separate tab

### DIFF
--- a/src/zui/ZUIMarkdown.tsx
+++ b/src/zui/ZUIMarkdown.tsx
@@ -12,7 +12,6 @@ interface ZUIMarkdownProps {
 const ZUIMarkdown: React.FC<ZUIMarkdownProps> = ({
   BoxProps,
   markdown,
-  // defaulting to true assuming this is the correct behavior in most cases
   forceTargetBlank = true,
 }) => {
   const dirtyHtml = marked(markdown, { breaks: true });
@@ -29,7 +28,6 @@ const ZUIMarkdown: React.FC<ZUIMarkdownProps> = ({
 
   return (
     <ZUICleanHtml
-      // passing targetBlankRef first allows overriding this behavior
       BoxProps={{ ref: targetBlankRef, ...BoxProps }}
       dirtyHtml={dirtyHtml}
     />


### PR DESCRIPTION
## Description
This PR uses the solution from https://github.com/zetkin/app.zetkin.org/pull/2803/files/5ce41f2dcb69d6705e1c7d111a4ead50d857a440#r2126920203 and implements this behavior as a default.


## Screenshots
Before:
<img width="1622" height="537" alt="Screenshot 2026-01-31 at 15 28 53" src="https://github.com/user-attachments/assets/4eb6a46a-288d-41c5-9cc6-2d8d9707f67f" />

After:
<img width="1622" height="537" alt="Screenshot 2026-01-31 at 16 30 18" src="https://github.com/user-attachments/assets/4e6b6d49-01d8-4aa4-ac3f-7a57ef61a452" />

## Changes
* Allow configuring ZUIMarkdown to open links from markdown-based HTML in separate tab
* Make this behavior the default

## Related issues
Resolves #2806
