### PR TITLE
Clear assignee input field after selecting

### DIFF
--- a/src/features/user/components/UserAutocomplete.tsx
+++ b/src/features/user/components/UserAutocomplete.tsx
@@ -20,7 +20,6 @@ type Props = {
 
 const UserAutocomplete: FC<Props> = ({ onSelect, orgId }) => {
   const [searchValue, setSearchValue] = useState<string>('');
-  const [selectedUser, setSelectedUser] = useState<ZetkinOrgUser | null>(null);
   const users = useOrgUsers(orgId);
 
   const filterOptions = (
@@ -50,7 +49,6 @@ const UserAutocomplete: FC<Props> = ({ onSelect, orgId }) => {
       isOptionEqualToValue={(option, value) => option.id === value.id}
       onChange={(event, value) => {
         onSelect(value);
-        setSelectedUser(null);
         setSearchValue('');
       }}
       onInputChange={(_, value) => {
@@ -81,7 +79,7 @@ const UserAutocomplete: FC<Props> = ({ onSelect, orgId }) => {
           </ListItem>
         );
       }}
-      value={selectedUser}
+      value={null}
     />
   );
 };


### PR DESCRIPTION
## Description
This PR clears the assignee input field in the Area Assignment after an assignee has been selected.


## Screenshots
<img width="408" height="554" alt="Screenshot 2026-02-15 at 14 46 26" src="https://github.com/user-attachments/assets/50e7e449-5e34-432c-bdea-6f2c33cae07a" />

https://github.com/user-attachments/assets/f578f56e-8672-4ae4-a985-79625f3a51f0

## Changes

Connects the UserAutocomplete input to new states for value and inputValue, allowing the state to be cleared after selection. It appears that both states are needed to control both the actual string search value, and the selected value from the autocomplete list.

## Notes to reviewer
Documentation for the MUI Autocomplete [here](https://mui.com/material-ui/react-autocomplete/#controlled-states)

The issue also refers to a problem with focusing in the input field after an assignee is selected, but that seems to have already been resolved, as it works as expected.

Tested on Firefox and Chrome.

## Related issues
Resolves #3362 
