### PR TITLE
Propose solution for fuzzy matching tags

### DIFF
--- a/src/features/import/hooks/useGuessTags.ts
+++ b/src/features/import/hooks/useGuessTags.ts
@@ -13,7 +13,6 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
     uiDataColumn.columnIndex
   );
   const fuse = new Fuse(tags.data || [], {
-    ignoreFieldNorm: true,
     includeScore: true,
     keys: ['title'],
     threshold: 0.25,
@@ -23,7 +22,7 @@ const useGuessTags = (orgId: number, uiDataColumn: UIDataColumn<TagColumn>) => {
     // Loop through each possible cell value
     const matchedRows = uiDataColumn.uniqueValues.reduce(
       (acc: TagColumn['mapping'], cellValue: CellData) => {
-        if (typeof cellValue === 'string') {
+        if (typeof cellValue === 'string' && cellValue.length > 2) {
           // Find tags with most similar name
           const results = fuse.search(cellValue);
 


### PR DESCRIPTION
## Description
This PR proposes a solution to make the guessing of tags more robust. It makes use of the `threshold` option of fuse.js instead of manually comparing the score.


## Screenshots
<img width="2558" height="1219" alt="image" src="https://github.com/user-attachments/assets/397c834e-5f9c-404c-8689-6f3b5bc705e9" />


## Changes
* Extends the options of fuse.js and removes manual checking of the score in `src/features/import/hooks/useGuessTags.ts`


## Notes to reviewer
1. Go to http://localhost:3000/organize/1/people
2. Upload the Excel linked in the issue


## Related issues
Resolves #3521
