### PR TITLE
Add Score Indicator for People Import Guessing

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
@@ -21,10 +21,8 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
   const subOrgs = useSubOrganizations(orgId).data || [];
   const activeOrgs = subOrgs.filter((subOrg) => subOrg.is_active);
   const guessOrgs = useGuessOrganization(activeOrgs, uiDataColumn);
-  const { deselectOrg, getSelectedOrgId, selectOrg } = useOrgMapping(
-    uiDataColumn.originalColumn,
-    uiDataColumn.columnIndex
-  );
+  const { deselectOrg, getSelectedOrgId, getSelectedScore, selectOrg } =
+    useOrgMapping(uiDataColumn.originalColumn, uiDataColumn.columnIndex);
 
   if (!activeOrgs.length) {
     return null;
@@ -53,22 +51,18 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
         <Typography sx={{ paddingBottom: 2 }} variant="h5">
           <Msg id={messageIds.configuration.configure.orgs.header} />
         </Typography>
-        <Button
-          onClick={() => {
-            guessOrgs();
-          }}
-        >
+        <Button onClick={() => guessOrgs()}>
           {messages.configuration.configure.orgs.guess()}
         </Button>
       </Box>
 
       <Box alignItems="center" display="flex" paddingY={2}>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.orgs.status().toLocaleUpperCase()}
           </Typography>
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.orgs
               .organizations()
@@ -85,6 +79,7 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
             onSelectOrg={(orgId) => selectOrg(orgId, uniqueValue)}
             orgs={sortedActiveOrgs}
             selectedOrgId={getSelectedOrgId(uniqueValue)}
+            selectedScore={getSelectedScore(uniqueValue)}
             title={uniqueValue.toString()}
           />
         </Box>
@@ -99,6 +94,7 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
             onSelectOrg={(orgId) => selectOrg(orgId, null)}
             orgs={activeOrgs}
             selectedOrgId={getSelectedOrgId(null)}
+            selectedScore={getSelectedScore(null)}
             title={messages.configuration.configure.tags.empty()}
           />
         </>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfig.tsx
@@ -21,7 +21,7 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
   const subOrgs = useSubOrganizations(orgId).data || [];
   const activeOrgs = subOrgs.filter((subOrg) => subOrg.is_active);
   const guessOrgs = useGuessOrganization(activeOrgs, uiDataColumn);
-  const { deselectOrg, getSelectedOrgId, selectOrg } = useOrgMapping(
+  const { deselectOrg, getSelectedOrgId, selectOrg, getScore } = useOrgMapping(
     uiDataColumn.originalColumn,
     uiDataColumn.columnIndex
   );
@@ -53,22 +53,18 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
         <Typography sx={{ paddingBottom: 2 }} variant="h5">
           <Msg id={messageIds.configuration.configure.orgs.header} />
         </Typography>
-        <Button
-          onClick={() => {
-            guessOrgs();
-          }}
-        >
+        <Button onClick={() => guessOrgs()}>
           {messages.configuration.configure.orgs.guess()}
         </Button>
       </Box>
 
       <Box alignItems="center" display="flex" paddingY={2}>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.orgs.status().toLocaleUpperCase()}
           </Typography>
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.orgs
               .organizations()
@@ -84,6 +80,7 @@ const OrgConfig: FC<OrgConfigProps> = ({ uiDataColumn }) => {
             onDeselectOrg={() => deselectOrg(uniqueValue)}
             onSelectOrg={(orgId) => selectOrg(orgId, uniqueValue)}
             orgs={sortedActiveOrgs}
+            score={getScore(uniqueValue)}
             selectedOrgId={getSelectedOrgId(uniqueValue)}
             title={uniqueValue.toString()}
           />

--- a/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfigRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward, Delete } from '@mui/icons-material';
+import { AutoAwesome, ArrowForward, Delete } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -14,6 +14,7 @@ import { FC, useState } from 'react';
 import messageIds from 'features/import/l10n/messageIds';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import { Msg, useMessages } from 'core/i18n';
