### PR TITLE
Events: Add "join event" CTA to calendar ICS

### DIFF
--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -3,8 +3,13 @@ import dayjs from 'dayjs';
 import { headers } from 'next/headers';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import { ZetkinEvent, ZetkinOrganization } from 'utils/types/zetkin';
+import {
+  ZetkinEvent,
+  ZetkinOrganization,
+  ZetkinUser,
+} from 'utils/types/zetkin';
 import icsFromEvents from 'features/public/utils/icsFromEvents';
+import { getBrowserLanguage } from 'utils/locale';
 
 export async function GET(
   _req: Request,
@@ -34,7 +39,20 @@ export async function GET(
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
-  return new Response(icsFromEvents(org.title, events, org), {
+  let user: ZetkinUser | null;
+
+  try {
+    user = await apiClient.get<ZetkinUser>('/api/users/me');
+  } catch (e) {
+    user = null;
+  }
+
+  const lang =
+    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+
+  const ics = await icsFromEvents(org.title, events, org, lang);
+
+  return new Response(ics, {
     headers: { 'Content-Type': 'text/calendar' },
   });
 }

--- a/src/app/o/[orgId]/events/[eventId]/cal.ics/route.ts
+++ b/src/app/o/[orgId]/events/[eventId]/cal.ics/route.ts
@@ -2,8 +2,13 @@ import { IncomingHttpHeaders } from 'http';
 import { headers } from 'next/headers';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import { ZetkinEvent, ZetkinOrganization } from 'utils/types/zetkin';
+import {
+  ZetkinEvent,
+  ZetkinOrganization,
+  ZetkinUser,
+} from 'utils/types/zetkin';
 import icsFromEvents from 'features/public/utils/icsFromEvents';
+import { getBrowserLanguage } from 'utils/locale';
 
 export async function GET(
   _req: Request,
@@ -27,7 +32,20 @@ export async function GET(
 
   const org = await apiClient.get<ZetkinOrganization>(`/api/orgs/${orgId}`);
 
-  return new Response(icsFromEvents(org.title, [event], org), {
+  let user: ZetkinUser | null;
+
+  try {
+    user = await apiClient.get<ZetkinUser>('/api/users/me');
+  } catch (e) {
+    user = null;
+  }
+
+  const lang =
+    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+
+  const ics = await icsFromEvents(org.title, [event], org, lang);
+
+  return new Response(ics, {
     headers: { 'Content-Type': 'text/calendar' },
   });
 }

--- a/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
@@ -7,8 +7,10 @@ import {
   ZetkinCampaign,
   ZetkinEvent,
   ZetkinOrganization,
+  ZetkinUser,
 } from 'utils/types/zetkin';
 import icsFromEvents from 'features/public/utils/icsFromEvents';
+import { getBrowserLanguage } from 'utils/locale';
 
 export async function GET(
   _req: Request,
@@ -41,7 +43,20 @@ export async function GET(
     `/api/orgs/${orgId}/campaigns/${projId}`
   );
 
-  return new Response(icsFromEvents(campaign.title, events, org), {
+  let user: ZetkinUser | null;
+
+  try {
+    user = await apiClient.get<ZetkinUser>('/api/users/me');
+  } catch (e) {
+    user = null;
+  }
+
+  const lang =
+    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+
+  const ics = await icsFromEvents(campaign.title, events, org, lang);
+
+  return new Response(ics, {
     headers: { 'Content-Type': 'text/calendar' },
   });
 }

--- a/src/features/public/l10n/messageIds.ts
+++ b/src/features/public/l10n/messageIds.ts
@@ -1,3 +1,5 @@
+import { ReactElement } from 'react';
+
 import { m, makeMessages } from 'core/i18n/messages';
 
 export default makeMessages('feat.home', {
@@ -47,6 +49,9 @@ export default makeMessages('feat.home', {
   },
   footer: {
     privacyPolicy: m('Privacy policy'),
+  },
+  ics: {
+    joinEvent: m<{ eventLink: ReactElement }>('Join event here: {eventLink}'),
   },
   newLandingPageAlert: {
     description: m(

--- a/src/features/public/utils/icsFromEvents.ts
+++ b/src/features/public/utils/icsFromEvents.ts
@@ -1,6 +1,12 @@
+'use server';
+
 import dayjs, { Dayjs } from 'dayjs';
+import { createIntl, createIntlCache } from 'react-intl';
 
 import { ZetkinEvent, ZetkinOrganization } from 'utils/types/zetkin';
+import { getMessages } from 'utils/locale';
+import messageIds from 'features/public/l10n/messageIds';
+import { stringToBool } from 'utils/stringUtils';
 
 const timeStamp = (t: Dayjs): string => t.format('YYYYMMDDTHHmmss');
 const formatString = (str: string): string =>
@@ -9,15 +15,37 @@ const formatString = (str: string): string =>
     .match(/.{1,74}/g)
     ?.join('\r\n\t') ?? '';
 
-export default function icsFromEvents(
+export default async function icsFromEvents(
   name: string,
   events: ZetkinEvent[],
-  org: ZetkinOrganization
-): string {
+  org: ZetkinOrganization,
+  lang: string
+): Promise<string> {
   const vLines: string[] = ['NAME:' + name, 'X-WR-CALNAME:' + name];
+
+  const messages = await getMessages(lang, ['feat.home']);
+
+  const joinEventCtaMsg =
+    messages['ics.joinEvent'] || messageIds.ics.joinEvent._defaultMessage;
+
+  const intlCache = createIntlCache();
+  const intl = createIntl({ locale: lang }, intlCache);
+
   events
     .filter((event) => !event.cancelled && event.published)
     .forEach((event) => {
+      const eventLink = `${stringToBool(process.env.ZETKIN_USE_TLS) ? 'https' : 'http'}://${process.env.ZETKIN_APP_HOST}/o/${org.id}/events/${event.id}`;
+
+      const joinEventCta = intl.formatMessage(
+        {
+          defaultMessage: joinEventCtaMsg,
+          id: 'feat.home.ics.joinEvent',
+        },
+        {
+          eventLink,
+        }
+      );
+
       vLines.push(`BEGIN:VEVENT`);
       vLines.push(`UID:${event.id}@${process.env.ZETKIN_APP_HOST}`);
       vLines.push(
@@ -31,12 +59,10 @@ export default function icsFromEvents(
       if (event.title || event.activity?.title) {
         vLines.push(`SUMMARY:${event.title || event.activity?.title || ''}`);
       }
-      if (event.info_text) {
-        vLines.push(`DESCRIPTION:${event.info_text ?? ''}`);
-      }
       vLines.push(
-        `URL:${process.env.ZETKIN_APP_HOST}/o/${org.id}/events/${event.id}`
+        `DESCRIPTION:${joinEventCta}${event.info_text ? '\n\n' + event.info_text : ''}`
       );
+      vLines.push(`URL:${eventLink}`);
       if (event.location) {
         vLines.push(`GEO:${event.location.lat};${event.location.lng}`);
         vLines.push(`LOCATION:${event.location.title}`);


### PR DESCRIPTION
## Description

This PR adds a call to action (CTA) to ics feeds at the top of the description, which includes the Zetkin event url. Several clients, such as Nextcloud and Google Calendar seem to not look at the ICS URL field, making it next to impossible to get to the event join link from major calendar implementations.

## Screenshots

[Add screenshots here]

<img width="851" height="588" alt="ical" src="https://github.com/user-attachments/assets/bea2dc29-6777-44ad-943a-57bf98a8026b" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds join event CTA to event description in ICS feeds
- Adds a message to format this CTA, language comes from user/browser

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

No

## Instructions for reviewer

- Go to /o/1
- Click on ⋮ and copy the ICS url
- Paste it into a new tab
- Import the resulting file in Google Calendar (best to do it in an account that you don't use as your actual calendar)
- Click on one of the resulting events
- Observe the new "Join event here: <url>" text before the event description

## Open questions

- I like my solution, it is very close to the existing patterns. But I think maybe I should move the language to the ICS URL instead? Since I'm not sure if we can count on calendar apps setting the language header correctly. What do you think?