### PR TITLE
change lint-stage to auto-fix before commiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   },
   "lint-staged": {
     "*": [
-      "npx prettier --check --ignore-unknown"
+      "npx prettier --write --ignore-unknown"
     ],
     "*.{js,ts,tsx}": [
       "eslint"


### PR DESCRIPTION
## Description

Changes the husky behavior to auto-fix what possible before commiting.

## Screenshots

Before commit:
<img width="1098" height="294" alt="image" src="https://github.com/user-attachments/assets/d410e3c0-50bd-4e31-be19-dfbcee032902" />

Commited diff:
<img width="949" height="276" alt="Screenshot 2026-03-27 at 12 51 13" src="https://github.com/user-attachments/assets/45ab8635-44d9-4fd3-bf98-e1930bb84bb0" />


## Changes

- Changes `--check` flag to `--write` flag in lint-staged description
