### PR TITLE
Make event participants editable 1 hour before start

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -290,8 +290,14 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
               ]}
             />
           );
-        } else if (type == 'booked') {
-          if (event && new Date(removeOffset(event.start_time)) < new Date(new Date().setHours(new Date().getHours() + 1))) {
+        } else if (event && type == 'booked') {
+          const eventStart = new Date(removeOffset(event.start_time));
+          const anHourFromNow = new Date(
+            new Date().setHours(new Date().getHours() + 1)
+          );
+          const canTakeAttendance = eventStart < anHourFromNow;
+
+          if (canTakeAttendance) {
             const options: ButtonOption[] = [
               {
                 callback: () => {

--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -291,7 +291,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
             />
           );
         } else if (type == 'booked') {
-          if (event && new Date(removeOffset(event.start_time)) < new Date()) {
+          if (event && new Date(removeOffset(event.start_time)) < new Date(new Date().setHours(new Date().getHours() + 1))) {
             const options: ButtonOption[] = [
               {
                 callback: () => {


### PR DESCRIPTION
## Description
This PR fixes issue  #3549. Participants can check in or be marked as cancellations or no shows  from 1 hour before an event starts.

## Changes

* Change: just added an hour in the condition for booked participants.

## Notes to reviewer
As mentioned in the issue, i have a hard time testing this because i can't edit or create events locally; i get 500 errors. If someone has an idea what the issue might be, or could checkout the branch to confirm that it works, help is appreciated! Note that my mac was recently entirely wiped, so maybe i am just missing some setup.

## Related issues
Resolves #3549 
