### PR TITLE
Update jest types to 29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/chance": "^1.1.3",
         "@types/is-url": "^1.2.30",
-        "@types/jest": "^27.0.2",
+        "@types/jest": "^29.0.0",
         "@types/leaflet": "^1.9.3",
         "@types/marked": "^4.0.3",
         "@types/negotiator": "^0.6.1",
@@ -217,7 +217,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -758,7 +757,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -780,7 +778,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -887,7 +884,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -922,7 +918,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -964,7 +959,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2688,7 +2682,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -3166,7 +3159,6 @@
     "node_modules/@mui/material": {
       "version": "7.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@mui/core-downloads-tracker": "^7.0.1",
@@ -3299,7 +3291,6 @@
     "node_modules/@mui/system": {
       "version": "7.0.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@mui/private-theming": "^7.0.1",
@@ -4344,7 +4335,6 @@
     "node_modules/@nivo/core": {
       "version": "0.80.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nivo/recompose": "0.80.0",
         "@react-spring/web": "9.4.5",
@@ -4533,7 +4523,6 @@
       "version": "1.56.1",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -7941,7 +7930,6 @@
       "version": "7.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8027,7 +8015,6 @@
       "version": "9.3.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8156,7 +8143,6 @@
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -8645,7 +8631,6 @@
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -8697,97 +8682,15 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.0.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "jest-diff": "^27.0.0",
-        "pretty-format": "^27.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/@jest/types": {
-      "version": "27.2.5",
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
-    },
-    "node_modules/@types/jest/node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/diff-sequences": {
-      "version": "27.0.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "27.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.0.6",
-        "jest-get-type": "^27.3.1",
-        "pretty-format": "^27.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-get-type": {
-      "version": "27.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "27.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^27.2.5",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
@@ -8878,7 +8781,6 @@
     "node_modules/@types/node": {
       "version": "22.19.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8931,7 +8833,6 @@
     "node_modules/@types/react": {
       "version": "18.0.18",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -8942,7 +8843,6 @@
       "version": "18.0.6",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -9096,7 +8996,6 @@
       "version": "8.46.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -9710,7 +9609,6 @@
     "node_modules/acorn": {
       "version": "8.12.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10729,7 +10627,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11952,7 +11849,6 @@
     "node_modules/date-fns": {
       "version": "2.26.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -11963,8 +11859,7 @@
     },
     "node_modules/dayjs": {
       "version": "1.10.7",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debounce-fn": {
       "version": "5.1.2",
@@ -13075,7 +12970,6 @@
       "version": "0.20.2",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13187,7 +13081,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13728,7 +13621,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14192,7 +14084,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16995,7 +16886,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -18302,7 +18192,6 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -18572,8 +18461,7 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.3",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/lettercoder": {
       "version": "0.0.4",
@@ -18816,7 +18704,6 @@
     "node_modules/maplibre-gl": {
       "version": "5.6.0",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -20446,7 +20333,6 @@
     "node_modules/next": {
       "version": "14.2.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -21628,7 +21514,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -21762,7 +21647,6 @@
       "version": "2.5.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -21858,7 +21742,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -22131,7 +22014,6 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -22290,7 +22172,6 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -22399,7 +22280,6 @@
     "node_modules/react-redux": {
       "version": "8.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -22438,7 +22318,6 @@
       "version": "0.14.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22606,7 +22485,6 @@
     "node_modules/redux": {
       "version": "4.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -23282,7 +23160,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -23428,7 +23305,6 @@
     "node_modules/servie": {
       "version": "4.3.3",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@servie/events": "^1.0.0",
         "byte-length": "^1.0.2",
@@ -23699,7 +23575,6 @@
     "node_modules/slate": {
       "version": "0.94.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "immer": "^9.0.6",
         "is-plain-object": "^5.0.0",
@@ -23955,7 +23830,6 @@
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.6.15.tgz",
       "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.15"
       },
@@ -24806,7 +24680,6 @@
       "version": "10.9.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -25438,7 +25311,6 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26279,7 +26151,6 @@
       "version": "5.92.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
@@ -26364,7 +26235,6 @@
       "version": "2.25.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/chance": "^1.1.3",
     "@types/is-url": "^1.2.30",
-    "@types/jest": "^27.0.2",
+    "@types/jest": "^29.0.0",
     "@types/leaflet": "^1.9.3",
     "@types/marked": "^4.0.3",
     "@types/negotiator": "^0.6.1",


### PR DESCRIPTION
Currently, when running `npm install`, we get this output:


```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: @testing-library/jest-dom@6.4.6
npm warn Found: @types/jest@27.0.3
npm warn node_modules/@types/jest
npm warn   dev @types/jest@"^27.0.2" from the root project
npm warn
npm warn Could not resolve dependency:
npm warn peerOptional @types/jest@">= 28" from @testing-library/jest-dom@6.4.6
npm warn node_modules/@testing-library/jest-dom
npm warn   @testing-library/jest-dom@"^6.4.2" from @storybook/test@8.1.10
npm warn   node_modules/@storybook/test
npm warn
npm warn Conflicting peer dependency: @types/jest@30.0.0
npm warn node_modules/@types/jest
npm warn   peerOptional @types/jest@">= 28" from @testing-library/jest-dom@6.4.6
npm warn   node_modules/@testing-library/jest-dom
npm warn     @testing-library/jest-dom@"^6.4.2" from @storybook/test@8.1.10
npm warn     node_modules/@storybook/test
```

Updating `@types/jest` to version 29 fixes this which should result in more compatible packages and fewer potentially confusing messages when initially setting up the project.