### PR TITLE
Add loading spinner fallbak to canvas location drawer

### DIFF
--- a/src/features/canvass/components/CanvassMapOverlays.tsx
+++ b/src/features/canvass/components/CanvassMapOverlays.tsx
@@ -105,7 +105,7 @@ const CanvassMapOverlays: FC<Props> = ({
                   width: '100vw',
                 }}
               >
-                <CircularProgress size={20} />
+                <CircularProgress />
               </Box>
             }
           >


### PR DESCRIPTION
## Description
This PR adds a loading spinner the the location drawer in canvassing


## Screenshots
Spinner displays while this is loading:
<img width="1909" height="356" alt="image" src="https://github.com/user-attachments/assets/b0d84836-f9b9-4f60-87da-f6751ce12877" />



## Changes

* Adds fallback state for Location canvass map overlay


## Related issues
Resolves #3511 
