### PR TITLE
Issue 3492/ics timezone utc export

### DIFF
--- a/src/features/public/utils/icsFromEvents.ts
+++ b/src/features/public/utils/icsFromEvents.ts
@@ -22,6 +22,11 @@ export default function icsFromEvents(
   events
     .filter((event) => !event.cancelled && event.published)
     .forEach((event) => {
+      const published = event.published;
+      if (!published) {
+        return;
+      }
+
       vLines.push(`BEGIN:VEVENT`);
       vLines.push(`UID:${event.id}@${process.env.ZETKIN_APP_HOST}`);
       vLines.push(
@@ -29,7 +34,7 @@ export default function icsFromEvents(
           org.email ?? 'noreply@zetkin.org'
         }`
       );
-      vLines.push(`DTSTAMP:${utcTimeStamp(event.published)}`);
+      vLines.push(`DTSTAMP:${utcTimeStamp(published)}`);
       vLines.push(`DTSTART:${utcTimeStamp(event.start_time)}`);
       vLines.push(`DTEND:${utcTimeStamp(event.end_time)}`);
       if (event.title || event.activity?.title) {


### PR DESCRIPTION
This PR fixes issue #3492 by making ICS event times timezone-explicit.

DTSTAMP, DTSTART, and DTEND are now exported in UTC with trailing Z
X-WR-TIMEZONE:UTC is added to the calendar header
Timestamp formatting now uses dayjs.utc(...)
Result: subscribed calendars (e.g. Google Calendar) should display the same event times as Zetkin instead of shifted times.

## Related issues
Resolves #3492
Issue: https://github.com/zetkin/app.zetkin.org/issues/3492
