### PR TITLE
Remove unused date-handling dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "41.0.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@date-io/date-fns": "1.x",
-        "@date-io/dayjs": "1.x",
         "@editorjs/editorjs": "^2.28.2",
         "@editorjs/header": "^2.8.1",
         "@editorjs/paragraph": "^2.11.3",
@@ -45,7 +43,6 @@
         "@vis.gl/react-maplibre": "^8.0.4",
         "@visx/wordcloud": "^3.12.0",
         "copy-to-clipboard": "^3.3.1",
-        "date-fns": "^2.22.1",
         "dayjs": "^1.10.6",
         "fuse.js": "^6.5.3",
         "intl-messageformat": "^10.3.1",
@@ -777,30 +774,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@date-io/core": {
-      "version": "1.3.13",
-      "license": "MIT"
-    },
-    "node_modules/@date-io/date-fns": {
-      "version": "1.3.13",
-      "license": "MIT",
-      "dependencies": {
-        "@date-io/core": "^1.3.13"
-      },
-      "peerDependencies": {
-        "date-fns": "^2.0.0"
-      }
-    },
-    "node_modules/@date-io/dayjs": {
-      "version": "1.3.13",
-      "license": "MIT",
-      "dependencies": {
-        "@date-io/core": "^1.3.13"
-      },
-      "peerDependencies": {
-        "dayjs": "^1.8.17"
       }
     },
     "node_modules/@editorjs/editorjs": {
@@ -11977,17 +11950,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.26.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "make-yaml": "ts-node src/tools/make-yaml.ts"
   },
   "dependencies": {
-    "@date-io/date-fns": "1.x",
-    "@date-io/dayjs": "1.x",
     "@editorjs/editorjs": "^2.28.2",
     "@editorjs/header": "^2.8.1",
     "@editorjs/paragraph": "^2.11.3",
@@ -62,7 +60,6 @@
     "@vis.gl/react-maplibre": "^8.0.4",
     "@visx/wordcloud": "^3.12.0",
     "copy-to-clipboard": "^3.3.1",
-    "date-fns": "^2.22.1",
     "dayjs": "^1.10.6",
     "fuse.js": "^6.5.3",
     "intl-messageformat": "^10.3.1",


### PR DESCRIPTION
The package.json currently contains 4 dependencies that can be used for better `Date` manipulation: `@date-io/date-fns`, `@date-io/dayjs`,  `date-fns` and `dayjs`. Out of those, only `dayjs` is actually used.

Let's remove the other ones to avoid future confusion.