### PR TITLE
Include events in default project activity filter

### DIFF
--- a/src/features/campaigns/hooks/useActivityFilters.ts
+++ b/src/features/campaigns/hooks/useActivityFilters.ts
@@ -10,6 +10,7 @@ const DEFAULT_FILTERS: ACTIVITIES[] = [
   ACTIVITIES.SURVEY,
   ACTIVITIES.TASK,
   ACTIVITIES.EMAIL,
+  ACTIVITIES.EVENT,
 ];
 
 export default function useActivityFilters(


### PR DESCRIPTION
## Description

This PR adds `ACTIVITIES.EVENT` to the `DEFAULT_FILTERS` array in `useActivityFilters`, so the project activities view (and "all projects" view) shows events by default instead of requiring users to enable the filter manually on each new browser/device.

## Screenshots

<img width="1605" height="615" alt="image" src="https://github.com/user-attachments/assets/534dfc52-c8b5-44d8-9bf2-af04ea52377f" />

<img width="1605" height="615" alt="image" src="https://github.com/user-attachments/assets/83045075-f973-4ead-9ecd-22da567ad882" />


## Changes

- Add `ACTIVITIES.EVENT` to the `DEFAULT_FILTERS` array in `useActivityFilters`

## AI usage

AI reviewed the change. 

## Instructions for reviewer

1. Run the dev server.
2. Open the browser devtools and clear any activities:*:filters entries from localStorage (or use a fresh profile / incognito).
3. Navigate to a project's activities page (and the "all projects" activities view).
4. Confirm the filter chip/dropdown shows Events selected alongside other categories — and that event rows appear in the list by default.

## Related issues

Resolves #3676

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
