### PR TITLE
fix: implement create person in list search

### DIFF
--- a/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/LocalPersonColumnType.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
   GridColDef,
@@ -13,6 +13,7 @@ import useAccessLevel from 'features/views/hooks/useAccessLevel';
 import useViewGrid from 'features/views/hooks/useViewGrid';
 import ZUIPersonGridCell from 'zui/ZUIPersonGridCell';
 import ZUIPersonGridEditCell from 'zui/ZUIPersonGridEditCell';
+import ZUICreatePerson from 'zui/ZUICreatePerson';
 import {
   COLUMN_TYPE,
   LocalPersonViewColumn,
@@ -88,6 +89,7 @@ const EditCell: FC<{
   column: LocalPersonViewColumn;
   row: ZetkinViewRow;
 }> = ({ cell, column, row }) => {
+  const [createPersonOpen, setCreatePersonOpen] = useState<boolean>(false);
   const api = useGridApiContext();
   const { orgId, viewId } = useRouter().query;
 
@@ -108,10 +110,26 @@ const EditCell: FC<{
     setCellValue(row.id, column.id, person?.id ?? null);
   };
 
+  if (createPersonOpen) {
+    return (
+      <ZUICreatePerson
+        onClose={() => setCreatePersonOpen(false)}
+        onSubmit={(_e, person) => {
+          if (!createPersonOpen) {
+            return;
+          }
+          updateCellValue(person);
+          setCreatePersonOpen(false);
+        }}
+        open={!!createPersonOpen}
+      />
+    );
+  }
+
   return (
     <ZUIPersonGridEditCell
       cell={cell}
-      onCreate={() => null}
+      onCreate={() => setCreatePersonOpen(true)}
       onUpdate={updateCellValue}
       removePersonLabel={messages.cells.localPerson.clearLabel()}
       restrictedMode={isRestrictedMode}


### PR DESCRIPTION
## Description

This PR implements the function for "Create Person" in the lists view, in the assignee column.

## Screenshots

https://github.com/user-attachments/assets/d417df53-c2e3-49c5-9040-c42fb14549eb

## Changes

- Added a function call to the Create Person button, which creates the person and passes it back to the cell update function for assignment.

## AI usage

No AI

## Instructions for reviewer

1. Go to https://app.dev.zetkin.org/organize/1/people/lists/2
2. Double click a cell in the column "Assignee"
3. Type some characters into the text box
4. In the box that show people that match the search for the text you typed in, at the bottom there is a button that says "Create"
5. Click the button
6. Fill in the dialog
7. Submit and verify the new person has been created and assigned

## Related issues

Resolves #3655 

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x ] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
