### PR TITLE
ZUIReorderable Nitpicks

### DIFF
--- a/src/zui/ZUIReorderable/index.tsx
+++ b/src/zui/ZUIReorderable/index.tsx
@@ -229,29 +229,29 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
               widgets={widgets.map((widget) => {
                 if (disableClick) {
                   // Hide all widgets when click is disabled
-                  return [widget, false];
+                  return { shown: false, widget };
                 }
 
                 if (
                   widget == ZUIReorderableWidget.MOVE_DOWN &&
                   index < items.length - 1
                 ) {
-                  return [widget, true];
+                  return { shown: true, widget };
                 } else if (
                   widget == ZUIReorderableWidget.MOVE_UP &&
                   index > 0
                 ) {
-                  return [widget, true];
+                  return { shown: true, widget };
                 } else if (
                   widget == ZUIReorderableWidget.DRAG &&
                   !disableDrag
                 ) {
-                  return [widget, true];
+                  return { shown: true, widget };
                 } else if (widget == ZUIReorderableWidget.MENU) {
-                  return [widget, true];
+                  return { shown: true, widget };
                 }
 
-                return [widget, false];
+                return { shown: false, widget };
               })}
               widgetsOnlyOnHover={widgetsOnlyOnHover}
               widgetsProps={widgetsProps}
@@ -260,6 +260,11 @@ const ZUIReorderable: FC<ZUIReorderableProps> = ({
       )}
     </Box>
   );
+};
+
+type WidgetState = {
+  shown: boolean;
+  widget: ZUIReorderableWidget;
 };
 
 const ZUIReorderableItem: FC<{
@@ -277,7 +282,7 @@ const ZUIReorderableItem: FC<{
   onClickUp: () => void;
   onDelete?: (id: IDType) => void;
   onNodeExists: (node: HTMLDivElement) => void;
-  widgets: [ZUIReorderableWidget, boolean][];
+  widgets: WidgetState[];
   widgetsOnlyOnHover?: boolean;
   widgetsProps?: BoxProps;
 }> = ({
@@ -331,7 +336,7 @@ const ZUIReorderableItem: FC<{
             zIndex: shown ? 10 : undefined,
           }}
         >
-          {widgets.map(([widget, shown]) => {
+          {widgets.map(({ widget, shown }) => {
             if (!shown && !centerWidgets) {
               return null;
             }


### PR DESCRIPTION
## Description

This PR fixes some very small but very important UX things about the ZUIReorderable component. 

## Changes

1. Most observerable, I fixed this alignment:

<img width="346" height="161" alt="alignment-wrong" src="https://github.com/user-attachments/assets/1a7111dc-751e-45ee-9e96-a0c1c53c0b8e" />
to
<img width="346" height="161" alt="alignment-correct" src="https://github.com/user-attachments/assets/91c942ea-1263-474d-a1c1-386f7cab3ab9" />

2. These buttons only show on hover in the smart search, but the hover event didn't trigger on the button area itself but only on the component. That was annoying because when the mouse leaves to the left and wants to click the icons again, it can't get to them. I made the hover hitbox also cover the area where the buttons would be.
3. A bit hard to explain. A state transition bug that became more observable after fixing the hover hitbox. It happened when reordering something upwards. Then, both the current and the element below show the reorderable buttons. This also happens on main when you drag diagonally so your mouse ends up on the current hover hitbox. This happened because the mouseOver event (which sets hovered to true) was being triggered on the old order after mouseUp after a drag, which then carried that state downwards, then retriggering mouseOver on the current event, ending up with two rows in hover state. I fixed that using `startTransition`

