### PR TITLE
Consolidate jest typing with `@jest/globals`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.17.9",
+        "@jest/globals": "^29.0.0",
         "@playwright/test": "~1.56.1",
         "@storybook/addon-docs": "9.1.19",
         "@storybook/addon-links": "9.1.19",
@@ -102,7 +103,6 @@
         "@testing-library/user-event": "^14.4.3",
         "@types/chance": "^1.1.3",
         "@types/is-url": "^1.2.30",
-        "@types/jest": "^29.0.0",
         "@types/leaflet": "^1.9.3",
         "@types/marked": "^4.0.3",
         "@types/negotiator": "^0.6.1",
@@ -2496,10 +2496,6 @@
         "geojson-rewind": "geojson-rewind"
       }
     },
-    "node_modules/@mapbox/geojson-rewind/node_modules/minimist": {
-      "version": "1.2.6",
-      "license": "MIT"
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "engines": {
@@ -2547,13 +2543,6 @@
         "gl-style-format": "dist/gl-style-format.mjs",
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/minimist": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -6363,13 +6352,8 @@
       "dependencies": {
         "locate-path": "^7.2.0",
         "path-exists": "^5.0.0",
+        "undici-types": "~5.26.4",
         "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/locate-path": {
@@ -6430,6 +6414,22 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/@storybook/preset-react-webpack/node_modules/resolve": {
+      "version": "1.22.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@storybook/preset-react-webpack/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -6442,6 +6442,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@storybook/preset-react-webpack/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/yocto-queue": {
       "version": "1.2.2",
@@ -6970,88 +6977,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-diff": "^27.0.0",
-        "pretty-format": "^27.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/jsdom": {
       "version": "21.1.7",
       "dev": true,
@@ -7139,7 +7064,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.1",
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -11874,6 +11801,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-import/node_modules/resolve": {
+      "version": "1.22.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "dev": true,
@@ -12522,7 +12470,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12530,7 +12480,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -16931,13 +16881,6 @@
       "version": "4.0.0",
       "license": "MIT"
     },
-    "node_modules/maplibre-gl/node_modules/minimist": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "dev": true,
@@ -17874,9 +17817,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "7.1.3",
@@ -22805,10 +22752,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/minimist": {
-      "version": "1.2.6",
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -23331,6 +23274,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.9",
+    "@jest/globals": "^29.0.0",
     "@playwright/test": "~1.56.1",
     "@storybook/addon-docs": "9.1.19",
     "@storybook/addon-links": "9.1.19",
@@ -121,7 +122,6 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/chance": "^1.1.3",
     "@types/is-url": "^1.2.30",
-    "@types/jest": "^29.0.0",
     "@types/leaflet": "^1.9.3",
     "@types/marked": "^4.0.3",
     "@types/negotiator": "^0.6.1",

--- a/src/core/caching/shouldLoad.spec.ts
+++ b/src/core/caching/shouldLoad.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import shouldLoad from './shouldLoad';
 import { remoteItem, remoteList } from 'utils/storeUtils';
 

--- a/src/features/areaAssignments/utils/getAreaData.spec.ts
+++ b/src/features/areaAssignments/utils/getAreaData.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { Household } from '../types';
 import getAreaData from './getAreaData';
 

--- a/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
+++ b/src/features/calendar/utils/clusterEventsForWeekCalender.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { CLUSTER_TYPE } from 'features/campaigns/hooks/useClusteredActivities';
 import clusterEventsForWeekCalender from './clusterEventsForWeekCalender';
 import { ZetkinEvent } from 'utils/types/zetkin';

--- a/src/features/canvass/hooks/useLocationHouseholdVisits.spec.tsx
+++ b/src/features/canvass/hooks/useLocationHouseholdVisits.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { act, render } from '@testing-library/react';
 import { FC, Suspense } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -6,7 +7,6 @@ import createStore from 'core/store';
 import mockApiClient from 'utils/testing/mocks/mockApiClient';
 import IApiClient from 'core/api/client/IApiClient';
 import useLocationHouseholdVisits from './useLocationHouseholdVisits';
-import loadLocationHouseholdVisits from '../rpc/loadLocationHouseholdVisits';
 import Environment from 'core/env/Environment';
 import { EnvProvider } from 'core/env/EnvContext';
 import { UserProvider } from 'core/env/UserContext';
@@ -36,15 +36,9 @@ describe('useLocationHouseholdVisits', () => {
       },
     ];
 
-    const rpcMock = jest.fn().mockImplementation(async (def, params) => {
-      if ((def as { name: string }).name === loadLocationHouseholdVisits.name) {
-        expect(params).toEqual({ assignmentId, locationId, orgId });
-        return { visits };
-      }
-      throw new Error('Unexpected RPC');
-    }) as unknown as jest.MockedFunction<IApiClient['rpc']>;
-
-    const apiClient = mockApiClient({ rpc: rpcMock });
+    const apiClient = mockApiClient({
+      rpc: jest.fn<IApiClient['rpc']>().mockResolvedValue({ visits }),
+    });
     const store = createStore();
     const env = new Environment(apiClient);
 
@@ -87,6 +81,11 @@ describe('useLocationHouseholdVisits', () => {
     });
 
     // After load, shows the loaded content
+    expect(apiClient.rpc.mock.calls.at(-1)?.[1]).toEqual({
+      assignmentId,
+      locationId,
+      orgId,
+    });
     expect(queryByText('loading')).toBeNull();
     expect(queryByText('loaded')).not.toBeNull();
     expect(queryByText('10')).not.toBeNull();

--- a/src/features/canvass/hooks/useVisitReporting.spec.ts
+++ b/src/features/canvass/hooks/useVisitReporting.spec.ts
@@ -1,6 +1,8 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 
 import useVisitReporting from './useVisitReporting';
+import IApiClient from 'core/api/client/IApiClient';
 import { makeWrapper } from 'utils/testing';
 import mockState from 'utils/testing/mocks/mockState';
 import createStore, { RootState } from 'core/store';
@@ -105,8 +107,8 @@ describe('useVisitReporting()', () => {
       const store = createStore(initialState);
       const newVisit = mockHouseholdVisit();
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({}),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue({}),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -175,8 +177,8 @@ describe('useVisitReporting()', () => {
       const store = createStore(initialState);
       const newVisit = mockHouseholdVisit();
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue(mockLocation),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue(mockLocation),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -297,8 +299,8 @@ describe('useVisitReporting()', () => {
       });
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({}),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue({}),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -372,8 +374,8 @@ describe('useVisitReporting()', () => {
       });
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue(mockLocation),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue(mockLocation),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -417,8 +419,8 @@ describe('useVisitReporting()', () => {
       });
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({}),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue({}),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -524,8 +526,8 @@ describe('useVisitReporting()', () => {
       });
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({}),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue({}),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -590,11 +592,14 @@ describe('useVisitReporting()', () => {
       const store = createStore(initialState);
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({}),
-        patch: jest.fn().mockImplementation((url, data) => ({
-          ...correctCurrentVisit,
-          ...data,
-        })),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue({}),
+        patch: jest
+          .fn<IApiClient['patch']>()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .mockImplementation((url: string, data: any) => ({
+            ...correctCurrentVisit,
+            ...data,
+          })),
       });
 
       const { result } = renderHook(
@@ -692,8 +697,8 @@ describe('useVisitReporting()', () => {
       });
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue(mockLocation),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue(mockLocation),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -776,8 +781,10 @@ describe('useVisitReporting()', () => {
         num_households_visited: 3,
       };
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({ id: LOCATION_ID, title: 'Loc' }),
-        patch: jest.fn().mockResolvedValue(updatedVisit),
+        get: jest
+          .fn<IApiClient['get']>()
+          .mockResolvedValue({ id: LOCATION_ID, title: 'Loc' }),
+        patch: jest.fn<IApiClient['patch']>().mockResolvedValue(updatedVisit),
       });
 
       const { result } = renderHook(
@@ -832,8 +839,10 @@ describe('useVisitReporting()', () => {
       };
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue({ id: LOCATION_ID, title: 'Loc' }),
-        post: jest.fn().mockResolvedValue(newVisit),
+        get: jest
+          .fn<IApiClient['get']>()
+          .mockResolvedValue({ id: LOCATION_ID, title: 'Loc' }),
+        post: jest.fn<IApiClient['post']>().mockResolvedValue(newVisit),
       });
 
       const { result } = renderHook(
@@ -918,8 +927,8 @@ describe('useVisitReporting()', () => {
       };
 
       const apiClient = mockApiClient({
-        get: jest.fn().mockResolvedValue(mockLocation),
-        rpc: jest.fn().mockResolvedValue(mockRpcResult),
+        get: jest.fn<IApiClient['get']>().mockResolvedValue(mockLocation),
+        rpc: jest.fn<IApiClient['rpc']>().mockResolvedValue(mockRpcResult),
       });
 
       const { result } = renderHook(

--- a/src/features/canvass/rpc/loadLocationHouseholdVisits.spec.ts
+++ b/src/features/canvass/rpc/loadLocationHouseholdVisits.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, jest } from '@jest/globals';
 import mockApiClient from 'utils/testing/mocks/mockApiClient';
 import { Zetkin2Household, ZetkinHouseholdVisit } from '../types';
 import { loadLocationHouseholdVisitsDef } from './loadLocationHouseholdVisits';
+import IApiClient from 'core/api/client/IApiClient';
 
 describe('loadLocationHouseholdVisits RPC', () => {
   it('loads visits for all households across multiple pages (>100)', async () => {
@@ -57,9 +58,7 @@ describe('loadLocationHouseholdVisits RPC', () => {
     });
 
     const apiClient = mockApiClient({
-      get: get as unknown as jest.MockedFunction<
-        <T>(path: string) => Promise<T>
-      >,
+      get: get as jest.Mock<IApiClient['get']>,
     });
 
     const result = await loadLocationHouseholdVisitsDef.handler(

--- a/src/features/canvass/utils/getVisitState.spec.ts
+++ b/src/features/canvass/utils/getVisitState.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import getVisitState from './getVisitState';
 
 describe('getVisitState()', () => {

--- a/src/features/canvass/utils/summarizeMetrics.spec.ts
+++ b/src/features/canvass/utils/summarizeMetrics.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import summarizeMetrics from './summarizeMetrics';
 
 describe('summarizeMetrics()', () => {

--- a/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
+++ b/src/features/duplicates/utils/sortValuesByFrequency.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import sortValuesByFrequency from './sortValuesByFrequency';
 
 describe('sortValuesByFrequency()', () => {

--- a/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.spec.ts
+++ b/src/features/emails/components/EmailEditor/EmailSettings/utils/blockProblems.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { OutputBlockData } from '@editorjs/editorjs';
 
 import blockProblems from './blockProblems';

--- a/src/features/emails/components/EmailEditor/EmailSettings/utils/formatUrl.spec.ts
+++ b/src/features/emails/components/EmailEditor/EmailSettings/utils/formatUrl.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import formatUrl from './formatUrl';
 
 describe('formatUrl()', () => {

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/utils/getAnchorTags.spec.ts
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/utils/getAnchorTags.spec.ts
@@ -1,4 +1,4 @@
-/** @jest-environment jsdom */
+import { describe, expect, it } from '@jest/globals';
 
 import getAnchorTags from './getAnchorTags';
 

--- a/src/features/emails/utils/deliveryProblems.spec.ts
+++ b/src/features/emails/utils/deliveryProblems.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import deliveryProblems from './deliveryProblems';
 import { ZetkinEmail } from 'utils/types/zetkin';
 import { BlockKind, DeliveryProblem, InlineNodeKind } from '../types';

--- a/src/features/emails/utils/editorjsBlocksToZetkinBlocks.spec.ts
+++ b/src/features/emails/utils/editorjsBlocksToZetkinBlocks.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import editorjsBlocksToZetkinBlocks from './editorjsBlocksToZetkinBlocks';
 import { BLOCK_TYPES, BlockKind, InlineNodeKind } from '../types';
 

--- a/src/features/emails/utils/getRelevantDataPoints.spec.ts
+++ b/src/features/emails/utils/getRelevantDataPoints.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import getRelevantDataPoints from './getRelevantDataPoints';
 
 describe('getRelevantDataPoints()', () => {

--- a/src/features/emails/utils/htmlToInlineNodes.spec.ts
+++ b/src/features/emails/utils/htmlToInlineNodes.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 /** @jest-environment jsdom */
 import htmlToInlineNodes from './htmlToInlineNodes';
 import { InlineNodeKind } from '../types';

--- a/src/features/emails/utils/inlineNodesToHtml.spec.ts
+++ b/src/features/emails/utils/inlineNodesToHtml.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { InlineNodeKind } from '../types';
 import inlineNodesToHtml from './inlineNodesToHtml';
 

--- a/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sort-keys */
+import { describe, expect, it } from '@jest/globals';
 import mjml2html from 'mjml';
 
 import renderEmailHtml from './renderEmailHtml';

--- a/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.spec.ts
+++ b/src/features/emails/utils/zetkinBlocksToEditorjsBlocks.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import zetkinBlocksToEditorjsBlocks from './zetkinBlocksToEditorjsBlocks';
 import { BLOCK_TYPES, BlockKind, InlineNodeKind } from '../types';
 

--- a/src/features/events/hooks/useParticipantPool.spec.ts
+++ b/src/features/events/hooks/useParticipantPool.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';

--- a/src/features/events/tests/createEvent.spec.tsx
+++ b/src/features/events/tests/createEvent.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';

--- a/src/features/events/tests/deleteEvent.spec.tsx
+++ b/src/features/events/tests/deleteEvent.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';

--- a/src/features/events/tests/movingParticipants.spec.tsx
+++ b/src/features/events/tests/movingParticipants.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';

--- a/src/features/events/tests/updateEvent.spec.tsx
+++ b/src/features/events/tests/updateEvent.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 
 import createStore from 'core/store';

--- a/src/features/events/utils/filterParticipants.spec.ts
+++ b/src/features/events/utils/filterParticipants.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import {
   filterParticipantsList,
   filterSignups,

--- a/src/features/import/utils/createPreviewData.spec.ts
+++ b/src/features/import/utils/createPreviewData.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 
 import createPreviewData from './createPreviewData';
 import { ColumnKind, Sheet } from '../types';

--- a/src/features/import/utils/dateParsing/parserFactory.spec.ts
+++ b/src/features/import/utils/dateParsing/parserFactory.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import parserFactory from './parserFactory';
 
 describe('parserFactory()', () => {

--- a/src/features/import/utils/getUniqueTags.spec.ts
+++ b/src/features/import/utils/getUniqueTags.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import getUniqueTags from './getUniqueTags';
 
 describe('getUniqueTags()', () => {

--- a/src/features/import/utils/hasUnfinishedMapping.spec.ts
+++ b/src/features/import/utils/hasUnfinishedMapping.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { ColumnKind } from '../types';
 import hasUnfinishedMapping from './hasUnfinishedMapping';
 

--- a/src/features/import/utils/hasWrongIDFormat.spec.ts
+++ b/src/features/import/utils/hasWrongIDFormat.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { ColumnKind } from '../types';
 import hasWrongIDFormat from './hasWrongIDFormat';
 

--- a/src/features/import/utils/prepareImportOperations.spec.ts
+++ b/src/features/import/utils/prepareImportOperations.spec.ts
@@ -1,5 +1,5 @@
 import { CountryCode } from 'libphonenumber-js';
-import { describe, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 
 import { organization as mockOrganization } from 'utils/testing/mocks/mockOrganization';
 import prepareImportOperations from './prepareImportOperations';

--- a/src/features/import/utils/problems/predictProblems.spec.ts
+++ b/src/features/import/utils/problems/predictProblems.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { CountryCode } from 'libphonenumber-js';
 
 import { ImportProblemKind } from './types';

--- a/src/features/import/utils/problems/problemsFromPreview.spec.ts
+++ b/src/features/import/utils/problems/problemsFromPreview.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { ImportProblemKind } from './types';
 import problemsFromPreview from './problemsFromPreview';
 import { ImportPreview, ImportPreviewProblemCode } from '../../types';

--- a/src/features/journeys/components/JourneyInstanceOutcome.spec.tsx
+++ b/src/features/journeys/components/JourneyInstanceOutcome.spec.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import JourneyInstanceOutcome from './JourneyInstanceOutcome';
 import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
 import { render } from 'utils/testing';

--- a/src/features/journeys/components/JourneyInstancesDataTable/index.spec.tsx
+++ b/src/features/journeys/components/JourneyInstancesDataTable/index.spec.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
 import JourneyInstancesDataTable from './index';
 import mockJourneyInstance from 'utils/testing/mocks/mockJourneyInstance';
 import { render } from 'utils/testing';

--- a/src/features/journeys/utils/journeyInstanceUtils.spec.ts
+++ b/src/features/journeys/utils/journeyInstanceUtils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { mockAppliedTag } from '../../../utils/testing/mocks/mockTag';
 import { ZetkinAppliedTag, ZetkinTagGroup } from 'utils/types/zetkin';
 import {

--- a/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
+++ b/src/features/surveys/utils/prepareSurveyApiSubmission.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
 import prepareSurveyApiSubmission from './prepareSurveyApiSubmission';
 
 describe('prepareSurveyApiSubmission()', () => {

--- a/src/features/tags/components/TagManager/TagManagerController.spec.tsx
+++ b/src/features/tags/components/TagManager/TagManagerController.spec.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import singletonRouter from 'next/router';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
@@ -18,9 +19,8 @@ jest.mock('react-redux', () => ({
 }));
 
 const assignTagCallback = jest.fn((tag: ZetkinTag) => tag);
-const createTagCallback = jest.fn<Promise<ZetkinTag>, [NewTag]>((tag) =>
-  Promise.resolve({ ...tag, id: 1 } as ZetkinTag)
-);
+const createTagCallback = (tag: NewTag) =>
+  Promise.resolve({ ...tag, id: 1 } as ZetkinTag);
 const unassignTagCallback = jest.fn((tag: ZetkinTag) => tag);
 const editTagCallback = jest.fn((tag: EditTag) => tag);
 const deleteTagCallback = jest.fn((tagId: number) => tagId);
@@ -231,12 +231,11 @@ describe('<TagManagerController />', () => {
   });
 
   describe('creating a tag', () => {
-    let onCreateTag: jest.Mock<Promise<ZetkinTag>, [tag: NewTag]>;
+    const onCreateTag = jest.fn((tag: NewTag) =>
+      Promise.resolve({ ...tag, id: 1857 } as ZetkinTag)
+    );
 
     beforeEach(() => {
-      onCreateTag = jest.fn((tag: NewTag) =>
-        Promise.resolve({ ...tag, id: 1857 } as ZetkinTag)
-      );
       assignTagCallback.mockReset();
       singletonRouter.query = {
         orgId: '1',
@@ -369,10 +368,11 @@ describe('<TagManagerController />', () => {
   });
 
   describe('editing a tag', () => {
-    let onCreateTag: jest.Mock<Promise<ZetkinTag>, [tag: NewTag]>;
+    const onCreateTag = jest.fn((tag: NewTag) =>
+      Promise.resolve(tag as ZetkinTag)
+    );
 
     beforeEach(() => {
-      onCreateTag = jest.fn((tag: NewTag) => Promise.resolve(tag as ZetkinTag));
       singletonRouter.query = {
         orgId: '1',
       };

--- a/src/features/tags/components/TagManager/components/TagChip.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 

--- a/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagDialog/TagDialog.spec.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest, test } from '@jest/globals';
 import singletonRouter from 'next/router';
 import userEvent from '@testing-library/user-event';
 
@@ -12,11 +13,10 @@ jest.mock('next/dist/client/router', () =>
 );
 
 describe('<TagDialog />', () => {
-  let onSubmit: jest.Mock<NewTag | EditTag, [tag: NewTag | EditTag]>;
+  const onSubmit = jest.fn((tag: NewTag | EditTag) => tag);
   const deleteTagCallback = jest.fn((tagId: number) => tagId);
 
   beforeEach(() => {
-    onSubmit = jest.fn((tag: NewTag | EditTag) => tag);
     singletonRouter.query = {
       orgId: '1',
     };

--- a/src/features/tags/components/TagManager/components/TagGroupDialog/TagGroupDialog.spec.tsx
+++ b/src/features/tags/components/TagManager/components/TagGroupDialog/TagGroupDialog.spec.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
 
 import messageIds from 'features/tags/l10n/messageIds';
@@ -8,10 +9,7 @@ import mockOrganization from 'utils/testing/mocks/mockOrganization';
 import { ZetkinTagGroupPatchBody } from 'features/tags/components/TagManager/types';
 
 describe('<TagGroupDialog />', () => {
-  let onSubmit: jest.Mock<
-    ZetkinTagGroupPatchBody,
-    [group: ZetkinTagGroupPatchBody]
-  >;
+  const onSubmit = jest.fn((body: ZetkinTagGroupPatchBody) => body);
   const onClose = jest.fn();
   const deleteGroupCallback = jest.fn((groupId: number) => groupId);
 
@@ -22,7 +20,6 @@ describe('<TagGroupDialog />', () => {
   };
 
   beforeEach(() => {
-    onSubmit = jest.fn((body: ZetkinTagGroupPatchBody) => body);
     onClose.mockClear();
     deleteGroupCallback.mockClear();
   });

--- a/src/features/tasks/components/TaskAssigneesList/TaskAssigneesList.spec.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/TaskAssigneesList.spec.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import singletonRouter from 'next/router';
 
 import { ASSIGNED_STATUS } from 'features/tasks/components/types';

--- a/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
+++ b/src/features/tasks/components/TaskAssigneesList/TaskStatusSubtitle.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, beforeEach, it, jest } from '@jest/globals';
 import singletonRouter from 'next/router';
 
 import { ASSIGNED_STATUS } from 'features/tasks/components/types';

--- a/src/features/views/components/ViewDataTable/utils.spec.ts
+++ b/src/features/views/components/ViewDataTable/utils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { COLUMN_TYPE } from 'features/views/components/types';
 import mockViewCol from 'utils/testing/mocks/mockViewCol';
 import mockViewRow from 'utils/testing/mocks/mockViewRow';

--- a/src/features/views/utils/getUniqueColumnName.spec.ts
+++ b/src/features/views/utils/getUniqueColumnName.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import getUniqueColumnName from './getUniqueColumnName';
 import { ZetkinViewColumn } from '../components/types';
 

--- a/src/utils/api/handleResponseData.spec.ts
+++ b/src/utils/api/handleResponseData.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import APIError from 'utils/apiError';
 import handleResponseData from './handleResponseData';
 import mockFetchResponse from 'utils/testing/mocks/mockFetchResponse';

--- a/src/utils/colorUtils.spec.ts
+++ b/src/utils/colorUtils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { getContrastColor } from './colorUtils';
 
 describe('getContrastColor()', () => {

--- a/src/utils/dateUtils.spec.ts
+++ b/src/utils/dateUtils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import mockEvent from 'utils/testing/mocks/mockEvent';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { getFirstAndLastEvent, removeOffset } from './dateUtils';
@@ -20,28 +22,25 @@ describe('getFirstAndLastEvent()', () => {
 
   it('Returns array of undefined if passed an empty array ', () => {
     const emptyArray: ZetkinEvent[] = [];
-    expect(getFirstAndLastEvent(emptyArray)).toMatchObject([
-      undefined,
-      undefined,
-    ]);
+    expect(getFirstAndLastEvent(emptyArray)).toEqual([undefined, undefined]);
   });
   it('Returns array with two of the same event if passed an array of one event', () => {
     const singleEventArray = [firstEvent];
-    expect(getFirstAndLastEvent(singleEventArray)).toMatchObject([
+    expect(getFirstAndLastEvent(singleEventArray)).toEqual([
       firstEvent,
       firstEvent,
     ]);
   });
   it('Returns first and last event when passed an array of multiple events', () => {
     const multiEventArray = [firstEvent, secondEvent, thirdEvent];
-    expect(getFirstAndLastEvent(multiEventArray)).toMatchObject([
+    expect(getFirstAndLastEvent(multiEventArray)).toEqual([
       firstEvent,
       thirdEvent,
     ]);
   });
   it('Returns first and last event when passed an array of multiple events out of order', () => {
     const multiEventArray = [firstEvent, thirdEvent, secondEvent];
-    expect(getFirstAndLastEvent(multiEventArray)).toMatchObject([
+    expect(getFirstAndLastEvent(multiEventArray)).toEqual([
       firstEvent,
       thirdEvent,
     ]);

--- a/src/utils/featureFlags/useFeature.spec.ts
+++ b/src/utils/featureFlags/useFeature.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 import { createElement, PropsWithChildren } from 'react';
 

--- a/src/utils/hooks/useDebounce.spec.ts
+++ b/src/utils/hooks/useDebounce.spec.ts
@@ -1,4 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 
 import useDebounce from './useDebounce';
 
@@ -12,7 +20,7 @@ describe('useDebounce()', () => {
   });
 
   it('calls the callback after the delay', () => {
-    const callback = jest.fn().mockResolvedValue(undefined);
+    const callback = jest.fn<(value: string) => Promise<void>>();
     const { result } = renderHook(() => useDebounce(callback, 400));
 
     act(() => {
@@ -29,8 +37,8 @@ describe('useDebounce()', () => {
   });
 
   it('uses the latest callback after re-render', () => {
-    const firstCallback = jest.fn().mockResolvedValue('first');
-    const secondCallback = jest.fn().mockResolvedValue('second');
+    const firstCallback = jest.fn<(value: string) => Promise<void>>();
+    const secondCallback = jest.fn<(value: string) => Promise<void>>();
 
     const { result, rerender } = renderHook(
       ({ callback }) => useDebounce(callback, 400),
@@ -62,7 +70,7 @@ describe('useDebounce()', () => {
     //
     // Each render creates a new arrow function closing over that
     // render's `onSave` prop. useDebounce should use the latest one.
-    const saveFn = jest.fn().mockResolvedValue(undefined);
+    const saveFn = jest.fn<(emailId: string, value: string) => Promise<void>>();
 
     const { result, rerender } = renderHook(
       ({ emailId }) =>
@@ -88,7 +96,7 @@ describe('useDebounce()', () => {
   });
 
   it('uses the new delay after re-render', () => {
-    const callback = jest.fn().mockResolvedValue(undefined);
+    const callback = jest.fn<(value: string) => Promise<void>>();
 
     const { result, rerender } = renderHook(
       ({ delay }) => useDebounce(callback, delay),

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { NextApiRequest } from 'next';
 
 import { getBrowserLanguage } from './locale';

--- a/src/utils/organize/organizations.spec.ts
+++ b/src/utils/organize/organizations.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { PersonOrganization } from './people';
 import { flattenTree, nestByParentId } from './organizations';
 

--- a/src/utils/organize/people.spec.ts
+++ b/src/utils/organize/people.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { isEqual } from 'lodash';
 
 import { flatOrgs } from './organizations.spec';

--- a/src/utils/storeUtils/findOrAddItem.spec.ts
+++ b/src/utils/storeUtils/findOrAddItem.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
 import { findOrAddItem } from 'utils/storeUtils/findOrAddItem';
 import { remoteList } from 'utils/storeUtils';
 

--- a/src/utils/storeUtils/remoteItemDeleted.spec.ts
+++ b/src/utils/storeUtils/remoteItemDeleted.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { remoteItemDeleted } from 'utils/storeUtils/remoteItemDeleted';
 import { remoteList } from 'utils/storeUtils';
 import { findOrAddItem } from './findOrAddItem';

--- a/src/utils/storeUtils/remoteItemUpdated.spec.ts
+++ b/src/utils/storeUtils/remoteItemUpdated.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
 import { remoteItemUpdated } from 'utils/storeUtils/remoteItemUpdated';
 import { remoteList } from 'utils/storeUtils';
 import { findOrAddItem } from './findOrAddItem';

--- a/src/utils/storeUtils/remoteListUtils.spec.ts
+++ b/src/utils/storeUtils/remoteListUtils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest, afterEach } from '@jest/globals';
+
 import { remoteList } from 'utils/storeUtils';
 import {
   remoteListCreated,

--- a/src/utils/stringUtils.spec.ts
+++ b/src/utils/stringUtils.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { isInteger, stringToBool, truncateOnMiddle } from './stringUtils';
 
 describe('stringToBool()', () => {

--- a/src/utils/testing/mocks/index.spec.ts
+++ b/src/utils/testing/mocks/index.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { mockObject } from '.';
 
 describe('mockObject', () => {

--- a/src/utils/testing/mocks/mockApiClient.ts
+++ b/src/utils/testing/mocks/mockApiClient.ts
@@ -1,10 +1,17 @@
+import { jest } from '@jest/globals';
+
 import IApiClient from 'core/api/client/IApiClient';
 
 type MockedApiClient = jest.Mocked<IApiClient>;
 
-export default function mockApiClient(
-  overrides?: Partial<MockedApiClient>
-): MockedApiClient {
+export default function mockApiClient(overrides?: {
+  delete?: jest.Mock<IApiClient['delete']>;
+  get?: jest.Mock<IApiClient['get']>;
+  patch?: jest.Mock<IApiClient['patch']>;
+  post?: jest.Mock<IApiClient['post']>;
+  put?: jest.Mock<IApiClient['put']>;
+  rpc?: jest.Mock<IApiClient['rpc']>;
+}): MockedApiClient {
   const defaultApiClient = {
     delete: jest.fn(),
     get: jest.fn(),
@@ -17,5 +24,5 @@ export default function mockApiClient(
   return {
     ...defaultApiClient,
     ...overrides,
-  };
+  } as MockedApiClient;
 }

--- a/src/utils/testing/setup.ts
+++ b/src/utils/testing/setup.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 jest.mock('next/font/google', () => ({
   Figtree: () => ({
     style: {

--- a/src/zui/ZUIDataTableSorting/index.spec.tsx
+++ b/src/zui/ZUIDataTableSorting/index.spec.tsx
@@ -1,5 +1,6 @@
 import { GridSortModel } from '@mui/x-data-grid-pro';
 import userEvent from '@testing-library/user-event';
+import { describe, expect, it, jest } from '@jest/globals';
 
 import { COLUMN_TYPE } from 'features/views/components/types';
 import columnTypes from 'features/views/components/ViewDataTable/columnTypes';
@@ -31,7 +32,7 @@ describe('ZUIDataTableSorting.tsx', () => {
     .slice(0, 2)
     .map((column) => ({ field: column.field, sort: 'asc' }));
 
-  const handleSetSortModel = jest.fn((sortModel) => sortModel);
+  const handleSetSortModel = jest.fn((sortModel: GridSortModel) => sortModel);
 
   it('renders correctly when sort model is empty', async () => {
     const { getByText } = render(
@@ -84,7 +85,7 @@ describe('ZUIDataTableSorting.tsx', () => {
     await userEvent.click(sortButton);
     await userEvent.click(getByText('zui.dataTableSorting.addButton'));
 
-    const updatedSortModel = handleSetSortModel.mock.calls.at(-1)?.[0];
+    const updatedSortModel = handleSetSortModel.mock.calls.at(-1)![0];
 
     rerender(
       <ZUIDataTableSorting

--- a/src/zui/ZUIDateTime/utils/convertDateTimeToLocal.spec.ts
+++ b/src/zui/ZUIDateTime/utils/convertDateTimeToLocal.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import convertDateTimeToLocal from './convertDateTimeToLocal';
 
 describe('convertDateTimeToLocal()', () => {

--- a/src/zui/ZUIEditTextInPlace/index.spec.tsx
+++ b/src/zui/ZUIEditTextInPlace/index.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/zui/ZUIOrgScopeSelect/useZUIOrgScopeSelect.spec.ts
+++ b/src/zui/ZUIOrgScopeSelect/useZUIOrgScopeSelect.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 
 import useZUIOrgScopeSelect from './useZUIOrgScopeSelect';

--- a/src/zui/ZUIRelativeTime/index.spec.tsx
+++ b/src/zui/ZUIRelativeTime/index.spec.tsx
@@ -1,3 +1,5 @@
+import { describe, expect, it } from '@jest/globals';
+
 import { render } from 'utils/testing';
 import ZUIRelativeTime from '.';
 

--- a/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useConfigurableDataGridColumns.test.ts
@@ -1,4 +1,5 @@
 import { GridColDef } from '@mui/x-data-grid-pro';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 import useConfigurableDataGridColumns, {
   StorageBackend,

--- a/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.spec.ts
+++ b/src/zui/ZUIUserConfigurableDataGrid/useModelsFromQueryString.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import mockRouter from 'next-router-mock';
 import { renderHook } from '@testing-library/react';
 

--- a/src/zui/hooks/useCommaPlural.spec.ts
+++ b/src/zui/hooks/useCommaPlural.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from '@jest/globals';
 import { IntlProvider } from 'react-intl';
 import { renderHook } from '@testing-library/react';
 import { createElement, PropsWithChildren } from 'react';


### PR DESCRIPTION
## Description
This PR consolidates all our tests to use the official test helpers provided by jest in `@jest/globals` instead of relying on the community maintained `@types/jest`. We already had some files that were using the imports to begin with.

Since the typings are a bit stricter now, I cleaned up some of the existing code.



