### PR TITLE
Add useEffect to set fieldValues on person change

### DIFF
--- a/src/features/profile/components/EditPersonDialog/index.tsx
+++ b/src/features/profile/components/EditPersonDialog/index.tsx
@@ -8,7 +8,7 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 import EditPersonFields from './EditPersonFields';
 import messageIds from '../../l10n/messageIds';
@@ -43,6 +43,9 @@ const EditPersonDialog: FC<EditPersonDialogProps> = ({
   } = useEditPerson(person, orgId);
   const [fieldValues, setFieldValues] = useState(person);
   const willUpdateValueMessage = hasUpdatedValues && !hasInvalidFields;
+  useEffect(() => {
+    setFieldValues(person);
+  }, [person]);
 
   return (
     <Dialog


### PR DESCRIPTION
## Description
This PR fixes so old values won't still be in the edit person dialog when switching to a new person

## Screenshots
https://github.com/user-attachments/assets/0cbb8925-ba99-4963-a523-f9145a4493d1

## Changes
- adds a useEffect to set fieldValues with new person info

## AI usage

No AI usage — I hammered the code out with my own two hands.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.
- Go to https://app.dev.zetkin.org/organize/1/people/2 , the profile page of Angela Davis
- Click on "Edit details" to open the edit person dialog
- While the dialog is open, use your keyboard to type "/" (on my keyboard that is Shift + 7)
- Search for "Irma"
- Click on one of the people named Irma that appears in the search

## Related issues

Resolves #3659 

## PR checklist

- [X] I have run the code, tried out the changes I made and I think they work
- [X] I have not included any changes outside the scope of the task I'm working on
- [X] I have made sure that formatting, linting and type checks pass locally
- [X] I have filled out this template and replaced all placeholders with the corresponding information
