### PR TITLE
Lists: Move view browser to react window

### DIFF
--- a/integrationTesting/tests/organize/views/list/delete.spec.ts
+++ b/integrationTesting/tests/organize/views/list/delete.spec.ts
@@ -5,7 +5,9 @@ import AllMembers from '../../../../mockData/orgs/KPD/people/views/AllMembers';
 import KPD from '../../../../mockData/orgs/KPD';
 
 const deleteView = async (page: Page) => {
-  await page.click('main [data-testid=ZUIEllipsisMenu-menuActivator]');
+  await page.click(
+    '[data-testid=view-browser-row] [data-testid=ZUIEllipsisMenu-menuActivator]'
+  );
   await page.click(`data-testid=ZUIEllipsisMenu-item-delete-item`);
   await page.click('button:text("Confirm")');
 };

--- a/integrationTesting/tests/organize/views/list/display.spec.ts
+++ b/integrationTesting/tests/organize/views/list/display.spec.ts
@@ -33,7 +33,7 @@ test.describe('Views list page', () => {
     moxy,
   }) => {
     moxy.setZetkinApiMock('/orgs/1/people/view_folders', 'get', []);
-    moxy.setZetkinApiMock('/orgs/1/people/views', 'get', [
+    const viewsRequest = moxy.setZetkinApiMock('/orgs/1/people/views', 'get', [
       AllMembers,
       {
         created: '2021-11-21T12:59:19',
@@ -49,6 +49,11 @@ test.describe('Views list page', () => {
     const rows = page.locator('[data-testid=view-browser-row]');
 
     await page.goto(appUri + '/organize/1/people');
+
+    await expect.poll(() => viewsRequest.log().length).toBe(1);
+
+    await expect(rows.locator('.MuiSkeleton-root')).toHaveCount(0);
+
     await rows.first().waitFor({ state: 'visible' });
 
     const numRows = await rows.count();

--- a/integrationTesting/tests/organize/views/list/display.spec.ts
+++ b/integrationTesting/tests/organize/views/list/display.spec.ts
@@ -46,7 +46,7 @@ test.describe('Views list page', () => {
       },
     ]);
 
-    const rows = page.locator('.MuiDataGrid-row');
+    const rows = page.locator('[data-testid=view-browser-row]');
 
     await page.goto(appUri + '/organize/1/people');
     await rows.first().waitFor({ state: 'visible' });

--- a/src/features/views/components/MoveViewDialog.tsx
+++ b/src/features/views/components/MoveViewDialog.tsx
@@ -21,6 +21,7 @@ import { ZetkinViewFolder } from './types';
 import useViewBrowserItems, {
   ViewBrowserBackItem,
   ViewBrowserItem,
+  ViewBrowserLoadingItem,
 } from '../hooks/useViewBrowserItems';
 import useViewBrowserMutations from '../hooks/useViewBrowserMutations';
 import useViewTree from '../hooks/useViewTree';
@@ -116,6 +117,12 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
   close,
   itemToMove,
 }) => {
+  if (itemToMove.type == 'back' || itemToMove.type === 'loading') {
+    throw new Error(
+      'Should not be possible to move a back button or loading indicator'
+    );
+  }
+
   const [viewedFolder, setViewedFolder] = useState(itemToMove.folderId);
 
   const { orgId } = useNumericRouteParams();
@@ -126,10 +133,6 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
   const messages = useMessages(messageIds);
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
-
-  if (itemToMove.type == 'back') {
-    throw new Error('Should not be possible to move a back button');
-  }
 
   const doMove = (folderId: number | null) => {
     moveItem(itemToMove.type, itemToMove.data.id, folderId);
@@ -163,8 +166,12 @@ const MoveViewDialog: FunctionComponent<MoveViewDialogProps> = ({
         <ZUIFuture future={itemsFuture}>
           {(data) => {
             const relevantItems = data.filter(
-              (item): item is Exclude<typeof item, ViewBrowserBackItem> =>
-                item.type != 'back'
+              (
+                item
+              ): item is Exclude<
+                typeof item,
+                ViewBrowserBackItem | ViewBrowserLoadingItem
+              > => item.type != 'back' && item.type !== 'loading'
             );
             if (relevantItems.length == 0) {
               return (

--- a/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserDragLayer.tsx
@@ -74,7 +74,7 @@ const BrowserDragLayer: FC = () => {
         >
           <Box display="flex" gap={2}>
             <BrowserItemIcon item={item} />
-            {item.title}
+            {'title' in item && item.title}
           </Box>
         </Paper>
       </Box>

--- a/src/features/views/components/ViewBrowser/BrowserEllipsisMenu.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserEllipsisMenu.tsx
@@ -1,0 +1,91 @@
+import { FC, useContext, useMemo } from 'react';
+
+import ZUIEllipsisMenu, { MenuItem } from 'zui/ZUIEllipsisMenu';
+import { useMessages } from 'core/i18n';
+import messageIds from 'features/views/l10n/messageIds';
+import useFolder from 'features/views/hooks/useFolder';
+import useViewMutations from 'features/views/hooks/useViewMutations';
+import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
+import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
+
+const BrowserEllipsisMenu: FC<{
+  item: ViewBrowserItem;
+  orgId: number;
+  setItemToBeMoved: (item: ViewBrowserItem) => void;
+  setItemToBeRenamed: (item: ViewBrowserItem) => void;
+}> = ({ item, orgId, setItemToBeMoved, setItemToBeRenamed }) => {
+  const messages = useMessages(messageIds);
+  const { deleteFolder } = useFolder(orgId);
+  const { deleteView, duplicateView } = useViewMutations(orgId);
+  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
+
+  const items: MenuItem[] = useMemo(() => {
+    if (item.type !== 'folder' && item.type !== 'view') {
+      return [];
+    }
+
+    return [
+      {
+        label: messages.browser.menu.rename(),
+        onSelect: (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setItemToBeRenamed(item);
+        },
+      },
+      {
+        id: 'delete-item',
+        label: messages.browser.menu.delete(),
+        onSelect: (e) => {
+          e.stopPropagation();
+          showConfirmDialog({
+            onSubmit: () => {
+              if (item.type == 'folder') {
+                deleteFolder(item.data.id);
+              } else if (item.type == 'view') {
+                deleteView(item.data.id);
+              }
+            },
+            title: messages.browser.confirmDelete[item.type].title(),
+            warningText: messages.browser.confirmDelete[item.type].warning(),
+          });
+        },
+      },
+      {
+        id: 'move-item',
+        label: messages.browser.menu.move(),
+        onSelect: (e) => {
+          e.stopPropagation();
+          setItemToBeMoved(item);
+        },
+      },
+      {
+        disabled: item.type != 'view',
+        id: 'duplicate-item',
+        label: messages.browser.menu.duplicate(),
+        onSelect: (e) => {
+          e.stopPropagation();
+          duplicateView(
+            item.data.id,
+            item.folderId,
+            messages.browser.menu.viewCopy({ viewName: item.title })
+          );
+        },
+      },
+    ];
+  }, [
+    deleteFolder,
+    deleteView,
+    duplicateView,
+    item,
+    messages.browser.confirmDelete,
+    messages.browser.menu,
+    setItemToBeMoved,
+    setItemToBeRenamed,
+    showConfirmDialog,
+  ]);
+
+  return <ZUIEllipsisMenu items={items} keepMounted={false} />;
+};
+
+export default BrowserEllipsisMenu;

--- a/src/features/views/components/ViewBrowser/BrowserItem.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserItem.tsx
@@ -1,5 +1,5 @@
 import NextLink from 'next/link';
-import { CircularProgress, Link, SxProps } from '@mui/material';
+import { CircularProgress, Link, Skeleton, SxProps } from '@mui/material';
 import { FC, MouseEvent, useContext } from 'react';
 
 import BrowserDraggableItem from './BrowserDragableItem';
@@ -9,14 +9,27 @@ import useViewBrowserMutations from 'features/views/hooks/useViewBrowserMutation
 import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
 import { BrowserRowContext } from './BrowserRow';
 import messageIds from 'features/views/l10n/messageIds';
+import RenameTextField from 'features/views/components/ViewBrowser/RenameTextField';
 
 interface BrowserItemProps {
   basePath: string;
   item: ViewBrowserItem;
   onClick: (ev: MouseEvent) => void;
+  renaming: boolean;
+  onRenamed: (
+    item: ViewBrowserItem,
+    newTitle: string,
+    canceled?: boolean
+  ) => void;
 }
 
-const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, onClick }) => {
+const BrowserItem: FC<BrowserItemProps> = ({
+  basePath,
+  item,
+  onClick,
+  renaming,
+  onRenamed,
+}) => {
   const dropProps = useContext(BrowserRowContext);
   const { orgId } = useNumericRouteParams();
   const { itemIsRenaming } = useViewBrowserMutations(orgId);
@@ -30,7 +43,9 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, onClick }) => {
     textDecoration: 'none',
   };
 
-  if (item.type == 'back') {
+  if (item.type === 'loading') {
+    return <Skeleton variant={'rounded'} width={400} />;
+  } else if (item.type == 'back') {
     const subPath = item.folderId ? 'folders/' + item.folderId : '';
 
     return (
@@ -57,6 +72,8 @@ const BrowserItem: FC<BrowserItemProps> = ({ basePath, item, onClick }) => {
         </Link>
       </NextLink>
     );
+  } else if (renaming) {
+    return <RenameTextField item={item} onRenamed={onRenamed} />;
   } else {
     return (
       <BrowserDraggableItem item={item}>

--- a/src/features/views/components/ViewBrowser/BrowserList.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserList.tsx
@@ -184,6 +184,7 @@ function Row({
   return (
     <BrowserRow enableDragAndDrop={enableDragAndDrop} item={row.item}>
       <Box
+        data-testid={'view-browser-row'}
         style={style}
         sx={{
           '&:hover': {

--- a/src/features/views/components/ViewBrowser/BrowserList.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserList.tsx
@@ -110,7 +110,9 @@ function Row({
                   }}
                   sx={{
                     '&:hover .sort-control-indicator-icon': {
-                      color: theme.palette.grey[500],
+                      color: sort
+                        ? theme.palette.primary.light
+                        : theme.palette.grey[500],
                     },
                     alignItems: 'center',
                     cursor: 'pointer',

--- a/src/features/views/components/ViewBrowser/BrowserList.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserList.tsx
@@ -1,0 +1,346 @@
+import { Box, Typography, useTheme } from '@mui/material';
+import {
+  Dispatch,
+  ReactNode,
+  Ref,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { List, RowComponentProps, useListRef } from 'react-window';
+import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
+
+import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
+import BrowserRow from 'features/views/components/ViewBrowser/BrowserRow';
+
+type GridColDefWidthSpec = {
+  width: number;
+};
+
+type GridColDefFlexSpec = {
+  flex: number;
+};
+
+type GridColDefSizeSpec = GridColDefWidthSpec | GridColDefFlexSpec;
+
+export type GridColDef = GridColDefSizeSpec & {
+  field: string;
+  headerName: string;
+  renderCell: (params: {
+    index: number;
+    renaming: boolean;
+    row: ViewBrowserItem;
+  }) => ReactNode;
+  sortable?: boolean;
+};
+
+export type GridSortDirection = 'asc' | 'desc';
+
+export type GridSortModel = readonly {
+  field: string;
+  sort: GridSortDirection;
+}[];
+
+export type ViewBrowserRow = {
+  item: ViewBrowserItem;
+  renaming: boolean;
+};
+
+type RowProps = {
+  columns: GridColDef[];
+  enableDragAndDrop?: boolean;
+  header?: ReactNode;
+  headerRef: Ref<HTMLDivElement | null>;
+  nonHeaderOpacity: string;
+  rows: ViewBrowserRow[];
+  sorting: Record<string, GridSortDirection | undefined>;
+  updateSorting: (field: string, sort: GridSortDirection | null) => void;
+};
+
+function Row({
+  columns,
+  enableDragAndDrop,
+  header,
+  headerRef,
+  rows,
+  index,
+  style,
+  nonHeaderOpacity,
+  sorting,
+  updateSorting,
+}: RowComponentProps<RowProps>) {
+  const theme = useTheme();
+
+  if (index === 0) {
+    return (
+      <Box style={style}>
+        <Box
+          ref={headerRef}
+          sx={{
+            overflow: 'hidden',
+          }}
+        >
+          {header}
+          <Box
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flexDirection: 'row',
+              height: '56px',
+              width: '100%',
+            }}
+          >
+            {columns.map((col, colIndex) => {
+              const sort = sorting[col.field];
+
+              return (
+                <Box
+                  key={colIndex}
+                  onClick={() => {
+                    let nextSort: GridSortDirection | null = null;
+                    if (!sort) {
+                      nextSort = 'asc';
+                    } else if (sort === 'asc') {
+                      nextSort = 'desc';
+                    }
+                    updateSorting(col.field, nextSort);
+                  }}
+                  sx={{
+                    '&:hover .sort-control-indicator-icon': {
+                      color: theme.palette.grey[500],
+                    },
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    flex: 'flex' in col ? col.flex : undefined,
+                    flexDirection: 'row',
+                    height: '100%',
+                    width: 'width' in col ? `${col.width}px` : undefined,
+                  }}
+                >
+                  {colIndex !== 0 && (
+                    <Box
+                      sx={{
+                        backgroundColor: theme.palette.grey[300],
+                        height: '20px',
+                        width: '2px',
+                      }}
+                    />
+                  )}
+                  <Box
+                    sx={{
+                      alignItems: 'center',
+                      display: 'flex',
+                      flexDirection: 'row',
+                      gap: '10px',
+                      padding: '0px 10px',
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        color: theme.palette.primary.light,
+                        fontSize: '0.875rem',
+                        fontWeight: 'bold',
+                        userSelect: 'none',
+                      }}
+                    >
+                      {col.headerName}
+                    </Typography>
+                    {col.sortable && (
+                      <Box
+                        className={'sort-control-indicator-icon'}
+                        sx={{
+                          alignItems: 'center',
+                          color: sort
+                            ? theme.palette.primary.light
+                            : 'transparent',
+                          display: 'flex',
+                          fontSize: 'md',
+                          transition: 'color 200ms ease',
+                        }}
+                      >
+                        {sort === 'desc' ? (
+                          <ArrowDownward fontSize={'inherit'} />
+                        ) : (
+                          <ArrowUpward fontSize={'inherit'} />
+                        )}
+                      </Box>
+                    )}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  const row = rows[index - 1];
+
+  return (
+    <BrowserRow enableDragAndDrop={enableDragAndDrop} item={row.item}>
+      <Box
+        style={style}
+        sx={{
+          '&:hover': {
+            backgroundColor: theme.palette.grey[200],
+          },
+          alignItems: 'center',
+          borderTop: `1px solid ${theme.palette.grey[300]}`,
+          display: 'flex',
+          flexDirection: 'row',
+          opacity: nonHeaderOpacity,
+          width: '100%',
+        }}
+      >
+        {columns.map((col, colIndex) => (
+          <Box
+            key={colIndex}
+            sx={{
+              alignItems: 'center',
+              display: 'flex',
+              flex: 'flex' in col ? col.flex : undefined,
+              flexDirection: 'row',
+              padding: '0px 10px',
+              width: 'width' in col ? `${col.width}px` : undefined,
+            }}
+          >
+            {col.renderCell({
+              index,
+              renaming: row.renaming,
+              row: row.item,
+            })}
+          </Box>
+        ))}
+      </Box>
+    </BrowserRow>
+  );
+}
+
+function BrowserList({
+  cols,
+  enableDragAndDrop,
+  header,
+  rows,
+  setSortModel,
+  sortModel,
+}: {
+  cols: GridColDef[];
+  enableDragAndDrop?: boolean;
+  header: ReactNode;
+  rows: ViewBrowserRow[];
+  setSortModel: Dispatch<SetStateAction<GridSortModel>>;
+  sortModel: GridSortModel;
+}) {
+  const listRef = useListRef(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [hasEvaluatedHeightOnce, setHasEvaluatedHeightOnce] = useState(false);
+
+  const resizeObserverRef = useRef<ResizeObserver>();
+
+  const headerRef: Ref<HTMLDivElement | null> = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
+
+      if (!el) {
+        return;
+      }
+
+      const ro = new ResizeObserver(() => {
+        requestAnimationFrame(() => {
+          const h = el.getBoundingClientRect().height;
+          setHeaderHeight(h);
+          setHasEvaluatedHeightOnce(true);
+        });
+      });
+      ro.observe(el);
+      resizeObserverRef.current = ro;
+    },
+    []
+  );
+
+  useEffect(() => {
+    const timeoutToEnsureUIEnabledOnUnexpectedState = setTimeout(() => {
+      setHasEvaluatedHeightOnce(true);
+    }, 1000);
+
+    return () => {
+      clearTimeout(timeoutToEnsureUIEnabledOnUnexpectedState);
+    };
+  }, []);
+
+  const hasHeader = !!header;
+
+  const getRowHeight = useCallback(
+    (index: number) => (index === 0 && hasHeader ? headerHeight : 50),
+    [hasHeader, headerHeight]
+  );
+
+  const sorting = useMemo(
+    () =>
+      sortModel.reduce(
+        (prev, cur) => {
+          prev[cur.field] = cur.sort;
+          return prev;
+        },
+        {} as Record<string, GridSortDirection | undefined>
+      ),
+    [sortModel]
+  );
+
+  const updateSorting = useCallback(
+    (field: string, dir: GridSortDirection | null) => {
+      setSortModel((current) => {
+        const hasField = current.some((entry) => entry.field === field);
+        if (hasField && dir) {
+          return current.map((entry) =>
+            entry.field === field ? { field: field, sort: dir } : entry
+          );
+        } else if (dir) {
+          return [...current, { field: field, sort: dir }];
+        } else if (hasField) {
+          return current.filter((entry) => entry.field !== field);
+        }
+        return current;
+      });
+    },
+    [setSortModel]
+  );
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        overflow: 'hidden',
+        width: '100%',
+      }}
+    >
+      <List
+        listRef={listRef}
+        rowComponent={Row}
+        rowCount={rows.length + 1}
+        rowHeight={getRowHeight}
+        rowProps={{
+          columns: cols,
+          enableDragAndDrop,
+          header: header,
+          headerRef: headerRef,
+          nonHeaderOpacity: hasEvaluatedHeightOnce ? '100%' : '0',
+          rows: rows,
+          sorting,
+          updateSorting,
+        }}
+      />
+    </Box>
+  );
+}
+
+export default BrowserList;

--- a/src/features/views/components/ViewBrowser/BrowserList.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserList.tsx
@@ -296,20 +296,13 @@ function BrowserList({
   );
 
   const updateSorting = useCallback(
-    (field: string, dir: GridSortDirection | null) => {
-      setSortModel((current) => {
-        const hasField = current.some((entry) => entry.field === field);
-        if (hasField && dir) {
-          return current.map((entry) =>
-            entry.field === field ? { field: field, sort: dir } : entry
-          );
-        } else if (dir) {
-          return [...current, { field: field, sort: dir }];
-        } else if (hasField) {
-          return current.filter((entry) => entry.field !== field);
-        }
-        return current;
-      });
+    (field: string, sort: GridSortDirection | null) => {
+      if (sort) {
+        setSortModel([{ field, sort }]);
+        return;
+      }
+
+      setSortModel([]);
     },
     [setSortModel]
   );

--- a/src/features/views/components/ViewBrowser/BrowserRow.tsx
+++ b/src/features/views/components/ViewBrowser/BrowserRow.tsx
@@ -1,16 +1,15 @@
 import { useDrop } from 'react-dnd';
 import { Box, useTheme } from '@mui/material';
-import { createContext, FC } from 'react';
-import { GridRow, GridRowProps } from '@mui/x-data-grid-pro';
+import { createContext, FC, PropsWithChildren } from 'react';
 
 import { useNumericRouteParams } from 'core/hooks';
 import useViewBrowserMutations from 'features/views/hooks/useViewBrowserMutations';
 import { ViewBrowserItem } from 'features/views/hooks/useViewBrowserItems';
 
-interface BrowserRowProps {
+type BrowserRowProps = {
+  enableDragAndDrop?: boolean;
   item: ViewBrowserItem;
-  rowProps: GridRowProps;
-}
+} & PropsWithChildren;
 
 export interface BrowserRowDropProps {
   active: boolean;
@@ -21,11 +20,15 @@ export const BrowserRowContext = createContext<BrowserRowDropProps>({
 });
 
 /**
- * Row component for MUI X DataGrid, to be used in the ViewBrowser.
+ * Row component to be used in the ViewBrowser.
  * Adds support for dropping views/folders onto the row, highlighting
  * the row when dragging over, etc.
  */
-const BrowserRow: FC<BrowserRowProps> = ({ item, rowProps }) => {
+const BrowserRow: FC<BrowserRowProps> = ({
+  item,
+  children,
+  enableDragAndDrop,
+}) => {
   const theme = useTheme();
   const { orgId } = useNumericRouteParams();
   const { moveItem } = useViewBrowserMutations(orgId);
@@ -35,14 +38,22 @@ const BrowserRow: FC<BrowserRowProps> = ({ item, rowProps }) => {
     BrowserRowDropProps
   >({
     accept: 'ITEM',
-    canDrop: (draggedItem) =>
-      draggedItem.type == 'view' || draggedItem.id != item.id,
+    canDrop: (draggedItem) => {
+      if (draggedItem.type === 'loading' || item.type === 'loading') {
+        return false;
+      }
+      return draggedItem.type == 'view' || draggedItem.id != item.id;
+    },
     collect: (monitor) => {
       return {
         active: monitor.isOver() && monitor.canDrop(),
       };
     },
     drop: (draggedItem) => {
+      if (item.type === 'loading') {
+        return;
+      }
+
       if (draggedItem.type == 'folder' || draggedItem.type == 'view') {
         const parentId = item.type == 'back' ? item.folderId : item.data.id;
         moveItem(draggedItem.type, draggedItem.data.id, parentId);
@@ -50,7 +61,11 @@ const BrowserRow: FC<BrowserRowProps> = ({ item, rowProps }) => {
     },
   });
 
-  let content = <GridRow {...rowProps} />;
+  if (!enableDragAndDrop) {
+    return children;
+  }
+
+  let content = children;
 
   if (item.type != 'view') {
     // If it's not a view, wrap it in a drop target

--- a/src/features/views/components/ViewBrowser/RenameTextField.tsx
+++ b/src/features/views/components/ViewBrowser/RenameTextField.tsx
@@ -1,0 +1,94 @@
+import { TextField } from '@mui/material';
+import {
+  ChangeEvent,
+  FC,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  ViewBrowserFolderItem,
+  ViewBrowserItem,
+  ViewBrowserViewItem,
+} from 'features/views/hooks/useViewBrowserItems';
+
+const RenameTextField: FC<{
+  item: ViewBrowserFolderItem | ViewBrowserViewItem;
+  onRenamed: (
+    item: ViewBrowserItem,
+    newTitle: string,
+    canceled?: boolean
+  ) => void;
+}> = ({ item, onRenamed }) => {
+  const inputRef = useRef<HTMLInputElement>();
+  const [value, setValue] = useState(item.title);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+
+    let canceled = false;
+
+    const onApply = () => {
+      if (canceled) {
+        return;
+      }
+
+      onRenamed(item, input.value, false);
+    };
+
+    const onKeypress = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        onApply();
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        canceled = true;
+        onRenamed(item, item.title, true);
+        return;
+      }
+    };
+
+    const onFocus = () => {
+      canceled = false;
+    };
+
+    input.addEventListener('blur', onApply);
+    input.addEventListener('focus', onFocus);
+    input.addEventListener('keydown', onKeypress);
+
+    requestAnimationFrame(() => {
+      input.focus();
+    });
+
+    return () => {
+      input.removeEventListener('blur', onApply);
+      input.removeEventListener('focus', onFocus);
+      input.removeEventListener('keydown', onKeypress);
+    };
+  }, [item, onRenamed]);
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  }, []);
+
+  return (
+    <TextField
+      inputRef={inputRef}
+      onChange={onChange}
+      sx={{
+        '& .MuiInputBase-input': {
+          py: '10px',
+        },
+      }}
+      value={value}
+    />
+  );
+};
+
+export default RenameTextField;

--- a/src/features/views/components/ViewBrowser/index.tsx
+++ b/src/features/views/components/ViewBrowser/index.tsx
@@ -1,45 +1,38 @@
 import NextLink from 'next/link';
-import {
-  DataGridPro,
-  GridColDef,
-  GridRowProps,
-  GridSortModel,
-  useGridApiRef,
-} from '@mui/x-data-grid-pro';
-import { FC, MouseEvent, useContext, useEffect, useState } from 'react';
+import { FC, MouseEvent, ReactNode, useMemo, useState } from 'react';
 import { Link, Theme, useMediaQuery } from '@mui/material';
 
 import BrowserDraggableItem from './BrowserDragableItem';
-import BrowserDragLayer from './BrowserDragLayer';
 import BrowserItem from './BrowserItem';
 import BrowserItemIcon from './BrowserItemIcon';
-import BrowserRow from './BrowserRow';
-import useFolder from 'features/views/hooks/useFolder';
 import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
-import useViewBrowserMutations from 'features/views/hooks/useViewBrowserMutations';
-import useViewMutations from 'features/views/hooks/useViewMutations';
-import { ZUIConfirmDialogContext } from 'zui/ZUIConfirmDialogProvider';
-import ZUIEllipsisMenu from 'zui/ZUIEllipsisMenu';
-import ZUIFuture from 'zui/ZUIFuture';
 import ZUIPerson from 'zui/ZUIPerson';
 import ZUIPersonHoverCard from 'zui/ZUIPersonHoverCard';
 import useViewBrowserItems, {
   ViewBrowserItem,
 } from 'features/views/hooks/useViewBrowserItems';
 import messageIds from 'features/views/l10n/messageIds';
-import MoveViewDialog from '../MoveViewDialog';
+import BrowserList, {
+  GridColDef,
+  GridSortModel,
+  ViewBrowserRow,
+} from 'features/views/components/ViewBrowser/BrowserList';
+import BrowserEllipsisMenu from 'features/views/components/ViewBrowser/BrowserEllipsisMenu';
+import useViewBrowserMutations from 'features/views/hooks/useViewBrowserMutations';
+import MoveViewDialog from 'features/views/components/MoveViewDialog';
+import BrowserDragLayer from 'features/views/components/ViewBrowser/BrowserDragLayer';
 
 interface ViewBrowserProps {
-  autoHeight?: boolean; // @deprecated
   basePath: string;
   enableDragAndDrop?: boolean;
   enableEllipsisMenu?: boolean;
   folderId?: number | null;
+  header?: ReactNode;
   onSelect?: (item: ViewBrowserItem, ev: MouseEvent) => void;
 }
 
-const TYPE_SORT_ORDER = ['back', 'folder', 'view'];
+const TYPE_SORT_ORDER = ['loading', 'back', 'folder', 'view'];
 
 function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
   const index0 = TYPE_SORT_ORDER.indexOf(v0.type);
@@ -48,12 +41,12 @@ function typeComparator(v0: ViewBrowserItem, v1: ViewBrowserItem): number {
 }
 
 const ViewBrowser: FC<ViewBrowserProps> = ({
-  autoHeight = true,
   basePath,
   enableDragAndDrop = true,
   enableEllipsisMenu = true,
   folderId = null,
   onSelect,
+  header,
 }) => {
   const { orgId } = useNumericRouteParams();
 
@@ -61,247 +54,229 @@ const ViewBrowser: FC<ViewBrowserProps> = ({
   const [sortModel, setSortModel] = useState<GridSortModel>([
     { field: 'title', sort: 'asc' },
   ]);
-  const { showConfirmDialog } = useContext(ZUIConfirmDialogContext);
   const isMobile = useMediaQuery((theme: Theme) =>
     theme.breakpoints.down('sm')
   );
-  const gridApiRef = useGridApiRef();
 
-  const { deleteView, duplicateView } = useViewMutations(orgId);
-  const { renameItem } = useViewBrowserMutations(orgId);
   const itemsFuture = useViewBrowserItems(orgId, folderId);
-  const { deleteFolder, recentlyCreatedFolder } = useFolder(orgId);
 
   const [itemToBeMoved, setItemToBeMoved] = useState<ViewBrowserItem | null>(
     null
   );
 
-  // If a folder was created, go into rename state
-  useEffect(() => {
-    if (gridApiRef.current && recentlyCreatedFolder) {
-      gridApiRef.current.startCellEditMode({
-        field: 'title',
-        id: 'folders/' + recentlyCreatedFolder.id,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recentlyCreatedFolder]);
+  const { renameItem } = useViewBrowserMutations(orgId);
 
-  const colDefs: GridColDef<ViewBrowserItem>[] = [
-    {
-      disableColumnMenu: true,
-      field: 'icon',
-      filterable: false,
-      headerName: '',
-      renderCell: (params) => {
-        const item = params.row;
-        const subPath = item.folderId ? 'folders/' + item.folderId : '';
-        if (item.type == 'back') {
-          return (
-            <NextLink href={`${basePath}/${subPath}`} legacyBehavior passHref>
-              <Link color="inherit" onClick={(ev) => onSelect?.(item, ev)}>
-                <BrowserItemIcon item={params.row} />
-              </Link>
-            </NextLink>
-          );
-        } else {
-          return (
-            <NextLink href={`${basePath}/${item.id}`} legacyBehavior passHref>
-              <Link color="inherit" onClick={(ev) => onSelect?.(item, ev)}>
-                <BrowserDraggableItem item={params.row}>
-                  <BrowserItemIcon item={params.row} />
-                </BrowserDraggableItem>
-              </Link>
-            </NextLink>
-          );
-        }
-      },
-      sortable: false,
-      width: 40,
-    },
-    {
-      disableColumnMenu: true,
-      editable: true,
-      field: 'title',
-      flex: 2,
-      headerName: messages.viewsList.columns.title(),
-      renderCell: (params) => {
-        const item = params.row;
-        return (
-          <BrowserItem
-            basePath={basePath}
-            item={params.row}
-            onClick={(ev) => {
-              onSelect?.(item, ev);
-            }}
-          />
-        );
-      },
-    },
-  ];
+  const [itemToBeRenamed, setItemToBeRenamed] =
+    useState<ViewBrowserItem | null>(null);
 
-  if (!isMobile) {
-    colDefs.push({
-      disableColumnMenu: true,
-      field: 'owner',
-      flex: 1,
-      headerName: messages.viewsList.columns.owner(),
-      renderCell: (params) => {
-        if (params.row.type == 'view') {
-          const owner = params.row.data.owner;
-          return (
-            <ZUIPersonHoverCard personId={owner.id}>
-              <ZUIPerson id={owner.id} name={owner.name} />
-            </ZUIPersonHoverCard>
-          );
-        } else {
-          return '';
-        }
-      },
-    });
-
-    if (enableEllipsisMenu) {
-      colDefs.push({
-        field: 'menu',
+  const colDefs: GridColDef[] = useMemo(() => {
+    const colDefs: GridColDef[] = [
+      {
+        field: 'icon',
         headerName: '',
         renderCell: (params) => {
           const item = params.row;
-          if (item.type == 'back') {
-            return null;
+
+          if (item.type === 'loading') {
+            return '';
           }
+
+          const subPath = item.folderId ? 'folders/' + item.folderId : '';
+          if (item.type == 'back') {
+            return (
+              <NextLink href={`${basePath}/${subPath}`} legacyBehavior passHref>
+                <Link
+                  color="inherit"
+                  onClick={(ev) => onSelect?.(item, ev)}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <BrowserItemIcon item={params.row} />
+                </Link>
+              </NextLink>
+            );
+          } else {
+            return (
+              <NextLink href={`${basePath}/${item.id}`} legacyBehavior passHref>
+                <Link
+                  color="inherit"
+                  onClick={(ev) => onSelect?.(item, ev)}
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <BrowserDraggableItem item={params.row}>
+                    <BrowserItemIcon item={params.row} />
+                  </BrowserDraggableItem>
+                </Link>
+              </NextLink>
+            );
+          }
+        },
+        sortable: false,
+        width: 40,
+      },
+      {
+        field: 'title',
+        flex: 2,
+        headerName: messages.viewsList.columns.title(),
+        renderCell: (params) => {
+          const item = params.row;
           return (
-            <ZUIEllipsisMenu
-              items={[
-                {
-                  label: messages.browser.menu.rename(),
-                  onSelect: (e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    gridApiRef.current.startCellEditMode({
-                      field: 'title',
-                      id: params.row.id,
-                    });
-                  },
-                },
-                {
-                  id: 'delete-item',
-                  label: messages.browser.menu.delete(),
-                  onSelect: (e) => {
-                    e.stopPropagation();
-                    showConfirmDialog({
-                      onSubmit: () => {
-                        if (item.type == 'folder') {
-                          deleteFolder(item.data.id);
-                        } else if (params.row.type == 'view') {
-                          deleteView(item.data.id);
-                        }
-                      },
-                      title: messages.browser.confirmDelete[item.type].title(),
-                      warningText:
-                        messages.browser.confirmDelete[item.type].warning(),
-                    });
-                  },
-                },
-                {
-                  id: 'move-item',
-                  label: messages.browser.menu.move(),
-                  onSelect: (e) => {
-                    e.stopPropagation();
-                    setItemToBeMoved(item);
-                  },
-                },
-                {
-                  disabled: item.type != 'view',
-                  id: 'duplicate-item',
-                  label: messages.browser.menu.duplicate(),
-                  onSelect: (e) => {
-                    e.stopPropagation();
-                    duplicateView(
-                      item.data.id,
-                      item.folderId,
-                      messages.browser.menu.viewCopy({ viewName: item.title })
-                    );
-                  },
-                },
-              ]}
-              keepMounted={false}
+            <BrowserItem
+              basePath={basePath}
+              item={params.row}
+              onClick={(ev) => {
+                onSelect?.(item, ev);
+              }}
+              onRenamed={(item, title, canceled) => {
+                if (
+                  !canceled &&
+                  (item.type === 'folder' || item.type === 'view')
+                ) {
+                  renameItem(item.type, item.data.id, title);
+                }
+                setItemToBeRenamed(null);
+              }}
+              renaming={params.renaming}
             />
           );
         },
-        width: 40,
+        sortable: true,
+      },
+    ];
+
+    if (!isMobile) {
+      colDefs.push({
+        field: 'owner',
+        flex: 1,
+        headerName: messages.viewsList.columns.owner(),
+        renderCell: (params) => {
+          if (params.row.type == 'view') {
+            const owner = params.row.data.owner;
+            return (
+              <ZUIPersonHoverCard personId={owner.id}>
+                <ZUIPerson id={owner.id} name={owner.name} />
+              </ZUIPersonHoverCard>
+            );
+          } else {
+            return '';
+          }
+        },
+        sortable: true,
+      });
+
+      if (enableEllipsisMenu) {
+        colDefs.push({
+          field: 'menu',
+          headerName: '',
+          renderCell: (params) => {
+            const item = params.row;
+            if (item.type == 'back' || item.type === 'loading') {
+              return null;
+            }
+            return (
+              <BrowserEllipsisMenu
+                item={item}
+                orgId={orgId}
+                setItemToBeMoved={setItemToBeMoved}
+                setItemToBeRenamed={setItemToBeRenamed}
+              />
+            );
+          },
+          width: 40,
+        });
+      }
+    }
+
+    return colDefs;
+  }, [
+    basePath,
+    enableEllipsisMenu,
+    isMobile,
+    messages.viewsList.columns,
+    onSelect,
+    orgId,
+    renameItem,
+  ]);
+
+  const items = useMemo(() => {
+    if (itemsFuture.isLoading) {
+      return Array.from<ViewBrowserItem>({ length: 40 }).fill({
+        type: 'loading',
       });
     }
-  }
+
+    if (!itemsFuture.data) {
+      return [];
+    }
+
+    return itemsFuture.data.sort((item0, item1) => {
+      const typeSort = typeComparator(item0, item1);
+      if (typeSort != 0) {
+        return typeSort;
+      }
+
+      if (
+        (item0.type === 'view' || item0.type === 'folder') &&
+        (item1.type === 'view' || item1.type === 'folder')
+      ) {
+        for (const column of sortModel) {
+          let sort = 0;
+          if (column.field == 'title') {
+            sort = item0.title.localeCompare(item1.title);
+          } else if (column.field == 'owner') {
+            sort = item0.owner.localeCompare(item1.owner);
+          }
+
+          if (sort != 0) {
+            return column.sort == 'asc' ? sort : -sort;
+          }
+        }
+      }
+
+      return 0;
+    });
+  }, [itemsFuture.data, itemsFuture.isLoading, sortModel]);
+
+  const rows: ViewBrowserRow[] = useMemo(
+    () =>
+      items.map((item) => ({
+        item: item,
+        renaming:
+          item.type !== 'loading' &&
+          !!itemToBeRenamed &&
+          itemToBeRenamed.type !== 'loading' &&
+          item.id === itemToBeRenamed.id,
+      })),
+    [itemToBeRenamed, items]
+  );
 
   return (
-    <ZUIFuture future={itemsFuture}>
-      {(data) => {
-        const rows = data.sort((item0, item1) => {
-          const typeSort = typeComparator(item0, item1);
-          if (typeSort != 0) {
-            return typeSort;
-          }
+    <>
+      {enableDragAndDrop && <BrowserDragLayer />}
 
-          // If we get this far, none of the items will be of the "back"
-          // type, because there is only one 'back' and typeComparator()
-          // always returns non-zero when the two items are of different
-          // type. We still check for "back" here, because TypeScript
-          // doesn't understand the logic described above.
-          if (item0.type != 'back' && item1.type != 'back') {
-            for (const column of sortModel) {
-              let sort = 0;
-              if (column.field == 'title') {
-                sort = item0.title.localeCompare(item1.title);
-              } else if (column.field == 'owner') {
-                sort = item0.owner.localeCompare(item1.owner);
-              }
+      <BrowserList
+        cols={colDefs}
+        enableDragAndDrop={enableDragAndDrop}
+        header={header}
+        rows={rows}
+        setSortModel={setSortModel}
+        sortModel={sortModel}
+      />
 
-              if (sort != 0) {
-                return column.sort == 'asc' ? sort : -sort;
-              }
-            }
-          }
-
-          return 0;
-        });
-
-        return (
-          <>
-            {enableDragAndDrop && <BrowserDragLayer />}
-            <DataGridPro
-              apiRef={gridApiRef}
-              autoHeight={autoHeight}
-              columns={colDefs}
-              disableRowSelectionOnClick
-              hideFooter
-              isCellEditable={(params) => params.row.type != 'back'}
-              onSortModelChange={(model) => setSortModel(model)}
-              processRowUpdate={(item) => {
-                if (item.type != 'back') {
-                  renameItem(item.type, item.data.id, item.title);
-                }
-                return item;
-              }}
-              rows={rows}
-              slots={{
-                row: (props: GridRowProps) => {
-                  const item = props.row as ViewBrowserItem;
-                  return <BrowserRow item={item} rowProps={props} />;
-                },
-              }}
-              sortingMode="server"
-              sx={{ borderWidth: 0 }}
-            />
-            {itemToBeMoved && (
-              <MoveViewDialog
-                close={() => setItemToBeMoved(null)}
-                itemToMove={itemToBeMoved}
-              />
-            )}
-          </>
-        );
-      }}
-    </ZUIFuture>
+      {itemToBeMoved && (
+        <MoveViewDialog
+          close={() => setItemToBeMoved(null)}
+          itemToMove={itemToBeMoved}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/features/views/hooks/useViewBrowserItems.ts
+++ b/src/features/views/hooks/useViewBrowserItems.ts
@@ -2,6 +2,10 @@ import useViewTree from './useViewTree';
 import { FutureBase, IFuture, ResolvedFuture } from 'core/caching/futures';
 import { ZetkinView, ZetkinViewFolder } from '../components/types';
 
+export interface ViewBrowserLoadingItem {
+  type: 'loading';
+}
+
 export interface ViewBrowserFolderItem {
   id: number | string;
   type: 'folder';
@@ -28,6 +32,7 @@ export type ViewBrowserBackItem = {
 };
 
 export type ViewBrowserItem =
+  | ViewBrowserLoadingItem
   | ViewBrowserFolderItem
   | ViewBrowserViewItem
   | ViewBrowserBackItem;

--- a/src/features/views/layout/FolderLayout.tsx
+++ b/src/features/views/layout/FolderLayout.tsx
@@ -1,5 +1,7 @@
+import { PropsWithChildren } from 'react';
+
 import PeopleActionButton from '../components/PeopleActionButton';
-import SimpleLayout from 'utils/layout/SimpleLayout';
+import { SimpleLayoutHeader } from 'utils/layout/SimpleLayout';
 import useFolder from '../hooks/useFolder';
 import useItemSummary from '../hooks/useItemSummary';
 import { useNumericRouteParams } from 'core/hooks';
@@ -7,13 +9,14 @@ import useViewBrowserMutations from '../hooks/useViewBrowserMutations';
 import ViewFolderSubtitle from '../components/ViewFolderSubtitle';
 import ZUIEditTextinPlace from 'zui/ZUIEditTextInPlace';
 import ZUIFuture from 'zui/ZUIFuture';
+import DefaultLayout from 'utils/layout/DefaultLayout';
 
 interface FolderLayoutProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   folderId: number;
 }
 
-const FolderLayout: React.FunctionComponent<FolderLayoutProps> = ({
+export const FolderHeader: React.FunctionComponent<FolderLayoutProps> = ({
   children,
   folderId,
 }) => {
@@ -24,24 +27,22 @@ const FolderLayout: React.FunctionComponent<FolderLayoutProps> = ({
   const { renameItem } = useViewBrowserMutations(orgId);
 
   return (
-    <ZUIFuture future={folderFuture}>
-      {(data) => (
-        <SimpleLayout
-          actionButtons={
-            <PeopleActionButton folderId={folderId} orgId={orgId} />
-          }
-          noPad
-          subtitle={
-            <ZUIFuture future={itemSummaryFuture}>
-              {(data) => (
-                <ViewFolderSubtitle
-                  numFolders={data.folders}
-                  numViews={data.views}
-                />
-              )}
-            </ZUIFuture>
-          }
-          title={
+    <SimpleLayoutHeader
+      actionButtons={<PeopleActionButton folderId={folderId} orgId={orgId} />}
+      noPad
+      subtitle={
+        <ZUIFuture future={itemSummaryFuture}>
+          {(data) => (
+            <ViewFolderSubtitle
+              numFolders={data.folders}
+              numViews={data.views}
+            />
+          )}
+        </ZUIFuture>
+      }
+      title={
+        <ZUIFuture future={folderFuture}>
+          {(data) => (
             <ZUIEditTextinPlace
               key={data.id}
               onChange={(newTitle) => {
@@ -49,13 +50,19 @@ const FolderLayout: React.FunctionComponent<FolderLayoutProps> = ({
               }}
               value={data.title}
             />
-          }
-        >
-          {children}
-        </SimpleLayout>
-      )}
-    </ZUIFuture>
+          )}
+        </ZUIFuture>
+      }
+    >
+      {children}
+    </SimpleLayoutHeader>
   );
+};
+
+const FolderLayout: React.FunctionComponent<PropsWithChildren> = ({
+  children,
+}) => {
+  return <DefaultLayout>{children}</DefaultLayout>;
 };
 
 export default FolderLayout;

--- a/src/features/views/layout/PeopleLayout.tsx
+++ b/src/features/views/layout/PeopleLayout.tsx
@@ -1,19 +1,23 @@
+import { PropsWithChildren } from 'react';
+
 import PeopleActionButton from '../components/PeopleActionButton';
 import { useMessages } from 'core/i18n';
 import useServerSide from 'core/useServerSide';
 import ViewFolderSubtitle from '../components/ViewFolderSubtitle';
 import ZUIFuture from 'zui/ZUIFuture';
 import messageIds from '../l10n/messageIds';
-import TabbedLayout from 'utils/layout/TabbedLayout';
+import { TabbedLayoutHeader } from 'utils/layout/TabbedLayout';
 import useItemSummary from '../hooks/useItemSummary';
 import useJoinSubmissions from 'features/joinForms/hooks/useJoinSubmissions';
 import { useNumericRouteParams } from 'core/hooks';
+import DefaultLayout from 'utils/layout/DefaultLayout';
 
 interface PeopleLayoutProps {
   children: React.ReactNode;
+  hideHeader?: boolean;
 }
 
-const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
+export const PeopleHeader: React.FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
   const { orgId } = useNumericRouteParams();
@@ -25,13 +29,8 @@ const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
     (submission) => submission.state === 'pending'
   );
 
-  const onServer = useServerSide();
-  if (onServer) {
-    return null;
-  }
-
   return (
-    <TabbedLayout
+    <TabbedLayoutHeader
       actionButtons={<PeopleActionButton folderId={null} orgId={orgId} />}
       baseHref={`/organize/${orgId}/people`}
       defaultTab="/"
@@ -65,7 +64,25 @@ const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
       title={messages.browserLayout.title()}
     >
       {children}
-    </TabbedLayout>
+    </TabbedLayoutHeader>
+  );
+};
+
+const PeopleLayout: React.FunctionComponent<PeopleLayoutProps> = ({
+  children,
+  hideHeader,
+}) => {
+  const messages = useMessages(messageIds);
+
+  const onServer = useServerSide();
+  if (onServer) {
+    return null;
+  }
+
+  return (
+    <DefaultLayout title={messages.browserLayout.title()}>
+      {hideHeader ? children : <PeopleHeader>{children}</PeopleHeader>}
+    </DefaultLayout>
   );
 };
 

--- a/src/pages/organize/[orgId]/people/folders/[folderId].tsx
+++ b/src/pages/organize/[orgId]/people/folders/[folderId].tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 
 import BackendApiClient from 'core/api/client/BackendApiClient';
-import FolderLayout from 'features/views/layout/FolderLayout';
+import FolderLayout, { FolderHeader } from 'features/views/layout/FolderLayout';
 import { PageWithLayout } from 'utils/types';
 import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
@@ -57,15 +57,14 @@ const PeopleViewsPage: PageWithLayout<PeopleViewsPageProps> = ({
       <ViewBrowser
         basePath={`/organize/${orgId}/people`}
         folderId={parseInt(folderId)}
+        header={<FolderHeader folderId={+folderId} />}
       />
     </>
   );
 };
 
-PeopleViewsPage.getLayout = function getLayout(page, props) {
-  return (
-    <FolderLayout folderId={parseInt(props.folderId)}>{page}</FolderLayout>
-  );
+PeopleViewsPage.getLayout = function getLayout(page) {
+  return <FolderLayout>{page}</FolderLayout>;
 };
 
 export default PeopleViewsPage;

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import messageIds from 'features/views/l10n/messageIds';
 import { PageWithLayout } from 'utils/types';
-import PeopleLayout from 'features/views/layout/PeopleLayout';
+import PeopleLayout, { PeopleHeader } from 'features/views/layout/PeopleLayout';
 import { scaffold } from 'utils/next';
 import { useMessages } from 'core/i18n';
 import useServerSide from 'core/useServerSide';
@@ -50,13 +50,16 @@ const PeopleViewsPage: PageWithLayout<PeopleViewsPageProps> = ({ orgId }) => {
       <Head>
         <title>{messages.browserLayout.title()}</title>
       </Head>
-      <ViewBrowser basePath={`/organize/${orgId}/people`} />
+      <ViewBrowser
+        basePath={`/organize/${orgId}/people`}
+        header={<PeopleHeader />}
+      />
     </>
   );
 };
 
 PeopleViewsPage.getLayout = function getLayout(page) {
-  return <PeopleLayout>{page}</PeopleLayout>;
+  return <PeopleLayout hideHeader={true}>{page}</PeopleLayout>;
 };
 
 export default PeopleViewsPage;

--- a/src/utils/layout/SimpleLayout.tsx
+++ b/src/utils/layout/SimpleLayout.tsx
@@ -18,7 +18,7 @@ interface SimpleLayoutProps {
   noPad?: boolean;
 }
 
-const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
+export const SimpleLayoutHeader: FunctionComponent<SimpleLayoutProps> = ({
   actionButtons,
   avatar,
   belowActionButtons,
@@ -36,23 +36,23 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
     : undefined;
 
   return (
-    <DefaultLayout title={title}>
-      <Box
-        display={fixedHeight ? 'flex' : 'block'}
-        flexDirection="column"
-        height={fixedHeight ? 1 : 'auto'}
-      >
-        <Header
-          actionButtons={actionButtons}
-          avatar={avatar}
-          belowActionButtons={belowActionButtons}
-          collapsed={collapsed}
-          ellipsisMenuItems={ellipsisMenuItems}
-          onToggleCollapsed={onToggleCollapsed}
-          subtitle={subtitle}
-          title={title}
-        />
-        {/* Page Content */}
+    <Box
+      display={fixedHeight ? 'flex' : 'block'}
+      flexDirection="column"
+      height={fixedHeight ? 1 : 'auto'}
+    >
+      <Header
+        actionButtons={actionButtons}
+        avatar={avatar}
+        belowActionButtons={belowActionButtons}
+        collapsed={collapsed}
+        ellipsisMenuItems={ellipsisMenuItems}
+        onToggleCollapsed={onToggleCollapsed}
+        subtitle={subtitle}
+        title={title}
+      />
+      {/* Page Content */}
+      {children && (
         <Box
           component="main"
           flexGrow={1}
@@ -66,7 +66,15 @@ const SimpleLayout: FunctionComponent<SimpleLayoutProps> = ({
         >
           <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
         </Box>
-      </Box>
+      )}
+    </Box>
+  );
+};
+
+const SimpleLayout: FunctionComponent<SimpleLayoutProps> = (props) => {
+  return (
+    <DefaultLayout title={props.title}>
+      <SimpleLayoutHeader {...props} />
     </DefaultLayout>
   );
 };

--- a/src/utils/layout/TabbedLayout.tsx
+++ b/src/utils/layout/TabbedLayout.tsx
@@ -40,7 +40,7 @@ interface TabbedLayoutProps {
   onClickAlertBtn?: () => void;
 }
 
-const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
+export const TabbedLayoutHeader: FunctionComponent<TabbedLayoutProps> = ({
   actionButtons,
   alertBtnMsg,
   alertMsg,
@@ -89,7 +89,7 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
   }));
 
   return (
-    <DefaultLayout title={title}>
+    <>
       {alertMsg && (
         <Alert
           action={
@@ -162,21 +162,31 @@ const TabbedLayout: FunctionComponent<TabbedLayoutProps> = ({
           </Tabs>
         </Collapse>
         {/* Page Content */}
-        <Box
-          component="main"
-          flexGrow={1}
-          minHeight={0}
-          p={fixedHeight ? 0 : 3}
-          position="relative"
-          role="tabpanel"
-          sx={{
-            overflow: 'hidden',
-            padding: noPad ? 0 : undefined,
-          }}
-        >
-          <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
-        </Box>
+        {children && (
+          <Box
+            component="main"
+            flexGrow={1}
+            minHeight={0}
+            p={fixedHeight ? 0 : 3}
+            position="relative"
+            role="tabpanel"
+            sx={{
+              overflow: 'hidden',
+              padding: noPad ? 0 : undefined,
+            }}
+          >
+            <PaneProvider fixedHeight={!!fixedHeight}>{children}</PaneProvider>
+          </Box>
+        )}
       </Box>
+    </>
+  );
+};
+
+const TabbedLayout: FunctionComponent<TabbedLayoutProps> = (props) => {
+  return (
+    <DefaultLayout title={props.title}>
+      <TabbedLayoutHeader {...props} />
     </DefaultLayout>
   );
 };

--- a/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
+++ b/src/zui/ZUIBulkPersonSelect/BrowserStep.tsx
@@ -29,7 +29,6 @@ const BrowserStep: FC<Props> = ({
       }}
     >
       <ViewBrowser
-        autoHeight={false}
         basePath=""
         enableDragAndDrop={false}
         enableEllipsisMenu={false}


### PR DESCRIPTION
## Description

This PR moves the view browser from a MUI Data Grid to react-window. This enables us to move the header into the virtualization context, making it possible to have a virtualized list and a header that scrolls out of the window. This improves performance on these operations:
- Sorting
- Loading the page / view browser contents
- Navigating to another page
- Opening / closing sidebar
- Updating elements in the list
- Resizing window

The only downside of this is that ctrl+f doesn't work anymore, which I know organizers use. This PR does not include an alternative method of searching the list. I recommend that we add a search bar next. I think it doesn't make sense to add a search bar first, because searching will be incredibly slow in the current non-virtualized view browser. 

Also, I'm not sure how it would interact with screen reader navigation. 

## Screenshots
[Add screenshots here]

<img width="1910" height="942" alt="view-browser" src="https://github.com/user-attachments/assets/37c82e8a-852b-41f6-9fa8-855622c3c2a3" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Refactors view browser to use react-window
- Moves page header of people and folder pages into the react-window context by splitting the header definition from the layout definition
- Adds list loading indicators to view browser pages

## AI usage

Did you use AI to create the code in this PR?

Nope

## Instructions for reviewer

- Go to /organize/1/people/
- Do all of these actions:
  - Create folder and list
  - Move folder and list
  - Navigate between folders and lists
  - Rename a folder and a list
  - Delete a folder and a list
  - Duplicate a list
  - Change sorting
  - Open/close sidebar
- Go to a call assignment caller page like /organize/1/projects/269/callassignments/209/callers
- Click into "Start typing..."
- Bulk add
- Make sure it works
- Go to some other pages to ensure the header/layout split didn't break anything unexpected

## Related issues

Follow up from https://github.com/zetkin/app.zetkin.org/pull/3196
Resolves https://github.com/zetkin/app.zetkin.org/issues/1553

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
