### PR TITLE
Fixing flaky tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,5 +123,16 @@ module.exports = {
         'yml/quotes': ['error', { prefer: 'single' }],
       },
     },
+    {
+      files: ['integrationTesting/**/*.ts', 'integrationTesting/**/*.tsx'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
+      },
+      rules: {
+        '@typescript-eslint/no-floating-promises': ['error'],
+      },
+    },
   ],
 };

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,3 +54,8 @@ import { render, fireEvent } from 'test-utils';
 ```
 
 The `react-intl` setup in tests does not render the text in the components and instead **renders the i18n string id**. When attempting to target strings in tests, search for the id that you expect, not the translated text.
+
+## Further Reading
+
+- [Jest Testing](docs/testing/jest.md) - Unit test patterns and conventions
+- [Playwright Testing](docs/testing/playwright.md) - Integration test patterns and conventions

--- a/docs/testing/playwright.md
+++ b/docs/testing/playwright.md
@@ -41,11 +41,170 @@ In its default mode of execution, Playwright runs the tests in a headless browse
 
 ## Writing Playwright tests
 
+### Test Structure
+
+Tests live in `integrationTesting/tests/`, organized by feature area:
+
+```
+integrationTesting/
+├── fixtures/
+│   └── next.ts          # Custom test fixtures
+├── mockData/
+│   └── orgs/KPD/        # Mock data for "KPD" organization
+└── tests/
+    └── organize/
+        ├── tags/
+        ├── views/
+        └── journeys/
+```
+
+Import the custom `test` fixture in every spec:
+
+```typescript
+import { expect } from '@playwright/test';
+import test from '../../../fixtures/next';
+import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
+import KPD from '../../../mockData/orgs/KPD';
+```
+
+### Fixtures
+
+The custom `test` fixture from `integrationTesting/fixtures/next.ts` provides:
+
+#### `login(user?, memberships?)`
+
+Sets up mocks for authentication. Uses Rosa Luxemburg as the default user.
+
+```typescript
+test.beforeEach(({ login }) => {
+  login(); // Uses default user
+  // or
+  login(customUser, customMemberships);
+});
+```
+
+#### `logout()`
+
+Removes authentication mocks without navigating.
+
+```typescript
+test.beforeEach(({ logout }) => {
+  logout();
+});
+```
+
+#### `moxy`
+
+Mock server that intercepts API requests. See Moxy section below.
+
+#### `appUri`
+
+Base URL for the Next.js app (includes port).
+
+```typescript
+await page.goto(appUri + '/organize/1/people');
+```
+
+#### `setBrowserDate(date)`
+
+Sets a fake "current date" for testing date-dependent UI.
+
+```typescript
+await setBrowserDate(new Date('1857-07-05'));
+```
+
+#### `fileServerUri`
+
+HTTP server for serving test files from `integrationTesting/mockFiles/`.
+
 ### Moxy
 
 Zetkins Playwright tests isolate the Next.js app from the back end very thoroughly by using [moxy](https://github.com/zetkin/moxy) to set up placeholder responses. This means the tests can run without the app ever actually communicating with the real back end. The purpose of this is to make the tests more deterministic, which means they should only break because of a problem with the code, because nobody can break them by mistake by changing something in the dev server's database that they depend on.
 
-The [code search results for `moxy.setZetkinApiMock`](https://github.com/search?q=repo%3Azetkin%2Fapp.zetkin.org%20moxy.setZetkinApiMock&type=code) are a great starting point to learn about setting up these API mocks.
+Moxy intercepts HTTP requests to the Zetkin API and returns mock responses.
+
+#### Basic Usage
+
+```typescript
+const mock = moxy.setZetkinApiMock('/orgs/1/people', 'get', people);
+// Returns a mock object with .log() and .removeMock()
+```
+
+#### Checking API Calls
+
+```typescript
+const createRequest = moxy.setZetkinApiMock(
+  '/orgs/1/people/tags',
+  'post',
+  newTag
+);
+
+// Later in test:
+await page.click('data-testid=SubmitButton');
+
+// Wait until API gets called using expect.poll()
+await expect.poll(() => createRequest.log().length).toBe(1);
+// Verify that the returned data is correct
+expect(createRequest.log()[0].data).toEqual({ title: 'Activist' });
+```
+
+#### Removing Mocks
+
+```typescript
+moxy.removeMock('/users/me', 'get');
+```
+
+#### Error Responses
+
+```typescript
+moxy.setZetkinApiMock('/api/path', 'post', null, 500); // 500 status
+```
+
+#### Cleanup
+
+Always call `moxy.teardown()` in `afterEach`:
+
+```typescript
+test.afterEach(({ moxy }) => {
+  moxy.teardown();
+});
+```
+
+### Selectors
+
+#### data-testid
+
+```typescript
+page.locator('data-testid=SubmitCancelButtons-submitButton');
+page.locator('data-testid=TagManager-TagDialog-titleField');
+```
+
+Add `data-testid` to components for stable test selectors.
+
+#### Text Selectors
+
+```typescript
+page.click('text=Add tag');
+page.locator('text=Add tag').click();
+```
+
+#### Compound Selectors
+
+```typescript
+// Chain with >>
+page.click(
+  'div[aria-label="timeline update"] >> [data-testid=ZUIEllipsisMenu-menuActivator]'
+);
+
+// :below() for relative positioning
+page.click('[data-slate-editor=true]:below(:text("added a note"))');
+```
+
+#### nth
+
+```typescript
+page.locator('input[name="options"] >> nth=0');
+```
 
 ### waitForNavigation
 
@@ -60,8 +219,8 @@ You won't find any examples of code written that way in Zetkin though. The probl
 
 ```typescript
 await Promise.all([
-  page.waitForNavigation(),
-  page.click(`text=${AllMembers.title}`),
+  page.waitForURL(appUri + '/expected-url'),
+  page.click('text=View Details'),
 ]);
 ```
 
@@ -74,4 +233,104 @@ Browser automation tests like these are notorious for sometimes failing randomly
 
 Using locators instead of `page.click()` maximizes our chances of Playwright's auto-waiting and auto-retrying saving us from a meaningless random test failure resulting from a race condition.
 
+```typescript
+// Avoid
+await page.click('text=Submit');
+
+// Prefer
+await page.locator('text=Submit').click();
+```
+
 There are lots of examples to learn from in the [code search results for `page.locator`](https://github.com/search?q=repo%3Azetkin%2Fapp.zetkin.org%20page.locator&type=code).
+
+### Mock Data
+
+Mock data lives in `integrationTesting/mockData/` and is organized by entity type:
+
+```typescript
+import ClaraZetkin from '../../../mockData/orgs/KPD/people/ClaraZetkin';
+import KPD from '../../../mockData/orgs/KPD';
+import ActivistTag from '../../../mockData/orgs/KPD/tags/Activist';
+```
+
+Use existing mock data objects or create new ones following the pattern:
+
+```typescript
+import { ZetkinPerson } from 'utils/types/zetkin';
+
+const ClaraZetkin: ZetkinPerson = {
+  id: 1,
+  first_name: 'Clara',
+  last_name: 'Zetkin',
+  // ... other fields
+};
+
+export default ClaraZetkin;
+```
+
+### Assertions
+
+#### expect.poll()
+
+Polls until a condition is true. Essential for async operations like API calls.
+
+```typescript
+await expect.poll(() => mock.log().length).toBe(1);
+```
+
+#### Standard Assertions
+
+```typescript
+await expect(page.locator('data-testid=ErrorMessage')).toBeVisible();
+await expect(page.locator('input[name="value"]')).toHaveValue('expected');
+await expect(page.locator('input[name="value"]')).toBeChecked();
+```
+
+### Basic Test Pattern
+
+```typescript
+test.describe('Feature name', () => {
+  test.beforeEach(async ({ page, appUri, moxy, login }) => {
+    login();
+    moxy.setZetkinApiMock('/orgs/1', 'get', KPD);
+    moxy.setZetkinApiMock(
+      `/orgs/1/people/${ClaraZetkin.id}`,
+      'get',
+      ClaraZetkin
+    );
+    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+  });
+
+  test.afterEach(({ moxy }) => {
+    moxy.teardown();
+  });
+
+  test('does something', async ({ page, moxy }) => {
+    // Test code here
+  });
+});
+```
+
+### Debugging Failed Tests
+
+Playwright captures screenshots, videos, and traces on failure.
+
+```bash
+# Open HTML report
+npx playwright show-report
+```
+
+The GitHub Actions also attach the report as an artifact.
+
+## Best Practices
+
+1. **Always cleanup in afterEach** - Call `moxy.teardown()` to reset mocks
+2. **Use data-testid** - Add test IDs to components for stable selectors
+3. **Prefer locators** - Use `page.locator().click()` over `page.click()`
+4. **Use expect.poll()** - For checking async conditions like API calls
+5. **Wrap navigation** - Use `Promise.all()` when clicking and waiting for navigation
+6. **Wait for elements** - Don't assume elements are ready; wait for them
+7. **Keep tests isolated** - Each test should set up its own mocks
+8. **Use mock data** - Import from `mockData/` rather than creating ad-hoc objects
+
+See the [Playwright Best Practices](https://playwright.dev/docs/best-practices) for more.

--- a/integrationTesting/fixtures/next.ts
+++ b/integrationTesting/fixtures/next.ts
@@ -67,7 +67,7 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
       const server: Server = await new Promise((resolve) => {
         const server = createServer((req, res) => {
           const parsedUrl = parse(req.url as string, true);
-          handle(req, res, parsedUrl);
+          void handle(req, res, parsedUrl);
         });
         server.listen((error: unknown) => {
           if (error) {

--- a/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/detail/delete.spec.ts
@@ -33,8 +33,10 @@ test.describe('Campaign detail page', async () => {
     await page.click('header [data-testid=ZUIEllipsisMenu-menuActivator]');
     await page.click('data-testid=ZUIEllipsisMenu-item-deleteCampaign');
 
-    await page.click('button:text("Confirm")');
-    await page.waitForURL(appUri + '/organize/1/projects');
+    await Promise.all([
+      page.waitForURL(appUri + '/organize/1/projects'),
+      page.click('button:text("Confirm")'),
+    ]);
     expect(log().length).toEqual(1);
   });
 });

--- a/integrationTesting/tests/organize/campaigns/list/create.spec.ts
+++ b/integrationTesting/tests/organize/campaigns/list/create.spec.ts
@@ -34,17 +34,10 @@ test.describe.skip('Campaigns list page', async () => {
     await page.fill('input:near(#status)', 'published');
     await page.fill('input:near(#visibility)', ReferendumSignatures.visibility);
 
-    await Promise.all([
-      // Page may navigate away from modal (#createCampaign) before it
-      // navigates to the new campaign, so wait for specific URL
-      page.waitForNavigation({
-        url: `**/organize/1/campaigns/${ReferendumSignatures.id}`,
-      }),
-      page.click('button:text("Submit")'),
-    ]);
+    await page.click('button:text("Submit")');
 
     // Check for redirect
-    expect(page.url()).toEqual(
+    await expect(page).toHaveURL(
       appUri + '/organize/1/campaigns/' + ReferendumSignatures.id
     );
   });

--- a/integrationTesting/tests/organize/journeys/instance-detail/close.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/close.spec.ts
@@ -81,18 +81,10 @@ test.describe('Journey instance detail page', () => {
       'data-testid=JourneyInstanceCloseButton-outcomeDialog >> data-testid=SubmitCancelButtons-submitButton'
     );
 
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() === 'POST'),
-      (async () => {
-        await submitButton.click({ force: true }); // To close the tag select popover
-        await submitButton.click();
-      })(),
-    ]);
+    await submitButton.click({ force: true }); // To close the tag select popover
+    await submitButton.click();
 
-    // Check requests to tags made
-    expect(tagPutMock.log().length).toEqual(1);
-
-    // Check patch request has correct data
-    expect(instanceCloseMock.log().length).toEqual(1);
+    await expect.poll(() => tagPutMock.log().length).toBe(1);
+    await expect.poll(() => instanceCloseMock.log().length).toBe(1);
   });
 });

--- a/integrationTesting/tests/organize/journeys/instance-detail/edit-summary.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/edit-summary.spec.ts
@@ -46,10 +46,9 @@ test.describe('Journey instance detail page', () => {
       newSummaryText
     );
 
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'PATCH'),
-      page.click('data-testid=SubmitCancelButtons-submitButton'),
-    ]);
+    await page.click('data-testid=SubmitCancelButtons-submitButton');
+
+    await expect.poll(() => patchJourneyReqLog().length).toBe(1);
 
     // Makes request with correct data
     expect(

--- a/integrationTesting/tests/organize/journeys/instance-detail/edit-type.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/edit-type.spec.ts
@@ -84,25 +84,19 @@ test.describe('Journey instance detail page', () => {
     );
 
     //Click type of journey to convert to, "Marxist Training"
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`
-      ),
-      page.waitForNavigation({
-        url: `**/organize/${KPD.id}/journeys/${MarxistTraining.id}/${ClarasOnboarding.id}`,
-      }),
-      page.locator('text=Marxist training').click(),
-    ]);
+    await page.locator('text=Marxist training').click();
 
     //Expect the id to be the MarxistJourney id.
