### PR TITLE
Issue: #3519. Enhance success option labels with icons in visit pages. 

### DIFF
--- a/src/features/canvass/components/LocationDialog/pages/BulkHouseholdVisitsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/BulkHouseholdVisitsPage.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Stack,
   Step,
   StepButton,
   StepContent,
@@ -9,7 +10,8 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
-import { FC, useEffect, useState } from 'react';
+import { Check, Close } from '@mui/icons-material';
+import { FC, ReactNode, useEffect, useState } from 'react';
 
 import { ZetkinMetric } from 'features/areaAssignments/types';
 import PageBase from './PageBase';
@@ -72,15 +74,33 @@ const BulkHouseholdVisitsPage: FC<BulkHouseholdVisitsPageProps> = ({
     >
       <Stepper activeStep={step} orientation="vertical">
         {metrics.map((metric, index) => {
+          const yesLabel = messages.visit.household.yesButtonLabel();
+          const noLabel = messages.visit.household.noButtonLabel();
+          const renderSuccessOptionLabel = (
+            icon: ReactNode,
+            label: string
+          ): ReactNode => (
+            <Stack alignItems="center" direction="row" gap={1}>
+              {icon}
+              <span>{label}</span>
+            </Stack>
+          );
+
           const options =
             metric.type == 'bool'
               ? [
                   {
-                    label: messages.visit.household.yesButtonLabel(),
+                    label: renderSuccessOptionLabel(
+                      <Check fontSize="small" />,
+                      yesLabel
+                    ),
                     value: 'yes',
                   },
                   {
-                    label: messages.visit.household.noButtonLabel(),
+                    label: renderSuccessOptionLabel(
+                      <Close fontSize="small" />,
+                      noLabel
+                    ),
                     value: 'no',
                   },
                 ]

--- a/src/features/canvass/components/LocationDialog/pages/BulkHouseholdVisitsPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/BulkHouseholdVisitsPage.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Stack,
   Step,
   StepButton,
   StepContent,
@@ -11,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Check, Close } from '@mui/icons-material';
-import { FC, ReactNode, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { ZetkinMetric } from 'features/areaAssignments/types';
 import PageBase from './PageBase';
@@ -74,33 +73,15 @@ const BulkHouseholdVisitsPage: FC<BulkHouseholdVisitsPageProps> = ({
     >
       <Stepper activeStep={step} orientation="vertical">
         {metrics.map((metric, index) => {
-          const yesLabel = messages.visit.household.yesButtonLabel();
-          const noLabel = messages.visit.household.noButtonLabel();
-          const renderSuccessOptionLabel = (
-            icon: ReactNode,
-            label: string
-          ): ReactNode => (
-            <Stack alignItems="center" direction="row" gap={1}>
-              {icon}
-              <span>{label}</span>
-            </Stack>
-          );
-
           const options =
             metric.type == 'bool'
               ? [
                   {
-                    label: renderSuccessOptionLabel(
-                      <Check fontSize="small" />,
-                      yesLabel
-                    ),
+                    label: messages.visit.household.yesButtonLabel(),
                     value: 'yes',
                   },
                   {
-                    label: renderSuccessOptionLabel(
-                      <Close fontSize="small" />,
-                      noLabel
-                    ),
+                    label: messages.visit.household.noButtonLabel(),
                     value: 'no',
                   },
                 ]
@@ -174,6 +155,12 @@ const BulkHouseholdVisitsPage: FC<BulkHouseholdVisitsPageProps> = ({
                         key={option.value.toString()}
                         value={option.value}
                       >
+                        {metric.defines_success && option.value === 'yes' && (
+                          <Check sx={{ marginRight: 1 }} />
+                        )}
+                        {metric.defines_success && option.value === 'no' && (
+                          <Close sx={{ marginRight: 1 }} />
+                        )}
                         {option.label}
                       </ToggleButton>
                     ))}

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Stack,
   Step,
   StepButton,
   StepContent,
@@ -9,8 +10,8 @@ import {
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
-import { Undo } from '@mui/icons-material';
-import { FC, useEffect, useState } from 'react';
+import { Check, Close, Undo } from '@mui/icons-material';
+import { FC, ReactNode, useEffect, useState } from 'react';
 
 import { ZetkinLocation, ZetkinMetric } from 'features/areaAssignments/types';
 import PageBase from './PageBase';
@@ -92,15 +93,33 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
     >
       <Stepper activeStep={step} orientation="vertical">
         {metrics.map((metric, index) => {
+          const yesLabel = messages.visit.household.yesButtonLabel();
+          const noLabel = messages.visit.household.noButtonLabel();
+          const renderSuccessOptionLabel = (
+            icon: ReactNode,
+            label: string
+          ): ReactNode => (
+            <Stack alignItems="center" direction="row" gap={1}>
+              {icon}
+              <span>{label}</span>
+            </Stack>
+          );
+
           const options =
             metric.type == 'bool'
               ? [
                   {
-                    label: messages.visit.household.yesButtonLabel(),
+                    label: renderSuccessOptionLabel(
+                      <Check fontSize="small" />,
+                      yesLabel
+                    ),
                     value: 'yes',
                   },
                   {
-                    label: messages.visit.household.noButtonLabel(),
+                    label: renderSuccessOptionLabel(
+                      <Close fontSize="small" />,
+                      noLabel
+                    ),
                     value: 'no',
                   },
                 ]

--- a/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
+++ b/src/features/canvass/components/LocationDialog/pages/HouseholdVisitPage.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  Stack,
   Step,
   StepButton,
   StepContent,
@@ -11,7 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import { Check, Close, Undo } from '@mui/icons-material';
-import { FC, ReactNode, useEffect, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import { ZetkinLocation, ZetkinMetric } from 'features/areaAssignments/types';
 import PageBase from './PageBase';
@@ -93,33 +92,15 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
     >
       <Stepper activeStep={step} orientation="vertical">
         {metrics.map((metric, index) => {
-          const yesLabel = messages.visit.household.yesButtonLabel();
-          const noLabel = messages.visit.household.noButtonLabel();
-          const renderSuccessOptionLabel = (
-            icon: ReactNode,
-            label: string
-          ): ReactNode => (
-            <Stack alignItems="center" direction="row" gap={1}>
-              {icon}
-              <span>{label}</span>
-            </Stack>
-          );
-
           const options =
             metric.type == 'bool'
               ? [
                   {
-                    label: renderSuccessOptionLabel(
-                      <Check fontSize="small" />,
-                      yesLabel
-                    ),
+                    label: messages.visit.household.yesButtonLabel(),
                     value: 'yes',
                   },
                   {
-                    label: renderSuccessOptionLabel(
-                      <Close fontSize="small" />,
-                      noLabel
-                    ),
+                    label: messages.visit.household.noButtonLabel(),
                     value: 'no',
                   },
                 ]
@@ -221,6 +202,12 @@ const HouseholdVisitPage: FC<HouseholdVisitPageProps> = ({
                         key={option.value.toString()}
                         value={option.value}
                       >
+                        {metric.defines_success && option.value === 'yes' && (
+                          <Check sx={{ marginRight: 1 }} />
+                        )}
+                        {metric.defines_success && option.value === 'no' && (
+                          <Close sx={{ marginRight: 1 }} />
+                        )}
                         {option.label}
                       </ToggleButton>
                     ))}


### PR DESCRIPTION
This pull request updates the household visit UI in both the bulk and single household visit pages to improve clarity and usability. The main change is that the "Yes" and "No" options for boolean metrics now include icons alongside the labels, making the options more visually distinct and easier to understand.

**UI improvements for household visit pages:**

* Updated the boolean metric options in `BulkHouseholdVisitsPage.tsx` and `HouseholdVisitPage.tsx` to display a checkmark icon next to "Yes" and a close icon next to "No", using a new `renderSuccessOptionLabel` function and the MUI `Stack` component for layout. [[1]](diffhunk://#diff-2ab17cec9ce197fbe75a864d95383b3c7f630fc25e7ac7c74877f998e4f5f9b7R77-R103) [[2]](diffhunk://#diff-53db16448f2da5b288eb555d3c2b7d31d1b85e4b3753eb189480a816c73fe113R96-R122)
* Added necessary imports for the new icons (`Check`, `Close`) and for the `Stack` component in both files. [[1]](diffhunk://#diff-2ab17cec9ce197fbe75a864d95383b3c7f630fc25e7ac7c74877f998e4f5f9b7R4) [[2]](diffhunk://#diff-2ab17cec9ce197fbe75a864d95383b3c7f630fc25e7ac7c74877f998e4f5f9b7L12-R14) [[3]](diffhunk://#diff-53db16448f2da5b288eb555d3c2b7d31d1b85e4b3753eb189480a816c73fe113R4) [[4]](diffhunk://#diff-53db16448f2da5b288eb555d3c2b7d31d1b85e4b3753eb189480a816c73fe113L12-R14)
