### PR TITLE
Use centralised gender localisation for people importer

### DIFF
--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -10,7 +10,8 @@ import { FC, useState } from 'react';
 
 import messageIds from 'features/duplicates/l10n/messageIds';
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
-import { useMessages } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
+import globalMessageIds from 'core/i18n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import { ZetkinPerson } from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
@@ -37,13 +38,10 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
 
   const getLabel = (value: string) => {
     if (field === NATIVE_PERSON_FIELDS.GENDER) {
-      if (value === 'f') {
-        return messages.modal.fieldSettings.gender.f();
-      } else if (value === 'm') {
-        return messages.modal.fieldSettings.gender.m();
-      } else if (value === 'o') {
-        return messages.modal.fieldSettings.gender.o();
+      if (value === 'f' || value === 'm' || value === 'o') {
+        return <Msg id={globalMessageIds.genderOptions[value]} />;
       }
+      return <Msg id={globalMessageIds.genderOptions.unspecified} />;
     }
 
     if (!value) {

--- a/src/features/duplicates/l10n/messageIds.ts
+++ b/src/features/duplicates/l10n/messageIds.ts
@@ -6,11 +6,6 @@ export default makeMessages('feat.duplicates', {
     fieldSettings: {
       data: m('Data'),
       field: m('Field'),
-      gender: {
-        f: m('Female'),
-        m: m('Male'),
-        o: m('Other'),
-      },
       noValue: m('No value'),
       title: m('Data to merge'),
     },


### PR DESCRIPTION
## Description
This PR replaces locally defined gender option strings with the global gender labels in the people importer


## Screenshots
<img width="1272" height="561" alt="image" src="https://github.com/user-attachments/assets/9a00f28c-7e2a-4bc5-8a39-0a2072a6a6bc" />



## Changes
[Add a list of features added/changed, bugs fixed etc]

* Removes locally defined gender strings
* Uses globally defined gender options in people importer mapping for csv uploads

## Note to reviewer

Unsure whether the scope of this issue is wider or it was only to address that specific instance

## Related issues
Resolves #3520 
