### PR TITLE
Surveys: add survey submissions to profile page

### DIFF
--- a/src/features/profile/components/PersonSurveySubmissionsCard.tsx
+++ b/src/features/profile/components/PersonSurveySubmissionsCard.tsx
@@ -1,0 +1,68 @@
+import { Card, ListItem, ListItemText } from '@mui/material';
+
+import messageIds from '../l10n/messageIds';
+import ZUIList from 'zui/ZUIList';
+import ZUISection from 'zui/ZUISection';
+import { useMessages } from 'core/i18n';
+import { ZetkinPerson } from 'utils/types/zetkin';
+import usePersonSurveySubmissions from 'features/profile/hooks/usePersonSurveySubmissions';
+import ZUIFuture from 'zui/ZUIFuture';
+import { usePanes } from 'utils/panes';
+import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
+
+const PersonSurveySubmissionsCard: React.FunctionComponent<{
+  orgId: number;
+  person: ZetkinPerson;
+}> = ({ orgId, person }) => {
+  const messages = useMessages(messageIds);
+  const surveySubmissionsFuture = usePersonSurveySubmissions(orgId, person);
+  const { openPane } = usePanes();
+
+  return (
+    <ZUISection title={messages.surveySubmissions.title()}>
+      <Card>
+        <ZUIFuture future={surveySubmissionsFuture}>
+          {(surveySubmissions) => (
+            <ZUIList
+              initialLength={4}
+              showMoreStep={surveySubmissions.length - 4}
+            >
+              {surveySubmissions.map((submission, idx) => (
+                <ListItem
+                  key={idx}
+                  divider
+                  onClick={() => {
+                    openPane({
+                      render() {
+                        return (
+                          <SurveySubmissionPane
+                            id={submission.id}
+                            orgId={orgId}
+                          />
+                        );
+                      },
+                      width: 400,
+                    });
+                  }}
+                  sx={(theme) => ({
+                    '&:hover': {
+                      backgroundColor: theme.palette.background.default,
+                    },
+                    cursor: 'pointer',
+                  })}
+                >
+                  <ListItemText
+                    primary={submission.survey.title}
+                    secondary={submission.survey.title}
+                  />
+                </ListItem>
+              ))}
+            </ZUIList>
+          )}
+        </ZUIFuture>
+      </Card>
+    </ZUISection>
+  );
+};
+
+export default PersonSurveySubmissionsCard;

--- a/src/features/profile/components/PersonSurveySubmissionsCard.tsx
+++ b/src/features/profile/components/PersonSurveySubmissionsCard.tsx
@@ -1,14 +1,61 @@
 import { Card, ListItem, ListItemText } from '@mui/material';
+import { useMemo } from 'react';
 
 import messageIds from '../l10n/messageIds';
 import ZUIList from 'zui/ZUIList';
 import ZUISection from 'zui/ZUISection';
 import { useMessages } from 'core/i18n';
-import { ZetkinPerson } from 'utils/types/zetkin';
+import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
 import usePersonSurveySubmissions from 'features/profile/hooks/usePersonSurveySubmissions';
 import ZUIFuture from 'zui/ZUIFuture';
 import { usePanes } from 'utils/panes';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
