### PR TITLE
Fix Color for Bulk Household Edit

### DIFF
--- a/src/app/beta/orgs/[orgId]/locations/[locationId]/households/[householdId]/route.ts
+++ b/src/app/beta/orgs/[orgId]/locations/[locationId]/households/[householdId]/route.ts
@@ -46,6 +46,7 @@ export async function PATCH(request: NextRequest, { params }: RouteMeta) {
 
   const payload = await request.json();
   const { color, ...zetkinPayload } = payload;
+  let notNullColor = color;
 
   if (color) {
     await HouseholdColorModel.findOneAndUpdate(
@@ -55,6 +56,11 @@ export async function PATCH(request: NextRequest, { params }: RouteMeta) {
       },
       { new: true, upsert: true }
     );
+  } else {
+    const householdColorModel = await HouseholdColorModel.findOne({
+      householdId: params.householdId,
+    });
+    notNullColor = (householdColorModel?.color ?? 'clear') as HouseholdColor;
   }
 
   const headers: IncomingHttpHeaders = {};
@@ -73,7 +79,7 @@ export async function PATCH(request: NextRequest, { params }: RouteMeta) {
 
   const householdWithColor: HouseholdWithColor = {
     ...household,
-    color: color ?? null,
+    color: notNullColor,
   };
 
   return NextResponse.json({

--- a/src/features/canvass/hooks/useEditHouseholds.ts
+++ b/src/features/canvass/hooks/useEditHouseholds.ts
@@ -8,7 +8,7 @@ export default function useEditHouseholds(orgId: number, locationId: number) {
 
   return async (
     householdIds: number[],
-    updates: { color?: string | null; level?: number }
+    updates: { color?: string; level?: number }
   ) => {
     const { updatedHouseholds } = await apiClient.rpc(editHouseholds, {
       color: updates.color,

--- a/src/features/canvass/rpc/editHouseholds.ts
+++ b/src/features/canvass/rpc/editHouseholds.ts
@@ -9,7 +9,7 @@ import {
 } from 'features/canvass/types';
 
 const paramsSchema = z.object({
-  color: z.optional(z.nullable(z.string())),
+  color: z.optional(z.string()),
   householdIds: z.array(z.number()),
   level: z.optional(z.number()),
   locationId: z.number(),
@@ -39,7 +39,7 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
       HouseholdWithColor,
       HouseholdPatchBody
     >(`/beta/orgs/${orgId}/locations/${locationId}/households/${householdId}`, {
-      color: (color ?? 'clear') as HouseholdColor,
+      color: color != undefined ? (color as HouseholdColor) : undefined,
       level,
     });
 


### PR DESCRIPTION
## Description

This PR fixes the reset of the colour coding of households that happens on each bulk edit (where no colour is set).

## Screenshots

<img width="549" height="678" alt="grafik" src="https://github.com/user-attachments/assets/fd45355e-ae93-46d9-a6ce-3f72e6077186" />

## Changes

- Fixes the reset of the colour coding of households

## Notes to reviewer

I could not test the PR, due to the timeout issues described in #3636.
However, the issue is quite simple. Both `null ?? 'clear' = 'clear'` and `undefined ?? 'clear' = 'clear'`, leading `undefined` to wrongly clear the color.

## Related issues

Resolves #3636
