### PR TITLE
Fix removing date value bug

### DIFF
--- a/src/features/profile/components/EditPersonDialog/EditPersonFields.tsx
+++ b/src/features/profile/components/EditPersonDialog/EditPersonFields.tsx
@@ -203,6 +203,8 @@ const EditPersonFields: FC<EditPersonFieldsProps> = ({
                   if (date) {
                     const dateStr = makeNaiveDateString(date.utc().toDate());
                     onChange(field.slug, dateStr);
+                  } else {
+                    onChange(field.slug, null);
                   }
                 }}
                 slotProps={{


### PR DESCRIPTION
## Description

This PR fixes a bug with the DatePicker on the Edit Profile Dialog, where the date value cannot be removed from the input field (it resets to the date from before and the undo button doesn't show up). The date can be removed now and the undo button is visible.   

## Screenshots

<img width="203" height="296" alt="image" src="https://github.com/user-attachments/assets/71fec70f-ccfe-4965-80c6-cd1b47e699eb" />

## Changes

- Changes that if the date value is null, it will be saved and displayed accordingly. 

## Related issues

Resolves #3653
