### PR TITLE
Tag Store Refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -918,6 +919,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -938,6 +940,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1009,6 +1012,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
       "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -1043,6 +1047,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1084,6 +1089,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2707,6 +2713,7 @@
     "node_modules/@mui/material": {
       "version": "7.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@mui/core-downloads-tracker": "^7.0.1",
@@ -2824,6 +2831,7 @@
     "node_modules/@mui/system": {
       "version": "7.0.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10",
         "@mui/private-theming": "^7.0.1",
@@ -4148,6 +4156,7 @@
       "version": "1.56.1",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -6243,6 +6252,7 @@
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6647,6 +6657,7 @@
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -6790,6 +6801,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6835,6 +6847,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6846,6 +6859,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6975,6 +6989,7 @@
       "version": "8.46.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -7494,6 +7509,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7553,6 +7569,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8378,6 +8395,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9626,7 +9644,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.10.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debounce-fn": {
       "version": "5.1.2",
@@ -10401,6 +10420,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10484,6 +10504,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10679,6 +10700,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -14027,6 +14049,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -14213,7 +14236,8 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.3",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lettercoder": {
       "version": "0.0.4",
@@ -14748,6 +14772,7 @@
     "node_modules/maplibre-gl": {
       "version": "5.6.0",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -16363,6 +16388,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -17471,6 +17497,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17625,6 +17652,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17892,6 +17920,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17995,6 +18024,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18076,6 +18106,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -18098,6 +18129,7 @@
       "version": "0.14.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18218,7 +18250,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -18881,6 +18914,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18984,6 +19018,7 @@
     "node_modules/servie": {
       "version": "4.3.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@servie/events": "^1.0.0",
         "byte-length": "^1.0.2",
@@ -19195,6 +19230,7 @@
     "node_modules/slate": {
       "version": "0.94.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "immer": "^9.0.6",
         "is-plain-object": "^5.0.0",
@@ -19486,6 +19522,7 @@
       "integrity": "sha512-P7K/b+Pn1sXJzwYCF6hH5Zjdrg4ZlA5Bz9rdOJEdvm6ev27XESDGI+Ql+dfUfUcGOym3Aud4MssJIDEF2ocsyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -20258,6 +20295,7 @@
       "version": "10.9.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -20533,6 +20571,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21137,6 +21176,7 @@
       "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21215,6 +21255,7 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",

--- a/src/features/tags/hooks/useCreateTag.ts
+++ b/src/features/tags/hooks/useCreateTag.ts
@@ -20,26 +20,26 @@ export default function useCreateTag(
         group: undefined,
         group_id: newGroup.id,
       };
-      dispatch(tagCreate());
+      dispatch(tagCreate([orgId]));
       const tagFuture = await apiClient
         .post<
           ZetkinTag,
           ZetkinTagPostBody
         >(`/api/orgs/${orgId}/people/tags`, tagWithNewGroup)
         .then((data: ZetkinTag) => {
-          dispatch(tagCreated(data));
+          dispatch(tagCreated([[orgId], data]));
           return data;
         });
       return tagFuture;
     } else {
-      dispatch(tagCreate());
+      dispatch(tagCreate([orgId]));
       const tagFuture = await apiClient
         .post<
           ZetkinTag,
           ZetkinTagPostBody
         >(`/api/orgs/${orgId}/people/tags`, tag)
         .then((data: ZetkinTag) => {
-          dispatch(tagCreated(data));
+          dispatch(tagCreated([[orgId], data]));
           return data;
         });
       return tagFuture;

--- a/src/features/tags/hooks/useCreateTagGroup.ts
+++ b/src/features/tags/hooks/useCreateTagGroup.ts
@@ -10,14 +10,14 @@ export default function useCreateTagGroup(
   const dispatch = useAppDispatch();
 
   const createTagGroup = async (newGroup: NewTag) => {
-    dispatch(tagGroupCreate());
+    dispatch(tagGroupCreate([orgId]));
     const tagGroupFuture = await apiClient
       .post<
         ZetkinTagGroup,
         ZetkinTagGroupPostBody
       >(`/api/orgs/${orgId}/tag_groups`, newGroup)
       .then((data: ZetkinTagGroup) => {
-        dispatch(tagGroupCreated(data));
+        dispatch(tagGroupCreated([[orgId], data]));
         return data;
       });
     return tagGroupFuture;

--- a/src/features/tags/hooks/useDeleteTag.ts
+++ b/src/features/tags/hooks/useDeleteTag.ts
@@ -7,7 +7,7 @@ export default function useDeleteTag(orgId: number) {
 
   return async (tagId: number) => {
     await apiClient.delete(`/api/orgs/${orgId}/people/tags/${tagId}`);
-    dispatch(tagDeleted(tagId));
+    dispatch(tagDeleted([tagId]));
 
     // TODO when the deleted tag was the last of its group, delete the group as well to avoid orphaned groups
   };

--- a/src/features/tags/hooks/useDeleteTagGroup.ts
+++ b/src/features/tags/hooks/useDeleteTagGroup.ts
@@ -13,13 +13,15 @@ export default function useDeleteTagGroup(orgId: number) {
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
   const tagMapper = useCallback(
-    (tags: number[]) =>
-      tags
-        .map((tagId) => tagsById[tagId])
-        .filter((tagItem) => !!tagItem)
-        .filter((tagItem) => !tagItem.deleted)
-        .map((tagItem) => tagItem.data)
-        .filter((tag) => !!tag),
+    (tagId: number) => {
+      const tag = tagsById[tagId];
+
+      if (tag?.deleted) {
+        return null;
+      }
+
+      return tag?.data ?? null;
+    },
     [tagsById]
   );
   const tagListState = useRemoteListMapping(tagIndex, tagMapper);

--- a/src/features/tags/hooks/useDeleteTagGroup.ts
+++ b/src/features/tags/hooks/useDeleteTagGroup.ts
@@ -1,18 +1,34 @@
+import { useCallback } from 'react';
+
 import { tagGroupDeleted } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import useTagMutations from 'features/tags/hooks/useTagMutations';
+import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 export default function useDeleteTagGroup(orgId: number) {
-  const tagList = useAppSelector((state) => state.tags.tagList);
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const { updateTag } = useTagMutations(orgId);
 
+  const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
+  const tagsById = useAppSelector((state) => state.tags.tagsById);
+  const tagMapper = useCallback(
+    (tags: number[]) =>
+      tags
+        .map((tagId) => tagsById[tagId])
+        .filter((tagItem) => !!tagItem)
+        .filter((tagItem) => !tagItem.deleted)
+        .map((tagItem) => tagItem.data)
+        .filter((tag) => !!tag),
+    [tagsById]
+  );
+  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+
   return async (tagGroupId: number) => {
     await apiClient.delete(`/api/orgs/${orgId}/tag_groups/${tagGroupId}`);
-    dispatch(tagGroupDeleted(tagGroupId));
+    dispatch(tagGroupDeleted([tagGroupId]));
 
-    for (const tagItem of tagList.items) {
+    for (const tagItem of tagListState?.items ?? []) {
       if (tagItem.data?.group?.id == tagGroupId) {
         await updateTag({
           ...tagItem.data,

--- a/src/features/tags/hooks/useDeleteTagGroup.ts
+++ b/src/features/tags/hooks/useDeleteTagGroup.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import { tagGroupDeleted } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import useTagMutations from 'features/tags/hooks/useTagMutations';
@@ -12,19 +10,7 @@ export default function useDeleteTagGroup(orgId: number) {
 
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
-  const tagMapper = useCallback(
-    (tagId: number) => {
-      const tag = tagsById[tagId];
-
-      if (tag?.deleted) {
-        return null;
-      }
-
-      return tag?.data ?? null;
-    },
-    [tagsById]
-  );
-  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+  const tagListState = useRemoteListMapping(tagIndex, tagsById);
 
   return async (tagGroupId: number) => {
     await apiClient.delete(`/api/orgs/${orgId}/tag_groups/${tagGroupId}`);

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -1,18 +1,41 @@
+import { useCallback } from 'react';
+
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinAppliedTag } from 'utils/types/zetkin';
 import { personTagsLoad, personTagsLoaded } from 'features/tags/store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 export default function usePersonTags(orgId: number, personId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const tagList = useAppSelector(
-    (state) => state.tags.tagsByPersonId[personId]
+  const tagIndex = useAppSelector(
+    (state) => state.tags.personTags[`${orgId}-${personId}`]
   );
+  const tags = useAppSelector((state) => state.tags.tagsById);
+  const groups = useAppSelector((state) => state.tags.groupsById);
+
+  const tagMapper = useCallback(
+    (personTags: { id: number; value: number | string | null }[]) =>
+      personTags
+        .map(
+          ({ id, value }) =>
+            tags[id]?.data &&
+            !tags[id]?.deleted &&
+            <ZetkinAppliedTag>{
+              ...tags[id].data,
+              group: tags[id].data.group && groups[tags[id].data.group.id],
+              value,
+            }
+        )
+        .filter((tag) => !!tag),
+    [tags, groups]
+  );
+  const tagList = useRemoteListMapping(tagIndex, tagMapper);
 
   return loadListIfNecessary(tagList, dispatch, {
-    actionOnLoad: () => personTagsLoad(personId),
-    actionOnSuccess: (tags) => personTagsLoaded([personId, tags]),
+    actionOnLoad: () => personTagsLoad([orgId, personId]),
+    actionOnSuccess: (tags) => personTagsLoaded([[orgId, personId], tags]),
     loader: () =>
       apiClient.get<ZetkinAppliedTag[]>(
         `/api/orgs/${orgId}/people/${personId}/tags`

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -16,19 +16,19 @@ export default function usePersonTags(orgId: number, personId: number) {
   const groups = useAppSelector((state) => state.tags.groupsById);
 
   const tagMapper = useCallback(
-    (personTags: { id: number; value: number | string | null }[]) =>
-      personTags
-        .map(
-          ({ id, value }) =>
-            tags[id]?.data &&
-            !tags[id]?.deleted &&
-            <ZetkinAppliedTag>{
-              ...tags[id].data,
-              group: tags[id].data.group && groups[tags[id].data.group.id],
-              value,
-            }
-        )
-        .filter((tag) => !!tag),
+    ({ id, value }: { id: number; value: number | string | null }) => {
+      const tag = tags[id];
+
+      if (!tag || !tag.data || tag.deleted) {
+        return null;
+      }
+
+      return <ZetkinAppliedTag>{
+        ...tag.data,
+        group: tag.data.group && groups[tag.data.group.id],
+        value,
+      };
+    },
     [tags, groups]
   );
   const tagList = useRemoteListMapping(tagIndex, tagMapper);

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -13,7 +13,6 @@ export default function usePersonTags(orgId: number, personId: number) {
     (state) => state.tags.personTags[`${orgId}-${personId}`]
   );
   const tags = useAppSelector((state) => state.tags.tagsById);
-  const groups = useAppSelector((state) => state.tags.groupsById);
 
   const tagMapper = useCallback(
     ({ id, value }: { id: number; value: number | string | null }) => {
@@ -25,11 +24,10 @@ export default function usePersonTags(orgId: number, personId: number) {
 
       return <ZetkinAppliedTag>{
         ...tag.data,
-        group: tag.data.group && groups[tag.data.group.id],
         value,
       };
     },
-    [tags, groups]
+    [tags]
   );
   const tagList = useRemoteListMapping(tagIndex, tagMapper);
 

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -4,52 +4,55 @@ import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinAppliedTag } from 'utils/types/zetkin';
 import { personTagsLoad, personTagsLoaded } from 'features/tags/store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
-import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
-import { remoteList } from 'utils/storeUtils';
-import { SafeRecord } from 'utils/types';
+import { RemoteItem, RemoteList } from 'utils/storeUtils';
 
 export default function usePersonTags(orgId: number, personId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const tagValueIndex = useAppSelector(
+  const personTags = useAppSelector(
     (state) => state.tags.personTags[`${orgId}-${personId}`]
   );
   const tagsById = useAppSelector((state) => state.tags.tagsById);
 
-  const tagIndex = useMemo(
-    () =>
-      remoteList<number>(
-        tagValueIndex?.items
-          .map((item) => item.data?.id)
-          .filter((value) => typeof value === 'number')
-      ),
-    [tagValueIndex]
-  );
-  const tagList = useRemoteListMapping(tagIndex, tagsById);
   const appliedTagList = useMemo(() => {
-    const valuesById = tagValueIndex
-      ? tagValueIndex.items.reduce(
-          (prev, cur) => {
-            if (!cur.data) {
-              return prev;
-            }
-            prev[cur.data.id] = cur.data.value;
-            return prev;
-          },
-          {} as SafeRecord<number, string | number | null>
-        )
-      : {};
+    if (typeof personTags === 'undefined') {
+      return personTags;
+    }
 
-    return remoteList<ZetkinAppliedTag>(
-      tagList?.items.map(
-        (tag) =>
-          <ZetkinAppliedTag>{
-            ...tag.data,
-            value: (tag.data && valuesById[tag.data.id]) || null,
-          }
-      )
-    );
-  }, [tagList?.items, tagValueIndex]);
+    if (!personTags.items) {
+      return undefined;
+    }
+
+    const items = personTags.items
+      .filter((item) => !item.deleted)
+      .map((item) => {
+        if (!item.data) {
+          return <RemoteItem<ZetkinAppliedTag>>{
+            ...item,
+            data: null,
+          };
+        }
+
+        const mapped = tagsById[item.data.id];
+        if (!mapped || mapped.deleted) {
+          return null;
+        }
+
+        return <RemoteItem<ZetkinAppliedTag>>{
+          ...item,
+          data: {
+            ...mapped.data,
+            value: item.data.value,
+          },
+        };
+      })
+      .filter((item) => !!item);
+
+    return <RemoteList<ZetkinAppliedTag>>{
+      ...personTags,
+      items: items,
+    };
+  }, [personTags, tagsById]);
 
   return loadListIfNecessary(appliedTagList, dispatch, {
     actionOnLoad: () => personTagsLoad([orgId, personId]),

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -1,37 +1,57 @@
-import { useCallback } from 'react';
+import { useMemo } from 'react';
 
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinAppliedTag } from 'utils/types/zetkin';
 import { personTagsLoad, personTagsLoaded } from 'features/tags/store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
+import { remoteList } from 'utils/storeUtils';
+import { SafeRecord } from 'utils/types';
 
 export default function usePersonTags(orgId: number, personId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const tagIndex = useAppSelector(
+  const tagValueIndex = useAppSelector(
     (state) => state.tags.personTags[`${orgId}-${personId}`]
   );
-  const tags = useAppSelector((state) => state.tags.tagsById);
+  const tagsById = useAppSelector((state) => state.tags.tagsById);
 
-  const tagMapper = useCallback(
-    ({ id, value }: { id: number; value: number | string | null }) => {
-      const tag = tags[id];
-
-      if (!tag || !tag.data || tag.deleted) {
-        return null;
-      }
-
-      return <ZetkinAppliedTag>{
-        ...tag.data,
-        value,
-      };
-    },
-    [tags]
+  const tagIndex = useMemo(
+    () =>
+      remoteList<number>(
+        tagValueIndex?.items
+          .map((item) => item.data?.id)
+          .filter((value) => typeof value === 'number')
+      ),
+    [tagValueIndex]
   );
-  const tagList = useRemoteListMapping(tagIndex, tagMapper);
+  const tagList = useRemoteListMapping(tagIndex, tagsById);
+  const appliedTagList = useMemo(() => {
+    const valuesById = tagValueIndex
+      ? tagValueIndex.items.reduce(
+          (prev, cur) => {
+            if (!cur.data) {
+              return prev;
+            }
+            prev[cur.data.id] = cur.data.value;
+            return prev;
+          },
+          {} as SafeRecord<number, string | number | null>
+        )
+      : {};
 
-  return loadListIfNecessary(tagList, dispatch, {
+    return remoteList<ZetkinAppliedTag>(
+      tagList?.items.map(
+        (tag) =>
+          <ZetkinAppliedTag>{
+            ...tag.data,
+            value: (tag.data && valuesById[tag.data.id]) || null,
+          }
+      )
+    );
+  }, [tagList?.items, tagValueIndex]);
+
+  return loadListIfNecessary(appliedTagList, dispatch, {
     actionOnLoad: () => personTagsLoad([orgId, personId]),
     actionOnSuccess: (tags) => personTagsLoaded([[orgId, personId], tags]),
     loader: () =>

--- a/src/features/tags/hooks/usePersonTags.ts
+++ b/src/features/tags/hooks/usePersonTags.ts
@@ -15,11 +15,7 @@ export default function usePersonTags(orgId: number, personId: number) {
   const tagsById = useAppSelector((state) => state.tags.tagsById);
 
   const appliedTagList = useMemo(() => {
-    if (typeof personTags === 'undefined') {
-      return personTags;
-    }
-
-    if (!personTags.items) {
+    if (!personTags?.items) {
       return undefined;
     }
 

--- a/src/features/tags/hooks/useTag.ts
+++ b/src/features/tags/hooks/useTag.ts
@@ -10,13 +10,11 @@ interface UseTagReturn {
 export default function useTag(orgId: number, tagId: number): UseTagReturn {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
-  const tags = useAppSelector((state) => state.tags);
+  const tag = useAppSelector((state) => state.tags.tagsById[tagId]);
 
-  const item = tags.tagList.items.find((item) => item.id == tagId);
-
-  const tagFuture = loadItemIfNecessary(item, dispatch, {
-    actionOnLoad: () => tagLoad(tagId),
-    actionOnSuccess: (tag) => tagLoaded(tag),
+  const tagFuture = loadItemIfNecessary(tag, dispatch, {
+    actionOnLoad: () => tagLoad([orgId, tagId]),
+    actionOnSuccess: (tag) => tagLoaded([[orgId], tag]),
     loader: () =>
       apiClient.get<ZetkinTag>(`/api/orgs/${orgId}/people/tags/${tagId}`),
   });

--- a/src/features/tags/hooks/useTagGroupMutations.ts
+++ b/src/features/tags/hooks/useTagGroupMutations.ts
@@ -14,7 +14,7 @@ export default function useTagGroupMutations(
   const dispatch = useAppDispatch();
 
   const updateTagGroup = async (tagGroup: ZetkinTagGroupPatchBody) => {
-    dispatch(tagGroupUpdate([tagGroup.id, Object.keys(tagGroup)]));
+    dispatch(tagGroupUpdate([[orgId, tagGroup.id], Object.keys(tagGroup)]));
 
     const updatedTagGroup = await apiClient.patch<
       ZetkinTagGroup,
@@ -24,7 +24,7 @@ export default function useTagGroupMutations(
       title: tagGroup.title,
     });
 
-    dispatch(tagGroupUpdated(updatedTagGroup));
+    dispatch(tagGroupUpdated([[orgId], updatedTagGroup]));
 
     return updatedTagGroup;
   };

--- a/src/features/tags/hooks/useTagGroups.ts
+++ b/src/features/tags/hooks/useTagGroups.ts
@@ -13,13 +13,15 @@ export default function useTagGroups(orgId: number) {
   const tagGroupIndex = useAppSelector((state) => state.tags.tagGroups[orgId]);
   const groupsById = useAppSelector((state) => state.tags.groupsById);
   const tagGroupMapper = useCallback(
-    (groups: number[]) =>
-      groups
-        .map((groupId) => groupsById[groupId])
-        .filter((group) => !!group)
-        .filter((group) => !group.deleted)
-        .map((group) => group.data)
-        .filter((group) => !!group),
+    (groupId: number) => {
+      const group = groupsById[groupId];
+
+      if (group?.deleted) {
+        return null;
+      }
+
+      return group?.data ?? null;
+    },
     [groupsById]
   );
   const tagGroupsList = useRemoteListMapping(tagGroupIndex, tagGroupMapper);

--- a/src/features/tags/hooks/useTagGroups.ts
+++ b/src/features/tags/hooks/useTagGroups.ts
@@ -1,16 +1,32 @@
+import { useCallback } from 'react';
+
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { tagGroupsLoad, tagGroupsLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 export default function useTagGroups(orgId: number) {
-  const tagGroupsList = useAppSelector((state) => state.tags.tagGroupList);
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
 
+  const tagGroupIndex = useAppSelector((state) => state.tags.tagGroups[orgId]);
+  const groupsById = useAppSelector((state) => state.tags.groupsById);
+  const tagGroupMapper = useCallback(
+    (groups: number[]) =>
+      groups
+        .map((groupId) => groupsById[groupId])
+        .filter((group) => !!group)
+        .filter((group) => !group.deleted)
+        .map((group) => group.data)
+        .filter((group) => !!group),
+    [groupsById]
+  );
+  const tagGroupsList = useRemoteListMapping(tagGroupIndex, tagGroupMapper);
+
   return loadListIfNecessary(tagGroupsList, dispatch, {
-    actionOnLoad: () => tagGroupsLoad(),
-    actionOnSuccess: (tagGroups) => tagGroupsLoaded(tagGroups),
+    actionOnLoad: () => tagGroupsLoad([orgId]),
+    actionOnSuccess: (tagGroups) => tagGroupsLoaded([[orgId], tagGroups]),
     loader: () => apiClient.get<ZetkinTag[]>(`/api/orgs/${orgId}/tag_groups`),
   });
 }

--- a/src/features/tags/hooks/useTagGroups.ts
+++ b/src/features/tags/hooks/useTagGroups.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { tagGroupsLoad, tagGroupsLoaded } from '../store';
@@ -12,19 +10,7 @@ export default function useTagGroups(orgId: number) {
 
   const tagGroupIndex = useAppSelector((state) => state.tags.tagGroups[orgId]);
   const groupsById = useAppSelector((state) => state.tags.groupsById);
-  const tagGroupMapper = useCallback(
-    (groupId: number) => {
-      const group = groupsById[groupId];
-
-      if (group?.deleted) {
-        return null;
-      }
-
-      return group?.data ?? null;
-    },
-    [groupsById]
-  );
-  const tagGroupsList = useRemoteListMapping(tagGroupIndex, tagGroupMapper);
+  const tagGroupsList = useRemoteListMapping(tagGroupIndex, groupsById);
 
   return loadListIfNecessary(tagGroupsList, dispatch, {
     actionOnLoad: () => tagGroupsLoad([orgId]),

--- a/src/features/tags/hooks/useTagMutations.ts
+++ b/src/features/tags/hooks/useTagMutations.ts
@@ -22,7 +22,7 @@ export default function useTagMutations(orgId: number): UseTagMutationsReturn {
         group: undefined,
         group_id: newGroup.id,
       };
-      dispatch(tagUpdate([tag.id, Object.keys(tagWithNewGroup)]));
+      dispatch(tagUpdate([[orgId, tag.id], Object.keys(tagWithNewGroup)]));
       // eslint-disable-next-line
       const { id, ...resourceWithoutId } = tagWithNewGroup;
       const tagFuture = await apiClient
@@ -31,13 +31,13 @@ export default function useTagMutations(orgId: number): UseTagMutationsReturn {
           Omit<ZetkinTagPatchBody, 'id'>
         >(`/api/orgs/${orgId}/people/tags/${tag.id}`, resourceWithoutId)
         .then((data: ZetkinTag) => {
-          dispatch(tagUpdated(data));
+          dispatch(tagUpdated([[orgId], data]));
           return data;
         });
       return tagFuture;
     } else {
       // Add tag with existing or no group
-      dispatch(tagUpdate([tag.id, Object.keys(tag)]));
+      dispatch(tagUpdate([[orgId, tag.id], Object.keys(tag)]));
       const tagFuture = await apiClient
         .patch<ZetkinTag, Omit<ZetkinTagPatchBody, 'id'>>(
           `/api/orgs/${orgId}/people/tags/${tag.id}`,
@@ -49,7 +49,7 @@ export default function useTagMutations(orgId: number): UseTagMutationsReturn {
           }
         )
         .then((data) => {
-          dispatch(tagUpdated(data));
+          dispatch(tagUpdated([[orgId], data]));
           return data;
         });
 

--- a/src/features/tags/hooks/useTagging.ts
+++ b/src/features/tags/hooks/useTagging.ts
@@ -25,14 +25,14 @@ export default function useTagging(orgId: number): UseTaggingReturn {
       `/api/orgs/${orgId}/people/${personId}/tags/${tagId}`,
       data
     );
-    dispatch(tagAssigned([personId, tag]));
+    dispatch(tagAssigned([[orgId, personId], tag]));
   };
 
   const removeFromPerson = async (personId: number, tagId: number) => {
     await apiClient.delete(
       `/api/orgs/${orgId}/people/${personId}/tags/${tagId}`
     );
-    dispatch(tagUnassigned([personId, tagId]));
+    dispatch(tagUnassigned([orgId, personId, tagId]));
   };
 
   return {

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -1,17 +1,33 @@
+import { useCallback } from 'react';
+
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinTag } from 'utils/types/zetkin';
 import { tagsLoad, tagsLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 export default function useTags(orgId: number): IFuture<ZetkinTag[]> {
-  const tagList = useAppSelector((state) => state.tags.tagList);
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
 
-  return loadListIfNecessary(tagList, dispatch, {
-    actionOnLoad: () => tagsLoad(),
-    actionOnSuccess: (tags) => tagsLoaded(tags),
+  const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
+  const tagsById = useAppSelector((state) => state.tags.tagsById);
+  const tagMapper = useCallback(
+    (tags: number[]) =>
+      tags
+        .map((tagId) => tagsById[tagId])
+        .filter((tagItem) => !!tagItem)
+        .filter((tagItem) => !tagItem.deleted)
+        .map((tagItem) => tagItem.data)
+        .filter((tag) => !!tag),
+    [tagsById]
+  );
+  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+
+  return loadListIfNecessary(tagListState, dispatch, {
+    actionOnLoad: () => tagsLoad([orgId]),
+    actionOnSuccess: (tags) => tagsLoaded([[orgId], tags]),
     loader: () => apiClient.get<ZetkinTag[]>(`/api/orgs/${orgId}/people/tags`),
   });
 }

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -14,13 +14,13 @@ export default function useTags(orgId: number): IFuture<ZetkinTag[]> {
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
   const tagMapper = useCallback(
-    (tags: number[]) =>
-      tags
-        .map((tagId) => tagsById[tagId])
-        .filter((tagItem) => !!tagItem)
-        .filter((tagItem) => !tagItem.deleted)
-        .map((tagItem) => tagItem.data)
-        .filter((tag) => !!tag),
+    (tagId: number) => {
+      const tag = tagsById[tagId];
+      if (tag?.deleted) {
+        return null;
+      }
+      return tag?.data ?? null;
+    },
     [tagsById]
   );
   const tagListState = useRemoteListMapping(tagIndex, tagMapper);

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinTag } from 'utils/types/zetkin';
@@ -13,17 +11,7 @@ export default function useTags(orgId: number): IFuture<ZetkinTag[]> {
 
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
-  const tagMapper = useCallback(
-    (tagId: number) => {
-      const tag = tagsById[tagId];
-      if (tag?.deleted) {
-        return null;
-      }
-      return tag?.data ?? null;
-    },
-    [tagsById]
-  );
-  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+  const tagListState = useRemoteListMapping(tagIndex, tagsById);
 
   return loadListIfNecessary(tagListState, dispatch, {
     actionOnLoad: () => tagsLoad([orgId]),

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { IFuture } from 'core/caching/futures';
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { ZetkinTag } from 'utils/types/zetkin';
@@ -11,9 +13,28 @@ export default function useTags(orgId: number): IFuture<ZetkinTag[]> {
 
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
+  const groupsById = useAppSelector((state) => state.tags.groupsById);
   const tagListState = useRemoteListMapping(tagIndex, tagsById);
+  const tagsWithGroups = useMemo(
+    () =>
+      tagListState && {
+        ...tagListState,
+        items: tagListState.items.map((tagItem) => ({
+          ...tagItem,
+          data: tagItem.data
+            ? {
+                ...tagItem.data,
+                group: tagItem.data.group
+                  ? (groupsById[tagItem.data.group.id]?.data ?? null)
+                  : null,
+              }
+            : null,
+        })),
+      },
+    [groupsById, tagListState]
+  );
 
-  return loadListIfNecessary(tagListState, dispatch, {
+  return loadListIfNecessary(tagsWithGroups, dispatch, {
     actionOnLoad: () => tagsLoad([orgId]),
     actionOnSuccess: (tags) => tagsLoaded([[orgId], tags]),
     loader: () => apiClient.get<ZetkinTag[]>(`/api/orgs/${orgId}/people/tags`),

--- a/src/features/tags/hooks/useTags.ts
+++ b/src/features/tags/hooks/useTags.ts
@@ -25,7 +25,8 @@ export default function useTags(orgId: number): IFuture<ZetkinTag[]> {
             ? {
                 ...tagItem.data,
                 group: tagItem.data.group
-                  ? (groupsById[tagItem.data.group.id]?.data ?? null)
+                  ? (groupsById[tagItem.data.group.id]?.data ??
+                    tagItem.data.group)
                   : null,
               }
             : null,

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -1,148 +1,239 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import {
-  remoteItemDeleted,
-  remoteItemLoad,
-  remoteItemUpdate,
-  remoteItemUpdated,
-  remoteList,
-  RemoteList,
-  remoteListCreated,
-  remoteListLoad,
-  remoteListLoaded,
-} from 'utils/storeUtils';
-import {
   ZetkinAppliedTag,
+  ZetkinOrganization,
+  ZetkinPerson,
   ZetkinTag,
   ZetkinTagGroup,
 } from 'utils/types/zetkin';
+import {
+  remoteListCreated,
+  remoteListLoad,
+  remoteListLoaded,
+} from 'utils/storeUtils/remoteListUtils';
+import {
+  RemoteItem,
+  remoteItemDeleted,
+  remoteItemLoad,
+  remoteItemLoaded,
+  remoteItemUpdate,
+  remoteItemUpdated,
+  RemoteList,
+} from 'utils/storeUtils';
+import { SafeRecord } from 'utils/types';
+
+type OrgId = ZetkinOrganization['id'];
+type PersonId = ZetkinPerson['id'];
+type TagId = ZetkinTag['id'];
+type TagGroupId = ZetkinTagGroup['id'];
 
 export interface TagsStoreSlice {
-  tagGroupList: RemoteList<ZetkinTagGroup>;
-  tagList: RemoteList<ZetkinTag>;
-  tagsByPersonId: Record<number, RemoteList<ZetkinAppliedTag>>;
+  tagsById: SafeRecord<TagId, RemoteItem<ZetkinTag>>;
+  groupsById: SafeRecord<TagGroupId, RemoteItem<ZetkinTagGroup>>;
+
+  orgTags: SafeRecord<OrgId, RemoteList<ZetkinTag['id']>>;
+  personTags: SafeRecord<
+    `${OrgId}-${PersonId}`,
+    RemoteList<{
+      id: TagId;
+      value: string | number | null;
+    }>
+  >;
+  tagGroups: SafeRecord<OrgId, RemoteList<TagGroupId>>;
 }
 
 const initialState: TagsStoreSlice = {
-  tagGroupList: remoteList(),
-  tagList: remoteList(),
-  tagsByPersonId: {},
+  groupsById: {},
+  orgTags: {},
+  personTags: {},
+  tagGroups: {},
+  tagsById: {},
 };
 
 const tagsSlice = createSlice({
   initialState: initialState,
   name: 'tags',
   reducers: {
-    personTagsLoad: (state, action: PayloadAction<number>) => {
-      const id = action.payload;
-      state.tagsByPersonId[id] = remoteListLoad(state.tagsByPersonId[id]);
+    personTagsLoad: (state, action: PayloadAction<[OrgId, PersonId]>) => {
+      const [orgId, personId] = action.payload;
+      const key = `${orgId}-${personId}` as const;
+
+      state.personTags[key] = remoteListLoad(state.personTags[key] ?? null);
     },
     personTagsLoaded: (
       state,
-      action: PayloadAction<[number, ZetkinAppliedTag[]]>
+      action: PayloadAction<[[OrgId, PersonId], ZetkinAppliedTag[]]>
     ) => {
-      const [id, tags] = action.payload;
-      state.tagsByPersonId[id] = remoteListLoaded(tags);
-    },
-    tagAssigned: (state, action: PayloadAction<[number, ZetkinTag]>) => {
-      const [personId, tag] = action.payload;
-      state.tagsByPersonId[personId] ||= remoteListCreated();
-      remoteItemUpdated(state.tagsByPersonId[personId], tag);
-    },
-    tagCreate: (state) => {
-      // TODO: This is inconsistent with other features. The list itself is not truly loading, just some of the contents
-      state.tagList.isLoading = true;
-    },
-    tagCreated: (state, action: PayloadAction<ZetkinTag>) => {
-      const tag = action.payload;
-      state.tagList.isLoading = false;
-      remoteItemUpdated(state.tagList, tag);
-    },
-    tagDeleted: (state, action: PayloadAction<number>) => {
-      const tagId = action.payload;
+      const [[orgId, personId], tags] = action.payload;
+      const key = `${orgId}-${personId}` as const;
 
-      remoteItemDeleted(state.tagList, tagId);
-
-      for (const personId in state.tagsByPersonId) {
-        state.tagsByPersonId[personId].items = state.tagsByPersonId[
-          personId
-        ].items.filter((item) => item.id != tagId);
-      }
-    },
-    tagGroupCreate: (state) => {
-      // TODO: This is inconsistent with other features. The list itself is not truly loading, just some of the contents
-      state.tagGroupList.isLoading = true;
-    },
-    tagGroupCreated: (state, action: PayloadAction<ZetkinTagGroup>) => {
-      const tagGroup = action.payload;
-      remoteItemUpdated(state.tagGroupList, tagGroup);
-    },
-    tagGroupDeleted: (state, action: PayloadAction<number>) => {
-      const tagGroupId = action.payload;
-      remoteItemDeleted(state.tagGroupList, tagGroupId);
-    },
-    tagGroupUpdate: (state, action: PayloadAction<[number, string[]]>) => {
-      const [tagGroupId, mutating] = action.payload;
-      remoteItemUpdate(state.tagGroupList, tagGroupId, mutating);
-    },
-    tagGroupUpdated: (state, action: PayloadAction<ZetkinTagGroup>) => {
-      const tagGroup = action.payload;
-      remoteItemUpdated(state.tagGroupList, tagGroup);
-
-      for (const tagItem of state.tagList.items) {
-        if (tagItem.data?.group?.id == tagGroup.id) {
-          tagItem.data.group = tagGroup;
+      tags.forEach((tag) => {
+        state.tagsById[tag.id] = remoteItemLoaded(tag);
+        if (tag.group) {
+          state.groupsById[tag.group.id] = remoteItemLoaded(tag.group);
         }
+      });
+
+      state.personTags[key] = remoteListLoaded(
+        tags.map((tag) => ({
+          id: tag.id,
+          value: tag.value,
+        }))
+      );
+    },
+    tagAssigned: (
+      state,
+      action: PayloadAction<[[OrgId, PersonId], ZetkinAppliedTag]>
+    ) => {
+      const [[orgId, personId], appliedTag] = action.payload;
+      const key = `${orgId}-${personId}` as const;
+      const { value, ...tag } = appliedTag;
+
+      state.tagsById[appliedTag.id] = remoteItemLoaded(tag);
+
+      state.personTags[key] ||= remoteListCreated();
+      remoteItemUpdated(state.personTags[key], {
+        id: appliedTag.id,
+        value: value,
+      });
+    },
+    tagCreate: (state, action: PayloadAction<[OrgId]>) => {
+      // TODO: This is inconsistent with other features. The list itself is not truly loading, just some of the contents
+      const [orgId] = action.payload;
+
+      state.orgTags[orgId] = remoteListLoad(state.orgTags[orgId]);
+    },
+    tagCreated: (state, action: PayloadAction<[[OrgId], ZetkinTag]>) => {
+      const [[orgId], tag] = action.payload;
+
+      state.tagsById[tag.id] = remoteItemLoaded(tag);
+
+      state.orgTags[orgId] ||= remoteListCreated();
+      state.orgTags[orgId].isLoading = false;
+      remoteItemUpdated(state.orgTags[orgId], tag.id);
+    },
+    tagDeleted: (state, action: PayloadAction<[TagId]>) => {
+      const [tagId] = action.payload;
+
+      if (state.tagsById[tagId]) {
+        state.tagsById[tagId].deleted = true;
       }
     },
-    tagGroupsLoad: (state) => {
-      state.tagGroupList.isLoading = true; // Same as above comment
-      state.tagGroupList = remoteListLoad(state.tagGroupList);
-    },
-    tagGroupsLoaded: (state, action: PayloadAction<ZetkinTagGroup[]>) => {
-      const tagGroups = action.payload;
-      state.tagGroupList = remoteListLoaded(tagGroups);
-    },
-    tagLoad: (state, action: PayloadAction<number>) => {
-      const tagId = action.payload;
-      remoteItemLoad(state.tagList, tagId);
-    },
-    tagLoaded: (state, action: PayloadAction<ZetkinTag>) => {
-      const tag = action.payload;
-      remoteItemUpdated(state.tagList, tag);
-    },
-    tagUnassigned: (state, action: PayloadAction<[number, number]>) => {
-      const [personId, tagId] = action.payload;
+    tagGroupCreate: (state, action: PayloadAction<[OrgId]>) => {
+      // TODO: This is inconsistent with other features. The list itself is not truly loading, just some of the contents
+      const [orgId] = action.payload;
 
-      if (!state.tagsByPersonId[personId]) {
+      state.tagGroups[orgId] ||= remoteListCreated();
+      state.tagGroups[orgId].isLoading = true;
+    },
+    tagGroupCreated: (
+      state,
+      action: PayloadAction<[[OrgId], ZetkinTagGroup]>
+    ) => {
+      const [[orgId], tagGroup] = action.payload;
+
+      state.groupsById[tagGroup.id] = remoteItemLoaded(tagGroup);
+
+      state.tagGroups[orgId] ||= remoteListCreated();
+      remoteItemUpdated(state.tagGroups[orgId], tagGroup.id);
+    },
+    tagGroupDeleted: (state, action: PayloadAction<[TagGroupId]>) => {
+      const [tagGroupId] = action.payload;
+
+      if (state.groupsById[tagGroupId]) {
+        state.groupsById[tagGroupId].deleted = true;
+      }
+    },
+    tagGroupUpdate: (
+      state,
+      action: PayloadAction<[[OrgId, TagGroupId], string[]]>
+    ) => {
+      const [[orgId, tagGroupId], mutating] = action.payload;
+
+      state.tagGroups[orgId] ||= remoteListCreated();
+      remoteItemUpdate(state.tagGroups[orgId], tagGroupId, mutating);
+    },
+    tagGroupUpdated: (
+      state,
+      action: PayloadAction<[[OrgId], ZetkinTagGroup]>
+    ) => {
+      const [[orgId], tagGroup] = action.payload;
+
+      state.groupsById[tagGroup.id] = remoteItemLoaded(tagGroup);
+
+      state.tagGroups[orgId] ||= remoteListCreated();
+      remoteItemUpdated(state.tagGroups[orgId], tagGroup.id);
+    },
+    tagGroupsLoad: (state, action: PayloadAction<[OrgId]>) => {
+      const [orgId] = action.payload;
+
+      state.tagGroups[orgId] = remoteListLoad(state.tagGroups[orgId]);
+    },
+    tagGroupsLoaded: (
+      state,
+      action: PayloadAction<[[OrgId], ZetkinTagGroup[]]>
+    ) => {
+      const [[orgId], tagGroups] = action.payload;
+
+      tagGroups.forEach((group) => {
+        state.groupsById[group.id] = remoteItemLoaded(group);
+      });
+
+      state.tagGroups[orgId] = remoteListLoaded(
+        tagGroups.map((group) => group.id)
+      );
+    },
+    tagLoad: (state, action: PayloadAction<[OrgId, TagId]>) => {
+      const [orgId, tagId] = action.payload;
+
+      state.orgTags[orgId] ||= remoteListCreated();
+      remoteItemLoad(state.orgTags[orgId], tagId);
+    },
+    tagLoaded: (state, action: PayloadAction<[[OrgId], ZetkinTag]>) => {
+      const [[orgId], tag] = action.payload;
+
+      state.tagsById[tag.id] = remoteItemLoaded(tag);
+
+      state.orgTags[orgId] ||= remoteListCreated();
+      remoteItemUpdated(state.orgTags[orgId], tag.id);
+    },
+    tagUnassigned: (state, action: PayloadAction<[OrgId, PersonId, TagId]>) => {
+      const [orgId, personId, tagId] = action.payload;
+      const key = `${orgId}-${personId}` as const;
+
+      if (!state.personTags[key]) {
         return;
       }
 
-      remoteItemDeleted(state.tagsByPersonId[personId], tagId);
+      remoteItemDeleted(state.personTags[key], tagId);
     },
-    tagUpdate: (state, action: PayloadAction<[number, string[]]>) => {
-      const [tagId, mutating] = action.payload;
-      remoteItemUpdate(state.tagList, tagId, mutating);
-    },
-    tagUpdated: (state, action: PayloadAction<ZetkinTag>) => {
-      const tag = action.payload;
-      remoteItemUpdated(state.tagList, tag);
+    tagUpdate: (state, action: PayloadAction<[[OrgId, TagId], string[]]>) => {
+      const [[orgId, tagId], mutating] = action.payload;
 
-      // Update tags on people
-      Object.values(state.tagsByPersonId).forEach((tagList) => {
-        tagList.items.forEach((item) => {
-          if (item.id == tag.id) {
-            item.data = { ...tag, value: item.data?.value || null };
-          }
-        });
+      state.orgTags[orgId] ||= remoteListCreated();
+      remoteItemUpdate(state.orgTags[orgId], tagId, mutating);
+    },
+    tagUpdated: (state, action: PayloadAction<[[OrgId], ZetkinTag]>) => {
+      const [[orgId], tag] = action.payload;
+
+      state.tagsById[tag.id] = remoteItemLoaded(tag);
+
+      state.orgTags[orgId] ||= remoteListCreated();
+      remoteItemUpdated(state.orgTags[orgId], tag.id);
+    },
+    tagsLoad: (state, action: PayloadAction<[OrgId]>) => {
+      const [orgId] = action.payload;
+      state.orgTags[orgId] = remoteListLoad(state.orgTags[orgId]);
+    },
+    tagsLoaded: (state, action: PayloadAction<[[OrgId], ZetkinTag[]]>) => {
+      const [[orgId], tags] = action.payload;
+
+      tags.forEach((tag) => {
+        state.tagsById[tag.id] = remoteItemLoaded(tag);
       });
-    },
-    tagsLoad: (state) => {
-      state.tagList = remoteListLoad(state.tagList);
-    },
-    tagsLoaded: (state, action: PayloadAction<ZetkinTag[]>) => {
-      const tags = action.payload;
-      state.tagList = remoteListLoaded(tags);
+
+      state.orgTags[orgId] = remoteListLoaded(tags.map((tag) => tag.id));
     },
   },
 });

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -70,9 +70,6 @@ const tagsSlice = createSlice({
 
       tags.forEach((tag) => {
         state.tagsById[tag.id] = remoteItemLoaded(tag);
-        if (tag.group) {
-          state.groupsById[tag.group.id] = remoteItemLoaded(tag.group);
-        }
       });
 
       state.personTags[key] = remoteListLoaded(

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -59,7 +59,7 @@ const tagsSlice = createSlice({
       const [orgId, personId] = action.payload;
       const key = `${orgId}-${personId}` as const;
 
-      state.personTags[key] = remoteListLoad(state.personTags[key] ?? null);
+      state.personTags[key] = remoteListLoad(state.personTags[key]);
     },
     personTagsLoaded: (
       state,

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -13,9 +13,9 @@ import {
   remoteListLoaded,
 } from 'utils/storeUtils/remoteListUtils';
 import {
+  remoteItem,
   RemoteItem,
   remoteItemDeleted,
-  remoteItemLoad,
   remoteItemLoaded,
   remoteItemUpdate,
   remoteItemUpdated,
@@ -185,10 +185,10 @@ const tagsSlice = createSlice({
       );
     },
     tagLoad: (state, action: PayloadAction<[OrgId, TagId]>) => {
-      const [orgId, tagId] = action.payload;
+      const [, tagId] = action.payload;
 
-      state.orgTags[orgId] ||= remoteListCreated();
-      remoteItemLoad(state.orgTags[orgId], tagId);
+      state.tagsById[tagId] = remoteItem(tagId);
+      state.tagsById[tagId].isLoading = true;
     },
     tagLoaded: (state, action: PayloadAction<[[OrgId], ZetkinTag]>) => {
       const [[orgId], tag] = action.payload;

--- a/src/features/tags/store.ts
+++ b/src/features/tags/store.ts
@@ -32,7 +32,7 @@ export interface TagsStoreSlice {
   tagsById: SafeRecord<TagId, RemoteItem<ZetkinTag>>;
   groupsById: SafeRecord<TagGroupId, RemoteItem<ZetkinTagGroup>>;
 
-  orgTags: SafeRecord<OrgId, RemoteList<ZetkinTag['id']>>;
+  orgTags: SafeRecord<OrgId, RemoteList<TagId>>;
   personTags: SafeRecord<
     `${OrgId}-${PersonId}`,
     RemoteList<{

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
@@ -25,8 +25,9 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { AppDispatch } from 'core/store';
 import { PersonTagViewColumn, ZetkinViewRow } from '../../../types';
 import { tagLoad, tagLoaded } from 'features/tags/store';
-import { RemoteList } from 'utils/storeUtils';
+import { RemoteItem } from 'utils/storeUtils';
 import ZUITagChip from 'zui/components/ZUITagChip';
+import { SafeRecord } from 'utils/types';
 
 type PersonTagViewCell = null | {
   value?: string;
@@ -44,17 +45,17 @@ export default class PersonTagColumnType implements IColumnType {
       apiClient: IApiClient;
       dispatch: AppDispatch;
       orgId: number;
-      tagListState: RemoteList<ZetkinTag>;
+      tagState?: SafeRecord<number, RemoteItem<ZetkinTag>>;
     }
   ): Omit<GridColDef, 'field'> {
-    const { apiClient, dispatch, orgId, tagListState } = optionalParams;
+    const { apiClient, dispatch, orgId, tagState } = optionalParams;
 
     const tagId = column.config.tag_id;
 
     let tag: ZetkinTag | null = null;
 
     if (!accessLevel) {
-      const tagItem = tagListState.items.find((item) => item.id == tagId);
+      const tagItem = tagState?.[tagId];
 
       const tagFuture = loadItemIfNecessary(tagItem, dispatch, {
         actionOnLoad: () => tagLoad([orgId, tagId]),

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/index.tsx
@@ -57,8 +57,8 @@ export default class PersonTagColumnType implements IColumnType {
       const tagItem = tagListState.items.find((item) => item.id == tagId);
 
       const tagFuture = loadItemIfNecessary(tagItem, dispatch, {
-        actionOnLoad: () => tagLoad(tagId),
-        actionOnSuccess: (tag) => tagLoaded(tag),
+        actionOnLoad: () => tagLoad([orgId, tagId]),
+        actionOnSuccess: (tag) => tagLoaded([[orgId], tag]),
         loader: () =>
           apiClient.get<ZetkinTag>(`/api/orgs/${orgId}/people/tags/${tagId}`),
       });

--- a/src/features/views/components/ViewDataTable/columnTypes/index.ts
+++ b/src/features/views/components/ViewDataTable/columnTypes/index.ts
@@ -17,8 +17,9 @@ import { UseViewGridReturn } from 'features/views/hooks/useViewGrid';
 import { ZetkinObjectAccess } from 'core/api/types';
 import { AppDispatch } from 'core/store';
 import { COLUMN_TYPE, ZetkinViewColumn } from 'features/views/components/types';
-import { RemoteList } from 'utils/storeUtils';
 import { ZetkinCustomField, ZetkinTag } from 'utils/types/zetkin';
+import { SafeRecord } from 'utils/types';
+import { RemoteItem } from 'utils/storeUtils';
 
 export interface IColumnType<
   ColumnType = ZetkinViewColumn,
@@ -33,7 +34,7 @@ export interface IColumnType<
       customFieldsInfo?: ZetkinCustomField[];
       dispatch?: AppDispatch;
       orgId?: number;
-      tagListState?: RemoteList<ZetkinTag>;
+      tagState?: SafeRecord<number, RemoteItem<ZetkinTag>>;
     }
   ): Omit<GridColDef, 'field'>;
   getSearchableStrings(cell: CellType, column: ColumnType): string[];

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -73,6 +73,7 @@ import useViewMutations from 'features/views/hooks/useViewMutations';
 import oldTheme from 'theme';
 import useViewBulkActions from 'features/views/hooks/useViewBulkActions';
 import { dayOfMonthOperator, monthOperator } from './customFilters/date';
+import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 declare module '@mui/x-data-grid-pro' {
   interface ColumnMenuPropsOverrides {
@@ -177,9 +178,24 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 }) => {
   const theme = useTheme();
   const messages = useMessages(messageIds);
+  const { orgId } = useNumericRouteParams();
+
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
-  const tagListState = useAppSelector((state) => state.tags.tagList);
+  const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
+  const tagsById = useAppSelector((state) => state.tags.tagsById);
+  const tagMapper = useCallback(
+    (tags: number[]) =>
+      tags
+        .map((tagId) => tagsById[tagId])
+        .filter((tag) => !!tag)
+        .filter((tag) => !tag.deleted)
+        .map((tag) => tag.data)
+        .filter((tag) => !!tag),
+    [tagsById]
+  );
+  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+
   const gridApiRef = useGridApiRef();
   const [addedId, setAddedId] = useState(0);
   const [columnToCreate, setColumnToCreate] =
@@ -207,7 +223,6 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const [, accessLevel] = useAccessLevel();
 
   const [quickSearch, setQuickSearch] = useState('');
-  const { orgId } = useNumericRouteParams();
 
   const { showSnackbar } = useContext(ZUISnackbarContext);
   const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -185,13 +185,15 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
   const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
   const tagsById = useAppSelector((state) => state.tags.tagsById);
   const tagMapper = useCallback(
-    (tags: number[]) =>
-      tags
-        .map((tagId) => tagsById[tagId])
-        .filter((tag) => !!tag)
-        .filter((tag) => !tag.deleted)
-        .map((tag) => tag.data)
-        .filter((tag) => !!tag),
+    (tagId: number) => {
+      const tag = tagsById[tagId];
+
+      if (tag?.deleted) {
+        return null;
+      }
+
+      return tag?.data ?? null;
+    },
     [tagsById]
   );
   const tagListState = useRemoteListMapping(tagIndex, tagMapper);

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -73,7 +73,6 @@ import useViewMutations from 'features/views/hooks/useViewMutations';
 import oldTheme from 'theme';
 import useViewBulkActions from 'features/views/hooks/useViewBulkActions';
 import { dayOfMonthOperator, monthOperator } from './customFilters/date';
-import useRemoteListMapping from 'utils/hooks/useRemoteListMapping';
 
 declare module '@mui/x-data-grid-pro' {
   interface ColumnMenuPropsOverrides {
@@ -182,21 +181,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
 
   const dispatch = useAppDispatch();
   const apiClient = useApiClient();
-  const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
-  const tagsById = useAppSelector((state) => state.tags.tagsById);
-  const tagMapper = useCallback(
-    (tagId: number) => {
-      const tag = tagsById[tagId];
-
-      if (tag?.deleted) {
-        return null;
-      }
-
-      return tag?.data ?? null;
-    },
-    [tagsById]
-  );
-  const tagListState = useRemoteListMapping(tagIndex, tagMapper);
+  const tagState = useAppSelector((state) => state.tags.tagsById);
 
   const gridApiRef = useGridApiRef();
   const [addedId, setAddedId] = useState(0);
@@ -465,7 +450,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           customFieldsInfo: customFields ?? [],
           dispatch,
           orgId,
-          tagListState,
+          tagState,
         });
         return {
           field: `col_${col.id}`,
@@ -483,7 +468,7 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
       avatarColumn,
       columns,
       accessLevel,
-      tagListState,
+      tagState,
       customFields,
       apiClient,
       dispatch,

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -63,11 +63,11 @@ const viewsSlice = createSlice({
         });
       })
       .addCase(tagAssigned, (state, action) => {
-        const [personId, tag] = action.payload;
+        const [[, personId], tag] = action.payload;
         setTagOnRelevantRows(state, personId, tag.id, tag);
       })
       .addCase(tagUnassigned, (state, action) => {
-        const [personId, tagId] = action.payload;
+        const [, personId, tagId] = action.payload;
         setTagOnRelevantRows(state, personId, tagId, null);
       })
       .addCase(callUpdated, (state, action) => {

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -159,9 +159,11 @@ export default function mockState(overrides?: RootState) {
       surveysWithElementsList: remoteList(),
     },
     tags: {
-      tagGroupList: remoteList(),
-      tagList: remoteList(),
-      tagsByPersonId: {},
+      groupsById: {},
+      orgTags: {},
+      personTags: {},
+      tagGroups: {},
+      tagsById: {},
     },
     tasks: {
       assignedTasksByTaskId: {},


### PR DESCRIPTION
## Description

This PR is a proposal for refactoring the tag store using an index-based approach, meaning that we store tags and groups by their id and reuse them across the app using indices. The point of this is to reduce duplicates, keep data consistent, reduce complexity, and provide a clear usage pattern.

## Changes

[Add a list of features added/changed, bugs fixed etc]

### Updated data structure:

```ts
// from
export interface TagStoreSlice {
  tagGroupList: RemoteList<ZetkinTagGroup>;
  tagList: RemoteList<ZetkinTag>;
  tagsByPersonId: Record<number, RemoteList<ZetkinAppliedTag>>;
}

// to
export interface TagsStoreSlice {
  tagsById: SafeRecord<TagId, RemoteItem<ZetkinTag>>;
  groupsById: SafeRecord<TagGroupId, RemoteItem<ZetkinTagGroup>>;

  orgTags: SafeRecord<OrgId, RemoteList<ZetkinTag['id']>>;
  personTags: SafeRecord<
    `${OrgId}-${PersonId}`,
    RemoteList<{
      id: TagId;
      value: string | number | null;
    }>
  >;
  tagGroups: SafeRecord<OrgId, RemoteList<TagGroupId>>;
}
```

- Uses named types such as `OrgId` to make it clear which `number` refers to which id
- Stores all objects in `tagsById` and `groupsById`
- Adds indices for `orgTags`, which are all tags in an org, `personTags`, which are assigned tags of a person and `tagGroups`, which are all tag groups within an org
- Uses `SafeRecord` to catch cases where accessed objects are `undefined` because the key doesn't exist

### Updated reducer signatures

```ts
// from
personTagsLoaded: (
  state,
  action: PayloadAction<[number, ZetkinAppliedTag[]]>
) => {}

// to
personTagsLoaded: (
  state,
  action: PayloadAction<[[OrgId, PersonId], ZetkinAppliedTag[]]>
) => {}
``` 

- Adds `orgId` where needed
- Wraps the set of needed ids in a separate array
- Uses named types such as `OrgId` to make it clear which `number` refers to which id

### Updated reducers, hooks and other `dispatch` calls

- Updates everything to use indices except for `useTag` related things, which only uses the direct `tagsById` state
- Introduces a mapping pattern, so indexed objects get resolved:

```ts
const tagIndex = useAppSelector((state) => state.tags.orgTags[orgId]);
const tagsById = useAppSelector((state) => state.tags.tagsById);
const tagListState = useRemoteListMapping(tagIndex, tagsById);
```

## Notes to reviewer

[Add instructions for testing]

There are some changes to `cacheUtils` needed. See https://github.com/zetkin/app.zetkin.org/pull/3668

I think maybe we could use `Branded` types for things like `OrgId`, but I think we could do that everywhere and that would be a huge refactor.

## Related issues

Related to #3635
Based on https://github.com/zetkin/app.zetkin.org/pull/3668