### PR TITLE
Add prefer-optional-chain ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,10 @@ module.exports = {
     {
       files: ['**/*.ts', '**/*.tsx', 'src/**/*.js'],
       parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: __dirname,
+      },
       env: {
         browser: true,
         node: true,
@@ -55,6 +59,7 @@ module.exports = {
             interfaces: ['signature', 'method', 'constructor', 'field'],
           },
         ],
+        '@typescript-eslint/prefer-optional-chain': 'error',
         curly: 'error',
         'import/order': [
           'error',

--- a/src/core/hooks/useRemoteList.ts
+++ b/src/core/hooks/useRemoteList.ts
@@ -24,7 +24,7 @@ export default function useRemoteList<
   const dispatch = useAppDispatch();
 
   const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteList);
-  const isLoaded = !remoteList || !remoteList?.loaded;
+  const isLoaded = !remoteList?.loaded;
 
   const promiseKey = hooks.cacheKey || hooks.loader.toString();
   const { cache, getExistingPromise } = usePromiseCache(promiseKey);

--- a/src/features/calendar/components/EventShiftModal/EventShiftTime.tsx
+++ b/src/features/calendar/components/EventShiftModal/EventShiftTime.tsx
@@ -240,7 +240,7 @@ const EventShiftTime: FC<EventShiftTimeProps> = ({
                   no: index + 1,
                 })}
                 onChange={(newShiftStart) => {
-                  if (newShiftStart && newShiftStart.isValid()) {
+                  if (newShiftStart?.isValid()) {
                     onEventShiftsChange([
                       ...eventShifts.slice(0, index),
                       dayjs(newShiftStart),

--- a/src/features/calendar/components/EventShiftModal/index.tsx
+++ b/src/features/calendar/components/EventShiftModal/index.tsx
@@ -154,7 +154,7 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
               eventTitle={eventTitle}
               locationId={locationId}
               onEventDateChange={(newDate) => {
-                if (newDate && newDate.isValid()) {
+                if (newDate?.isValid()) {
                   setInvalidDate(false);
                   setEventDate(newDate);
                 } else {
@@ -189,13 +189,13 @@ const EventShiftModal: FC<EventShiftModalProps> = ({ close, dates, open }) => {
               eventStartTime={eventStartTime}
               invalidShiftTimes={invalidShiftTimes}
               onEventEndTimeChange={(newEndTime) => {
-                if (newEndTime && newEndTime.isValid()) {
+                if (newEndTime?.isValid()) {
                   setEventEndTime(newEndTime);
                 }
               }}
               onEventShiftsChange={(newShifts) => setEventShifts(newShifts)}
               onEventStartTimeChange={(newStartTime) => {
-                if (newStartTime && newStartTime.isValid()) {
+                if (newStartTime?.isValid()) {
                   setEventStartTime(newStartTime);
                 }
               }}

--- a/src/features/call/components/Report/reportSteps.tsx
+++ b/src/features/call/components/Report/reportSteps.tsx
@@ -355,7 +355,7 @@ export const reportSteps: ReportStep[] = [
     },
     name: 'wrongNumber',
     renderQuestion: (report, onReportUpdate, target) => {
-      if (target && target.alt_phone && target.phone) {
+      if (target?.alt_phone && target.phone) {
         return (
           <WrongNumber
             key="wrongNumber"

--- a/src/features/call/hooks/useCallInitialization.ts
+++ b/src/features/call/hooks/useCallInitialization.ts
@@ -50,7 +50,7 @@ export default function useCallInitialization() {
   const assignmentIdFromQuery = queryParams?.get('assignment');
 
   const lanesAssignedToUser =
-    callLanes && callLanes.version == CURRENT_CALL_LANES_VERSION
+    callLanes?.version == CURRENT_CALL_LANES_VERSION
       ? callLanes.lanes.filter((lane) =>
           userCallAssignments.some(
             (assignment) => assignment.id == lane.assignmentId
@@ -79,7 +79,7 @@ export default function useCallInitialization() {
   let canInitialize = false;
   if (assignmentIdFromQuery) {
     canInitialize = true;
-  } else if (callLanes && callLanes.version == CURRENT_CALL_LANES_VERSION) {
+  } else if (callLanes?.version == CURRENT_CALL_LANES_VERSION) {
     const thisUserHasSavedLanes =
       activeLanes.length > 0 && !!user && callLanes.userId == user.id;
 

--- a/src/features/duplicates/store.tsx
+++ b/src/features/duplicates/store.tsx
@@ -56,7 +56,7 @@ const potentialDuplicatesSlice = createSlice({
         (item) => item.id === potentialDuplicate.id
       );
 
-      if (item && item.data) {
+      if (item?.data) {
         item.data = potentialDuplicate;
       }
     },

--- a/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
+++ b/src/features/emails/components/EmailEditor/tools/InlineLink/index.tsx
@@ -58,7 +58,7 @@ export function linkToolFactory(title: string) {
 
     onToolClose(): void {
       //If the input is empty, remove anchor tag
-      if (this._input && this._input.value.length === 0) {
+      if (this._input?.value.length === 0) {
         if (this._selectedAnchor) {
           this._selectedAnchor.replaceWith(
             ...Array.from(this._selectedAnchor.childNodes)

--- a/src/features/events/components/EventPopper/EventPopperProvider.tsx
+++ b/src/features/events/components/EventPopper/EventPopperProvider.tsx
@@ -52,7 +52,7 @@ export const EventPopperProvider: FC<EventPopperPropviderProps> = ({
         },
       }}
     >
-      {cluster && cluster.kind === CLUSTER_TYPE.SINGLE && (
+      {cluster?.kind === CLUSTER_TYPE.SINGLE && (
         <SingleEventPopper
           anchorPosition={singleAnchorPosition}
           event={cluster.events[0]}

--- a/src/features/events/components/EventTypeAutocomplete.tsx
+++ b/src/features/events/components/EventTypeAutocomplete.tsx
@@ -215,7 +215,7 @@ const EventTypeAutocomplete: FC<EventTypeAutocompleteProps> = ({
                             deleteType(option.id);
                             //If the current event has the deleted event type,
                             //set the current event's type to null
-                            if (value && option.id == value.id) {
+                            if (option.id == value?.id) {
                               onChange(null);
                             }
                           }

--- a/src/features/events/components/EventURLCard.tsx
+++ b/src/features/events/components/EventURLCard.tsx
@@ -21,7 +21,7 @@ const EventURLCard = ({
   const messages = useMessages(messageIds);
   const eventUrl = useMemo(
     () =>
-      event != null && event.data
+      event?.data
         ? `${location.protocol}//${location.host}/o/${event.data.organization.id}/events/${eventId}`
         : '',
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/events/hooks/useEvent.ts
+++ b/src/features/events/hooks/useEvent.ts
@@ -14,7 +14,7 @@ export default function useEvent(
 
   const item = eventList.items.find((item) => item.id == id);
 
-  if (item && item.deleted) {
+  if (item?.deleted) {
     return null;
   }
 

--- a/src/features/files/components/FileLibraryDialog/index.tsx
+++ b/src/features/files/components/FileLibraryDialog/index.tsx
@@ -45,7 +45,7 @@ const FileLibraryDialog: FC<Props> = ({
           <FilePreview
             file={selectedFile}
             onBack={() => setSelectedFile(null)}
-            onSelect={() => onSelectFile && onSelectFile(selectedFile)}
+            onSelect={() => onSelectFile(selectedFile)}
           />
         )}
         {!selectedFile && (

--- a/src/features/import/components/ImportDialog/Configure/Configuration/EnumConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/EnumConfig.tsx
@@ -23,12 +23,17 @@ const EnumConfig: FC<EnumConfigProps> = ({ uiDataColumn }) => {
     uiDataColumn.columnIndex
   );
 
-  if (!fields?.length) {
+  if (!fields || fields.length === 0) {
     return null;
   }
   const field = fields.find(
     (field) => field.slug === uiDataColumn.originalColumn.field
   );
+
+  if (!field) {
+    return null;
+  }
+
   const options = field?.enum_choices;
   if (!options?.length) {
     return null;

--- a/src/features/import/components/ImportDialog/Configure/Configuration/EnumConfig.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/EnumConfig.tsx
@@ -23,14 +23,14 @@ const EnumConfig: FC<EnumConfigProps> = ({ uiDataColumn }) => {
     uiDataColumn.columnIndex
   );
 
-  if (!fields || !fields.length) {
+  if (!fields?.length) {
     return null;
   }
   const field = fields.find(
     (field) => field.slug === uiDataColumn.originalColumn.field
   );
   const options = field?.enum_choices;
-  if (!options || !options.length) {
+  if (!options?.length) {
     return null;
   }
 

--- a/src/features/import/components/ImportDialog/Configure/Configuration/index.tsx
+++ b/src/features/import/components/ImportDialog/Configure/Configuration/index.tsx
@@ -38,29 +38,24 @@ const Configuration: FC<ConfigurationProps> = ({
       flexDirection="column"
       height="100%"
     >
-      {uiDataColumn && uiDataColumn.originalColumn.kind == ColumnKind.TAG && (
+      {uiDataColumn?.originalColumn.kind == ColumnKind.TAG && (
         <TagConfig uiDataColumn={uiDataColumn as UIDataColumn<TagColumn>} />
       )}
-      {uiDataColumn &&
-        uiDataColumn.originalColumn.kind == ColumnKind.ID_FIELD && (
-          <IdConfig
-            uiDataColumn={uiDataColumn as UIDataColumn<IDFieldColumn>}
-          />
-        )}
-      {uiDataColumn &&
-        uiDataColumn.originalColumn.kind == ColumnKind.ORGANIZATION && (
-          <OrgConfig uiDataColumn={uiDataColumn as UIDataColumn<OrgColumn>} />
-        )}
-      {uiDataColumn &&
-        uiDataColumn.originalColumn.kind == ColumnKind.GENDER && (
-          <GenderConfig
-            uiDataColumn={uiDataColumn as UIDataColumn<GenderColumn>}
-          />
-        )}
-      {uiDataColumn && uiDataColumn.originalColumn.kind == ColumnKind.DATE && (
+      {uiDataColumn?.originalColumn.kind == ColumnKind.ID_FIELD && (
+        <IdConfig uiDataColumn={uiDataColumn as UIDataColumn<IDFieldColumn>} />
+      )}
+      {uiDataColumn?.originalColumn.kind == ColumnKind.ORGANIZATION && (
+        <OrgConfig uiDataColumn={uiDataColumn as UIDataColumn<OrgColumn>} />
+      )}
+      {uiDataColumn?.originalColumn.kind == ColumnKind.GENDER && (
+        <GenderConfig
+          uiDataColumn={uiDataColumn as UIDataColumn<GenderColumn>}
+        />
+      )}
+      {uiDataColumn?.originalColumn.kind == ColumnKind.DATE && (
         <DateConfig uiDataColumn={uiDataColumn as UIDataColumn<DateColumn>} />
       )}
-      {uiDataColumn && uiDataColumn.originalColumn.kind == ColumnKind.ENUM && (
+      {uiDataColumn?.originalColumn.kind == ColumnKind.ENUM && (
         <EnumConfig uiDataColumn={uiDataColumn as UIDataColumn<EnumColumn>} />
       )}
     </Box>

--- a/src/features/journeys/components/JourneyMilestoneCard.tsx
+++ b/src/features/journeys/components/JourneyMilestoneCard.tsx
@@ -101,7 +101,7 @@ const JourneyMilestoneCard = ({
                 clearButtonLabel: messages.instance.dueDateInputClear(),
               }}
               onChange={(newDeadline) => {
-                if (newDeadline && newDeadline.isValid()) {
+                if (newDeadline?.isValid()) {
                   const dateStr = newDeadline.format('YYYY-MM-DD');
                   updateMilestoneStatus({ deadline: dateStr });
                 } else if (!newDeadline) {

--- a/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
+++ b/src/features/organizations/components/OrganizationSwitcher/useOrgSwitcher.ts
@@ -9,7 +9,7 @@ import useLocalStorage from 'zui/hooks/useLocalStorage';
 function makeFlatOrgData(orgData: TreeItemData[]): TreeItemData[] {
   let children = [] as TreeItemData[];
   const flatOrgData = orgData.map((org) => {
-    if (org.children && org.children.length) {
+    if (org.children?.length) {
       children = [...children, ...org.children];
     }
     return org;

--- a/src/features/organizations/components/OrganizationsList.tsx
+++ b/src/features/organizations/components/OrganizationsList.tsx
@@ -25,7 +25,7 @@ const OrganizationsList = () => {
   return (
     <ZUIFuture future={organizations} ignoreDataWhileLoading>
       {(data) => {
-        if (organizations.data && organizations.data.length == 0) {
+        if (organizations.data?.length == 0) {
           return (
             <Alert icon={<Key />} severity="error">
               <AlertTitle>

--- a/src/features/organizations/components/PublicEventSignup.tsx
+++ b/src/features/organizations/components/PublicEventSignup.tsx
@@ -74,7 +74,7 @@ export const PublicEventSignup: FC<Props> = ({ event, onSignupSuccess }) => {
     let normalizedPhone: string | null = null;
     if (trimmedPhone) {
       const parsed = parsePhoneNumberFromString(trimmedPhone);
-      if (!parsed || !parsed.isValid()) {
+      if (!parsed?.isValid()) {
         setError(eventMessages.publicEventSignup.errors.phoneFormat());
         return;
       }

--- a/src/features/search/components/SearchDialog/SearchField.tsx
+++ b/src/features/search/components/SearchDialog/SearchField.tsx
@@ -57,7 +57,7 @@ const SearchField: React.FunctionComponent<SearchFieldProps> = ({
 
   useEffect(() => {
     // Focus when opening the component
-    if (input && input.current) {
+    if (input?.current) {
       input.current.focus();
     }
   }, [input]);

--- a/src/features/settings/store.tsx
+++ b/src/features/settings/store.tsx
@@ -46,7 +46,7 @@ const settingsSlice = createSlice({
         (item) => item.id === membershipId
       );
 
-      if (item && item.data) {
+      if (item?.data) {
         item.data.role = membership.role;
         item.data = { ...item.data, ...membership, id: membershipId };
       } else {

--- a/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/QueryOverviewListItem.tsx
+++ b/src/features/smartSearch/components/SmartSearchDialog/QueryOverview/QueryOverviewListItem.tsx
@@ -69,17 +69,14 @@ const QueryOverviewListItem: FC<QueryOverviewListItemProps> = ({
           {canEdit && (
             <IconButton
               data-testid="QueryOverview-editFilterButton"
-              onClick={() => onClickEdit && onClickEdit()}
+              onClick={() => onClickEdit?.()}
               size="small"
             >
               <Edit fontSize="small" />
             </IconButton>
           )}
           {canDelete && (
-            <IconButton
-              onClick={() => onClickDelete && onClickDelete()}
-              size="small"
-            >
+            <IconButton onClick={() => onClickDelete?.()} size="small">
               <Delete fontSize="small" />
             </IconButton>
           )}

--- a/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
+++ b/src/features/smartSearch/components/filters/SurveyOption/DisplaySurveyOption.tsx
@@ -46,7 +46,7 @@ const DisplaySurveyOption = ({
     element?.type == ELEMENT_TYPE.QUESTION ? element.question : null;
 
   const options =
-    question && question.response_type == RESPONSE_TYPE.OPTIONS
+    question?.response_type == RESPONSE_TYPE.OPTIONS
       ? (optionIds.map((oId) =>
           question.options?.find((option) => option.id == oId)
         ) as ZetkinSurveyOption[])

--- a/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
+++ b/src/features/smartSearch/components/sankeyDiagram/makeSankeySegments.ts
@@ -42,8 +42,7 @@ export default function makeSankeySegments(
   const firstElement = statsCopy[0];
 
   const allFilterWithNoOrgConfig =
-    firstElement &&
-    firstElement.filter.type == FILTER_TYPE.ALL &&
+    firstElement?.filter.type == FILTER_TYPE.ALL &&
     !('organizations' in firstElement.filter.config);
 
   const allFilterWithThisOrgInConfig =

--- a/src/features/smartSearch/components/utils.ts
+++ b/src/features/smartSearch/components/utils.ts
@@ -28,7 +28,7 @@ export const getTimeFrameWithConfig = (config: {
   before?: string;
 }): TimeFrameConfig => {
   const { after, before } = config;
-  if (after && after.slice(0, 1) === '-') {
+  if (after?.slice(0, 1) === '-') {
     return {
       numDays: +after.substring(1, after.length - 1),
       timeFrame: TIME_FRAME.LAST_FEW_DAYS,

--- a/src/features/surveys/rpc/getSurveyResponseStats.ts
+++ b/src/features/surveys/rpc/getSurveyResponseStats.ts
@@ -131,7 +131,7 @@ const collectIncrementalStats = (
   responseStatsCounters: Record<string, ResponseStatsCounter>
 ) => {
   responses.forEach((response) => {
-    if (!response || !response.responses) {
+    if (!response?.responses) {
       return;
     }
 

--- a/src/features/tags/components/TagManager/components/TagChip.tsx
+++ b/src/features/tags/components/TagManager/components/TagChip.tsx
@@ -76,7 +76,7 @@ const TagChip: React.FunctionComponent<{
 
   return (
     <Box
-      onClick={() => !disabled && onClick && onClick(tag)}
+      onClick={() => !disabled && onClick?.(tag)}
       sx={{
         '& > span': { maxWidth: '100%' },
         '&:hover': {

--- a/src/features/tags/utils/compareTags.ts
+++ b/src/features/tags/utils/compareTags.ts
@@ -5,20 +5,20 @@ export default function compareTags(
   tag1: ZetkinAppliedTag | null
 ): number {
   //only compare titles if they are not null
-  if (tag0 && tag0.title && tag1 && tag1.title) {
+  if (tag0?.title && tag1?.title) {
     const titleComparison = tag0.title.localeCompare(tag1.title);
     if (titleComparison !== 0) {
       return titleComparison;
     }
-  } else if (tag0 && tag0.title) {
+  } else if (tag0?.title) {
     return -1;
-  } else if (tag1 && tag1.title) {
+  } else if (tag1?.title) {
     return 1;
   }
 
   // If 'title' properties are equal, proceed to compare 'value' properties
-  if (tag0 && tag0.value != null) {
-    if (tag1 && tag1.value != null) {
+  if (tag0?.value != null) {
+    if (tag1?.value != null) {
       if (typeof tag0.value === 'string' && typeof tag1.value === 'string') {
         if (isNaN(Number(tag0.value)) && isNaN(Number(tag1.value))) {
           return tag0.value.localeCompare(tag1.value);

--- a/src/features/tasks/components/TaskDetailsForm/index.tsx
+++ b/src/features/tasks/components/TaskDetailsForm/index.tsx
@@ -245,12 +245,11 @@ const TaskDetailsForm = ({
         select
         value={campaignId ?? ''}
       >
-        {campaigns &&
-          campaigns.map((c) => (
-            <MenuItem key={c.id} value={c.id}>
-              {c.title}
-            </MenuItem>
-          ))}
+        {campaigns?.map((c) => (
+          <MenuItem key={c.id} value={c.id}>
+            {c.title}
+          </MenuItem>
+        ))}
       </TextField>
 
       <TextField

--- a/src/features/tasks/components/TaskTypeDetailsSection/CollectDemographicsDetails.tsx
+++ b/src/features/tasks/components/TaskTypeDetailsSection/CollectDemographicsDetails.tsx
@@ -24,8 +24,7 @@ const CollectDemographicsDetails: React.FunctionComponent<
     <TaskProperty
       title={messages.configs.collectDemographics.fields.demographic()}
       value={
-        taskConfig.fields &&
-        taskConfig.fields.length &&
+        taskConfig.fields?.length &&
         messages.configs.collectDemographics.fields.dempographicOptions[
           fieldMessages[taskConfig.fields[0]]
         ]()

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/ChoiceCategories.tsx
@@ -58,8 +58,7 @@ const ChoiceCategories = ({
                 if (!choice) {
                   return;
                 }
-                const alreadyInView =
-                  choice.alreadyInView && choice.alreadyInView(existingColumns);
+                const alreadyInView = choice.alreadyInView?.(existingColumns);
                 return (
                   <Grid key={filteredKey} size={{ lg: 4, sm: 6, xs: 12 }}>
                     <ColumnChoiceCard

--- a/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
+++ b/src/features/views/components/ViewColumnDialog/ColumnGallery/SearchResults.tsx
@@ -28,9 +28,7 @@ const SearchResults = ({
         if (!searchResult) {
           return;
         }
-        const alreadyInView =
-          searchResult.alreadyInView &&
-          searchResult.alreadyInView(existingColumns);
+        const alreadyInView = searchResult.alreadyInView?.(existingColumns);
         return (
           <Grid key={searchResult.key} size={{ lg: 4, sm: 6, xs: 12 }}>
             <ColumnChoiceCard

--- a/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/ValueTagCell.tsx
+++ b/src/features/views/components/ViewDataTable/columnTypes/PersonTagColumnType/ValueTagCell.tsx
@@ -11,7 +11,7 @@ interface CellContentProps {
 }
 
 const ValueTagCell: FC<CellContentProps> = ({ tag }) => {
-  const isEmpty = !tag.value || !tag.value.toString().trim().length;
+  const isEmpty = !tag.value?.toString().trim().length;
 
   return (
     <Box

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -777,11 +777,12 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           onSave={onSaveCreateColumn}
         />
       )}
-      {renderConfigDialog?.(
-        columnToConfigure,
-        onConfigureColumnCancel,
-        onConfigureColumnSave
-      )}
+      {columnToConfigure &&
+        renderConfigDialog?.(
+          columnToConfigure,
+          onConfigureColumnCancel,
+          onConfigureColumnSave
+        )}
     </>
   );
 };

--- a/src/features/views/components/ViewDataTable/index.tsx
+++ b/src/features/views/components/ViewDataTable/index.tsx
@@ -777,12 +777,11 @@ const ViewDataTable: FunctionComponent<ViewDataTableProps> = ({
           onSave={onSaveCreateColumn}
         />
       )}
-      {renderConfigDialog &&
-        renderConfigDialog(
-          columnToConfigure,
-          onConfigureColumnCancel,
-          onConfigureColumnSave
-        )}
+      {renderConfigDialog?.(
+        columnToConfigure,
+        onConfigureColumnCancel,
+        onConfigureColumnSave
+      )}
     </>
   );
 };

--- a/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
+++ b/src/features/views/components/ViewSurveySubmissionPreview/index.tsx
@@ -80,9 +80,7 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
                 <Box marginBottom={1}>{mostRecent.matchingContent}</Box>
                 {!isRestricted && (
                   <Button
-                    onClick={() =>
-                      onOpenSubmission && onOpenSubmission(mostRecent.id)
-                    }
+                    onClick={() => onOpenSubmission?.(mostRecent.id)}
                     startIcon={<AssignmentTurnedInOutlined />}
                   >
                     <Msg id={messageIds.surveyPreview.mostRecent.openButton} />
@@ -121,9 +119,7 @@ const ViewSurveySubmissionPreview: FC<ViewSurveySubmissionPreviewProps> = ({
                       </Typography>
                       {!isRestricted && (
                         <Button
-                          onClick={() =>
-                            onOpenSubmission && onOpenSubmission(submission.id)
-                          }
+                          onClick={() => onOpenSubmission?.(submission.id)}
                           startIcon={<AssignmentTurnedInOutlined />}
                         >
                           <Msg id={messageIds.surveyPreview.older.openButton} />

--- a/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[campId]/events/[eventId]/index.tsx
@@ -51,7 +51,7 @@ interface EventPageProps {
 const EventPage: PageWithLayout<EventPageProps> = ({ orgId, eventId }) => {
   const eventFuture = useEvent(parseInt(orgId), parseInt(eventId));
 
-  if (!eventFuture || !eventFuture.data) {
+  if (!eventFuture?.data) {
     return null;
   }
 

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -130,7 +130,7 @@ export const scaffold =
       authLevel = 0;
     }
 
-    if (ctx.user && apiSession && apiSession.factors) {
+    if (ctx.user && apiSession?.factors) {
       const hasEmailAuth = apiSession.factors.includes('email_password');
       const hasUnverifiedEmail = !ctx.user.email_is_verified;
       const unverifiedIsNotAllowed = !options?.allowUnverified;

--- a/src/zui/ZUITextEditor/helpers.ts
+++ b/src/zui/ZUITextEditor/helpers.ts
@@ -244,10 +244,7 @@ const shouldBeRemoved = (node: NodeEntry<Ancestor>): boolean => {
       'children' in node[0].children[0] &&
       Object.prototype.hasOwnProperty.call(node[0].children[0], 'children')
     ) {
-      if (
-        node[0].children[0].children[0] &&
-        node[0].children[0].children[0].text === ''
-      ) {
+      if (node[0].children[0].children[0]?.text === '') {
         return true;
       }
     }

--- a/src/zui/ZUITextEditor/index.tsx
+++ b/src/zui/ZUITextEditor/index.tsx
@@ -186,20 +186,19 @@ const ZUITextEditor: React.FunctionComponent<ZUITextEditorProps> = ({
             </Collapse>
           </Slate>
         )}
-        {fileUploads &&
-          fileUploads.map((fileUpload) => {
-            return (
-              <ZetkinFileUploadChip
-                key={fileUpload.key}
-                fileUpload={fileUpload}
-                onDelete={() => {
-                  if (onCancelFile) {
-                    onCancelFile(fileUpload);
-                  }
-                }}
-              />
-            );
-          })}
+        {fileUploads?.map((fileUpload) => {
+          return (
+            <ZetkinFileUploadChip
+              key={fileUpload.key}
+              fileUpload={fileUpload}
+              onDelete={() => {
+                if (onCancelFile) {
+                  onCancelFile(fileUpload);
+                }
+              }}
+            />
+          );
+        })}
       </Box>
     </ClickAwayListener>
   );

--- a/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
+++ b/src/zui/ZUITimeline/updates/elements/PrettyEmail.tsx
@@ -110,7 +110,7 @@ const EmailHeader: React.FC<{ headers: LetterparserNode['headers'] }> = ({
           ([key]) => key.toLowerCase() == headerName.toLowerCase()
         );
 
-        if (matchedHeader && matchedHeader[1]) {
+        if (matchedHeader?.[1]) {
           const values = matchedHeader[1].split(',');
 
           return (

--- a/src/zui/components/ZUITagChip/index.tsx
+++ b/src/zui/components/ZUITagChip/index.tsx
@@ -113,7 +113,7 @@ const ZUITagChip: FC<ZUITagChipProps> = ({
 
   return (
     <Box
-      onClick={() => !disabled && onClick && onClick(tag)}
+      onClick={() => !disabled && onClick?.(tag)}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       sx={{


### PR DESCRIPTION
## Description

This PR adds the `@typescript/prefer-optional-chain` rule to ESLint, and fixes any errors raised.

## Changes

- Adds `@typescript/prefer-optional-chain`
- Changes
  - Everywhere that an error was raised when running the linter
  - Everywhere that TS errors were raised when fixing the lint errors 

## AI usage

Did you use AI to create the code in this PR?

NOPE

## Instructions for reviewer

We need to test the code changes which could possibly introduce bugs. These are changes which do more than e.g. `data && data.id` -> `data?.id`.

Ways to test:

- `FileLibraryDialog`: [ TODO ] Place where this is used
- `EnumConfig`
- `ViewDataTable` 

## Related issues

Supports #3702 
Replaces #3461 
Informs: #3706 

## PR checklist

- [ ] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
  - I think I haven't, but review could be helpful to confirm this.
- [x] I have made sure that formatting, linting and type checks pass locally
- [ ] I have filled out this template and replaced all placeholders with the corresponding information
