### PR TITLE
Only allow writable custom fields in join form configuration

### DIFF
--- a/src/features/joinForms/panes/JoinFormPane.tsx
+++ b/src/features/joinForms/panes/JoinFormPane.tsx
@@ -36,8 +36,6 @@ const JoinFormPane: FC<Props> = ({ orgId, formId }) => {
       field !== NATIVE_PERSON_FIELDS.EXT_ID && field !== NATIVE_PERSON_FIELDS.ID
   );
 
-  // Only include custom fields that either belong to this org or are
-  // shared from parent org with org_write='suborgs'
   const writableCustomFields =
     customFields.data?.filter(
       (field) => field.organization.id == orgId || field.org_write == 'suborgs'
@@ -52,7 +50,7 @@ const JoinFormPane: FC<Props> = ({ orgId, formId }) => {
       (nativeSlug) => nativeSlug == slug
     );
     if (isNativeField) {
-      const typedSlug = slug as (typeof nativePersonFields)[number];
+      const typedSlug = slug as typeof nativePersonFields[number];
       return globalMessages.personFields[typedSlug]();
     } else {
       const field = customFields.data?.find((field) => field.slug == slug);


### PR DESCRIPTION
## Description
This PR filters out non-writable custom fields in the join form configuration. I.e. it allows selection of custom fields from the current organization or a shared field from a parent organization which has `org_write` set to `'suborgs'`.

## Screenshots
This is in a sub-organization, where both extra text and extra date are shared from the parent organization, but only the extra text field allows the current organization to write to it.
<img width="693" height="941" alt="image" src="https://github.com/user-attachments/assets/e3405850-2c36-4146-8912-108a1e1ecf58" />

## Changes
* Filters out non-writable fields in the join form configuration.

## Notes to reviewer
To allow shared fields to be configured at all without a server error, merge zetkin/zetkin-platform#1059
