### PR TITLE
Caller UI: Improve performance / add useUnfinishedCalls

### DIFF
--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -10,7 +10,6 @@ import { updateLaneStep } from '../store';
 import useServerSide from 'core/useServerSide';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import ZUIText from 'zui/components/ZUIText';
-import useOutgoingCalls from '../hooks/useOutgoingCalls';
 import useCallMutations from '../hooks/useCallMutations';
 import CallSwitchModal from '../components/CallSwitchModal';
 import ZUIModal from 'zui/components/ZUIModal';
@@ -20,6 +19,7 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import CallHeader from './CallHeader';
 import CallPanels from './CallPanels';
+import useUnfinishedCalls from 'features/call/hooks/useUnfinishedCalls';
 
 const Call: FC = () => {
   const messages = useMessages(messageIds);
@@ -38,7 +38,6 @@ const Call: FC = () => {
 
   const { abandonUnfinishedCall, skipCurrentCall, switchToUnfinishedCall } =
     useCallMutations(assignment.organization.id);
-  const outgoingCalls = useOutgoingCalls();
 
   const lane = useAppSelector(
     (state) => state.call.lanes[state.call.activeLaneIndex]
@@ -47,11 +46,8 @@ const Call: FC = () => {
     (state) => state.call.lanes[state.call.activeLaneIndex].report
   );
 
-  const unfinishedCalls = outgoingCalls.filter((c) => {
-    const isUnfinishedCall = c.state == 0;
-    const isNotCurrentCall = call ? call.id != c.id : true;
-
-    return isUnfinishedCall && isNotCurrentCall;
+  const unfinishedCalls = useUnfinishedCalls().filter((c) => {
+    return call ? call.id != c.id : true;
   });
 
   const switchedTo = allUserAssignments.find(

--- a/src/features/call/hooks/useCurrentCall.ts
+++ b/src/features/call/hooks/useCurrentCall.ts
@@ -7,9 +7,13 @@ export default function useCurrentCall(): ZetkinCall | null {
   const activeLane = state.lanes[state.activeLaneIndex];
   const currentCallId = activeLane.currentCallId;
 
-  const currentCall = state.outgoingCalls.items.find(
-    (item: RemoteItem<ZetkinCall>) => item.id === currentCallId
-  );
+  const currentCall =
+    state.outgoingCalls.items.find(
+      (item: RemoteItem<ZetkinCall>) => item.id === currentCallId
+    ) ||
+    state.unfinishedCalls.items.find(
+      (item: RemoteItem<ZetkinCall>) => item.id === currentCallId
+    );
 
   return currentCall?.data ?? null;
 }

--- a/src/features/call/hooks/useUnfinishedCalls.ts
+++ b/src/features/call/hooks/useUnfinishedCalls.ts
@@ -1,0 +1,21 @@
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { unfinishedCallsLoad, unfinishedCallsLoaded } from '../store';
+import { ZetkinCall } from '../types';
+import useRemoteList from 'core/hooks/useRemoteList';
+
+export default function useUnfinishedCalls(): ZetkinCall[] {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const outgoingList = useAppSelector((state) => state.call.unfinishedCalls);
+
+  return useRemoteList(outgoingList, {
+    actionOnLoad: () => dispatch(unfinishedCallsLoad()),
+    actionOnSuccess: (data) => dispatch(unfinishedCallsLoaded(data)),
+    loader: () => {
+      return apiClient.get<
+        ZetkinCall[]
+      >(`/api/users/me/outgoing_calls?p=0&pp=200&filter=state==0
+        `);
+    },
+  });
+}

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -27,6 +27,7 @@ export default function mockState(overrides?: RootState) {
       myAssignmentsList: remoteList(),
       outgoingCalls: remoteList(),
       queueHasError: null,
+      unfinishedCalls: remoteList(),
       upcomingEventsList: remoteList(),
     },
     callAssignments: {


### PR DESCRIPTION
## Description
The caller UI's performance has one huge bottleneck. The call to `/api/users/me/outgoing_calls?p=0&pp=200`, which takes 14 seconds for me. Unless the user doesn't enter the call log modal, they don't need that data though, as it gets filtered by `state==0` instantly to get all unfinished calls. We can improve on this by calling the API with an additional filter argument `&filter=state==0`, which gives us only the unfinished calls and takes 247ms for me. 


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a new hook `useUnfinishedCalls`
* Wires it's state up in `state.ts` and other places just like `useOutgoingCalls`
* Use the new hook in `Call.tsx`


## Notes to reviewer
[Add instructions for testing]
I find the state structure in features/call very confusing. For example, `useCurrentCall` basically requires you to call `useOutgoingCalls` (now: or `useUnfinishedCalls`) somewhere so it gets populated with data. My changes didn't help that. I don't have a clear enough overview over what can happen in that feature to propose a solution though.
