### PR TITLE
Add code convention documentation

### DIFF
--- a/docs/code-conventions/CODE_CONVENTIONS.md
+++ b/docs/code-conventions/CODE_CONVENTIONS.md
@@ -1,0 +1,37 @@
+# CODE CONVENTIONS
+
+This directory contains the project's agreed coding conventions. It serves as a practical reference for consistent, readable, and maintainable code across the codebase.
+
+## Contents
+
+### Current Rules
+
+- [`EQUALITY_OPERATOR.md`](./rules/EQUALITY_OPERATOR.md)
+- [`TEMPLATE.md`](./TEMPLATE.md) (for creating new rule files)
+
+### In This Document
+
+- [`Reasoning`](#reasoning)
+- [`Contribution`](#contribution)
+
+## Reasoning
+
+This documentation is a living source of truth for binding coding conventions. It provides a clear baseline for implementation decisions and review discussions.
+
+If you disagree with an existing rule or think a rule is missing, open a pull request, actively own the proposal, and follow the process in [`Contribution`](#contribution).
+
+This is work in progress and intentionally iterative. It does not claim to be complete at any stage.
+
+## Contribution
+
+Pull requests are welcome for new rules and changes to existing rules.
+
+- Open changes as **DRAFT PRs**.
+- The PR author owns the process end to end:
+  - Actively drive the discussion.
+  - Provide a clear description of the proposal.
+  - Address feedback and open concerns.
+  - Push the proposal to a clear decision.
+- Start code and linter implementation only after alignment is reached to avoid unnecessary work.
+- Convention updates, code changes, and linter updates must be delivered in the same PR.
+- The PR leaves **DRAFT** status only when the agreed convention is fully implemented in code and tooling in that same PR.

--- a/docs/code-conventions/TEMPLATE.md
+++ b/docs/code-conventions/TEMPLATE.md
@@ -1,0 +1,36 @@
+# RULE_NAME
+
+Only keep sections that add concrete value. Remove sections that are not needed for a specific rule.
+
+## Summary
+
+One short paragraph that explains the rule.
+
+## Rule
+
+- Use clear, testable statements ("must", "must not", "should").
+- Keep each bullet focused on one requirement.
+
+## Description
+
+Describe the rule in detail, including its intent and what it should achieve.
+
+## Do's
+
+```ts
+// Add an example that follows the rule
+```
+
+## Don'ts
+
+```ts
+// Add an example that violates the rule
+```
+
+## Exceptions
+
+List allowed exceptions (if any) and when they apply.
+
+## References
+
+- Related internal docs or external references.

--- a/docs/code-conventions/rules/EQUALITY_OPERATOR.md
+++ b/docs/code-conventions/rules/EQUALITY_OPERATOR.md
@@ -1,0 +1,95 @@
+# Equality Operator
+
+## Summary
+
+Use strict equality operators (`===` and `!==`) by default. They make comparisons explicit, avoid JavaScript type coercion, and reduce the risk of unexpected runtime behavior when values do not match their intended types.
+
+## Rule
+
+- Code must use `===` and `!==` by default.
+- Code must not use `==` or `!=` for general value comparisons.
+- Comparisons should match the actual intent of the check.
+- When checking for a missing or falsy value, code should use `!value` or `!!value` as appropriate.
+- When checking specifically for `null` and `undefined`, code should use an explicit nullish check instead of a general falsy check.
+- If optional chaining or nullish-aware access already expresses the null-safe intent, remove redundant explicit `null`/`undefined` guards instead of duplicating checks.
+- When checking for missing, empty, or whitespace-only strings, code should use an explicit string check instead of relying on equality operators alone.
+- When comparing values from external boundaries such as APIs, user input, query params, storage, or third-party libraries, code should prefer explicit narrowing or validation before branching on equality.
+
+## Description
+
+Strict equality should be the default because it compares values without implicit type coercion. This makes code easier to read, easier to review, and less likely to behave unexpectedly when runtime values differ from their declared types.
+
+In TypeScript, types help prevent many incorrect comparisons at compile time, but runtime mismatches can still occur at boundaries, through type assertions, or through third-party code. Using strict equality does not solve invalid runtime data, but it avoids adding JavaScript coercion on top of already-wrong inputs.
+
+The goal of this rule is not to ban every use of loose equality. The goal is to make comparisons intentional. If the intent is to check for one exact value, use strict equality. If the intent is to check for a missing or generally falsy value, use a falsy check. If the intent is to check specifically for `null` or `undefined`, make that nullish intent explicit.
+
+## Do's
+
+```ts
+if (status === 'open') {
+  handleOpen();
+}
+
+if (count !== 0) {
+  renderCount(count);
+}
+
+if (!email) {
+  openMissingEmailDialog();
+}
+
+if (!email?.trim()) {
+  openMissingEmailDialog();
+}
+
+if (value === null || value === undefined) {
+  handleMissingValue();
+}
+
+const page = Number(searchParams.get('page'));
+if (Number.isFinite(page) && page === 0) {
+  handleFirstPage();
+}
+```
+
+## Don'ts
+
+```ts
+if (status == 'open') {
+  handleOpen();
+}
+
+if (count != 0) {
+  renderCount(count);
+}
+
+if (email == null) {
+  openMissingEmailDialog();
+}
+
+if (email === undefined) {
+  // too narrow if the real intent is "missing or empty"
+  openMissingEmailDialog();
+}
+
+if (value == 0) {
+  // true for 0, "0", false, and ""
+  handleZero();
+}
+
+if (payload.value === 0) {
+  // avoid branching on unvalidated boundary data without narrowing first
+  handleZero();
+}
+```
+
+## Exceptions
+
+- Use explicit nullish checks such as `value === null || value === undefined` when the intent is specifically to distinguish `null`/`undefined` from other falsy values like `''`, `0`, or `false`.
+- Loose equality may be used in rare cases where coercion is explicitly intended and improves clarity, but this should be exceptional and easy to justify in review.
+
+## References
+
+- [ESLint: `eqeqeq` rule](https://eslint.org/docs/latest/rules/eqeqeq)
+- [TypeScript Handbook: Narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html)
+- [MDN: Equality comparisons and sameness](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Equality_comparisons_and_sameness)


### PR DESCRIPTION
## Description

This PR adds code convention documentation.

## Changes

- Adds
  - CODE_CONVENTION.md describing the purpose of the docs
  - TEMPLATE.md as a template for making new code rules docs
  - rules/EQUALITY_OPERATOR.md which describes a new rule about using strict equality operators

## AI usage

Nope!

## Instructions for reviewer
 
Read the docs 😉 

## Related issues

Replaces: #3461 

Will be making new PRs for starting on implementing new ES lint rules to match these conventions.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
