### PR TITLE
Fix "my" pages filters UX being inconsistent

### DIFF
--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -17,6 +17,7 @@ import {
   Hotel,
 } from '@mui/icons-material';
 import { DateRangeCalendar, DateRangePickerDay } from '@mui/x-date-pickers-pro';
+import { partition } from 'lodash';
 
 import EventCard from './EventCard';
 import { LaneStep, ZetkinCallTarget } from '../types';
@@ -98,22 +99,16 @@ const Activities: FC<ActivitiesProps> = ({
             onClick={() => onClearFilters()}
           />
         )}
-        {baseFilters.map((filter) => (
-          <ZUIFilterButton
-            key={filter.key}
-            active={filter.active}
-            label={filter.label}
-            onClick={filter.onClick}
-          />
-        ))}
-        {eventFilters.map((filter) => (
-          <ZUIFilterButton
-            key={filter.key}
-            active={filter.active}
-            label={filter.label}
-            onClick={filter.onClick}
-          />
-        ))}
+        {partition([...baseFilters, ...eventFilters], (filter) => filter.active)
+          .flat()
+          .map((filter) => (
+            <ZUIFilterButton
+              key={filter.key}
+              active={filter.active}
+              label={filter.label}
+              onClick={filter.onClick}
+            />
+          ))}
       </Box>
       {showNoActivities && (
         <Box

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -250,7 +250,7 @@ const AllEventsList: FC = () => {
       label: messages.allEventsList.filterButtonLabels.today(),
       onClick: () => {
         setFilters({
-          date: 'today',
+          date: dateFilterState == 'today' ? null : 'today',
           range: null,
         });
       },
@@ -261,7 +261,7 @@ const AllEventsList: FC = () => {
       label: messages.allEventsList.filterButtonLabels.tomorrow(),
       onClick: () => {
         setFilters({
-          date: 'tomorrow',
+          date: dateFilterState == 'tomorrow' ? null : 'tomorrow',
           range: null,
         });
       },
@@ -272,7 +272,7 @@ const AllEventsList: FC = () => {
       label: messages.allEventsList.filterButtonLabels.thisWeek(),
       onClick: () => {
         setFilters({
-          date: 'thisWeek',
+          date: dateFilterState == 'thisWeek' ? null : 'thisWeek',
           range: null,
         });
       },
@@ -288,7 +288,14 @@ const AllEventsList: FC = () => {
             )
           : CalendarMonthOutlined,
       onClick: () => {
-        setDrawerContent('calendar');
+        if (dateFilterState == 'custom') {
+          setFilters({
+            date: null,
+            range: null,
+          });
+        } else {
+          setDrawerContent('calendar');
+        }
       },
     },
     ...(moreThanOneOrgHasEvents

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -137,11 +137,11 @@ const AllEventsList: FC = () => {
 
   const getDateRange = (): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
-    if (!dateFilterState || dateFilterState == 'custom') {
+    if (!dateFilterState || dateFilterState === 'custom') {
       return customDatesToFilterBy;
-    } else if (dateFilterState == 'today') {
+    } else if (dateFilterState === 'today') {
       return [today, null];
-    } else if (dateFilterState == 'tomorrow') {
+    } else if (dateFilterState === 'tomorrow') {
       return [today.add(1, 'day'), null];
     } else {
       //dateFilterState is 'thisWeek'
@@ -165,7 +165,7 @@ const AllEventsList: FC = () => {
 
   const filteredEvents = allEvents
     .filter((event) => {
-      if (orgIdsToFilterBy.length == 0) {
+      if (orgIdsToFilterBy.length === 0) {
         return true;
       }
       return orgIdsToFilterBy.includes(event.organization.id);
@@ -173,7 +173,7 @@ const AllEventsList: FC = () => {
     .filter((event) => {
       if (
         !dateFilterState ||
-        (dateFilterState == 'custom' && !customDatesToFilterBy[0])
+        (dateFilterState === 'custom' && !customDatesToFilterBy[0])
       ) {
         return true;
       }
@@ -245,50 +245,50 @@ const AllEventsList: FC = () => {
 
   const filters = [
     {
-      active: dateFilterState == 'today',
+      active: dateFilterState === 'today',
       key: 'today',
       label: messages.allEventsList.filterButtonLabels.today(),
       onClick: () => {
         setFilters({
-          date: dateFilterState == 'today' ? null : 'today',
+          date: dateFilterState === 'today' ? null : 'today',
           range: null,
         });
       },
     },
     {
-      active: dateFilterState == 'tomorrow',
+      active: dateFilterState === 'tomorrow',
       key: 'tomorrow',
       label: messages.allEventsList.filterButtonLabels.tomorrow(),
       onClick: () => {
         setFilters({
-          date: dateFilterState == 'tomorrow' ? null : 'tomorrow',
+          date: dateFilterState === 'tomorrow' ? null : 'tomorrow',
           range: null,
         });
       },
     },
     {
-      active: dateFilterState == 'thisWeek',
+      active: dateFilterState === 'thisWeek',
       key: 'thisWeek',
       label: messages.allEventsList.filterButtonLabels.thisWeek(),
       onClick: () => {
         setFilters({
-          date: dateFilterState == 'thisWeek' ? null : 'thisWeek',
+          date: dateFilterState === 'thisWeek' ? null : 'thisWeek',
           range: null,
         });
       },
     },
     {
-      active: dateFilterState == 'custom',
+      active: dateFilterState === 'custom',
       key: 'custom',
       label:
-        dateFilterState == 'custom' && customDatesToFilterBy[0]
+        dateFilterState === 'custom' && customDatesToFilterBy[0]
           ? getDatesFilteredBy(
               customDatesToFilterBy[1],
               customDatesToFilterBy[0]
             )
           : CalendarMonthOutlined,
       onClick: () => {
-        if (dateFilterState == 'custom') {
+        if (dateFilterState === 'custom') {
           setFilters({
             date: null,
             range: null,
@@ -301,12 +301,20 @@ const AllEventsList: FC = () => {
     ...(moreThanOneOrgHasEvents
       ? [
           {
-            active: !!orgIdsToFilterBy.length,
+            active: orgIdsToFilterBy?.length > 0,
             key: 'orgs',
             label: messages.allEventsList.filterButtonLabels.organizations({
               numOrgs: orgIdsToFilterBy.length,
             }),
-            onClick: () => setDrawerContent('orgs'),
+            onClick: () => {
+              if (orgIdsToFilterBy?.length > 0) {
+                setFilters({
+                  orgs: [],
+                });
+              } else {
+                setDrawerContent('orgs');
+              }
+            },
           },
         ]
       : []),
@@ -316,7 +324,15 @@ const AllEventsList: FC = () => {
             active: eventTypeFilter.isFiltered,
             key: 'eventTypes',
             label: eventTypeFilter.filterButtonLabel,
-            onClick: () => setDrawerContent('eventTypes'),
+            onClick: () => {
+              if (eventTypeFilter.isFiltered) {
+                setFilters({
+                  types: [],
+                });
+              } else {
+                setDrawerContent('eventTypes');
+              }
+            },
           },
         ]
       : []),
@@ -365,7 +381,7 @@ const AllEventsList: FC = () => {
           ))}
         </Box>
       )}
-      {filteredEvents.length == 0 && (
+      {filteredEvents.length === 0 && (
         <Box
           alignItems="center"
           display="flex"
@@ -412,7 +428,7 @@ const AllEventsList: FC = () => {
       ))}
       <ZUIDrawerModal
         onClose={() => setDrawerContent(null)}
-        open={drawerContent == 'calendar'}
+        open={drawerContent === 'calendar'}
       >
         <Box
           alignItems="center"
@@ -474,7 +490,7 @@ const AllEventsList: FC = () => {
       </ZUIDrawerModal>
       <ZUIDrawerModal
         onClose={() => setDrawerContent(null)}
-        open={drawerContent == 'orgs'}
+        open={drawerContent === 'orgs'}
       >
         <List>
           {orgs.map((org) => (
@@ -503,7 +519,7 @@ const AllEventsList: FC = () => {
       </ZUIDrawerModal>
       <ZUIDrawerModal
         onClose={() => setDrawerContent(null)}
-        open={drawerContent == 'eventTypes'}
+        open={drawerContent === 'eventTypes'}
       >
         <List>
           {eventTypeFilter.eventTypeLabels.map((eventType) => (

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -309,7 +309,7 @@ const AllEventsList: FC = () => {
             onClick: () => {
               if (orgIdsToFilterBy?.length > 0) {
                 setFilters({
-                  orgs: [],
+                  orgs: null,
                 });
               } else {
                 setDrawerContent('orgs');
@@ -327,7 +327,7 @@ const AllEventsList: FC = () => {
             onClick: () => {
               if (eventTypeFilter.isFiltered) {
                 setFilters({
-                  types: [],
+                  types: null,
                 });
               } else {
                 setDrawerContent('eventTypes');

--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -45,7 +45,10 @@ const MyActivitiesList: FC = () => {
               onClick={() => setFilteredKinds([])}
             />
           )}
-          {kinds.map((kind) => {
+          {[
+            ...kinds.filter((kind) => filteredKinds.includes(kind)),
+            ...kinds.filter((kind) => !filteredKinds.includes(kind)),
+          ].map((kind) => {
             const active = filteredKinds.includes(kind);
             return (
               <ZUIFilterButton

--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useState } from 'react';
 import { Box, Fade } from '@mui/material';
-import { GroupWorkOutlined, Hotel } from '@mui/icons-material';
+import { GroupWorkOutlined, Hotel, Clear } from '@mui/icons-material';
 
 import { Msg, useMessages } from 'core/i18n';
 import MyActivityListItem from 'features/my/components/MyActivityListItem';
@@ -37,6 +37,14 @@ const MyActivitiesList: FC = () => {
     <Box display="flex" flexDirection="column" gap={1} m={1}>
       {kinds.length > 1 && (
         <Box display="flex" gap={1}>
+          {filteredKinds.length > 0 && (
+            <ZUIFilterButton
+              active={true}
+              circular
+              label={Clear}
+              onClick={() => setFilteredKinds([])}
+            />
+          )}
           {kinds.map((kind) => {
             const active = filteredKinds.includes(kind);
             return (

--- a/src/features/public/pages/PublicOrgPage.tsx
+++ b/src/features/public/pages/PublicOrgPage.tsx
@@ -119,67 +119,86 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
 
   const filters = [
     {
-      active: dateFilterState == 'today',
+      active: dateFilterState === 'today',
       key: 'today',
       label: messages.allEventsList.filterButtonLabels.today(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'today',
+            dateFilterState: dateFilterState === 'today' ? null : 'today',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'tomorrow',
+      active: dateFilterState === 'tomorrow',
       key: 'tomorrow',
       label: messages.allEventsList.filterButtonLabels.tomorrow(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'tomorrow',
+            dateFilterState: dateFilterState === 'tomorrow' ? null : 'tomorrow',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'thisWeek',
+      active: dateFilterState === 'thisWeek',
       key: 'thisWeek',
       label: messages.allEventsList.filterButtonLabels.thisWeek(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'thisWeek',
+            dateFilterState: dateFilterState === 'thisWeek' ? null : 'thisWeek',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'custom',
+      active: dateFilterState === 'custom',
       key: 'custom',
       label:
-        dateFilterState == 'custom' && customDatesToFilterBy[0]
+        dateFilterState === 'custom' && customDatesToFilterBy[0]
           ? getDatesFilteredBy(
               customDatesToFilterBy[1],
               customDatesToFilterBy[0]
             )
           : CalendarMonthOutlined,
       onClick: () => {
-        setDrawerContent('calendar');
+        if (dateFilterState === 'custom') {
+          dispatch(
+            filtersUpdated({
+              customDatesToFilterBy: [null, null],
+              dateFilterState: null,
+            })
+          );
+        } else {
+          setDrawerContent('calendar');
+        }
       },
     },
     ...(moreThanOneOrgHasEvents
       ? [
           {
-            active: !!orgIdsToFilterBy.length,
+            active: orgIdsToFilterBy?.length > 0,
             key: 'orgs',
             label: messages.allEventsList.filterButtonLabels.organizations({
               numOrgs: orgIdsToFilterBy.length,
             }),
-            onClick: () => setDrawerContent('orgs'),
+            onClick: () => {
+              if (orgIdsToFilterBy?.length > 0) {
+                dispatch(
+                  filtersUpdated({
+                    orgIdsToFilterBy: [],
+                  })
+                );
+              } else {
+                setDrawerContent('orgs');
+              }
+            },
           },
         ]
       : []),
@@ -189,7 +208,17 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
             active: eventTypeFilter.isFiltered,
             key: 'eventTypes',
             label: eventTypeFilter.filterButtonLabel,
-            onClick: () => setDrawerContent('eventTypes'),
+            onClick: () => {
+              if (eventTypeFilter.isFiltered) {
+                dispatch(
+                  filtersUpdated({
+                    eventTypesToFilterBy: [],
+                  })
+                );
+              } else {
+                setDrawerContent('eventTypes');
+              }
+            },
           },
         ]
       : []),

--- a/src/features/public/pages/PublicProjPage.tsx
+++ b/src/features/public/pages/PublicProjPage.tsx
@@ -92,56 +92,65 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
 
   const filters = [
     {
-      active: dateFilterState == 'today',
+      active: dateFilterState === 'today',
       key: 'today',
       label: messages.publicProjectPage.eventList.filterButtonLabels.today(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'today',
+            dateFilterState: dateFilterState === 'today' ? null : 'today',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'tomorrow',
+      active: dateFilterState === 'tomorrow',
       key: 'tomorrow',
       label: messages.publicProjectPage.eventList.filterButtonLabels.tomorrow(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'tomorrow',
+            dateFilterState: dateFilterState === 'tomorrow' ? null : 'tomorrow',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'thisWeek',
+      active: dateFilterState === 'thisWeek',
       key: 'thisWeek',
       label: messages.publicProjectPage.eventList.filterButtonLabels.thisWeek(),
       onClick: () => {
         dispatch(
           filtersUpdated({
             customDatesToFilterBy: [null, null],
-            dateFilterState: 'thisWeek',
+            dateFilterState: dateFilterState === 'thisWeek' ? null : 'thisWeek',
           })
         );
       },
     },
     {
-      active: dateFilterState == 'custom',
+      active: dateFilterState === 'custom',
       key: 'custom',
       label:
-        dateFilterState == 'custom' && customDatesToFilterBy[0]
+        dateFilterState === 'custom' && customDatesToFilterBy[0]
           ? getDatesFilteredBy(
               customDatesToFilterBy[1],
               customDatesToFilterBy[0]
             )
           : CalendarMonthOutlined,
       onClick: () => {
-        setDrawerContent('calendar');
+        if (dateFilterState === 'custom') {
+          dispatch(
+            filtersUpdated({
+              customDatesToFilterBy: [null, null],
+              dateFilterState: null,
+            })
+          );
+        } else {
+          setDrawerContent('calendar');
+        }
       },
     },
     ...(eventTypeFilter.shouldShowFilter
@@ -150,7 +159,17 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
             active: eventTypeFilter.isFiltered,
             key: 'eventTypes',
             label: eventTypeFilter.filterButtonLabel,
-            onClick: () => setDrawerContent('eventTypes'),
+            onClick: () => {
+              if (eventTypeFilter.isFiltered) {
+                dispatch(
+                  filtersUpdated({
+                    eventTypesToFilterBy: [],
+                  })
+                );
+              } else {
+                setDrawerContent('eventTypes');
+              }
+            },
           },
         ]
       : []),
@@ -267,7 +286,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
           ))}
         </Box>
       )}
-      {filteredEvents.length == 0 && (
+      {filteredEvents.length === 0 && (
         <Box
           alignItems="center"
           display="flex"
@@ -336,7 +355,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
       ))}
       <ZUIDrawerModal
         onClose={() => setDrawerContent(null)}
-        open={drawerContent == 'calendar'}
+        open={drawerContent === 'calendar'}
       >
         <Box
           alignItems="center"
@@ -400,7 +419,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
       </ZUIDrawerModal>
       <ZUIDrawerModal
         onClose={() => setDrawerContent(null)}
-        open={drawerContent == 'eventTypes'}
+        open={drawerContent === 'eventTypes'}
       >
         <List>
           {eventTypeFilter.eventTypeLabels.map((eventType) => (


### PR DESCRIPTION
## Description
This PR changes how the filters work. When talking to an UX expert (Johan) we decided that probably you won't need to filter specifically on two filters, so to make the filters work more consistent we changed both kind filter in the home page, and time filters in the feed work like radio buttons. We removed the clear filter button, since now you "clear" by selecting show all and deselecting event types.



## Screenshots
https://github.com/user-attachments/assets/e1e35c11-3909-40da-ad57-4e0b87dd1f7e


## Changes
* Change kinds/date selection to work as radio buttons
* Add "all activities", "all time" radio buttons
* Add separator to make it more obvious which filter buttons are related



## Related issues
Resolves #3499 
