### PR TITLE
API v2 proxy: fix 401 handling

### DIFF
--- a/src/app/api2/[...path]/route.ts
+++ b/src/app/api2/[...path]/route.ts
@@ -70,10 +70,10 @@ async function proxy(
   }
 
   let zetkinResponse: Response = await makeZetkinApiRequest();
+  let payload = await zetkinResponse.json();
 
   if (zetkinResponse.status == 401) {
-    const errorPayload = await zetkinResponse.json();
-    if (errorPayload.error?.includes('invalid_token')) {
+    if (payload.error?.includes('invalid_token')) {
       if (session.tokenData?.refresh_token) {
         const refreshData = new URLSearchParams({
           grant_type: 'refresh_token',
@@ -91,12 +91,11 @@ async function proxy(
           method: 'POST',
         });
 
-        const payload = await refreshResponse.json();
-
-        session.tokenData = payload;
+        session.tokenData = await refreshResponse.json();
         await session.save();
 
         zetkinResponse = await makeZetkinApiRequest();
+        payload = zetkinResponse.json();
       }
     }
   }
@@ -104,8 +103,6 @@ async function proxy(
   if (zetkinResponse.status == 204) {
     return new NextResponse(null, { status: 204 });
   } else {
-    const zetkinPayload = await zetkinResponse.json();
-
-    return NextResponse.json(zetkinPayload, { status: zetkinResponse.status });
+    return NextResponse.json(payload, { status: zetkinResponse.status });
   }
 }


### PR DESCRIPTION
## Description
This PR fixes a mishandle of 401 responses that don't have a refresh token. The current code returns a http 500 Internal Server Error, because it reads `.json()` twice, resulting in this error on the proxy:
```
 ⨯ TypeError: Body is unusable: Body has already been read
```

I fixed it by moving .json() into a separate variable, making sure it is read exactly once. 

## Notes to reviewer
[Add instructions for testing]
- Log out of app.dev.zetkin.org
- Go to https://app.dev.zetkin.org/api2/orgs/1/areas
- Observe there is an error 500
- Go to the preview server at the same path
- Observe it is an error 401 with json body `{"error":"invalid_token","error_description":"Invalid token: access token is invalid"}`

