### PR TITLE
Fix timer, observer, and ref cleanup leaks in 8 components

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
+++ b/src/features/calendar/components/CalendarWeekView/EventDayLane.tsx
@@ -74,11 +74,11 @@ const EventDayLane: FC<EventDayLaneProps> = ({
       }
     }
 
-    laneRef.current?.addEventListener('mousedown', handleMouseDown);
+    const node = laneRef.current;
+    node?.addEventListener('mousedown', handleMouseDown);
 
     return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      laneRef.current?.removeEventListener('mousedown', handleMouseDown);
+      node?.removeEventListener('mousedown', handleMouseDown);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [laneRef.current]);

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -258,13 +258,12 @@ const CallSwitchModal: FC<CallSwitchModalProps> = ({
 
   const modalRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (modalRef.current) {
+    const node = modalRef.current;
+    if (node) {
       const addListener = (ev: KeyboardEvent) => ev.stopPropagation();
-      modalRef.current.addEventListener('keydown', addListener);
+      node.addEventListener('keydown', addListener);
 
-      return () =>
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        modalRef.current?.removeEventListener('keydown', addListener);
+      return () => node.removeEventListener('keydown', addListener);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalRef.current]);

--- a/src/features/call/components/InstructionsSection.tsx
+++ b/src/features/call/components/InstructionsSection.tsx
@@ -35,14 +35,16 @@ const InstructionsSection: FC<Props> = ({ call, instructions, step }) => {
   );
 
   useEffect(() => {
+    let timerId: ReturnType<typeof setTimeout>;
     if (step == LaneStep.REPORT) {
       setSelectedTab('instructions');
-      setTimeout(() => {
+      timerId = setTimeout(() => {
         setSelectedTab('about');
       }, 600);
     } else {
       setSelectedTab('instructions');
     }
+    return () => clearTimeout(timerId);
   }, [step]);
 
   if (call && step == LaneStep.REPORT) {

--- a/src/features/campaigns/components/ActivityList/index.tsx
+++ b/src/features/campaigns/components/ActivityList/index.tsx
@@ -51,6 +51,7 @@ const LazyActivitiesBox = ({
     });
 
     observer.observe(boxRef.current);
+    return () => observer.disconnect();
   }, [boxRef]);
 
   return inView ? (

--- a/src/features/canvass/components/EncouragingSparkle.tsx
+++ b/src/features/canvass/components/EncouragingSparkle.tsx
@@ -10,7 +10,8 @@ type Props = {
 
 const EncouragingSparkle: FC<Props> = ({ duration = 2000, onComplete }) => {
   useEffect(() => {
-    setTimeout(() => onComplete?.(), duration);
+    const timerId = setTimeout(() => onComplete?.(), duration);
+    return () => clearTimeout(timerId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/zui/ZUIDataTableSearch.tsx
+++ b/src/zui/ZUIDataTableSearch.tsx
@@ -61,7 +61,8 @@ const DataTableSearch: React.FunctionComponent<ZUIDataTableSearchProps> = ({
 
   useEffect(() => {
     if (open) {
-      setTimeout(() => textFieldInputRef.current?.focus(), 50);
+      const timerId = setTimeout(() => textFieldInputRef.current?.focus(), 50);
+      return () => clearTimeout(timerId);
     }
   }, [open]);
 

--- a/src/zui/ZUITextfieldToClipboard.tsx
+++ b/src/zui/ZUITextfieldToClipboard.tsx
@@ -10,11 +10,17 @@ const ZUITextfieldToClipboard: React.FunctionComponent<{
   copyText: string | number | boolean;
 }> = ({ children, copyText }) => {
   const [copied, setCopied] = useState<boolean>(false);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout>>();
+
+  React.useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
 
   const handleClick = () => {
     copy(copyText.toString());
     setCopied(true);
-    setTimeout(() => setCopied(false), 2500);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2500);
   };
 
   return (

--- a/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
+++ b/src/zui/ZUITimeline/updates/TimelineJourneyInstance.tsx
@@ -28,19 +28,24 @@ const TimelineJourneyInstance: React.FunctionComponent<Props> = ({
   // No one wants to click a "show less" button. This way they don't have to:
   // Also roughly centers the content they've just asked to read
   useEffect(() => {
+    let timerId: ReturnType<typeof setTimeout>;
     if (expandSummary && !!textRef) {
       const offset = textRef?.current?.offsetTop as number;
       window.scrollTo({
         behavior: 'smooth',
         top: offset - 100,
       });
-      setTimeout(() => {
+      timerId = setTimeout(() => {
         setCurrentScroll(offset - 100);
         window.addEventListener('scroll', closeOnScroll);
       }, 1000);
     } else {
       window.removeEventListener('scroll', closeOnScroll);
     }
+    return () => {
+      clearTimeout(timerId);
+      window.removeEventListener('scroll', closeOnScroll);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandSummary]);
 


### PR DESCRIPTION
## Summary

Fixes resource cleanup issues across 8 components. Three types of leaks:

1. **setTimeout without cleanup** (5 files) — timers that could fire after unmount, calling setState on unmounted components
2. **IntersectionObserver without disconnect** (1 file) — observer persisting after unmount
3. **Stale ref in cleanup function** (2 files) — `ref.current` read in the cleanup could be null because React clears refs before running cleanup

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `EncouragingSparkle.tsx` | 2s timer, `onComplete` fires after unmount | Capture timer ID, `clearTimeout` in cleanup |
| `InstructionsSection.tsx` | 600ms tab-switch timer not cleared | Capture timer ID, `clearTimeout` in cleanup |
| `TimelineJourneyInstance.tsx` | 1s timer + scroll listener leak | `clearTimeout` + `removeEventListener` in cleanup |
| `ZUITextfieldToClipboard.tsx` | Multiple clicks queue uncancelled timers | Use ref for timer ID, clear previous on click and on unmount |
| `ZUIDataTableSearch.tsx` | 50ms focus timer not cleared | `clearTimeout` in cleanup |
| `ActivityList/index.tsx` | IntersectionObserver never disconnected | `observer.disconnect()` in cleanup |
| `EventDayLane.tsx` | `laneRef.current` stale in cleanup | Capture `laneRef.current` in local variable |
| `CallSwitchModal.tsx` | `modalRef.current` stale in cleanup | Capture `modalRef.current` in local variable |

## Test plan
- [x] All 1368 existing tests pass
- [x] All pre-commit hooks (lint, prettier, typecheck) pass on every commit
- [ ] Verify CallerLog component works correctly during calls
- [ ] Verify timeline expand/collapse works on journey instances
- [ ] Verify copy-to-clipboard button shows "Copied" feedback