### PR TITLE
Emails: fix email feature showing incorrect error message

### DIFF
--- a/src/features/emails/layout/EmailLayout.tsx
+++ b/src/features/emails/layout/EmailLayout.tsx
@@ -34,7 +34,7 @@ const EmailLayout: FC<EmailLayoutProps> = ({
   const emailStatsFuture = useEmailStats(orgId, emailId);
   const emailState = useEmailState(orgId, emailId);
   const organization = useOrganization(orgId).data;
-  const themes = useEmailThemes(orgId).data || [];
+  const themes = useEmailThemes(orgId);
 
   if (!email || !organization) {
     return null;
@@ -121,7 +121,13 @@ const EmailLayout: FC<EmailLayoutProps> = ({
       >
         {children}
       </TabbedLayout>
-      <Dialog open={themes.length == 0}>
+      <Dialog
+        open={
+          !themes.isLoading &&
+          !themes.error &&
+          (!themes.data || themes.data.length === 0)
+        }
+      >
         <Box
           alignItems="center"
           display="flex"


### PR DESCRIPTION
## Description
This PR fixes an incorrect error message in the email feature. Before, the dialog shown in the screenshot would trigger whenever `themes.length` is 0, which was also the case when the data wasn't loaded yet. This PR ensures we check whether the themes are loaded before showing the error message.


## Screenshots
[Add screenshots here]
<img width="849" height="720" alt="email-error-message" src="https://github.com/user-attachments/assets/ac690f33-4430-4d0d-9790-2b865ac790cc" />



The error message says "Your organization does not have access to the email feature at the moment."
