### PR TITLE
Issue 3509/area stats spinner never stops

### DIFF
--- a/src/features/areaAssignments/components/AreaStatsCard.tsx
+++ b/src/features/areaAssignments/components/AreaStatsCard.tsx
@@ -1,0 +1,88 @@
+import { FC } from 'react';
+import useAssignmentAreaStats from 'features/areaAssignments/hooks/useAssignmentAreaStats';
+import useAssignmentAreaGraph from 'features/areaAssignments/hooks/useAssignmentAreaGraph';
+import AreaCard from 'features/areaAssignments/components/AreaCard';
+import { ZetkinAssignmentAreaStatsItem } from 'features/areaAssignments/types';
+import ZUIFutures from 'zui/ZUIFutures';
+import { ZetkinAreaAssignment } from '../types';
+
+type AreaStatsCardProps = {
+  orgId: number;
+  areaAssId: number;
+  assignment: ZetkinAreaAssignment;
+};
+
+const AreaStatsCard: FC<AreaStatsCardProps> = ({
+  orgId,
+  areaAssId,
+  assignment,
+}) => {
+  const areasStats = useAssignmentAreaStats(orgId, areaAssId);
+  const dataGraph = useAssignmentAreaGraph(orgId, areaAssId);
+  return (
+    <ZUIFutures futures={{ areasStats, dataGraph }}>
+      {({ data: { areasStats, dataGraph } }) => {
+        const filteredAreas = dataGraph
+          .map((area) => {
+            return areasStats.stats.filter(
+              (item) => item.area_id === area.area_id
+            );
+          })
+          .flat();
+
+        const sortedAreas = filteredAreas
+          .map((area) => {
+            const successfulVisitsTotal =
+              dataGraph
+                .find((graph) => graph.area_id === area.area_id)
+                ?.data.reduce((sum, item) => sum + item.successfulVisits, 0) ||
+              0;
+
+            return {
+              area,
+              successfulVisitsTotal,
+            };
+          })
+          .sort((a, b) => b.successfulVisitsTotal - a.successfulVisitsTotal)
+          .map(({ area }) => area);
+
+        const maxHouseholdVisits = Math.max(
+          ...dataGraph.flatMap((areaCard) =>
+            areaCard.data.map((graphData) => graphData.householdVisits)
+          )
+        );
+
+        const noAreaData = dataGraph.find((graph) => !graph.area_id);
+        if (noAreaData && noAreaData.data.length > 0) {
+          const latestEntry = [...noAreaData.data].sort(
+            (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+          )[0];
+
+          const num_successful_visited_households =
+            latestEntry.successfulVisits;
+
+          const num_visited_households = latestEntry.householdVisits;
+
+          const noArea: ZetkinAssignmentAreaStatsItem = {
+            area_id: null,
+            num_households: 0,
+            num_locations: 0,
+            num_successful_visited_households,
+            num_visited_households,
+            num_visited_locations: 0,
+          };
+          sortedAreas.push(noArea);
+        }
+        return (
+          <AreaCard
+            areas={sortedAreas}
+            assignment={assignment}
+            data={dataGraph}
+            maxVisitedHouseholds={maxHouseholdVisits}
+          />
+        );
+      }}
+    </ZUIFutures>
+  );
+};
+export default AreaStatsCard;

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
@@ -4,7 +4,6 @@ import { Edit } from '@mui/icons-material';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 
-import AreaCard from 'features/areaAssignments/components/AreaCard';
 import { AREAS } from 'utils/featureFlags';
 import AreaAssignmentLayout from 'features/areaAssignments/layouts/AreaAssignmentLayout';
 import { PageWithLayout } from 'utils/types';
@@ -13,13 +12,11 @@ import { scaffold } from 'utils/next';
 import useAreaAssignment from 'features/areaAssignments/hooks/useAreaAssignment';
 import useAreaAssignmentStats from 'features/areaAssignments/hooks/useAreaAssignmentStats';
 import ZUIFutures from 'zui/ZUIFutures';
-import useAssignmentAreaStats from 'features/areaAssignments/hooks/useAssignmentAreaStats';
-import useAssignmentAreaGraph from 'features/areaAssignments/hooks/useAssignmentAreaGraph';
-import { ZetkinAssignmentAreaStatsItem } from 'features/areaAssignments/types';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areaAssignments/l10n/messageIds';
 import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
 import { AREA_STATS, hasFeature } from 'utils/featureFlags';
+import AreaStatsCard from 'features/areaAssignments/components/AreaStatsCard';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -46,8 +43,6 @@ const AreaAssignmentPage: PageWithLayout<AreaAssignmentPageProps> = ({
   const sessionsFuture = useAreaAssignees(parseInt(orgId), areaAssId);
   const assignmentFuture = useAreaAssignment(parseInt(orgId), areaAssId);
   const statsFuture = useAreaAssignmentStats(parseInt(orgId), areaAssId);
-  const areasStats = useAssignmentAreaStats(parseInt(orgId), areaAssId);
-  const dataGraph = useAssignmentAreaGraph(parseInt(orgId), areaAssId);
   const router = useRouter();
 
   const numAreas = new Set(
@@ -132,84 +127,11 @@ const AreaAssignmentPage: PageWithLayout<AreaAssignmentPageProps> = ({
                   </Card>
                   {hasAreaFeature && (
                     <Grid container spacing={2}>
-                      <ZUIFutures futures={{ areasStats, dataGraph }}>
-                        {({ data: { areasStats, dataGraph } }) => {
-                          const filteredAreas = dataGraph
-                            .map((area) => {
-                              return areasStats.stats.filter(
-                                (item) => item.area_id === area.area_id
-                              );
-                            })
-                            .flat();
-
-                          const sortedAreas = filteredAreas
-                            .map((area) => {
-                              const successfulVisitsTotal =
-                                dataGraph
-                                  .find(
-                                    (graph) => graph.area_id === area.area_id
-                                  )
-                                  ?.data.reduce(
-                                    (sum, item) => sum + item.successfulVisits,
-                                    0
-                                  ) || 0;
-
-                              return {
-                                area,
-                                successfulVisitsTotal,
-                              };
-                            })
-                            .sort(
-                              (a, b) =>
-                                b.successfulVisitsTotal -
-                                a.successfulVisitsTotal
-                            )
-                            .map(({ area }) => area);
-
-                          const maxHouseholdVisits = Math.max(
-                            ...dataGraph.flatMap((areaCard) =>
-                              areaCard.data.map(
-                                (graphData) => graphData.householdVisits
-                              )
-                            )
-                          );
-
-                          const noAreaData = dataGraph.find(
-                            (graph) => !graph.area_id
-                          );
-                          if (noAreaData && noAreaData.data.length > 0) {
-                            const latestEntry = [...noAreaData.data].sort(
-                              (a, b) =>
-                                new Date(b.date).getTime() -
-                                new Date(a.date).getTime()
-                            )[0];
-
-                            const num_successful_visited_households =
-                              latestEntry.successfulVisits;
-
-                            const num_visited_households =
-                              latestEntry.householdVisits;
-
-                            const noArea: ZetkinAssignmentAreaStatsItem = {
-                              area_id: null,
-                              num_households: 0,
-                              num_locations: 0,
-                              num_successful_visited_households,
-                              num_visited_households,
-                              num_visited_locations: 0,
-                            };
-                            sortedAreas.push(noArea);
-                          }
-                          return (
-                            <AreaCard
-                              areas={sortedAreas}
-                              assignment={assignment}
-                              data={dataGraph}
-                              maxVisitedHouseholds={maxHouseholdVisits}
-                            />
-                          );
-                        }}
-                      </ZUIFutures>
+                      <AreaStatsCard
+                        orgId={parseInt(orgId)}
+                        areaAssId={areaAssId}
+                        assignment={assignment}
+                      />
                     </Grid>
                   )}
                 </>

--- a/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/areaassignments/[areaAssId]/index.tsx
@@ -19,6 +19,7 @@ import { ZetkinAssignmentAreaStatsItem } from 'features/areaAssignments/types';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/areaAssignments/l10n/messageIds';
 import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
+import { AREA_STATS, hasFeature } from 'utils/featureFlags';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
@@ -52,6 +53,8 @@ const AreaAssignmentPage: PageWithLayout<AreaAssignmentPageProps> = ({
   const numAreas = new Set(
     sessionsFuture.data?.map((session) => session.area_id) ?? []
   ).size;
+
+  const hasAreaFeature = hasFeature(AREA_STATS, parseInt(orgId), process.env);
 
   return (
     <>
@@ -127,83 +130,88 @@ const AreaAssignmentPage: PageWithLayout<AreaAssignmentPageProps> = ({
                       />
                     </Box>
                   </Card>
-                  <Grid container spacing={2}>
-                    <ZUIFutures futures={{ areasStats, dataGraph }}>
-                      {({ data: { areasStats, dataGraph } }) => {
-                        const filteredAreas = dataGraph
-                          .map((area) => {
-                            return areasStats.stats.filter(
-                              (item) => item.area_id === area.area_id
-                            );
-                          })
-                          .flat();
+                  {hasAreaFeature && (
+                    <Grid container spacing={2}>
+                      <ZUIFutures futures={{ areasStats, dataGraph }}>
+                        {({ data: { areasStats, dataGraph } }) => {
+                          const filteredAreas = dataGraph
+                            .map((area) => {
+                              return areasStats.stats.filter(
+                                (item) => item.area_id === area.area_id
+                              );
+                            })
+                            .flat();
 
-                        const sortedAreas = filteredAreas
-                          .map((area) => {
-                            const successfulVisitsTotal =
-                              dataGraph
-                                .find((graph) => graph.area_id === area.area_id)
-                                ?.data.reduce(
-                                  (sum, item) => sum + item.successfulVisits,
-                                  0
-                                ) || 0;
+                          const sortedAreas = filteredAreas
+                            .map((area) => {
+                              const successfulVisitsTotal =
+                                dataGraph
+                                  .find(
+                                    (graph) => graph.area_id === area.area_id
+                                  )
+                                  ?.data.reduce(
+                                    (sum, item) => sum + item.successfulVisits,
+                                    0
+                                  ) || 0;
 
-                            return {
-                              area,
-                              successfulVisitsTotal,
-                            };
-                          })
-                          .sort(
-                            (a, b) =>
-                              b.successfulVisitsTotal - a.successfulVisitsTotal
-                          )
-                          .map(({ area }) => area);
-
-                        const maxHouseholdVisits = Math.max(
-                          ...dataGraph.flatMap((areaCard) =>
-                            areaCard.data.map(
-                              (graphData) => graphData.householdVisits
+                              return {
+                                area,
+                                successfulVisitsTotal,
+                              };
+                            })
+                            .sort(
+                              (a, b) =>
+                                b.successfulVisitsTotal -
+                                a.successfulVisitsTotal
                             )
-                          )
-                        );
+                            .map(({ area }) => area);
 
-                        const noAreaData = dataGraph.find(
-                          (graph) => !graph.area_id
-                        );
-                        if (noAreaData && noAreaData.data.length > 0) {
-                          const latestEntry = [...noAreaData.data].sort(
-                            (a, b) =>
-                              new Date(b.date).getTime() -
-                              new Date(a.date).getTime()
-                          )[0];
+                          const maxHouseholdVisits = Math.max(
+                            ...dataGraph.flatMap((areaCard) =>
+                              areaCard.data.map(
+                                (graphData) => graphData.householdVisits
+                              )
+                            )
+                          );
 
-                          const num_successful_visited_households =
-                            latestEntry.successfulVisits;
+                          const noAreaData = dataGraph.find(
+                            (graph) => !graph.area_id
+                          );
+                          if (noAreaData && noAreaData.data.length > 0) {
+                            const latestEntry = [...noAreaData.data].sort(
+                              (a, b) =>
+                                new Date(b.date).getTime() -
+                                new Date(a.date).getTime()
+                            )[0];
 
-                          const num_visited_households =
-                            latestEntry.householdVisits;
+                            const num_successful_visited_households =
+                              latestEntry.successfulVisits;
 
-                          const noArea: ZetkinAssignmentAreaStatsItem = {
-                            area_id: null,
-                            num_households: 0,
-                            num_locations: 0,
-                            num_successful_visited_households,
-                            num_visited_households,
-                            num_visited_locations: 0,
-                          };
-                          sortedAreas.push(noArea);
-                        }
-                        return (
-                          <AreaCard
-                            areas={sortedAreas}
-                            assignment={assignment}
-                            data={dataGraph}
-                            maxVisitedHouseholds={maxHouseholdVisits}
-                          />
-                        );
-                      }}
-                    </ZUIFutures>
-                  </Grid>
+                            const num_visited_households =
+                              latestEntry.householdVisits;
+
+                            const noArea: ZetkinAssignmentAreaStatsItem = {
+                              area_id: null,
+                              num_households: 0,
+                              num_locations: 0,
+                              num_successful_visited_households,
+                              num_visited_households,
+                              num_visited_locations: 0,
+                            };
+                            sortedAreas.push(noArea);
+                          }
+                          return (
+                            <AreaCard
+                              areas={sortedAreas}
+                              assignment={assignment}
+                              data={dataGraph}
+                              maxVisitedHouseholds={maxHouseholdVisits}
+                            />
+                          );
+                        }}
+                      </ZUIFutures>
+                    </Grid>
+                  )}
                 </>
               )}
             </Box>

--- a/src/utils/featureFlags/index.ts
+++ b/src/utils/featureFlags/index.ts
@@ -6,3 +6,4 @@ export const OFFICIALS = 'FEAT_OFFICIALS';
 export const TASKS = 'FEAT_TASKS';
 export const PERSON_NOTES = 'FEAT_PERSON_NOTES';
 export const UNAUTH_EVENT_SIGNUP = 'FEAT_UNAUTH_EVENT_SIGNUP';
+export const AREA_STATS = 'FEAT_AREA_STATS';


### PR DESCRIPTION
## Description

This PR moves area stats on the organizer pages, the area assignment overview behind a feature flag, so it is easy to turn back on once it has been implemented in the API. Meanwhile, this makes sure that the loading spinner does not just load infinitely and sends requests to an unimplemented endpoint.

## Screenshots

[Add screenshots here]

## Changes

- Adds a AreaStatsCard component

## Notes to reviewer
I am unsure if feature flags is the correct way to do this. Also the name of the component I extracted logic into might not follow your conventions.

## Related issues

Resolves #3509
