### PR TITLE
Activist Portal: Fix infinite loading from non-existent published events

### DIFF
--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -102,10 +102,13 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
         isPublished = new Date(event.published) < new Date();
       }
       if (event.campaign && isPublished) {
-        const campaign = await apiClient.get<ZetkinCampaign>(
-          `/api/orgs/${event.organization.id}/campaigns/${event.campaign.id}`
-        );
+        const campaign = await apiClient
+          .get<ZetkinCampaign>(
+            `/api/orgs/${event.organization.id}/campaigns/${event.campaign.id}`
+          )
+          .catch(() => null);
         isPublished =
+          !!campaign &&
           !campaign.archived &&
           campaign.published &&
           campaign.visibility == 'open';


### PR DESCRIPTION
## Description

This PR fixes an issue in the activist portal where it would show the loading spinner indefinitely.

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds error handling for campaign fetch calls in the getAllEvents RPC.

## Notes to reviewer
[Add instructions for testing]

To reproduce the infinite loading spinner, do this:
- Create a project in an org your user follows. Publish & publish it. 
- Create an event in thatt probject. Publish it.
- Delete the project
- Go to /my/feed

This PR fixes it by catching the 404 error. However, I think that the backend shouldn't output events from deleted projects.

