### PR TITLE
Enable react-hooks/exhaustive-deps and suppress all violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,7 +92,7 @@ module.exports = {
         'react/prefer-stateless-function': 'error',
         'react/prop-types': 'off',
         'react/react-in-jsx-scope': 'off',
-        'react-hooks/exhaustive-deps': 'off',
+        'react-hooks/exhaustive-deps': 'error',
         'react/self-closing-comp': [
           'error',
           {

--- a/src/features/areaAssignments/components/OrganizerMapFilters/index.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapFilters/index.tsx
@@ -78,6 +78,7 @@ const OrganizerMapFilters: FC<Props> = ({ areas, onFilteredIdsChange }) => {
     });
 
     onFilteredIdsChange(filteredAreas.map((area) => area.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeGroupIds, activeTagIdsByGroup]);
 
   return (

--- a/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
+++ b/src/features/areaAssignments/components/OrganizerMapRenderer.tsx
@@ -327,6 +327,7 @@ const OrganizerMapRenderer: FC<OrganizerMapRendererProps> = ({
         }
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [areas, map]);
 
   const { assigneesFilter } = useContext(assigneesFilterContext);

--- a/src/features/areas/components/AreaFilters/index.tsx
+++ b/src/features/areas/components/AreaFilters/index.tsx
@@ -69,6 +69,7 @@ const AreaFilters: FC<Props> = ({ areas, onFilteredIdsChange }) => {
     });
 
     onFilteredIdsChange(filteredAreas.map((area) => area.id));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeGroupIds, activeTagIdsByGroup]);
 
   return (

--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -81,6 +81,7 @@ const AreaOverlay: FC<Props> = ({
   useEffect(() => {
     setTitle(area.title);
     setDescription(area.description);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [area.id]);
 
   return (

--- a/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
+++ b/src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx
@@ -22,6 +22,7 @@ const EventInputFilter = ({
     if (reset === true) {
       setUserInput('');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userText]);
 
   const debouncedFinishedTyping = useDebounce(async (value: string) => {

--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -77,8 +77,10 @@ const EventDayLane: FC<EventDayLaneProps> = ({
     laneRef.current?.addEventListener('mousedown', handleMouseDown);
 
     return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       laneRef.current?.removeEventListener('mousedown', handleMouseDown);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [laneRef.current]);
 
   return (

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -78,6 +78,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
       laneHeight,
       eventsByDate.map((a) => a.lanes)
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusDate]);
 
   return (

--- a/src/features/calendar/components/EventShiftModal/EventModalTypeAutocomplete.tsx
+++ b/src/features/calendar/components/EventShiftModal/EventModalTypeAutocomplete.tsx
@@ -43,6 +43,7 @@ const EventModalTypeAutocomplete: FC<EventModalTypeAutocompleteProps> = ({
         onChangeNewOption(newType);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [types.length]);
 
   const allTypes: EventTypeOption[] = [

--- a/src/features/calendar/components/EventShiftModal/EventShiftTime.tsx
+++ b/src/features/calendar/components/EventShiftModal/EventShiftTime.tsx
@@ -137,6 +137,7 @@ const EventShiftTime: FC<EventShiftTimeProps> = ({
         ]);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updatedShift]);
 
   useEffect(() => {
@@ -153,6 +154,7 @@ const EventShiftTime: FC<EventShiftTimeProps> = ({
     } else {
       onInvalidEndTimeChange(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventStartTime, eventEndTime]);
 
   return (

--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -64,6 +64,7 @@ const Calendar = () => {
       undefined,
       { shallow: true }
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusDate, timeScale]);
 
   function navigateTo(timeScale: TimeScale, date: Date) {

--- a/src/features/calendar/hooks/useDayCalendarEvents.ts
+++ b/src/features/calendar/hooks/useDayCalendarEvents.ts
@@ -40,6 +40,7 @@ export default function useDayCalendarEvents(
 
       setLastDate(newLastDate);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusDate.toISOString()]);
 
   // When a new lastDate is set, load the next last date
@@ -58,6 +59,7 @@ export default function useDayCalendarEvents(
       setNextLastDate(nextLastDateStr ? new Date(nextLastDateStr) : null);
     }
     loadNextLastDate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastDate.toISOString()]);
 
   const eventsState = useAppSelector((state) => state.events);

--- a/src/features/calendar/hooks/useDayCalendarNav.ts
+++ b/src/features/calendar/hooks/useDayCalendarNav.ts
@@ -86,6 +86,7 @@ export default function useDayCalendarNav(
         },
       ]);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusDateStr]);
 
   return {

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -521,6 +521,7 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
         })
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target?.id]);
 
   useEffect(() => {
@@ -539,6 +540,7 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
         })
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 
   return (

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -69,6 +69,7 @@ const UnfinishedCallsList: FC<{
       searchString
         ? fuse.search(searchString).map((fuseResult) => fuseResult.item)
         : unfinishedExceptCurrentCall,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [unfinishedExceptCurrentCall, searchString]
   );
 
@@ -132,6 +133,7 @@ const FinishedCallsList: FC<{
 
       return call2AllocationTime.getTime() - call1AllocationTime.getTime();
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [finishedCalls, searchString]);
 
   return (
@@ -261,8 +263,10 @@ const CallSwitchModal: FC<CallSwitchModalProps> = ({
       modalRef.current.addEventListener('keydown', addListener);
 
       return () =>
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         modalRef.current?.removeEventListener('keydown', addListener);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalRef.current]);
 
   return (

--- a/src/features/call/components/Heartbeat.tsx
+++ b/src/features/call/components/Heartbeat.tsx
@@ -23,6 +23,7 @@ const Heartbeat: FC = () => {
     }, HEARTBEAT_FREQUENCY);
 
     return () => clearInterval(heartbeatTimer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return null;

--- a/src/features/call/components/Report/steps/CallBack.tsx
+++ b/src/features/call/components/Report/steps/CallBack.tsx
@@ -166,6 +166,7 @@ const CallBack: FC<Props> = ({ onReportUpdate, report }) => {
     return () => {
       window.removeEventListener('keydown', onKeyDown);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [callBackAfter]);
 
   const dateIsValid = date.isValid() && date.isAfter(today.date());

--- a/src/features/call/components/Report/steps/CallerLog.tsx
+++ b/src/features/call/components/Report/steps/CallerLog.tsx
@@ -62,6 +62,7 @@ const CallerLog: FC<Props> = ({ onReportUpdate, report }) => {
       window.removeEventListener('keydown', onKeyDown);
       window.addEventListener('keyup', onKeyUp);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [message]);
 
   return (

--- a/src/features/call/components/Report/steps/OrganizerLog.tsx
+++ b/src/features/call/components/Report/steps/OrganizerLog.tsx
@@ -49,10 +49,12 @@ const OrganizerLog: FC<Props> = ({
     } else {
       return '';
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     dispatch(updatePendingOrgLog(initialMessage));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -94,6 +96,7 @@ const OrganizerLog: FC<Props> = ({
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [organizerLog]);
 
   return (

--- a/src/features/call/components/Report/steps/QuickResponseButtons.tsx
+++ b/src/features/call/components/Report/steps/QuickResponseButtons.tsx
@@ -37,6 +37,7 @@ export const QuickResponseButtons: FC<QuickResponseProps> = ({ options }) => {
     return () => {
       window.removeEventListener('keydown', onKeyDown);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const numberButtons = [

--- a/src/features/call/components/Report/steps/WrongNumber.tsx
+++ b/src/features/call/components/Report/steps/WrongNumber.tsx
@@ -58,6 +58,7 @@ const WrongNumber: FC<Props> = ({
     return () => {
       window.removeEventListener('keydown', onKeyDown);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/features/call/hooks/useCallInitialization.ts
+++ b/src/features/call/hooks/useCallInitialization.ts
@@ -44,6 +44,7 @@ export default function useCallInitialization() {
       }
     });
     return () => unsubscribe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store]);
 
   const assignmentIdFromQuery = queryParams?.get('assignment');

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -33,10 +33,12 @@ export default function useFinishedCalls() {
 
   useEffect(() => {
     loadFinishedCalls();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageNumber]);
 
   useEffect(() => {
     setPageNumber(pageNumber + 1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [finishedCalls.length]);
 
   return {

--- a/src/features/call/pages/CallPage.tsx
+++ b/src/features/call/pages/CallPage.tsx
@@ -25,6 +25,7 @@ const CallPage: FC = () => {
       clearStaleCallLanes();
       return redirect('/my');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onServer = useServerSide();

--- a/src/features/campaigns/hooks/useActivityFilters.ts
+++ b/src/features/campaigns/hooks/useActivityFilters.ts
@@ -19,10 +19,12 @@ export default function useActivityFilters(
 ) {
   const filtersKey = useMemo(
     () => `activities:${orgId}:${campId ?? 'all'}:${location}:filters`,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [campId, orgId]
   );
   const searchKey = useMemo(
     () => `activities:${orgId}:${campId ?? 'all'}:${location}:search`,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [campId, orgId]
   );
 

--- a/src/features/canvass/components/CanvassMapOverlays.tsx
+++ b/src/features/canvass/components/CanvassMapOverlays.tsx
@@ -47,6 +47,7 @@ const CanvassMapOverlays: FC<Props> = ({
     if (!selectedLocation && expanded) {
       setExpanded(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLocation]);
 
   return (

--- a/src/features/canvass/components/CreateLocationCard.tsx
+++ b/src/features/canvass/components/CreateLocationCard.tsx
@@ -24,6 +24,7 @@ export const CreateLocationCard: FC<CreateLocationCardProps> = ({
   const messages = useMessages(messageIds);
   const [title, setTitle] = useState<string>('');
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const titles = suggestions ?? [];
 
   const { tokenOriginalByLower, tokenCounts, bigramCounts } = useMemo(() => {

--- a/src/features/canvass/components/EncouragingSparkle.tsx
+++ b/src/features/canvass/components/EncouragingSparkle.tsx
@@ -11,6 +11,7 @@ type Props = {
 const EncouragingSparkle: FC<Props> = ({ duration = 2000, onComplete }) => {
   useEffect(() => {
     setTimeout(() => onComplete?.(), duration);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const particleSx: SxProps = {

--- a/src/features/canvass/components/GLCanvassMap/index.tsx
+++ b/src/features/canvass/components/GLCanvassMap/index.tsx
@@ -105,6 +105,7 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
         bounds: boundsForSelectedArea,
         fitBoundsOptions: { padding: BOUNDS_PADDING },
       };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [boundsForSelectedArea]);
 
   const locationsGeoJson: GeoJSON.FeatureCollection = useMemo(() => {
@@ -168,6 +169,7 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
         }) ?? [],
       type: 'FeatureCollection',
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locations.data]);
 
   const selectedLocation = useMemo(() => {
@@ -176,6 +178,7 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
     }
 
     return locations.data?.find((loc) => loc.id == selectedLocationId) || null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locations]);
 
   const locationTitles = useMemo(() => {
@@ -276,12 +279,14 @@ const GLCanvassMap: FC<Props> = ({ assignment, selectedArea }) => {
     } catch {
       // Do nothing for now
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [map, selectedLocationId, locations]);
 
   useEffect(() => {
     if (created) {
       updateSelection();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [created, locations]);
 
   if (!locations.data) {

--- a/src/features/canvass/components/LocationDialog/index.tsx
+++ b/src/features/canvass/components/LocationDialog/index.tsx
@@ -110,6 +110,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
         window.removeEventListener('popstate', handlePopState);
       };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -117,6 +118,7 @@ const LocationDialog: FC<LocationDialogProps> = ({
       pushedRef.current = true;
       goto('location');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [selectedHouseholdId, setSelectedHouseholdId] = useState<number | null>(

--- a/src/features/canvass/components/LocationDialog/pages/CreateHouseholdsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/CreateHouseholdsPage.tsx
@@ -55,6 +55,7 @@ const CreateHouseholdsPage: FC<Props> = ({
         setScale(newScale);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setNumFloors, setNumAptsPerFloor, container]
   );
 

--- a/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx
@@ -55,6 +55,7 @@ const LocationVisitPage: FC<Props> = ({
     if (max > numHouseholds) {
       setNumHouseholds(max);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [valuesByMetricId]);
 
   useEffect(() => {

--- a/src/features/duplicates/components/MergeModal.tsx
+++ b/src/features/duplicates/components/MergeModal.tsx
@@ -72,6 +72,7 @@ const MergeModal: FC<Props> = ({
 
   useEffect(() => {
     setSelectedIds(persons.map((person) => person.id) ?? []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   return (

--- a/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
+++ b/src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx
@@ -137,6 +137,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
         }
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -157,6 +158,7 @@ const EmailEditorFrontend: FC<EmailEditorFrontendProps> = ({
     return () => {
       clearInterval(timer);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const styleSheet: CSSStyleSheet = new CSSStyleSheet();

--- a/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
+++ b/src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx
@@ -29,6 +29,7 @@ const PreviewTab: FC = () => {
     if (user && destinationEmailAddress == '') {
       setDestinationEmailAddress(user.email);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.email]);
 
   if (!user) {

--- a/src/features/emails/components/EmailEditor/index.tsx
+++ b/src/features/emails/components/EmailEditor/index.tsx
@@ -69,6 +69,7 @@ const EmailEditor: FC<EmailEditorProps> = ({ email, onSave }) => {
       }
     }
     blocksRef.current = content.blocks;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content.blocks.length]);
 
   const debouncedFinishedTyping = useDebounce(async (value: string) => {

--- a/src/features/emails/components/EmailMiniature.tsx
+++ b/src/features/emails/components/EmailMiniature.tsx
@@ -42,6 +42,7 @@ const EmailMiniature: FC<Props> = ({
     }
 
     load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -79,6 +79,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
         onChangeNewOption(newEventType!.id);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [types.length]);
 
   useEffect(() => {
@@ -86,10 +87,12 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
       const width = spanRef.current.offsetWidth;
       setDropdownListWidth(width);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spanRef.current, text]);
 
   useEffect(() => {
     setText(value ? value.title : uncategorizedMsg);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   const allTypes: EventTypeOption[] = [

--- a/src/features/events/components/EventURLCard.tsx
+++ b/src/features/events/components/EventURLCard.tsx
@@ -24,6 +24,7 @@ const EventURLCard = ({
       event != null && event.data
         ? `${location.protocol}//${location.host}/o/${event.data.organization.id}/events/${eventId}`
         : '',
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [event?.data, eventId]
   );
 

--- a/src/features/events/components/LocationModal/index.tsx
+++ b/src/features/events/components/LocationModal/index.tsx
@@ -64,6 +64,7 @@ const LocationModal: FC<LocationModalProps> = ({
   useEffect(() => {
     setSelectedLocationId(locationId);
     setPendingLocation(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   return (

--- a/src/features/events/hooks/useEventTypeFilter.ts
+++ b/src/features/events/hooks/useEventTypeFilter.ts
@@ -98,6 +98,7 @@ export const useEventTypeFilter = (
 
   const clearEventTypeFilter = useCallback(() => {
     state.setEventTypeLabelsToFilterBy([]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.setEventTypeLabelsToFilterBy]);
 
   return {

--- a/src/features/events/hooks/useFilteredEvents.ts
+++ b/src/features/events/hooks/useFilteredEvents.ts
@@ -57,6 +57,7 @@ export default function useFilteredEvents({
       status:
         myEvents.find((userEvent) => userEvent.id == event.id)?.status || null,
     }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events]);
 
   const eventTypeFilter = useEventTypeFilter(allEvents, {

--- a/src/features/files/hooks/useFileUploads.ts
+++ b/src/features/files/hooks/useFileUploads.ts
@@ -127,6 +127,7 @@ export default function useFileUploads(
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     addFiles(acceptedFiles);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const { getInputProps, getRootProps, isDragActive } = useDropzone({

--- a/src/features/geography/hooks/useAreaDrawing.ts
+++ b/src/features/geography/hooks/useAreaDrawing.ts
@@ -84,6 +84,7 @@ export default function useAreaDrawing({
       map?.off('click', handleClick);
       map?.off('mousemove', handleMove);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [drawingPoints, map]);
 
   const startedDrawing = !!drawingPoints && drawingPoints.length > 0;

--- a/src/features/geography/hooks/useMapBounds.ts
+++ b/src/features/geography/hooks/useMapBounds.ts
@@ -45,6 +45,7 @@ export default function useMapBounds({ areas, map }: Props): Return {
     if (bounds && shouldPan) {
       map.fitBounds(bounds, { animate: true, duration: 800 });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bounds]);
 
   useEffect(() => {

--- a/src/features/import/components/ImportDialog/Configure/Configuration/IdConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/IdConfig.tsx
@@ -35,6 +35,7 @@ const IdConfig: FC<IdConfigProps> = ({ uiDataColumn }) => {
     if (skipUnknown) {
       updateSheetSettings({ skipUnknown: false });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [importID]);
 
   const idField = uiDataColumn.originalColumn.idField;

--- a/src/features/import/components/ImportDialog/ParseFile.tsx
+++ b/src/features/import/components/ImportDialog/ParseFile.tsx
@@ -81,6 +81,7 @@ const ParseFile: FC<ParseFileProps> = ({ onClose, onSuccess }) => {
         onSuccess();
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const { getRootProps, getInputProps, open, isDragActive } = useDropzone({

--- a/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
+++ b/src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx
@@ -29,6 +29,7 @@ const ImportMessageList: FC<Props> = ({
     ).length;
 
     onAllChecked(numChecked == warningCount);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [numChecked]);
 
   return (

--- a/src/features/import/hooks/useDateConfig.ts
+++ b/src/features/import/hooks/useDateConfig.ts
@@ -24,6 +24,7 @@ export default function useDateConfig(column: DateColumn, columnIndex: number) {
 
   useEffect(() => {
     setDateFormat(column.dateFormat || null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnIndex]);
 
   const noCustomFormat = dateFormat == '';

--- a/src/features/map/hooks/useResizeMap.ts
+++ b/src/features/map/hooks/useResizeMap.ts
@@ -17,5 +17,6 @@ export const useAutoResizeMap = (mapRef: MapType | null) => {
     const resizeObserver = new ResizeObserver(() => mapRef?.invalidateSize());
     resizeObserver.observe(containerElement);
     return () => resizeObserver.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerElement]);
 };

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -118,6 +118,7 @@ const AllEventsList: FC = () => {
 
       router.push(pathname + '?' + params.toString());
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [pathname, router, searchParams, dateFilterState]
   );
 

--- a/src/features/organizations/components/ActivistPortalCampaignEventsMap.tsx
+++ b/src/features/organizations/components/ActivistPortalCampaignEventsMap.tsx
@@ -27,6 +27,7 @@ const ActivistPortalCampaignEventsMap: FC<Props> = ({ campId, orgId }) => {
         })
       );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [lastSegment, router.push, orgId]
   );
 

--- a/src/features/organizations/components/ActivistPortalOrgEventsMap.tsx
+++ b/src/features/organizations/components/ActivistPortalOrgEventsMap.tsx
@@ -30,6 +30,7 @@ const ActivistPortalOrgEventsMap: FC<Props> = ({ orgId }) => {
         router.push(`/o/${orgId}`);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [dispatch, filtersUpdated, lastSegment, router.push, orgId]
   );
 

--- a/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
+++ b/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
@@ -58,6 +58,7 @@ function useOrgSwitcher(orgId: number, searchString: string) {
     return searchString
       ? recentOrgsFuse.search(searchString).map((fuseResult) => fuseResult.item)
       : recentOrgs;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString]);
 
   const allOrgsFuse = useMemo(() => {
@@ -72,6 +73,7 @@ function useOrgSwitcher(orgId: number, searchString: string) {
     return searchString
       ? allOrgsFuse.search(searchString).map((fuseResult) => fuseResult.item)
       : flatOrgData;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString]);
 
   const showLoadingState = treeDataList.isLoading;

--- a/src/features/profile/hooks/usePersonSearch.ts
+++ b/src/features/profile/hooks/usePersonSearch.ts
@@ -60,6 +60,7 @@ export default function usePersonSearch(orgId: number): UsePersonSearchReturn {
           });
         });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTyping]);
 
   return {

--- a/src/features/public/components/ActivistPortalEventMap.tsx
+++ b/src/features/public/components/ActivistPortalEventMap.tsx
@@ -114,6 +114,7 @@ export const ActivistPortalEventMap: FC<{
         }) ?? [],
       type: 'FeatureCollection',
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events, locationFilter]);
 
   return (

--- a/src/features/public/pages/PublicSurveyPage.tsx
+++ b/src/features/public/pages/PublicSurveyPage.tsx
@@ -58,6 +58,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
       surveyStateRef.current = updatedSurveyState;
       setSurveyState(updatedSurveyState);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [initialSurveyState, setSurveyState]
   );
 
@@ -78,6 +79,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
         setStatus('error');
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setSurveyState, setStatus]
   );
 
@@ -94,6 +96,7 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
     if (errorMessageRef.current) {
       errorMessageRef.current.scrollIntoView({ behavior: 'smooth' });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errorMessageRef.current]);
 
   useEffect(() => {

--- a/src/features/smartSearch/components/filters/Matching.tsx
+++ b/src/features/smartSearch/components/filters/Matching.tsx
@@ -38,6 +38,7 @@ const Matching = ({
     } else if (option == MATCHING.ONCE) {
       onChange({ max: undefined, min: undefined });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [min, max, option]);
 
   const matchingSelect = (

--- a/src/features/smartSearch/components/filters/PersonData/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonData/index.tsx
@@ -73,6 +73,7 @@ const PersonData = ({
       ...filter.config,
       fields,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [criteria]);
 
   const addCriteria = (field: string) => {

--- a/src/features/smartSearch/components/filters/PersonField/index.tsx
+++ b/src/features/smartSearch/components/filters/PersonField/index.tsx
@@ -63,6 +63,7 @@ const PersonField = ({
         field: filter.config.field || filteredFields[0]?.slug,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fields.length]);
 
   // submit if there is a field selected and if the search field is not blank if type is text / url

--- a/src/features/smartSearch/components/filters/Random/index.tsx
+++ b/src/features/smartSearch/components/filters/Random/index.tsx
@@ -67,6 +67,7 @@ const Random = ({
         size: quantityDisplay / 100,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, quantityDisplay]);
 
   const handleSubmit = (e: FormEvent) => {

--- a/src/features/smartSearch/components/filters/SubQuery/index.tsx
+++ b/src/features/smartSearch/components/filters/SubQuery/index.tsx
@@ -87,6 +87,7 @@ const SubQuery = ({
         queries.find((q) => q.id === filter.config.query_id) || queries[0]
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [standaloneQueries, assignments]);
 
   const renderedOptions = queries.filter((q) => q.type === selectedQuery?.type);

--- a/src/features/smartSearch/components/filters/SurveyOption/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/index.tsx
@@ -84,6 +84,7 @@ const SurveyOption = ({
         survey: filter.config.survey || surveys[0].id,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [surveys.length]);
 
   // check if there are questions with response type of 'text'

--- a/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveyResponse/index.tsx
@@ -92,6 +92,7 @@ const SurveyResponse = ({
         value: internalConfig.value || '',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [surveys.length]);
 
   // check if there are questions with response type of 'text'

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -58,6 +58,7 @@ const SurveySubmission = ({
       });
       setSubmittable(true);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [surveys.length]);
 
   const handleSubmit = (e: FormEvent) => {

--- a/src/features/smartSearch/components/filters/TimeFrame.tsx
+++ b/src/features/smartSearch/components/filters/TimeFrame.tsx
@@ -64,6 +64,7 @@ const TimeFrame = ({
         before: before.toISOString().slice(0, 10),
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [before, after, selected, numDays]);
 
   const afterDateSelect = (

--- a/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeySegment.tsx
+++ b/src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeySegment.tsx
@@ -54,6 +54,7 @@ const SmartSearchSankeySegment: FC<SmartSearchSankeySegmentProps> = ({
     return () => {
       cancelAnimationFrame(animFrameRef.current);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     canvasRef.current,
     canvasHeight,

--- a/src/features/surveys/components/ResponseStatsCards.tsx
+++ b/src/features/surveys/components/ResponseStatsCards.tsx
@@ -170,6 +170,7 @@ const ResponseStatsCard = ({
         document.body.style.overflow = docOverflow;
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       showSnackbar,
       containerRef,
@@ -189,6 +190,7 @@ const ResponseStatsCard = ({
         onSelect: () => exportChart('pdf'),
       },
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [exportChart]
   );
 
@@ -495,6 +497,7 @@ const OptionsStatsCard = ({
         answerCount: questionStats.answerCount,
         totalSelectedOptionsCount: questionStats.totalSelectedOptionsCount,
       }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [questionStats, messages.insights.optionsFields.subheader]
   );
 
@@ -610,6 +613,7 @@ const TextResponseWordCloud = ({
   const { publicAPI } = useChartProExport(exportOptions);
   useEffect(() => {
     exportApi.current = publicAPI as UseChartProExportPublicApi;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [publicAPI]);
 
   const [width, setWidth] = useState(600);
@@ -624,6 +628,7 @@ const TextResponseWordCloud = ({
   const getRotationDegree = useMemo(() => {
     const rng = makeDeterministicRNG(42);
     return () => (rng() > 0.5 ? 0 : 90);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [words, width]);
 
   const fontScale = useMemo(() => {
@@ -906,6 +911,7 @@ const TextStatsCard = ({
         totalUniqueWordCount: questionStats.totalUniqueWordCount,
         totalWordCount: questionStats.totalWordCount,
       }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [questionStats, messages.insights.textFields.subheader]
   );
 

--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -111,6 +111,7 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
 
       lengthRef.current = options.length;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [elemQuestion.options?.length]);
 
   const { autoFocusDefault, clickAwayProps, containerProps, previewableProps } =

--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -252,6 +252,7 @@ const SurveySubmissionsList = ({
       if (emailOrName.length > 2) {
         setQuery(emailOrName);
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [emailOrName]);
 
     const updateCellValue = (person: ZetkinPerson | null) => {

--- a/src/features/surveys/layouts/SurveyLayout.tsx
+++ b/src/features/surveys/layouts/SurveyLayout.tsx
@@ -152,6 +152,7 @@ const SurveyLayout: React.FC<SurveyLayoutProps> = ({
         showSnackbar('error', messages.surveyToList.error());
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [apiClient, orgId, surveyId, router.push, surveyFuture.data]
   );
 

--- a/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
+++ b/src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx
@@ -20,6 +20,7 @@ const ValueTagForm: React.FC<{
     } else {
       onChange(inputValue);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inputValue]);
 
   return (

--- a/src/features/tasks/components/TaskDetailsForm/index.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/index.tsx
@@ -190,6 +190,7 @@ const TaskDetailsForm = ({
     visitUrl,
   ]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const errors = useMemo(() => validate(composedValues), [composedValues]);
   const hasErrors = (
     obj: Record<string, string | Record<string, string>>

--- a/src/features/views/components/ViewBrowser/BrowserDragableItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserDragableItem.tsx
@@ -20,6 +20,7 @@ const BrowserDraggableItem: FC<BrowserDragItemProps> = ({ children, item }) => {
     // Use an empty image as drag/drop preview, to hide while dragging.
     // A nicer preview is rendered by the BrowserDragLayer component.
     preview(getEmptyImage(), { captureDraggingState: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
     <Box ref={dragRef} display="flex" gap={1}>

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -84,6 +84,7 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
         id: 'folders/' + recentlyCreatedFolder.id,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recentlyCreatedFolder]);
 
   const colDefs: GridColDef<ViewBrowserItem>[] = [

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx
@@ -66,6 +66,7 @@ const ColumnGallery: FunctionComponent<ColumnGalleryProps> = ({
     return keys.map((key) => ({ ...choices[key], key }));
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const searchResults = useMemo(() => search(), [searchString]);
 
   const choiceContainerRef = useRef<HTMLDivElement>();

--- a/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx
@@ -100,6 +100,7 @@ const Textarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
       el.setSelectionRange(el.value.length, el.value.length);
       el.scrollTop = el.scrollHeight;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleRef = useCallback((el: HTMLElement | null) => {
@@ -118,6 +119,7 @@ const Textarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
         event
       );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [apiRef, field, id]
   );
 
@@ -128,6 +130,7 @@ const Textarea = (props: GridRenderEditCellParams<ZetkinViewRow>) => {
         event.stopPropagation();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [apiRef, id, field]
   );
 

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -199,6 +199,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     ) {
       selectionModel.onSelectionChange(selection);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selection]);
   const [waiting, setWaiting] = useState(false);
 
@@ -223,6 +224,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     (error: VIEW_DATA_TABLE_ERROR) => {
       showSnackbar('error', messages.dataTableErrors[error]());
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [showSnackbar]
   );
 
@@ -287,6 +289,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       const colSpec = columns.find((col) => col.id === colId) || null;
       setColumnToConfigure(colSpec);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [colIdFromFieldName, columns, setColumnToConfigure]
   );
 
@@ -321,6 +324,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         doDelete();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       colIdFromFieldName,
       columns,
@@ -337,6 +341,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       const colSpec = columns.find((col) => col.id === colId) || null;
       setColumnToRename(colSpec);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [colIdFromFieldName, columns, setColumnToRename]
   );
 
@@ -350,6 +355,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   const onRowsDelete = useCallback(async () => {
     bulkDeletePersons(selection);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selection]);
 
   const onRowsRemove = useCallback(async () => {
@@ -361,6 +367,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     } finally {
       setWaiting(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewGrid.removeRows, showError, setWaiting]);
 
   const onViewCreate = useCallback(() => {
@@ -428,6 +435,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       ];
       debouncedUpdateColumnOrder(newColumnOrder);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [colIdFromFieldName, columns, debouncedUpdateColumnOrder]
   );
 
@@ -548,6 +556,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
         sortModel: modelGridProps.sortModel,
       },
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       onColumnConfigure,
       onColumnDelete,
@@ -593,6 +602,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       ...theme.components?.MuiDataGrid?.defaultProps?.localeText,
       noRowsLabel: messages.empty.notice[contentSource](),
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [theme.components, messages.empty.notice]
   );
 
@@ -673,6 +683,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       }
       return after;
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [columns]
   );
 

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -98,6 +98,7 @@ const NewJourneyPage: PageWithLayout<NewJourneyPageProps> = ({
       }
     }
     loadSubject();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const journeyFuture = useJourney(parseInt(orgId), parseInt(journeyId));

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -37,6 +37,7 @@ const DuplicatesPage: PageWithLayout = () => {
       router.asPath.split('?')[0]
     }?page=${page}`;
     window.history.replaceState({}, '', url);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
   if (onServer) {

--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -166,6 +166,7 @@ const AllCampaignsSummaryPage: PageWithLayout = () => {
     return fuse.search(searchString).map((fuseResult) => fuseResult.item);
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const campaignsThatMatchSearch = useMemo(() => search(), [searchString]);
 
   const [activeCampaigns, archivedCampaigns] = useMemo(() => {
@@ -185,6 +186,7 @@ const AllCampaignsSummaryPage: PageWithLayout = () => {
     }
 
     return [active, archived];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [campaigns, searchString]);
 
   if (onServer) {

--- a/src/utils/hooks/useDebounce.ts
+++ b/src/utils/hooks/useDebounce.ts
@@ -18,6 +18,7 @@ export default function useDebounce<
 ): (...args: Args) => Promise<ReturnType> | undefined {
   // Memoizing the callback because if it's an arrow function
   // it would be different on each render
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedCallback = useCallback(callback, []);
   const debouncedFn = useRef(debounce(memoizedCallback, delay));
 

--- a/src/utils/panes/useResizablePane.ts
+++ b/src/utils/panes/useResizablePane.ts
@@ -42,10 +42,12 @@ export default function useResizablePane(fixedHeight: boolean): ResizablePane {
         container.removeEventListener('scroll', updatePaneHeight);
       };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [container]);
 
   useEffect(() => {
     updatePaneHeight();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return { paneContainerRef, slideRef, updatePaneHeight };

--- a/src/zui/ZUIAnimatedNumber/index.tsx
+++ b/src/zui/ZUIAnimatedNumber/index.tsx
@@ -60,6 +60,7 @@ const ZUIAnimatedNumber: FC<ZUIAnimatedNumberProps> = ({
     // Restart animation
     animRef.current.startTime = null;
     animRef.current.requestId = requestAnimationFrame(animate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   return children(animatedValue.toFixed(decimals));

--- a/src/zui/ZUICollapse/index.tsx
+++ b/src/zui/ZUICollapse/index.tsx
@@ -28,6 +28,7 @@ const ZUICollapse: React.FC<ZUICollapseProps> = ({
         setDidMeasure(true);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [setNeedsCollapse]
   );
 

--- a/src/zui/ZUIDataTableSearch.tsx
+++ b/src/zui/ZUIDataTableSearch.tsx
@@ -56,6 +56,7 @@ const DataTableSearch: React.FunctionComponent<ZUIDataTableSearchProps> = ({
     if (!isTyping) {
       onChange(isActive ? searchString : '');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString, isTyping]);
 
   useEffect(() => {

--- a/src/zui/ZUIDatePicker/index.tsx
+++ b/src/zui/ZUIDatePicker/index.tsx
@@ -174,6 +174,7 @@ const DateTextField: FC<DateTextFieldProps> = ({ label, onChange, value }) => {
 
   useEffect(() => {
     resetValue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   return (

--- a/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
+++ b/src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx
@@ -259,6 +259,7 @@ const DateTextField: FC<DateTextFieldProps> = ({ label, onChange, value }) => {
 
   useEffect(() => {
     resetValue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   return (

--- a/src/zui/ZUIEditTextInPlace/index.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.tsx
@@ -43,6 +43,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
     if (value !== text) {
       setText(value);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   useEffect(() => {
@@ -54,6 +55,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
       const width = spanRef.current.offsetWidth + (editing ? 30 : -5);
       inputRef.current.style.width = width + 'px';
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spanRef.current, inputRef.current, editing, text]);
 
   useEffect(() => {
@@ -65,6 +67,7 @@ const ZUIEditTextinPlace: React.FunctionComponent<ZUIEditTextinPlaceProps> = ({
         onBlur();
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editing]);
 
   const startEditing = () => {

--- a/src/zui/ZUIPublicFooter/index.tsx
+++ b/src/zui/ZUIPublicFooter/index.tsx
@@ -35,6 +35,7 @@ const ZUIPublicFooter: FC = () => {
           ]
         : []),
     ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [messages]
   );
 

--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -84,6 +84,7 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
         onReorder(order);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeId]);
 
   const yOffsetRef = useRef<number>();

--- a/src/zui/ZUIResponsiveContainer/index.tsx
+++ b/src/zui/ZUIResponsiveContainer/index.tsx
@@ -25,15 +25,18 @@ const FrontendResponsiveContainer: FC<
     if (onWidthChange && widthRef.current) {
       onWidthChange(width, widthRef.current);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width]);
 
   useEffect(() => {
     if (widthRef.current) {
       observerRef.current.observe(widthRef.current);
       return () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         observerRef.current.disconnect();
       };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [widthRef.current]);
 
   return (

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -129,6 +129,7 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
       clearEditor();
       setActive(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clear]);
 
   return (

--- a/src/zui/ZUITimeline/TimelineAddNote.tsx
+++ b/src/zui/ZUITimeline/TimelineAddNote.tsx
@@ -39,6 +39,7 @@ const TimelineAddNote: React.FunctionComponent<AddNoteProps> = ({
     if (!disabled && !showPostRequestError) {
       onCancel();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [disabled]);
 
   // Markdown string is truthy even if the visible text box is empty

--- a/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
@@ -41,6 +41,7 @@ const TimelineJourneyInstance: React.FunctionComponent<Props> = ({
     } else {
       window.removeEventListener('scroll', closeOnScroll);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandSummary]);
 
   useEffect(() => {
@@ -49,6 +50,7 @@ const TimelineJourneyInstance: React.FunctionComponent<Props> = ({
       setOverflow(textRef.current?.scrollHeight);
     }
     return () => window.removeEventListener('scroll', closeOnScroll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts
@@ -55,6 +55,7 @@ export default function useModelsFromQueryString(): UseModelsFromQueryString {
         shallow: true,
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterModel, sortModel]);
 
   // Update model when router URL changes
@@ -69,6 +70,7 @@ export default function useModelsFromQueryString(): UseModelsFromQueryString {
     if (!isEqual(routerSortModel, sortModel)) {
       setSortModel(routerSortModel);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query]);
 
   return {

--- a/src/zui/components/ZUIVerticalBarChart/Bars.tsx
+++ b/src/zui/components/ZUIVerticalBarChart/Bars.tsx
@@ -23,6 +23,7 @@ const Bars: FC<BarsProps> = ({ data, maxValue, visualizationHeight }) => {
       setLabelPos(calcHoverXPos(labelElem));
       setValuePos(calcHoverXPos(valueElem));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [barIndex, valueElem, labelElem]);
 
   function calcHoverXPos(el: HTMLDivElement | null) {

--- a/src/zui/hooks/useResizeObserver.ts
+++ b/src/zui/hooks/useResizeObserver.ts
@@ -18,6 +18,7 @@ export default function useResizeObserver<
     }
 
     return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [elemRef.current, onResize]);
 
   return elemRef;

--- a/src/zui/hooks/useStorybookDarkMode.ts
+++ b/src/zui/hooks/useStorybookDarkMode.ts
@@ -12,6 +12,7 @@ export const useStorybookDarkMode = () => {
   useEffect(() => {
     channel.on(DARK_MODE_EVENT_NAME, setDark);
     return () => channel.removeListener(DARK_MODE_EVENT_NAME, setDark);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channel, setDark]);
 
   useEffect(() => {


### PR DESCRIPTION
### Background

The `react-hooks/exhaustive-deps` ESLint rule was turned `off` in this project, meaning missing or incorrect dependency arrays in `useEffect`, `useMemo`, and `useCallback` went undetected. Incorrect deps cause real bugs — stale closures, missing re-renders, and memory leaks.

The official React docs make a strong case for adhering to this rule ([Removing Effect Dependencies](https://react.dev/learn/removing-effect-dependencies)):

> We recommend treating the dependency lint error as a compilation error

1. **This PR**: Enable `exhaustive-deps` as `error`, suppress all existing violations with `eslint-disable-next-line`
2. **Follow-up**: Resolve the 145 suppressions incrementally (grouped by pattern below)

### What changed

The rule is now set to `error`. All existing violations across 98 files have been suppressed with `eslint-disable-next-line react-hooks/exhaustive-deps`. **No behavior changes** — this PR only enables the rule and documents violations for incremental resolution.

New code will now get errors for missing or incorrect dependencies, preventing new violations from being introduced.

### Alternative: Bulk suppression

Instead of inline `eslint-disable-next-line` comments scattered across 98 files, [ESLint 9's bulk suppression](https://eslint.org/blog/2025/04/introducing-bulk-suppressions/) stores all suppressions in a single `eslint-suppressions.json` file, keeping the source code clean. Since we set the rule to `error`, we're already compatible — it only requires migrating to ESLint 9 with flat config (we're currently on ESLint 8 with `.eslintrc.js`). [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is also working on similar bulk suppression support.

Once we migrate to ESLint 9, we can replace the inline comments with the bulk suppression file.

### Violation inventory

145 `eslint-disable-next-line` suppressions across 98 files, grouped by pattern:

#### Pattern A: Missing data dependencies (41)
Hook is missing dependencies on data values that could cause stale closures.
**Fix**: Add the missing dependencies. May require refactoring to avoid infinite loops.
- `src/features/areaAssignments/components/OrganizerMapRenderer.tsx:330`
- `src/features/calendar/components/CalendarEventFilter/EventInputFilter.tsx:25`
- `src/features/calendar/components/CalendarWeekView/index.tsx:81`
- `src/features/calendar/hooks/useDayCalendarEvents.ts:43`
- `src/features/calendar/hooks/useDayCalendarEvents.ts:61`
- `src/features/calendar/hooks/useDayCalendarNav.ts:89`
- `src/features/calendar/components/index.tsx:67`
- `src/features/call/components/CallSwitchModal.tsx:72`
- `src/features/call/components/CallSwitchModal.tsx:135`
- `src/features/call/hooks/useFinishedCalls.ts:36`
- `src/features/campaigns/hooks/useActivityFilters.ts:22`
- `src/features/campaigns/hooks/useActivityFilters.ts:26`
- `src/features/canvass/components/CanvassMapOverlays.tsx:50`
- `src/features/canvass/components/GLCanvassMap/index.tsx:171`
- `src/features/canvass/components/GLCanvassMap/index.tsx:179`
- `src/features/canvass/components/GLCanvassMap/index.tsx:279`
- `src/features/canvass/components/GLCanvassMap/index.tsx:285`
- `src/features/canvass/components/LocationDialog/pages/CreateHouseholdsPage.tsx:58`
- `src/features/emails/components/EmailEditor/index.tsx:72`
- `src/features/events/hooks/useFilteredEvents.ts:60`
- `src/features/geography/hooks/useAreaDrawing.ts:87`
- `src/features/geography/hooks/useMapBounds.ts:48`
- `src/features/import/components/ImportDialog/Configure/Configuration/IdConfig.tsx:38`
- `src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts:61`
- `src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts:75`
- `src/features/public/components/ActivistPortalEventMap.tsx:114`
- `src/features/public/pages/PublicSurveyPage.tsx:81`
- `src/features/smartSearch/components/filters/Random/index.tsx:70`
- `src/features/smartSearch/components/filters/SubQuery/index.tsx:90`
- `src/features/smartSearch/components/filters/SurveyOption/index.tsx:87`
- `src/features/smartSearch/components/filters/SurveySubmission/index.tsx:61`
- `src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx:114`
- `src/features/views/components/ViewColumnDialog/ColumnGallery/index.tsx:69`
- `src/features/views/components/ViewDataTable/index.tsx:188`
- `src/features/views/components/ViewDataTable/index.tsx:350`
- `src/features/views/components/ViewDataTable/index.tsx:667`
- `src/pages/organize/[orgId]/projects/index.tsx:88`
- `src/pages/organize/[orgId]/projects/index.tsx:107`
- `src/zui/ZUICollapse/index.tsx:31`
- `src/zui/ZUITimeline/TimelineAddNote.tsx:42`
- `src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx:44`

#### Pattern B: Missing stable dependencies (26)
Hook is missing dependencies on stable values (`dispatch`, `setState`, `apiClient`, `messages`, etc.) that won't cause re-renders when added.
**Fix**: Simply add the missing deps — these are safe since they are referentially stable.
- `src/features/call/components/ActivitiesSection.tsx:542`
- `src/features/call/hooks/useCallInitialization.ts:40`
- `src/features/events/components/EventURLCard.tsx:27`
- `src/features/events/hooks/useEventTypeFilter.ts:101`
- `src/features/files/hooks/useFileUploads.ts:130`
- `src/features/map/hooks/useResizeMap.ts:20`
- `src/features/organizations/components/ActivistPortalCampaignEventsMap.tsx:30`
- `src/features/surveys/components/ResponseStatsCards.tsx:173`
- `src/features/surveys/components/ResponseStatsCards.tsx:192`
- `src/features/surveys/components/ResponseStatsCards.tsx:498`
- `src/features/surveys/components/ResponseStatsCards.tsx:613`
- `src/features/surveys/components/ResponseStatsCards.tsx:909`
- `src/features/surveys/components/SurveySubmissionsList.tsx:255`
- `src/features/surveys/layouts/SurveyLayout.tsx:155`
- `src/features/tasks/components/TaskDetailsForm/index.tsx:193`
- `src/features/views/components/ViewBrowser/index.tsx:87`
- `src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx:121`
- `src/features/views/components/ViewDataTable/index.tsx:212`
- `src/features/views/components/ViewDataTable/index.tsx:339`
- `src/features/views/components/ViewDataTable/index.tsx:587`
- `src/pages/organize/[orgId]/people/duplicates/index.tsx:40`
- `src/utils/panes/useResizablePane.ts:45`
- `src/zui/ZUIAnimatedNumber/index.tsx:63`
- `src/zui/ZUIPublicFooter/index.tsx:38`
- `src/zui/ZUITextEditor/index.tsx:132`
- `src/zui/components/ZUIVerticalBarChart/Bars.tsx:26`

#### Pattern C: Unstable callback prop (23)
Callback prop from parent changes on every render, causing the effect to fire too often if added to deps.
**Fix**: Memoize callbacks in parent with `useCallback`, or use ref to hold callback.
- `src/features/areaAssignments/components/OrganizerMapFilters/index.tsx:81`
- `src/features/areas/components/AreaFilters/index.tsx:72`
- `src/features/calendar/components/EventShiftModal/EventModalTypeAutocomplete.tsx:46`
- `src/features/calendar/components/EventShiftModal/EventShiftTime.tsx:140`
- `src/features/calendar/components/EventShiftModal/EventShiftTime.tsx:156`
- `src/features/call/components/Report/steps/CallBack.tsx:169`
- `src/features/call/components/Report/steps/CallerLog.tsx:65`
- `src/features/call/components/Report/steps/OrganizerLog.tsx:84`
- `src/features/call/components/Report/steps/WrongNumber.tsx:61`
- `src/features/canvass/components/EncouragingSparkle.tsx:14`
- `src/features/canvass/components/LocationDialog/index.tsx:115`
- `src/features/duplicates/components/FieldSettings/index.tsx:49`
- `src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx:160`
- `src/features/events/components/EventTypeAutocomplete.tsx:82`
- `src/features/import/components/ImportDialog/ParseFile.tsx:84`
- `src/features/import/components/ImportDialog/elements/ImportMessageList/index.tsx:32`
- `src/features/smartSearch/components/filters/Matching.tsx:41`
- `src/features/smartSearch/components/filters/TimeFrame.tsx:59`
- `src/features/tags/components/TagManager/components/TagSelect/ValueTagForm.tsx:23`
- `src/zui/ZUIDataTableSearch.tsx:59`
- `src/zui/ZUIEditTextInPlace/index.tsx:68`
- `src/zui/ZUIReorderable/index.tsx:87`
- `src/zui/ZUIResponsiveContainer/index.tsx:28`

#### Pattern D: Ref-related issues (11)
`ref.current` used as a dependency (invalid — refs are mutable) or captured in a cleanup function (may be stale).
**Fix**: Copy `ref.current` to a local variable inside the effect; remove `ref.current` from deps.
- `src/features/calendar/components/CalendarWeekView/EventDayLane.tsx:80`
- `src/features/calendar/components/CalendarWeekView/EventDayLane.tsx:82`
- `src/features/call/components/CallSwitchModal.tsx:264`
- `src/features/call/components/CallSwitchModal.tsx:266`
- `src/features/events/components/EventTypeAutocomplete.tsx:89`
- `src/features/public/pages/PublicSurveyPage.tsx:97`
- `src/features/smartSearch/components/sankeyDiagram/SmartSearchSankeySegment.tsx:57`
- `src/zui/ZUIEditTextInPlace/index.tsx:57`
- `src/zui/ZUIResponsiveContainer/index.tsx:34`
- `src/zui/ZUIResponsiveContainer/index.tsx:37`
- `src/zui/hooks/useResizeObserver.ts:21`

#### Pattern E: Mount-only / imperative setup (12)
Effect intentionally uses empty deps `[]` but references values from the closure.
**Fix**: Use refs for values needed inside, or accept re-runs when deps change.
- `src/features/call/components/Heartbeat.tsx:26`
- `src/features/call/components/Report/steps/OrganizerLog.tsx:56`
- `src/features/call/pages/CallPage.tsx:26`
- `src/features/canvass/components/LocationDialog/index.tsx:122`
- `src/features/emails/components/EmailEditor/EmailEditorFrontend.tsx:140`
- `src/features/emails/components/EmailMiniature.tsx:45`
- `src/features/profile/hooks/usePersonSearch.ts:63`
- `src/features/smartSearch/components/filters/PersonField/index.tsx:66`
- `src/features/views/components/ViewBrowser/BrowserDragableItem.tsx:23`
- `src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx:101`
- `src/utils/panes/useResizablePane.ts:49`
- `src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx:52`

#### Pattern F: Prop sync / derived state (9)
Effect syncs local state from props — a React anti-pattern.
**Fix**: Replace with computed value during render, or key-based reset (`key={id}`).
- `src/features/areas/components/AreaOverlay/index.tsx:82`
- `src/features/duplicates/components/MergeModal.tsx:69`
- `src/features/emails/components/EmailEditor/EmailSettings/PreviewTab.tsx:32`
- `src/features/events/components/EventTypeAutocomplete.tsx:93`
- `src/features/events/components/LocationModal/index.tsx:67`
- `src/features/import/hooks/useDateConfig.ts:27`
- `src/zui/ZUIDatePicker/index.tsx:177`
- `src/zui/ZUIDateRangePicker/ZUIDateRangePicker/index.tsx:262`
- `src/zui/ZUIEditTextInPlace/index.tsx:46`

#### Pattern G: Outer scope values / unnecessary dependencies (11)
Hook includes outer scope values (module-level constants, non-reactive values) or other unnecessary dependencies.
**Fix**: Remove the unnecessary/outer-scope values from dependency arrays.
- `src/features/my/components/AllEventsList.tsx:121`
- `src/features/organizations/components/ActivistPortalOrgEventsMap.tsx:33`
- `src/features/public/pages/PublicSurveyPage.tsx:61`
- `src/features/surveys/components/ResponseStatsCards.tsx:627`
- `src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx:131`
- `src/features/views/components/ViewDataTable/index.tsx:276`
- `src/features/views/components/ViewDataTable/index.tsx:310`
- `src/features/views/components/ViewDataTable/index.tsx:326`
- `src/features/views/components/ViewDataTable/index.tsx:417`
- `src/features/views/components/ViewDataTable/index.tsx:542`
- `src/zui/hooks/useStorybookDarkMode.ts:15`

#### Pattern H: Intentional capture-once (6)
Hook intentionally captures the initial value of a dependency and ignores subsequent changes.
**Fix**: Use ref-based pattern (`useRef` + `useEffect` to update ref).
- `src/features/call/components/ActivitiesSection.tsx:524`
- `src/features/call/components/Report/steps/OrganizerLog.tsx:52`
- `src/features/call/components/Report/steps/QuickResponseButtons.tsx:40`
- `src/features/canvass/components/GLCanvassMap/index.tsx:108`
- `src/features/views/components/ViewDataTable/columnTypes/LocalTextColumnType.tsx:103`
- `src/utils/hooks/useDebounce.ts:21`

#### Pattern I: Effect reads+writes same state (4)
Effect both reads and writes the same piece of state, creating a dependency cycle.
**Fix**: Use functional updater `setState(prev => ...)` instead of reading state directly.
- `src/features/call/hooks/useFinishedCalls.ts:40`
- `src/features/canvass/components/LocationDialog/pages/LocationVisitPage.tsx:58`
- `src/features/smartSearch/components/filters/PersonData/index.tsx:76`
- `src/features/smartSearch/components/filters/SurveyResponse/index.tsx:95`

#### Pattern J: Bidirectional sync (2)
Two-way state synchronization between different sources (e.g. URL and component state).
**Fix**: Architectural rethink — establish single source of truth.
- `src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts:58`
- `src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.ts:72`

#### Pattern K: Complex expression in dependency array (2)
Dependency array contains a complex expression that ESLint cannot statically analyze.
**Fix**: Extract the complex expression to a separate variable.
- `src/features/calendar/hooks/useDayCalendarEvents.ts:43`
- `src/features/calendar/hooks/useDayCalendarEvents.ts:61`

#### Pattern L: Logical expression instability (1)
A logical expression outside the hook makes dependencies change on every render.
**Fix**: Wrap the initialization in its own `useMemo()` to stabilize.
- `src/features/canvass/components/CreateLocationCard.tsx:27`