### PR TITLE
Activist Portal: Add project/org links to cards

### DIFF
--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -95,12 +95,16 @@ const MyActivitiesList: FC = () => {
               info={[
                 {
                   Icon: GroupWorkOutlined,
-                  labels: activity.data.campaign
-                    ? [
-                        activity.data.campaign.title,
-                        activity.data.organization.title,
-                      ]
-                    : [activity.data.organization.title],
+                  labels: [
+                    activity.data.campaign && {
+                      href: `/o/${activity.data.organization.id}/projects/${activity.data.campaign.id}`,
+                      text: activity.data.campaign.title,
+                    },
+                    activity.data.organization && {
+                      href: `/o/${activity.data.organization.id}`,
+                      text: activity.data.organization.title,
+                    },
+                  ].filter((label) => !!label),
                 },
               ]}
               title={

--- a/src/features/my/components/MyActivityListItem.tsx
+++ b/src/features/my/components/MyActivityListItem.tsx
@@ -3,7 +3,7 @@ import { OverridableComponent } from '@mui/material/OverridableComponent';
 import { FC } from 'react';
 
 import ZUIItemCard from 'zui/components/ZUIItemCard';
-import ZUIIconLabel from 'zui/components/ZUIIconLabel';
+import ZUIIconLabel, { ZUILabelText } from 'zui/components/ZUIIconLabel';
 
 type Props = {
   actions?: JSX.Element[];
@@ -12,7 +12,7 @@ type Props = {
   image?: string;
   info: {
     Icon: OverridableComponent<SvgIconTypeMap<unknown, 'svg'>>;
-    labels: string[];
+    labels: ZUILabelText[];
   }[];
   title: string;
 };

--- a/src/features/public/components/AreaAssignmentListItem.tsx
+++ b/src/features/public/components/AreaAssignmentListItem.tsx
@@ -37,9 +37,15 @@ const AreaAssignmentListItem: FC<Props> = ({ assignment, href }) => {
         {
           Icon: GroupWorkOutlined,
           labels: [
-            campaign.campaignFuture.data?.title,
-            organization.data?.title,
-          ].filter((label) => !!label) as string[],
+            campaign.campaignFuture.data && {
+              href: `/o/${campaign.campaignFuture.data.organization.id}/projects/${campaign.campaignFuture.data.id}`,
+              text: campaign.campaignFuture.data.title,
+            },
+            organization.data && {
+              href: `/o/${organization.data.id}`,
+              text: organization.data.title,
+            },
+          ].filter((label) => !!label),
         },
       ]}
       title={assignment.title || messages.defaultTitles.areaAssignment()}

--- a/src/features/public/components/EventListItem.tsx
+++ b/src/features/public/components/EventListItem.tsx
@@ -40,9 +40,16 @@ const EventListItem: FC<Props> = ({ event, href, onClickSignUp }) => {
       info={[
         {
           Icon: GroupWorkOutlined,
-          labels: [event.campaign?.title, event.organization.title].filter(
-            (label) => !!label
-          ) as string[],
+          labels: [
+            event.campaign && {
+              href: `/o/${event.organization.id}/projects/${event.campaign.id}`,
+              text: event.campaign.title,
+            },
+            {
+              href: `/o/${event.organization.id}`,
+              text: event.organization.title,
+            },
+          ].filter((label) => !!label),
         },
         {
           Icon: WatchLaterOutlined,

--- a/src/zui/components/ZUIIconLabel/index.tsx
+++ b/src/zui/components/ZUIIconLabel/index.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, Link, Typography } from '@mui/material';
+import NextLink from 'next/link';
 
 import { MUIIcon, ZUIPrimary, ZUISecondary, ZUISize } from '../types';
 import ZUIIcon from '../ZUIIcon';
@@ -9,6 +10,14 @@ const TextVariants = {
   medium: 'bodySmRegular',
   small: 'bodySmRegular',
 } as const;
+
+export type ZUILabelText =
+  | string
+  | {
+      href: string;
+      openInNewTab?: boolean;
+      text: string;
+    };
 
 export type ZUIIconLabelProps = {
   /**
@@ -28,7 +37,7 @@ export type ZUIIconLabelProps = {
   /**
    * The label
    */
-  label: string | string[];
+  label: ZUILabelText | ZUILabelText[];
 
   /**
    * If true, the text will not overflow and end with an ellipsis.
@@ -45,6 +54,31 @@ export type ZUIIconLabelProps = {
   size?: ZUISize;
 };
 
+const getLabelText = (label: ZUILabelText, key: number | string) => {
+  if (typeof label === 'string') {
+    return label;
+  }
+
+  return (
+    <Link
+      key={key}
+      component={NextLink}
+      href={label.href}
+      rel={label.openInNewTab ? 'noopener noreferrer' : ''}
+      sx={{
+        '&:hover': {
+          color: 'text.primary',
+        },
+        color: 'inherit',
+      }}
+      target={label.openInNewTab ? '_blank' : ''}
+      underline={'hover'}
+    >
+      {label.text}
+    </Link>
+  );
+};
+
 const ZUIIconLabel: FC<ZUIIconLabelProps> = ({
   color = 'primary',
   icon,
@@ -55,19 +89,23 @@ const ZUIIconLabel: FC<ZUIIconLabelProps> = ({
   const labels: ReactNode[] = [];
 
   if (Array.isArray(label)) {
+    let i = 0;
+
     label.forEach((text, index) => {
       if (index > 0) {
         labels.push(
-          <Typography key={index} component="span" sx={{ mx: 1 }}>
+          <Typography key={i} component="span" sx={{ mx: 1 }}>
             ·
           </Typography>
         );
+        i++;
       }
 
-      labels.push(text);
+      labels.push(getLabelText(text, i));
+      i++;
     });
   } else {
-    labels.push(label);
+    labels.push(getLabelText(label, 0));
   }
 
   return (


### PR DESCRIPTION
## Description
This PR adds links where users would expect links in activity feed cards.


## Screenshots
[Add screenshots here]

<img width="476" height="664" alt="feed-links" src="https://github.com/user-attachments/assets/0960fef2-b599-4948-bbcd-17208de569d2" />

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds possibility to include links in ZUIIconLabel
* Adds links to all types of feed elements: Event, Call assignment, Area assignment - there were these titles of organizations and projects to which I added links to

The style matches the other labels but on hover, it goes to text.primary (black) and gets an underline to mark it as a link.

## Related issues
Split and improved from https://github.com/zetkin/app.zetkin.org/pull/3122