+    await expect
+      .poll(() => patchReqLog<{ journey_id: number }>().length)
+      .toBe(1);
     expect(patchReqLog<{ journey_id: number }>()[0].data?.journey_id).toBe(
       MarxistTraining.id
     );
 
     //Expect redirect to journey instance paage with new journey id.
-    expect(page.url()).toEqual(
-      appUri +
-        `/organize/${KPD.id}/journeys/${MarxistTraining.id}/${ClarasOnboarding.id}`
+    await page.waitForURL(
+      `**/organize/${KPD.id}/journeys/${MarxistTraining.id}/${ClarasOnboarding.id}`
     );
   });
 

--- a/integrationTesting/tests/organize/journeys/instance-detail/navigate.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/navigate.spec.ts
@@ -33,8 +33,9 @@ test.describe('Journey instance page', () => {
 
     await page.goto(appUri + '/organize/1/journeys/1/1');
     await page.locator('button[role="tab"]:has-text("Milestones")').click();
-    await page.waitForNavigation();
 
-    expect(page.url()).toEqual(appUri + '/organize/1/journeys/1/1/milestones');
+    await expect(page).toHaveURL(
+      appUri + '/organize/1/journeys/1/1/milestones'
+    );
   });
 });

--- a/integrationTesting/tests/organize/journeys/instance-detail/notes.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/notes.spec.ts
@@ -79,12 +79,9 @@ test.describe('Journey instance notes', () => {
     await page.click('[data-slate-editor=true]');
     await page.type('[data-slate-editor=true]', newNote.text);
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/notes`
-      ),
-      page.click('[data-testid=TimelineAddNote-submitButton]'),
-    ]);
+    await page.click('[data-testid=TimelineAddNote-submitButton]');
+
+    await expect.poll(() => notePostMock.log().length).toBe(1);
 
     expect(notePostMock.log()[0].data).toEqual({
       file_ids: [],
@@ -123,14 +120,11 @@ test.describe('Journey instance notes', () => {
       newNote.text
     );
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/notes/${NoteUpdate.details.note.id}`
-      ),
-      page.click(
-        `[data-testid=TimelineNoteAdded-submitButton-note-${NoteUpdate.details.note.id}]`
-      ),
-    ]);
+    await page.click(
+      `[data-testid=TimelineNoteAdded-submitButton-note-${NoteUpdate.details.note.id}]`
+    );
+
+    await expect.poll(() => notePatchMock.log().length).toBe(1);
 
     expect(notePatchMock.log()[0].data).toEqual({
       text: `${newNote.text}\n`,

--- a/integrationTesting/tests/organize/journeys/instance-detail/reopen.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/reopen.spec.ts
@@ -45,14 +45,9 @@ test.describe('Journey instance details page', () => {
 
       await page.goto(appUri + '/organize/1/journeys/1/1');
 
-      await Promise.all([
-        // Wait for request to resolve
-        page.waitForResponse(
-          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`
-        ),
-        // Click close instance button
-        reopenButton.click(),
-      ]);
+      await reopenButton.click();
+
+      await expect.poll(() => patchInstanceMock.log().length).toBe(1);
 
       await openStatus.waitFor({ state: 'visible' });
 

--- a/integrationTesting/tests/organize/journeys/instance-detail/sidebar.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-detail/sidebar.spec.ts
@@ -85,20 +85,15 @@ test.describe('Journey instance detail page sidebar', () => {
       ClarasOnboarding
     );
 
-    //click Angela in search results and wait for response
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`
-      ),
-      page
-        .locator(
-          `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
-        )
-        .click(),
-    ]);
+    //click Angela in search results
+    await page
+      .locator(
+        `text=${ClarasOnboarding.assignees[0].first_name} ${ClarasOnboarding.assignees[0].last_name}`
+      )
+      .click();
 
     //Expect PUT-request to be done
-    expect(putTagLog().length).toEqual(1);
+    await expect.poll(() => putTagLog().length).toBe(1);
 
     //Expect Add assignee-button to be visible
     expect(
@@ -122,47 +117,32 @@ test.describe('Journey instance detail page sidebar', () => {
       ClarasOnboarding
     );
     //DELETE Angela from list of assignees
-    moxy.setZetkinApiMock(
+    const { log: deleteLog } = moxy.setZetkinApiMock(
       `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/assignees/${ClarasOnboarding.assignees[0].id}`,
       'delete'
     );
 
     await page.goto(appUri + '/organize/1/journeys/1/1');
 
-    // Set up two parallel async tracks
-    await Promise.all([
-      // Track A waits for HTTP requests and updates mocks to reflect that
-      // an assignee has been deleted
-      (async () => {
-        await page.waitForRequest((res) => res.method() == 'DELETE');
+    // Hover over Angela
+    await page
+      .locator(`data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}`)
+      .hover();
 
-        // Update journey instance mock with no assignees
+    // Set up parallel tracks: update mock and click delete
+    await Promise.all([
+      (async () => {
+        await page.waitForRequest((req) => req.method() == 'DELETE');
         moxy.setZetkinApiMock(
           `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
           'get',
           { ...ClarasOnboarding, assignees: [] }
         );
-
         await page.waitForResponse(
-          (res) =>
-            res.request().method() === 'GET' &&
-            res
-              .request()
-              .url()
-              .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
+          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`
         );
       })(),
-
-      // Track B performs UI interactions in parallel with track A
       (async () => {
-        // Hover over Angela
-        await page
-          .locator(
-            `data-testid=JourneyPerson-${ClarasOnboarding.assignees[0].id}`
-          )
-          .hover();
-
-        // Click X icon
         await page
           .locator(
             `data-testid=JourneyPerson-remove-${ClarasOnboarding.assignees[0].id}`
@@ -171,7 +151,9 @@ test.describe('Journey instance detail page sidebar', () => {
       })(),
     ]);
 
-    // Wait a short while for React to re-render after data has been retrieved
+    await expect.poll(() => deleteLog().length).toBe(1);
+
+    // Wait for React to re-render
     await page.waitForTimeout(200);
 
     //there should be no Angela in list of assignees
@@ -252,20 +234,15 @@ test.describe('Journey instance detail page sidebar', () => {
       ClarasOnboarding
     );
 
-    //click Clara in search results and awit for response
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`
-      ),
-      page
-        .locator(
-          `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
-        )
-        .click(),
-    ]);
+    //click Clara in search results
+    await page
+      .locator(
+        `text=${ClarasOnboarding.subjects[0].first_name} ${ClarasOnboarding.subjects[0].last_name}`
+      )
+      .click();
 
     //Expect PUT-request to be done
-    expect(putTagLog().length).toEqual(1);
+    await expect.poll(() => putTagLog().length).toBe(1);
 
     //Expect Add subject-button to be visible
     expect(
@@ -289,45 +266,35 @@ test.describe('Journey instance detail page sidebar', () => {
       'get',
       ClarasOnboarding
     );
-    //DELETE Angela from list of assignees
-    moxy.setZetkinApiMock(
+    //DELETE Clara from list of subjects
+    const { log: deleteLog } = moxy.setZetkinApiMock(
       `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/subjects/${ClarasOnboarding.subjects[0].id}`,
       'delete'
     );
 
     await page.goto(appUri + '/organize/1/journeys/1/1');
 
-    // Set up two parallel async tracks
+    // Hover over Clara
+    await page
+      .locator(
+        `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
+      )
+      .hover();
+
+    // Set up parallel tracks: update mock and click delete
     await Promise.all([
       (async () => {
         await page.waitForRequest((req) => req.method() == 'DELETE');
-
-        // Update journey instance mocke, with no subjects
         moxy.setZetkinApiMock(
           `/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`,
           'get',
           { ...ClarasOnboarding, subjects: [] }
         );
-
         await page.waitForResponse(
-          (res) =>
-            res.request().method() === 'GET' &&
-            res
-              .request()
-              .url()
-              .endsWith(`/journey_instances/${ClarasOnboarding.id}`)
+          `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}`
         );
       })(),
-
       (async () => {
-        // Hover over Clara
-        await page
-          .locator(
-            `[data-testid=ZetkinSection-subjects] [data-testid=JourneyPerson-${ClarasOnboarding.subjects[0].id}]`
-          )
-          .hover();
-
-        // Click X icon
         await page
           .locator(
             `data-testid=JourneyPerson-remove-${ClarasOnboarding.subjects[0].id}`
@@ -336,10 +303,12 @@ test.describe('Journey instance detail page sidebar', () => {
       })(),
     ]);
 
-    // Wait for React to re-render after response
+    await expect.poll(() => deleteLog().length).toBe(1);
+
+    // Wait for React to re-render
     await page.waitForTimeout(200);
 
-    //there should be no Clara in list of subejcts
+    //there should be no Clara in list of subjects
     expect(
       await page
         .locator(
@@ -366,18 +335,10 @@ test.describe('Journey instance detail page sidebar', () => {
       MemberOnboarding
     );
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/${KPD.id}/people/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/tag_groups`),
-      await page.goto(appUri + '/organize/1/journeys/1/1'),
-    ]);
+    await page.goto(appUri + '/organize/1/journeys/1/1');
 
-    expect(
-      await page.locator(`text="${ActivistTag.title}"`).isVisible()
-    ).toBeTruthy();
-    expect(
-      await page.locator(`text="${PlaysGuitarTag.title}"`).isVisible()
-    ).toBeTruthy();
+    await expect(page.locator(`text="${ActivistTag.title}"`)).toBeVisible();
+    await expect(page.locator(`text="${PlaysGuitarTag.title}"`)).toBeVisible();
   });
   test('let user assign a tag to the journey instance', async ({
     appUri,
@@ -406,23 +367,14 @@ test.describe('Journey instance detail page sidebar', () => {
       'put'
     );
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/${KPD.id}/people/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/tag_groups`),
-      page.goto(appUri + '/organize/1/journeys/1/1'),
-    ]);
+    await page.goto(appUri + '/organize/1/journeys/1/1');
 
     await page.locator('text=Add tag').click();
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/tags/${CodingSkillsTag.id}`
-      ),
-      page.click(`text=${CodingSkillsTag.title}`),
-    ]);
+    await page.click(`text=${CodingSkillsTag.title}`);
 
     // Expect to have made request to put tag
-    expect(putTagLog().length).toEqual(1);
+    await expect.poll(() => putTagLog().length).toBe(1);
   });
   test('lets user unassign a tag from the journey instance', async ({
     appUri,
@@ -450,18 +402,12 @@ test.describe('Journey instance detail page sidebar', () => {
       'delete'
     );
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/${KPD.id}/people/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/tag_groups`),
-      page.goto(appUri + '/organize/1/journeys/1/1'),
-    ]);
+    await page.goto(appUri + '/organize/1/journeys/1/1');
 
     await page.locator(`text="${ActivistTag.title}"`).hover();
     await page.locator(`[data-testid=TagChip-deleteButton]`).first().click();
 
     // Expect to have made request to delete tag
-    await expect(() => {
-      expect(deleteTagLog()).toHaveLength(1);
-    }).toPass();
+    await expect.poll(() => deleteTagLog().length).toBe(1);
   });
 });

--- a/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
@@ -136,13 +136,12 @@ test.describe('Creating a journey instance from journey instance page', () => {
 
     await page.locator('data-testid=SubmitCancelButtons-submitButton').click();
 
-    await expect.poll(() => instMock.log().length).toBe(1);
-
     // Expect requests to have been made to:
     // * POST to create journey instance
     // * PUT to add assignee
     // * PUT to add subject
     // * PUT to assign tag
+    await expect.poll(() => instMock.log().length).toBe(1);
     await expect.poll(() => assigneeMock.log().length).toBe(1);
     await expect.poll(() => subjectMock.log().length).toBe(1);
     await expect.poll(() => tagMock.log().length).toBe(1);

--- a/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-list/create.spec.ts
@@ -24,16 +24,15 @@ test.describe('Creating a journey instance from journey instance page', () => {
 
     await page.goto(appUri + '/organize/1/journeys/2');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.locator('data-testid=JourneyInstanceOverviewPage-addFab').click(),
-    ]);
+    await page
+      .locator('data-testid=JourneyInstanceOverviewPage-addFab')
+      .click();
 
-    expect(
-      await page
-        .locator('data-testid=SubmitCancelButtons-submitButton')
-        .textContent()
-    ).toEqual('Create new Marxist training');
+    await expect(page).toHaveURL(/journeys\/2\/new/);
+
+    await expect(
+      page.locator('data-testid=SubmitCancelButtons-submitButton')
+    ).toHaveText('Create new Marxist training');
 
     expect(await page.locator('data-testid=page-title').textContent()).toEqual(
       'New Marxist training'
@@ -56,15 +55,11 @@ test.describe('Creating a journey instance from journey instance page', () => {
     await page.locator('[data-testid=page-title] input').press('Enter');
     await page.locator('data-testid=AutoTextArea-textarea').type('Some info');
 
-    await Promise.all([
-      page.waitForResponse((res) => res.url().includes('createNew')),
-      page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
-    ]);
+    await page.locator('data-testid=SubmitCancelButtons-submitButton').click();
+
+    await expect.poll(() => instMock.log().length).toBe(1);
 
     const requests = instMock.log<ZetkinJourneyInstance>();
-    await expect(() => {
-      expect(requests.length).toBe(1);
-    }).toPass();
     expect(requests[0].data?.title).toEqual('My training');
     expect(requests[0].data?.opening_note).toEqual('Some info');
   });
@@ -139,19 +134,17 @@ test.describe('Creating a journey instance from journey instance page', () => {
       .locator('data-testid=SubmitCancelButtons-submitButton')
       .click({ force: true });
 
-    await Promise.all([
-      page.waitForResponse(async (res) => res.url().includes('createNew')),
-      page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
-    ]);
+    await page.locator('data-testid=SubmitCancelButtons-submitButton').click();
+
+    await expect.poll(() => instMock.log().length).toBe(1);
 
     // Expect requests to have been made to:
     // * POST to create journey instance
     // * PUT to add assignee
     // * PUT to add subject
     // * PUT to assign tag
-    expect(instMock.log().length).toBe(1);
-    expect(assigneeMock.log().length).toBe(1);
-    expect(subjectMock.log().length).toBe(1);
-    expect(tagMock.log().length).toBe(1);
+    await expect.poll(() => assigneeMock.log().length).toBe(1);
+    await expect.poll(() => subjectMock.log().length).toBe(1);
+    await expect.poll(() => tagMock.log().length).toBe(1);
   });
 });

--- a/integrationTesting/tests/organize/journeys/instance-list/persists.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-list/persists.spec.ts
@@ -56,8 +56,8 @@ test.describe('Journey instance list', () => {
     const secondRow = rows.nth(2);
     await secondRow.waitFor();
 
-    expect(firstRow).toContainText('Better');
-    expect(secondRow).toContainText('Another');
+    await expect(firstRow).toContainText('Better');
+    await expect(secondRow).toContainText('Another');
     expect(await rows.count()).toBe(3);
 
     // Reload the page
@@ -70,8 +70,8 @@ test.describe('Journey instance list', () => {
     const secondRowAfterRefresh = rowsAfterRefresh.nth(2);
     await secondRowAfterRefresh.waitFor();
 
-    expect(firstRowAfterRefresh).toContainText('Better');
-    expect(secondRowAfterRefresh).toContainText('Another');
+    await expect(firstRowAfterRefresh).toContainText('Better');
+    await expect(secondRowAfterRefresh).toContainText('Another');
     expect(await rowsAfterRefresh.count()).toBe(3);
   });
 });

--- a/integrationTesting/tests/organize/journeys/instance-milestones/milestones.spec.ts
+++ b/integrationTesting/tests/organize/journeys/instance-milestones/milestones.spec.ts
@@ -103,13 +103,10 @@ test.describe('Journey instance page Milestones tab', () => {
     await datePicker.first().click();
     await june24.waitFor({ state: 'visible' });
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/milestones/${AttendMeeting.id}`
-      ),
-      //Click June 24 to trigger setting new deadline
-      await june24.click(),
-    ]);
+    //Click June 24 to trigger setting new deadline
+    await june24.click();
+
+    await expect.poll(() => patchReqLog().length).toBe(1);
 
     //Expect the deadline to be the newly set deadline
     expect(
@@ -137,19 +134,16 @@ test.describe('Journey instance page Milestones tab', () => {
 
     await page.goto(appUri + '/organize/1/journeys/1/1/milestones');
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/milestones/${AttendMeeting.id}`
-      ),
-      //Click "clear"-button
-      page
-        .locator(
-          '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-datePicker] button[aria-label*="Choose"]'
-        )
-        .first()
-        .click(),
-      page.locator('.MuiPickersLayout-actionBar button').first().click(),
-    ]);
+    //Click "clear"-button
+    await page
+      .locator(
+        '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-datePicker] button[aria-label*="Choose"]'
+      )
+      .first()
+      .click();
+    await page.locator('.MuiPickersLayout-actionBar button').first().click();
+
+    await expect.poll(() => patchReqLog().length).toBe(1);
 
     //Expect deadline to be set to null
     expect(patchReqLog<ZetkinJourneyMilestoneStatus>()[0].data?.deadline).toBe(
@@ -181,18 +175,15 @@ test.describe('Journey instance page Milestones tab', () => {
 
     await page.goto(appUri + '/organize/1/journeys/1/1/milestones');
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/milestones/${AttendMeeting.id}`
-      ),
-      //Click "completed"-checkbox in first JourneyMilestoneCard
-      await page
-        .locator(
-          '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-completed]'
-        )
-        .first()
-        .click(),
-    ]);
+    //Click "completed"-checkbox in first JourneyMilestoneCard
+    await page
+      .locator(
+        '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-completed]'
+      )
+      .first()
+      .click();
+
+    await expect.poll(() => patchReqLog().length).toBe(1);
 
     const submittedDate = new Date(
       patchReqLog<ZetkinJourneyMilestoneStatus>()[0].data!.completed!
@@ -232,17 +223,14 @@ test.describe('Journey instance page Milestones tab', () => {
 
     await page.goto(appUri + '/organize/1/journeys/1/1/milestones');
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/journey_instances/${ClarasOnboarding.id}/milestones/${AttendMeeting.id}`
-      ),
-      //Click "completed"-checkbox in JourneyMilestoneCard
-      await page
-        .locator(
-          '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-completed]'
-        )
-        .click(),
-    ]);
+    //Click "completed"-checkbox in JourneyMilestoneCard
+    await page
+      .locator(
+        '[data-testid=JourneyMilestoneCard] [data-testid=JourneyMilestoneCard-completed]'
+      )
+      .click();
+
+    await expect.poll(() => patchReqLog().length).toBe(1);
 
     expect(patchReqLog<ZetkinJourneyMilestoneStatus>()[0].data?.completed).toBe(
       null

--- a/integrationTesting/tests/organize/profile/journeys.spec.ts
+++ b/integrationTesting/tests/organize/profile/journeys.spec.ts
@@ -45,13 +45,10 @@ test.describe('Profile page journeys section', () => {
     await page.goto(appUri + `/organize/${KPD.id}/people/${ClaraZetkin.id}`);
 
     await page.locator('data-testid=PersonJourneysCard-addButton').click();
-    await Promise.all([
-      page.waitForNavigation(),
-      page.locator(`text=${MarxistTraining.title}`).click(),
-    ]);
+    await page.locator(`text=${MarxistTraining.title}`).click();
 
-    expect(page.url()).toMatch(/journeys\/2\/new/);
-    expect(page.url()).toMatch(/\?subject=1$/);
+    await page.waitForURL(/journeys\/2\/new/);
+    await expect(page).toHaveURL(/\?subject=1$/);
   });
 
   test('is not visible if the organization does not have any journeys.', async ({

--- a/integrationTesting/tests/organize/profile/tags.spec.ts
+++ b/integrationTesting/tests/organize/profile/tags.spec.ts
@@ -39,9 +39,6 @@ test.describe('Profile page tags section', () => {
     await expect(page.locator(`text="${ActivistTag.title}"`)).toBeVisible();
 
     expect(
-      await page.locator(`text="${ActivistTag.title}"`).isVisible()
-    ).toBeTruthy();
-    expect(
       await page.locator(`text="${CodingTag.title}"`).isVisible()
     ).toBeTruthy();
   });

--- a/integrationTesting/tests/organize/profile/tags.spec.ts
+++ b/integrationTesting/tests/organize/profile/tags.spec.ts
@@ -34,12 +34,9 @@ test.describe('Profile page tags section', () => {
       CodingTag,
     ]);
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/${KPD.id}/people/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/tag_groups`),
-      page.goto(appUri + `/organize/${KPD.id}/people/${ClaraZetkin.id}`),
-    ]);
+    await page.goto(appUri + `/organize/${KPD.id}/people/${ClaraZetkin.id}`);
+
+    await expect(page.locator(`text="${ActivistTag.title}"`)).toBeVisible();
 
     expect(
       await page.locator(`text="${ActivistTag.title}"`).isVisible()

--- a/integrationTesting/tests/organize/search.spec.ts
+++ b/integrationTesting/tests/organize/search.spec.ts
@@ -24,6 +24,10 @@ test.describe('Search', async () => {
     login();
   });
 
+  test.afterEach(async ({ moxy }) => {
+    moxy.teardown();
+  });
+
   test('opens the search dialog when entering "/" hotkey', async ({
     page,
     moxy,

--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -590,7 +590,9 @@ test.describe('User submitting a survey', () => {
     });
   });
 
-  test('preserves inputs on error', async ({ appUri, page }) => {
+  test('preserves inputs on error', async ({ appUri, moxy, page }) => {
+    moxy.setZetkinApiMock(apiPostPath, 'post', null, 500);
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
     );

--- a/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
+++ b/integrationTesting/tests/organize/surveys/submitting-survey.spec.ts
@@ -38,6 +38,10 @@ test.describe('User submitting a survey', () => {
   });
 
   test('submits text input', async ({ appUri, moxy, page }) => {
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
     );
@@ -45,15 +49,11 @@ test.describe('User submitting a survey', () => {
     await page.fill('[name="2.text"]', 'Topple capitalism');
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toEqual({
       responses: [
         {
@@ -154,31 +154,23 @@ test.describe('User submitting a survey', () => {
       }
     );
 
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     await page.locator('input[name="1.options"][value="1"]').click();
 
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toEqual({
       responses: [
         {
@@ -291,16 +283,12 @@ test.describe('User submitting a survey', () => {
       }
     );
 
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     await page.locator('input[name="3.options"][value="1"]').click();
@@ -308,15 +296,11 @@ test.describe('User submitting a survey', () => {
 
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toEqual({
       responses: [
         {
@@ -363,16 +347,12 @@ test.describe('User submitting a survey', () => {
       }
     );
 
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     const selectInput = await page.locator(
@@ -387,15 +367,11 @@ test.describe('User submitting a survey', () => {
 
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toEqual({
       responses: [
         {
@@ -506,14 +482,9 @@ test.describe('User submitting a survey', () => {
       }
     );
 
-    // Respond when survey is submitted
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
-    );
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
 
     // Navigate to survey and submit without touching the select widget (or any)
     await page.goto(
@@ -527,15 +498,11 @@ test.describe('User submitting a survey', () => {
 
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toEqual({
       responses: [
         {
@@ -548,16 +515,12 @@ test.describe('User submitting a survey', () => {
   });
 
   test('submits email signature', async ({ appUri, moxy, page }) => {
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     await page.locator('input[name="1.options"][value="1"]').click();
@@ -567,15 +530,11 @@ test.describe('User submitting a survey', () => {
     await page.fill('input[name="sig.first_name"]', 'Test');
     await page.fill('input[name="sig.last_name"]', 'User');
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toMatchObject({
       signature: {
         email: 'testuser@example.org',
@@ -586,62 +545,46 @@ test.describe('User submitting a survey', () => {
   });
 
   test('submits user signature', async ({ appUri, moxy, page }) => {
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     await page.locator('input[name="1.options"][value="1"]').click();
     await page.fill('[name="2.text"]', 'Topple capitalism');
     await page.locator('input[name="sig"][value="user"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toMatchObject({
       signature: 'user',
     });
   });
 
   test('submits anonymous signature', async ({ appUri, moxy, page }) => {
+    const { log: postLog } = moxy.setZetkinApiMock(apiPostPath, 'post', {
+      timestamp: '1857-05-07T13:37:00.000Z',
+    });
+
     await page.goto(
       `${appUri}/o/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}`
-    );
-
-    moxy.setZetkinApiMock(
-      `/orgs/${KPDMembershipSurvey.organization.id}/surveys/${KPDMembershipSurvey.id}/submissions`,
-      'post',
-      {
-        timestamp: '1857-05-07T13:37:00.000Z',
-      }
     );
 
     await page.locator('input[name="1.options"][value="1"]').click();
     await page.fill('[name="2.text"]', 'Topple capitalism');
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
-    const log = moxy.log(`/v1${apiPostPath}`);
-    expect(log.length).toBe(1);
+    await expect.poll(() => postLog().length).toBe(1);
 
-    const data = log[0].data as ZetkinSurveyApiSubmission;
+    const data = postLog()[0].data as ZetkinSurveyApiSubmission;
     expect(data).toMatchObject({
       signature: null,
     });
@@ -657,10 +600,7 @@ test.describe('User submitting a survey', () => {
     await page.locator('input[name="sig"][value="anonymous"]').click();
     await page.locator('data-testid=Survey-acceptTerms').click();
 
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'POST'),
-      page.locator('data-testid=Survey-submit').click(),
-    ]);
+    await page.locator('data-testid=Survey-submit').click();
 
     await expect(page.locator('data-testid=Survey-error')).toBeVisible();
     await expect(

--- a/integrationTesting/tests/organize/tags/add.spec.ts
+++ b/integrationTesting/tests/organize/tags/add.spec.ts
@@ -92,10 +92,9 @@ test.describe('Tag manager', () => {
       .locator('data-testid=TagManager-TagSelect-searchField')
       .type('Revolutionary');
 
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'PUT'),
-      page.locator('data-testid=SubmitCancelButtons-submitButton').click(),
-    ]);
+    await page.locator('data-testid=SubmitCancelButtons-submitButton').click();
+
+    await expect.poll(() => putTagLog().length).toBe(1);
 
     // Expect to have made request to put tag
     expect(putTagLog()[0].data).toEqual({

--- a/integrationTesting/tests/organize/tags/create.spec.ts
+++ b/integrationTesting/tests/organize/tags/create.spec.ts
@@ -59,19 +59,10 @@ test.describe('Tag manager', () => {
       [ActivistTag, CodingSkillsTag, ActivistTag]
     );
 
-    await Promise.all([
-      page.waitForResponse('**/orgs/1/people/tags'),
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
-      ),
-      page.click('data-testid=SubmitCancelButtons-submitButton'),
-    ]);
+    await page.click('data-testid=SubmitCancelButtons-submitButton');
 
-    // Check that request made to create tag
-    expect(createTagRequest.log().length).toEqual(1);
-
-    // Check that request made to apply tag
-    expect(assignNewTagRequest.log().length).toEqual(1);
+    await expect.poll(() => createTagRequest.log().length).toBe(1);
+    await expect.poll(() => assignNewTagRequest.log().length).toBe(1);
   });
 
   test('lets user create a tag group and tag with that group', async ({
@@ -107,22 +98,10 @@ test.describe('Tag manager', () => {
     );
     await page.click(`text=Add "${SkillsGroup.title}"`);
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/1/tag_groups`),
-      page.waitForResponse('**/orgs/1/people/tags'),
-      page.waitForResponse(
-        `**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags/${ActivistTag.id}`
-      ),
-      page.click('data-testid=SubmitCancelButtons-submitButton'),
-    ]);
+    await page.click('data-testid=SubmitCancelButtons-submitButton');
 
-    // Check that request made to create group
-    expect(createTagGroupRequest.log().length).toEqual(1);
-
-    // Check that request made to create tag
-    expect(createTagRequest.log().length).toEqual(1);
-
-    // Check that request made to apply tag
-    expect(assignNewTagRequest.log().length).toEqual(1);
+    await expect.poll(() => createTagGroupRequest.log().length).toBe(1);
+    await expect.poll(() => createTagRequest.log().length).toBe(1);
+    await expect.poll(() => assignNewTagRequest.log().length).toBe(1);
   });
 });

