### PR TITLE
Update lodash to 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "leaflet": "^1.9.3",
         "letterparser": "^0.0.8",
         "libphonenumber-js": "^1.10.51",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "maplibre-gl": "^5.6.0",
         "marked": "^4.0.16",
         "mjml": "^4.15.3",
@@ -16501,7 +16501,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "leaflet": "^1.9.3",
     "letterparser": "^0.0.8",
     "libphonenumber-js": "^1.10.51",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "maplibre-gl": "^5.6.0",
     "marked": "^4.0.16",
     "mjml": "^4.15.3",


### PR DESCRIPTION
This PR updates lodash to the lastest patch version which resolves a warning about a vulnerability. 