### PR TITLE
Fix Smart Search Event Type Selection Issue

### DIFF
--- a/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CampaignParticipation/index.tsx
@@ -186,7 +186,7 @@ const CampaignParticipation = ({
                 onChange={(e) => {
                   handleActivitySelectChange(e.target.value);
                 }}
-                value={filter.config.campaign || DEFAULT_VALUE}
+                value={filter.config.activity || DEFAULT_VALUE}
               />
             ),
             addRemoveSelect: (


### PR DESCRIPTION
## Description

This PR fixes a configuration issue on the `CampaignParticipation` Smart Search filter. For `activitySelect` the value field on the `StyledAutocomplete` was referencing the `campaign` filter config. 

## Screenshots

https://github.com/user-attachments/assets/8cdb905d-3352-430a-aba1-7a3900f74ccd


## Changes

- Fixes the likely typo

## Notes to reviewer

- Go to a Smart Search list and add an events filter
- Check if the event type selection behaves as expected, especially when a project is also selected

## Related issues

Resolves #3651 
