### PR TITLE
Add public URL card to email overview

### DIFF
--- a/src/features/emails/components/EmailURLCard.tsx
+++ b/src/features/emails/components/EmailURLCard.tsx
@@ -1,0 +1,36 @@
+import React, { useMemo } from 'react';
+
+import useMessages from 'core/i18n/useMessages';
+import messageIds from '../l10n/messageIds';
+import ZUIURLCard from 'zui/components/ZUIURLCard';
+import useEmail from '../hooks/useEmail';
+
+interface EmailURLCardProps {
+  isOpen: boolean;
+  orgId: number;
+  emailId: number;
+}
+
+const EmailURLCard = ({ isOpen, orgId, emailId }: EmailURLCardProps) => {
+  const email = useEmail(orgId, emailId);
+  const messages = useMessages(messageIds);
+
+  const relativeUrl = useMemo(
+    () =>
+      email.data
+        ? `/o/${email.data.organization.id}/viewmail/${email.data.uuid}`
+        : '',
+    [email.data]
+  );
+
+  return (
+    <ZUIURLCard
+      absoluteUrl={`${location.protocol}//${location.host}${relativeUrl}`}
+      isOpen={isOpen}
+      messages={messages.urlCard}
+      relativeUrl={relativeUrl}
+    />
+  );
+};
+
+export default EmailURLCard;

--- a/src/features/emails/l10n/messageIds.ts
+++ b/src/features/emails/l10n/messageIds.ts
@@ -255,6 +255,14 @@ export default makeMessages('feat.emails', {
       'You have been unsubscribed from mass email from {org}.'
     ),
   },
+  urlCard: {
+    nowAccepting: m('Everyone can view the email at this link'),
+    open: m('Public view'),
+    preview: m('Future direct link'),
+    previewPortal: m('Preview email'),
+    visitPortal: m('Visit email'),
+    willAccept: m('Everyone will be able to view the email at this link'),
+  },
   varDefaults: {
     target: m('reader'),
   },

--- a/src/features/emails/utils/deliveryProblems.spec.ts
+++ b/src/features/emails/utils/deliveryProblems.spec.ts
@@ -63,6 +63,7 @@ const mockEmail = (emailOverrides?: Partial<ZetkinEmail>): ZetkinEmail => {
     },
     theme: { frame_mjml: null, id: 1 },
     title: 'Welcome email for new members',
+    uuid: '2079ac84-cca5-4cfa-851a-2089e357e81d',
     ...emailOverrides,
   };
 };

--- a/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
@@ -424,6 +424,7 @@ export default function mockEmail(
       title: '',
     },
     title: '',
+    uuid: '',
     ...overrides,
   };
 }

--- a/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/emails/[emailId]/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import Head from 'next/head';
 import { GetServerSideProps } from 'next';
 
@@ -9,10 +9,11 @@ import EmailTargetsReady from 'features/emails/components/EmailTargetsReady';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import useEmail from 'features/emails/hooks/useEmail';
-import useEmailState from 'features/emails/hooks/useEmailState';
+import useEmailState, { EmailState } from 'features/emails/hooks/useEmailState';
 import useEmailStats from 'features/emails/hooks/useEmailStats';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
+import EmailURLCard from 'features/emails/components/EmailURLCard';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -52,37 +53,44 @@ const EmailPage: PageWithLayout = () => {
         <title>{email.title}</title>
       </Head>
       <Box>
-        <Box display="flex" flexDirection="column">
-          <EmailTargets
-            email={email}
-            isLoading={mutating.includes('locked')}
-            isLocked={isLocked}
-            isTargeted={isTargeted}
-            onToggleLocked={() => updateEmail({ locked: !email.locked })}
-            readyTargets={readyTargets}
-            state={emailState}
-            targets={numTargetMatches}
-            updateTargets={updateTargets}
-          />
-          <Box display="flex" gap={2} paddingTop={2}>
-            <Box flex={1}>
-              <EmailTargetsBlocked
-                blacklisted={numBlocked.blacklisted}
-                missingEmail={numBlocked.noEmail}
-                total={numBlocked.any}
-                unsubscribed={numBlocked.unsubscribed}
-              />
-            </Box>
-            <Box flex={1}>
-              <EmailTargetsReady
-                lockedReadyTargets={lockedReadyTargets}
-                missingEmail={numBlocked.noEmail}
-                readyTargets={readyTargets}
-                state={emailState}
-              />
-            </Box>
-          </Box>
-        </Box>
+        <Grid container spacing={2}>
+          <Grid size={{ md: 8 }}>
+            <EmailTargets
+              email={email}
+              isLoading={mutating.includes('locked')}
+              isLocked={isLocked}
+              isTargeted={isTargeted}
+              onToggleLocked={() => updateEmail({ locked: !email.locked })}
+              readyTargets={readyTargets}
+              state={emailState}
+              targets={numTargetMatches}
+              updateTargets={updateTargets}
+            />
+          </Grid>
+          <Grid size={{ md: 4 }}>
+            <EmailURLCard
+              emailId={emailId}
+              isOpen={emailState == EmailState.SENT}
+              orgId={orgId}
+            />
+          </Grid>
+          <Grid size={{ md: 6 }}>
+            <EmailTargetsBlocked
+              blacklisted={numBlocked.blacklisted}
+              missingEmail={numBlocked.noEmail}
+              total={numBlocked.any}
+              unsubscribed={numBlocked.unsubscribed}
+            />
+          </Grid>
+          <Grid size={{ md: 6 }}>
+            <EmailTargetsReady
+              lockedReadyTargets={lockedReadyTargets}
+              missingEmail={numBlocked.noEmail}
+              readyTargets={readyTargets}
+              state={emailState}
+            />
+          </Grid>
+        </Grid>
       </Box>
     </>
   );

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -576,6 +576,7 @@ export interface ZetkinEmail {
   content: string | null;
   title: string | null;
   target: ZetkinQuery;
+  uuid: string;
 }
 
 export interface ZetkinLink {


### PR DESCRIPTION
## Description
This PR adds the urlCard to the email Overview page to be able to share the publicly available link - not requiring authentication.

## Screenshots

<img width="1528" height="948" alt="grafik" src="https://github.com/user-attachments/assets/c19d1003-ec21-45e8-a351-ffe1d68f47a7" />


## Changes

* Adds URL card to email page


## Notes to reviewer

- The layout behaves not super nice with different screen sizes (e.g., mobile) 🤷 


## Related issues
Resolves #3347
