### PR TITLE
Add error handling to RPC router

### DIFF
--- a/src/core/rpc/router.ts
+++ b/src/core/rpc/router.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { RPCRouteDef } from './types';
+import { ApiClientError } from 'core/api/errors';
 
 export class RPCRouter {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -33,11 +34,19 @@ export class RPCRouter {
 
     const apiClient = new BackendApiClient(req.headers);
 
-    const result = await def.handler(inputParams.data, apiClient, req);
+    try {
+      const result = await def.handler(inputParams.data, apiClient, req);
 
-    res.status(200).json({
-      result,
-    });
+      res.status(200).json({
+        result,
+      });
+    } catch (e) {
+      res.status(e instanceof ApiClientError ? e.status : 500).json({
+        error: {
+          title: 'Unknown Error',
+        },
+      });
+    }
   }
 
   register<ParamsType, ResultType>(


### PR DESCRIPTION
## Description
This PR adds error handling to the RPC router. 

I noticed this when investigating the infinite loading spinners on projects/[projId]/activities, which are caused by this. (and very long server selection timeouts and mongodb being down in my case)

Before, it would show this error as:
```
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
```
<img width="700" alt="rpc-error-handling-issue" src="https://github.com/user-attachments/assets/18a700d8-8eab-4532-b758-02efcf3e74c9" />

