### PR TITLE
Caller UI: Improve performance / make it load only necessary survey elements

### DIFF
--- a/src/features/call/components/Survey.tsx
+++ b/src/features/call/components/Survey.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/system';
 import { FC, useRef } from 'react';
 import { ChevronLeft } from '@mui/icons-material';
 
-import { ZetkinSurveyExtended } from 'utils/types/zetkin';
+import { ZetkinSurvey } from 'utils/types/zetkin';
 import SurveyForm from 'features/surveys/components/SurveyForm';
 import ZUIText from 'zui/components/ZUIText';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
@@ -15,7 +15,7 @@ import ZUIButton from 'zui/components/ZUIButton';
 import ZUIDivider from 'zui/components/ZUIDivider';
 
 type Props = {
-  survey: ZetkinSurveyExtended;
+  survey: ZetkinSurvey;
 };
 
 const Survey: FC<Props> = ({ survey }) => {

--- a/src/features/call/components/SurveyCard.tsx
+++ b/src/features/call/components/SurveyCard.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 
 import MyActivityListItem from 'features/home/components/MyActivityListItem';
 import ZUIButton from 'zui/components/ZUIButton';
-import { ZetkinSurveyExtended } from 'utils/types/zetkin';
+import { ZetkinSurvey } from 'utils/types/zetkin';
 import ZUILabel from 'zui/components/ZUILabel';
 import ZUIText from 'zui/components/ZUIText';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
@@ -13,7 +13,7 @@ import { surveySubmissionDeleted } from '../store';
 
 type SurveyCardProps = {
   onSelectSurvey: (surveyId: number) => void;
-  survey: ZetkinSurveyExtended;
+  survey: ZetkinSurvey;
 };
 
 const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {

--- a/src/features/call/hooks/useFilteredActivities.ts
+++ b/src/features/call/hooks/useFilteredActivities.ts
@@ -2,10 +2,10 @@ import dayjs, { Dayjs } from 'dayjs';
 
 import { useAppSelector } from 'core/hooks';
 import useUpcomingEvents from './useUpcomingEvents';
-import useSurveysWithElements from 'features/surveys/hooks/useSurveysWithElements';
 import { getUTCDateWithoutTime } from 'utils/dateUtils';
 import useCurrentCall from './useCurrentCall';
-import { ZetkinEvent, ZetkinSurveyExtended } from 'utils/types/zetkin';
+import { ZetkinEvent, ZetkinSurvey } from 'utils/types/zetkin';
+import useSurveys from 'features/surveys/hooks/useSurveys';
 
 type ActivityBase = {
   visibleFrom: Date | null;
@@ -18,7 +18,7 @@ type EventActivity = ActivityBase & {
 };
 
 type SurveyActivity = ActivityBase & {
-  data: ZetkinSurveyExtended;
+  data: ZetkinSurvey;
   kind: 'survey';
 };
 
@@ -26,7 +26,7 @@ export type Activity = EventActivity | SurveyActivity;
 
 export default function useFilteredActivities(orgId: number) {
   const events = useUpcomingEvents(orgId);
-  const surveys = useSurveysWithElements(orgId).data || [];
+  const surveys = useSurveys(orgId).data || [];
   const {
     filterState,
     customDatesToFilterEventsBy,

--- a/src/features/surveys/components/SurveyForm/index.tsx
+++ b/src/features/surveys/components/SurveyForm/index.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material';
 import { FC } from 'react';
 
 import {
-  ZetkinSurveyExtended,
+  ZetkinSurvey,
   ZetkinSurveyQuestionElement,
   ZetkinSurveyTextQuestionElement,
 } from 'utils/types/zetkin';
@@ -11,11 +11,13 @@ import TextQuestion from './TextQuestion';
 import OptionsQuestion from './OptionsQuestion';
 import useServerSide from 'core/useServerSide';
 import LinkifiedText from './LinkifiedText';
+import useSurveyElements from 'features/surveys/hooks/useSurveyElements';
+import ZUIFuture from 'zui/ZUIFuture';
 
 type SurveyFormProps = {
   initialValues?: Record<string, string | string[]>;
   onChange?: (name: string, value: string | string[]) => void;
-  survey: ZetkinSurveyExtended;
+  survey: ZetkinSurvey;
 };
 
 const isTextQuestionType = (
@@ -30,6 +32,7 @@ const SurveyForm: FC<SurveyFormProps> = ({
   survey,
 }) => {
   const isServer = useServerSide();
+  const extendedSurvey = useSurveyElements(survey.organization.id, survey.id);
 
   if (isServer) {
     return null;
@@ -44,61 +47,70 @@ const SurveyForm: FC<SurveyFormProps> = ({
         paddingY: '1rem',
       }}
     >
-      {survey.elements
-        .filter((element) => element.hidden !== true)
-        .map((element) => {
-          const isTextBlock = element.type == 'text';
-          const isTextQuestion = !isTextBlock && isTextQuestionType(element);
-          const isOptionsQuestion = !isTextBlock && !isTextQuestion;
+      <ZUIFuture future={extendedSurvey}>
+        {(data) => (
+          <>
+            {data
+              .filter((element) => element.hidden !== true)
+              .map((element) => {
+                const isTextBlock = element.type == 'text';
+                const isTextQuestion =
+                  !isTextBlock && isTextQuestionType(element);
+                const isOptionsQuestion = !isTextBlock && !isTextQuestion;
 
-          return (
-            <Box key={element.id}>
-              {isTextBlock && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '0.5rem',
-                    wordBreak: 'break-word',
-                  }}
-                >
-                  <ZUIText variant="headingMd">
-                    {element.text_block.header}
-                  </ZUIText>
-                  <ZUIText renderLineBreaks={true}>
-                    {element.text_block.content && (
-                      <LinkifiedText text={element.text_block.content} />
+                return (
+                  <Box key={element.id}>
+                    {isTextBlock && (
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '0.5rem',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        <ZUIText variant="headingMd">
+                          {element.text_block.header}
+                        </ZUIText>
+                        <ZUIText renderLineBreaks={true}>
+                          {element.text_block.content && (
+                            <LinkifiedText text={element.text_block.content} />
+                          )}
+                        </ZUIText>
+                      </Box>
                     )}
-                  </ZUIText>
-                </Box>
-              )}
-              {isTextQuestion && (
-                <TextQuestion
-                  element={element}
-                  initialValue={initialValues[`${element.id}.text`] as string}
-                  name={`${element.id}.text`}
-                  onChange={(newValue) => {
-                    if (onChange) {
-                      onChange(`${element.id}.text`, newValue);
-                    }
-                  }}
-                />
-              )}
-              {isOptionsQuestion && (
-                <OptionsQuestion
-                  element={element}
-                  initialValue={initialValues[`${element.id}.options`]}
-                  name={`${element.id}.options`}
-                  onChange={(newValue) => {
-                    if (onChange) {
-                      onChange(`${element.id}.options`, newValue);
-                    }
-                  }}
-                />
-              )}
-            </Box>
-          );
-        })}
+                    {isTextQuestion && (
+                      <TextQuestion
+                        element={element}
+                        initialValue={
+                          initialValues[`${element.id}.text`] as string
+                        }
+                        name={`${element.id}.text`}
+                        onChange={(newValue) => {
+                          if (onChange) {
+                            onChange(`${element.id}.text`, newValue);
+                          }
+                        }}
+                      />
+                    )}
+                    {isOptionsQuestion && (
+                      <OptionsQuestion
+                        element={element}
+                        initialValue={initialValues[`${element.id}.options`]}
+                        name={`${element.id}.options`}
+                        onChange={(newValue) => {
+                          if (onChange) {
+                            onChange(`${element.id}.options`, newValue);
+                          }
+                        }}
+                      />
+                    )}
+                  </Box>
+                );
+              })}
+          </>
+        )}
+      </ZUIFuture>
     </Box>
   );
 };


### PR DESCRIPTION
## Description
This PR attempts reduces fetch calls on the caller UI by making it load only the necessary elements at a time. Currently, it fetches all surveys and then all survey elements of all surveys. Callers usually only need one or two. The UI doesn't need the extended version in most places, so we can just load the elements when the caller clicks on the survey.

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes `useFilteredActivities` so it only loads via `useSurveys`
* Adds `useSurveyElements` to `SurveyForm`

## Notes to reviewer
Note, that the loading of surveys is non blocking, which means that the UI loads fast, but after a while, the surveys appear. After this PR, the surveys should show pretty much instantly.
