### PR TITLE
Stop pulling column-renderers into shared _app bundle (-60%)

### DIFF
--- a/src/features/events/hooks/useEventsFromDateRange.ts
+++ b/src/features/events/hooks/useEventsFromDateRange.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 
 import range from 'utils/range';
 import shouldLoad from 'core/caching/shouldLoad';
@@ -6,6 +7,8 @@ import { ZetkinEvent } from 'utils/types/zetkin';
 import { ACTIVITIES, EventActivity } from 'features/campaigns/types';
 import { eventRangeLoad, eventRangeLoaded } from '../store';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+
+dayjs.extend(utc);
 
 export default function useEventsFromDateRange(
   startDate: Date,

--- a/src/features/views/store.ts
+++ b/src/features/views/store.ts
@@ -2,7 +2,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { Call } from 'features/callAssignments/apiTypes';
 import { callUpdated } from 'features/callAssignments/store';
-import columnTypes from './components/ViewDataTable/columnTypes';
 import { DeleteFolderReport } from './rpc/deleteFolder';
 import notEmpty from 'utils/notEmpty';
 import { PersonViewFilterConfig } from 'features/smartSearch/components/types';
@@ -28,6 +27,8 @@ import { personsDeleted } from 'features/profile/store';
 type ZetkinObjectAccessWithId = ZetkinObjectAccess & {
   id: number;
 };
+
+const SUPPORTED_COLUMN_TYPES = new Set<string>(Object.values(COLUMN_TYPE));
 
 export interface ViewsStoreSlice {
   accessByViewId: Record<number | string, RemoteList<ZetkinObjectAccessWithId>>;
@@ -285,7 +286,7 @@ const viewsSlice = createSlice({
       const [viewId, columns] = action.payload;
       const supportedColumns = columns.map((column) => {
         const copy: ZetkinViewColumn = { ...column };
-        if (!Object.keys(columnTypes).includes(copy.type)) {
+        if (!SUPPORTED_COLUMN_TYPES.has(copy.type)) {
           copy.type = COLUMN_TYPE.UNSUPPORTED;
         }
 


### PR DESCRIPTION
## Description

Removes a single import in `src/features/views/store.ts` that was pulling the entire column-renderer chain (13 React components + `@mui/x-data-grid-pro` + transitive ZUI/MUI deps) into the shared Pages-Router `_app.js` bundle on every page.

The original code did `Object.keys(columnTypes).includes(copy.type)` for a tiny set-membership check. Replacing it with `new Set<string>(Object.values(COLUMN_TYPE))` is semantically identical — same string set — but has zero runtime imports.

Bundle impact (measured with the production build output):

| Bundle | main | this PR | Δ |
|---|---:|---:|---:|
| `pages/_app.js` (parsed) | 551 KB | 220 KB | **-331 KB (-60%)** |
| First Load JS shared by all | 642 KB | 301 KB | **-341 KB (-53%)** |

A follow-up commit fixes a latent bug that the bundle change surfaced: `useEventsFromDateRange.ts` calls `dayjs(...).utc(true)` but never loaded the `dayjs/plugin/utc` plugin itself — it relied on a side-effect import via the old column-renderer chain. With the import gone, the `/organize/{org}/projects` page crashed with `dayjs(...).utc is not a function`. Adding the missing `dayjs.extend(utc)` in the hook makes it self-sufficient.

## Screenshots

N/A — no visual changes.

## Changes

- Drops the `columnTypes` import from `views/store.ts` and switches the supported-type check to a `Set<string>(Object.values(COLUMN_TYPE))`.
- Adds `dayjs.extend(utc)` in `useEventsFromDateRange.ts` so the hook no longer relies on a side-effect from another module.

## AI usage

Yes — used Claude Code (Opus 4.7) for the bundle-analyzer investigation, identifying the column-renderer chain as the heavy importer, debugging the post-fix client-side crash on the projects page (capturing console errors via a temporary Playwright spec to find the `dayjs.utc is not a function` trace), and writing this PR description.

## Instructions for reviewer

1. **Verify bundle reduction**:
   ```
   npm run build
   ```
   Inspect the build output: `pages/_app.js` should drop from ~551 KB to ~220 KB. The `First Load JS shared by all` line should drop from ~642 KB to ~301 KB.
2. **Verify the projects page still renders**:
   - `npm run start -- -p 3000`
   - Log in and visit `/organize/{org}/projects` — should render the project list without the `Application error: client-side exception` banner.
3. **Verify view rendering still works** (the original `columnTypes` lookup was for views):
   - Visit `/organize/{org}/people/lists/{viewId}` — columns of every supported type should render. Unsupported column types (server returns an unknown `type` value) should still fall back to the `UNSUPPORTED` column type.

## Related issues

None.


## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
