### PR TITLE
Fix small type errors on main

### DIFF
--- a/src/app/o/[orgId]/viewmail/[emailId]/page.tsx
+++ b/src/app/o/[orgId]/viewmail/[emailId]/page.tsx
@@ -32,7 +32,7 @@ export default async function Page({ params }: PageProps) {
       `/api/orgs/${orgId}/emails/${emailId}`
     );
 
-    const emailHtml = renderEmailHtml(email, {
+    const emailHtml = await renderEmailHtml(email, {
       'target.first_name': messages.varDefaults.target(),
       'target.full_name': messages.varDefaults.target(),
       'target.last_name': messages.varDefaults.target(),

--- a/src/features/emails/utils/rendering/previewEmailThemeHtml.ts
+++ b/src/features/emails/utils/rendering/previewEmailThemeHtml.ts
@@ -15,7 +15,7 @@ export default async function previewEmailThemeHtml(
     return '';
   }
 
-  const output = mjml2html(mjml);
+  const output = await mjml2html(mjml);
 
   return output.html;
 }

--- a/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.spec.ts
@@ -94,8 +94,8 @@ describe('renderEmailHtml', () => {
       'target.first_name': 'friend',
     });
 
-    // The expected output is HTML as returned by MJML
-    const expected = mjml2html({
+    // HTML as returned by MJML
+    const parseResults = await mjml2html({
       tagName: 'mjml',
       attributes: {},
       children: [
@@ -144,9 +144,9 @@ describe('renderEmailHtml', () => {
           ],
         },
       ],
-    }).html;
+    });
 
-    expect(output).toEqual(expected);
+    expect(output).toEqual(parseResults.html);
   });
 
   it('returns MJML-rendered HTML for email with frame', async () => {
@@ -236,7 +236,7 @@ describe('renderEmailHtml', () => {
     const output = renderEmailHtml(email, {});
 
     // The expected output is HTML as returned by MJML
-    const expected = mjml2html({
+    const parseResults = await mjml2html({
       tagName: 'mjml',
       attributes: {},
       children: [
@@ -306,9 +306,9 @@ describe('renderEmailHtml', () => {
           ],
         },
       ],
-    }).html;
+    });
 
-    expect(output).toEqual(expected);
+    expect(output).toEqual(parseResults.html);
   });
 
   it('sanitizes user inputs', async () => {

--- a/src/features/emails/utils/rendering/renderEmailHtml.ts
+++ b/src/features/emails/utils/rendering/renderEmailHtml.ts
@@ -5,10 +5,10 @@ import EmailMJMLConverter from './EmailMJMLConverter';
 import { ZetkinEmail } from 'utils/types/zetkin';
 import { EmailContent, InlineNodeKind } from 'features/emails/types';
 
-export default function renderEmailHtml(
+export default async function renderEmailHtml(
   email: ZetkinEmail,
   variableValues: Record<string, string>
-): string {
+) {
   const { theme, content } = email;
 
   if (!content) {
@@ -38,7 +38,7 @@ export default function renderEmailHtml(
     return '';
   }
 
-  const output = mjml2html(mjml);
+  const output = await mjml2html(mjml);
 
   return output.html;
 }

--- a/src/features/joinForms/components/JoinFormSelect.tsx
+++ b/src/features/joinForms/components/JoinFormSelect.tsx
@@ -26,12 +26,12 @@ const JoinFormSelect: FC<Props> = ({
       <Select
         label={messages.forms()}
         onChange={(ev) => {
-          const value = ev.target.value;
-          setValue(value);
-          if (value === 'all') {
+          const val = ev.target.value;
+          setValue(val);
+          if (val === 'all') {
             onFormSelect(undefined);
           } else {
-            onFormSelect(forms.find((f) => f.id === value));
+            onFormSelect(forms.find((f) => f.id === val));
           }
         }}
         value={value}

--- a/src/features/joinForms/components/JoinFormSelect.tsx
+++ b/src/features/joinForms/components/JoinFormSelect.tsx
@@ -26,11 +26,12 @@ const JoinFormSelect: FC<Props> = ({
       <Select
         label={messages.forms()}
         onChange={(ev) => {
-          setValue(ev.target.value);
-          if (ev.target.value === 'all') {
+          const value = ev.target.value;
+          setValue(value);
+          if (value === 'all') {
             onFormSelect(undefined);
           } else {
-            onFormSelect(forms.find((f) => f.id === ev.target.value)!);
+            onFormSelect(forms.find((f) => f.id === value));
           }
         }}
         value={value}

--- a/src/features/joinForms/components/JoinFormSelect.tsx
+++ b/src/features/joinForms/components/JoinFormSelect.tsx
@@ -28,7 +28,7 @@ const JoinFormSelect: FC<Props> = ({
       <Select
         label={messages.forms()}
         onChange={(ev) => {
-          const val = ev.target.value;
+          const val = ev.target.value as 'all' | number;
           setSelectValue(val);
           if (val === 'all') {
             onFormSelect(undefined);

--- a/src/features/joinForms/components/JoinFormSelect.tsx
+++ b/src/features/joinForms/components/JoinFormSelect.tsx
@@ -17,7 +17,9 @@ const JoinFormSelect: FC<Props> = ({
   forms = [],
   onFormSelect = () => {},
 }) => {
-  const [value, setValue] = useState<number | 'all'>(formId || 'all');
+  const [selectValue, setSelectValue] = useState<number | 'all'>(
+    formId || 'all'
+  );
   const messages = useMessages(messageIds);
 
   return (
@@ -27,14 +29,14 @@ const JoinFormSelect: FC<Props> = ({
         label={messages.forms()}
         onChange={(ev) => {
           const val = ev.target.value;
-          setValue(val);
+          setSelectValue(val);
           if (val === 'all') {
             onFormSelect(undefined);
           } else {
             onFormSelect(forms.find((f) => f.id === val));
           }
         }}
-        value={value}
+        value={selectValue}
       >
         <MenuItem selected={!formId} value="all">
           {messages.submissionPane.allForms()}

--- a/src/features/joinForms/components/JoinFormSelect.tsx
+++ b/src/features/joinForms/components/JoinFormSelect.tsx
@@ -1,11 +1,5 @@
-import { FC } from 'react';
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
-} from '@mui/material';
+import { FC, useState } from 'react';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 import { useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
@@ -23,20 +17,24 @@ const JoinFormSelect: FC<Props> = ({
   forms = [],
   onFormSelect = () => {},
 }) => {
+  const [value, setValue] = useState<number | 'all'>(formId || 'all');
   const messages = useMessages(messageIds);
-
-  const onChange = (event: SelectChangeEvent<number>) => {
-    if (event.target.value === 'all') {
-      onFormSelect(undefined);
-    } else {
-      onFormSelect(forms.find((f) => f.id === event.target.value)!);
-    }
-  };
 
   return (
     <FormControl sx={{ minWidth: 200 }}>
       <InputLabel>{messages.forms()}</InputLabel>
-      <Select label={messages.forms()} onChange={onChange} value={formId}>
+      <Select
+        label={messages.forms()}
+        onChange={(ev) => {
+          setValue(ev.target.value);
+          if (ev.target.value === 'all') {
+            onFormSelect(undefined);
+          } else {
+            onFormSelect(forms.find((f) => f.id === ev.target.value)!);
+          }
+        }}
+        value={value}
+      >
         <MenuItem selected={!formId} value="all">
           {messages.submissionPane.allForms()}
         </MenuItem>


### PR DESCRIPTION
## Description

This PR fixes a few minor type errors that appeared after i merged main this afternoon. I don't know why but I guess it might be because CI ran on "old" linting rules before some things were merged? 

## Screenshots
nothing visual

## Changes
- Adds missing `await` in 4 places
- Changes the value of an input that was incorrectly typed.

## AI usage

Did you use AI to create the code in this PR? nope

## Instructions for reviewer
If the tests pass, it should be working

## Related issues
none

## PR checklist
- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
