### PR TITLE
Use pointer events to stop element from blocking map

### DIFF
--- a/src/features/canvass/components/CanvassMapOverlays.tsx
+++ b/src/features/canvass/components/CanvassMapOverlays.tsx
@@ -59,12 +59,17 @@ const CanvassMapOverlays: FC<Props> = ({
             gap: 8,
             justifyContent: 'center',
             padding: 8,
+            pointerEvents: 'none',
             position: 'absolute',
             width: '100%',
             zIndex: 1000,
           }}
         >
-          <Button onClick={() => onToggleCreating(true)} variant="contained">
+          <Button
+            onClick={() => onToggleCreating(true)}
+            sx={{ pointerEvents: 'all' }}
+            variant="contained"
+          >
             <Msg id={messageIds.map.addLocation.add} />
           </Button>
         </Box>


### PR DESCRIPTION
## Description
This PR fixes issue where part of map wasn't interactive
The containing element of the button blocked pointer events from reaching the map. This PR sets `pointer-events: none` on the parent element, then `pointer-events: all` on the actual button element.


## Screenshots
https://github.com/user-attachments/assets/5120e951-b919-43cf-b5c5-91973fc6bfde



## Changes
* Adds pointer-events: none to enclosing element to enable map clicks.


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #3562 