--- a/integrationTesting/tests/organize/tags/edit.spec.ts
+++ b/integrationTesting/tests/organize/tags/edit.spec.ts
@@ -51,11 +51,9 @@ test.describe('Tag manager', () => {
       'New tag title'
     );
 
-    // Check that request made to edit tag with correct values
-    await Promise.all([
-      page.click('data-testid=SubmitCancelButtons-submitButton'),
-      page.waitForResponse(`**/orgs/1/people/tags/${ActivistTag.id}`),
-    ]);
+    await page.click('data-testid=SubmitCancelButtons-submitButton');
+
+    await expect.poll(() => editTagRequest.log().length).toBe(1);
 
     expect(editTagRequest.log()[0].data).toEqual({
       group_id: ActivistTag.group?.id,

--- a/integrationTesting/tests/organize/tags/list.spec.ts
+++ b/integrationTesting/tests/organize/tags/list.spec.ts
@@ -39,12 +39,9 @@ test.describe('Tag manager', () => {
       PlaysGuitarTag,
     ]);
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/${KPD.id}/people/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/people/${ClaraZetkin.id}/tags`),
-      page.waitForResponse(`**/orgs/${KPD.id}/tag_groups`),
-      page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`),
-    ]);
+    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+
+    await expect(page.locator(`text="${ActivistTag.title}"`)).toBeVisible();
 
     expect(
       await page.locator(`text="${ActivistTag.title}"`).isVisible()

--- a/integrationTesting/tests/organize/tags/list.spec.ts
+++ b/integrationTesting/tests/organize/tags/list.spec.ts
@@ -44,9 +44,6 @@ test.describe('Tag manager', () => {
     await expect(page.locator(`text="${ActivistTag.title}"`)).toBeVisible();
 
     expect(
-      await page.locator(`text="${ActivistTag.title}"`).isVisible()
-    ).toBeTruthy();
-    expect(
       await page.locator(`text="${OrganizerTag.title}"`).isVisible()
     ).toBeTruthy();
     expect(

--- a/integrationTesting/tests/organize/tags/remove.spec.ts
+++ b/integrationTesting/tests/organize/tags/remove.spec.ts
@@ -60,7 +60,7 @@ test.describe('Tags manager', () => {
 
     moxy.setZetkinApiMock(`/orgs/1/people/${ClaraZetkin.id}/tags`, 'get', []);
 
-    await expect(tagToDelete).toHaveCount(0);
+    await expect(tagToDelete).not.toBeVisible();
 
     // Expect to have made request to delete tag
     expect(deleteTagLog().length).toEqual(1);

--- a/integrationTesting/tests/organize/tags/remove.spec.ts
+++ b/integrationTesting/tests/organize/tags/remove.spec.ts
@@ -37,25 +37,27 @@ test.describe('Tags manager', () => {
       'delete'
     );
 
-    const tagToDelete = page.locator(
-      `data-testid=TagManager-groupedTags-ungrouped >> text="${PlaysGuitarTag.title}"`
-    );
-    const deleteButton = page.locator('[data-testid=TagChip-deleteButton]');
+    const tagToDelete = page
+      .locator('[data-testid=TagManager-groupedTags-ungrouped]')
+      .locator('[data-testid=TagChip-value]')
+      .filter({ hasText: PlaysGuitarTag.title });
+    const chipRoot = tagToDelete.locator('..').locator('..');
+    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
 
     await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
-    await tagToDelete.waitFor({ state: 'visible' });
+
+    await expect(tagToDelete).toBeVisible();
 
     await tagToDelete.hover();
-    await deleteButton.waitFor({ state: 'visible' });
+    await expect(deleteButton).toBeVisible();
 
-    await Promise.all([
-      page.waitForRequest((req) => req.method() == 'DELETE'),
-      deleteButton.click(),
-    ]);
+    await deleteButton.click();
+
+    await expect.poll(() => deleteTagLog().length).toBeGreaterThan(0);
 
     moxy.setZetkinApiMock(`/orgs/1/people/${ClaraZetkin.id}/tags`, 'get', []);
 
-    await tagToDelete.waitFor({ state: 'hidden' });
+    await expect(tagToDelete).toHaveCount(0);
 
     // Expect to have made request to delete tag
     expect(deleteTagLog().length).toEqual(1);
@@ -75,19 +77,32 @@ test.describe('Tags manager', () => {
       'get',
       [PlaysGuitarTag]
     );
-    moxy.setZetkinApiMock(
+    const { log: deleteTagLog } = moxy.setZetkinApiMock(
       `/orgs/1/people/${ClaraZetkin.id}/tags/${PlaysGuitarTag.id}`,
       'delete',
       undefined,
       401
     );
 
+    const tagChip = page
+      .locator('[data-testid=TagManager-groupedTags-ungrouped]')
+      .locator('[data-testid=TagChip-value]')
+      .filter({ hasText: PlaysGuitarTag.title });
+    const chipRoot = tagChip.locator('..').locator('..');
+    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
+
     await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
 
-    await page.locator(`text="${PlaysGuitarTag.title}"`).hover();
-    await page.locator('[data-testid=TagChip-deleteButton]').click();
+    await expect(tagChip).toBeVisible();
+
+    await tagChip.hover();
+
+    await expect(deleteButton).toBeVisible();
+    await deleteButton.click();
+
+    await expect.poll(() => deleteTagLog().length).toBeGreaterThan(0);
 
     // Show error
-    await page.locator('data-testid=Snackbar-error').waitFor();
+    await expect(page.locator('[data-testid=Snackbar-error]')).toBeVisible();
   });
 });

--- a/integrationTesting/tests/organize/tags/remove.spec.ts
+++ b/integrationTesting/tests/organize/tags/remove.spec.ts
@@ -53,6 +53,7 @@ test.describe('Tags manager', () => {
 
     await expect(deleteButton).toBeVisible();
 
+    // wait for button animation to finish
     await page.waitForTimeout(200);
     await deleteButton.click({ force: true });
 
@@ -102,6 +103,8 @@ test.describe('Tags manager', () => {
     const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
 
     await expect(deleteButton).toBeVisible();
+
+    // wait for button animation to finish
     await page.waitForTimeout(200);
     await deleteButton.click({ force: true });
 

--- a/integrationTesting/tests/organize/tags/remove.spec.ts
+++ b/integrationTesting/tests/organize/tags/remove.spec.ts
@@ -37,21 +37,24 @@ test.describe('Tags manager', () => {
       'delete'
     );
 
+    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+
     const tagToDelete = page
       .locator('[data-testid=TagManager-groupedTags-ungrouped]')
       .locator('[data-testid=TagChip-value]')
       .filter({ hasText: PlaysGuitarTag.title });
-    const chipRoot = tagToDelete.locator('..').locator('..');
-    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
-
-    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
 
     await expect(tagToDelete).toBeVisible();
 
     await tagToDelete.hover();
+
+    const chipRoot = tagToDelete.locator('..').locator('..');
+    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
+
     await expect(deleteButton).toBeVisible();
 
-    await deleteButton.click();
+    await page.waitForTimeout(200);
+    await deleteButton.click({ force: true });
 
     await expect.poll(() => deleteTagLog().length).toBeGreaterThan(0);
 
@@ -84,25 +87,28 @@ test.describe('Tags manager', () => {
       401
     );
 
+    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
+
     const tagChip = page
       .locator('[data-testid=TagManager-groupedTags-ungrouped]')
       .locator('[data-testid=TagChip-value]')
       .filter({ hasText: PlaysGuitarTag.title });
-    const chipRoot = tagChip.locator('..').locator('..');
-    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
-
-    await page.goto(appUri + `/organize/1/people/${ClaraZetkin.id}`);
 
     await expect(tagChip).toBeVisible();
 
     await tagChip.hover();
 
+    const chipRoot = tagChip.locator('..').locator('..');
+    const deleteButton = chipRoot.locator('[data-testid=TagChip-deleteButton]');
+
     await expect(deleteButton).toBeVisible();
-    await deleteButton.click();
+    await page.waitForTimeout(200);
+    await deleteButton.click({ force: true });
 
     await expect.poll(() => deleteTagLog().length).toBeGreaterThan(0);
 
-    // Show error
-    await expect(page.locator('[data-testid=Snackbar-error]')).toBeVisible();
+    const snackbar = page.locator('[data-testid=Snackbar-error]');
+
+    await expect(snackbar).toBeVisible();
   });
 });

--- a/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
@@ -122,10 +122,9 @@ test.describe('Task detail page', () => {
     await page.goto(appUri + '/organize/1/projects/1/tasks/1');
     await image.waitFor({ state: 'visible' });
 
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'PATCH'),
-      page.locator('data-testid=ZetkinEditableImage-resetButton').click(),
-    ]);
+    await page.locator('data-testid=ZetkinEditableImage-resetButton').click();
+
+    await expect.poll(() => patchLog().length).toBe(1);
 
     expect(patchLog()[0].data).toEqual({
       cover_file_id: null,

--- a/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/cover-image.spec.ts
@@ -73,13 +73,7 @@ test.describe('Task detail page', () => {
 
     moxy.setZetkinApiMock('/orgs/1/tasks/1', 'get', taskWithFile);
 
-    await Promise.all([
-      page.waitForRequest((req) => req.method() === 'PATCH'),
-      page.waitForResponse((res) =>
-        res.request().url().includes('clara_and_rosa.jpg')
-      ),
-      page.locator('data-testid=FileLibraryDialog-useButton').click(),
-    ]);
+    await page.locator('data-testid=FileLibraryDialog-useButton').click();
 
     await page.locator('data-testid=TaskPreviewSection-section').waitFor();
 

--- a/integrationTesting/tests/organize/tasks/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/delete.spec.ts
@@ -33,13 +33,10 @@ test.describe('Task detail pagee', async () => {
       await page.click('header [data-testid=ZUIEllipsisMenu-menuActivator]');
       await page.click('data-testid=ZUIEllipsisMenu-item-deleteTask');
 
-      await Promise.all([
-        page.waitForNavigation(),
-        page.click('button:text("Confirm")'),
-      ]);
+      await page.click('button:text("Confirm")');
 
-      expect(page.url()).toEqual(appUri + '/organize/1/projects/1');
-      expect(log().length).toEqual(1);
+      await expect(page).toHaveURL(appUri + '/organize/1/projects/1');
+      await expect.poll(() => log().length).toBe(1);
     });
   });
 });

--- a/integrationTesting/tests/organize/tasks/detail/update-target.spec.ts
+++ b/integrationTesting/tests/organize/tasks/detail/update-target.spec.ts
@@ -47,14 +47,23 @@ test.describe('Task detail page', async () => {
     await page.click('data-testid=StartsWith-select-all');
     await page.click('data-testid=FilterForm-saveButton');
 
-    await Promise.all([
-      page.waitForResponse(
-        `**/orgs/1/people/queries/${SpeakToFriend.target.id}`
-      ),
-      page.click('data-testid=QueryOverview-saveButton'),
-    ]);
+    await page.click('data-testid=QueryOverview-saveButton');
 
     // Check body of request
+    await expect
+      .poll(
+        () =>
+          moxy
+            .log()
+            .filter(
+              (req) =>
+                req.method === 'PATCH' &&
+                req.path ===
+                  `/v1/orgs/1/people/queries/${SpeakToFriend.target.id}`
+            ).length
+      )
+      .toBeGreaterThan(0);
+
     const patchRequest = moxy
       .log()
       .find(

--- a/integrationTesting/tests/organize/views/detail/add-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/add-row.spec.ts
@@ -67,8 +67,6 @@ test.describe('View detail page', () => {
 
     await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
 
-    await page.waitForTimeout(500);
-
     // Make sure the row was added
     expect(
       moxy

--- a/integrationTesting/tests/organize/views/detail/add-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/add-row.spec.ts
@@ -122,8 +122,6 @@ test.describe('View detail page', () => {
 
     await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
 
-    await page.waitForTimeout(500);
-
     // Make sure the row was added
     await expect
       .poll(() =>

--- a/integrationTesting/tests/organize/views/detail/add-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/add-row.spec.ts
@@ -65,10 +65,9 @@ test.describe('View detail page', () => {
     await page.click('[name=person]');
     await page.fill('[name=person]', `${NewPerson.last_name}`);
 
-    await Promise.all([
-      page.waitForResponse('**/orgs/1/people/views/1/rows'),
-      page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`),
-    ]);
+    await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
+
+    await page.waitForTimeout(500);
 
     // Make sure the row was added
     expect(
@@ -121,20 +120,21 @@ test.describe('View detail page', () => {
     await page.click('[name=person]');
     await page.fill('[name=person]', `${NewPerson.last_name}`);
 
-    await Promise.all([
-      page.waitForResponse(`**/orgs/1/people/views/1/rows/${NewPerson.id}`),
-      page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`),
-    ]);
+    await page.click(`text="${NewPerson.first_name} ${NewPerson.last_name}"`);
+
+    await page.waitForTimeout(500);
 
     // Make sure the row was added
-    expect(
-      moxy
-        .log()
-        .find(
-          (req) =>
-            req.method === 'PUT' &&
-            req.path === `/v1/orgs/1/people/views/1/rows/${NewPerson.id}`
-        )
-    ).toBeTruthy();
+    await expect
+      .poll(() =>
+        moxy
+          .log()
+          .find(
+            (req) =>
+              req.method === 'PUT' &&
+              req.path === `/v1/orgs/1/people/views/1/rows/${NewPerson.id}`
+          )
+      )
+      .toBeTruthy();
   });
 });

--- a/integrationTesting/tests/organize/views/detail/create.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/create.spec.ts
@@ -61,12 +61,11 @@ test.describe('View detail page', () => {
       .click();
     await page.locator('button:has-text("handle selection")').click();
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page
-        .locator('[role="menuitem"]:has-text("create list from selection")')
-        .click(),
-    ]);
+    await page
+      .locator('[role="menuitem"]:has-text("create list from selection")')
+      .click();
+
+    await page.waitForURL(appUri + `/organize/1/people/lists/${NewView.id}`);
 
     // Get POST requests for creating new view and columns
     const moxyLog = moxy.log<{ title: string }>();
@@ -96,10 +95,5 @@ test.describe('View detail page', () => {
     // Expect that the correct rows were added
     expect(rowPutLogs[0].path).toMatch(/1$/);
     expect(rowPutLogs[1].path).toMatch(/2$/);
-
-    // Expect that user is navigated to new view's page
-    expect(page.url()).toEqual(
-      appUri + `/organize/1/people/lists/${NewView.id}`
-    );
   });
 });

--- a/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-column.spec.ts
@@ -30,7 +30,7 @@ test.describe('View detail page', () => {
     appUri,
     moxy,
   }) => {
-    moxy.setZetkinApiMock(
+    const { log: deleteLog } = moxy.setZetkinApiMock(
       `/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`,
       'delete'
     );
@@ -38,18 +38,15 @@ test.describe('View detail page', () => {
     await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete first column
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'DELETE'),
-      (async () => {
-        await page.hover('[role=columnheader]:has-text("First name")');
-        await page.click(
-          '[role=columnheader]:has-text("First name") [aria-label="First name column menu"]'
-        );
-        await page.click(
-          `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
-        );
-      })(),
-    ]);
+    await page.hover('[role=columnheader]:has-text("First name")');
+    await page.click(
+      '[role=columnheader]:has-text("First name") [aria-label="First name column menu"]'
+    );
+    await page.click(
+      `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
+    );
+
+    await expect.poll(() => deleteLog().length).toBe(1);
 
     // Check body of request
     const columnDeleteRequest = moxy
@@ -68,7 +65,7 @@ test.describe('View detail page', () => {
     appUri,
     moxy,
   }) => {
-    moxy.setZetkinApiMock(
+    const { log: deleteLog } = moxy.setZetkinApiMock(
       `/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`,
       'delete',
       undefined,
@@ -78,22 +75,16 @@ test.describe('View detail page', () => {
     await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete first column
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'DELETE'),
-      (async () => {
-        await page.hover('[role=columnheader]:has-text("First name")');
-        await page.click(
-          '[role=columnheader]:has-text("First name") [aria-label="First name column menu"]'
-        );
-        await page.click(
-          `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
-        );
-      })(),
-    ]);
+    await page.hover('[role=columnheader]:has-text("First name")');
+    await page.click(
+      '[role=columnheader]:has-text("First name") [aria-label="First name column menu"]'
+    );
+    await page.click(
+      `data-testid=delete-column-button-col_${AllMembersColumns[0].id}`
+    );
 
-    await page.locator('data-testid=Snackbar-error').waitFor();
-
-    await expect(page.locator('data-testid=Snackbar-error')).toHaveCount(1);
+    await expect.poll(() => deleteLog().length).toBe(1);
+    await expect(page.locator('data-testid=Snackbar-error')).toBeVisible();
   });
 
   test('the user must confirm deletion of a column with local data', async ({
@@ -101,27 +92,24 @@ test.describe('View detail page', () => {
     appUri,
     moxy,
   }) => {
-    moxy.setZetkinApiMock(
-      `/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`,
+    const { log: deleteLog } = moxy.setZetkinApiMock(
+      `/orgs/1/people/views/1/columns/${AllMembersColumns[2].id}`,
       'delete'
     );
 
     await page.goto(appUri + '/organize/1/people/lists/1');
 
     // Delete local column
-    await Promise.all([
-      page.waitForResponse((res) => res.request().method() == 'DELETE'),
-      (async () => {
-        await page.hover('[role=columnheader]:has-text("Active")');
-        await page.click(
-          '[role=columnheader]:has-text("Active") [aria-label="Active column menu"]'
-        );
-        await page.click(
-          `data-testid=delete-column-button-col_${AllMembersColumns[2].id}`
-        );
-        await page.click('button:text("Confirm")');
-      })(),
-    ]);
+    await page.hover('[role=columnheader]:has-text("Active")');
+    await page.click(
+      '[role=columnheader]:has-text("Active") [aria-label="Active column menu"]'
+    );
+    await page.click(
+      `data-testid=delete-column-button-col_${AllMembersColumns[2].id}`
+    );
+    await page.click('button:text("Confirm")');
+
+    await expect.poll(() => deleteLog().length).toBe(1);
 
     // Check body of request
     const columnDeleteRequest = moxy

--- a/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete-row.spec.ts
@@ -26,7 +26,7 @@ test.describe('View detail page', () => {
   });
 
   test('lets user remove row from view', async ({ page, appUri, moxy }) => {
-    moxy.setZetkinApiMock(
+    const { log: deleteLog } = moxy.setZetkinApiMock(
       '/orgs/1/people/views/1/rows/1',
       'delete',
       undefined,
@@ -48,24 +48,11 @@ test.describe('View detail page', () => {
     await page.locator('[role="menuitem"]:has-text("remove")').click();
     await expect(page.locator(confirmButtonInModal)).toBeVisible();
 
-    await Promise.all([
-      page.waitForResponse((res) =>
-        res.url().includes('/api/views/removeRows')
-      ),
-      page.locator(confirmButtonInModal).click(),
-    ]);
+    await page.locator(confirmButtonInModal).click();
 
     await expect(page.locator(confirmButtonInModal)).toBeHidden();
 
     // Check for delete request
-    expect(
-      moxy
-        .log()
-        .find(
-          (req) =>
-            req.method === 'DELETE' &&
-            req.path === '/v1/orgs/1/people/views/1/rows/1'
-        )
-    ).toBeTruthy();
+    await expect.poll(() => deleteLog().length).toBe(1);
   });
 });

--- a/integrationTesting/tests/organize/views/detail/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/delete.spec.ts
@@ -37,6 +37,13 @@ test.describe('View detail page', () => {
   });
 
   test('lets user delete the view', async ({ page, appUri, moxy }) => {
+    const { log: deleteLog } = moxy.setZetkinApiMock(
+      '/orgs/1/people/views/1',
+      'delete',
+      undefined,
+      204
+    );
+    moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
     moxy.setZetkinApiMock('/orgs/1/people/views/1', 'get', AllMembers);
     moxy.setZetkinApiMock('/orgs/1/people/views/1/rows', 'get', AllMembersRows);
     moxy.setZetkinApiMock(
@@ -44,39 +51,14 @@ test.describe('View detail page', () => {
       'get',
       AllMembersColumns
     );
-    moxy.setZetkinApiMock('/orgs/1/people/views/1', 'delete', undefined, 204);
-    moxy.setZetkinApiMock('/orgs/1/people/views', 'get', []);
 
     await page.goto(appUri + '/organize/1/people/lists/1');
 
-    // Wait for navigation after deleting
-    await Promise.all([
-      (async () => {
-        // Check that the request to delete was made successfully
-        await page.waitForResponse(
-          (res) =>
-            res.request().method() === 'DELETE' &&
-            res
-              .request()
-              .url()
-              .includes(`/orgs/1/people/views/${AllMembers.id}`)
-        );
+    await deleteView(page);
 
-        const deleteViewRequest = moxy
-          .log()
-          .find(
-            (mock) =>
-              mock.method === 'DELETE' &&
-              mock.path === `/v1/orgs/1/people/views/${AllMembers.id}`
-          );
-        expect(deleteViewRequest).toBeTruthy();
-      })(),
-      page.waitForNavigation(),
-      deleteView(page),
-    ]);
+    await expect.poll(() => deleteLog().length).toBe(1);
 
-    // Check navigates back to views list
-    await expect(page.url()).toEqual(appUri + `/organize/${KPD.id}/people`);
+    await expect(page).toHaveURL(appUri + `/organize/${KPD.id}/people`);
   });
 
   test('shows error snackbar if error deleting view', async ({

--- a/integrationTesting/tests/organize/views/detail/jump.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/jump.spec.ts
@@ -33,7 +33,7 @@ test.describe('View detail page', () => {
     await page.click('data-testid=view-jump-menu-button');
 
     // Assert that the input is automatically focused, and type in part of the title of NewView
-    expect(
+    await expect(
       page.locator('data-testid=view-jump-menu-popover >> input')
     ).toBeFocused();
     await page.fill(

--- a/integrationTesting/tests/organize/views/detail/jump.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/jump.spec.ts
@@ -43,12 +43,9 @@ test.describe('View detail page', () => {
 
     // Press down to select view and enter to navigate
     await page.keyboard.press('ArrowDown');
-
-    await Promise.all([page.waitForNavigation(), page.keyboard.press('Enter')]);
+    await page.keyboard.press('Enter');
 
     // Assert that we navigate away to the new view
-    expect(page.url()).toEqual(
-      appUri + `/organize/1/people/lists/${NewView.id}`
-    );
+    await page.waitForURL(appUri + `/organize/1/people/lists/${NewView.id}`);
   });
 });

--- a/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename-column.spec.ts
@@ -54,14 +54,23 @@ test.describe('View detail page', () => {
 
     await page.fill('#rename-column-title-field', newTitle);
 
-    await Promise.all([
-      page.waitForResponse((res) =>
-        res.url().includes(`/views/1/columns/${AllMembersColumns[0].id}`)
-      ),
-      page.click('button:text("Save")'),
-    ]);
+    await page.click('button:text("Save")');
 
     // Check body of request
+    await expect
+      .poll(
+        () =>
+          moxy
+            .log()
+            .filter(
+              (mock) =>
+                mock.method === 'PATCH' &&
+                mock.path ===
+                  `/v1/orgs/1/people/views/1/columns/${AllMembersColumns[0].id}`
+            ).length
+      )
+      .toBeGreaterThan(0);
+
     const columnPatchRequest = moxy
       .log()
       .find(

--- a/integrationTesting/tests/organize/views/detail/rename.spec.ts
+++ b/integrationTesting/tests/organize/views/detail/rename.spec.ts
@@ -26,26 +26,27 @@ test.describe('View detail page', () => {
   });
 
   test('allows title to be changed', async ({ page, appUri, moxy }) => {
-    moxy.setZetkinApiMock('/v1/orgs/1/people/views/1', 'patch');
+    const { log: patchLog } = moxy.setZetkinApiMock(
+      '/orgs/1/people/views/1',
+      'patch'
+    );
 
-    const inputSelector = 'data-testid=page-title >> input';
+    const input = page.locator('data-testid=page-title').locator('input');
 
     // Click to edit, fill and submit change
     await page.goto(appUri + '/organize/1/people/lists/1');
-    await page.click(inputSelector);
-    await page.fill(inputSelector, 'Friends of Zetkin');
-    await Promise.all([
-      page.waitForResponse('**/orgs/1/people/views/1'),
-      page.keyboard.press('Enter'),
-    ]);
 
-    // Check body of request
-    const titleUpdateRequest = moxy
-      .log()
-      .find(
-        (mock) =>
-          mock.method === 'PATCH' && mock.path === '/v1/orgs/1/people/views/1'
-      );
-    expect(titleUpdateRequest?.data).toEqual({ title: 'Friends of Zetkin' });
+    await expect(input).toBeVisible();
+
+    await input.click();
+    await input.fill('Friends of Zetkin');
+    await input.press('Enter');
+    await input.blur();
+
+    await expect.poll(() => patchLog().length).toBe(1);
+
+    expect(patchLog()[0].data).toEqual({
+      title: 'Friends of Zetkin',
+    });
   });
 });

--- a/integrationTesting/tests/organize/views/list/create.spec.ts
+++ b/integrationTesting/tests/organize/views/list/create.spec.ts
@@ -36,10 +36,11 @@ test.describe.skip('Views list page', () => {
 
     await page.goto(appUri + '/organize/1/people');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click('data-testid=create-view-action-button'),
-    ]);
+    await page.click('data-testid=create-view-action-button');
+
+    await expect(page).toHaveURL(
+      appUri + `/organize/1/people/views/${NewView.id}`
+    );
 
     // Get POST requests for creating new view and columns
     const columnPostLogs = moxy
@@ -62,11 +63,6 @@ test.describe.skip('Views list page', () => {
     expect(viewPostLogs[0].data?.title).toEqual('New View');
     expect(columnPostLogs[0].data?.title).toEqual('First name');
     expect(columnPostLogs[1].data?.title).toEqual('Last name');
-
-    // Expect that user is navigated to new view's page
-    await expect(page.url()).toEqual(
-      appUri + `/organize/1/people/views/${NewView.id}`
-    );
   });
 
   test('shows an error dialog if there is an error creating the new view', async ({

--- a/integrationTesting/tests/organize/views/list/navigate.spec.ts
+++ b/integrationTesting/tests/organize/views/list/navigate.spec.ts
@@ -1,5 +1,3 @@
-import { expect } from '@playwright/test';
-
 import test from '../../../../fixtures/next';
 import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import KPD from '../../../../mockData/orgs/KPD';
@@ -24,13 +22,8 @@ test.describe('Views list page', () => {
 
     await page.goto(appUri + '/organize/1/people');
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(`text=${AllMembers.title}`),
-    ]);
+    await page.click(`text=${AllMembers.title}`);
 
-    await expect(page.url()).toEqual(
-      appUri + `/organize/1/people/lists/${AllMembers.id}`
-    );
+    await page.waitForURL(appUri + `/organize/1/people/lists/${AllMembers.id}`);
   });
 });


### PR DESCRIPTION
## Description

This PR fixes lots of flaky playwright test patterns. I ran the action 20 times in a row to make sure the tests aren't flaky anymore.

## Changes

[Add a list of features added/changed, bugs fixed etc]

I used an AI agent to fix all of the tests. In particular, I did the following: 
- I set up a testing branch on my fork that can run the playwright test 5 times in a row in GH Actions
- I told the AI the error and that it should fix all flaky test patterns it finds that way across the app
- Repeated that cycle around 5 times
- Once stable, I ran the tests on GH Actions 20 times and none failed

Here is a summary of the changes:
Here’s your rewritten version with proper Markdown code ticks for code snippets:

---

Here is a summary of the changes:

1. **Race condition: `Promise.all` with `waitForResponse` + `click` → `expect.poll()`**

   * Replaced

     ```js
     Promise.all([page.waitForResponse(...), click()])
     ```

     with simpler

     ```js
     click()
     await expect.poll(() => mockLog().length).toBe(1)
     ```

2. **URL assertions → `expect(page).toHaveURL()`**

   ```js
   expect(page.url()).toEqual()
   ```

   →

   ```js
   await expect(page).toHaveURL()
   ```

3. **Navigation waits → `waitForURL` or removed**

   ```js
   Promise.all([page.waitForNavigation(), click()])
   ```

   →

   ```js
   click()
   await page.waitForURL(...)
   ```

4. **Mock response/log tracking → direct `log()` access**

   ```js
   const log = moxy.log(path)
   ```

   →

   ```js
   const { log } = moxy.setZetkinApiMock(...)
   await expect.poll(() => log().length).toBe(1)
   ```

5. **Unreliable `.toPass()` wrappers → removed (kept only where needed)**

6. **Tag chip locators → more specific selectors**

   * Using

     ```js
     [data-testid=TagChip-value]
     ```

     filter instead of text-only locators

7. **Multiple initial response waits → removed/redundant**

   ```js
   Promise.all([waitForResponse(...), waitForResponse(...)...])
   ```

   → removed for initial page loads

8. **Text content assertions → Playwright matchers**

   ```js
   expect(el.textContent()).toEqual()
   ```

   →

   ```js
   await expect(el).toHaveText()
   ```