+import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+
+const SurveySubmissionList: React.FunctionComponent<{
+  orgId: number;
+  submissions: ZetkinSurveySubmission[];
+}> = ({ orgId, submissions }) => {
+  const { openPane } = usePanes();
+
+  const sortedSubmissions = useMemo(() => {
+    return submissions.sort(
+      (a, b) => Date.parse(b.submitted) - Date.parse(a.submitted)
+    );
+  }, [submissions]);
+
+  return (
+    <ZUIList initialLength={4} showMoreStep={sortedSubmissions.length - 4}>
+      {sortedSubmissions.map((submission, idx) => (
+        <ListItem
+          key={idx}
+          divider
+          onClick={() => {
+            openPane({
+              render() {
+                return (
+                  <SurveySubmissionPane id={submission.id} orgId={orgId} />
+                );
+              },
+              width: 400,
+            });
+          }}
+          sx={(theme) => ({
+            '&:hover': {
+              backgroundColor: theme.palette.background.default,
+            },
+            cursor: 'pointer',
+          })}
+        >
+          <ListItemText
+            primary={submission.survey.title}
+            secondary={<ZUIRelativeTime datetime={submission.submitted} />}
+          />
+        </ListItem>
+      ))}
+    </ZUIList>
+  );
+};
 
 const PersonSurveySubmissionsCard: React.FunctionComponent<{
   orgId: number;
@@ -16,48 +63,16 @@ const PersonSurveySubmissionsCard: React.FunctionComponent<{
 }> = ({ orgId, person }) => {
   const messages = useMessages(messageIds);
   const surveySubmissionsFuture = usePersonSurveySubmissions(orgId, person);
-  const { openPane } = usePanes();
 
   return (
     <ZUISection title={messages.surveySubmissions.title()}>
       <Card>
         <ZUIFuture future={surveySubmissionsFuture}>
           {(surveySubmissions) => (
-            <ZUIList
-              initialLength={4}
-              showMoreStep={surveySubmissions.length - 4}
-            >
-              {surveySubmissions.map((submission, idx) => (
-                <ListItem
-                  key={idx}
-                  divider
-                  onClick={() => {
-                    openPane({
-                      render() {
-                        return (
-                          <SurveySubmissionPane
-                            id={submission.id}
-                            orgId={orgId}
-                          />
-                        );
-                      },
-                      width: 400,
-                    });
-                  }}
-                  sx={(theme) => ({
-                    '&:hover': {
-                      backgroundColor: theme.palette.background.default,
-                    },
-                    cursor: 'pointer',
-                  })}
-                >
-                  <ListItemText
-                    primary={submission.survey.title}
-                    secondary={submission.survey.title}
-                  />
-                </ListItem>
-              ))}
-            </ZUIList>
+            <SurveySubmissionList
+              orgId={orgId}
+              submissions={surveySubmissions}
+            />
           )}
         </ZUIFuture>
       </Card>

--- a/src/features/profile/components/PersonSurveySubmissionsCard.tsx
+++ b/src/features/profile/components/PersonSurveySubmissionsCard.tsx
@@ -1,8 +1,7 @@
-import { Card, ListItem, ListItemText } from '@mui/material';
-import { useMemo } from 'react';
+import { Box, Button, Card, List, ListItem, ListItemText } from '@mui/material';
+import { useMemo, useState } from 'react';
 
 import messageIds from '../l10n/messageIds';
-import ZUIList from 'zui/ZUIList';
 import ZUISection from 'zui/ZUISection';
 import { useMessages } from 'core/i18n';
 import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
@@ -11,6 +10,9 @@ import ZUIFuture from 'zui/ZUIFuture';
 import { usePanes } from 'utils/panes';
 import SurveySubmissionPane from 'features/surveys/panes/SurveySubmissionPane';
 import ZUIRelativeTime from 'zui/ZUIRelativeTime';
+import Msg from 'core/i18n/Msg';
+
+const initialItemCount = 4;
 
 const SurveySubmissionList: React.FunctionComponent<{
   orgId: number;
@@ -24,9 +26,19 @@ const SurveySubmissionList: React.FunctionComponent<{
     );
   }, [submissions]);
 
+  const [showMore, setShowMore] = useState(false);
+
+  const shownSubmissions = useMemo(
+    () =>
+      showMore
+        ? sortedSubmissions
+        : sortedSubmissions.slice(0, initialItemCount),
+    [sortedSubmissions, showMore]
+  );
+
   return (
-    <ZUIList initialLength={4} showMoreStep={sortedSubmissions.length - 4}>
-      {sortedSubmissions.map((submission, idx) => (
+    <List disablePadding>
+      {shownSubmissions.map((submission, idx) => (
         <ListItem
           key={idx}
           divider
@@ -53,7 +65,18 @@ const SurveySubmissionList: React.FunctionComponent<{
           />
         </ListItem>
       ))}
-    </ZUIList>
+
+      {sortedSubmissions.length > initialItemCount && !showMore && (
+        <Button fullWidth onClick={() => setShowMore(true)}>
+          <Box textAlign="center">
+            <Msg
+              id={messageIds.surveySubmissions.showMore}
+              values={{ numExtra: sortedSubmissions.length - initialItemCount }}
+            />
+          </Box>
+        </Button>
+      )}
+    </List>
   );
 };
 

--- a/src/features/profile/hooks/usePersonSurveySubmissions.ts
+++ b/src/features/profile/hooks/usePersonSurveySubmissions.ts
@@ -1,0 +1,35 @@
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import {
+  personSurveySubmissionsLoad,
+  personSurveySubmissionsLoaded,
+} from '../store';
+import { ZetkinPerson, ZetkinSurveySubmission } from 'utils/types/zetkin';
+import { loadListIfNecessary } from 'core/caching/cacheUtils';
+
+export default function usePersonSurveySubmissions(
+  orgId: number,
+  person: Pick<ZetkinPerson, 'first_name' | 'last_name' | 'id'>
+) {
+  const apiClient = useApiClient();
+  const dispatch = useAppDispatch();
+  const personSurveySubmissions = useAppSelector(
+    (state) => state.profiles.surveySubmissionsByPersonId[person.id]
+  );
+
+  return loadListIfNecessary(personSurveySubmissions, dispatch, {
+    actionOnLoad: () => personSurveySubmissionsLoad(person.id),
+    actionOnSuccess: (data) => personSurveySubmissionsLoaded([person.id, data]),
+    loader: async () => {
+      const allSubmissionsWithSimilarName = await apiClient.post<
+        ZetkinSurveySubmission[],
+        { q: string }
+      >(`/api/orgs/${orgId}/search/surveysubmission`, {
+        q: `${person.first_name} ${person.last_name}`,
+      });
+
+      return allSubmissionsWithSimilarName.filter(
+        (submission) => submission.respondent?.id === person.id
+      );
+    },
+  });
+}

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -60,6 +60,9 @@ export default makeMessages('feat.profile', {
     noRole: m('No role'),
   },
   saveButton: m('Save'),
+  surveySubmissions: {
+    title: m('Survey Submissions'),
+  },
   tabs: {
     manage: m('Manage'),
     profile: m('Profile'),

--- a/src/features/profile/l10n/messageIds.ts
+++ b/src/features/profile/l10n/messageIds.ts
@@ -61,6 +61,7 @@ export default makeMessages('feat.profile', {
   },
   saveButton: m('Save'),
   surveySubmissions: {
+    showMore: m<{ numExtra: number }>('+ {numExtra} more'),
     title: m('Survey Submissions'),
   },
   tabs: {

--- a/src/features/profile/store.ts
+++ b/src/features/profile/store.ts
@@ -6,8 +6,14 @@ import {
   remoteItem,
   RemoteList,
   remoteList,
+  remoteListLoad,
+  remoteListLoaded,
 } from 'utils/storeUtils';
-import { ZetkinCustomField, ZetkinPerson } from 'utils/types/zetkin';
+import {
+  ZetkinCustomField,
+  ZetkinPerson,
+  ZetkinSurveySubmission,
+} from 'utils/types/zetkin';
 import { ZetkinPersonNote } from './types';
 
 export type PersonOrgData = {
@@ -23,6 +29,10 @@ export interface ProfilesStoreSlice {
   orgsByPersonId: Record<number, RemoteItem<PersonOrgData>>;
   notesByPersonId: Record<number, RemoteList<ZetkinPersonNote>>;
   personById: Record<number, RemoteItem<ZetkinPerson>>;
+  surveySubmissionsByPersonId: Record<
+    number,
+    RemoteList<ZetkinSurveySubmission>
+  >;
 }
 
 const initialState: ProfilesStoreSlice = {
@@ -30,6 +40,7 @@ const initialState: ProfilesStoreSlice = {
   notesByPersonId: {},
   orgsByPersonId: {},
   personById: {},
+  surveySubmissionsByPersonId: {},
 };
 
 const profilesSlice = createSlice({
@@ -132,6 +143,19 @@ const profilesSlice = createSlice({
         loaded: new Date().toISOString(),
       });
     },
+    personSurveySubmissionsLoad: (state, action: PayloadAction<number>) => {
+      const id = action.payload;
+      state.surveySubmissionsByPersonId[id] = remoteListLoad(
+        state.surveySubmissionsByPersonId[id] ?? null
+      );
+    },
+    personSurveySubmissionsLoaded: (
+      state,
+      action: PayloadAction<[number, ZetkinSurveySubmission[]]>
+    ) => {
+      const [id, submissions] = action.payload;
+      state.surveySubmissionsByPersonId[id] = remoteListLoaded(submissions);
+    },
     personUpdate: (state, action: PayloadAction<[number, string[]]>) => {
       const [personId, attributes] = action.payload;
       const item = state.personById[personId];
@@ -197,4 +221,6 @@ export const {
   personUpdated,
   personsDeleted,
   personsMerged,
+  personSurveySubmissionsLoad,
+  personSurveySubmissionsLoaded,
 } = profilesSlice.actions;

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -26,6 +26,7 @@ import PersonLngLatMap from 'features/profile/components/PersonLngLatMap';
 import PersonNotes from 'features/profile/components/PersonNotes';
 import { PERSON_NOTES } from 'utils/featureFlags';
 import useFeature from 'utils/featureFlags/useFeature';
+import PersonSurveySubmissionsCard from 'features/profile/components/PersonSurveySubmissionsCard';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
@@ -147,6 +148,9 @@ const PersonProfilePage: PageWithLayout = () => {
         )}
         <Grid size={{ lg: 4, xs: 12 }}>
           <PersonOrganizationsCard orgId={orgId} personId={personId} />
+        </Grid>
+        <Grid size={{ lg: 4, xs: 12 }}>
+          <PersonSurveySubmissionsCard orgId={orgId} person={person} />
         </Grid>
         {hasPersonNotesFeature && (
           <Grid size={{ lg: 4, xs: 12 }}>

--- a/src/utils/testing/mocks/mockState.ts
+++ b/src/utils/testing/mocks/mockState.ts
@@ -136,6 +136,7 @@ export default function mockState(overrides?: RootState) {
       notesByPersonId: {},
       orgsByPersonId: {},
       personById: {},
+      surveySubmissionsByPersonId: {},
     },
     search: {
       matchesByQuery: {},


### PR DESCRIPTION
## Description

This PR adds a section containing survey submissions in the profile page.

## Screenshots
[Add screenshots here]

<img width="3840" height="2058" alt="survey-submissions-in-profile-page" src="https://github.com/user-attachments/assets/06110aa7-508b-4427-83f8-9cd21ab4cee2" />

## Changes

- Adds survey submissions view to profile page
- Adds hook to fetch survey submissions by person object via the Search API
- Adds pane when clicking onto

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

No AI was harmed during the making of this PR. 

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Go to /organize/1/people/2
- Observe the new "Survey Submissions" section

Note, that this uses the Search API to fetch survey submissions. We should add an API that fetches surveys by person id. And I believe the Search API returns surveys that are deleted. As a result, the pane shows them. And since the pane doesn't handle any errors, it shows up as loading forever. 

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
