### PR TITLE
Use skeleton to fully render event popper while loading data

### DIFF
--- a/src/features/events/components/EventPopper/SingleEvent.tsx
+++ b/src/features/events/components/EventPopper/SingleEvent.tsx
@@ -11,7 +11,7 @@ import {
   People,
   PlaceOutlined,
 } from '@mui/icons-material';
-import { Box, Button, Link, Typography } from '@mui/material';
+import { Box, Button, Link, Skeleton, Typography } from '@mui/material';
 import React, { FC, useContext, useState } from 'react';
 import router from 'next/router';
 
@@ -78,6 +78,12 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
   const signedParticipants = respondents.filter(
     (r) => !participants.some((p) => p.id === r.id)
   );
+
+  const isLoading =
+    participantsFuture.isLoading ||
+    respondentsFuture.isLoading ||
+    state == EventState.UNKNOWN;
+  const showSignups = signedParticipants.length > 0 || isLoading;
 
   const handleMove = () => {
     setIsMoveDialogOpen(true);
@@ -206,7 +212,7 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
         </Typography>
       </Box>
       <Box display="flex" flexDirection="column" gap={1} sx={{ mb: 2 }}>
-        {signedParticipants.length > 0 && (
+        {showSignups && (
           <>
             <Box
               alignItems="center"
@@ -226,18 +232,28 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
                   size="xs"
                 />
               </Box>
-              <Typography
-                color={
-                  (signedParticipants.length ?? 0) > 0 ? 'red' : 'secondary'
-                }
-              >
-                {signedParticipants.length ?? 0}
-              </Typography>
+              {isLoading ? (
+                <Skeleton width={20} />
+              ) : (
+                <Typography
+                  color={
+                    (signedParticipants.length ?? 0) > 0 ? 'red' : 'secondary'
+                  }
+                >
+                  {signedParticipants.length ?? 0}
+                </Typography>
+              )}
             </Box>
-            <ParticipantAvatars
-              orgId={orgId}
-              participants={signedParticipants}
-            />
+            {isLoading ? (
+              <Skeleton height={20} variant="rectangular" width="100%" />
+            ) : (
+              signedParticipants.length > 0 && (
+                <ParticipantAvatars
+                  orgId={orgId}
+                  participants={signedParticipants}
+                />
+              )
+            )}
           </>
         )}
         <Box alignItems="center" display="flex" justifyContent="space-between">
@@ -254,11 +270,15 @@ const SingleEvent: FC<SingleEventProps> = ({ event, onClickAway }) => {
             numerator={event.num_participants_available}
           />
         </Box>
-        {availableParticipants.length > 0 && (
-          <ParticipantAvatars
-            orgId={orgId}
-            participants={availableParticipants}
-          />
+        {isLoading ? (
+          <Skeleton height={20} variant="rectangular" width="100%" />
+        ) : (
+          availableParticipants.length > 0 && (
+            <ParticipantAvatars
+              orgId={orgId}
+              participants={availableParticipants}
+            />
+          )
         )}
         <Box alignItems="center" display="flex" justifyContent="space-between">
           <Box alignItems="center" display="flex">


### PR DESCRIPTION
## Description
This PR adds skeletons to the event popper in order to stop it from exceeding the viewport when asynchronously loaded data arrives.


## Video

https://github.com/user-attachments/assets/9ee87b17-e348-4377-b94b-89fe0a17b368


## Changes
* Adds skeletons to the event popper.


## Notes to reviewer
Please see the comment at https://github.com/zetkin/app.zetkin.org/issues/2276#issuecomment-3893957843 , which explains why I think this approach should work well for users. Please let me know if there is anything I missed.


## Related issues
Resolves #2276 
