### PR TITLE
Add StyledAutocomplete to Survey Column Dialogs

### DIFF
--- a/src/features/smartSearch/components/inputs/StyledAutocomplete.tsx
+++ b/src/features/smartSearch/components/inputs/StyledAutocomplete.tsx
@@ -16,7 +16,7 @@ import Autocomplete, {
 import useMediaQuery from '@mui/material/useMediaQuery';
 import ListSubheader from '@mui/material/ListSubheader';
 import Popper from '@mui/material/Popper';
-import { styled, useTheme } from '@mui/material/styles';
+import { styled, Theme, useTheme } from '@mui/material/styles';
 import {
   List,
   ListImperativeAPI,
@@ -30,6 +30,7 @@ import {
   AutocompleteChangeReason,
   AutocompleteValue,
 } from '@mui/material/useAutocomplete/useAutocomplete';
+import { SystemStyleObject } from '@mui/system';
 
 const LISTBOX_PADDING = 8; // px
 
@@ -206,6 +207,7 @@ type Item = {
 type Props = {
   clearable?: boolean;
   items: Item[];
+  label?: string;
   minWidth?: string;
   onChange?: (
     event: React.SyntheticEvent & { target: { value: string } },
@@ -213,6 +215,7 @@ type Props = {
     reason: AutocompleteChangeReason,
     details?: AutocompleteChangeDetails<Item>
   ) => void;
+  sx?: SystemStyleObject<Theme>;
   value?: string | number;
 };
 
@@ -349,7 +352,7 @@ const StyledAutocomplete: FC<Props> = (props) => {
             position: 'relative',
           }}
         >
-          <TextField {...params} />
+          <TextField {...params} label={props.label} variant={'standard'} />
           <Typography
             sx={{
               fontSize: '34px',
@@ -387,56 +390,17 @@ const StyledAutocomplete: FC<Props> = (props) => {
       slots={{
         popper: StyledPopper,
       }}
-      sx={(theme) => ({
+      sx={{
+        '& .MuiAutocomplete-clearIndicator': {
+          display: 'none',
+        },
         '& .MuiFormControl-root': {
           verticalAlign: 'baseline',
         },
-        '& .MuiOutlinedInput-notchedOutline': {
-          border: 'none',
-          padding: 0,
-        },
-        '& .MuiOutlinedInput-root': {
-          border: 'none',
-          borderRadius: 0,
-          padding: 0,
-        },
-        '& .MuiOutlinedInput-root .MuiInputBase-input': {
+        '& .MuiInputBase-root .MuiInputBase-input': {
           fontSize: '34px',
           padding: 0,
           textOverflow: 'clip',
-        },
-        '& .MuiOutlinedInput-root.Mui-focused:after': {
-          borderBottom: `2px solid ${theme.palette.primary.main}`,
-          transform: 'scaleX(1) translateX(0)',
-        },
-        '& .MuiOutlinedInput-root:after': {
-          bottom: 0,
-          content: '""',
-          left: 0,
-          position: 'absolute',
-          right: 0,
-          transform: 'scaleX(0)',
-          transition: 'transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms',
-        },
-        '& .MuiOutlinedInput-root:before': {
-          borderBottom: '1px solid rgba(0, 0, 0, 0.42)',
-          bottom: 0,
-          content: '""',
-          left: 0,
-          pointerEvents: 'none',
-          position: 'absolute',
-          right: 0,
-          transition:
-            'border-bottom-color 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-        },
-        '& .MuiOutlinedInput-root:hover:before': {
-          borderBottom: `2px solid black`,
-        },
-        '& .MuiSvgIcon-root': {
-          color: 'rgba(0, 0, 0, 0.54)',
-        },
-        '& .MuiSvgIcon-root:hover': {
-          color: 'rgba(0, 0, 0, 0.54)',
         },
         '&.MuiAutocomplete-hasPopupIcon.MuiAutocomplete-hasClearIcon .MuiOutlinedInput-root':
           {
@@ -446,7 +410,8 @@ const StyledAutocomplete: FC<Props> = (props) => {
         minWidth: props.minWidth,
         verticalAlign: 'bottom',
         width: 'fit-content',
-      })}
+        ...props.sx,
+      }}
       value={valueItem}
     />
   );

--- a/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponseConfig.tsx
@@ -6,7 +6,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { ChangeEventHandler, useState } from 'react';
+import { SyntheticEvent, useState } from 'react';
 
 import { COLUMN_TYPE, SelectedViewColumn } from '../types';
 import {
@@ -21,6 +21,7 @@ import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 import useSurveyElements from 'features/surveys/hooks/useSurveyElements';
+import StyledAutocomplete from 'features/smartSearch/components/inputs/StyledAutocomplete';
 
 interface SurveyResponseConfigProps {
   onOutputConfigured: (columns: SelectedViewColumn[]) => void;
@@ -35,10 +36,10 @@ const SurveyResponseConfig = ({
   onOutputConfigured,
 }: SurveyResponseConfigProps) => {
   const { orgId } = useNumericRouteParams();
-  const surveys = useSurveys(orgId);
+  const surveysFuture = useSurveys(orgId);
   const messages = useMessages(messageIds);
 
-  const [surveyId, setSurveyId] = useState<number | null>();
+  const [surveyId, setSurveyId] = useState<number | undefined>();
   const selectedSurvey = useSurveyElements(orgId, surveyId ?? null);
   const [selectedQuestion, setSelectedQuestion] =
     useState<ZetkinSurveyQuestionElement | null>(null);
@@ -46,8 +47,10 @@ const SurveyResponseConfig = ({
     SURVEY_QUESTION_OPTIONS.ALL_OPTIONS
   );
 
-  const onSurveyChange: ChangeEventHandler<{ value: unknown }> = (ev) => {
-    setSurveyId(ev.target.value as number);
+  const onSurveyChange = (
+    ev: SyntheticEvent & { target: { value: string } }
+  ) => {
+    setSurveyId(+ev.target.value);
     setSelectedQuestion(null);
     onOutputConfigured([]);
   };
@@ -65,25 +68,34 @@ const SurveyResponseConfig = ({
   };
 
   return (
-    <ZUIFuture future={surveys}>
-      {(data) => {
+    <ZUIFuture future={surveysFuture}>
+      {(surveys) => {
         return (
           <FormControl sx={{ width: 300 }}>
-            <TextField
-              fullWidth
+            <StyledAutocomplete
+              clearable={true}
+              items={surveys.map((survey) => ({
+                group: survey.campaign?.title,
+                id: survey.id,
+                label: survey.title,
+              }))}
               label={messages.columnDialog.choices.surveyResponse.surveyField()}
-              margin="normal"
               onChange={onSurveyChange}
-              select
-              value={surveyId || ''}
-              variant="standard"
-            >
-              {data.map((survey) => (
-                <MenuItem key={survey.id} value={survey.id}>
-                  {survey.title}
-                </MenuItem>
-              ))}
-            </TextField>
+              sx={{
+                '& .MuiInputBase-input': {
+                  textOverflow: 'ellipsis',
+                },
+                '& .MuiInputBase-root .MuiInputBase-input': {
+                  fontSize: 'inherit',
+                },
+                '&.MuiAutocomplete-hasPopupIcon.MuiAutocomplete-hasClearIcon .MuiAutocomplete-inputRoot':
+                  {
+                    paddingRight: '24px',
+                  },
+                width: '100%',
+              }}
+              value={surveyId}
+            />
             {!!surveyId && (
               <ZUIFuture future={selectedSurvey}>
                 {(data) => {

--- a/src/features/views/components/ViewColumnDialog/SurveyResponsePluralConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveyResponsePluralConfig.tsx
@@ -1,5 +1,5 @@
-import { Autocomplete, FormControl, MenuItem, TextField } from '@mui/material';
-import { ChangeEventHandler, useState } from 'react';
+import { Autocomplete, FormControl, TextField } from '@mui/material';
+import { SyntheticEvent, useState } from 'react';
 
 import { useMessages } from 'core/i18n';
 import { COLUMN_TYPE, SelectedViewColumn } from '../types';
@@ -13,6 +13,7 @@ import { useNumericRouteParams } from 'core/hooks';
 import ZUIFuture from 'zui/ZUIFuture';
 import useSurveys from 'features/surveys/hooks/useSurveys';
 import useSurveyElements from 'features/surveys/hooks/useSurveyElements';
+import StyledAutocomplete from 'features/smartSearch/components/inputs/StyledAutocomplete';
 
 interface SurveyResponsePluralConfigProps {
   onOutputConfigured: (columns: SelectedViewColumn[]) => void;
@@ -22,16 +23,18 @@ const SurveyResponsesConfig = ({
   onOutputConfigured,
 }: SurveyResponsePluralConfigProps) => {
   const { orgId } = useNumericRouteParams();
-  const surveys = useSurveys(orgId);
+  const surveysFuture = useSurveys(orgId);
   const messages = useMessages(messageIds);
-  const [surveyId, setSurveyId] = useState<number | null>();
+  const [surveyId, setSurveyId] = useState<number | undefined>();
   const selectedSurvey = useSurveyElements(orgId, surveyId ?? null);
   const [selectedQuestions, setSelectedQuestions] = useState<
     ZetkinSurveyQuestionElement[]
   >([]);
 
-  const onSurveyChange: ChangeEventHandler<{ value: unknown }> = (ev) => {
-    setSurveyId(ev.target.value as number);
+  const onSurveyChange = (
+    ev: SyntheticEvent & { target: { value: string } }
+  ) => {
+    setSurveyId(+ev.target.value);
     setSelectedQuestions([]);
   };
 
@@ -47,25 +50,34 @@ const SurveyResponsesConfig = ({
   };
 
   return (
-    <ZUIFuture future={surveys}>
-      {(data) => {
+    <ZUIFuture future={surveysFuture}>
+      {(surveys) => {
         return (
           <FormControl sx={{ width: 300 }}>
-            <TextField
-              fullWidth
+            <StyledAutocomplete
+              clearable={true}
+              items={surveys.map((survey) => ({
+                group: survey.campaign?.title,
+                id: survey.id,
+                label: survey.title,
+              }))}
               label={messages.columnDialog.choices.surveyResponses.surveyField()}
-              margin="normal"
               onChange={onSurveyChange}
-              select
-              value={surveyId || ''}
-              variant="standard"
-            >
-              {data.map((survey) => (
-                <MenuItem key={survey.id} value={survey.id}>
-                  {survey.title}
-                </MenuItem>
-              ))}
-            </TextField>
+              sx={{
+                '& .MuiInputBase-input': {
+                  textOverflow: 'ellipsis',
+                },
+                '& .MuiInputBase-root .MuiInputBase-input': {
+                  fontSize: 'inherit',
+                },
+                '&.MuiAutocomplete-hasPopupIcon.MuiAutocomplete-hasClearIcon .MuiAutocomplete-inputRoot':
+                  {
+                    paddingRight: '24px',
+                  },
+                width: '100%',
+              }}
+              value={surveyId}
+            />
             {surveyId ? (
               <ZUIFuture future={selectedSurvey}>
                 {(data) => {

--- a/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
+++ b/src/features/views/components/ViewColumnDialog/SurveySubmitDateConfig.tsx
@@ -1,16 +1,12 @@
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Typography,
-} from '@mui/material';
+import { FormControl, Typography } from '@mui/material';
+import { SyntheticEvent, useState } from 'react';
 
 import { COLUMN_TYPE, SelectedViewColumn } from '../types';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from 'features/views/l10n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
 import useSurveys from 'features/surveys/hooks/useSurveys';
+import StyledAutocomplete from 'features/smartSearch/components/inputs/StyledAutocomplete';
 
 interface SurveySubmitDateConfigProps {
   onOutputConfigured: (columns: SelectedViewColumn[]) => void;
@@ -22,37 +18,53 @@ const SurveySubmitDateConfig = ({
   const messages = useMessages(messageIds);
   const { orgId } = useNumericRouteParams();
   const surveys = useSurveys(orgId).data || [];
+  const [surveyId, setSurveyId] = useState<number | undefined>();
+
+  const onSurveyChange = (
+    ev: SyntheticEvent & { target: { value: string } }
+  ) => {
+    if (!ev.target.value) {
+      return;
+    }
+    const surveyId = +ev.target.value;
+    setSurveyId(surveyId);
+    onOutputConfigured([
+      {
+        config: {
+          survey_id: surveyId,
+        },
+        title: surveys?.find((survey) => survey.id === surveyId)?.title || '',
+        type: COLUMN_TYPE.SURVEY_SUBMITTED,
+      },
+    ]);
+  };
 
   return !surveys || surveys.length > 0 ? (
     <FormControl sx={{ width: 300 }}>
-      <InputLabel>
-        {messages.columnDialog.editor.fieldLabels.survey()}
-      </InputLabel>
-      <Select
-        onChange={(evt) => {
-          if (!evt.target.value) {
-            return;
-          }
-          const surveyId = evt.target.value as number;
-          onOutputConfigured([
+      <StyledAutocomplete
+        clearable={true}
+        items={surveys.map((survey) => ({
+          group: survey.campaign?.title,
+          id: survey.id,
+          label: survey.title,
+        }))}
+        label={messages.columnDialog.editor.fieldLabels.survey()}
+        onChange={onSurveyChange}
+        sx={{
+          '& .MuiInputBase-input': {
+            textOverflow: 'ellipsis',
+          },
+          '& .MuiInputBase-root .MuiInputBase-input': {
+            fontSize: 'inherit',
+          },
+          '&.MuiAutocomplete-hasPopupIcon.MuiAutocomplete-hasClearIcon .MuiAutocomplete-inputRoot':
             {
-              config: {
-                survey_id: surveyId,
-              },
-              title:
-                surveys?.find((survey) => survey.id === surveyId)?.title || '',
-              type: COLUMN_TYPE.SURVEY_SUBMITTED,
+              paddingRight: '24px',
             },
-          ]);
+          width: '100%',
         }}
-        variant="standard"
-      >
-        {surveys?.map((survey) => (
-          <MenuItem key={survey.id} value={survey.id}>
-            {survey.title}
-          </MenuItem>
-        ))}
-      </Select>
+        value={surveyId}
+      />
     </FormControl>
   ) : (
     <Typography>


### PR DESCRIPTION
## Description

This PR adds the StyledAutocomplete from https://github.com/zetkin/app.zetkin.org/pull/3231 to dialogs that pop up when adding columns related to surveys. There, we currently use simple selects, but this PR will allow users to search and it will group surveys by project.

## Screenshots
[Add screenshots here]
<img width="2040" height="1959" alt="column-survey-autocomplete" src="https://github.com/user-attachments/assets/52152732-932e-42f6-9808-d1e8559a8b22" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Streamlines styles of StyledAutocomplete and adds properties to fit the style of the column dialogs
- Adds StyledAutocomplete to the three survey-related column types

## AI usage

Did you use AI to create the code in this PR?

No AI was harmed during the making of this PR.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Go to /organize/1/people/lists/2
- Add a survey responses column, and observe the field where you select surveys

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
