### PR TITLE
Hide Show in Map Button on unrelated tabs

### DIFF
--- a/src/features/public/layouts/EventMapLayout.tsx
+++ b/src/features/public/layouts/EventMapLayout.tsx
@@ -37,6 +37,7 @@ type Props = {
   header: JSX.Element;
   renderMap: () => JSX.Element;
   showMap: boolean;
+  showMobileFab?: boolean;
 };
 
 const EventMapLayout: FC<Props> = ({
@@ -44,13 +45,14 @@ const EventMapLayout: FC<Props> = ({
   header,
   renderMap,
   showMap,
+  showMobileFab = true,
 }) => {
   const [mobileMapVisible, setMobileMapVisible] = useState(false);
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-  const showMapMobile = isMobile && showMap;
+  const showMapMobile = isMobile && showMap && showMobileFab;
   const showMapDesktop = !isMobile && showMap;
   const shouldMountMap = useDelayOnTrue(transitionDuration, showMapDesktop);
 

--- a/src/features/public/layouts/PublicOrgLayout.tsx
+++ b/src/features/public/layouts/PublicOrgLayout.tsx
@@ -104,6 +104,7 @@ const PublicOrgLayout: FC<Props> = ({ children, org }) => {
       }
       renderMap={() => <ActivistPortalOrgEventsMap orgId={org.id} />}
       showMap={true}
+      showMobileFab={lastSegment === navBarItems[0].value}
     >
       <NoSsr>{children}</NoSsr>
     </EventMapLayout>


### PR DESCRIPTION
…on mobile

## Description
This PR hides the `Show in map` floating action button on the explore tab when in mobile view.


## Screenshots
<img width="300" height="1142" alt="image" src="https://github.com/user-attachments/assets/053613c7-ab0b-4eb8-923e-808866dc6307" />
<img width="300" height="1142" alt="image" src="https://github.com/user-attachments/assets/9027c9b0-f884-4396-8342-068ab9529b1a" />

## Changes

* The prop prop 'showMobileFab' was added to the `EventsMapLayout.tsx` to control the visibility of the FAB on mobile 
* This propery was added to the `publicOrgLayout.tsx` to only show the FAB on the first tab


## Notes to reviewer
1. Go to http://localhost:3000/o/1
2. Click on Explore in the tab bar.

## Related issues
Resolves #3468 
