### PR TITLE
Fix organize page crash by future reconstruction

### DIFF
--- a/src/features/organizations/hooks/useOfficialMemberships.ts
+++ b/src/features/organizations/hooks/useOfficialMemberships.ts
@@ -1,4 +1,9 @@
-import { IFuture } from 'core/caching/futures';
+import {
+  ErrorFuture,
+  IFuture,
+  LoadingFuture,
+  ResolvedFuture,
+} from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinMembership } from 'utils/types/zetkin';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
@@ -18,9 +23,13 @@ export default function useOfficialMemberships(): IFuture<ZetkinMembership[]> {
       apiClient.get<ZetkinMembership[]>(`/api/users/me/memberships`),
   });
 
-  if (future.data) {
-    future.data = future.data.filter((m) => m.role != null);
+  if (future.error) {
+    return new ErrorFuture(future.error);
   }
 
-  return future;
+  if (future.isLoading) {
+    return new LoadingFuture();
+  }
+
+  return new ResolvedFuture((future.data || []).filter((m) => m.role != null));
 }


### PR DESCRIPTION
## Description
This PR fixes the crash on /organize detailed in https://github.com/zetkin/app.zetkin.org/issues/3458


## Screenshots
[Add screenshots here]
<img width="1262" height="976" alt="yay-no-crash" src="https://github.com/user-attachments/assets/0b97cdcd-d05a-4871-b025-460f35cba407" />

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Makes the `useOfficialMemberships` hook reconstruct the future to get safe access to setting `data`


## Notes to reviewer
[Add instructions for testing]
It's not pure, but it is the pattern I have seen throughout Zetkin

## Related issues
Resolves https://github.com/zetkin/app.zetkin.org/issues/3458
