### PR TITLE
fix: add overflow visible to header layout

### DIFF
--- a/src/zui/ZUIHeader.tsx
+++ b/src/zui/ZUIHeader.tsx
@@ -113,6 +113,7 @@ const Header: React.FC<HeaderProps> = ({
                   data-testid="page-title"
                   noWrap
                   sx={{
+                    lineHeight: '1.5',
                     marginBottom: '8px',
                     transition: 'margin 0.3s ease',
                   }}


### PR DESCRIPTION
## Description

The headers on the page layouts under the `/organize` route are being clipped by just a couple of pixels.  The line height of the component was rather low, at 1.1. Setting the line height to 1.5 allowed for the entire header to be displayed properly without affecting other overflow properties. 

## Screenshots

<img width="482" height="194" alt="Screenshot 2026-02-15 at 15 24 04" src="https://github.com/user-attachments/assets/6cd71328-1fb1-4192-a30a-d843fcbbc2bb" />

<img width="482" height="194" alt="Screenshot 2026-02-15 at 15 24 08" src="https://github.com/user-attachments/assets/1fc2e694-cfd0-4f9d-9fdf-e9e66f441a46" />

## Changes

* Adds a line of CSS to the title in the ZUI header.

## Related issues

Undocumented issue. 
