### PR TITLE
#3610: catch 403 exception and return empty list, when customFields not accessible for user with whom the list was shared

### DIFF
--- a/src/features/profile/hooks/useCustomFields.ts
+++ b/src/features/profile/hooks/useCustomFields.ts
@@ -12,6 +12,7 @@ export default function useCustomFields(
   const fieldsList = useAppSelector((state) => state.profiles.fieldsList);
 
   return loadListIfNecessary(fieldsList, dispatch, {
+    actionOnError: () => fieldsLoaded([]),
     actionOnLoad: () => fieldsLoad(),
     actionOnSuccess: (fields) => fieldsLoaded(fields),
     loader: async () =>


### PR DESCRIPTION
## Description

This PR to resolve #3610 would just catch the 403 exception and return an empty list for the customField, so the shared list is loaded at least for the user. 

## Changes

Adds `actionOnError: () => fieldsLoaded([]),` to useCustomFields.  

## Notes to reviewer

In the ticket it was mentioned, to solve this issue properly, the src/features/views/components/ViewDataTable/index.tsx should load the customFields only on demand (instead of getting them passed directly). 

As I can see, it's only used in src/features/views/components/ViewDataTable/columnTypes/PersonFieldColumnType.tsx
```
    const customField = customFieldsInfo?.find(
      (cf) => cf.slug === column.config.field
    );
```
and then this customField is only used to determine, if the column is a date: `const isDate = customField?.type === CUSTOM_FIELD_TYPE.DATE;` to later render the field as date field.

So one could avoid calling the custom fields, when columns doesn't contain src/features/views/components/ViewDataTable/columnTypes/PersonFieldColumnType.tsx
but in src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx columnsFuture is still a promise, so it cannot be checked yet, ZUIFutures will resolve it only at the same time as customFieldsFuture.
