### PR TITLE
Removed all padding and margin from ListItemText in importer

### DIFF
--- a/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Mapping/FieldSelect.tsx
@@ -227,9 +227,7 @@ const FieldSelect: FC<FieldSelectProps> = ({
       onClose={() => setOpen(false)}
       onOpen={() => setOpen(true)}
       open={open}
-      sx={{
-        opacity: column.originalColumn.selected ? '' : '50%',
-      }}
+      sx={{ opacity: column.originalColumn.selected ? '' : '50%' }}
       value={getValue()}
     >
       <ListSubheader>


### PR DESCRIPTION
## Description
Removed all padding and margin from MuiListItemText-root class. So now the box is not growing with 9 pixels. 

## Screenshots
[Add screenshots here]


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds…
* Changes…


## Notes to reviewer
[Add instructions for testing]
When importing and choosing a type, nothing moves anymore. 


## Related issues
#3505 
