### PR TITLE
Make it more clear what email linking dialog will do

### DIFF
--- a/src/features/surveys/components/SurveyLinkDialog.tsx
+++ b/src/features/surveys/components/SurveyLinkDialog.tsx
@@ -55,25 +55,40 @@ const SurveyLinkDialog = ({
           </Box>
 
           <Box
-            mb={2}
             sx={{
-              alignItems: 'start',
+              alignItems: 'center',
               display: 'flex',
-              flexDirection: 'column',
+              flexWrap: 'wrap',
+              gap: 2,
+              marginBlock: 2,
             }}
           >
-            {email}
-            <ArrowDownward
-              color="secondary"
-              sx={{
-                opacity: '50%',
-              }}
-            />
-            {person.email}
+            <Box>
+              <Box
+                sx={{
+                  fontSize: '0.825rem',
+                }}
+              >
+                {messages.surveyDialog.new().toLocaleUpperCase()}
+              </Box>
+              <Box sx={{ fontWeight: 'bold' }}>{email}</Box>
+            </Box>
+            <Box>
+              <Box
+                sx={{
+                  fontSize: '0.825rem',
+                }}
+              >
+                {messages.surveyDialog.old().toLocaleUpperCase()}
+              </Box>
+              <Box sx={{ fontWeight: 'bold', textDecoration: 'line-through' }}>
+                {person.email}
+              </Box>
+            </Box>
           </Box>
           {messages.surveyDialogDifferentEmail.description()}
         </DialogContent>
-        <DialogActions sx={{ padding: '20px 24px' }}>
+        <DialogActions sx={{ padding: '24px' }}>
           <Button onClick={onClose}>
             {messages.surveyDialogDifferentEmail.keep()}
           </Button>

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -235,6 +235,8 @@ export default makeMessages('feat.surveys', {
     description: m(
       'The person you have just linked does not have an email address while the survey response does. Would you like to add it the person?'
     ),
+    new: m('New'),
+    old: m('Old'),
     title: m('Add email address'),
   },
   surveyDialogDifferentEmail: {


### PR DESCRIPTION
## Description
This PR changes layout of email linking dialog to make it more clear which email will be replaced


## Screenshots
<img width="601" height="343" alt="Screenshot_2026-03-08_18-51-05" src="https://github.com/user-attachments/assets/83b05c93-82e6-4fe9-a9c8-b8917db495a8" />
<img width="601" height="406" alt="Screenshot_2026-03-08_18-52-08" src="https://github.com/user-attachments/assets/d639d6ce-5eb1-4678-8d26-cbcae83cdfba" />




## Changes
* Changes email replacement layout


## Notes to reviewer
[Add instructions for testing]


## Related issues
Resolves #3559 
