### PR TITLE
3382: fix location change update after location edit

### DIFF
--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -250,12 +250,17 @@ const areaAssignmentSlice = createSlice({
     },
     locationUpdated: (state, action: PayloadAction<ZetkinLocation>) => {
       const location = action.payload;
+      const updateStategy = (itemToUpdate: RemoteItem<ZetkinLocation>) =>
+        ({
+          ...itemToUpdate.data,
+          ...location,
+        } as ZetkinLocation);
 
       Object.values(state.locationsByAssignmentId).forEach((list) => {
-        remoteItemUpdated(list, location);
+        remoteItemUpdated(list, location, updateStategy);
       });
       Object.values(state.locationsByAssignmentIdAndAreaId).forEach((list) => {
-        remoteItemUpdated(list, location);
+        remoteItemUpdated(list, location, updateStategy);
       });
     },
     locationsLoad: (state, action: PayloadAction<string>) => {

--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -149,7 +149,11 @@ const LocationDialog: FC<LocationDialogProps> = ({
           onBack={() => back()}
           onClose={onClose}
           onSave={async (title, description) => {
-            await updateLocation({ description, title });
+            await updateLocation({ 
+              ...location,
+              description, 
+              title 
+            });
             back();
           }}
         />

--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -149,8 +149,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
           onBack={() => back()}
           onClose={onClose}
           onSave={async (title, description) => {
-            await updateLocation({
-              ...location,
+            await updateLocation(location, {
               description,
               title,
             });

--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -149,10 +149,10 @@ const LocationDialog: FC<LocationDialogProps> = ({
           onBack={() => back()}
           onClose={onClose}
           onSave={async (title, description) => {
-            await updateLocation({ 
+            await updateLocation({
               ...location,
-              description, 
-              title 
+              description,
+              title,
             });
             back();
           }}

--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -149,7 +149,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
           onBack={() => back()}
           onClose={onClose}
           onSave={async (title, description) => {
-            await updateLocation(location, {
+            await updateLocation({
               description,
               title,
             });

--- a/src/features/canvass/hooks/useLocationMutations.ts
+++ b/src/features/canvass/hooks/useLocationMutations.ts
@@ -50,17 +50,12 @@ export default function useLocationMutations(
       );
       dispatch(householdUpdated([locationId, household]));
     },
-    updateLocation: async (
-      oldLocation: ZetkinLocation,
-      data: ZetkinLocationPatchBody
-    ) => {
+    updateLocation: async (data: ZetkinLocationPatchBody) => {
       const location = await apiClient.patch<
         ZetkinLocation,
         ZetkinLocationPatchBody
       >(`/api2/orgs/${orgId}/locations/${locationId}`, data);
-      // to preserve the stats
-      const combined = { ...oldLocation, ...location };
-      dispatch(locationUpdated(combined));
+      dispatch(locationUpdated(location));
     },
   };
 }

--- a/src/features/canvass/hooks/useLocationMutations.ts
+++ b/src/features/canvass/hooks/useLocationMutations.ts
@@ -50,12 +50,17 @@ export default function useLocationMutations(
       );
       dispatch(householdUpdated([locationId, household]));
     },
-    updateLocation: async (data: ZetkinLocationPatchBody) => {
+    updateLocation: async (
+      oldLocation: ZetkinLocation,
+      data: ZetkinLocationPatchBody
+    ) => {
       const location = await apiClient.patch<
         ZetkinLocation,
         ZetkinLocationPatchBody
       >(`/api2/orgs/${orgId}/locations/${locationId}`, data);
-      dispatch(locationUpdated(location));
+      // to preserve the stats
+      const combined = { ...oldLocation, ...location };
+      dispatch(locationUpdated(combined));
     },
   };
 }

--- a/src/utils/storeUtils/remoteItemUpdated.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.ts
@@ -12,10 +12,11 @@ import { findOrAddItem } from './findOrAddItem';
  */
 export function remoteItemUpdated<DataType extends RemoteData>(
   list: RemoteList<DataType>,
-  updatedData: DataType
+  updatedData: DataType,
+  updateStategy?: (itemToUpdate: RemoteItem<DataType>) => DataType
 ): RemoteItem<DataType> {
   const item = findOrAddItem(list, updatedData.id);
-  item.data = updatedData;
+  item.data = updateStategy ? updateStategy(item) : updatedData;
   item.mutating = [];
   item.isLoading = false;
   item.isStale = false;


### PR DESCRIPTION
## Description
This PR resolves the household visit stats location marker not preserved problem. 

## Screenshots
<img width="1432" height="840" alt="image" src="https://github.com/user-attachments/assets/a22d4be6-ce7a-4848-b7c1-3cd6aa2bc939" />

## Changes
When applying the changed location name and description, the other attributes of the location are now kept now.

## Notes to reviewer
* create in organization 1 one canvass activity and household, add visits
* http://localhost:3000/canvass/96/areas/131?step=edit - change name and see afterwards that the marker not loosing the visits stats

## Related issues
Resolves #3382 
