### PR TITLE
issue-3699 Fix wrong privacy policy for unauthenticated signup and survey

### DIFF
--- a/src/app/o/[orgId]/events/[eventId]/page.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/page.tsx
@@ -21,12 +21,21 @@ export default async function Page({ params: { eventId, orgId } }: Props) {
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
 
+  const privacyUrl =
+    process.env.ZETKIN_PRIVACY_POLICY_LINK || 'https://zetkin.org/privacy';
+
   try {
     const event = await apiClient.get<ZetkinEvent>(
       `/api/orgs/${orgId}/actions/${eventId}`
     );
 
-    return <PublicEventPage eventId={event.id} orgId={event.organization.id} />;
+    return (
+      <PublicEventPage
+        eventId={event.id}
+        orgId={event.organization.id}
+        privacyUrl={privacyUrl}
+      />
+    );
   } catch (e) {
     if (e instanceof ApiClientError && e.status === 404) {
       notFound();

--- a/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
@@ -24,6 +24,9 @@ const Page: FC<Props> = async ({ params }) => {
 
   const { orgId, surveyId } = params;
 
+  const privacyUrl =
+    process.env.ZETKIN_PRIVACY_POLICY_LINK || 'https://zetkin.org/privacy';
+
   let survey: ZetkinSurveyExtended;
   try {
     survey = await apiClient.get<ZetkinSurveyExtended>(
@@ -44,7 +47,9 @@ const Page: FC<Props> = async ({ params }) => {
     user = null;
   }
 
-  return <PublicSurveyPage survey={survey} user={user} />;
+  return (
+    <PublicSurveyPage privacyUrl={privacyUrl} survey={survey} user={user} />
+  );
 };
 
 export default Page;

--- a/src/features/organizations/components/PublicEventSignup.tsx
+++ b/src/features/organizations/components/PublicEventSignup.tsx
@@ -21,9 +21,14 @@ import eventMessageIds from 'features/events/l10n/messageIds';
 type Props = {
   event: ZetkinEventWithStatus;
   onSignupSuccess?: () => void;
+  privacyUrl: string;
 };
 
-export const PublicEventSignup: FC<Props> = ({ event, onSignupSuccess }) => {
+export const PublicEventSignup: FC<Props> = ({
+  event,
+  onSignupSuccess,
+  privacyUrl,
+}) => {
   const messages = useMessages(messageIds);
   const eventMessages = useMessages(eventMessageIds);
   const [firstName, setFirstName] = useState('');
@@ -33,9 +38,6 @@ export const PublicEventSignup: FC<Props> = ({ event, onSignupSuccess }) => {
   const [gdprConsent, setGdprConsent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
-
-  const privacyUrl =
-    process.env.ZETKIN_PRIVACY_POLICY_LINK || 'https://zetkin.org/privacy';
 
   const { isSubmitting, submit } = usePublicEventSignup(event, {
     onError: setError,

--- a/src/features/public/pages/PublicEventPage.tsx
+++ b/src/features/public/pages/PublicEventPage.tsx
@@ -47,9 +47,10 @@ import ZUISnackbarContext from 'zui/ZUISnackbarContext';
 type Props = {
   eventId: number;
   orgId: number;
+  privacyUrl: string;
 };
 
-export const PublicEventPage: FC<Props> = ({ eventId, orgId }) => {
+export const PublicEventPage: FC<Props> = ({ eventId, orgId, privacyUrl }) => {
   const isMobile = useIsMobile();
   const messages = useMessages(messageIds);
   const myEvents = useMyEvents();
@@ -246,7 +247,7 @@ export const PublicEventPage: FC<Props> = ({ eventId, orgId }) => {
                 padding={2}
                 width={isFullScreen && showDescriptionSection ? '40%' : '100%'}
               >
-                <SignUpSection event={event} />
+                <SignUpSection event={event} privacyUrl={privacyUrl} />
                 <DateAndLocation event={event} />
                 {isLoggedInAsContactPerson && (
                   <ParticipatingInfo
@@ -331,7 +332,8 @@ const ContactPersonSection: FC<{
 
 const SignUpSection: FC<{
   event: ZetkinEventWithStatus;
-}> = ({ event }) => {
+  privacyUrl: string;
+}> = ({ event, privacyUrl }) => {
   const messages = useMessages(messageIds);
   const user = useUser();
   const pathname = usePathname();
@@ -374,6 +376,7 @@ const SignUpSection: FC<{
               <PublicEventSignup
                 event={event}
                 onSignupSuccess={() => setSignupSuccessful(true)}
+                privacyUrl={privacyUrl}
               />
             </Box>
             {!signupSuccessful && (

--- a/src/features/public/pages/PublicSurveyPage.tsx
+++ b/src/features/public/pages/PublicSurveyPage.tsx
@@ -34,11 +34,16 @@ import {
 } from 'features/public/hooks/useSurveyFormState';
 
 type PublicSurveyPageProps = {
+  privacyUrl: string;
   survey: ZetkinSurveyExtended;
   user: ZetkinUser | null;
 };
 
-const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
+const PublicSurveyPage: FC<PublicSurveyPageProps> = ({
+  privacyUrl,
+  survey,
+  user,
+}) => {
   const messages = useMessages(messageIds);
   const isMobile = useIsMobile();
   const [isLoading, setIsLoading] = useState(false);
@@ -108,9 +113,6 @@ const PublicSurveyPage: FC<PublicSurveyPageProps> = ({ survey, user }) => {
   const showForm = status == 'editing' || status == 'error';
   const showSuccess = status == 'submitted';
   const showErrorAlert = status == 'error';
-
-  const privacyUrl =
-    process.env.ZETKIN_PRIVACY_POLICY_LINK || 'https://zetkin.org/privacy';
 
   return (
     <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}>


### PR DESCRIPTION
## Description

This PR fixes wrong privacy policy for unauthenticated signup and survey. Issue was, that .env data could not be used on the level it was added. Problem also existed for survey inspite of the issue.

## Screenshots

<img width="1296" height="839" alt="image" src="https://github.com/user-attachments/assets/e62a5cca-d7b1-415d-aece-5ff0116e58a8" />

## Changes

Environment variable was not available client side and therefore passed through via server component

## AI usage

No AI was used, but Max' brain was picked a bit

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

According to https://github.com/zetkin/app.zetkin.org/issues/3699

This requires running the app locally, so that you can configure it's environment variables.

Make sure the unauthenticated signup feature is enabled locally. In either .env.local or .env.development the FEAT_UNAUTH_EVENT_SIGNUP=* variable should be set
Make sure the privacy policy is configured to something other than the default. In either .env.local or .env.development set ZETKIN_PRIVACY_POLICY_LINK=https://example.com
In an incognito window (to make sure you're not logged in) Go to http://localhost:3000/o/1
Go to the page of any event
On the right hand side, click the "Privacy policy" link

## Related issues

Resolves #[3699]

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
