### PR TITLE
Surveys: make survey privacy policy link open in new tab

### DIFF
--- a/src/features/public/pages/PublicSurveyPage.tsx
+++ b/src/features/public/pages/PublicSurveyPage.tsx
@@ -221,6 +221,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
                   </ZUIText>
                   <ZUILink
                     href={privacyUrl}
+                    openInNewTab={true}
                     text={messages.surveyForm.policy.text()}
                   />
                 </FormGroup>


### PR DESCRIPTION
## Description
This PR makes the privacy policy link open in a new tab. Because guess what happens when you fill out a survey and want to read the privacy policy - your answers are gone. 

Edit: After https://github.com/zetkin/app.zetkin.org/pull/3451 , it would be less important, but I still think this should open in a new tab
