### PR TITLE
Fix e2e test bugs

### DIFF
--- a/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
@@ -33,12 +33,8 @@ test.describe('Campaign detail page', async () => {
     await page.click('header [data-testid=ZUIEllipsisMenu-menuActivator]');
     await page.click('data-testid=ZUIEllipsisMenu-item-deleteCampaign');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click('button:text("Confirm")'),
-    ]);
-
-    expect(page.url()).toEqual(appUri + '/organize/1/projects');
+    await page.click('button:text("Confirm")');
+    await page.waitForURL(appUri + '/organize/1/projects');
     expect(log().length).toEqual(1);
   });
 });

--- a/integrationTesting/tests/organize/tags/add.spec.ts
+++ b/integrationTesting/tests/organize/tags/add.spec.ts
@@ -42,8 +42,8 @@ test.describe('Tag manager', () => {
     const addTagButton = page.locator('text=Add tag');
     const playsGuitar = page.locator('text=Plays Guitar');
 
-    page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
-    addTagButton.waitFor({ state: 'visible' });
+    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+    await addTagButton.waitFor({ state: 'visible' });
 
     await page.locator('text=Add tag').click();
 


### PR DESCRIPTION
## Description
This PR fixes two pre-existing bugs in e2e tests that cause flaky failures.

## Changes
  * Adds missing `await` on `page.goto()` and `addTagButton.waitFor()` in `tags/add.spec.ts`
  * Replaces deprecated `page.waitForNavigation()` with `page.waitForURL()` in `campaigns/detail/delete.spec.ts`

## Notes to reviewer
Both issues were always bugs but were masked by fast local hardware. They surface as flaky timeouts on CI.