+import { mapScoreToColour } from './TagConfigRow';
 
 interface OrgConfigRowProps {
   italic?: boolean;
@@ -22,6 +23,7 @@ interface OrgConfigRowProps {
   onDeselectOrg: () => void;
   orgs: Pick<ZetkinOrganization, 'id' | 'title'>[];
   selectedOrgId: number | null;
+  selectedScore: number | null;
   title: string;
 }
 
@@ -32,6 +34,7 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
   onDeselectOrg,
   orgs,
   selectedOrgId,
+  selectedScore,
   title,
 }) => {
   const messages = useMessages(messageIds);
@@ -45,21 +48,16 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
         <Box
           alignItems="flex-start"
           display="flex"
+          flex={1}
           justifyContent="space-between"
           paddingTop={1}
-          width="50%"
         >
           <Box display="flex" sx={{ wordBreak: 'break-all' }} width="100%">
             <Typography fontStyle={italic ? 'italic' : ''}>{title}</Typography>
           </Box>
           <ArrowForward color="secondary" sx={{ marginRight: 1 }} />
         </Box>
-        <Box
-          alignItems="flex-start"
-          display="flex"
-          paddingRight={1}
-          width="50%"
-        >
+        <Box flex={1} paddingRight={1}>
           {!showSelect && (
             <Button onClick={() => setMapping(true)}>
               <Msg
@@ -71,7 +69,7 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
             </Button>
           )}
           {showSelect && (
-            <>
+            <Box alignItems="flex-start" display="flex">
               <FormControl fullWidth size="small">
                 <InputLabel>
                   <Msg
@@ -102,7 +100,23 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
               >
                 <Delete color="secondary" />
               </IconButton>
-            </>
+            </Box>
+          )}
+          {showSelect && selectedScore != null && (
+            <Box
+              display="flex"
+              sx={{
+                color: mapScoreToColour(selectedScore),
+                marginTop: '5px',
+              }}
+            >
+              <AutoAwesome sx={{ marginRight: '5px' }} />
+              <Typography variant="body2">
+                {selectedScore < 0.01
+                  ? messages.configuration.configure.orgs.scorePerfect()
+                  : messages.configuration.configure.orgs.scoreImperfect()}
+              </Typography>
+            </Box>
           )}
         </Box>
       </Box>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/OrgConfigRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward, Delete } from '@mui/icons-material';
