### PR TITLE
Pages Router: move pages redux store into ref

### DIFF
--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -198,4 +198,3 @@ export default function createStore(
 
 export type Store = ReturnType<typeof createStore>;
 export type AppDispatch = Store['dispatch'];
-export const store = createStore();

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,9 +6,9 @@ import { LicenseInfo } from '@mui/x-data-grid-pro';
 import { NoSsr } from '@mui/base';
 import NProgress from 'nprogress';
 import Router from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-import { store } from 'core/store';
+import createStore, { Store } from 'core/store';
 import BrowserApiClient from 'core/api/client/BrowserApiClient';
 import Environment from 'core/env/Environment';
 import { PageWithLayout } from '../utils/types';
@@ -40,6 +40,12 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   const c = Component as PageWithLayout;
   const getLayout = c.getLayout || ((page) => page);
 
+  const storeRef = useRef<Store | null>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = createStore();
+  }
+
   if (typeof window !== 'undefined') {
     window.__reactRendered = true;
   }
@@ -64,7 +70,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
       env={env}
       lang={lang}
       messages={messages}
-      store={store}
+      store={storeRef.current}
       user={pageProps.user}
     >
       <CssBaseline />


### PR DESCRIPTION
## Description
This PR moves redux store creation on the pages router to a ref rather than being a global variable. This is more safe in nextjs. We already do this on the app router.

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Makes _app use a ref to create the redux store
* Removes the globally created redux store as it is not needed anymore

## Notes to reviewer

@richardolsson knows why this is important :)

