### PR TITLE
#3609: Link to public org page now leads to gen3

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org
+ZETKIN_APP_DOMAIN=http://localhost:3000
 ZETKIN_GEN2_ORGANIZE_URL=http://organize.dev.zetkin.org
 ZETKIN_GEN2_CALL_URL=http://call.dev.zetkin.org
 

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-ZETKIN_APP_DOMAIN=http://localhost:3000
+ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org
 ZETKIN_GEN2_ORGANIZE_URL=http://organize.dev.zetkin.org
 ZETKIN_GEN2_CALL_URL=http://call.dev.zetkin.org
 

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -8,7 +8,6 @@ import OfficialList from 'features/settings/components/OfficialList';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import SettingsLayout from 'features/settings/layout/SettingsLayout';
-import { useEnv } from 'core/hooks';
 import useNumericRouteParams from 'core/hooks/useNumericRouteParams';
 import useOfficialMemberships from 'features/settings/hooks/useOfficialMemberships';
 import useServerSide from 'core/useServerSide';
@@ -32,7 +31,6 @@ const SettingsPage: PageWithLayout = () => {
   const { orgId } = useNumericRouteParams();
   const listFuture = useOfficialMemberships(orgId).data || [];
   const messages = useMessages(messageIds);
-  const env = useEnv();
   const publicOrgUrl = `${location.protocol}//${location.host}/o/${orgId}`;
 
   const adminList = listFuture.filter((user) => user.role === 'admin');

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -33,7 +33,7 @@ const SettingsPage: PageWithLayout = () => {
   const listFuture = useOfficialMemberships(orgId).data || [];
   const messages = useMessages(messageIds);
   const env = useEnv();
-  const publicOrgUrl = `${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}`;
+  const publicOrgUrl = `${location.protocol}//${location.host}/o/${orgId}`;
 
   const adminList = listFuture.filter((user) => user.role === 'admin');
   const organizerList = listFuture.filter((user) => user.role === 'organizer');


### PR DESCRIPTION
Fix for https://github.com/zetkin/app.zetkin.org/issues/3609

Changed ZETKIN_APP_DOMAIN to use local host instead of old gen2 link

## Description

The wrong link occurs in app.zetkin.org/src/pages/organize/[orgId]/settings/index.tsx on line 105 where it uses href={publicOrgUrl}

this is defined on line 36: const publicOrgUrl = `${env.vars.ZETKIN_APP_DOMAIN}/o/${orgId}`;

Main cause of issue was ZETKIN_APP_DOMAIN in .env.development pointing to the gen2 website

## Screenshots

[Add screenshots here]

## Changes

Changed ZETKIN_APP_DOMAIN=http://www.dev.zetkin.org to ZETKIN_APP_DOMAIN=http://localhost:3000

## Notes to reviewer

Unsure if pointing to http://localhost:3000 is the best or desired way to fix.  It points to the right site on local server (which I believe was the main problem) but the code used in index.tsx looks to be using less dynamic methods than similar parts like survey or events

## Related issues

Resolves #3609 
