### PR TITLE
3610 with refactor view data table

### DIFF
--- a/src/features/profile/hooks/useCustomFields.ts
+++ b/src/features/profile/hooks/useCustomFields.ts
@@ -12,6 +12,7 @@ export default function useCustomFields(
   const fieldsList = useAppSelector((state) => state.profiles.fieldsList);
 
   return loadListIfNecessary(fieldsList, dispatch, {
+    actionOnError: () => fieldsLoaded([]),
     actionOnLoad: () => fieldsLoad(),
     actionOnSuccess: (fields) => fieldsLoaded(fields),
     loader: async () =>

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -73,6 +73,7 @@ import useViewMutations from 'features/views/hooks/useViewMutations';
 import oldTheme from 'theme';
 import useViewBulkActions from 'features/views/hooks/useViewBulkActions';
 import { dayOfMonthOperator, monthOperator } from './customFilters/date';
+import useCustomFields from 'features/profile/hooks/useCustomFields';
 
 declare module '@mui/x-data-grid-pro' {
   interface ColumnMenuPropsOverrides {
@@ -136,7 +137,6 @@ const getFilterOperators = (
 
 interface ViewDataTableProps {
   columns: ZetkinViewColumn[];
-  customFields?: ZetkinCustomField[];
   disableAdd?: boolean;
   disableConfigure?: boolean;
   rows: ZetkinViewRow[];
@@ -168,7 +168,6 @@ const slots = {
 
 const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   columns,
-  customFields,
   disableAdd = false,
   disableConfigure,
   rows,
@@ -208,6 +207,12 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   const [quickSearch, setQuickSearch] = useState('');
   const { orgId } = useNumericRouteParams();
+  const [customFields, setCustomFields] = useState<ZetkinCustomField[]>([]);
+  const {
+    data: customFieldData,
+    error: customFieldError,
+    isLoading: customIsLoading,
+  } = useCustomFields(orgId);
 
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -227,6 +232,18 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [showSnackbar]
   );
+
+  useEffect(() => {
+    if (!customIsLoading && !customFields && customFieldData) {
+      setCustomFields(customFieldData);
+    }
+  }, [customFieldData, customIsLoading, customFields]);
+
+  useEffect(() => {
+    if (customFieldError) {
+      showError(VIEW_DATA_TABLE_ERROR.CREATE_COLUMN);
+    }
+  }, [customFieldError, customIsLoading, showError]);
 
   const updateColumn = useCallback(
     async (id: number, data: Omit<Partial<ZetkinViewColumn>, 'id'>) => {

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -62,7 +62,6 @@ import ViewDataTableFooter, {
 } from 'features/views/components/ViewDataTable/ViewDataTableFooter';
 import ViewDataTableToolbar from './ViewDataTableToolbar';
 import {
-  ZetkinCustomField,
   ZetkinPerson,
   ZetkinViewColumn,
   ZetkinViewRow,
@@ -207,12 +206,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   const [quickSearch, setQuickSearch] = useState('');
   const { orgId } = useNumericRouteParams();
-  const [customFields, setCustomFields] = useState<ZetkinCustomField[]>([]);
-  const {
-    data: customFieldData,
-    error: customFieldError,
-    isLoading: customIsLoading,
-  } = useCustomFields(orgId);
+  const { data: customFields } = useCustomFields(orgId);
 
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
@@ -232,18 +226,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [showSnackbar]
   );
-
-  useEffect(() => {
-    if (!customIsLoading && !customFields && customFieldData) {
-      setCustomFields(customFieldData);
-    }
-  }, [customFieldData, customIsLoading, customFields]);
-
-  useEffect(() => {
-    if (customFieldError) {
-      showError(VIEW_DATA_TABLE_ERROR.CREATE_COLUMN);
-    }
-  }, [customFieldError, customIsLoading, showError]);
 
   const updateColumn = useCallback(
     async (id: number, data: Omit<Partial<ZetkinViewColumn>, 'id'>) => {

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -13,7 +13,6 @@ import useViewGrid from 'features/views/hooks/useViewGrid';
 import ViewDataTable from 'features/views/components/ViewDataTable';
 import ZUIFutures from 'zui/ZUIFutures';
 import { ZetkinView } from 'features/views/components/types';
-import useCustomFields from 'features/profile/hooks/useCustomFields';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -91,7 +90,6 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
   const parsedViewId = parseInt(viewId);
   const { columnsFuture, rowsFuture } = useViewGrid(parsedOrgId, parsedViewId);
   const viewFuture = useView(parsedOrgId, parsedViewId);
-  const customFieldsFuture = useCustomFields(parsedOrgId);
 
   if (onServer) {
     return null;
@@ -101,12 +99,11 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
     <ZUIFutures
       futures={{
         cols: columnsFuture,
-        customFields: customFieldsFuture,
         rows: rowsFuture,
         view: viewFuture,
       }}
     >
-      {({ data: { cols, customFields, rows, view } }) => (
+      {({ data: { cols, rows, view } }) => (
         <>
           <Head>
             <title>{view.title}</title>
@@ -116,7 +113,6 @@ const SingleViewPage: PageWithLayout<SingleViewPageProps> = ({
             {!columnsFuture.isLoading || !!columnsFuture.data?.length ? (
               <ViewDataTable
                 columns={cols}
-                customFields={customFields}
                 rows={rows}
                 rowSelection={{
                   mode: 'selectWithBulkActions',

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -15,7 +15,6 @@ import { ZetkinMembership } from 'utils/types/zetkin';
 import { ZetkinObjectAccess } from 'core/api/types';
 import ZUIFutures from 'zui/ZUIFutures';
 import { ZetkinView } from 'features/views/components/types';
-import useCustomFields from 'features/profile/hooks/useCustomFields';
 
 const scaffoldOptions = {
   allowNonOfficials: true,
@@ -110,7 +109,6 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
 
   const { columnsFuture, rowsFuture } = useViewGrid(parsedOrgId, parsedViewId);
   const viewFuture = useView(parsedOrgId, parsedViewId);
-  const customFieldsFuture = useCustomFields(parsedOrgId);
   const canConfigure = accessLevel == 'configure';
 
   const onServer = useServerSide();
@@ -122,12 +120,11 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
     <ZUIFutures
       futures={{
         cols: columnsFuture,
-        customFields: customFieldsFuture,
         rows: rowsFuture,
         view: viewFuture,
       }}
     >
-      {({ data: { cols, customFields, rows, view } }) => (
+      {({ data: { cols, rows, view } }) => (
         <>
           <Head>
             <title>{view.title}</title>
@@ -136,7 +133,6 @@ const SharedViewPage: PageWithLayout<SharedViewPageProps> = ({
             {!columnsFuture.isLoading ? (
               <ViewDataTable
                 columns={cols}
-                customFields={customFields}
                 disableConfigure={!canConfigure}
                 rows={rows}
                 view={view}


### PR DESCRIPTION
## Description

This PR is an alternative / addition to https://github.com/zetkin/app.zetkin.org/pull/3613, to examine, how to refactor view data list to call useCustomFields there, although I'm not sure, how to decide whether the call to useCustomFields is needed or not (as suggested in the ticket #3610 "to fetch the custom fields when they are needed, instead of at the top level")

## Changes
Moved the call of useCustomFields to src/features/views/components/ViewDataTable/index.tsx in a useEffect hook.
