### PR TITLE
Fix in-place array sort mutations across 5 files

### DIFF
--- a/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
+++ b/src/features/events/components/SelectionBar/getOffsetStartEnd.ts
@@ -5,7 +5,7 @@ export default function getOffsetStartEnd(
   events: ZetkinEvent[],
   offset: number
 ) {
-  const sortedEvents = events.sort((firstEvent, secondEvent) => {
+  const sortedEvents = [...events].sort((firstEvent, secondEvent) => {
     const firstEventStartDate = new Date(firstEvent.start_time);
     const secondEventStartDate = new Date(secondEvent.start_time);
     if (dateIsBefore(firstEventStartDate, secondEventStartDate)) {

--- a/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/SurveySubmittedColumnType.tsx
@@ -52,7 +52,7 @@ const Cell: FC<{ cell: SurveySubmittedViewCell | undefined }> = ({ cell }) => {
     return null;
   }
 
-  const sorted = cell.sort((sub0, sub1) => {
+  const sorted = [...cell].sort((sub0, sub1) => {
     const d0 = new Date(sub0.submitted);
     const d1 = new Date(sub1.submitted);
     return d1.getTime() - d0.getTime();

--- a/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
+++ b/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
@@ -33,7 +33,7 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
 }) => {
   const sorted = useMemo(
     () =>
-      submissions.sort((sub0, sub1) => {
+      [...submissions].sort((sub0, sub1) => {
         const d0 = new Date(sub0.submitted);
         const d1 = new Date(sub1.submitted);
         return d1.getTime() - d0.getTime();

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -14,14 +14,14 @@ export const getNewDateWithOffset = (date: Date, offset: number): Date => {
 export const getFirstAndLastEvent = (
   campaignEvents: ZetkinEvent[]
 ): (ZetkinEvent | undefined)[] => {
-  const sortedCampaignEvents = campaignEvents.sort((a, b) =>
+  const sortedCampaignEvents = [...campaignEvents].sort((a, b) =>
     dayjs(a.start_time).diff(dayjs(b.start_time))
   );
   const firstEvent = sortedCampaignEvents.length
-    ? campaignEvents[0]
+    ? sortedCampaignEvents[0]
     : undefined;
   const lastEvent = firstEvent
-    ? campaignEvents[campaignEvents.length - 1]
+    ? sortedCampaignEvents[sortedCampaignEvents.length - 1]
     : undefined;
   return [firstEvent, lastEvent];
 };

--- a/src/zui/ZUITimeline/useFilterUpdates.tsx
+++ b/src/zui/ZUITimeline/useFilterUpdates.tsx
@@ -59,7 +59,7 @@ const useFilterUpdates = (updates: ZetkinUpdate[]) => {
 
   // Sorts and groups only when the updates are changed
   const groupedUpdates = useMemo(() => {
-    const sortedUpdates = updates.sort(
+    const sortedUpdates = [...updates].sort(
       (u0, u1) =>
         new Date(u1.timestamp).getTime() - new Date(u0.timestamp).getTime()
     );


### PR DESCRIPTION
## Summary

JavaScript's `Array.sort()` mutates the original array in-place. In 5 places, `.sort()` was called on function parameters, props, or data grid cell data, unintentionally modifying the caller's data.

In `getFirstAndLastEvent`, this also masked a second bug: the function read from `campaignEvents[0]` instead of `sortedCampaignEvents[0]`, which only worked because `.sort()` had mutated the original array.

All fixes: `array.sort()` → `[...array].sort()`.

### Changes

| File | Context | Impact |
|------|---------|--------|
| `ViewSurveySubmissionPreview/index.tsx` | `.sort()` on `submissions` prop inside `useMemo` | Mutates parent component's data |
| `useFilterUpdates.tsx` | `.sort()` on `updates` parameter inside `useMemo` | Mutates caller's array |
| `SurveySubmittedColumnType.tsx` | `.sort()` on `cell` from data grid row model | Mutates data grid internal data |
| `dateUtils.ts` | `.sort()` on `campaignEvents` parameter + reading from unsorted array | Mutates caller's data; reading from wrong variable was masked by mutation |
| `getOffsetStartEnd.ts` | `.sort()` on `events` parameter | Mutates caller's data |

## Test plan
- [x] All existing tests pass (the `dateUtils` test for out-of-order events now correctly validates the fix)
- [x] Pre-commit hooks pass on every commit
- [x] Verify survey submission previews render in correct order
- [x] Verify timeline updates display in correct order