### PR TITLE
Stop filters from resetting when closing map filter panel

### DIFF
--- a/src/features/areaAssignments/components/OrganizerMap.tsx
+++ b/src/features/areaAssignments/components/OrganizerMap.tsx
@@ -30,7 +30,6 @@ import {
   ZetkinLocation,
 } from '../types';
 import flipForLeaflet from 'features/areas/utils/flipForLeaflet';
-import { assigneesFilterContext } from './OrganizerMapFilters/AssigneeFilterContext';
 import OrganizerMapFilters from './OrganizerMapFilters';
 import OrganizerMapFilterBadge from './OrganizerMapFilters/OrganizerMapFilterBadge';
 import AreaSelect from './AreaSelect';
@@ -84,7 +83,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
   const [filteredAreaIds, setFilteredAreaIds] = useState<null | number[]>(null);
   const [selectedId, setSelectedId] = useState(0);
   const [filterText, setFilterText] = useState('');
-  const { onAssigneesFilterChange } = useContext(assigneesFilterContext);
   const { setActiveGroupIds, setActiveTagIdsByGroup } =
     useContext(areaFilterContext);
   const router = useRouter();
@@ -134,8 +132,6 @@ const OrganizerMap: FC<OrganizerMapProps> = ({
     startTransition(() => {
       setSettingsOpen(null);
       setSelectedId(0);
-      onAssigneesFilterChange(null);
-      setFilteredAreaIds(null);
       setActiveGroupIds([]);
       setActiveTagIdsByGroup({});
       setFilterText('');


### PR DESCRIPTION
## Description
This PR makes it so filters to show assigned or unassigned areas will not be reset when closing filter panel


## Screenshots
<img width="1719" height="2436" alt="Screen Shot 2026-02-28 at 11 31 57" src="https://github.com/user-attachments/assets/7aa32ef9-1e0c-4e0b-98be-1f6d7cb75f79" />


## Changes

* Remove setting values to null in `clearAndCloseSettings`


## Notes to reviewer
The issue was labelled as "medium" but my change is just removing 3 lines of code. Maybe I missed something?

## Related issues
Resolves #3510 
