### PR TITLE
Minor fixes in the Call UI

### DIFF
--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -28,7 +28,9 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
             <Box alignItems="center" display="flex" gap={1}>
               <ZUIIcon color="secondary" icon={Phone} size="small" />
               <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
-                <ZUIText>{call.target.phone}</ZUIText>
+                <ZUIText sx={{ fontFamily: 'monospace' }}>
+                  {call.target.phone}
+                </ZUIText>
               </Box>
             </Box>
           )}
@@ -36,7 +38,9 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
             <Box alignItems="center" display="flex" gap={1}>
               <ZUIIcon color="secondary" icon={Phone} size="small" />
               <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
-                <ZUIText>{call.target.alt_phone}</ZUIText>
+                <ZUIText sx={{ fontFamily: 'monospace' }}>
+                  {call.target.alt_phone}
+                </ZUIText>
               </Box>
             </Box>
           )}

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -38,7 +38,7 @@ import { MUIIcon } from 'zui/components/types';
 import Survey from './Survey';
 import ZUISection from 'zui/components/ZUISection';
 import messageIds from '../l10n/messageIds';
-import { useMessages } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
 
 type Filter = {
   active: boolean;
@@ -126,7 +126,9 @@ const Activities: FC<ActivitiesProps> = ({
           }}
         >
           <ZUIIcon color="secondary" icon={Chair} size="large" />
-          <ZUIText color="secondary">No activities</ZUIText>
+          <ZUIText color="secondary">
+            <Msg id={messageIds.activities.empty} />
+          </ZUIText>
         </Box>
       )}
       {showNoSignups && (
@@ -140,7 +142,12 @@ const Activities: FC<ActivitiesProps> = ({
           }}
         >
           <ZUIIcon color="secondary" icon={Hotel} size="large" />
-          <ZUIText color="secondary">{`${target?.first_name} is not booked or signed up for any events.`}</ZUIText>
+          <ZUIText color="secondary">
+            <Msg
+              id={messageIds.activities.noBookings}
+              values={{ name: target.first_name }}
+            />
+          </ZUIText>
         </Box>
       )}
       {activities.map((activity) => {

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -531,25 +531,6 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target?.id]);
 
-  useEffect(() => {
-    if (step == LaneStep.REPORT) {
-      dispatch(
-        filtersUpdated({
-          customDatesToFilterEventsBy: [null, null],
-          eventDateFilterState: null,
-          filterState: {
-            alreadyIn: false,
-            events: false,
-            surveys: false,
-            thisCall: true,
-          },
-          projectIdsToFilterActivitiesBy: [],
-        })
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step]);
-
   return (
     <>
       <Box sx={{ height: '100%', width: '100%' }}>

--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -2,7 +2,6 @@
 
 import { Alert, Box, Slide, Snackbar } from '@mui/material';
 import { FC, useState } from 'react';
-import { useRouter } from 'next/navigation';
 
 import useCurrentCall from '../hooks/useCurrentCall';
 import { LaneStep } from '../types';
@@ -22,13 +21,16 @@ import messageIds from '../l10n/messageIds';
 import CallHeader from './CallHeader';
 import CallPanels from './CallPanels';
 
-const Call: FC<{ onResetAfterError: () => void }> = ({ onResetAfterError }) => {
+type Props = {
+  onResetAfterError: (urlToNavigateTo: string) => void;
+};
+
+const Call: FC<Props> = ({ onResetAfterError }) => {
   const messages = useMessages(messageIds);
   const dispatch = useAppDispatch();
   const onServer = useServerSide();
   const assignment = useCurrentAssignment();
   const allUserAssignments = useMyAssignments();
-  const router = useRouter();
 
   const [callLogOpen, setCallLogOpen] = useState(false);
   const [assignmentSwitchedTo, setAssignmentSwitchedTo] = useState<
@@ -115,17 +117,11 @@ const Call: FC<{ onResetAfterError: () => void }> = ({ onResetAfterError }) => {
         }
         primaryButton={{
           label: messages.unexpectedError.reloadButton(),
-          onClick: () => {
-            onResetAfterError();
-            router.push(`/call/${assignment.id}`);
-          },
+          onClick: () => onResetAfterError(`/call/${assignment.id}`),
         }}
         secondaryButton={{
           label: messages.unexpectedError.backToMyZetkinButton(),
-          onClick: () => {
-            onResetAfterError();
-            router.push('/my');
-          },
+          onClick: () => onResetAfterError('/my'),
         }}
         title={messages.unexpectedError.title()}
       >

--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -22,7 +22,7 @@ import messageIds from '../l10n/messageIds';
 import CallHeader from './CallHeader';
 import CallPanels from './CallPanels';
 
-const Call: FC<{ clearCallLanes: () => void }> = ({ clearCallLanes }) => {
+const Call: FC<{ onResetAfterError: () => void }> = ({ onResetAfterError }) => {
   const messages = useMessages(messageIds);
   const dispatch = useAppDispatch();
   const onServer = useServerSide();
@@ -116,14 +116,14 @@ const Call: FC<{ clearCallLanes: () => void }> = ({ clearCallLanes }) => {
         primaryButton={{
           label: messages.unexpectedError.reloadButton(),
           onClick: () => {
-            clearCallLanes();
+            onResetAfterError();
             router.push(`/call/${assignment.id}`);
           },
         }}
         secondaryButton={{
           label: messages.unexpectedError.backToMyZetkinButton(),
           onClick: () => {
-            clearCallLanes();
+            onResetAfterError();
             router.push('/my');
           },
         }}

--- a/src/features/call/components/CallHeader.tsx
+++ b/src/features/call/components/CallHeader.tsx
@@ -23,6 +23,7 @@ import prepareSurveyApiSubmission from 'features/surveys/utils/prepareSurveyApiS
 import { useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import useFilteredActivities from '../hooks/useFilteredActivities';
+import notEmpty from 'utils/notEmpty';
 
 type Props = {
   assignment: ZetkinCallAssignment;
@@ -139,9 +140,13 @@ const CallHeader: FC<Props> = ({
               lastName={call.target.last_name}
             />
             <ZUIText variant="headingLg">{call.target.name}</ZUIText>
-            <ZUIText color="secondary" variant="headingLg">
+            <ZUIText
+              color="secondary"
+              sx={{ fontFamily: 'monospace' }}
+              variant="headingLg"
+            >
               {[call.target.phone, call.target.alt_phone]
-                .filter((number) => !!number)
+                .filter(notEmpty)
                 .join('/')}
             </ZUIText>
           </>

--- a/src/features/call/components/CallPanels.tsx
+++ b/src/features/call/components/CallPanels.tsx
@@ -285,11 +285,14 @@ const CallPanels: FC<Props> = ({
           left: lane.step == LaneStep.SUMMARY ? 'calc(100% / 4)' : '120%',
           position: 'relative',
           transition: lane.step != LaneStep.CALL ? 'left 0.5s' : '',
-          visibility:
-            !call &&
-            (lane.step == LaneStep.CALL || lane.step == LaneStep.REPORT)
-              ? 'hidden'
-              : undefined,
+          visibility: () => {
+            const noCurrentCall = !call;
+            const inCallOrReport =
+              lane.step == LaneStep.CALL || lane.step == LaneStep.REPORT;
+            const hideSummary = noCurrentCall && inCallOrReport;
+
+            return hideSummary ? 'hidden' : undefined;
+          },
           width: lane.step == LaneStep.SUMMARY ? 1 / 2 : 1 / 3,
         }}
       >

--- a/src/features/call/components/CallSummary.tsx
+++ b/src/features/call/components/CallSummary.tsx
@@ -44,7 +44,10 @@ const CallSummary: FC<Props> = ({
   );
 
   const hasUnfinishedCalls = unfinishedCalls.length > 0;
-  const hasError = !!reportSubmissionError;
+  const hasReportSubmissionError = !!reportSubmissionError;
+  const hasPreviousCallMissingError =
+    !hasReportSubmissionError && !previousCall;
+  const noErrors = !hasReportSubmissionError && !hasPreviousCallMissingError;
 
   return (
     <Box
@@ -63,20 +66,35 @@ const CallSummary: FC<Props> = ({
           gap: 2,
         }}
       >
-        {hasError && (
+        {hasReportSubmissionError && (
           <>
             <Box sx={{ paddingY: 2 }}>
               <ZUIIcon color="error" icon={Close} size="large" />
             </Box>
             <ZUIText variant="headingLg">
-              <Msg id={messageIds.summary.error.title} />
+              <Msg id={messageIds.summary.reportSubmissionError.title} />
             </ZUIText>
             <ZUIText variant="headingSm">
-              <Msg id={messageIds.summary.error.description} />
+              <Msg id={messageIds.summary.reportSubmissionError.description} />
             </ZUIText>
           </>
         )}
-        {!hasError && (
+        {hasPreviousCallMissingError && (
+          <>
+            <Box sx={{ paddingY: 2 }}>
+              <ZUIIcon color="error" icon={Close} size="large" />
+            </Box>
+            <ZUIText variant="headingLg">
+              <Msg id={messageIds.summary.previousCallMissingError.title} />
+            </ZUIText>
+            <ZUIText variant="headingSm">
+              <Msg
+                id={messageIds.summary.previousCallMissingError.description}
+              />
+            </ZUIText>
+          </>
+        )}
+        {noErrors && (
           <Box
             sx={{
               alignItems: 'center',
@@ -90,16 +108,17 @@ const CallSummary: FC<Props> = ({
               <Msg id={messageIds.summary.title.success} />
             </ZUIText>
             <ZUIText color="secondary" variant="headingSm">
-              {hasUnfinishedCalls ? (
+              {hasUnfinishedCalls && (
                 <Msg id={messageIds.summary.unfinishedCallsMessage} />
-              ) : (
+              )}
+              {!hasUnfinishedCalls && previousCall && (
                 <Msg
                   id={
                     messageIds.summary.callSummary[
                       callStateToString[reportState]
                     ]
                   }
-                  values={{ name: previousCall?.target.name || '' }}
+                  values={{ name: previousCall.target.name }}
                 />
               )}
             </ZUIText>

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -276,7 +276,7 @@ const CallSwitchModal: FC<CallSwitchModalProps> = ({
           display: 'flex',
           flexDirection: 'column',
           gap: 1,
-          minHeight: 400,
+          height: 400,
           overflowX: 'hidden',
           paddingRight: 1,
           paddingTop: 2,

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -107,7 +107,7 @@ const FinishedCallsList: FC<{
 }> = ({ onCall, orgId, searchString }) => {
   const messages = useMessages(messageIds);
   const { switchToPreviousCall } = useCallMutations(orgId);
-  const { loading, finishedCalls } = useFinishedCalls();
+  const { isLoading, finishedCalls } = useFinishedCalls();
 
   const fuse = useMemo(() => {
     return new Fuse(finishedCalls, {
@@ -123,18 +123,10 @@ const FinishedCallsList: FC<{
   }, [finishedCalls]);
 
   const filteredFinishedCalls = useMemo(() => {
-    const calls = searchString
+    return searchString
       ? fuse.search(searchString).map((fuseResult) => fuseResult.item)
       : finishedCalls;
-
-    return calls.toSorted((call1, call2) => {
-      const call1AllocationTime = new Date(call1.allocation_time);
-      const call2AllocationTime = new Date(call2.allocation_time);
-
-      return call2AllocationTime.getTime() - call1AllocationTime.getTime();
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [finishedCalls, searchString]);
+  }, [finishedCalls, fuse, searchString]);
 
   return (
     <>
@@ -231,7 +223,7 @@ const FinishedCallsList: FC<{
           <ZUIDivider />
         </Fragment>
       ))}
-      {loading && (
+      {isLoading && (
         <Box
           sx={{
             alignItems: 'center',

--- a/src/features/call/components/EventCard.tsx
+++ b/src/features/call/components/EventCard.tsx
@@ -17,6 +17,8 @@ import ZUIText from 'zui/components/ZUIText';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinCallTarget } from '../types';
 import ZUISignUpChip from 'zui/components/ZUISignUpChip';
+import messageIds from '../l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
 
 type EventCardProps = {
   event: ZetkinEvent;
@@ -24,6 +26,7 @@ type EventCardProps = {
 };
 
 const EventCard: FC<EventCardProps> = ({ event, target }) => {
+  const messages = useMessages(messageIds);
   const intl = useIntl();
   const { signUp, undoSignup } = useEventCallActions(
     event.organization.id,
@@ -46,14 +49,21 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
         isTargetBooked
           ? [
               <ZUIText key={event.id}>
-                {`${target.first_name} is already booked.`}{' '}
+                <Msg
+                  id={messageIds.activities.events.alreadyBooked}
+                  values={{ name: target.first_name }}
+                />
               </ZUIText>,
             ]
           : [
               <>
                 <ZUIButton
                   key={event.id}
-                  label={isSignedUp ? 'Undo sign up' : 'Sign up'}
+                  label={
+                    isSignedUp
+                      ? messages.activities.events.undoSignUp()
+                      : messages.activities.events.signUp()
+                  }
                   onClick={() => (isSignedUp ? undoSignup() : signUp())}
                   variant="primary"
                 />
@@ -72,7 +82,7 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
         {
           Icon: GroupWorkOutlined,
           labels: [
-            event.campaign?.title ?? 'Untitled project',
+            event.campaign?.title ?? messages.activities.untitled.project(),
             event.organization.title,
           ],
         },
@@ -88,10 +98,16 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
         },
         {
           Icon: LocationOnOutlined,
-          labels: [event.location?.title ?? 'No location'],
+          labels: [
+            event.location?.title ?? messages.activities.events.noLocation(),
+          ],
         },
       ]}
-      title={event.title || event.activity?.title || 'Untitled event'}
+      title={
+        event.title ||
+        event.activity?.title ||
+        messages.activities.untitled.event()
+      }
     />
   );
 };

--- a/src/features/call/components/EventCard.tsx
+++ b/src/features/call/components/EventCard.tsx
@@ -81,6 +81,7 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
       info={[
         {
           Icon: GroupWorkOutlined,
+          key: 'project',
           labels: [
             event.campaign?.title ?? messages.activities.untitled.project(),
             event.organization.title,
@@ -88,6 +89,7 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
         },
         {
           Icon: WatchLaterOutlined,
+          key: 'time',
           labels: [
             timeSpanToString(
               new Date(removeOffset(event.start_time)),
@@ -98,6 +100,7 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
         },
         {
           Icon: LocationOnOutlined,
+          key: 'location',
           labels: [
             event.location?.title ?? messages.activities.events.noLocation(),
           ],

--- a/src/features/call/components/Report/steps/CallBack.tsx
+++ b/src/features/call/components/Report/steps/CallBack.tsx
@@ -211,6 +211,30 @@ const CallBack: FC<Props> = ({ onReportUpdate, report }) => {
             value={time}
           />
         </Box>
+        <ZUIButton
+          disabled={!dateIsValid}
+          endIcon={dateIsValid && !isMobile ? LooksOneOutlined : undefined}
+          label={
+            dateIsValid
+              ? messages.report.steps.callBack.question.callBackButtonLabel({
+                  date:
+                    time.value == 'any' ? (
+                      <ZUIDate datetime={callBackAfter} />
+                    ) : (
+                      <ZUIDateTime datetime={callBackAfter} />
+                    ),
+                })
+              : messages.report.steps.callBack.question.invalidDateButtonLabel()
+          }
+          onClick={() => {
+            onReportUpdate({
+              ...report,
+              callBackAfter,
+              step: 'organizerAction',
+            });
+          }}
+          variant="secondary"
+        />
         <Box
           sx={{
             alignItems: isMobile ? 'flex-start' : 'center',
@@ -245,30 +269,6 @@ const CallBack: FC<Props> = ({ onReportUpdate, report }) => {
             />
           </Box>
         </Box>
-        <ZUIButton
-          disabled={!dateIsValid}
-          endIcon={dateIsValid && !isMobile ? LooksOneOutlined : undefined}
-          label={
-            dateIsValid
-              ? messages.report.steps.callBack.question.callBackButtonLabel({
-                  date:
-                    time.value == 'any' ? (
-                      <ZUIDate datetime={callBackAfter} />
-                    ) : (
-                      <ZUIDateTime datetime={callBackAfter} />
-                    ),
-                })
-              : messages.report.steps.callBack.question.invalidDateButtonLabel()
-          }
-          onClick={() => {
-            onReportUpdate({
-              ...report,
-              callBackAfter,
-              step: 'organizerAction',
-            });
-          }}
-          variant="secondary"
-        />
       </Stack>
     </StepBase>
   );

--- a/src/features/call/components/SkipCallDialog.tsx
+++ b/src/features/call/components/SkipCallDialog.tsx
@@ -1,6 +1,8 @@
+import { useMessages } from 'core/i18n';
 import useCallMutations from '../hooks/useCallMutations';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 import ZUIModal from 'zui/components/ZUIModal';
+import messageIds from '../l10n/messageIds';
 
 type SkipCallDialogProps = {
   assignment: ZetkinCallAssignment;
@@ -17,26 +19,27 @@ const SkipCallDialog: React.FC<SkipCallDialogProps> = ({
   onClose,
   targetName,
 }) => {
+  const messages = useMessages(messageIds);
   const { skipCurrentCall } = useCallMutations(assignment.organization.id);
 
   return (
     <ZUIModal
       open={open}
       primaryButton={{
-        label: 'Skip',
+        label: messages.skipCallDialog.confirmButton({ name: targetName }),
         onClick: () => {
           skipCurrentCall(assignment.id, callId);
           onClose();
         },
       }}
       secondaryButton={{
-        label: 'Resume',
+        label: messages.skipCallDialog.cancelButton(),
         onClick: () => {
           onClose();
         },
       }}
       size="small"
-      title={`Skip ${targetName} call?`}
+      title={messages.skipCallDialog.title({ name: targetName })}
     />
   );
 };

--- a/src/features/call/components/Survey.tsx
+++ b/src/features/call/components/Survey.tsx
@@ -13,12 +13,15 @@ import {
 } from '../store';
 import ZUIButton from 'zui/components/ZUIButton';
 import ZUIDivider from 'zui/components/ZUIDivider';
+import { useMessages } from 'core/i18n';
+import messageIds from '../l10n/messageIds';
 
 type Props = {
   survey: ZetkinSurvey;
 };
 
 const Survey: FC<Props> = ({ survey }) => {
+  const messages = useMessages(messageIds);
   const dispatch = useAppDispatch();
   const responseBySurveyId = useAppSelector(
     (state) =>
@@ -36,7 +39,7 @@ const Survey: FC<Props> = ({ survey }) => {
     >
       <Box sx={{ left: 20, position: 'absolute', top: 16 }}>
         <ZUIButton
-          label="Back to activities"
+          label={messages.activities.survey.backButton()}
           onClick={() => {
             const response = responseBySurveyId[survey.id];
 

--- a/src/features/call/components/SurveyCard.tsx
+++ b/src/features/call/components/SurveyCard.tsx
@@ -9,6 +9,8 @@ import ZUIText from 'zui/components/ZUIText';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 import ZUIModal from 'zui/components/ZUIModal';
 import { surveySubmissionDeleted } from '../store';
+import messageIds from '../l10n/messageIds';
+import { Msg, useMessages } from 'core/i18n';
 
 type SurveyCardProps = {
   onSelectSurvey: (surveyId: number) => void;
@@ -16,6 +18,7 @@ type SurveyCardProps = {
 };
 
 const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
+  const messages = useMessages(messageIds);
   const dispatch = useAppDispatch();
   const [clearModalOpen, setClearModalOpen] = useState(false);
   const responseBySurveyId = useAppSelector(
@@ -40,7 +43,11 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
         actions={[
           <Fragment key={survey.id}>
             <ZUIButton
-              label={hasMeaningfulContent ? 'Edit responses' : 'Fill out'}
+              label={
+                hasMeaningfulContent
+                  ? messages.activities.survey.editButton()
+                  : messages.activities.survey.fillOutButton()
+              }
               onClick={() => onSelectSurvey(survey.id)}
               variant="primary"
             />
@@ -48,7 +55,7 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
               //TODO: Create ZUI Component for Survey in progress label
               <>
                 <ZUIButton
-                  label={'Clear responses'}
+                  label={messages.activities.survey.clearButton()}
                   onClick={() => setClearModalOpen(true)}
                   variant="secondary"
                 />
@@ -66,7 +73,7 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
                   })}
                 >
                   <ZUIText color="inherit" variant="bodySmRegular">
-                    {'Survey in progress'}
+                    <Msg id={messageIds.activities.survey.inProgress} />
                   </ZUIText>
                 </Box>
               </>
@@ -78,30 +85,32 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
           {
             Icon: GroupWorkOutlined,
             labels: [
-              survey.campaign?.title ?? 'Untitled project',
+              survey.campaign?.title ?? messages.activities.untitled.project(),
               survey.organization.title,
             ],
           },
         ]}
-        title={survey.title ?? 'Untitled Survey'}
+        title={survey.title ?? messages.activities.untitled.survey()}
       />
       <ZUIModal
         open={clearModalOpen}
         primaryButton={{
-          label: 'Clear responses',
+          label: messages.activities.survey.clearButton(),
           onClick: () => {
             dispatch(surveySubmissionDeleted(survey.id));
             setClearModalOpen(false);
           },
         }}
         secondaryButton={{
-          label: 'Cancel',
+          label: messages.activities.survey.cancelButton(),
           onClick: () => {
             setClearModalOpen(false);
           },
         }}
         size="small"
-        title={`Do you want to remove the responses for ${survey.title} ?`}
+        title={messages.activities.survey.confirmClearSurvey({
+          title: survey.title ?? messages.activities.untitled.survey(),
+        })}
       />
     </>
   );

--- a/src/features/call/components/SurveyCard.tsx
+++ b/src/features/call/components/SurveyCard.tsx
@@ -84,6 +84,7 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
         info={[
           {
             Icon: GroupWorkOutlined,
+            key: 'project',
             labels: [
               survey.campaign?.title ?? messages.activities.untitled.project(),
               survey.organization.title,

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -14,10 +14,9 @@ export default function useFinishedCalls() {
 
   const loadPage = async (pageNumber: number) => {
     dispatch(finishedCallsLoad());
-    const newLoadedFinishedCalls = await apiClient.get<
-      FinishedCall[]
-    >(`/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0
-         `);
+    const newLoadedFinishedCalls = await apiClient.get<FinishedCall[]>(
+      `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
+    );
 
     allLoadedCalls = [...allLoadedCalls, ...newLoadedFinishedCalls];
     dispatch(finishedCallsLoaded(allLoadedCalls));

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -1,48 +1,41 @@
-import { useEffect, useState } from 'react';
-
-import { useApiClient, useAppDispatch } from 'core/hooks';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { FinishedCall } from '../types';
 import { finishedCallsLoad, finishedCallsLoaded } from '../store';
+import shouldLoad from 'core/caching/shouldLoad';
+import notEmpty from 'utils/notEmpty';
 
 export default function useFinishedCalls() {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
 
-  const [finishedCalls, setFinishedCalls] = useState<FinishedCall[]>([]);
-  const [pageNumber, setPageNumber] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const finishedCallsList = useAppSelector((state) => state.call.finishedCalls);
 
-  const loadFinishedCalls = async () => {
+  let allLoadedCalls: FinishedCall[] = [];
+
+  const loadPage = async (pageNumber: number) => {
     dispatch(finishedCallsLoad());
-    if (finishedCalls.length == 0) {
-      setLoading(true);
-    }
     const newLoadedFinishedCalls = await apiClient.get<
       FinishedCall[]
     >(`/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0
          `);
 
-    const loadedFinishedCalls = [...finishedCalls, ...newLoadedFinishedCalls];
-    dispatch(finishedCallsLoaded(loadedFinishedCalls));
-    setFinishedCalls(loadedFinishedCalls);
+    allLoadedCalls = [...allLoadedCalls, ...newLoadedFinishedCalls];
+    dispatch(finishedCallsLoaded(allLoadedCalls));
 
-    if (newLoadedFinishedCalls.length == 0) {
-      setLoading(false);
+    if (newLoadedFinishedCalls.length > 0) {
+      loadPage(pageNumber + 1);
     }
   };
 
-  useEffect(() => {
-    loadFinishedCalls();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageNumber]);
-
-  useEffect(() => {
-    setPageNumber(pageNumber + 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [finishedCalls.length]);
+  if (shouldLoad(finishedCallsList)) {
+    loadPage(0);
+  }
 
   return {
-    finishedCalls,
-    loading,
+    finishedCalls: finishedCallsList.items
+      .filter((item) => !item.deleted)
+      .map((item) => item.data)
+      .filter(notEmpty),
+    isLoading: finishedCallsList.isLoading,
   };
 }

--- a/src/features/call/hooks/useSubmitReport.ts
+++ b/src/features/call/hooks/useSubmitReport.ts
@@ -1,7 +1,7 @@
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import { ZetkinSurveyApiSubmission } from 'utils/types/zetkin';
 import submitSurveysRpc from '../rpc/submitSurveysAndUpdateCall';
-import { reportSubmitted, setReportSubmissionError } from '../store';
+import { reportSubmitted, reportSubmissionErrorAdded } from '../store';
 import { CallState, Report } from '../types';
 import calculateReportState from '../components/Report/utils/calculateReportState';
 
@@ -44,7 +44,7 @@ export default function useSubmitReport(orgId: number) {
     if (result.kind == 'success') {
       dispatch(reportSubmitted(result.updatedCall));
     } else {
-      dispatch(setReportSubmissionError(result));
+      dispatch(reportSubmissionErrorAdded(result));
     }
   };
 }

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -386,7 +386,7 @@ export default makeMessages('feat.call', {
       title: m('Something went wrong when the report was being submitted.'),
     },
     title: {
-      success: m('Done!'),
+      success: m('Call done!'),
     },
     unfinishedCallsMessage: m(
       'But, before you move on: you have unfinished calls, deal with them!'

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -35,6 +35,13 @@ export default makeMessages('feat.call', {
   },
   activities: {
     description: m<{ name: string }>('Acting as {name}'),
+    empty: m('No activities'),
+    events: {
+      alreadyBooked: m<{ name: string }>('{name} is already signed up.'),
+      noLocation: m('No physical location'),
+      signUp: m('Sign up'),
+      undoSignUp: m('Undo sign-up'),
+    },
     filters: {
       basic: {
         alreadyIn: m('Already in'),
@@ -57,11 +64,29 @@ export default makeMessages('feat.call', {
         '{numProjects, plural, =0{Context} =1{1 project} other{# projects}}'
       ),
     },
+    noBookings: m<{ name: string }>(
+      '{name} is not booked or signed up for any events.'
+    ),
     projects: {
       wihoutProjectLabel: m('No project'),
     },
-
+    survey: {
+      backButton: m('Back to activities'),
+      cancelButton: m('Cancel'),
+      clearButton: m('Clear responses'),
+      confirmClearSurvey: m<{ title: string }>(
+        'Do you want to remove the responses for {title}?'
+      ),
+      editButton: m('Edit'),
+      fillOutButton: m('Fill out'),
+      inProgress: m('Survey in progress'),
+    },
     title: m('Activities'),
+    untitled: {
+      event: m('Untitled event'),
+      project: m('Untitled project'),
+      survey: m('Untitled survey'),
+    },
   },
   callAlert: {
     description: m('No more calls left in queue'),

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -379,7 +379,13 @@ export default makeMessages('feat.call', {
       success: m<{ name: string }>('You talked to {name}'),
       wrongNumber: m<{ name: string }>('We had the wrong number for ${name}'),
     },
-    error: {
+    previousCallMissingError: {
+      description: m(
+        'The report was submitted and you can keep calling as normal'
+      ),
+      title: m('Could not load previous call'),
+    },
+    reportSubmissionError: {
       description: m(
         'The call is now among your unfinished calls and you can go back and try submitting the report again.'
       ),

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -386,7 +386,7 @@ export default makeMessages('feat.call', {
       title: m('Something went wrong when the report was being submitted.'),
     },
     title: {
-      success: m('Woop woop!'),
+      success: m('Done!'),
     },
     unfinishedCallsMessage: m(
       'But, before you move on: you have unfinished calls, deal with them!'

--- a/src/features/call/pages/CallPage.tsx
+++ b/src/features/call/pages/CallPage.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import { FC, useEffect } from 'react';
 import { redirect } from 'next/navigation';
 import { ErrorBoundary } from 'react-error-boundary';
+import { useRouter } from 'next/navigation';
 
 import useServerSide from 'core/useServerSide';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
@@ -15,6 +16,7 @@ import { Msg } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 
 const CallPage: FC = () => {
+  const router = useRouter();
   const { clearCallLanes, clearStaleCallLanes, initialize, canInitialize } =
     useCallInitialization();
 
@@ -69,7 +71,14 @@ const CallPage: FC = () => {
           </Box>
         }
       >
-        {canInitialize && <Call onResetAfterError={() => clearCallLanes()} />}
+        {canInitialize && (
+          <Call
+            onResetAfterError={(urlToNavigateTo: string) => {
+              clearCallLanes();
+              router.push(urlToNavigateTo);
+            }}
+          />
+        )}
       </ErrorBoundary>
     </main>
   );

--- a/src/features/call/pages/CallPage.tsx
+++ b/src/features/call/pages/CallPage.tsx
@@ -69,7 +69,7 @@ const CallPage: FC = () => {
           </Box>
         }
       >
-        {canInitialize && <Call clearCallLanes={() => clearCallLanes()} />}
+        {canInitialize && <Call onResetAfterError={() => clearCallLanes()} />}
       </ErrorBoundary>
     </main>
   );

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -453,9 +453,18 @@ const CallSlice = createSlice({
     },
     updateLaneStep: (state, action: PayloadAction<LaneStep>) => {
       const step = action.payload;
+      const activeLane = state.lanes[state.activeLaneIndex];
+      activeLane.step = step;
 
-      const lane = state.lanes[state.activeLaneIndex];
-      lane.step = step;
+      if (step == LaneStep.REPORT) {
+        activeLane.filters = {
+          ...emptyFilters,
+          filterState: {
+            ...emptyFilters.filterState,
+            thisCall: true,
+          },
+        };
+      }
     },
     updatePendingOrgLog: (state, action: PayloadAction<string>) => {
       const lane = state.lanes[state.activeLaneIndex];

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -301,6 +301,13 @@ const CallSlice = createSlice({
       lane.filters = emptyFilters;
       lane.selectedSurveyId = null;
     },
+    reportSubmissionErrorAdded: (
+      state,
+      action: PayloadAction<ReportSubmissionError>
+    ) => {
+      const lane = state.lanes[state.activeLaneIndex];
+      lane.reportSubmissionError = action.payload;
+    },
     reportSubmitted: (state, action: PayloadAction<ZetkinUpdatedCall>) => {
       const lane = state.lanes[state.activeLaneIndex];
       lane.reportSubmissionError = null;
@@ -337,13 +344,6 @@ const CallSlice = createSlice({
       const report = action.payload;
       const lane = state.lanes[state.activeLaneIndex];
       lane.report = report;
-    },
-    setReportSubmissionError: (
-      state,
-      action: PayloadAction<ReportSubmissionError>
-    ) => {
-      const lane = state.lanes[state.activeLaneIndex];
-      lane.reportSubmissionError = action.payload;
     },
     surveyDeselected: (state) => {
       const lane = state.lanes[state.activeLaneIndex];
@@ -490,7 +490,7 @@ export const {
   reportUpdated,
   surveyDeselected,
   surveySelected,
-  setReportSubmissionError,
+  reportSubmissionErrorAdded,
   surveySubmissionAdded,
   surveySubmissionDeleted,
   updateLaneStep,

--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -95,6 +95,7 @@ const MyActivitiesList: FC = () => {
               info={[
                 {
                   Icon: GroupWorkOutlined,
+                  key: 'project',
                   labels: [
                     activity.data.campaign && {
                       href: `/o/${activity.data.organization.id}/projects/${activity.data.campaign.id}`,

--- a/src/features/my/components/MyActivityListItem.tsx
+++ b/src/features/my/components/MyActivityListItem.tsx
@@ -12,6 +12,7 @@ type Props = {
   image?: string;
   info: {
     Icon: OverridableComponent<SvgIconTypeMap<unknown, 'svg'>>;
+    key: string;
     labels: ZUILabelText[];
   }[];
   title: string;

--- a/src/features/public/components/AreaAssignmentListItem.tsx
+++ b/src/features/public/components/AreaAssignmentListItem.tsx
@@ -36,6 +36,7 @@ const AreaAssignmentListItem: FC<Props> = ({ assignment, href }) => {
       info={[
         {
           Icon: GroupWorkOutlined,
+          key: 'project',
           labels: [
             campaign.campaignFuture.data && {
               href: `/o/${campaign.campaignFuture.data.organization.id}/projects/${campaign.campaignFuture.data.id}`,

--- a/src/features/public/components/EventListItem.tsx
+++ b/src/features/public/components/EventListItem.tsx
@@ -40,6 +40,7 @@ const EventListItem: FC<Props> = ({ event, href, onClickSignUp }) => {
       info={[
         {
           Icon: GroupWorkOutlined,
+          key: 'project',
           labels: [
             event.campaign && {
               href: `/o/${event.organization.id}/projects/${event.campaign.id}`,
@@ -53,6 +54,7 @@ const EventListItem: FC<Props> = ({ event, href, onClickSignUp }) => {
         },
         {
           Icon: WatchLaterOutlined,
+          key: 'time',
           labels: [
             timeSpanToString(
               new Date(removeOffset(event.start_time)),
@@ -63,6 +65,7 @@ const EventListItem: FC<Props> = ({ event, href, onClickSignUp }) => {
         },
         {
           Icon: LocationOnOutlined,
+          key: 'location',
           labels: [
             event.location?.title || messages.defaultTitles.noLocation(),
           ],

--- a/src/zui/components/ZUIItemCard/index.tsx
+++ b/src/zui/components/ZUIItemCard/index.tsx
@@ -1,4 +1,4 @@
-import { FC, PropsWithChildren } from 'react';
+import { FC, Fragment, PropsWithChildren } from 'react';
 import { Avatar, Box, Stack, Typography } from '@mui/material';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -228,7 +228,7 @@ const ZUIItemCard: FC<ItemCard> = (props) => {
                     </ZUIText>
                   );
                 } else {
-                  return c;
+                  return <Fragment key={c.key}>{c}</Fragment>;
                 }
               })}
             </Stack>


### PR DESCRIPTION
## Description

This PR completes some minor code hygiene and UI updates that were left over after #3513 and that came in from a recent user test.

## Screenshots

<img width="1308" height="882" alt="bild" src="https://github.com/user-attachments/assets/c022d328-009f-4893-92bd-d128ada7b492" />

## Changes

- Adds monospace font to phone numbers
- Refactors how finished calls are loaded 
- Call log dialog fixed height 
- Changes the order of buttons in the CallBack step of the report
- Adds an error message if there is no previous call when coming to the Summary step
- Localises remaining hardcoded strings
- Does some name changing
- Moves the responsibility of navigation from Call to CallPage

## Notes to reviewer

None of the above changes were from serious bugs, so there should be not major difference in behaviour to the code. 

The refactor in this pr with the most logic to it is the one about loading finished calls. Test this by clicking the "Call Log" button at the bottom left corner. 

When I have worked on this i have tried with throttling the connection to slower connection to see if bugs would come out.

## Related issues

The refactor of the loading of previous calls resolves #3558 
