### PR TITLE
Cleanup & test calendar and date handling related code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "slate-history": "^0.66.0",
         "slate-react": "^0.98.3",
         "slugify": "^1.6.5",
+        "temporal-polyfill": "^0.3.2",
         "timezones-list": "^3.0.2",
         "tsconfig-paths": "^4.1.2",
         "unified": "^10.1.2",
@@ -19914,6 +19915,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/terser": {
       "version": "5.46.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "slate-history": "^0.66.0",
     "slate-react": "^0.98.3",
     "slugify": "^1.6.5",
+    "temporal-polyfill": "^0.3.2",
     "timezones-list": "^3.0.2",
     "tsconfig-paths": "^4.1.2",
     "unified": "^10.1.2",

--- a/src/features/calendar/components/CalendarDayView/Day/index.tsx
+++ b/src/features/calendar/components/CalendarDayView/Day/index.tsx
@@ -46,8 +46,8 @@ const Day = ({ date, dayInfo }: { date: Date; dayInfo: DaySummary }) => {
         gap={1}
         justifyItems="flex-start"
       >
-        {dayInfo.events
-          .sort(
+        {dayInfo
+          .toSorted(
             (a, b) =>
               new Date(a.data.start_time).getTime() -
               new Date(b.data.start_time).getTime()

--- a/src/features/calendar/components/CalendarDayView/PreviousDayPrompt.tsx
+++ b/src/features/calendar/components/CalendarDayView/PreviousDayPrompt.tsx
@@ -29,7 +29,7 @@ const PreviousDayPrompt = ({
         <Typography color={oldTheme.palette.secondary.main}>
           <Msg
             id={messageIds.lastDayWithEvents}
-            values={{ numEvents: daySummary.events.length }}
+            values={{ numEvents: daySummary.length }}
           />
         </Typography>
         <Button

--- a/src/features/calendar/components/utils.test.ts
+++ b/src/features/calendar/components/utils.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from '@jest/globals';
+
+import { getActivitiesByDay } from './utils';
+import { CampaignActivity } from 'features/campaigns/types';
+import { mockEvent } from 'features/campaigns/hooks/useClusteredActivities.spec';
+
+describe('getActivitiesByDay', () => {
+  it('returns an empty object when given no activities', () => {
+    expect(getActivitiesByDay([])).toEqual({});
+  });
+
+  it('groups a single-day event correctly', () => {
+    const event: CampaignActivity = mockEvent(1, {
+      end_time: '2026-05-10T12:00:00',
+      start_time: '2026-05-10T10:00:00',
+      title: 'Single Day Event',
+    });
+    const result = getActivitiesByDay([event]);
+    expect(result).toMatchObject({
+      '2026-05-10': [
+        {
+          data: {
+            end_time: '2026-05-10T12:00:00',
+            start_time: '2026-05-10T10:00:00',
+            title: 'Single Day Event',
+          },
+        },
+      ],
+    });
+  });
+
+  it('splits a multi-day event across days', () => {
+    const event = mockEvent(2, {
+      end_time: '2026-05-12T12:00:00',
+      start_time: '2026-05-10T10:00:00',
+      title: 'Multi Day Event',
+    });
+    const result = getActivitiesByDay([event]);
+    expect(result).toMatchObject({
+      '2026-05-10': [
+        {
+          data: {
+            end_time: '2026-05-10T23:59:59',
+            start_time: '2026-05-10T10:00:00',
+          },
+        },
+      ],
+      '2026-05-11': [
+        {
+          data: {
+            end_time: '2026-05-11T23:59:59',
+            start_time: '2026-05-11T00:00:00',
+          },
+        },
+      ],
+      '2026-05-12': [
+        {
+          data: {
+            end_time: '2026-05-12T12:00:00',
+            start_time: '2026-05-12T00:00:00',
+          },
+        },
+      ],
+    });
+  });
+
+  it('handles overlapping events on the same day', () => {
+    const event1 = mockEvent(3, {
+      end_time: '2026-05-10T10:00:00',
+      start_time: '2026-05-10T08:00:00',
+      title: 'Event 1',
+    });
+    const event2 = mockEvent(4, {
+      end_time: '2026-05-10T11:00:00',
+      start_time: '2026-05-10T09:00:00',
+      title: 'Event 2',
+    });
+    const result = getActivitiesByDay([event1, event2]);
+    expect(result).toMatchObject({
+      '2026-05-10': [
+        {
+          data: {
+            end_time: '2026-05-10T10:00:00',
+            start_time: '2026-05-10T08:00:00',
+            title: 'Event 1',
+          },
+        },
+        {
+          data: {
+            end_time: '2026-05-10T11:00:00',
+            start_time: '2026-05-10T09:00:00',
+            title: 'Event 2',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -36,49 +36,6 @@ const makeIsoDateString = (date: Date): string | null => {
   }
 };
 
-export const getFutureDays = (
-  activitiesHashMap: Record<string, DaySummary>,
-  targetDate: Date
-): [string, DaySummary][] => {
-  return Object.entries(activitiesHashMap).filter(([dateString]) => {
-    const activityDay = dayjs(dateString);
-    return (
-      activityDay.isSame(targetDate, 'day') || activityDay.isAfter(targetDate)
-    );
-  });
-};
-
-export const getPreviousDay = (
-  activities: Record<string, DaySummary>,
-  target: Date
-): [Date, DaySummary] | null => {
-  const dates = Object.keys(activities).map(
-    (dateString) => new Date(dateString)
-  );
-  const datesBeforeTarget = dates.filter(
-    (date) => !dayjs(date).isSame(target, 'day') && dayjs(date).isBefore(target)
-  );
-
-  const closestDateBeforeTarget = datesBeforeTarget.reduce(
-    (previousClosestDate: Date | undefined, date) => {
-      if (dayjs(date).isAfter(previousClosestDate)) {
-        return date;
-      }
-      return previousClosestDate;
-    },
-    datesBeforeTarget[0]
-  );
-
-  const closestDateIsoString =
-    closestDateBeforeTarget && makeIsoDateString(closestDateBeforeTarget);
-
-  if (closestDateIsoString) {
-    return [closestDateBeforeTarget, activities[closestDateIsoString]];
-  }
-
-  return null;
-};
-
 export interface DaySummary {
   endingActivities: NonEventActivity[];
   events: EventActivity[] | never[];

--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import dayjs from 'dayjs';
 
-import { NonEventActivity } from 'features/campaigns/hooks/useClusteredActivities';
 import range from 'utils/range';
 import { removeOffset } from 'utils/dateUtils';
 import { ZetkinEvent } from 'utils/types/zetkin';
@@ -28,211 +26,81 @@ export function isAllDay(start: string, end: string): boolean {
   return false;
 }
 
-const makeIsoDateString = (date: Date): string | null => {
-  try {
-    return date.toISOString().slice(0, 10);
-  } catch {
-    return null;
-  }
-};
+export type DaySummary = EventActivity[];
 
-export interface DaySummary {
-  endingActivities: NonEventActivity[];
-  events: EventActivity[] | never[];
-  startingActivities: NonEventActivity[];
-}
-
-const applyToHashmap = (
-  dateHashmap: Record<string, DaySummary>,
-  key: string,
-  event: EventActivity
-) => {
-  // If date already in hashmap
-  if (key in dateHashmap) {
-    const targetProperty = dateHashmap[key];
-    dateHashmap[key] = {
-      ...targetProperty,
-      events: [...targetProperty.events, event],
-    };
-  } else {
-    // If date not yet in dateHashmap
-    dateHashmap[key] = {
-      endingActivities: [],
-      events: [event],
-      startingActivities: [],
-    };
-  }
-};
 export type MultiDayEvent = ZetkinEvent & {
   originalEndTime: string;
   originalStartTime: string;
 };
 
-export type MultiDayEventActivity = {
-  data: MultiDayEvent;
-  kind: ACTIVITIES.EVENT;
-};
+const endOfDay = (date: Temporal.PlainDateTime) =>
+  date.with({ hour: 23, minute: 59, second: 59 });
+
+const startOfDay = (date: Temporal.PlainDateTime) =>
+  date.with({ hour: 0, minute: 0, second: 0 });
 
 export const getActivitiesByDay = (
-  activities: (CampaignActivity | MultiDayEventActivity)[]
+  activities: CampaignActivity[]
 ): Record<string, DaySummary> => {
   const dateHashmap: Record<string, DaySummary> = {};
+  const applyToHashmap = (date: Temporal.PlainDate, event: EventActivity) => {
+    const key = date.toString();
+    dateHashmap[key] = [...(dateHashmap[key] ?? []), event];
+  };
 
   // Events
   activities
     .filter((activity) => activity.kind === ACTIVITIES.EVENT)
-    .forEach(
-      // @ts-ignore
-      (event: EventActivity) => {
-        const startTime = dayjs(event.data.start_time);
-        const isoDateString = makeIsoDateString(startTime.toDate());
-        const endTime = dayjs(event.data.end_time);
-        if (isoDateString) {
-          // If single day event
-          if (startTime.isSame(endTime, 'day')) {
-            applyToHashmap(dateHashmap, isoDateString, event);
-          } else {
-            // If multi day event
-            const eventDays = Math.abs(startTime.diff(endTime, 'days')) + 1; // Number of days the event spans
+    .forEach((event: EventActivity) => {
+      const startTime = Temporal.PlainDateTime.from(event.data.start_time);
+      const endTime = Temporal.PlainDateTime.from(event.data.end_time);
+      const startDate = startTime.toPlainDate();
+      const endDate = endTime.toPlainDate();
+      // If single day event
+      if (startDate.equals(endDate)) {
+        applyToHashmap(startDate, event);
+      } else {
+        // If multi day event
+        const eventDays = startDate.until(endDate).total('days') + 1;
 
-            // Multi day events are added to each date they span.
-            // The first day goes from the start time to 24:00
-            // Complete days in the middle go from 00:00 - 24:00
-            // The last day goes from 00:00 - the end time
-            range(eventDays).forEach((dayIndex) => {
-              const dayOfEvent = startTime.add(dayIndex, 'day');
-              const dayOfEventIsoDate = makeIsoDateString(dayOfEvent.toDate());
-              if (!dayOfEventIsoDate) {
-                return;
-              }
+        // Multi day events are added to each date they span.
+        // The first day goes from the start time to 24:00
+        // Complete days in the middle go from 00:00 - 24:00
+        // The last day goes from 00:00 - the end time
+        range(eventDays).forEach((dayIndex) => {
+          const dayOfEvent = startTime.add({ days: dayIndex });
 
-              if (dayIndex === 0) {
+          const modifiedEvent = {
+            ...event,
+            data: {
+              ...event.data,
+              originalEndTime: event.data.end_time,
+              originalStartTime: event.data.start_time,
+              ...(() => {
                 // First day of multi day event
-                const firstDayEvent = {
-                  ...event,
-                  data: {
-                    ...event.data,
-                    end_time: dayOfEvent
-                      .hour(24)
-                      .minute(0)
-                      .second(0)
-                      .millisecond(0)
-                      .toISOString(),
-                    originalEndTime: event.data.end_time,
-                    originalStartTime: event.data.start_time,
-                  },
-                };
-
-                applyToHashmap(dateHashmap, dayOfEventIsoDate, firstDayEvent);
-              }
-              if (
-                // Complete day within multi day event
-                !dayOfEvent.isSame(startTime, 'day') &&
-                !dayOfEvent.isSame(endTime, 'day')
-              ) {
-                const completeDayEvent = {
-                  ...event,
-                  data: {
-                    ...event.data,
-                    end_time: dayOfEvent
-                      .hour(24)
-                      .minute(0)
-                      .second(0)
-                      .millisecond(0)
-                      .toISOString(),
-                    originalEndTime: event.data.end_time,
-                    originalStartTime: event.data.start_time,
-                    start_time: dayOfEvent
-                      .hour(0)
-                      .minute(0)
-                      .second(0)
-                      .millisecond(0)
-                      .toISOString(),
-                  },
-                };
-                applyToHashmap(
-                  dateHashmap,
-                  dayOfEventIsoDate,
-                  completeDayEvent
-                );
-              }
-              if (dayIndex === eventDays - 1) {
+                if (dayIndex === 0) {
+                  return {
+                    end_time: endOfDay(dayOfEvent).toString(),
+                  };
+                }
                 // Final day of multi day event
-                const finalDayEvent = {
-                  ...event,
-                  data: {
-                    ...event.data,
-                    originalEndTime: event.data.end_time,
-                    originalStartTime: event.data.start_time,
-                    start_time: dayOfEvent
-                      .hour(0)
-                      .minute(0)
-                      .second(0)
-                      .millisecond(0)
-                      .toISOString(),
-                  },
+                if (dayIndex === eventDays - 1) {
+                  return {
+                    start_time: startOfDay(dayOfEvent).toString(),
+                  };
+                }
+                // Day between start and end
+                return {
+                  end_time: endOfDay(dayOfEvent).toString(),
+                  start_time: startOfDay(dayOfEvent).toString(),
                 };
-                applyToHashmap(dateHashmap, dayOfEventIsoDate, finalDayEvent);
-              }
-            });
-          }
-        }
+              })(),
+            },
+          };
+          applyToHashmap(dayOfEvent.toPlainDate(), modifiedEvent);
+        });
       }
-    );
-
-  // Non events
-  // activities
-  //   .filter((event) => event.kind !== ACTIVITIES.EVENT)
-  //   .forEach(
-  //     // @ts-ignore
-  //     (activity: NonEventActivity) => {
-  //       const startTime = dayjs(activity.startDate);
-  //       const startTimeIsoDateString = makeIsoDateString(startTime.toDate());
-  //       const endTime = dayjs(activity.endDate);
-  //       const endTimeIsoDateString = makeIsoDateString(endTime.toDate());
-
-  //       // Assign activity start time to date hashmap
-  //       if (startTimeIsoDateString) {
-  //         if (startTimeIsoDateString in dateHashmap) {
-  //           const startTimeTargetDate = dateHashmap[startTimeIsoDateString];
-  //           dateHashmap[startTimeIsoDateString] = {
-  //             ...startTimeTargetDate,
-  //             startingActivities: [
-  //               ...startTimeTargetDate.startingActivities,
-  //               activity,
-  //             ],
-  //           };
-  //         } else {
-  //           dateHashmap[startTimeIsoDateString] = {
-  //             endingActivities: [],
-  //             events: [],
-  //             startingActivities: [activity],
-  //           };
-  //         }
-  //       }
-
-  //       // Assign activity end time to date hashmap
-  //       if (endTimeIsoDateString) {
-  //         if (endTimeIsoDateString in dateHashmap) {
-  //           const endTimeTargetDate = dateHashmap[endTimeIsoDateString];
-  //           dateHashmap[endTimeIsoDateString] = {
-  //             ...endTimeTargetDate,
-  //             startingActivities: [
-  //               ...endTimeTargetDate.startingActivities,
-  //               activity,
-  //             ],
-  //           };
-  //         } else {
-  //           dateHashmap[endTimeIsoDateString] = {
-  //             endingActivities: [activity],
-  //             events: [],
-  //             startingActivities: [],
-  //           };
-  //         }
-  //       }
-  //     }
-  //   );
-
+    });
   return dateHashmap;
 };
 

--- a/src/features/calendar/hooks/useDayCalendarNav.ts
+++ b/src/features/calendar/hooks/useDayCalendarNav.ts
@@ -45,16 +45,12 @@ export default function useDayCalendarNav(
       if (prevEventDay) {
         setPrevActivityDay([
           new Date(prevEventDay.date),
-          {
-            endingActivities: [],
-            events: prevEventDay.events.map((event) => ({
-              data: event,
-              kind: ACTIVITIES.EVENT,
-              visibleFrom: event.published ? new Date(event.published) : null,
-              visibleUntil: new Date(event.end_time),
-            })),
-            startingActivities: [],
-          },
+          prevEventDay.events.map((event) => ({
+            data: event,
+            kind: ACTIVITIES.EVENT,
+            visibleFrom: event.published ? new Date(event.published) : null,
+            visibleUntil: new Date(event.end_time),
+          })),
         ]);
       }
     }
@@ -70,20 +66,16 @@ export default function useDayCalendarNav(
     if (nextEntry) {
       setNextActivityDay([
         new Date(nextEntry[0]),
-        {
-          endingActivities: [],
-          events: nextEntry[1].items
-            .filter((item) => !!item.data)
-            .map((item) => ({
-              data: item.data!,
-              kind: ACTIVITIES.EVENT,
-              visibleFrom: item.data!.published
-                ? new Date(item.data!.published)
-                : null,
-              visibleUntil: null,
-            })),
-          startingActivities: [],
-        },
+        nextEntry[1].items
+          .filter((item) => !!item.data)
+          .map((item) => ({
+            data: item.data!,
+            kind: ACTIVITIES.EVENT,
+            visibleFrom: item.data!.published
+              ? new Date(item.data!.published)
+              : null,
+            visibleUntil: null,
+          })),
       ]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/calendar/hooks/useMonthCalendarEvents.ts
+++ b/src/features/calendar/hooks/useMonthCalendarEvents.ts
@@ -47,7 +47,7 @@ export default function useMonthCalendarEvents({
   const curDate = new Date(startDate);
   while (curDate.getTime() <= endDate.getTime()) {
     const activitiesOnCurrentDay =
-      datesWithActivities[dayjs(curDate).format('YYYY-MM-DD')]?.events || [];
+      datesWithActivities[dayjs(curDate).format('YYYY-MM-DD')] || [];
 
     const clusters: AnyClusteredEvent[] = [
       ...clusterEvents(activitiesOnCurrentDay),

--- a/src/features/campaigns/hooks/useClusteredActivities.spec.ts
+++ b/src/features/campaigns/hooks/useClusteredActivities.spec.ts
@@ -52,7 +52,10 @@ const mockEventData: ZetkinEvent = {
   start_time: '1857-07-05T13:37:00.000Z',
 };
 
-function mockEvent(id: number, data: Partial<ZetkinEvent>): EventActivity {
+export function mockEvent(
+  id: number,
+  data: Partial<ZetkinEvent>
+): EventActivity {
   return {
     data: {
       ...mockEventData,

--- a/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
+++ b/src/features/events/components/EventPopper/MultiEventPopper/MultiEventListItem.tsx
@@ -8,13 +8,13 @@ import EventSelectionCheckBox from '../../EventSelectionCheckBox';
 import EventWarningIcons from '../../EventWarningIcons';
 import LocationLabel from '../../LocationLabel';
 import messageIds from 'features/events/l10n/messageIds';
-import { MultiDayEvent } from 'features/calendar/components/utils';
 import { removeOffset } from 'utils/dateUtils';
 import StatusDot from '../StatusDot';
 import useEventState from 'features/events/hooks/useEventState';
 import { useMessages } from 'core/i18n';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import ZUIIconLabel from 'zui/ZUIIconLabel';
+import { MultiDayEvent } from 'features/calendar/components/utils';
 
 interface MultiEventListItemProps {
   clusterType: CLUSTER_TYPE;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { NoSsr } from '@mui/material';
 import NProgress from 'nprogress';
 import Router from 'next/router';
 import { useEffect, useRef } from 'react';
+import 'temporal-polyfill/global';
 
 import createStore, { Store } from 'core/store';
 import BrowserApiClient from 'core/api/client/BrowserApiClient';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,4 +1,4 @@
-import dayjs, { Dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 
 import { ZetkinEvent } from 'utils/types/zetkin';
 
@@ -45,21 +45,6 @@ export const removeOffset = (datetime: string): string => {
 };
 
 /**
- * Plugin for dayjs which overrides default `dayjs.toJson()` method to return an ISO
- * datetime string which uses the local time.
- *
- * Default behaviour returns an ISO datetime string in UTC time.
- */
-export const LocalTimeToJsonPlugin = (
-  options: never,
-  dayjsClass: typeof Dayjs
-): void => {
-  dayjsClass.prototype.toJSON = function () {
-    return this.format('YYYY-MM-DDTHH:mm:ss');
-  };
-};
-
-/**
  * @param date
  * @returns string in YYYY-MM-DD format
  */
@@ -81,28 +66,8 @@ export function makeNaiveTimeString(date: Date): string {
     .padStart(2, '0')}`;
 }
 
-/**
- * Takes an ISO datestring and returns a boolean that says if the date is in the futre or not.
- * @param datestring
- * @returns boolean
- */
-export function isInFuture(datestring: string): boolean {
-  const now = new Date();
-  const date = new Date(datestring);
-
-  return date > now;
-}
-
 export function isSameDate(first: Date, second: Date): boolean {
   return dayjs(first).isSame(dayjs(second), 'day');
-}
-
-export function isValidDate(date: Date): boolean {
-  if (date && !isNaN(date.getTime())) {
-    return true;
-  } else {
-    return false;
-  }
 }
 
 export function dateIsAfter(first: Date, second: Date): boolean {

--- a/src/utils/testing/setup.ts
+++ b/src/utils/testing/setup.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import 'temporal-polyfill/global';
 
 jest.mock('next/font/google', () => ({
   Figtree: () => ({


### PR DESCRIPTION
## Description

This PR fixes a couple of bugs related to time zone handling in the calendar (e.g. #3665) by introducing the new [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) API to the codebase.

## Screenshots

### Multi-day event
<img width="2976" height="2648" alt="CleanShot 2026-05-18 at 16 14 05@2x" src="https://github.com/user-attachments/assets/9e356dda-0bcc-41e3-96c7-2976774b65df" />

### All-day event
<img width="2976" height="2648" alt="CleanShot 2026-05-18 at 16 14 11@2x" src="https://github.com/user-attachments/assets/65313c49-0de5-4e5e-83fe-1f1d73a970bf" />


### Change in behavior
|before|after|
|-|-|
| <img width="2976" height="2648" alt="CleanShot 2026-05-18 at 16 13 46@2x" src="https://github.com/user-attachments/assets/71d1bbec-0643-4aa6-ad22-14d8977a0a77" />|<img width="2976" height="2648" alt="CleanShot 2026-05-18 at 16 13 57@2x" src="https://github.com/user-attachments/assets/9871bf88-05e7-4f95-8c97-f4bc597ff3fe" />|


## Changes

- Removes the unused `endingActivities` and `startingActivities` fields from `DaySummary` and pulls the `events` to the top level.
- Removes a couple of unused date/time related functions from the codebase entirely.
- Removes code from `getActivitiesByDay` that was commented out
- Fixes the implementation of `getActivitiesByDay` to actually be compliant with the doc string and adds a couple of tests to verify

## AI usage

I let an LLM scaffold the tests but then edited them manually (which led me to their current form which showed that the actual implementation was indeed buggy).

## Instructions for reviewer

This can be tested on this calendar: https://app.dev.zetkin.org/organize/1/projects/514/calendar?focusDate=2026-05-10&timeScale=month
Note that all day events currently show up twice and multi day events also show up wrong (especially when they are set to a time that is a different day in the local time zone (e.g. Berlin/Malmö) when compared to UTC.

## Related issues

Resolves #3665

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
