### PR TITLE
Fix: Guard draft state of editing

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/OpenQuestionBlock.tsx
@@ -147,9 +147,6 @@ const OpenQuestionBlock: FC<OpenQuestionBlockProps> = ({
               margin="normal"
               onChange={(event) => {
                 handleSelect(event);
-                setMultiline(
-                  event.target.value === FIELDTYPE.MULTILINE ? true : false
-                );
               }}
               select
               SelectProps={{


### PR DESCRIPTION
## Description
Restore question block state on rerender and handle editing status with `useRef`.

## Changes
[Add a list of features added/changed, bugs fixed etc]

* Changes OpenQuestionBlock


## Notes to reviewer
I think about improving the change and generalizing the solution. But as it is already a fix, I thought about creating the pull request nevertheless.


## Related issues
Resolves #2510
