### PR TITLE
Issue 3625/survey submission smart filter states

### DIFF
--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -1,5 +1,5 @@
 import { MenuItem } from '@mui/material';
-import { FormEvent, useCallback } from 'react';
+import { FormEvent } from 'react';
 
 import FilterForm from '../../FilterForm';
 import StyledAutocomplete from '../../inputs/StyledAutocomplete';
@@ -44,35 +44,29 @@ const SurveySubmission = ({
   const { filter, setConfig, setOp } =
     useSmartSearchFilter<SurveySubmissionFilterConfig>(initialFilter);
 
-  const handleSubmit = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault();
-      onSubmit(filter);
-    },
-    [filter, onSubmit]
-  );
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit(filter);
+  };
 
-  const handleTimeFrameChange = useCallback(
-    (range: { after?: string; before?: string }) => {
-      setConfig({
-        ...filter.config,
-        operator: 'submitted',
-        ...range,
-      });
-    },
-    [filter.config, setConfig]
-  );
+  const handleTimeFrameChange = (range: {
+    after?: string;
+    before?: string;
+  }) => {
+    setConfig({
+      ...filter.config,
+      operator: 'submitted',
+      ...range,
+    });
+  };
 
-  const handleSurveySelectChange = useCallback(
-    (surveyValue: string) => {
-      setConfig({
-        ...filter.config,
-        operator: 'submitted',
-        survey: +surveyValue,
-      });
-    },
-    [filter.config, setConfig]
-  );
+  const handleSurveySelectChange = (surveyValue: string) => {
+    setConfig({
+      ...filter.config,
+      operator: 'submitted',
+      survey: +surveyValue,
+    });
+  };
 
   const submittable =
     !!filter.config.survey && filter.config.operator === 'submitted';

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -55,8 +55,9 @@ const SurveySubmission = ({
   }) => {
     setConfig({
       ...filter.config,
+      after: range.after,
+      before: range.before,
       operator: 'submitted',
-      ...range,
     });
   };
 

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -15,13 +15,11 @@ import {
   ZetkinSmartSearchFilter,
 } from 'features/smartSearch/components/types';
 import messageIds from 'features/smartSearch/l10n/messageIds';
-import { Msg, useMessages } from 'core/i18n';
+import { Msg } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 
 const localMessageIds = messageIds.filters.surveySubmission;
-
-const DEFAULT_VALUE = 'none';
 
 interface SurveySubmissionProps {
   filter:
@@ -40,7 +38,6 @@ const SurveySubmission = ({
   onCancel,
   filter: initialFilter,
 }: SurveySubmissionProps): JSX.Element => {
-  const messages = useMessages(localMessageIds);
   const { orgId } = useNumericRouteParams();
   const surveys = useSurveys(orgId).data || [];
 
@@ -119,19 +116,13 @@ const SurveySubmission = ({
             ),
             surveySelect: (
               <StyledAutocomplete
-                items={[
-                  {
-                    group: 'pinned',
-                    id: DEFAULT_VALUE,
-                    label: messages.surveySelect.any(),
-                  },
-                  ...surveys.map((s) => ({
-                    id: s.id,
-                    label: s.title,
-                  })),
-                ]}
+                clearable={true}
+                items={surveys.map((s) => ({
+                  id: s.id,
+                  label: s.title,
+                }))}
                 onChange={(e) => handleSurveySelectChange(e.target.value)}
-                value={filter.config.survey || DEFAULT_VALUE}
+                value={filter.config.survey}
               />
             ),
             timeFrame: (

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -54,10 +54,9 @@ const SurveySubmission = ({
 
   const handleTimeFrameChange = useCallback(
     (range: { after?: string; before?: string }) => {
-      const { operator, survey } = filter.config;
       setConfig({
-        operator,
-        survey,
+        ...filter.config,
+        operator: 'submitted',
         ...range,
       });
     },

--- a/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
+++ b/src/features/smartSearch/components/filters/SurveySubmission/index.tsx
@@ -1,5 +1,5 @@
 import { MenuItem } from '@mui/material';
-import { FormEvent, useState } from 'react';
+import { FormEvent, useCallback } from 'react';
 
 import FilterForm from '../../FilterForm';
 import StyledAutocomplete from '../../inputs/StyledAutocomplete';
@@ -44,40 +44,42 @@ const SurveySubmission = ({
   const { orgId } = useNumericRouteParams();
   const surveys = useSurveys(orgId).data || [];
 
-  const [submittable, setSubmittable] = useState(false);
-
   const { filter, setConfig, setOp } =
     useSmartSearchFilter<SurveySubmissionFilterConfig>(initialFilter);
 
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    onSubmit(filter);
-  };
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      onSubmit(filter);
+    },
+    [filter, onSubmit]
+  );
 
-  const handleTimeFrameChange = (range: {
-    after?: string;
-    before?: string;
-  }) => {
-    const { operator, survey } = filter.config;
-    setConfig({
-      operator,
-      survey,
-      ...range,
-    });
-  };
+  const handleTimeFrameChange = useCallback(
+    (range: { after?: string; before?: string }) => {
+      const { operator, survey } = filter.config;
+      setConfig({
+        operator,
+        survey,
+        ...range,
+      });
+    },
+    [filter.config, setConfig]
+  );
 
-  const handleSurveySelectChange = (surveyValue: string) => {
-    if (surveyValue === DEFAULT_VALUE) {
-      setSubmittable(false);
-    } else {
+  const handleSurveySelectChange = useCallback(
+    (surveyValue: string) => {
       setConfig({
         ...filter.config,
         operator: 'submitted',
         survey: +surveyValue,
       });
-      setSubmittable(true);
-    }
-  };
+    },
+    [filter.config, setConfig]
+  );
+
+  const submittable =
+    !!filter.config.survey && filter.config.operator === 'submitted';
 
   return (
     <FilterForm

--- a/src/features/smartSearch/components/inputs/StyledAutocomplete.tsx
+++ b/src/features/smartSearch/components/inputs/StyledAutocomplete.tsx
@@ -248,7 +248,10 @@ const StyledAutocomplete: FC<Props> = (props) => {
 
   const valueItem = useMemo(() => {
     if (props.value !== undefined) {
-      return options.find((item) => item.id === props.value);
+      const matchingValue = options.find((item) => item.id === props.value);
+      if (matchingValue) {
+        return matchingValue;
+      }
     }
 
     if (props.clearable) {


### PR DESCRIPTION
## Description

This PR fixes several issues with the survey submission filter. 

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Removes the "a survey" state and makes the autocomplete clearable
- Fixes clearable autocompletes disappearing when deleting all text and clicking away
- Fixes time frame selection clearing org selection
- Removes the `submittable` state handling logic and creates a `const submittable` that validates the input based on the current filter state
- Also, I moved the handlers into `useCallback`

## Related issues

Resolves https://github.com/zetkin/app.zetkin.org/issues/3625
Resolves https://github.com/zetkin/app.zetkin.org/issues/3626
