### PR TITLE
Add bulk selection size to button label

### DIFF
--- a/src/locale/da.yml
+++ b/src/locale/da.yml
@@ -1499,11 +1499,6 @@ feat:
         header: Ældre besvarelser
         openButton: Vis
     toolbar:
-      bulk:
-        createList: Opret liste fra udvalg
-        delete: Slet valgte personer fra organisationen
-        handleSelection: 'Behandle udvalg ({numSelected})'
-        removeFromList: Fjern valgte personer fra listen
       createColumn: Ny kolonne
     viewLayout:
       actions:

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -3512,7 +3512,6 @@ feat:
       bulk:
         createList: Liste aus Auswahl erstellen
         delete: Ausgewählte Personen aus der Organisation löschen
-        handleSelection: 'Auswahl bearbeiten ({numSelected})'
         removeFromList: Ausgewählte Personen aus der Liste entfernen
       createColumn: Neue Spalte
     viewLayout:

--- a/src/locale/nl.yml
+++ b/src/locale/nl.yml
@@ -2580,11 +2580,6 @@ feat:
         header: Oudere toevoegingen
         openButton: Toon
     toolbar:
-      bulk:
-        createList: Lijst uit selectie maken
-        delete: Geselecteerde personen uit de organisatie verwijderen
-        handleSelection: 'Selectie verwerken ({numSelected})'
-        removeFromList: Geselecteerde personen uit de lijst verwijderen
       createColumn: Nieuwe kolom
     viewLayout:
       actions:

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -3605,7 +3605,6 @@ feat:
       bulk:
         createList: Lag liste av valgte
         delete: Slett valgte folk fra organisasjonen
-        handleSelection: 'Behandle utvalg ({numSelected})'
         removeFromList: Fjern valgte folk fra lista
       createColumn: Ny kolonne
     viewLayout:

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -3414,7 +3414,6 @@ feat:
       bulk:
         createList: Skapa en ny lista med valda personer
         delete: Radera valda personer från organisationen
-        handleSelection: 'Hantera urval ({numSelected})'
         removeFromList: Ta bort valda personer från lista
       createColumn: Ny kolumn
     viewLayout:


### PR DESCRIPTION
## Description
This PR adds the selection count to the label of a list's bulk operation button. Additionally, it aligns the i18n files wrt. the bulk operation button for Danish, Dutch, German, Norwegian and Swedish.


## Screenshots
<img width="1622" height="586" alt="Screenshot 2026-02-12 at 22 53 23" src="https://github.com/user-attachments/assets/8e86bd8f-5633-4dc6-8c67-0451b47f6073" />



## Changes

* Adds size indicator.
* Aligns translation for bulk operations.

## Notes to reviewer

I can't fully verify the correctness of the translations added for Danish and Dutch, but this is what Deepl suggested. IMHO, it's better to have this than the English fallback. Open for removing it though.

## Related issues
Resolves #3443 
