### PR TITLE
Set zoom level for public single event maps

### DIFF
--- a/src/features/public/components/ActivistPortalEventMap.tsx
+++ b/src/features/public/components/ActivistPortalEventMap.tsx
@@ -13,7 +13,7 @@ import { Latitude, Longitude } from 'features/areas/types';
 import { getGeoJSONFeaturesAtLocations } from 'features/map/utils/locationFiltering';
 import useMapMarkerClick from '../hooks/useMapMarkerClick';
 
-const defaultFitBoundOptions = { padding: 80 };
+const defaultFitBoundOptions = { maxZoom: 16, padding: 80 };
 
 export const ActivistPortalEventMap: FC<{
   events: ZetkinEventWithStatus[];
@@ -41,7 +41,6 @@ export const ActivistPortalEventMap: FC<{
         map.fitBounds(bounds, {
           animate: true,
           duration: 1200,
-          maxZoom: 16,
           ...defaultFitBoundOptions,
         });
       }


### PR DESCRIPTION
## Description

This PR sets the default zoom level to 15 in `src/features/public/components/ActivistPortalEventMap.tsx`. This prevents the map from zooming in so far that it becomes unhelpful. 

The component ActivistPortalEventMap is beeing used in the public project page (/o/[orgId]/projects/[projId]) and in the public organization page (/o/[orgId]).

After this change the maps of the public project page and public organization page will not zoom in too far when there is only one event.

When clicking on the event marker, the old zoom level of 16 still is used.

Project page with one event - now with sensible zoom level:

<img width="1606" height="896" alt="image" src="https://github.com/user-attachments/assets/547659ce-7f17-4ec2-88e4-7e7263e5fa4c" />

Organization page with one event - now with sensible zoom level:

<img width="1606" height="896" alt="image" src="https://github.com/user-attachments/assets/a2dfe1c3-9c73-4062-9717-0c2518dc0cd1" />

## Changes

- Set zoom level for public single event maps

## AI usage

I did let AI generate a plan for a change which I afterwards implemented and tested afterwards. 

## Instructions for reviewer

### Test project view

- Go to http://localhost:3000/organize/1/projects
- Create a project and give it a clear name
- Press the three little dots in the top right corner to edit the event, and set it to be "public" and "published"
- Click "create" in the top right corner and select to create a new event
- Give the event a clear name and select a location, and then press in the top right corner to "Publish" the event
- Go to the public project page of the project you created: http://localhost:3000/o/1/projects/yourProjectId
- Verify that the new event has a sensible zoom level

### Test organization view

- Go to http://localhost:3000/o/11
- This organization has one single event
- Verify that the event has a sensible zoom level

## Related issues

Resolves #3656

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
