### PR TITLE
Use h1 for title & add header types to ZUIText

### DIFF
--- a/src/features/public/components/ActivistPortalHeader/index.tsx
+++ b/src/features/public/components/ActivistPortalHeader/index.tsx
@@ -138,7 +138,9 @@ const ActivistPortalHeader: FC<Props> = ({
           >
             <Box>
               {typeof title == 'string' ? (
-                <ZUIText variant="headingLg">{title}</ZUIText>
+                <ZUIText component="h1" variant="headingLg">
+                  {title}
+                </ZUIText>
               ) : (
                 title
               )}

--- a/src/zui/components/ZUIText/index.tsx
+++ b/src/zui/components/ZUIText/index.tsx
@@ -15,7 +15,7 @@ type TextVariant =
 type ZUITextProps = {
   children: ReactNode;
   color?: ZUIPrimary | ZUISecondary | 'inherit';
-  component?: 'div' | 'p' | 'span';
+  component?: 'div' | 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   gutterBottom?: boolean;
   noWrap?: boolean;
   renderLineBreaks?: boolean;


### PR DESCRIPTION
## Description

This PR changes the title of a public event page to be an h1, to help with screenreaders and ensure heading semantics in the page.
It also adds the type of headers to the ZUIText component, which is use in the MUI Typography component. The typography supports changing the element to h1, and it won't change the look since we still pass `variant="headingLg"`.

## Screenshots
<img width="1090" height="788" alt="It's a header!" src="https://github.com/user-attachments/assets/5a76a5db-4312-4421-8129-515d5770ca4e" />

## Changes

- Changes the text to be inside a `h1` instead of a `p`
- Adds header types to the ZUIText component

## AI usage
None. This is human-made, artisanal code.

## Instructions for reviewer

- Go to any public event page
- See that the header is a h1

## Related issues

Resolves #3641 

## PR checklist

- [X] I have run the code, tried out the changes I made and I think they work
- [X] I have not included any changes outside the scope of the task I'm working on
- [X] I have made sure that formatting, linting and type checks pass locally
- [X] I have filled out this template and replaced all placeholders with the corresponding information
