### PR TITLE
Change bounds padding on map

### DIFF
--- a/src/features/public/components/ActivistPortalEventMap.tsx
+++ b/src/features/public/components/ActivistPortalEventMap.tsx
@@ -19,6 +19,7 @@ export const ActivistPortalEventMap: FC<{
   setLocationFilter: (geojsonToFilterBy: GeoJSON.Feature[]) => void;
 }> = ({ events, locationFilter, setLocationFilter }) => {
   const [map, setMap] = useState<MapType | null>(null);
+  const defaultFitBoundOptions = { padding: 80 };
 
   const onMarkerClick = useCallback(
     (geojsonFeatures: GeoJSON.Feature[]) => {
@@ -40,7 +41,7 @@ export const ActivistPortalEventMap: FC<{
           animate: true,
           duration: 1200,
           maxZoom: 16,
-          padding: 20,
+          ...defaultFitBoundOptions,
         });
       }
 
@@ -123,7 +124,7 @@ export const ActivistPortalEventMap: FC<{
             map.fitBounds(bounds, {
               animate: true,
               duration: 800,
-              padding: 20,
+              ...defaultFitBoundOptions,
             });
           }
         }}
@@ -137,7 +138,7 @@ export const ActivistPortalEventMap: FC<{
         ref={(map) => setMap(map?.getMap() ?? null)}
         initialViewState={{
           bounds,
-          fitBoundsOptions: { padding: 150 },
+          fitBoundsOptions: defaultFitBoundOptions,
         }}
         mapStyle={env.vars.MAPLIBRE_STYLE}
         onClick={(ev) => {


### PR DESCRIPTION
## Description
This PR reduces the bounds padding in the map to better focus on the available events on the map


## Screenshots
<img width="300" height="1142" alt="image" src="https://github.com/user-attachments/assets/6748b876-1529-4aa3-8a27-97251c55d817" />


## Changes
* In `ActivistPortalEventMap.tsx` a new `defaultFitBoundOptions` was introduced to hold default fitBounds option to apply to all call of `map.fitBounds` and passed to these calls


## Notes to reviewer
1. Go to http://localhost:3000/o/1
2. Open the map

## Related issues
* Resolves #3470 
* Resolves #3500 
