### PR TITLE
Add call UI activities search

### DIFF
--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -178,16 +178,18 @@ const Activities: FC<ActivitiesProps> = ({
           </ZUIText>
         </Box>
       )}
-      <ZUITextField
-        endIcon={Close}
-        fullWidth
-        onChange={(newValue) => {
-          setSearchString(newValue);
-        }}
-        onEndIconClick={() => setSearchString('')}
-        startIcon={Search}
-        value={searchString}
-      />
+      {activities.length !== 0 && (
+        <ZUITextField
+          endIcon={Close}
+          fullWidth
+          onChange={(newValue) => {
+            setSearchString(newValue);
+          }}
+          onEndIconClick={() => setSearchString('')}
+          startIcon={Search}
+          value={searchString}
+        />
+      )}
       {filteredActivities.map((activity) => {
         if (target && activity.kind == ACTIVITIES.EVENT) {
           return (

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -91,8 +91,11 @@ const Activities: FC<ActivitiesProps> = ({
   const filteredActivities = useMemo(
     () =>
       searchString
-        ? fuse.search(searchString).map((fuseResult) => fuseResult.item)
-        : activities,
+        ? fuse
+            .search(searchString)
+            .map((fuseResult) => fuseResult.item)
+            .sort((a, b) => a.data.id - b.data.id)
+        : [...activities.sort((a, b) => a.data.id - b.data.id)],
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activities, searchString]
   );

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -44,6 +44,7 @@ import ZUISection from 'zui/components/ZUISection';
 import messageIds from '../l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
 import ZUITextField from 'zui/components/ZUITextField';
+import useDebounce from 'utils/hooks/useDebounce';
 
 type Filter = {
   active: boolean;
@@ -76,6 +77,8 @@ const Activities: FC<ActivitiesProps> = ({
   target,
 }) => {
   const [searchString, setSearchString] = useState<string>('');
+  const [debouncedSearchString, setDebouncedSearchString] =
+    useState<string>('');
   const fuse = useMemo(() => {
     return new Fuse(activities, {
       keys: [
@@ -88,20 +91,36 @@ const Activities: FC<ActivitiesProps> = ({
       threshold: 0.4,
     });
   }, [activities]);
+
+  const debouncedSetSearchString = useDebounce(async (value: string) => {
+    setDebouncedSearchString(value);
+  }, 300);
+
+  const handleSearchStringChange = (value: string) => {
+    setSearchString(value);
+    debouncedSetSearchString(value);
+  };
+
+  const clearSearchString = () => {
+    setSearchString('');
+    setDebouncedSearchString('');
+  };
+
   const filteredActivities = useMemo(
     () =>
-      searchString
+      debouncedSearchString
         ? fuse
-            .search(searchString)
+            .search(debouncedSearchString)
             .map((fuseResult) => fuseResult.item)
             .sort((a, b) => a.data.id - b.data.id)
         : [...activities.sort((a, b) => a.data.id - b.data.id)],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activities, searchString]
+    [activities, debouncedSearchString]
   );
 
   useEffect(() => {
-    setSearchString('');
+    clearSearchString();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [target]);
 
   if (!target) {
@@ -183,9 +202,9 @@ const Activities: FC<ActivitiesProps> = ({
           endIcon={Close}
           fullWidth
           onChange={(newValue) => {
-            setSearchString(newValue);
+            handleSearchStringChange(newValue);
           }}
-          onEndIconClick={() => setSearchString('')}
+          onEndIconClick={() => clearSearchString()}
           startIcon={Search}
           value={searchString}
         />

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -11,6 +11,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useIntl } from 'react-intl';
 import {
   CalendarMonthOutlined,
+  Close,
   Chair,
   Clear,
   GroupWork,
@@ -171,10 +172,12 @@ const Activities: FC<ActivitiesProps> = ({
         </Box>
       )}
       <ZUITextField
+        endIcon={Close}
         fullWidth
         onChange={(newValue) => {
           setSearchString(newValue);
         }}
+        onEndIconClick={() => setSearchString('')}
         startIcon={Search}
         value={searchString}
       />

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -97,6 +97,10 @@ const Activities: FC<ActivitiesProps> = ({
     [activities, searchString]
   );
 
+  useEffect(() => {
+    setSearchString('');
+  }, [target]);
+
   if (!target) {
     return null;
   }

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import {
   Avatar,
   Box,
@@ -15,9 +15,11 @@ import {
   Clear,
   GroupWork,
   Hotel,
+  Search,
 } from '@mui/icons-material';
 import { DateRangeCalendar, DateRangePickerDay } from '@mui/x-date-pickers-pro';
 import { partition } from 'lodash';
+import Fuse from 'fuse.js';
 
 import EventCard from './EventCard';
 import { LaneStep, ZetkinCallTarget } from '../types';
@@ -40,6 +42,7 @@ import Survey from './Survey';
 import ZUISection from 'zui/components/ZUISection';
 import messageIds from '../l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
+import ZUITextField from 'zui/components/ZUITextField';
 
 type Filter = {
   active: boolean;
@@ -71,6 +74,28 @@ const Activities: FC<ActivitiesProps> = ({
   showNoSignups,
   target,
 }) => {
+  const [searchString, setSearchString] = useState<string>('');
+  const fuse = useMemo(() => {
+    return new Fuse(activities, {
+      keys: [
+        'data.campaign.title',
+        'data.organization.title',
+        'data.location.title',
+        'data.title',
+        'data.activity.title',
+      ],
+      threshold: 0.4,
+    });
+  }, [activities]);
+  const filteredActivities = useMemo(
+    () =>
+      searchString
+        ? fuse.search(searchString).map((fuseResult) => fuseResult.item)
+        : activities,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activities, searchString]
+  );
+
   if (!target) {
     return null;
   }
@@ -145,7 +170,15 @@ const Activities: FC<ActivitiesProps> = ({
           </ZUIText>
         </Box>
       )}
-      {activities.map((activity) => {
+      <ZUITextField
+        fullWidth
+        onChange={(newValue) => {
+          setSearchString(newValue);
+        }}
+        startIcon={Search}
+        value={searchString}
+      />
+      {filteredActivities.map((activity) => {
         if (target && activity.kind == ACTIVITIES.EVENT) {
           return (
             <EventCard


### PR DESCRIPTION
## Description

This PR adds a search box to the list of activities visible in the new call interface.

## Screenshots

https://github.com/user-attachments/assets/96cc3d20-2a25-4b13-8111-609689cf1028



## Changes
- Adds search box to call ui activities list
- Adds clear button

## AI usage
Made without assistance of AI. Any possible bugs are entirely the fault of my own.

## Instructions for reviewer

- Start a call activity
- Use the textbox above the search to filter activities or surveys 
## Related issues

Resolves #3634 

## PR checklist

- [X] I have run the code, tried out the changes I made and I think they work
- [X] I have not included any changes outside the scope of the task I'm working on
- [X] I have made sure that formatting, linting and type checks pass locally
- [X] I have filled out this template and replaced all placeholders with the corresponding information
