### PR TITLE
Fix survey insights subtitle wording for multi-select questions (#3576)

### DIFF
--- a/src/features/surveys/components/ResponseStatsCards.tsx
+++ b/src/features/surveys/components/ResponseStatsCards.tsx
@@ -493,13 +493,21 @@ const OptionsStatsCard = ({
   const messages = useMessages(messageIds);
 
   const subheader = useMemo(
-    () =>
-      messages.insights.optionsFields.subheader({
-        answerCount: questionStats.answerCount,
-        totalSelectedOptionsCount: questionStats.totalSelectedOptionsCount,
-      }),
+    () => {
+      const isMultiple = questionStats.question.question.response_config.widget_type === 'checkbox';
+      if (isMultiple) {
+        return messages.insights.optionsFields.subheaderMultiple({
+          answerCount: questionStats.answerCount,
+          totalSelectedOptionsCount: questionStats.totalSelectedOptionsCount,
+        });
+      } else {
+        return messages.insights.optionsFields.subheaderSingle({
+          answerCount: questionStats.answerCount,
+        });
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [questionStats, messages.insights.optionsFields.subheader]
+    [questionStats, messages.insights.optionsFields.subheaderMultiple, messages.insights.optionsFields.subheaderSingle]
   );
 
   const exportApi = useRef<UseChartProExportPublicApi>();

--- a/src/features/surveys/l10n/messageIds.ts
+++ b/src/features/surveys/l10n/messageIds.ts
@@ -114,11 +114,16 @@ export default makeMessages('feat.surveys', {
       toPng: m('Export to png'),
     },
     optionsFields: {
-      subheader: m<{
+      subheaderMultiple: m<{
         answerCount: number;
         totalSelectedOptionsCount: number;
       }>(
-        'In total, there were {answerCount, plural, =1 {1 answer} other {# answers}} and {totalSelectedOptionsCount, plural, =1 {1 selected option} other {# selected options}}.'
+        '{answerCount, plural, =1 {1 response} other {# responses}}, {totalSelectedOptionsCount, plural, =1 {1 option} other {# options}} selected in total.'
+      ),
+      subheaderSingle: m<{
+        answerCount: number;
+      }>(
+        '{answerCount, plural, =1 {1 response} other {# responses}}.'
       ),
       tabs: {
         barPlot: m('Bar'),

--- a/src/locale/da.yml
+++ b/src/locale/da.yml
@@ -1044,6 +1044,25 @@ feat:
       previewPortal: Se forhåndsvisning af spørgeskemaet i aktivistportalen
       visitPortal: Se spørgeskema i aktivistportalen
       willAccept: Vil acceptere besvarelser gennem dette link
+    insights:
+      error: Der opstod en ukendt fejl under indlæsning.
+      export:
+        errorUnknown: Der opstod en ukendt fejl under eksport.
+        toPdf: Eksporter som PDF
+        toPng: Eksporter som PNG
+      optionsFields:
+        subheaderMultiple: '{answerCount, plural, =1 {1 svar} other {# svar}}, {totalSelectedOptionsCount, plural, =1 {1 mulighed} other {# muligheder}} valgt i alt.'
+        subheaderSingle: '{answerCount, plural, =1 {1 svar} other {# svar}}.'
+        tabs:
+          barPlot: Søjle
+          piePlot: Lagkage
+        warningMultipleSelectedOptionsPie: Bemærk, at dette spørgsmål tillader respondenter at vælge mere end én mulighed, og {respondentCount, plural, =1 {1 respondent} other {# respondenter}} gjorde det. Dette kan gøre lagkagediagrammet misvisende.
+      textFields:
+        subheader: I alt var der {answerCount, plural, =1 {1 svar} other {# svar}}, {totalWordCount, plural, =1 {1 ord} other {# ord}} og {totalUniqueWordCount, plural, =1 {1 unikt ord} other {# unikke ord}}.
+        tabs:
+          responses: Svar
+          wordCloud: Sky
+          wordFrequencies: Søjle
   tags:
     dialog:
       colorErrorText: Indtast venligst en gyldig hex-kode

--- a/src/locale/de.yml
+++ b/src/locale/de.yml
@@ -2872,9 +2872,8 @@ feat:
         toPdf: Als PDF exportieren
         toPng: Als PNG exportieren
       optionsFields:
-        subheader: Insgesamt gab es {answerCount, plural, =1 {1 Antwort} other {#
-          Antworten}} und {totalSelectedOptionsCount, plural, =1 {1 ausgewählte
-          Option} other {# ausgewählte Optionen}}.
+        subheaderMultiple: '{answerCount, plural, =1 {1 Antwort} other {# Antworten}}, {totalSelectedOptionsCount, plural, =1 {1 Option} other {# Optionen}} insgesamt ausgewählt.'
+        subheaderSingle: '{answerCount, plural, =1 {1 Antwort} other {# Antworten}}.'
         tabs:
           barPlot: Balkendiagramm
           piePlot: Kreisdiagramm

--- a/src/locale/en.yml
+++ b/src/locale/en.yml
@@ -2103,6 +2103,25 @@ feat:
       previewPortal: Preview survey in activist portal
       visitPortal: Visit survey in activist portal
       willAccept: Will accept submissions at this link
+    insights:
+      error: An unknown error occurred while loading.
+      export:
+        errorUnknown: An unknown error occurred while Zetkin exported.
+        toPdf: Export as PDF
+        toPng: Export as PNG
+      optionsFields:
+        subheaderMultiple: '{answerCount, plural, =1 {1 response} other {# responses}}, {totalSelectedOptionsCount, plural, =1 {1 option} other {# options}} selected in total.'
+        subheaderSingle: '{answerCount, plural, =1 {1 response} other {# responses}}.'
+        tabs:
+          barPlot: Bar
+          piePlot: Pie
+        warningMultipleSelectedOptionsPie: Note that this question allows respondents to choose more than one option, and {respondentCount, plural, =1 {1 respondent} other {# respondents}} did. This may make the pie chart misleading.
+      textFields:
+        subheader: In total, there were {answerCount, plural, =1 {1 answer} other {# answers}}, {totalWordCount, plural, =1 {1 word} other {# words}} and {totalUniqueWordCount, plural, =1 {1 unique word} other {# unique words}}.
+        tabs:
+          responses: Response
+          wordCloud: Cloud
+          wordFrequencies: Bar
   tags:
     dialog:
       colorErrorText: Please enter a valid hex code

--- a/src/locale/nl.yml
+++ b/src/locale/nl.yml
@@ -2093,6 +2093,25 @@ feat:
       previewPortal: Preview de vragenlijst in activistenportaal
       visitPortal: Bezoek de vragenlijst in activistenportaal
       willAccept: Inzendingen zijn nu mogelijk via deze link
+    insights:
+      error: Er is een onbekende fout opgetreden tijdens het laden.
+      export:
+        errorUnknown: Er is een onbekende fout opgetreden tijdens het exporteren.
+        toPdf: Exporteren als PDF
+        toPng: Exporteren als PNG
+      optionsFields:
+        subheaderMultiple: '{answerCount, plural, =1 {1 antwoord} other {# antwoorden}}, {totalSelectedOptionsCount, plural, =1 {1 optie} other {# opties}} in totaal geselecteerd.'
+        subheaderSingle: '{answerCount, plural, =1 {1 antwoord} other {# antwoorden}}.'
+        tabs:
+          barPlot: Staaf
+          piePlot: Taart
+        warningMultipleSelectedOptionsPie: Let op dat deze vraag respondenten toelaat meer dan één optie te kiezen, en {respondentCount, plural, =1 {1 respondent} other {# respondenten}} deed dat. Dit kan het taartdiagram misleidend maken.
+      textFields:
+        subheader: In totaal waren er {answerCount, plural, =1 {1 antwoord} other {# antwoorden}}, {totalWordCount, plural, =1 {1 woord} other {# woorden}} en {totalUniqueWordCount, plural, =1 {1 uniek woord} other {# unieke woorden}}.
+        tabs:
+          responses: Antwoord
+          wordCloud: Wolk
+          wordFrequencies: Staaf
   tags:
     dialog:
       colorErrorText: Gebruik een geldige hex code

--- a/src/locale/nn.yml
+++ b/src/locale/nn.yml
@@ -2954,11 +2954,8 @@ feat:
         toPdf: Eksporter som PDF
         toPng: Eksporter som PNG
       optionsFields:
-        subheader: >+
-          Det er totalt {answerCount, plural, =1 {1 svar} other {# svar}} og
-          {totalSelectedOptionsCount, plural, =1 {1 valgt alternativ} other {#
-          valgte alternativer}}.
-
+        subheaderMultiple: '{answerCount, plural, =1 {1 svar} other {# svar}}, {totalSelectedOptionsCount, plural, =1 {1 alternativ} other {# alternativer}} valgt totalt.'
+        subheaderSingle: '{answerCount, plural, =1 {1 svar} other {# svar}}.'
         tabs:
           barPlot: Søyler
           piePlot: Kake

--- a/src/locale/sv.yml
+++ b/src/locale/sv.yml
@@ -2771,8 +2771,12 @@ feat:
         toPdf: Exportera till pdf
         toPng: Exportera till png
       optionsFields:
+        subheaderMultiple: '{answerCount, plural, =1 {1 svar} other {# svar}}, {totalSelectedOptionsCount, plural, =1 {1 alternativ} other {# alternativ}} valda totalt.'
+        subheaderSingle: '{answerCount, plural, =1 {1 svar} other {# svar}}.'
         tabs:
           barPlot: Stapel
+          piePlot: Paj
+        warningMultipleSelectedOptionsPie: Observera att denna fråga tillåter respondenter att välja mer än ett alternativ, och {respondentCount, plural, =1 {1 respondent} other {# respondenter}} gjorde det. Detta kan göra pajdiagrammet missvisande.
       textFields:
         tabs:
           responses: Svar


### PR DESCRIPTION
## Description
Fix survey insights subtitle wording for multi-select questions (#3576)

## Screenshots
[
<img width="754" height="586" alt="addedLogic" src="https://github.com/user-attachments/assets/72f90315-bc5c-4cee-8cd5-a6bc454e8cf6" />
<img width="753" height="591" alt="subdheaderMultiple(Line117)" src="https://github.com/user-attachments/assets/b73c2140-796b-4ee3-8324-90194158507c" />
<img width="751" height="588" alt="subdheaderSingle(Line123)" src="https://github.com/user-attachments/assets/0db2daa3-4d69-498c-9b92-61e1513da35a" />
]


## Changes
1. Updated message definitions in messageIds.ts
2. Modified the component logic in ResponseStatsCards.tsx

* Adds…
* Changes…
1. Replaced the single subheader message subheaderSingle and subheaderMultiple.
2. Added logic to check questionStats.question.question.response_src/features/components/ResponseStatsCards.tsx to determine if multiple selections are allowed.
3. Uses appropriate message based on question type.
4. 
## Notes to reviewer
[Pending Review]

## Related issues
Resolves #[3576]
Pending Review
