### PR TITLE
Activist Portal: Make root redirect faster

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,7 +77,10 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       };
     } else {
       return {
-        props: {},
+        redirect: {
+          destination: '/my/home',
+          permanent: false,
+        },
       };
     }
   },


### PR DESCRIPTION
## Description
This PR makes the root redirect faster. Ever wondered why you see "Redirecting..." when redirection can happen instantly? It's because we're redirecting to home in client rendering. But we can just make the page return a 307 redirect, which makes it way faster.


## Screenshots
[Add screenshots here]

Getting rid of this:
<img width="500" alt="redirecting" src="https://github.com/user-attachments/assets/3f393bb6-fa8c-414e-8b98-2cba0eae204f" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds a redirection rule to / in case ?code= is not defined and reroutes to /my/home

## Related issues
Related to the already closed https://github.com/zetkin/app.zetkin.org/issues/3210
