### PR TITLE
Fix prettierignore path

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,7 +21,7 @@ test-results
 /build
 
 # public
-public/
+/public
 
 # vercel
 .vercel


### PR DESCRIPTION
## Description

This PR changes public/ to /public in .prettierignore. This is to prevent prettier from ignoring files beginning with the word "public", case insensitive.

Please don't ask me how many hours I spent trying to understand why my autoformat suddenly stopped working when editing "PublicOrgPage"  🙃


## Changes
- Changes `public/` to `/public` in .prettierignore

