### PR TITLE
fix: prevent overlay from covering selected area by panning

### DIFF
--- a/src/features/areas/components/AreaOverlay/index.tsx
+++ b/src/features/areas/components/AreaOverlay/index.tsx
@@ -28,6 +28,8 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areas/l10n/messageIds';
 import { ZUIExpandableText } from 'zui/ZUIExpandableText';
 
+export const AREA_OVERLAY_WIDTH = 400;
+
 type Props = {
   area: ZetkinArea;
   editing: boolean;
@@ -87,8 +89,8 @@ const AreaOverlay: FC<Props> = ({
         bottom: '1rem',
         display: 'flex',
         flexDirection: 'column',
-        maxWidth: 400,
-        minWidth: 400,
+        maxWidth: AREA_OVERLAY_WIDTH,
+        minWidth: AREA_OVERLAY_WIDTH,
         overflow: 'auto',
         padding: 2,
         position: 'absolute',


### PR DESCRIPTION
## Description
This PR prevents the Area Overlay from covering the area after a user selects it in the Geography view.

This is done by panning, but if panning would put part of the area outside the view (most likely to the left) it will instead pan _and zoom out_ to make sure the entire are fits.

I am not sure this is the preferred solution, but following the feedback in #3073, I figured I'd make another proof-of-concept for people to try out. No hard feelings if we still find this to be not ideal, and closing the PR 🙂 

## Screenshots

The first two examples shows only panning, and the two last examples show panning and zooming out.



https://github.com/user-attachments/assets/ad70624c-375f-4a36-8e7a-2fe640b2944f




## Changes

* Adds a `useEffect` that triggers when the `selectedArea` changes.
  * Checks if the area would be obscured by the overlay, and if so
  * calculates new bounds and fits to them


## Notes to reviewer

Go to `/organize/1/geography`, or a similar map


## Related issues
Resolves #2915 
