### PR TITLE
Introduce useIndexedDB hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-storybook": "9.1.19",
         "eslint-plugin-yml": "^0.13.0",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "jest": "^29.0.0",
         "jest-environment-jsdom": "^30.2.0",
@@ -11236,6 +11237,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
         "eslint-plugin-react": "^7.22.0",
         "eslint-plugin-storybook": "9.1.19",
         "eslint-plugin-yml": "^0.13.0",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "jest": "^29.0.0",
         "jest-environment-jsdom": "^30.2.0",
@@ -13597,6 +13598,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-storybook": "9.1.19",
     "eslint-plugin-yml": "^0.13.0",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^9.1.7",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-storybook": "9.1.19",
     "eslint-plugin-yml": "^0.13.0",
+    "fake-indexeddb": "^6.2.5",
     "husky": "^9.1.7",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^30.2.0",

--- a/src/utils/testing/setup.ts
+++ b/src/utils/testing/setup.ts
@@ -1,5 +1,10 @@
 import { jest } from '@jest/globals';
 
+if (!global.structuredClone) {
+  global.structuredClone = <T>(value: T): T =>
+    JSON.parse(JSON.stringify(value));
+}
+
 jest.mock('next/font/google', () => ({
   Figtree: () => ({
     style: {

--- a/src/zui/hooks/useIndexedDB.spec.ts
+++ b/src/zui/hooks/useIndexedDB.spec.ts
@@ -1,0 +1,200 @@
+import 'fake-indexeddb/auto';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useIndexedDB } from './useIndexedDB';
+
+describe('useIndexedDB', () => {
+  const deleteDatabase = async (name: string) => {
+    await act(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.deleteDatabase(name);
+
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+        request.onblocked = () =>
+          reject(new Error(`Failed to delete blocked database: ${name}`));
+      });
+    });
+  };
+
+  const openDatabase = async (
+    name: string,
+    version: number,
+    storeName: string
+  ): Promise<IDBDatabase> => {
+    return await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(name, version);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName);
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+      request.onblocked = () =>
+        reject(new Error(`Open blocked for database: ${name}`));
+    });
+  };
+
+  const waitForReady = async <
+    T extends {
+      error: string | null;
+      loading: boolean;
+    }
+  >(result: {
+    current: T;
+  }) => {
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+  };
+
+  afterEach(async () => {
+    await deleteDatabase('test-db-1');
+    await deleteDatabase('test-db-2');
+    await deleteDatabase('test-db-3');
+    await deleteDatabase('test-db-4');
+  });
+
+  test('setItem/getItem/removeItem roundtrip', async () => {
+    const { result, unmount } = renderHook(() =>
+      useIndexedDB<{ a: number }>('test-db-1', 'store-1', { version: 1 })
+    );
+
+    await waitForReady(result);
+
+    await act(async () => {
+      await result.current.setItem('k1', { a: 1 });
+    });
+
+    expect(result.current.data).toEqual({ a: 1 });
+    expect(result.current.error).toBeNull();
+
+    let value: { a: number } | null = null;
+
+    await act(async () => {
+      value = await result.current.getItem('k1');
+    });
+
+    expect(value).toEqual({ a: 1 });
+    expect(result.current.data).toEqual({ a: 1 });
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      await result.current.removeItem('k1');
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      value = await result.current.getItem('k1');
+    });
+
+    expect(value).toBeNull();
+    expect(result.current.data).toBeNull();
+
+    await act(async () => {
+      unmount();
+    });
+  });
+
+  test('getAllKeys and clear', async () => {
+    const { result, unmount } = renderHook(() =>
+      useIndexedDB<string>('test-db-2', 'store-1', { version: 1 })
+    );
+
+    await waitForReady(result);
+
+    await act(async () => {
+      await result.current.setItem('a', 'A');
+      await result.current.setItem('b', 'B');
+    });
+
+    let keys: string[] = [];
+
+    await act(async () => {
+      keys = await result.current.getAllKeys();
+    });
+
+    expect(new Set(keys)).toEqual(new Set(['a', 'b']));
+
+    await act(async () => {
+      await result.current.clear();
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await act(async () => {
+      keys = await result.current.getAllKeys();
+    });
+
+    expect(keys).toEqual([]);
+
+    await act(async () => {
+      unmount();
+    });
+  });
+
+  test('calls onStaleVersionDetected and sets error on versionchange', async () => {
+    const onStaleVersionDetected = jest.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useIndexedDB('test-db-3', 'store-1', {
+        onStaleVersionDetected,
+        version: 1,
+      })
+    );
+
+    await waitForReady(result);
+
+    let upgradedDb: IDBDatabase;
+
+    await act(async () => {
+      upgradedDb = await openDatabase('test-db-3', 2, 'store-1');
+    });
+
+    await waitFor(() => {
+      expect(onStaleVersionDetected).toHaveBeenCalledTimes(1);
+      expect(result.current.error).toMatch(/new version/i);
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      upgradedDb.close();
+      unmount();
+    });
+  });
+
+  test('calls onUpgradeNeeded with correct old and new versions', async () => {
+    const onUpgradeNeeded = jest.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useIndexedDB('test-db-4', 'store-1', {
+        onUpgradeNeeded,
+        version: 3,
+      })
+    );
+
+    await waitForReady(result);
+
+    expect(onUpgradeNeeded).toHaveBeenCalledTimes(1);
+
+    const [db, oldVersion, newVersion] = onUpgradeNeeded.mock.calls[0];
+
+    expect(db).toBeInstanceOf(IDBDatabase);
+    expect(oldVersion).toBe(0);
+    expect(newVersion).toBe(3);
+
+    await act(async () => {
+      unmount();
+    });
+  });
+});

