### PR TITLE
[Smart Search] Fix survey submission filter

### DIFF
--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -70,7 +70,11 @@ const SurveySubmission = ({
     if (surveyValue === DEFAULT_VALUE) {
       setSubmittable(false);
     } else {
-      setConfig({ ...filter.config, survey: +surveyValue });
+      setConfig({
+        ...filter.config,
+        operator: 'submitted',
+        survey: +surveyValue,
+      });
       setSubmittable(true);
     }
   };


### PR DESCRIPTION
## Description

I may have broken the survey submission filter in https://github.com/zetkin/app.zetkin.org/pull/3607 . Sorry about that. This PR fixes that. 

In #3607 , I removed a `useEffect`, which I believed to just select the first element, which didn't make sense for autocomplete. However, this `useEffect` also added the required field `operator: 'submitted'`. Without that, the filter won't work at all. So any user adding a new filter of this type will make the filter invalid. I added that property now to the `handleSurveySelectChange` handler, which fixes this.

If you're interested, here is the change I am talking about specifically: https://github.com/zetkin/app.zetkin.org/commit/526e3272e70971de431d1f7279639820feca8797 at src/features/smartSearch/components/filters/SurveySubmission/index.tsx#53
