### PR TITLE
Find Duplicates: Fix bug causing lost values when manually selecting people

### DIFF
--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -7,7 +7,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 
 import FieldSettingsRow from './FieldSettingsRow';
 import messageIds from 'features/duplicates/l10n/messageIds';
@@ -20,6 +20,7 @@ interface FieldSettingsProps {
   customFields: ZetkinCustomField[];
   duplicates: ZetkinPerson[];
   onChange: (field: NATIVE_PERSON_FIELDS, selectedValue: string) => void;
+  resetKey: string;
   setOverrides: React.Dispatch<
     React.SetStateAction<Partial<ZetkinPerson> | null>
   >;
@@ -29,24 +30,28 @@ const FieldSettings: FC<FieldSettingsProps> = ({
   customFields,
   duplicates,
   onChange,
+  resetKey,
   setOverrides,
 }) => {
   const theme = useTheme();
   const messages = useMessages(messageIds);
+  const lastResetKeyRef = useRef<string | null>(null);
   const { hasConflictingValues, fieldValues, initialOverrides } = useMemo(
     () => getFieldSettings({ customFields, duplicates }),
     [customFields, duplicates]
   );
 
   useEffect(() => {
-    setOverrides((prev) => {
-      if (prev) {
-        return prev;
-      }
+    const resetKeyChanged = lastResetKeyRef.current !== resetKey;
 
-      return initialOverrides;
-    });
-  }, [initialOverrides]);
+    if (resetKeyChanged) {
+      lastResetKeyRef.current = resetKey;
+      setOverrides(initialOverrides);
+      return;
+    }
+
+    setOverrides((prev) => (prev ? prev : initialOverrides));
+  }, [initialOverrides, resetKey, setOverrides]);
 
   return (
     <Box>

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -64,6 +64,12 @@ const MergeModal: FC<Props> = ({
     null
   );
 
+  const resetKey = Array.from(
+    new Set([...selectedIds, ...additionalPeople.map((person) => person.id)])
+  )
+    .sort((a, b) => a - b)
+    .join(',');
+
   useEffect(() => {
     setSelectedIds(persons.map((person) => person.id) ?? []);
   }, [open]);
@@ -126,6 +132,7 @@ const MergeModal: FC<Props> = ({
                     setOverrides({ ...overrides, [`${field}`]: value });
                   }
                 }}
+                resetKey={resetKey}
                 setOverrides={setOverrides}
               />
             )}


### PR DESCRIPTION
## Description
This PR resolves a bug in the MergeModal when adding people manually to the duplication set. 
When adding a person the form, and the internal state of the FieldSettings components updates, but the `overrides` state in the parent was not updating. 

## Changes

* Adds a `resetKey` in MergeModal computed from the people selection that will trigger a useEffect in FieldSettings updating the `overrides`

## Notes to reviewer
- I did not have enough time for extensively testing this. 

