### PR TITLE
Change User menu links

### DIFF
--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -70,10 +70,9 @@ export default makeMessages('feat.organizations', {
       viewInMap: m('View in map'),
     },
     menu: {
-      allEvents: m('All events'),
       logout: m('Logout'),
-      myActivities: m('My activities'),
       myZetkin: m('My Zetkin'),
+      organize: m('Organize'),
       settings: m('Settings'),
     },
     tabs: {

--- a/src/features/public/components/ActivistPortalHeader/index.tsx
+++ b/src/features/public/components/ActivistPortalHeader/index.tsx
@@ -52,7 +52,7 @@ const ActivistPortalHeader: FC<Props> = ({
       ...(isOfficial
         ? [
             {
-              label: 'Organize',
+              label: messages.home.menu.organize(),
               onClick: () => router.push('/organize'),
             },
           ]


### PR DESCRIPTION
## Description
This PR restructures the Avatar User menu


## Screenshots
<img width="184" height="231" alt="Screenshot 2026-02-14 at 19 48 10" src="https://github.com/user-attachments/assets/154d4984-539c-4321-9ff4-17d0e1582d04" />



## Changes
* Adds Organize link if applicable
* Changes the links to My Zetkin


## Notes to reviewer
None


## Related issues
Resolves #3469
