### PR TITLE
Refactor Caching AreaAssignments, Areas, Call

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignment.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignment.ts
@@ -7,15 +7,15 @@ export default function useAreaAssignment(orgId: number, areaAssId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const areaAssignmenList = useAppSelector(
-    (state) => state.areaAssignments.areaAssignmentList.items
+    (state) => state.areaAssignments.areaAssignmentsByOrgId[orgId]?.items ?? []
   );
   const areaAssignmentItem = areaAssignmenList.find(
     (item) => item.id == areaAssId
   );
 
   return loadItemIfNecessary(areaAssignmentItem, dispatch, {
-    actionOnLoad: () => areaAssignmentLoad(areaAssId),
-    actionOnSuccess: (data) => areaAssignmentLoaded(data),
+    actionOnLoad: () => areaAssignmentLoad([orgId, areaAssId]),
+    actionOnSuccess: (data) => areaAssignmentLoaded([orgId, data]),
     loader: () =>
       apiClient.get<ZetkinAreaAssignment>(
         `/api2/orgs/${orgId}/area_assignments/${areaAssId}`

--- a/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
@@ -20,7 +20,7 @@ export default function useAreaAssignmentActivities(
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const list = useAppSelector(
-    (state) => state.areaAssignments.areaAssignmentList
+    (state) => state.areaAssignments.areaAssignmentsByOrgId[orgId]
   );
 
   const hasAreaAssignments = useFeature(AREAS);
@@ -29,8 +29,8 @@ export default function useAreaAssignmentActivities(
   }
 
   const future = loadListIfNecessary(list, dispatch, {
-    actionOnLoad: () => areaAssignmentsLoad(),
-    actionOnSuccess: (data) => areaAssignmentsLoaded(data),
+    actionOnLoad: () => areaAssignmentsLoad(orgId),
+    actionOnSuccess: (data) => areaAssignmentsLoaded([orgId, data]),
     loader: () =>
       apiClient.get<ZetkinAreaAssignment[]>(
         `/api2/orgs/${orgId}/area_assignments`

--- a/src/features/areaAssignments/hooks/useAreaAssignmentMutations.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentMutations.ts
@@ -50,7 +50,7 @@ export default function useAreaAssignmentMutations(
       await apiClient.delete(
         `/api2/orgs/${orgId}/area_assignments/${areaAssId}`
       );
-      dispatch(areaAssignmentDeleted(areaAssId));
+      dispatch(areaAssignmentDeleted([orgId, areaAssId]));
     },
     deleteMetric: async (metricId: number) => {
       await apiClient.delete(
@@ -77,7 +77,7 @@ export default function useAreaAssignmentMutations(
         ZetkinAreaAssignmentPatchbody
       >(`/api2/orgs/${orgId}/area_assignments/${areaAssId}`, data);
 
-      dispatch(areaAssignmentUpdated(updated));
+      dispatch(areaAssignmentUpdated([orgId, updated]));
     },
     updateMetric: async (metricId: number, data: ZetkinMetricPatchBody) => {
       const updated = await apiClient.patch<

--- a/src/features/areaAssignments/hooks/useCanvassInstructions.ts
+++ b/src/features/areaAssignments/hooks/useCanvassInstructions.ts
@@ -14,7 +14,8 @@ export default function useAreaAssignmentInstructions(
   const areaAssignmentsSlice = useAppSelector(
     (state: RootState) => state.areaAssignments
   );
-  const canvassAssignmentItems = areaAssignmentsSlice.areaAssignmentList.items;
+  const canvassAssignmentItems =
+    areaAssignmentsSlice.areaAssignmentsByOrgId[orgId]?.items ?? [];
   const key = `canvassInstructions-${areaAssId}`;
   //Used to force re-render
   const [pointlessState, setPointlessState] = useState(0);

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -33,7 +33,7 @@ export interface AreaAssignmentsStoreSlice {
     number,
     RemoteItem<ZetkinAssignmentAreaStats & { id: number }>
   >;
-  areaAssignmentList: RemoteList<ZetkinAreaAssignment>;
+  areaAssignmentsByOrgId: Record<number, RemoteList<ZetkinAreaAssignment>>;
   areasByAssignmentId: Record<string, RemoteList<Zetkin2Area>>;
   assigneesByAssignmentId: Record<
     number,
@@ -49,7 +49,7 @@ export interface AreaAssignmentsStoreSlice {
 }
 
 const initialState: AreaAssignmentsStoreSlice = {
-  areaAssignmentList: remoteList(),
+  areaAssignmentsByOrgId: {},
   areaGraphByAssignmentId: {},
   areaStatsByAssignmentId: {},
   areasByAssignmentId: {},
@@ -69,38 +69,57 @@ const areaAssignmentSlice = createSlice({
       action: PayloadAction<ZetkinAreaAssignment>
     ) => {
       const areaAssignment = action.payload;
-      remoteItemUpdated(state.areaAssignmentList, areaAssignment);
+      const orgId = areaAssignment.organization_id;
+      if (!state.areaAssignmentsByOrgId[orgId]) {
+        state.areaAssignmentsByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areaAssignmentsByOrgId[orgId], areaAssignment);
     },
-    areaAssignmentDeleted: (state, action: PayloadAction<number>) => {
-      const areaAssId = action.payload;
-      remoteItemDeleted(state.areaAssignmentList, areaAssId);
+    areaAssignmentDeleted: (state, action: PayloadAction<[number, number]>) => {
+      const [orgId, areaAssId] = action.payload;
+      if (state.areaAssignmentsByOrgId[orgId]) {
+        remoteItemDeleted(state.areaAssignmentsByOrgId[orgId], areaAssId);
+      }
     },
-    areaAssignmentLoad: (state, action: PayloadAction<number>) => {
-      const areaAssId = action.payload;
-      remoteItemLoad(state.areaAssignmentList, areaAssId);
+    areaAssignmentLoad: (state, action: PayloadAction<[number, number]>) => {
+      const [orgId, areaAssId] = action.payload;
+      if (!state.areaAssignmentsByOrgId[orgId]) {
+        state.areaAssignmentsByOrgId[orgId] = remoteList();
+      }
+      remoteItemLoad(state.areaAssignmentsByOrgId[orgId], areaAssId);
     },
     areaAssignmentLoaded: (
       state,
-      action: PayloadAction<ZetkinAreaAssignment>
+      action: PayloadAction<[number, ZetkinAreaAssignment]>
     ) => {
-      const areaAssignment = action.payload;
-      remoteItemUpdated(state.areaAssignmentList, areaAssignment);
+      const [orgId, areaAssignment] = action.payload;
+      if (!state.areaAssignmentsByOrgId[orgId]) {
+        state.areaAssignmentsByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areaAssignmentsByOrgId[orgId], areaAssignment);
     },
     areaAssignmentUpdated: (
       state,
-      action: PayloadAction<ZetkinAreaAssignment>
+      action: PayloadAction<[number, ZetkinAreaAssignment]>
     ) => {
-      const updatedArea = action.payload;
-      remoteItemUpdated(state.areaAssignmentList, updatedArea);
+      const [orgId, updatedArea] = action.payload;
+      if (!state.areaAssignmentsByOrgId[orgId]) {
+        state.areaAssignmentsByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areaAssignmentsByOrgId[orgId], updatedArea);
     },
-    areaAssignmentsLoad: (state) => {
-      state.areaAssignmentList = remoteListLoad(state.areaAssignmentList);
+    areaAssignmentsLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      state.areaAssignmentsByOrgId[orgId] = remoteListLoad(
+        state.areaAssignmentsByOrgId[orgId]
+      );
     },
     areaAssignmentsLoaded: (
       state,
-      action: PayloadAction<ZetkinAreaAssignment[]>
+      action: PayloadAction<[number, ZetkinAreaAssignment[]]>
     ) => {
-      state.areaAssignmentList = remoteListLoaded(action.payload);
+      const [orgId, areaAssignments] = action.payload;
+      state.areaAssignmentsByOrgId[orgId] = remoteListLoaded(areaAssignments);
     },
     areaGraphLoad: (state, action: PayloadAction<number>) => {
       const assignmentId = action.payload;

--- a/src/features/areas/hooks/useAreaMutations.ts
+++ b/src/features/areas/hooks/useAreaMutations.ts
@@ -9,7 +9,7 @@ export default function useAreaMutations(orgId: number, areaId: number) {
   return {
     async deleteArea() {
       await apiClient.delete(`/api2/orgs/${orgId}/areas/${areaId}`);
-      dispatch(areaDeleted(areaId));
+      dispatch(areaDeleted([orgId, areaId]));
     },
     async updateArea(data: Zetkin2AreaPostBody) {
       const area = await apiClient.patch<Zetkin2Area, Zetkin2AreaPostBody>(
@@ -17,7 +17,7 @@ export default function useAreaMutations(orgId: number, areaId: number) {
         data
       );
 
-      dispatch(areaUpdated(area));
+      dispatch(areaUpdated([orgId, area]));
     },
   };
 }

--- a/src/features/areas/hooks/useAreas.ts
+++ b/src/features/areas/hooks/useAreas.ts
@@ -7,11 +7,11 @@ import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 export default function useAreas(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const list = useAppSelector((state) => state.areas.areaList);
+  const list = useAppSelector((state) => state.areas.areasByOrgId[orgId]);
 
   return loadListIfNecessary(list, dispatch, {
-    actionOnLoad: () => areasLoad(),
-    actionOnSuccess: (data) => areasLoaded(data),
+    actionOnLoad: () => areasLoad(orgId),
+    actionOnSuccess: (data) => areasLoaded([orgId, data]),
     loader: async () =>
       fetchAllPaginated<Zetkin2Area>((page) =>
         apiClient.get(`/api2/orgs/${orgId}/areas?size=100&page=${page}`)

--- a/src/features/areas/store.ts
+++ b/src/features/areas/store.ts
@@ -13,12 +13,12 @@ import { Zetkin2Area } from './types';
 import { ZetkinAppliedTag } from 'utils/types/zetkin';
 
 export interface AreasStoreSlice {
-  areaList: RemoteList<Zetkin2Area>;
+  areasByOrgId: Record<number, RemoteList<Zetkin2Area>>;
   tagsByAreaId: Record<string, RemoteList<ZetkinAppliedTag>>;
 }
 
 const initialState: AreasStoreSlice = {
-  areaList: remoteList(),
+  areasByOrgId: {},
   tagsByAreaId: {},
 };
 
@@ -28,30 +28,46 @@ const areasSlice = createSlice({
   reducers: {
     areaCreated: (state, action: PayloadAction<Zetkin2Area>) => {
       const area = action.payload;
-      remoteItemUpdated(state.areaList, area);
+      const orgId = area.organization_id;
+      if (!state.areasByOrgId[orgId]) {
+        state.areasByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areasByOrgId[orgId], area);
     },
-    areaDeleted: (state, action: PayloadAction<number>) => {
-      const deletedId = action.payload;
-      remoteItemDeleted(state.areaList, deletedId);
+    areaDeleted: (state, action: PayloadAction<[number, number]>) => {
+      const [orgId, deletedId] = action.payload;
+      if (state.areasByOrgId[orgId]) {
+        remoteItemDeleted(state.areasByOrgId[orgId], deletedId);
+      }
     },
-    areaLoad: (state, action: PayloadAction<string>) => {
-      const areaId = action.payload;
-      remoteItemLoad(state.areaList, areaId);
+    areaLoad: (state, action: PayloadAction<[number, string]>) => {
+      const [orgId, areaId] = action.payload;
+      if (!state.areasByOrgId[orgId]) {
+        state.areasByOrgId[orgId] = remoteList();
+      }
+      remoteItemLoad(state.areasByOrgId[orgId], areaId);
     },
-    areaLoaded: (state, action: PayloadAction<Zetkin2Area>) => {
-      const area = action.payload;
-      remoteItemUpdated(state.areaList, area);
+    areaLoaded: (state, action: PayloadAction<[number, Zetkin2Area]>) => {
+      const [orgId, area] = action.payload;
+      if (!state.areasByOrgId[orgId]) {
+        state.areasByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areasByOrgId[orgId], area);
     },
-    areaUpdated: (state, action: PayloadAction<Zetkin2Area>) => {
-      const area = action.payload;
-      remoteItemUpdated(state.areaList, area);
+    areaUpdated: (state, action: PayloadAction<[number, Zetkin2Area]>) => {
+      const [orgId, area] = action.payload;
+      if (!state.areasByOrgId[orgId]) {
+        state.areasByOrgId[orgId] = remoteList();
+      }
+      remoteItemUpdated(state.areasByOrgId[orgId], area);
     },
-    areasLoad: (state) => {
-      state.areaList = remoteListLoad(state.areaList);
+    areasLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      state.areasByOrgId[orgId] = remoteListLoad(state.areasByOrgId[orgId]);
     },
-    areasLoaded: (state, action: PayloadAction<Zetkin2Area[]>) => {
-      const areas = action.payload;
-      state.areaList = remoteListLoaded(areas);
+    areasLoaded: (state, action: PayloadAction<[number, Zetkin2Area[]]>) => {
+      const [orgId, areas] = action.payload;
+      state.areasByOrgId[orgId] = remoteListLoaded(areas);
     },
   },
 });

--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -36,11 +36,10 @@ const Call: FC<{ clearCallLanes: () => void }> = ({ clearCallLanes }) => {
   >(null);
   const [skipCallModalOpen, setSkipCallModalOpen] = useState(false);
 
-  const call = useCurrentCall();
-
+  const call = useCurrentCall(assignment.organization.id);
   const { abandonUnfinishedCall, skipCurrentCall, switchToUnfinishedCall } =
     useCallMutations(assignment.organization.id);
-  const unfinishedCalls = useUnfinishedCalls();
+  const unfinishedCalls = useUnfinishedCalls(assignment.organization.id);
 
   const lane = useAppSelector(
     (state) => state.call.lanes[state.call.activeLaneIndex]

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -44,8 +44,8 @@ const UnfinishedCallsList: FC<{
   const { abandonUnfinishedCall, switchToUnfinishedCall } =
     useCallMutations(orgId);
 
-  const currentCall = useCurrentCall();
-  const unfinishedCalls = useUnfinishedCalls();
+  const currentCall = useCurrentCall(orgId);
+  const unfinishedCalls = useUnfinishedCalls(orgId);
 
   const unfinishedExceptCurrentCall = unfinishedCalls.filter((call) =>
     currentCall ? currentCall.id != call.id : true
@@ -107,7 +107,7 @@ const FinishedCallsList: FC<{
 }> = ({ onCall, orgId, searchString }) => {
   const messages = useMessages(messageIds);
   const { switchToPreviousCall } = useCallMutations(orgId);
-  const { loading, finishedCalls } = useFinishedCalls();
+  const { loading, finishedCalls } = useFinishedCalls(orgId);
 
   const fuse = useMemo(() => {
     return new Fuse(finishedCalls, {

--- a/src/features/call/hooks/useAllocateCall.ts
+++ b/src/features/call/hooks/useAllocateCall.ts
@@ -31,7 +31,7 @@ export default function useAllocateCall(
         `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
         {}
       );
-      dispatch(newCallAllocated(call));
+      dispatch(newCallAllocated([orgId, call]));
     } catch (e) {
       const queueError =
         e instanceof Error ? e : new Error('Empty queue error');
@@ -39,7 +39,7 @@ export default function useAllocateCall(
         message: queueError.message,
         name: queueError.name,
       };
-      dispatch(allocateCallError(serialized));
+      dispatch(allocateCallError([orgId, serialized]));
       return queueError;
     }
   };

--- a/src/features/call/hooks/useCallMutations.ts
+++ b/src/features/call/hooks/useCallMutations.ts
@@ -28,13 +28,13 @@ export default function useCallMutations(orgId: number) {
       await apiClient.delete(
         `/api/orgs/${assignment.organization.id}/calls/${callId}`
       );
-      dispatch(unfinishedCallAbandoned(callId));
+      dispatch(unfinishedCallAbandoned([orgId, callId]));
     }
   };
 
   const quitCurrentCall = async (callId: number) => {
     await apiClient.delete(`/api/orgs/${orgId}/calls/${callId}`);
-    dispatch(quitCall(callId));
+    dispatch(quitCall([orgId, callId]));
   };
 
   const skipCurrentCall = async (
@@ -48,14 +48,14 @@ export default function useCallMutations(orgId: number) {
         `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
         {}
       );
-      dispatch(callSkippedLoaded([skippedCallId, newCall]));
+      dispatch(callSkippedLoaded([orgId, skippedCallId, newCall]));
     } catch (e) {
       const error = e instanceof Error ? e : new Error('Error skipping call');
       const serialized = {
         message: error.message,
         name: error.name,
       };
-      dispatch(allocateCallError(serialized));
+      dispatch(allocateCallError([orgId, serialized]));
       return error;
     }
   };
@@ -78,7 +78,7 @@ export default function useCallMutations(orgId: number) {
           target_id: targetId,
         }
       );
-      dispatch(allocatePreviousCall(newCall));
+      dispatch(allocatePreviousCall([orgId, newCall]));
     }
   };
 

--- a/src/features/call/hooks/useCurrentCall.ts
+++ b/src/features/call/hooks/useCurrentCall.ts
@@ -1,12 +1,12 @@
 import { useAppSelector } from 'core/hooks';
 import { UnfinishedCall } from '../types';
 
-export default function useCurrentCall(): UnfinishedCall | null {
+export default function useCurrentCall(orgId: number): UnfinishedCall | null {
   const state = useAppSelector((state) => state.call);
   const activeLane = state.lanes[state.activeLaneIndex];
   const currentCallId = activeLane.currentCallId;
 
-  const currentCall = state.unfinishedCalls.items.find(
+  const currentCall = state.unfinishedCallsByOrgId[orgId]?.items.find(
     (item) => item.id == currentCallId
   );
 

--- a/src/features/call/hooks/useFilteredActivities.ts
+++ b/src/features/call/hooks/useFilteredActivities.ts
@@ -43,7 +43,7 @@ export default function useFilteredActivities(orgId: number) {
     (state) =>
       state.call.lanes[state.call.activeLaneIndex].submissionDataBySurveyId
   );
-  const target = useCurrentCall()?.target ?? null;
+  const target = useCurrentCall(orgId)?.target ?? null;
 
   const today = new Date();
   const activeSurveys = surveys.filter(

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -4,7 +4,7 @@ import { useApiClient, useAppDispatch } from 'core/hooks';
 import { FinishedCall } from '../types';
 import { finishedCallsLoad, finishedCallsLoaded } from '../store';
 
-export default function useFinishedCalls() {
+export default function useFinishedCalls(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
 
@@ -13,7 +13,7 @@ export default function useFinishedCalls() {
   const [loading, setLoading] = useState(false);
 
   const loadFinishedCalls = async () => {
-    dispatch(finishedCallsLoad());
+    dispatch(finishedCallsLoad(orgId));
     if (finishedCalls.length == 0) {
       setLoading(true);
     }
@@ -23,7 +23,7 @@ export default function useFinishedCalls() {
          `);
 
     const loadedFinishedCalls = [...finishedCalls, ...newLoadedFinishedCalls];
-    dispatch(finishedCallsLoaded(loadedFinishedCalls));
+    dispatch(finishedCallsLoaded([orgId, loadedFinishedCalls]));
     setFinishedCalls(loadedFinishedCalls);
 
     if (newLoadedFinishedCalls.length == 0) {

--- a/src/features/call/hooks/useSubmitReport.ts
+++ b/src/features/call/hooks/useSubmitReport.ts
@@ -42,7 +42,7 @@ export default function useSubmitReport(orgId: number) {
       submissions,
     });
     if (result.kind == 'success') {
-      dispatch(reportSubmitted(result.updatedCall));
+      dispatch(reportSubmitted([orgId, result.updatedCall]));
     } else {
       dispatch(setReportSubmissionError(result));
     }

--- a/src/features/call/hooks/useUnfinishedCalls.ts
+++ b/src/features/call/hooks/useUnfinishedCalls.ts
@@ -3,13 +3,15 @@ import { UnfinishedCall } from '../types';
 import useRemoteList from 'core/hooks/useRemoteList';
 import { unfinishedCallsLoad, unfinishedCallsLoaded } from '../store';
 
-export default function useUnfinishedCalls(): UnfinishedCall[] {
+export default function useUnfinishedCalls(orgId: number): UnfinishedCall[] {
   const apiClient = useApiClient();
-  const unfinishedCalls = useAppSelector((state) => state.call.unfinishedCalls);
+  const unfinishedCalls = useAppSelector(
+    (state) => state.call.unfinishedCallsByOrgId[orgId]
+  );
 
   return useRemoteList(unfinishedCalls, {
-    actionOnLoad: () => unfinishedCallsLoad(),
-    actionOnSuccess: (data) => unfinishedCallsLoaded(data),
+    actionOnLoad: () => unfinishedCallsLoad(orgId),
+    actionOnSuccess: (data) => unfinishedCallsLoaded([orgId, data]),
     loader: () => {
       return apiClient.get<
         UnfinishedCall[]

--- a/src/features/call/hooks/useUpcomingEvents.ts
+++ b/src/features/call/hooks/useUpcomingEvents.ts
@@ -5,13 +5,15 @@ import useRemoteList from 'core/hooks/useRemoteList';
 
 export default function useUpcomingEvents(orgId: number): ZetkinEvent[] {
   const apiClient = useApiClient();
-  const list = useAppSelector((state) => state.call.upcomingEventsList);
+  const list = useAppSelector(
+    (state) => state.call.upcomingEventsByOrgId[orgId]
+  );
 
   const todaysDate = new Date().toISOString().split('T')[0];
 
   return useRemoteList(list, {
-    actionOnLoad: () => eventsLoad(),
-    actionOnSuccess: (data) => eventsLoaded(data),
+    actionOnLoad: () => eventsLoad(orgId),
+    actionOnSuccess: (data) => eventsLoaded([orgId, data]),
     loader: async () => {
       const filterParam = encodeURIComponent(`start_time>${todaysDate}`);
       const url = `/api/orgs/${orgId}/actions?filter=${filterParam}`;

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -17,11 +17,11 @@ import { SerializedError } from './hooks/useAllocateCall';
 
 export interface CallStoreSlice {
   activeLaneIndex: number;
-  finishedCalls: RemoteList<FinishedCall>;
-  upcomingEventsList: RemoteList<ZetkinEvent>;
+  finishedCallsByOrgId: Record<number, RemoteList<FinishedCall>>;
+  upcomingEventsByOrgId: Record<number, RemoteList<ZetkinEvent>>;
   lanes: LaneState[];
   myAssignmentsList: RemoteList<ZetkinCallAssignment>;
-  unfinishedCalls: RemoteList<UnfinishedCall>;
+  unfinishedCallsByOrgId: Record<number, RemoteList<UnfinishedCall>>;
   queueError: SerializedError | null;
 }
 
@@ -54,20 +54,23 @@ const emptyReport: Report = {
 
 const initialState: CallStoreSlice = {
   activeLaneIndex: 0,
-  finishedCalls: remoteList(),
+  finishedCallsByOrgId: {},
   lanes: [],
   myAssignmentsList: remoteList(),
   queueError: null,
-  unfinishedCalls: remoteList(),
-  upcomingEventsList: remoteList(),
+  unfinishedCallsByOrgId: {},
+  upcomingEventsByOrgId: {},
 };
 
 const CallSlice = createSlice({
   initialState,
   name: 'call',
   reducers: {
-    allocateCallError: (state, action: PayloadAction<SerializedError>) => {
-      const error = action.payload;
+    allocateCallError: (
+      state,
+      action: PayloadAction<[number, SerializedError]>
+    ) => {
+      const [orgId, error] = action.payload;
       state.queueError = error;
 
       const lane = state.lanes[state.activeLaneIndex];
@@ -75,13 +78,19 @@ const CallSlice = createSlice({
       lane.submissionDataBySurveyId = {};
       lane.respondedEventIds = [];
       lane.callIsBeingAllocated = false;
-      state.unfinishedCalls.isLoading = false;
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].isLoading = false;
     },
     allocateNewCall: (state) => {
       state.lanes[state.activeLaneIndex].callIsBeingAllocated = true;
     },
-    allocatePreviousCall: (state, action: PayloadAction<UnfinishedCall>) => {
-      const newCall = action.payload;
+    allocatePreviousCall: (
+      state,
+      action: PayloadAction<[number, UnfinishedCall]>
+    ) => {
+      const [orgId, newCall] = action.payload;
       state.queueError = null;
 
       const currentLaneIndex = state.activeLaneIndex;
@@ -120,7 +129,10 @@ const CallSlice = createSlice({
         state.activeLaneIndex = state.lanes.length - 1;
       }
 
-      state.unfinishedCalls.items.push(
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].items.push(
         remoteItem(newCall.id, {
           data: newCall,
           isLoading: false,
@@ -134,19 +146,22 @@ const CallSlice = createSlice({
     },
     callSkippedLoaded: (
       state,
-      action: PayloadAction<[number, UnfinishedCall]>
+      action: PayloadAction<[number, number, UnfinishedCall]>
     ) => {
-      const [skippedCallId, newCall] = action.payload;
-      state.unfinishedCalls.items = state.unfinishedCalls.items.filter(
-        (item) => item.id != skippedCallId
-      );
+      const [orgId, skippedCallId, newCall] = action.payload;
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].items = state.unfinishedCallsByOrgId[
+        orgId
+      ].items.filter((item) => item.id != skippedCallId);
 
       state.queueError = null;
 
       const activeLane = state.lanes[state.activeLaneIndex];
       activeLane.currentCallId = newCall.id;
 
-      state.unfinishedCalls.items.push(
+      state.unfinishedCallsByOrgId[orgId].items.push(
         remoteItem(newCall.id, {
           data: newCall,
           isLoading: false,
@@ -178,12 +193,17 @@ const CallSlice = createSlice({
 
       lane.respondedEventIds = eventIds.filter((id) => id != eventIdToRemove);
     },
-    eventsLoad: (state) => {
-      state.upcomingEventsList.isLoading = true;
+    eventsLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      if (!state.upcomingEventsByOrgId[orgId]) {
+        state.upcomingEventsByOrgId[orgId] = remoteList();
+      }
+      state.upcomingEventsByOrgId[orgId].isLoading = true;
     },
-    eventsLoaded: (state, action: PayloadAction<ZetkinEvent[]>) => {
-      state.upcomingEventsList = remoteList(action.payload);
-      state.upcomingEventsList.loaded = new Date().toISOString();
+    eventsLoaded: (state, action: PayloadAction<[number, ZetkinEvent[]]>) => {
+      const [orgId, events] = action.payload;
+      state.upcomingEventsByOrgId[orgId] = remoteList(events);
+      state.upcomingEventsByOrgId[orgId].loaded = new Date().toISOString();
     },
     filtersUpdated: (
       state,
@@ -194,12 +214,20 @@ const CallSlice = createSlice({
       const lane = state.lanes[state.activeLaneIndex];
       lane.filters = { ...lane.filters, ...updatedFilters };
     },
-    finishedCallsLoad: (state) => {
-      state.finishedCalls.isLoading = true;
+    finishedCallsLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      if (!state.finishedCallsByOrgId[orgId]) {
+        state.finishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.finishedCallsByOrgId[orgId].isLoading = true;
     },
-    finishedCallsLoaded: (state, action: PayloadAction<FinishedCall[]>) => {
-      state.finishedCalls = remoteList(action.payload);
-      state.finishedCalls.loaded = new Date().toISOString();
+    finishedCallsLoaded: (
+      state,
+      action: PayloadAction<[number, FinishedCall[]]>
+    ) => {
+      const [orgId, calls] = action.payload;
+      state.finishedCallsByOrgId[orgId] = remoteList(calls);
+      state.finishedCallsByOrgId[orgId].loaded = new Date().toISOString();
     },
     initiateAssignment: (
       state,
@@ -259,13 +287,19 @@ const CallSlice = createSlice({
         (item) => (item.loaded = timestamp)
       );
     },
-    newCallAllocated: (state, action: PayloadAction<UnfinishedCall>) => {
-      const newCall = action.payload;
+    newCallAllocated: (
+      state,
+      action: PayloadAction<[number, UnfinishedCall]>
+    ) => {
+      const [orgId, newCall] = action.payload;
       const lane = state.lanes[state.activeLaneIndex];
-      lane.currentCallId = action.payload.id;
+      lane.currentCallId = newCall.id;
       state.queueError = null;
 
-      state.unfinishedCalls.items.push(
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].items.push(
         remoteItem(newCall.id, {
           data: newCall,
           isLoading: false,
@@ -285,13 +319,16 @@ const CallSlice = createSlice({
     previousCallClear: (state) => {
       state.lanes[state.activeLaneIndex].previousCall = null;
     },
-    quitCall: (state, action: PayloadAction<number>) => {
-      const deletedCallId = action.payload;
+    quitCall: (state, action: PayloadAction<[number, number]>) => {
+      const [orgId, deletedCallId] = action.payload;
       const lane = state.lanes[state.activeLaneIndex];
 
-      state.unfinishedCalls.items = state.unfinishedCalls.items.filter(
-        (item) => item.id != deletedCallId
-      );
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].items = state.unfinishedCallsByOrgId[
+        orgId
+      ].items.filter((item) => item.id != deletedCallId);
 
       lane.currentCallId = null;
       lane.step = LaneStep.START;
@@ -301,13 +338,19 @@ const CallSlice = createSlice({
       lane.filters = emptyFilters;
       lane.selectedSurveyId = null;
     },
-    reportSubmitted: (state, action: PayloadAction<ZetkinUpdatedCall>) => {
+    reportSubmitted: (
+      state,
+      action: PayloadAction<[number, ZetkinUpdatedCall]>
+    ) => {
       const lane = state.lanes[state.activeLaneIndex];
       lane.reportSubmissionError = null;
-      const updatedCall = action.payload;
+      const [orgId, updatedCall] = action.payload;
       lane.previousCall = updatedCall;
 
-      const callItem = state.unfinishedCalls.items.find(
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      const callItem = state.unfinishedCallsByOrgId[orgId].items.find(
         (item) => item.id == updatedCall.id
       );
 
@@ -315,10 +358,15 @@ const CallSlice = createSlice({
         const data = callItem.data;
 
         if (data) {
-          state.unfinishedCalls.items = state.unfinishedCalls.items.filter(
-            (call) => call.id != updatedCall.id
-          );
-          state.finishedCalls.items.push({
+          state.unfinishedCallsByOrgId[orgId].items =
+            state.unfinishedCallsByOrgId[orgId].items.filter(
+              (call) => call.id != updatedCall.id
+            );
+
+          if (!state.finishedCallsByOrgId[orgId]) {
+            state.finishedCallsByOrgId[orgId] = remoteList();
+          }
+          state.finishedCallsByOrgId[orgId].items.push({
             ...callItem,
             data: {
               ...data,
@@ -421,12 +469,18 @@ const CallSlice = createSlice({
         state.activeLaneIndex = indexOfNewLane;
       }
     },
-    unfinishedCallAbandoned: (state, action: PayloadAction<number>) => {
-      const abandonedCallId = action.payload;
+    unfinishedCallAbandoned: (
+      state,
+      action: PayloadAction<[number, number]>
+    ) => {
+      const [orgId, abandonedCallId] = action.payload;
 
-      state.unfinishedCalls.items = state.unfinishedCalls.items.filter(
-        (item) => item.id != abandonedCallId
-      );
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].items = state.unfinishedCallsByOrgId[
+        orgId
+      ].items.filter((item) => item.id != abandonedCallId);
 
       const indexOfLaneWhereAbandonedCallIsCurrent = state.lanes.findIndex(
         (lane) => lane.currentCallId == abandonedCallId
@@ -444,12 +498,20 @@ const CallSlice = createSlice({
         }
       }
     },
-    unfinishedCallsLoad: (state) => {
-      state.unfinishedCalls.isLoading = true;
+    unfinishedCallsLoad: (state, action: PayloadAction<number>) => {
+      const orgId = action.payload;
+      if (!state.unfinishedCallsByOrgId[orgId]) {
+        state.unfinishedCallsByOrgId[orgId] = remoteList();
+      }
+      state.unfinishedCallsByOrgId[orgId].isLoading = true;
     },
-    unfinishedCallsLoaded: (state, action: PayloadAction<UnfinishedCall[]>) => {
-      state.unfinishedCalls = remoteList(action.payload);
-      state.unfinishedCalls.loaded = new Date().toISOString();
+    unfinishedCallsLoaded: (
+      state,
+      action: PayloadAction<[number, UnfinishedCall[]]>
+    ) => {
+      const [orgId, calls] = action.payload;
+      state.unfinishedCallsByOrgId[orgId] = remoteList(calls);
+      state.unfinishedCallsByOrgId[orgId].loaded = new Date().toISOString();
     },
     updateLaneStep: (state, action: PayloadAction<LaneStep>) => {
       const step = action.payload;

--- a/src/features/canvass/hooks/useVisitReporting.spec.ts
+++ b/src/features/canvass/hooks/useVisitReporting.spec.ts
@@ -14,6 +14,7 @@ import mockLocationVisit from 'utils/testing/mocks/mockLocationVisit';
 import { ZetkinLocation } from 'features/areaAssignments/types';
 import submitHouseholdVisits from '../rpc/submitHouseholdVisits';
 
+const ORG_ID = 1;
 const ASSIGNMENT_ID = 11;
 const LOCATION_ID = 101;
 const HOUSEHOLD_ID = 1001;
@@ -29,6 +30,8 @@ describe('useVisitReporting()', () => {
 
     beforeEach(() => {
       initialState = mockState();
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID] =
+        remoteList();
       initialState.areaAssignments.locationsByAssignmentId[ASSIGNMENT_ID] =
         remoteList();
       initialState.canvass.visitsByAssignmentAndLocationId[ASSIGNMENT_ID] = {
@@ -36,7 +39,7 @@ describe('useVisitReporting()', () => {
       };
       initialState.canvass.visitsByAssignmentId[ASSIGNMENT_ID] =
         remoteListLoaded([]);
-      initialState.areaAssignments.areaAssignmentList.items.push(
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID].items.push(
         remoteItem(ASSIGNMENT_ID, {
           data: mockAreaAssignment({
             id: ASSIGNMENT_ID,
@@ -212,6 +215,8 @@ describe('useVisitReporting()', () => {
 
     beforeEach(() => {
       initialState = mockState();
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID] =
+        remoteList();
       initialState.areaAssignments.locationsByAssignmentId[ASSIGNMENT_ID] =
         remoteList();
       initialState.canvass.visitsByAssignmentAndLocationId[ASSIGNMENT_ID] = {
@@ -219,7 +224,7 @@ describe('useVisitReporting()', () => {
       };
       initialState.canvass.visitsByAssignmentId[ASSIGNMENT_ID] =
         remoteListLoaded([]);
-      initialState.areaAssignments.areaAssignmentList.items.push(
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID].items.push(
         remoteItem(ASSIGNMENT_ID, {
           data: mockAreaAssignment({
             id: ASSIGNMENT_ID,
@@ -732,10 +737,12 @@ describe('useVisitReporting()', () => {
 
     beforeEach(() => {
       initialState = mockState();
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID] =
+        remoteList();
       initialState.canvass.visitsByAssignmentAndLocationId[ASSIGNMENT_ID] = {
         [LOCATION_ID]: remoteListLoaded([]),
       };
-      initialState.areaAssignments.areaAssignmentList.items.push(
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID].items.push(
         remoteItem(ASSIGNMENT_ID, {
           data: mockAreaAssignment({
             id: ASSIGNMENT_ID,
@@ -874,10 +881,11 @@ describe('useVisitReporting()', () => {
 
   describe('Household-level reportHouseholdVisits()', () => {
     let initialState: RootState;
-    const ORG_ID = 1;
 
     beforeEach(() => {
       initialState = mockState();
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID] =
+        remoteList();
       initialState.canvass.visitsByAssignmentAndLocationId[ASSIGNMENT_ID] = {
         [LOCATION_ID]: remoteListLoaded([]),
       };
@@ -886,7 +894,7 @@ describe('useVisitReporting()', () => {
       initialState.canvass.visitsByAssignmentId[ASSIGNMENT_ID] = remoteList();
       initialState.canvass.visitsByAssignmentId[ASSIGNMENT_ID].loaded =
         new Date().toISOString();
-      initialState.areaAssignments.areaAssignmentList.items.push(
+      initialState.areaAssignments.areaAssignmentsByOrgId[ORG_ID].items.push(
         remoteItem(ASSIGNMENT_ID, {
           data: mockAreaAssignment({
             id: ASSIGNMENT_ID,

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -23,12 +23,12 @@ export default function mockState(overrides?: RootState) {
     },
     call: {
       activeLaneIndex: 0,
-      finishedCalls: remoteList(),
+      finishedCallsByOrgId: {},
       lanes: [],
       myAssignmentsList: remoteList(),
       queueError: null,
-      unfinishedCalls: remoteList(),
-      upcomingEventsList: remoteList(),
+      unfinishedCallsByOrgId: {},
+      upcomingEventsByOrgId: {},
     },
     callAssignments: {
       assignmentList: remoteList(),

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -15,7 +15,7 @@ export default function mockState(overrides?: RootState) {
       statsByAreaAssId: {},
     },
     areas: {
-      areaList: remoteList(),
+      areasByOrgId: {},
       tagsByAreaId: {},
     },
     breadcrumbs: {

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -4,7 +4,7 @@ import { remoteItem, remoteList } from 'utils/storeUtils';
 export default function mockState(overrides?: RootState) {
   const emptyState: RootState = {
     areaAssignments: {
-      areaAssignmentList: remoteList(),
+      areaAssignmentsByOrgId: {},
       areaGraphByAssignmentId: {},
       areaStatsByAssignmentId: {},
       areasByAssignmentId: {},


### PR DESCRIPTION
## Description

This PR refactors the Caching to use Records instead of lists. Each commit addresses one component.

## Changes

- Refactors the Caching to use Records instead of lists

## Notes to reviewer

We plan to add further commits as long as this PR is not merged

## Related issues

Related to #3635