+import { Warning, ArrowForward, Delete } from '@mui/icons-material';
 import {
   Box,
   Button,
@@ -14,6 +14,7 @@ import { FC, useState } from 'react';
 import messageIds from 'features/import/l10n/messageIds';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import { Msg, useMessages } from 'core/i18n';
+import { oldThemePalette } from 'oldThemePalette';
 
 interface OrgConfigRowProps {
   italic?: boolean;
@@ -22,6 +23,7 @@ interface OrgConfigRowProps {
   onDeselectOrg: () => void;
   orgs: Pick<ZetkinOrganization, 'id' | 'title'>[];
   selectedOrgId: number | null;
+  score?: number | null;
   title: string;
 }
 
@@ -32,12 +34,14 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
   onDeselectOrg,
   orgs,
   selectedOrgId,
+  score,
   title,
 }) => {
   const messages = useMessages(messageIds);
   const [mapping, setMapping] = useState(false);
 
   const showSelect = mapping || selectedOrgId;
+  const showScoreWarning = showSelect && score != null && score >= 0.01;
 
   return (
     <Box display="flex" flexDirection="column">
@@ -45,21 +49,16 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
         <Box
           alignItems="flex-start"
           display="flex"
+          flex={1}
           justifyContent="space-between"
           paddingTop={1}
-          width="50%"
         >
           <Box display="flex" sx={{ wordBreak: 'break-all' }} width="100%">
             <Typography fontStyle={italic ? 'italic' : ''}>{title}</Typography>
           </Box>
           <ArrowForward color="secondary" sx={{ marginRight: 1 }} />
         </Box>
-        <Box
-          alignItems="flex-start"
-          display="flex"
-          paddingRight={1}
-          width="50%"
-        >
+        <Box flex={1} paddingRight={1}>
           {!showSelect && (
             <Button onClick={() => setMapping(true)}>
               <Msg
@@ -71,7 +70,7 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
             </Button>
           )}
           {showSelect && (
-            <>
+            <Box alignItems="flex-start" display="flex">
               <FormControl fullWidth size="small">
                 <InputLabel>
                   <Msg
@@ -102,7 +101,23 @@ const OrgConfigRow: FC<OrgConfigRowProps> = ({
               >
                 <Delete color="secondary" />
               </IconButton>
-            </>
+            </Box>
+          )}
+          {showScoreWarning && (
+            <Box
+              display="flex"
+              sx={{
+                color: oldThemePalette.warning.main,
+                marginTop: '8px',
+              }}
+            >
+              <Warning fontSize="small" sx={{ margin: '0px 8px 0px 4px' }} />
+              <Typography variant="body2">
+                <Msg
+                  id={messageIds.configuration.configure.orgs.scoreImperfect}
+                />
+              </Typography>
+            </Box>
           )}
         </Box>
       </Box>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
@@ -37,21 +37,17 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
         <Typography sx={{ paddingBottom: 2 }} variant="h5">
           <Msg id={messageIds.configuration.configure.tags.header} />
         </Typography>
-        <Button
-          onClick={() => {
-            guessTags();
-          }}
-        >
+        <Button onClick={() => guessTags()}>
           {messages.configuration.configure.tags.guess()}
         </Button>
       </Box>
       <Box alignItems="center" display="flex" paddingY={2}>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {uiDataColumn.title.toLocaleUpperCase()}
           </Typography>
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.tags
               .tagsHeader()

--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfig.tsx
@@ -19,7 +19,7 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
   const { orgId } = useNumericRouteParams();
   const messages = useMessages(messageIds);
   const guessTags = useGuessTags(orgId, uiDataColumn);
-  const { assignTag, getAssignedTags, unAssignTag } = useTagConfig(
+  const { assignTag, getAssignedTags, unAssignTag, getScore } = useTagConfig(
     orgId,
     uiDataColumn.originalColumn,
     uiDataColumn.columnIndex
@@ -37,21 +37,17 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
         <Typography sx={{ paddingBottom: 2 }} variant="h5">
           <Msg id={messageIds.configuration.configure.tags.header} />
         </Typography>
-        <Button
-          onClick={() => {
-            guessTags();
-          }}
-        >
+        <Button onClick={() => guessTags()}>
           {messages.configuration.configure.tags.guess()}
         </Button>
       </Box>
       <Box alignItems="center" display="flex" paddingY={2}>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {uiDataColumn.title.toLocaleUpperCase()}
           </Typography>
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <Typography variant="body2">
             {messages.configuration.configure.tags
               .tagsHeader()
@@ -69,6 +65,7 @@ const TagConfig: FC<TagConfigProps> = ({ uiDataColumn }) => {
               assignTag({ id: tag.id }, uniqueValue)
             }
             onUnassignTag={(tag: ZetkinTag) => unAssignTag(tag.id, uniqueValue)}
+            score={getScore(uniqueValue)}
             title={uniqueValue.toString()}
           />
         </>

--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfigRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward } from '@mui/icons-material';
+import { AutoAwesome, ArrowForward } from '@mui/icons-material';
 import { FC } from 'react';
 import { Box, Typography } from '@mui/material';
 
@@ -16,6 +16,46 @@ interface TagConfigRowProps {
   title: string;
 }
 
+const clamp = (v: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, v));
+
+// valueToHsl maps the value on a range from 0 to max
+// to colours: rgba(0,0,0,0.87) -> yellow -> red.
+// The current default of max is based on the filter defined in useGuessTags.ts.
+export function mapScoreToColour(value: number, max: number = 0.25) {
+  const v = clamp(Number(value) || 0, 0, max);
+  const t = max > 0 ? v / max : 1; // normalized 0..1
+
+  const black = { a: 0.6, b: 0, g: 0, r: 0 };
+  const yellow = { a: 1, b: 0, g: 127, r: 255 };
+  const red = { a: 1, b: 0, g: 0, r: 255 };
+
+  const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+  let from, localT, to;
+  if (t <= 0.5) {
+    // interpolate black -> yellow for t in [0, 0.5]
+    from = black;
+    to = yellow;
+    localT = t / 0.5;
+  } else {
+    // interpolate yellow -> red for t in (0.5, 1]
+    from = yellow;
+    to = red;
+    localT = (t - 0.5) / 0.5;
+  }
+
+  const r = Math.round(lerp(from.r, to.r, localT));
+  const g = Math.round(lerp(from.g, to.g, localT));
+  const b = Math.round(lerp(from.b, to.b, localT));
+  const a = lerp(from.a, to.a, localT);
+
+  // alpha with up to 2 decimal places
+  const alphaStr = Math.round(a * 100) / 100;
+
+  return `rgba(${r}, ${g}, ${b}, ${alphaStr})`;
+}
+
 const TagConfigRow: FC<TagConfigRowProps> = ({
   assignedTags,
   italic,
@@ -30,16 +70,16 @@ const TagConfigRow: FC<TagConfigRowProps> = ({
         <Box
           alignItems="flex-start"
           display="flex"
+          flex={1}
           justifyContent="space-between"
           paddingTop={1}
-          width="50%"
         >
           <Box display="flex" sx={{ wordBreak: 'break-all' }} width="100%">
             <Typography fontStyle={italic ? 'italic' : ''}>{title}</Typography>
           </Box>
           <ArrowForward color="secondary" sx={{ marginRight: 1 }} />
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <TagManager
             assignedTags={assignedTags}
             disableEditTags
@@ -47,6 +87,25 @@ const TagConfigRow: FC<TagConfigRowProps> = ({
             onAssignTag={(tag) => onAssignTag(tag)}
             onUnassignTag={(tag) => onUnassignTag(tag)}
           />
+          {assignedTags.length == 1 && assignedTags[0].score != null && (
+            <Box
+              display="flex"
+              sx={{
+                color: mapScoreToColour(assignedTags[0].score),
+              }}
+            >
+              <AutoAwesome sx={{ 'margin-right': '5px' }} />
+              <Typography variant="body2">
+                <Msg
+                  id={
+                    assignedTags[0].score < 0.01
+                      ? messageIds.configuration.configure.orgs.scorePerfect
+                      : messageIds.configuration.configure.orgs.scoreImperfect
+                  }
+                />
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
       <Typography color="secondary">

--- a/src/features/import/components/ImportDialog/Configure/Configuration/TagConfigRow.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/TagConfigRow.tsx
@@ -1,4 +1,4 @@
-import { ArrowForward } from '@mui/icons-material';
+import { Warning, ArrowForward } from '@mui/icons-material';
 import { FC } from 'react';
 import { Box, Typography } from '@mui/material';
 
@@ -6,6 +6,7 @@ import messageIds from 'features/import/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import TagManager from 'features/tags/components/TagManager';
 import { ZetkinAppliedTag } from 'utils/types/zetkin';
+import { oldThemePalette } from 'oldThemePalette';
 
 interface TagConfigRowProps {
   assignedTags: ZetkinAppliedTag[];
@@ -13,6 +14,7 @@ interface TagConfigRowProps {
   numRows: number;
   onAssignTag: (tag: ZetkinAppliedTag) => void;
   onUnassignTag: (tag: ZetkinAppliedTag) => void;
+  score?: number | null;
   title: string;
 }
 
@@ -22,24 +24,28 @@ const TagConfigRow: FC<TagConfigRowProps> = ({
   numRows,
   onAssignTag,
   onUnassignTag,
+  score,
   title,
 }) => {
+  const showScoreWarning =
+    assignedTags.length == 1 && score != null && score >= 0.01;
+
   return (
     <Box display="flex" flexDirection="column">
       <Box display="flex">
         <Box
           alignItems="flex-start"
           display="flex"
+          flex={1}
           justifyContent="space-between"
           paddingTop={1}
-          width="50%"
         >
           <Box display="flex" sx={{ wordBreak: 'break-all' }} width="100%">
             <Typography fontStyle={italic ? 'italic' : ''}>{title}</Typography>
           </Box>
           <ArrowForward color="secondary" sx={{ marginRight: 1 }} />
         </Box>
-        <Box width="50%">
+        <Box flex={1}>
           <TagManager
             assignedTags={assignedTags}
             disableEditTags
@@ -47,6 +53,22 @@ const TagConfigRow: FC<TagConfigRowProps> = ({
             onAssignTag={(tag) => onAssignTag(tag)}
             onUnassignTag={(tag) => onUnassignTag(tag)}
           />
+          {showScoreWarning && (
+            <Box
+              display="flex"
+              sx={{
+                color: oldThemePalette.warning.main,
+                marginTop: '8px',
+              }}
+            >
+              <Warning fontSize="small" sx={{ margin: '0px 8px 0px 4px' }} />
+              <Typography variant="body2">
+                <Msg
+                  id={messageIds.configuration.configure.tags.scoreImperfect}
+                />
+              </Typography>
+            </Box>
+          )}
         </Box>
       </Box>
       <Typography color="secondary">

--- a/src/features/import/hooks/useGuessOrganization.ts
+++ b/src/features/import/hooks/useGuessOrganization.ts
@@ -33,10 +33,14 @@ const useGuessOrganization = (
           );
           // If there is a match, guess it
           if (goodResults.length > 0) {
+            const bestTag = goodResults.sort(
+              (a, b) => (a.score ?? 1) - (b.score ?? 1)
+            )[0];
             return [
               ...acc,
               {
-                orgId: goodResults[0].item.id,
+                orgId: bestTag.item.id,
+                score: bestTag.score,
                 value: orgTitle,
               },
             ];

--- a/src/features/import/hooks/useGuessOrganization.ts
+++ b/src/features/import/hooks/useGuessOrganization.ts
@@ -3,9 +3,7 @@ import Fuse from 'fuse.js';
 import { UIDataColumn } from './useUIDataColumn';
 import useOrgMapping from './useOrgMapping';
 import { ZetkinSubOrganization } from 'utils/types/zetkin';
-import { CellData, OrgColumn } from '../types';
-
-type OrgMap = { orgId: number; value: CellData };
+import { OrgColumn } from '../types';
 
 const useGuessOrganization = (
   orgs: ZetkinSubOrganization[],
@@ -23,7 +21,7 @@ const useGuessOrganization = (
   const guessOrgs = () => {
     // Loop through each possible cell value
     const matchedRows = uiDataColumn.uniqueValues.reduce(
-      (acc: OrgMap[], orgTitle: string | number) => {
+      (acc: OrgColumn['mapping'], orgTitle: string | number) => {
         if (typeof orgTitle === 'string') {
           // Find orgs with most similar name
           const results = fuse.search(orgTitle);
@@ -33,10 +31,14 @@ const useGuessOrganization = (
           );
           // If there is a match, guess it
           if (goodResults.length > 0) {
+            const bestOrg = goodResults.sort(
+              (a, b) => (a.score ?? 1) - (b.score ?? 1)
+            )[0];
             return [
               ...acc,
               {
-                orgId: goodResults[0].item.id,
+                orgId: bestOrg.item.id,
+                score: bestOrg.score,
                 value: orgTitle,
               },
             ];

--- a/src/features/import/hooks/useGuessTags.ts
+++ b/src/features/import/hooks/useGuessTags.ts
@@ -28,10 +28,14 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
 
           // If there is a match, guess it
           if (results.length > 0) {
+            const bestTag = results.sort(
+              (a, b) => (a.score ?? 1) - (b.score ?? 1)
+            )[0];
             return [
               ...acc,
               {
-                tags: [{ id: results[0].item.id }],
+                score: bestTag.score,
+                tags: [{ id: bestTag.item.id }],
                 value: cellValue,
               },
             ];

--- a/src/features/import/hooks/useOrgMapping.ts
+++ b/src/features/import/hooks/useOrgMapping.ts
@@ -13,13 +13,21 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     return null;
   };
 
+  const getSelectedScore = (value: CellData): number | null => {
+    if (column.kind == ColumnKind.ORGANIZATION) {
+      const map = column.mapping.find((m) => m.value === value);
+      return map?.score || null;
+    }
+    return null;
+  };
+
   const selectOrg = (orgId: number, value: CellData) => {
     if (column.kind == ColumnKind.ORGANIZATION) {
       // Check if there is already a map for this row value to an org ID
       const map = column.mapping.find((map) => map.value == value);
       // If no map for that value
       if (!map) {
-        const newMap = { orgId: orgId, value: value };
+        const newMap = { orgId: orgId, score: undefined, value: value };
         dispatch(
           // Add value to mapping for the column
           columnUpdate([
@@ -35,7 +43,7 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
         // Find mappings that are not for this row value
         const filteredMapping = column.mapping.filter((m) => m.value != value);
         // New orgId for that row value
-        const updatedMap = { ...map, orgId: orgId };
+        const updatedMap = { ...map, orgId: orgId, score: undefined };
 
         dispatch(
           columnUpdate([
@@ -50,7 +58,9 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     }
   };
 
-  const selectOrgs = (mapping: { orgId: number; value: CellData }[]) => {
+  const selectOrgs = (
+    mapping: { orgId: number; score?: number; value: CellData }[]
+  ) => {
     if (column.kind == ColumnKind.ORGANIZATION) {
       dispatch(
         columnUpdate([
@@ -83,5 +93,11 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     }
   };
 
-  return { deselectOrg, getSelectedOrgId, selectOrg, selectOrgs };
+  return {
+    deselectOrg,
+    getSelectedOrgId,
+    getSelectedScore,
+    selectOrg,
+    selectOrgs,
+  };
 }

--- a/src/features/import/hooks/useOrgMapping.ts
+++ b/src/features/import/hooks/useOrgMapping.ts
@@ -1,6 +1,6 @@
 import { columnUpdate } from '../store';
 import { useAppDispatch } from 'core/hooks';
-import { CellData, Column, ColumnKind } from '../types';
+import { CellData, Column, ColumnKind, OrgColumn } from '../types';
 
 export default function useOrgMapping(column: Column, columnIndex: number) {
   const dispatch = useAppDispatch();
@@ -13,13 +13,21 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     return null;
   };
 
+  const getScore = (value: CellData): number | null => {
+    if (column.kind == ColumnKind.ORGANIZATION) {
+      const map = column.mapping.find((m) => m.value === value);
+      return map?.score || null;
+    }
+    return null;
+  };
+
   const selectOrg = (orgId: number, value: CellData) => {
     if (column.kind == ColumnKind.ORGANIZATION) {
       // Check if there is already a map for this row value to an org ID
       const map = column.mapping.find((map) => map.value == value);
       // If no map for that value
       if (!map) {
-        const newMap = { orgId: orgId, value: value };
+        const newMap = { orgId: orgId, score: undefined, value: value };
         dispatch(
           // Add value to mapping for the column
           columnUpdate([
@@ -35,7 +43,7 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
         // Find mappings that are not for this row value
         const filteredMapping = column.mapping.filter((m) => m.value != value);
         // New orgId for that row value
-        const updatedMap = { ...map, orgId: orgId };
+        const updatedMap = { ...map, orgId: orgId, score: undefined };
 
         dispatch(
           columnUpdate([
@@ -50,7 +58,7 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     }
   };
 
-  const selectOrgs = (mapping: { orgId: number; value: CellData }[]) => {
+  const selectOrgs = (mapping: OrgColumn['mapping']) => {
     if (column.kind == ColumnKind.ORGANIZATION) {
       dispatch(
         columnUpdate([
@@ -83,5 +91,11 @@ export default function useOrgMapping(column: Column, columnIndex: number) {
     }
   };
 
-  return { deselectOrg, getSelectedOrgId, selectOrg, selectOrgs };
+  return {
+    deselectOrg,
+    getScore,
+    getSelectedOrgId,
+    selectOrg,
+    selectOrgs,
+  };
 }

--- a/src/features/import/hooks/useTagConfig.ts
+++ b/src/features/import/hooks/useTagConfig.ts
@@ -72,7 +72,7 @@ export default function useTagConfig(
       const assignedTags = map?.tags
         .map((tag) => tags.find((t) => t.id == tag.id))
         .filter(notEmpty)
-        .map((tag) => ({ ...tag, value: null }));
+        .map((tag) => ({ ...tag, score: map.score, value: null }));
       return assignedTags || [];
     }
     return [];

--- a/src/features/import/hooks/useTagConfig.ts
+++ b/src/features/import/hooks/useTagConfig.ts
@@ -20,6 +20,7 @@ export default function useTagConfig(
 
       if (!map) {
         const newMap = {
+          score: undefined,
           tags: [{ id: tag.id }],
           value: value,
         };
@@ -37,7 +38,7 @@ export default function useTagConfig(
         const updatedTags = map.tags.concat({
           id: tag.id,
         });
-        const updatedMap = { ...map, tags: updatedTags };
+        const updatedMap = { ...map, score: undefined, tags: updatedTags };
 
         dispatch(
           columnUpdate([
@@ -64,6 +65,14 @@ export default function useTagConfig(
         ])
       );
     }
+  };
+
+  const getScore = (value: CellData): number | null => {
+    if (column.kind == ColumnKind.TAG) {
+      const map = column.mapping.find((m) => m.value === value);
+      return map?.score || null;
+    }
+    return null;
   };
 
   const getAssignedTags = (value: CellData): ZetkinAppliedTag[] => {
@@ -112,5 +121,5 @@ export default function useTagConfig(
     }
   };
 
-  return { assignTag, assignTags, getAssignedTags, unAssignTag };
+  return { assignTag, assignTags, getAssignedTags, getScore, unAssignTag };
 }

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -113,6 +113,8 @@ export default makeMessages('feat.import', {
         guess: m('Guess organisations'),
         header: m('Map values to organizations'),
         organizations: m('Organization'),
+        scoreImperfect: m('This is not a perfect match'),
+        scorePerfect: m('This is a perfect match'),
         showOrganizationSelectButton: m('Map to...'),
         status: m('Status'),
       },
@@ -123,6 +125,8 @@ export default makeMessages('feat.import', {
         numberOfRows: m<{ numRows: number }>(
           '{numRows, plural, =1 {1 row} other {# rows}}'
         ),
+        scoreImperfect: m('This is not a perfect match'),
+        scorePerfect: m('This is a perfect match'),
         tagsHeader: m('Tags'),
       },
     },

--- a/src/features/import/l10n/messageIds.ts
+++ b/src/features/import/l10n/messageIds.ts
@@ -110,9 +110,10 @@ export default makeMessages('feat.import', {
         ),
       },
       orgs: {
-        guess: m('Guess organisations'),
+        guess: m('Guess organizations'),
         header: m('Map values to organizations'),
         organizations: m('Organization'),
+        scoreImperfect: m('This is not a perfect match'),
         showOrganizationSelectButton: m('Map to...'),
         status: m('Status'),
       },
@@ -123,6 +124,7 @@ export default makeMessages('feat.import', {
         numberOfRows: m<{ numRows: number }>(
           '{numRows, plural, =1 {1 row} other {# rows}}'
         ),
+        scoreImperfect: m('This is not a perfect match'),
         tagsHeader: m('Tags'),
       },
     },

--- a/src/features/import/types.ts
+++ b/src/features/import/types.ts
@@ -123,6 +123,7 @@ export type IDFieldColumn = BaseColumn & {
 export type TagColumn = BaseColumn & {
   kind: ColumnKind.TAG;
   mapping: {
+    score?: number;
     tags: { id: number }[];
     value: CellData;
   }[];
@@ -132,6 +133,7 @@ export type OrgColumn = BaseColumn & {
   kind: ColumnKind.ORGANIZATION;
   mapping: {
     orgId: number | null;
+    score?: number;
     value: CellData;
   }[];
 };

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -910,7 +910,7 @@ feat:
           zetkinIDInfo: A Zetkin ID is the ID of a person already in Zetkin. You would
             have it in a file if you exported data from Zetkin.
         orgs:
-          guess: Guess organisations
+          guess: Guess organizations
           header: Map values to organizations
           organizations: Organization
           showOrganizationSelectButton: Map to...

--- a/src/utils/types/zetkin.ts
+++ b/src/utils/types/zetkin.ts
@@ -449,7 +449,10 @@ export interface ZetkinTag {
   value_type: 'text' | null;
 }
 
-export type ZetkinAppliedTag = ZetkinTag & { value: string | number | null };
+export type ZetkinAppliedTag = ZetkinTag & {
+  score?: number;
+  value: string | number | null;
+};
 
 export interface ZetkinTagPostBody extends Partial<
   Omit<ZetkinTag, 'id' | 'group' | 'organization'>


### PR DESCRIPTION
## Description
This PR adds a visual indicator in the form of a green to red circle to the people import organization and tag guessing representing the score of the guessing. The score column is only visible if the guessing has been used.


## Screenshots

<img width="733" height="588" alt="grafik" src="https://github.com/user-attachments/assets/cc2a44ca-b23e-4f5b-88db-c98f4cda0b1e" />
<img width="728" height="589" alt="grafik" src="https://github.com/user-attachments/assets/57b1135d-d904-4333-84f8-bd8bcbd8671c" />


## Changes

* Adds visual indicator for people import tag/organization guessing precision


## Notes to reviewer

I, personally, do not like that the selected tags get reset when clicking the guess button (even when the guessing does not find any new value). Also, the limit for matching might be a bit small. For most of the tags, one or two differing characters are enough to not be selected 🤷 

Also, it is up to discussion if the colour range is a good idea or if it might just rather be a checkbox indicating a "perfect match".


## Related issues
Resolves #2278
