### PR TITLE
#3608: hide buttons and show loading indicator in place of grid

### DIFF
--- a/src/features/settings/components/AddOfficialButton.tsx
+++ b/src/features/settings/components/AddOfficialButton.tsx
@@ -11,12 +11,14 @@ import { Msg, useMessages } from 'core/i18n';
 
 interface AddOfficialButtonProps {
   orgId: number;
-  disabledList: ZetkinMembership[];
+  disabled: boolean;
+  peopleToDisable: ZetkinMembership[];
   roleType: 'admin' | 'organizer';
 }
 
 const AddOfficialButton = ({
-  disabledList,
+  peopleToDisable,
+  disabled,
   orgId,
   roleType,
 }: AddOfficialButtonProps) => {
@@ -24,8 +26,9 @@ const AddOfficialButton = ({
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const addAdmin = roleType === 'admin';
   const { updateRole } = useOfficialMutations(orgId);
+
   const getOptionExtraLabel = (personId: number) => {
-    if (disabledList.some((person) => person.profile.id === personId)) {
+    if (peopleToDisable.some((person) => person.profile.id === personId)) {
       return (
         <Box
           sx={{
@@ -41,9 +44,11 @@ const AddOfficialButton = ({
     }
     return '';
   };
+
   return (
     <>
       <Button
+        disabled={disabled}
         onClick={(ev) => {
           setAnchorEl(ev.target as Element);
         }}
@@ -86,7 +91,7 @@ const AddOfficialButton = ({
           <ZUIPersonSelect
             disabled
             getOptionDisabled={(option) =>
-              disabledList.some((person) => person.profile.id == option.id)
+              peopleToDisable.some((person) => person.profile.id == option.id)
             }
             getOptionExtraLabel={(option) => {
               return getOptionExtraLabel(option.id);

--- a/src/features/settings/components/OfficialList.tsx
+++ b/src/features/settings/components/OfficialList.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
-import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
-import { Button, FormControl, Typography } from '@mui/material';
+import { ArrowDownward, ArrowUpward, InfoOutline } from '@mui/icons-material';
+import { Box, Button, FormControl, Typography } from '@mui/material';
 import { DataGridPro, GridColDef } from '@mui/x-data-grid-pro';
 
 import messageIds from '../l10n/messageIds';
@@ -14,11 +14,16 @@ import ZUIPersonAvatar from 'zui/ZUIPersonAvatar';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 
 interface OfficialListProps {
+  emptyListMessage: string;
   orgId: number;
   officialList: ZetkinMembership[];
 }
 
-const OfficialList: FC<OfficialListProps> = ({ orgId, officialList }) => {
+const OfficialList: FC<OfficialListProps> = ({
+  orgId,
+  officialList,
+  emptyListMessage,
+}) => {
   const messages = useMessages(messageIds);
   const { removeAccess, updateRole } = useOfficialMutations(orgId);
   const user = useCurrentUser();
@@ -33,6 +38,22 @@ const OfficialList: FC<OfficialListProps> = ({ orgId, officialList }) => {
     }
     return a.profile.name.localeCompare(b.profile.name);
   });
+
+  if (sortedOfficialList.length == 0) {
+    return (
+      <Box
+        sx={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 4,
+        }}
+      >
+        <InfoOutline color="disabled" fontSize="large" />
+        <Typography color="secondary">{emptyListMessage}</Typography>
+      </Box>
+    );
+  }
 
   const columns: GridColDef[] = [
     {

--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -17,6 +17,7 @@ export default makeMessages('feat.settings', {
       description: m(
         'Administrators have full access to creating, editing and deleting any type of content.'
       ),
+      empty: m('You have not added any administrators yet.'),
       roleInheritance: m('Administrator in'),
       title: m('Administrators'),
     },
@@ -28,6 +29,7 @@ export default makeMessages('feat.settings', {
       description: m(
         'Organizers have enough privileges to do things like organizing campaigns and managing existing call assignments.'
       ),
+      empty: m('You have not added any organizers yet.'),
       roleInheritance: m('Organizer in'),
       title: m('Organizers'),
     },

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -83,11 +83,7 @@ const SettingsPage: PageWithLayout = () => {
             </Typography>
           </Box>
           {membershipsLoading ? (
-            <Box>
-              <Skeleton sx={{ height: '50px' }} />
-              <Skeleton sx={{ height: '50px' }} />
-              <Skeleton sx={{ height: '50px' }} />
-            </Box>
+            <Skeleton sx={{ height: '156px', transform: 'scale(1)' }} />
           ) : (
             <OfficialList
               emptyListMessage={messages.officials.administrators.empty()}
@@ -127,11 +123,7 @@ const SettingsPage: PageWithLayout = () => {
             </Typography>
           </Box>
           {membershipsLoading ? (
-            <Box>
-              <Skeleton sx={{ height: '50px' }} />
-              <Skeleton sx={{ height: '50px' }} />
-              <Skeleton sx={{ height: '50px' }} />
-            </Box>
+            <Skeleton sx={{ height: '156px', transform: 'scale(1)' }} />
           ) : (
             <OfficialList
               emptyListMessage={messages.officials.organizers.empty()}

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { GetServerSideProps } from 'next';
 import { OpenInNew } from '@mui/icons-material';
-import { Box, Grid, Link, Typography } from '@mui/material';
+import { Box, Grid, Link, Skeleton, Typography } from '@mui/material';
 
 import AddOfficialButton from 'features/settings/components/AddOfficialButton';
 import messageIds from 'features/settings/l10n/messageIds';
@@ -16,8 +16,6 @@ import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
-import { ZetkinMembership } from 'utils/types/zetkin';
-import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -31,34 +29,21 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 );
 
 const SettingsPage: PageWithLayout = () => {
+  const messages = useMessages(messageIds);
   const onServer = useServerSide();
   const { orgId } = useNumericRouteParams();
-  const {
-    data: memberships,
-    error: membershipsError,
-    isLoading: membershipsLoading,
-  } = useOfficialMemberships(orgId);
-  const messages = useMessages(messageIds);
+
   const env = useEnv();
   const publicOrgUrl = `${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}`;
 
-  const [adminList, setAdminList] = useState<ZetkinMembership[] | null>(null);
-  const [organizerList, setOrganizerList] = useState<ZetkinMembership[] | null>(
-    null
-  );
-
-  useEffect(() => {
-    if (!membershipsLoading && memberships && !adminList && !organizerList) {
-      setAdminList(memberships.filter((user) => user.role === 'admin'));
-      setOrganizerList(memberships.filter((user) => user.role === 'organizer'));
-    }
-  }, [memberships, membershipsLoading, adminList, organizerList]);
-
-  useEffect(() => {
-    if (membershipsError) {
-      // showError;
-    }
-  }, [membershipsError]);
+  const { data: memberships, isLoading: membershipsLoading } =
+    useOfficialMemberships(orgId);
+  const [admins, organizers] = useMemo(() => {
+    const admins = memberships?.filter((user) => user.role === 'admin') || [];
+    const organizers =
+      memberships?.filter((user) => user.role === 'organizer') || [];
+    return [admins, organizers];
+  }, [memberships]);
 
   if (onServer) {
     return null;
@@ -66,63 +51,98 @@ const SettingsPage: PageWithLayout = () => {
 
   return (
     <Grid container spacing={2}>
-      <Grid size={{ md: 8 }}>
-        <Box
-          alignItems="center"
-          display="flex"
-          justifyContent="space-between"
-          sx={{
-            marginBottom: '15px',
-            marginTop: '15px',
-          }}
-        >
-          <Typography variant="h4">
-            <Msg id={messageIds.officials.administrators.title} />
-          </Typography>
-          {!membershipsLoading && (
-            <AddOfficialButton
-              disabledList={adminList || []}
+      <Grid
+        size={{ md: 8 }}
+        sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}
+      >
+        <Box>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+              paddingBottom: 2,
+            }}
+          >
+            <Box
+              sx={{
+                alignItems: 'center',
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Typography variant="h4">
+                <Msg id={messageIds.officials.administrators.title} />
+              </Typography>
+              <AddOfficialButton
+                disabled={membershipsLoading}
+                orgId={orgId}
+                peopleToDisable={admins}
+                roleType="admin"
+              />
+            </Box>
+            <Typography variant="body2">
+              <Msg id={messageIds.officials.administrators.description} />
+            </Typography>
+          </Box>
+          {membershipsLoading ? (
+            <Box>
+              <Skeleton sx={{ height: '50px' }} />
+              <Skeleton sx={{ height: '50px' }} />
+              <Skeleton sx={{ height: '50px' }} />
+            </Box>
+          ) : (
+            <OfficialList
+              emptyListMessage={messages.officials.administrators.empty()}
+              officialList={admins}
               orgId={orgId}
-              roleType="admin"
             />
           )}
         </Box>
-        <Typography mb={2} variant="body2">
-          <Msg id={messageIds.officials.administrators.description} />
-        </Typography>
-        {membershipsLoading ? (
-          <ZUILogoLoadingIndicator />
-        ) : (
-          <OfficialList officialList={adminList || []} orgId={orgId} />
-        )}
-        <Box
-          alignItems="center"
-          display="flex"
-          justifyContent="space-between"
-          sx={{
-            marginBottom: '15px',
-            marginTop: '40px',
-          }}
-        >
-          <Typography variant="h4">
-            <Msg id={messageIds.officials.organizers.title} />
-          </Typography>
-          {!membershipsLoading && (
-            <AddOfficialButton
-              disabledList={organizerList || []}
+        <Box>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+              paddingBottom: 2,
+            }}
+          >
+            <Box
+              sx={{
+                alignItems: 'center',
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Typography variant="h4">
+                <Msg id={messageIds.officials.organizers.title} />
+              </Typography>
+              <AddOfficialButton
+                disabled={membershipsLoading}
+                orgId={orgId}
+                peopleToDisable={organizers}
+                roleType="organizer"
+              />
+            </Box>
+            <Typography variant="body2">
+              <Msg id={messageIds.officials.organizers.description} />
+            </Typography>
+          </Box>
+          {membershipsLoading ? (
+            <Box>
+              <Skeleton sx={{ height: '50px' }} />
+              <Skeleton sx={{ height: '50px' }} />
+              <Skeleton sx={{ height: '50px' }} />
+            </Box>
+          ) : (
+            <OfficialList
+              emptyListMessage={messages.officials.organizers.empty()}
+              officialList={organizers}
               orgId={orgId}
-              roleType="organizer"
             />
           )}
         </Box>
-        <Typography mb={2} variant="body2">
-          <Msg id={messageIds.officials.organizers.description} />
-        </Typography>
-        {membershipsLoading ? (
-          <ZUILogoLoadingIndicator />
-        ) : (
-          <OfficialList officialList={organizerList || []} orgId={orgId} />
-        )}
       </Grid>
       <Grid size={{ md: 4 }}>
         <ZUICard

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { GetServerSideProps } from 'next';
 import { OpenInNew } from '@mui/icons-material';
 import { Box, Grid, Link, Typography } from '@mui/material';
@@ -15,6 +16,8 @@ import useServerSide from 'core/useServerSide';
 import ZUICard from 'zui/ZUICard';
 import ZUITextfieldToClipboard from 'zui/ZUITextfieldToClipboard';
 import { Msg, useMessages } from 'core/i18n';
+import { ZetkinMembership } from 'utils/types/zetkin';
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 
 export const getServerSideProps: GetServerSideProps = scaffold(
   async () => {
@@ -30,13 +33,32 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 const SettingsPage: PageWithLayout = () => {
   const onServer = useServerSide();
   const { orgId } = useNumericRouteParams();
-  const listFuture = useOfficialMemberships(orgId).data || [];
+  const {
+    data: memberships,
+    error: membershipsError,
+    isLoading: membershipsLoading,
+  } = useOfficialMemberships(orgId);
   const messages = useMessages(messageIds);
   const env = useEnv();
   const publicOrgUrl = `${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}`;
 
-  const adminList = listFuture.filter((user) => user.role === 'admin');
-  const organizerList = listFuture.filter((user) => user.role === 'organizer');
+  const [adminList, setAdminList] = useState<ZetkinMembership[] | null>(null);
+  const [organizerList, setOrganizerList] = useState<ZetkinMembership[] | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!membershipsLoading && memberships && !adminList && !organizerList) {
+      setAdminList(memberships.filter((user) => user.role === 'admin'));
+      setOrganizerList(memberships.filter((user) => user.role === 'organizer'));
+    }
+  }, [memberships, membershipsLoading, adminList, organizerList]);
+
+  useEffect(() => {
+    if (membershipsError) {
+      // showError;
+    }
+  }, [membershipsError]);
 
   if (onServer) {
     return null;
@@ -57,16 +79,22 @@ const SettingsPage: PageWithLayout = () => {
           <Typography variant="h4">
             <Msg id={messageIds.officials.administrators.title} />
           </Typography>
-          <AddOfficialButton
-            disabledList={adminList}
-            orgId={orgId}
-            roleType="admin"
-          />
+          {!membershipsLoading && (
+            <AddOfficialButton
+              disabledList={adminList || []}
+              orgId={orgId}
+              roleType="admin"
+            />
+          )}
         </Box>
         <Typography mb={2} variant="body2">
           <Msg id={messageIds.officials.administrators.description} />
         </Typography>
-        <OfficialList officialList={adminList} orgId={orgId} />
+        {membershipsLoading ? (
+          <ZUILogoLoadingIndicator />
+        ) : (
+          <OfficialList officialList={adminList || []} orgId={orgId} />
+        )}
         <Box
           alignItems="center"
           display="flex"
@@ -79,16 +107,22 @@ const SettingsPage: PageWithLayout = () => {
           <Typography variant="h4">
             <Msg id={messageIds.officials.organizers.title} />
           </Typography>
-          <AddOfficialButton
-            disabledList={organizerList}
-            orgId={orgId}
-            roleType="organizer"
-          />
+          {!membershipsLoading && (
+            <AddOfficialButton
+              disabledList={organizerList || []}
+              orgId={orgId}
+              roleType="organizer"
+            />
+          )}
         </Box>
         <Typography mb={2} variant="body2">
           <Msg id={messageIds.officials.organizers.description} />
         </Typography>
-        <OfficialList officialList={organizerList} orgId={orgId} />
+        {membershipsLoading ? (
+          <ZUILogoLoadingIndicator />
+        ) : (
+          <OfficialList officialList={organizerList || []} orgId={orgId} />
+        )}
       </Grid>
       <Grid size={{ md: 4 }}>
         <ZUICard


### PR DESCRIPTION
## Description

This PR introduces loading indicators on organization settings page, to show that the list of admins and organizers are still loading. Also the buttons to add admins / organizers are hidden while loading.

## Screenshots

<img width="1429" height="786" alt="Bildschirmfoto 2026-03-28 um 15 58 57" src="https://github.com/user-attachments/assets/466baada-49cd-446b-8836-b5dff223ef85" />

## Changes
- retrieving isLoading and error from useOfficialMemberships hook and setting the actual list via useEffect
- hide add admin button and hide add organizer button while isLoading == true
- show Zetkin loading in place of admin list and organizer list while isLoading == true

## Notes to reviewer
Just open http://localhost:3000/organize/1/settings and see the loading indicators and the not visible buttons, they will appear after a while like the admin list and organizer as well.

## Related issues

Resolves #3608