### PR TITLE
Fix case sensitivity bug in survey respondent management

### DIFF
--- a/src/features/surveys/components/SurveySubmissionsList.tsx
+++ b/src/features/surveys/components/SurveySubmissionsList.tsx
@@ -265,7 +265,9 @@ const SurveySubmissionsList = ({
       const respondentEmail = row.respondent?.email;
       if (person) {
         const personHasNoEmail = person.email == null || person.email == '';
-        const personHasDifferentEmail = person.email !== respondentEmail;
+        const personHasDifferentEmail =
+          person.email &&
+          person.email.toLowerCase() !== respondentEmail?.toLowerCase();
         if (
           (personHasNoEmail && respondentEmail != undefined) ||
           (personHasDifferentEmail && respondentEmail != undefined)


### PR DESCRIPTION
## Description

This PR simply fixes a bug in the unlinked survey respondent management (#3667). With this fix, the case of the person's email and the respondent's email is ignored, meaning differences in case in the email won't trigger the "update person email" dialog.

## Screenshots

Not relevant

## Changes

- Changes how person and respondent emails are compared in `SurveySubmissionsList.tsx`, preventing "update person email" dialog from showing if the emails are equivalent.

## Notes to reviewer

First time contributing so I found this small issue to get started. Happy to hear what I should do differently:)

## Related issues

Resolves #3667