--- a/src/zui/hooks/useIndexedDB.ts
+++ b/src/zui/hooks/useIndexedDB.ts
@@ -1,0 +1,241 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface UseIndexedDBOptions {
+  version?: number;
+  onUpgradeNeeded?: (
+    db: IDBDatabase,
+    oldVersion: number,
+    newVersion: number
+  ) => void;
+  onStaleVersionDetected?: () => void;
+}
+
+interface UseIndexedDBReturn<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+  setItem: (key: string, value: T) => Promise<void>;
+  getItem: (key: string) => Promise<T | null>;
+  removeItem: (key: string) => Promise<void>;
+  clear: () => Promise<void>;
+  getAllKeys: () => Promise<string[]>;
+}
+
+export function useIndexedDB<T>(
+  databaseName: string,
+  storeName: string,
+  options: UseIndexedDBOptions = {}
+): UseIndexedDBReturn<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [db, setDb] = useState<IDBDatabase | null>(null);
+
+  const dbRef = useRef<IDBDatabase | null>(null);
+
+  const { version = 1, onUpgradeNeeded, onStaleVersionDetected } = options;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    let cancelled = false;
+
+    const closeCurrentDb = () => {
+      if (dbRef.current) {
+        try {
+          dbRef.current.close();
+        } catch {
+          // ignore
+        } finally {
+          dbRef.current = null;
+        }
+      }
+    };
+
+    const attachVersionChangeHandler = (database: IDBDatabase) => {
+      database.onversionchange = () => {
+        closeCurrentDb();
+        if (!cancelled) {
+          setDb(null);
+          setLoading(false);
+          setError(
+            'A new version of the app data is available. Please reload this tab to continue.'
+          );
+
+          onStaleVersionDetected?.();
+        }
+      };
+    };
+
+    const initDB = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        closeCurrentDb();
+
+        const request = indexedDB.open(databaseName, version);
+
+        request.onblocked = () => {
+          if (!cancelled) {
+            setError(
+              'Database open/upgrade is blocked by another tab that still has the database open. Close other tabs or reload them to continue.'
+            );
+            setLoading(false);
+          }
+        };
+
+        request.onerror = () => {
+          if (!cancelled) {
+            setError(`Failed to open database: ${request.error?.message}`);
+            setLoading(false);
+          }
+        };
+
+        request.onsuccess = () => {
+          const database = request.result;
+          dbRef.current = database;
+          attachVersionChangeHandler(database);
+
+          if (!cancelled) {
+            setDb(database);
+            setLoading(false);
+          }
+        };
+
+        request.onupgradeneeded = (event) => {
+          const database = request.result;
+          dbRef.current = database;
+          attachVersionChangeHandler(database);
+
+          const oldVersion = event.oldVersion;
+          const newVersion = event.newVersion || version;
+
+          if (!database.objectStoreNames.contains(storeName)) {
+            database.createObjectStore(storeName);
+          }
+
+          if (onUpgradeNeeded) {
+            onUpgradeNeeded(database, oldVersion, newVersion);
+          }
+        };
+      } catch (err) {
+        if (!cancelled) {
+          setError(`IndexedDB initialization error: ${err}`);
+          setLoading(false);
+        }
+      }
+    };
+
+    void initDB();
+
+    return () => {
+      cancelled = true;
+      closeCurrentDb();
+    };
+  }, [
+    databaseName,
+    storeName,
+    version,
+    onUpgradeNeeded,
+    onStaleVersionDetected,
+  ]);
+
+  const runStoreRequest = useCallback(
+    <R = undefined>(
+      mode: IDBTransactionMode,
+      makeRequest: (store: IDBObjectStore) => IDBRequest<R>,
+      onSuccess?: (result: R) => void
+    ): Promise<R> => {
+      if (!db) {
+        throw new Error('Database not initialized');
+      }
+
+      return new Promise<R>((resolve, reject) => {
+        const transaction = db.transaction([storeName], mode);
+        const store = transaction.objectStore(storeName);
+        const request = makeRequest(store);
+
+        request.onsuccess = () => {
+          const result = request.result as R;
+          onSuccess?.(result);
+          resolve(result);
+        };
+
+        request.onerror = () => {
+          const op = mode === 'readonly' ? 'read from' : 'write to';
+          const errorMsg = `Failed to ${op} store: ${request.error?.message}`;
+          setError(errorMsg);
+          reject(new Error(errorMsg));
+        };
+      });
+    },
+    [db, storeName]
+  );
+
+  const setItem = useCallback(
+    async (key: string, value: T): Promise<void> => {
+      await runStoreRequest<IDBValidKey>(
+        'readwrite',
+        (store) => store.put(value, key),
+        () => setData(value)
+      );
+    },
+    [runStoreRequest]
+  );
+
+  const getItem = useCallback(
+    async (key: string): Promise<T | null> => {
+      const result = await runStoreRequest<T | undefined>(
+        'readonly',
+        (store) => store.get(key),
+        (value) => setData((value as T | undefined) ?? null)
+      );
+
+      return (result as T | undefined) ?? null;
+    },
+    [runStoreRequest]
+  );
+
+  const removeItem = useCallback(
+    async (key: string): Promise<void> => {
+      await runStoreRequest(
+        'readwrite',
+        (store) => store.delete(key),
+        () => setData(null)
+      );
+    },
+    [runStoreRequest]
+  );
+
+  const clear = useCallback(async (): Promise<void> => {
+    await runStoreRequest(
+      'readwrite',
+      (store) => store.clear(),
+      () => setData(null)
+    );
+  }, [runStoreRequest]);
+
+  const getAllKeys = useCallback(async (): Promise<string[]> => {
+    const keys = await runStoreRequest<IDBValidKey[]>('readonly', (store) =>
+      store.getAllKeys()
+    );
+
+    return keys.map(String);
+  }, [runStoreRequest]);
+
+  return {
+    clear,
+    data,
+    error,
+    getAllKeys,
+    getItem,
+    loading,
+    removeItem,
+    setItem,
+  };
+}


### PR DESCRIPTION
## Description
This PR introduces the `useIndexedDB` hook.


## Screenshots

_no screenshots_


## Changes

* Adds an implementation (+ tests) for how to work with IndexedDB from a React hook.


## Notes to reviewer
The implementation is based on useHooks.io's `useIndexedDB` hook.


## Related issues
Relates to #2979 + superseeds #3503
