### PR TITLE
Fix type issues in specs

### DIFF
--- a/src/utils/testing/setup.ts
+++ b/src/utils/testing/setup.ts
@@ -42,7 +42,7 @@ if (typeof HTMLCanvasElement !== 'undefined') {
         'moveTo',
         'lineTo',
         'stroke',
-        'fill'
+        'fill',
       ];
 
       type MockCanvasContext = Pick<

--- a/src/zui/components/ZUIModal/index.spec.tsx
+++ b/src/zui/components/ZUIModal/index.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, jest } from '@jest/globals';
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/zui/components/ZUIModal/usePreventKeyboardPropagation.spec.ts
+++ b/src/zui/components/ZUIModal/usePreventKeyboardPropagation.spec.ts
@@ -1,11 +1,19 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { usePreventKeyboardPropagation } from './usePreventKeyboardPropagation';
 
 describe('usePreventKeyboardPropagation', () => {
   let mockElement: HTMLDivElement;
-  let addEventListenerSpy: jest.SpyInstance;
-  let removeEventListenerSpy: jest.SpyInstance;
+  let addEventListenerSpy: ReturnType<typeof jest.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
     mockElement = document.createElement('div');
@@ -35,6 +43,7 @@ describe('usePreventKeyboardPropagation', () => {
     });
 
     await waitFor(() => {
+      expect(addEventListenerSpy).toHaveBeenCalledTimes(3);
       expect(addEventListenerSpy).toHaveBeenCalledWith(
         'keydown',
         expect.any(Function),
@@ -93,6 +102,7 @@ describe('usePreventKeyboardPropagation', () => {
 
     unmount();
 
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(3);
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       'keydown',
       expect.any(Function),
@@ -154,13 +164,6 @@ describe('usePreventKeyboardPropagation', () => {
       expect(addEventListenerSpy).toHaveBeenCalled();
     });
 
-    // Get the handler that was registered
-    const keydownHandler = addEventListenerSpy.mock.calls.find(
-      (call) => call[0] === 'keydown'
-    )?.[1] as EventListener;
-
-    expect(keydownHandler).toBeDefined();
-
     // Create a mock keyboard event
     const event = new KeyboardEvent('keydown', { bubbles: true, key: '1' });
     const stopPropagationSpy = jest.spyOn(event, 'stopPropagation');
@@ -169,8 +172,7 @@ describe('usePreventKeyboardPropagation', () => {
       'stopImmediatePropagation'
     );
 
-    // Call the handler
-    keydownHandler(event);
+    mockElement.dispatchEvent(event);
 
     expect(stopPropagationSpy).toHaveBeenCalled();
     expect(stopImmediatePropagationSpy).toHaveBeenCalled();
@@ -189,10 +191,22 @@ describe('usePreventKeyboardPropagation', () => {
       expect(addEventListenerSpy).toHaveBeenCalled();
     });
 
-    // Verify all listeners use capture: true
-    addEventListenerSpy.mock.calls.forEach((call) => {
-      expect(call[2]).toEqual({ capture: true });
-    });
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(3);
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function),
+      { capture: true }
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keyup',
+      expect.any(Function),
+      { capture: true }
+    );
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'keypress',
+      expect.any(Function),
+      { capture: true }
+    );
   });
 
   it('handles null element gracefully', () => {


### PR DESCRIPTION
## Description

This PR resolves a tiny linting issue and mainly updates two spec files. These were merged into main after we moved to `@jest/globals` without importing jest and jest methods explicitly.

## Changes

- Fixes a trailing comma issue from prettier
- Imports jest methods explicitly
- Replaces `addEventListenerSpy.mock.calls` assertions with `hasBeenCalledWith` assertions. This is mainly because I found it convoluted to type the `.mock.calls` internals. 

