### PR TITLE
Proxy avatar redirects server-side in all environments

### DIFF
--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -58,12 +58,9 @@ export default async function handle(
       const result = await fetch(url, { redirect: 'manual' });
       const location = result.headers.get('location');
 
-      // In dev, proxy the image server-side to avoid HTTPS-only mode issues
+      // Proxy image redirects server-side
       const shouldProxy =
-        !stringToBool(process.env.ZETKIN_USE_TLS) &&
-        location &&
-        result.status >= 300 &&
-        result.status < 400;
+        location && result.status >= 300 && result.status < 400;
 
       if (shouldProxy) {
         const imageResponse = await fetch(location);


### PR DESCRIPTION
## Description

This PR fixes org avatars failing to load on public pages in production. 

@jfilter provides some details on the issue here: https://github.com/zetkin/app.zetkin.org/pull/3304#issuecomment-4054805431

The solution is to remove the check for the env variable to ensure we always return image bytes to the frontend and avoid any redirects.

## Changes

- Removes the env variable check in the `shouldProxy` condition

## Related issues

Resolves #3623 
