### PR TITLE
Emails: add button to send emails to event participants

### DIFF
--- a/src/core/rpc/index.ts
+++ b/src/core/rpc/index.ts
@@ -36,6 +36,7 @@ import { getSurveyResponseStatsDef } from 'features/surveys/rpc/getSurveyRespons
 import { getPublicOrganizationsDef } from 'features/public/rpc/organizations';
 import { addParticipantsDef } from 'features/events/rpc/addParticipants';
 import { getRootOrganizationDef } from 'features/organizations/rpc/getRootOrganization';
+import { createEmailFromEventParticipantsDef } from 'features/events/rpc/createEmailFromEventParticipants';
 
 export function createRPCRouter() {
   const rpcRouter = new RPCRouter();
@@ -50,6 +51,7 @@ export function createRPCRouter() {
   rpcRouter.register(surveyToListDef);
   rpcRouter.register(getTaskStatsRouteDef);
   rpcRouter.register(addBulkOptionsDef);
+  rpcRouter.register(createEmailFromEventParticipantsDef);
   rpcRouter.register(getEventStatsDef);
   rpcRouter.register(getPrevEventDayDef);
   rpcRouter.register(getNextEventDayDef);

--- a/src/features/emails/store.ts
+++ b/src/features/emails/store.ts
@@ -57,6 +57,11 @@ const emailsSlice = createSlice({
       state.emailList.isLoading = false;
       state.emailList.items.push(remoteItem(email.id, { data: email }));
     },
+    emailCreatedNoRedirect: (state, action: PayloadAction<ZetkinEmail>) => {
+      const email = action.payload;
+      state.emailList.isLoading = false;
+      state.emailList.items.push(remoteItem(email.id, { data: email }));
+    },
     emailDeleted: (state, action: PayloadAction<number>) => {
       const emailId = action.payload;
       const item = state.emailList.items.find((item) => item.id === emailId);
@@ -304,6 +309,7 @@ export const {
   configsLoaded,
   emailCreate,
   emailCreated,
+  emailCreatedNoRedirect,
   emailDeleted,
   emailLinksLoad,
   emailLinksLoaded,

--- a/src/features/events/components/EventActionButtons.tsx
+++ b/src/features/events/components/EventActionButtons.tsx
@@ -5,9 +5,10 @@ import {
   CancelOutlined,
   ContentCopy,
   Delete,
+  Email,
   RestoreOutlined,
 } from '@mui/icons-material';
-import React, { useContext, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import dayjs from 'dayjs';
 
 import messageIds from '../l10n/messageIds';
@@ -20,6 +21,9 @@ import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 import ZUIDatePicker from 'zui/ZUIDatePicker';
 import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
 import ChangeProjectDialog from '../../projects/components/ChangeProjectDialog';
+import useCreateEmailFromEventParticipants from 'features/events/hooks/useCreateEmailFromEventParticipants';
+import useEmailThemes from 'features/emails/hooks/useEmailThemes';
+import useEmailConfigs from 'features/emails/hooks/useEmailConfigs';
 
 interface EventActionButtonsProps {
   event: ZetkinEvent;
@@ -37,6 +41,40 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
   const router = useRouter();
   const duplicateEvent = useDuplicateEvent(orgId, event.id);
   const [isMoveDialogOpen, setIsMoveDialogOpen] = useState(false);
+
+  const themes = useEmailThemes(orgId).data || [];
+  const configs = useEmailConfigs(orgId).data || [];
+  const createEmailFromEventParticipants =
+    useCreateEmailFromEventParticipants();
+
+  const onSelectSendEmailToParticipants = useCallback(() => {
+    const eventTitle =
+      event.title || event.activity?.title || messages.common.noTitle();
+    createEmailFromEventParticipants({
+      emailTitle:
+        messages.eventActionButtons.sendEmailToParticipants.emailSubject({
+          eventTitle,
+        }),
+      eventId: event.id,
+      orgId: event.organization.id,
+    }).then((email) => {
+      window.open(
+        `/organize/${email.organization.id}/projects/${
+          email.campaign?.id || 'standalone'
+        }/emails/${email.id}/compose`,
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+  }, [
+    createEmailFromEventParticipants,
+    event.activity?.title,
+    event.id,
+    event.organization.id,
+    event.title,
+    messages.common,
+    messages.eventActionButtons.sendEmailToParticipants,
+  ]);
 
   const published =
     !!event.published && new Date(event.published) <= new Date();
@@ -170,6 +208,19 @@ const EventActionButtons: React.FunctionComponent<EventActionButtonsProps> = ({
               },
               startIcon: <Delete />,
             },
+            ...(configs.length && themes.length > 0
+              ? [
+                  {
+                    label: (
+                      <>
+                        {messages.eventActionButtons.sendEmailToParticipants.buttonTitle()}
+                      </>
+                    ),
+                    onSelect: onSelectSendEmailToParticipants,
+                    startIcon: <Email />,
+                  },
+                ]
+              : []),
           ]}
         />
       </Box>

--- a/src/features/events/hooks/useCreateEmailFromEventParticipants.ts
+++ b/src/features/events/hooks/useCreateEmailFromEventParticipants.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+
+import { emailCreate, emailCreatedNoRedirect } from 'features/emails/store';
+import { useApiClient, useAppDispatch } from 'core/hooks';
+import { ZetkinEmail } from 'utils/types/zetkin';
+import createEmailFromEventParticipants from 'features/events/rpc/createEmailFromEventParticipants';
+
+export type EmailToEventParticipantsParams = {
+  emailTitle: string;
+  eventId: number;
+  orgId: number;
+};
+
+export default function useCreateEmailFromEventParticipants(): (
+  params: EmailToEventParticipantsParams
+) => Promise<ZetkinEmail> {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+
+  return useCallback(
+    async (params: EmailToEventParticipantsParams) => {
+      dispatch(emailCreate());
+      const email = await apiClient.rpc<
+        EmailToEventParticipantsParams,
+        ZetkinEmail
+      >(createEmailFromEventParticipants, params);
+      dispatch(emailCreatedNoRedirect(email));
+      return email;
+    },
+    [apiClient, dispatch]
+  );
+}

--- a/src/features/events/l10n/messageIds.ts
+++ b/src/features/events/l10n/messageIds.ts
@@ -22,6 +22,10 @@ export default makeMessages('feat.events', {
     move: m('Move'),
     publish: m('Publish'),
     restore: m('Restore'),
+    sendEmailToParticipants: {
+      buttonTitle: m('Send email to participants'),
+      emailSubject: m<{ eventTitle: string }>('Re: {eventTitle}'),
+    },
     unpublish: m('Unpublish'),
     warning: m<{ eventTitle: string }>('"{eventTitle}" will be deleted.'),
     warningCancel: m<{ eventTitle: string }>(

--- a/src/features/events/rpc/createEmailFromEventParticipants.ts
+++ b/src/features/events/rpc/createEmailFromEventParticipants.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { makeRPCDef } from 'core/rpc/types';
+import {
+  ZetkinEmail,
+  ZetkinEmailPostBody,
+  ZetkinEvent,
+  ZetkinQuery,
+  ZetkinSmartSearchFilter,
+} from 'utils/types/zetkin';
+import { FILTER_TYPE, OPERATION } from 'features/smartSearch/components/types';
+
+const paramsSchema = z.object({
+  emailTitle: z.string(),
+  eventId: z.number(),
+  orgId: z.number(),
+});
+type Params = z.input<typeof paramsSchema>;
+type Result = ZetkinEmail;
+
+type ZetkinEmailPatchBody = Partial<Omit<ZetkinEmail, 'locked'>> & {
+  campaign_id?: number;
+  locked?: boolean;
+};
+
+export const createEmailFromEventParticipantsDef = {
+  handler: handle,
+  name: 'createEmailFromEventParticipants',
+  schema: paramsSchema,
+};
+
+export default makeRPCDef<Params, Result>(
+  createEmailFromEventParticipantsDef.name
+);
+
+async function handle(params: Params, apiClient: IApiClient) {
+  const { emailTitle, eventId, orgId } = params;
+
+  const event = await apiClient.get<ZetkinEvent>(
+    `/api/orgs/${orgId}/actions/${eventId}`
+  );
+
+  const createdEmail = await apiClient.post<ZetkinEmail, ZetkinEmailPostBody>(
+    `/api/orgs/${orgId}/emails`,
+    {
+      campaign_id: event.campaign?.id || null,
+      subject: emailTitle,
+      title: emailTitle,
+    }
+  );
+
+  const filterSpec: ZetkinSmartSearchFilter[] = [
+    {
+      config: {
+        action: eventId,
+        state: 'signed_up',
+      },
+      op: OPERATION.ADD,
+      type: FILTER_TYPE.EVENT_PARTICIPATION,
+    },
+    {
+      config: {
+        action: eventId,
+        state: 'booked',
+      },
+      op: OPERATION.ADD,
+      type: FILTER_TYPE.EVENT_PARTICIPATION,
+    },
+  ];
+
+  const targetQuery = await apiClient.patch<ZetkinQuery, Partial<ZetkinQuery>>(
+    `/api/orgs/${orgId}/people/queries/${createdEmail.target.id}`,
+    {
+      filter_spec: filterSpec,
+    }
+  );
+
+  await apiClient.patch<ZetkinEmail, ZetkinEmailPatchBody>(
+    `/api/orgs/${orgId}/emails/${createdEmail.id}`,
+    {
+      locked: true,
+    }
+  );
+
+  return {
+    ...createdEmail,
+    target: {
+      ...targetQuery,
+      filter_spec: filterSpec,
+    },
+  };
+}


### PR DESCRIPTION
## Description
This PR adds a button to the event ellipsis menu to send emails to event participants. It uses the event participation filter introduced in https://github.com/zetkin/app.zetkin.org/pull/3546 . 


## Screenshots
[Add screenshots here]
<img width="1081" height="862" alt="event-to-email" src="https://github.com/user-attachments/assets/5a40dad3-78ce-461d-9ece-58879a4f900b" />
<img width="1911" height="986" alt="email" src="https://github.com/user-attachments/assets/3f5949fa-a98a-4cf7-8dbd-34555252e1da" />


## Changes
[Add a list of features added/changed, bugs fixed etc]

The button works like this: 
- Create a new email
- Add a smart query target to the email that selects all booked and all signed up participants
- Lock the target group
- Open a new tab in the browser to the compose tab of the email


## Notes to reviewer
[Add instructions for testing]
This depends on https://github.com/zetkin/app.zetkin.org/pull/3546 which depends on backend changes. I branched off of that PR and made that branch the target of this PR. Once merged, we can retarget this PR to target main.