### PR TITLE
Lists/ZUI: Allow unmounting of zui ellipsis menus

### DIFF
--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -223,6 +223,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
                   },
                 },
               ]}
+              keepMounted={false}
             />
           );
         },

--- a/src/zui/ZUIEllipsisMenu/index.tsx
+++ b/src/zui/ZUIEllipsisMenu/index.tsx
@@ -32,12 +32,14 @@ export interface ZUIEllipsisMenuProps {
   items: MenuItem[];
   anchorOrigin?: { horizontal: horizontalType; vertical: verticalType };
   transformOrigin?: { horizontal: horizontalType; vertical: verticalType };
+  keepMounted?: boolean;
 }
 
 const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
   items,
   anchorOrigin,
   transformOrigin,
+  keepMounted = true,
 }) => {
   const messages = useMessages(messageIds);
 
@@ -66,7 +68,7 @@ const ZUIEllipsisMenu: FunctionComponent<ZUIEllipsisMenuProps> = ({
         anchorOrigin={
           anchorOrigin ?? { horizontal: 'left', vertical: 'bottom' }
         }
-        keepMounted
+        keepMounted={keepMounted}
         onClose={() => setMenuActivator(null)}
         open={Boolean(menuActivator)}
         sx={{


### PR DESCRIPTION
## Description
This PR improves the performance of the view browser by allowing zui ellispis menus to unmount. `keepMounted` is good in many cases, but not in huge lists with small menus.


## Screenshots
[Add screenshots here]
Before
<img width="1910" height="936" alt="keep-mounted" src="https://github.com/user-attachments/assets/f99e4c3d-06a4-455e-8bf0-5f53e9449432" />
(these nodes are all the dropdowns in the ellipsis menus of the rows)
After
<img width="1902" height="940" alt="allowed-unmount" src="https://github.com/user-attachments/assets/d8105c8b-28ba-4bae-b16d-799912911c5a" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds the option to disable `keepMounted` in zui ellipsis menus
* Allows unmounting for view browser

