### PR TITLE
Change activist maps to show events within selected date range

### DIFF
--- a/src/features/organizations/components/ActivistPortalCampaignEventsMap.tsx
+++ b/src/features/organizations/components/ActivistPortalCampaignEventsMap.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const ActivistPortalCampaignEventsMap: FC<Props> = ({ campId, orgId }) => {
-  const { allEvents } = useFilteredCampaignEvents(orgId, campId);
+  const { filteredEvents } = useFilteredCampaignEvents(orgId, campId);
   const dispatch = useAppDispatch();
   const filters = useAppSelector((state) => state.organizations.filters);
   const path = usePathname();
@@ -33,7 +33,7 @@ const ActivistPortalCampaignEventsMap: FC<Props> = ({ campId, orgId }) => {
 
   return (
     <ActivistPortalEventMap
-      events={allEvents}
+      events={filteredEvents}
       locationFilter={filters.geojsonToFilterBy}
       setLocationFilter={onLocationFilterChange}
     />

--- a/src/features/organizations/components/ActivistPortalOrgEventsMap.tsx
+++ b/src/features/organizations/components/ActivistPortalOrgEventsMap.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const ActivistPortalOrgEventsMap: FC<Props> = ({ orgId }) => {
-  const { allEvents } = useFilteredOrgEvents(orgId);
+  const { filteredEvents } = useFilteredOrgEvents(orgId);
   const dispatch = useAppDispatch();
   const filters = useAppSelector((state) => state.organizations.filters);
   const path = usePathname();
@@ -36,7 +36,7 @@ const ActivistPortalOrgEventsMap: FC<Props> = ({ orgId }) => {
 
   return (
     <ActivistPortalEventMap
-      events={allEvents}
+      events={filteredEvents}
       locationFilter={filters.geojsonToFilterBy}
       setLocationFilter={onLocationFilterChange}
     />


### PR DESCRIPTION
## Description

This PR makes the public activist maps only show events within the date range selected in the sidebar.

## Screenshots

[Peek 2026-05-10 11-22.webm](https://github.com/user-attachments/assets/c7d7239f-74f4-4c4f-9319-d27fb9e77297)

## Changes

- Changes the activist organization event map
- Changes the activist campaign event map

## AI usage

No AI was used.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Prepare by making sure there's events with locations this week and after this week, I used organize/1/projects/513 for testing.
- On /o/1 or o/1/projects/513 try filter events using the "Today", "Tomorrow", "This week" or date filters, just like the sidebar updates, the events with a physical location should be hidden or show up as they are filtered.

## Related issues

Resolves #3627 

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
