### PR TITLE
fix: admin users should have access to edit cells on shared lists

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalBoolColumnType.tsx
@@ -77,7 +77,7 @@ const Cell: FC<{
   );
 
   const checked = !!cell;
-  const [isRestricted] = useAccessLevel();
+  const [, accessLevel] = useAccessLevel();
 
   return (
     <Box
@@ -91,7 +91,7 @@ const Cell: FC<{
       <Checkbox
         checked={checked}
         color="success"
-        disabled={isRestricted}
+        disabled={accessLevel === 'readonly'}
         onChange={onChange}
         tabIndex={-1}
       />

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
@@ -100,8 +100,7 @@ export default class PersonTagColumnType implements IColumnType {
     ev: MuiEvent<KeyboardEvent<HTMLElement>>,
     accessLevel: ZetkinObjectAccess['level']
   ): void {
-    if (accessLevel) {
-      // Any non-null value means we're in restricted mode
+    if (accessLevel === 'readonly') {
       return;
     }
 
@@ -229,12 +228,12 @@ const BasicTagCell: FC<{
   const { tagFuture } = useTag(orgId, tagId);
   const { assignToPerson, removeFromPerson } = useTagging(orgId);
 
-  const [isRestricted] = useAccessLevel();
+  const [isRestricted, accessLevel] = useAccessLevel();
 
   if (cell) {
     return (
       <ZUITagChip
-        disabled={isRestricted}
+        disabled={accessLevel === 'readonly'}
         onDelete={() => {
           removeFromPerson(personId, tagId);
         }}

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
@@ -53,7 +53,7 @@ export default class PersonTagColumnType implements IColumnType {
 
     let tag: ZetkinTag | null = null;
 
-    if (!accessLevel) {
+    if (accessLevel !== 'readonly') {
       const tagItem = tagListState.items.find((item) => item.id == tagId);
 
       const tagFuture = loadItemIfNecessary(tagItem, dispatch, {
@@ -228,7 +228,7 @@ const BasicTagCell: FC<{
   const { tagFuture } = useTag(orgId, tagId);
   const { assignToPerson, removeFromPerson } = useTagging(orgId);
 
-  const [isRestricted, accessLevel] = useAccessLevel();
+  const [, accessLevel] = useAccessLevel();
 
   if (cell) {
     return (
@@ -241,7 +241,7 @@ const BasicTagCell: FC<{
       />
     );
   } else {
-    if (!isRestricted) {
+    if (accessLevel !== 'readonly') {
       // Only render "ghost" tag in full-access (non-restricted) mode, as it's
       // likely that a user in restricted mode will not have access to assign
       // (or even retrieve) the tag.


### PR DESCRIPTION
## Description
Admin users should be able to edit shared lists in the [organize/1/people/lists/195/shared](https://app.dev.zetkin.org/organize/1/people/lists/195/shared) view. However, the view is currently restricting users from clicking on the checkbox, and only allows admin users to edit using key press. 

The first thing is that the boolean prop `isRestricted` was set to true for the shared view, regardless of the type of user trying to access. One option to resolve this is to change isRestricted to be based on accessLevel. 

However, the reason for the inconsistent behavior with keyPress vs click is because of the setup in `LocalBoolColumnType.tsx`. The handleKeyDown function disables functionality based on the accessLevel, while the checkbox itself is disabled based on the isRestricted prop. I have changed the checkbox to be disabled based on accessLevel, so the functionality is consistent. 

The issue with inability to toggle the tags is a bit different. The ability to edit these is based on whether or not accessLevel is null. There is/was a comment in src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx explaining that any non-null value means we are in restricted mode, but it seems like maybe this is outdated. 

## Screenshots

https://github.com/user-attachments/assets/cf51e4a3-f2c6-47e3-85b5-4e4904352e79

## Notes to reviewer
It was noted on the issue that #2844 might be related. I tried to load the shared list view as a regular user with and without my changes, but the network returns 403 forbidden at the backend custom fields endpoint, so it is something to be addressed in another PR and potentially on the backend side. 

## Related issues
Resolves #3574 
