### PR TITLE
Make the /my pages load 8x faster by not suspending on remote data

### DIFF
--- a/src/core/hooks/useRemoteItemFuture.spec.tsx
+++ b/src/core/hooks/useRemoteItemFuture.spec.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, render } from '@testing-library/react';
+import { FC } from 'react';
+import { Provider as ReduxProvider, useSelector } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import useRemoteItemFuture from './useRemoteItemFuture';
+import { RemoteItem, remoteItem } from 'utils/storeUtils';
+
+type ItemObjectForTest = { id: number; name: string };
+type StoreState = {
+  item: RemoteItem<ItemObjectForTest> | null;
+};
+
+type RemoteItemHooksForTest = {
+  actionOnError?: (err: unknown) => { payload: unknown; type: string };
+  actionOnLoad: () => { payload: undefined; type: string };
+  actionOnSuccess: (item: ItemObjectForTest) => {
+    payload: ItemObjectForTest;
+    type: string;
+  };
+  cacheKey?: string;
+  isNecessary?: () => boolean;
+  loader: () => Promise<ItemObjectForTest>;
+  staleWhileRevalidate?: boolean;
+};
+
+describe('useRemoteItemFuture()', () => {
+  it('reports loading without suspending and triggers a load when the item does not exist', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent(null);
+    hooks.cacheKey = 'item-future-initial';
+
+    const { queryByText } = render();
+
+    // No Suspense boundary exists: the hook must not suspend
+    expect(queryByText('loading')).not.toBeNull();
+    expect(queryByText('loaded')).toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+    expect(store.dispatch).toHaveBeenNthCalledWith(1, {
+      payload: undefined,
+      type: 'load',
+    });
+
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('Clara Zetkin')).not.toBeNull();
+  });
+
+  it('returns data without load when the item has been loaded recently', async () => {
+    const { hooks, render, store } = setupWrapperComponent(
+      remoteItem(1, {
+        data: { id: 1, name: 'Clara Zetkin' },
+        loaded: new Date().toISOString(),
+      })
+    );
+    hooks.cacheKey = 'item-future-loaded';
+
+    const { queryByText } = render();
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(hooks.loader).not.toHaveBeenCalled();
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('Clara Zetkin')).not.toBeNull();
+  });
+
+  it('loads without dispatching actionOnLoad when the item is already marked as loading', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent({
+      ...remoteItem<ItemObjectForTest>(1),
+      data: null,
+      isLoading: true,
+    });
+    hooks.cacheKey = 'item-future-already-loading';
+
+    const { queryByText } = render();
+
+    expect(queryByText('loading')).not.toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(1);
+    expect(store.dispatch).toHaveBeenCalledWith({
+      payload: { id: 1, name: 'Clara Zetkin' },
+      type: 'loaded',
+    });
+  });
+
+  it('returns stale data while re-fetching', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent(
+      remoteItem(1, {
+        data: { id: 1, name: 'Clara Zetkin' },
+        loaded: new Date(1857, 6, 5).toISOString(),
+      })
+    );
+    hooks.cacheKey = 'item-future-stale';
+
+    const { queryByText } = render();
+
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('Clara Zetkin')).not.toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+  });
+});
+
+function setupWrapperComponent(
+  initialItem: RemoteItem<ItemObjectForTest> | null
+) {
+  const store = configureStore<StoreState>({
+    preloadedState: {
+      item: initialItem,
+    },
+    reducer: (state, action) => {
+      if (action.type == 'load') {
+        return {
+          item: {
+            ...remoteItem<ItemObjectForTest>(1),
+            isLoading: true,
+          },
+        };
+      } else if (action.type == 'loaded') {
+        return {
+          item: remoteItem(1, {
+            data: { id: 1, name: 'Clara Zetkin' },
+            loaded: new Date().toISOString(),
+          }),
+        };
+      }
+
+      return state || { item: null };
+    },
+  });
+  jest.spyOn(store, 'dispatch');
+
+  const promise = Promise.resolve({ id: 1, name: 'Clara Zetkin' });
+
+  const hooks: RemoteItemHooksForTest = {
+    actionOnLoad: () => ({ payload: undefined, type: 'load' }),
+    actionOnSuccess: (data: ItemObjectForTest) => ({
+      payload: data,
+      type: 'loaded',
+    }),
+    loader: () => promise,
+  };
+
+  jest.spyOn(hooks, 'loader');
+
+  const Component: FC = () => {
+    const item = useSelector<StoreState, RemoteItem<ItemObjectForTest> | null>(
+      (state) => state.item
+    );
+
+    const future = useRemoteItemFuture(item, hooks);
+
+    if (future.isLoading && !future.data) {
+      return <p>loading</p>;
+    }
+
+    return (
+      <div>
+        <p>loaded</p>
+        <p>{future.data?.name}</p>
+      </div>
+    );
+  };
+
+  return {
+    hooks,
+    promise,
+    render: () =>
+      render(
+        <ReduxProvider store={store}>
+          <Component />
+        </ReduxProvider>
+      ),
+    store,
+  };
+}

--- a/src/core/hooks/useRemoteItemFuture.spec.tsx
+++ b/src/core/hooks/useRemoteItemFuture.spec.tsx
@@ -32,7 +32,6 @@ describe('useRemoteItemFuture()', () => {
 
     const { queryByText } = render();
 
-    // No Suspense boundary exists: the hook must not suspend
     expect(queryByText('loading')).not.toBeNull();
     expect(queryByText('loaded')).toBeNull();
 

--- a/src/core/hooks/useRemoteItemFuture.ts
+++ b/src/core/hooks/useRemoteItemFuture.ts
@@ -6,13 +6,6 @@ import { useAppDispatch } from '.';
 import usePromiseCache from './usePromiseCache';
 import { IFuture, LoadingFuture, RemoteItemFuture } from 'core/caching/futures';
 
-/**
- * Non-suspending variant of {@link useRemoteItem}: identical loading and
- * caching behavior, but returns an {@link IFuture} instead of throwing the
- * fetch promise. Use it on paths that render on first mount, where committing
- * a Suspense fallback is undesirable (React 19 throttles fallback reveals by
- * up to 300ms, and suspending above a page-level boundary blanks the app).
- */
 export default function useRemoteItemFuture<
   DataType,
   OnLoadPayload = void,
@@ -37,7 +30,7 @@ export default function useRemoteItemFuture<
   const { cache, getExistingPromise } = usePromiseCache(promiseKey);
   const staleWhileRevalidate = hooks.staleWhileRevalidate ?? true;
 
-  const fireLoadIfNotInFlight = (dispatchLoadAction: boolean) => {
+  const loadOnce = (dispatchLoadAction: boolean) => {
     if (getExistingPromise()) {
       return;
     }
@@ -66,18 +59,17 @@ export default function useRemoteItemFuture<
   };
 
   if (!remoteItem) {
-    fireLoadIfNotInFlight(true);
+    loadOnce(true);
     return new LoadingFuture();
   }
 
   if (remoteItem.isLoading && !remoteItem.data) {
-    // No need to dispatch actionOnLoad: already loading
-    fireLoadIfNotInFlight(false);
+    loadOnce(false);
     return new LoadingFuture();
   }
 
   if (loadIsNecessary) {
-    fireLoadIfNotInFlight(true);
+    loadOnce(true);
 
     if (!remoteItem.data || !staleWhileRevalidate) {
       return new LoadingFuture();

--- a/src/core/hooks/useRemoteItemFuture.ts
+++ b/src/core/hooks/useRemoteItemFuture.ts
@@ -1,0 +1,88 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import shouldLoad from 'core/caching/shouldLoad';
+import { RemoteItem } from 'utils/storeUtils';
+import { useAppDispatch } from '.';
+import usePromiseCache from './usePromiseCache';
+import { IFuture, LoadingFuture, RemoteItemFuture } from 'core/caching/futures';
+
+/**
+ * Non-suspending variant of {@link useRemoteItem}: identical loading and
+ * caching behavior, but returns an {@link IFuture} instead of throwing the
+ * fetch promise. Use it on paths that render on first mount, where committing
+ * a Suspense fallback is undesirable (React 19 throttles fallback reveals by
+ * up to 300ms, and suspending above a page-level boundary blanks the app).
+ */
+export default function useRemoteItemFuture<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType,
+>(
+  remoteItem: RemoteItem<DataType> | undefined | null,
+  hooks: {
+    actionOnError?: (err: unknown) => PayloadAction<unknown>;
+    actionOnLoad: () => PayloadAction<OnLoadPayload>;
+    actionOnSuccess: (items: DataType) => PayloadAction<OnSuccessPayload>;
+    cacheKey?: string;
+    isNecessary?: () => boolean;
+    loader: () => Promise<DataType>;
+    staleWhileRevalidate?: boolean;
+  }
+): IFuture<DataType> {
+  const dispatch = useAppDispatch();
+
+  const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteItem);
+
+  const promiseKey = hooks.cacheKey || hooks.loader.toString();
+  const { cache, getExistingPromise } = usePromiseCache(promiseKey);
+  const staleWhileRevalidate = hooks.staleWhileRevalidate ?? true;
+
+  const fireLoadIfNotInFlight = (dispatchLoadAction: boolean) => {
+    if (getExistingPromise()) {
+      return;
+    }
+
+    const promise = Promise.resolve()
+      .then(() => {
+        if (dispatchLoadAction) {
+          dispatch(hooks.actionOnLoad());
+        }
+      })
+      .then(() => hooks.loader())
+      .then((val) => {
+        dispatch(hooks.actionOnSuccess(val));
+        return val;
+      })
+      .catch((err: unknown) => {
+        if (hooks.actionOnError) {
+          dispatch(hooks.actionOnError(err));
+          return null;
+        } else {
+          throw err;
+        }
+      });
+
+    cache(promise);
+  };
+
+  if (!remoteItem) {
+    fireLoadIfNotInFlight(true);
+    return new LoadingFuture();
+  }
+
+  if (remoteItem.isLoading && !remoteItem.data) {
+    // No need to dispatch actionOnLoad: already loading
+    fireLoadIfNotInFlight(false);
+    return new LoadingFuture();
+  }
+
+  if (loadIsNecessary) {
+    fireLoadIfNotInFlight(true);
+
+    if (!remoteItem.data || !staleWhileRevalidate) {
+      return new LoadingFuture();
+    }
+  }
+
+  return new RemoteItemFuture(remoteItem);
+}

--- a/src/core/hooks/useRemoteListFuture.spec.tsx
+++ b/src/core/hooks/useRemoteListFuture.spec.tsx
@@ -1,0 +1,227 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, render } from '@testing-library/react';
+import { FC } from 'react';
+import { Provider as ReduxProvider, useSelector } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import useRemoteListFuture from './useRemoteListFuture';
+import { RemoteList, remoteList } from 'utils/storeUtils';
+
+type ListObjectForTest = { id: number; name: string };
+type StoreState = {
+  list: RemoteList<ListObjectForTest>;
+};
+
+type RemoteListHooksForTest = {
+  actionOnError?: (err: unknown) => { payload: unknown; type: string };
+  actionOnLoad: () => { payload: undefined; type: string };
+  actionOnSuccess: (items: ListObjectForTest[]) => {
+    payload: ListObjectForTest[];
+    type: string;
+  };
+  cacheKey?: string;
+  isNecessary?: () => boolean;
+  loader: () => Promise<ListObjectForTest[]>;
+  staleWhileRevalidate?: boolean;
+};
+
+describe('useRemoteListFuture()', () => {
+  it('reports loading without suspending and triggers a load when the data has not yet been loaded', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent();
+    hooks.cacheKey = 'list-future-initial';
+
+    const { queryByText } = render();
+
+    // No Suspense boundary exists: the hook must not suspend
+    expect(queryByText('loading')).not.toBeNull();
+    expect(queryByText('loaded')).toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+    expect(store.dispatch).toHaveBeenNthCalledWith(1, {
+      payload: undefined,
+      type: 'load',
+    });
+    expect(store.dispatch).toHaveBeenNthCalledWith(2, {
+      payload: [{ id: 1, name: 'Clara Zetkin' }],
+      type: 'loaded',
+    });
+
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('loaded')).not.toBeNull();
+  });
+
+  it('returns data without load when the data has been loaded recently', async () => {
+    const { hooks, render, store } = setupWrapperComponent({
+      ...remoteList([
+        {
+          id: 1,
+          name: 'Clara Zetkin',
+        },
+      ]),
+      loaded: new Date().toISOString(),
+    });
+    hooks.cacheKey = 'list-future-loaded';
+
+    const { queryByText } = render();
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+    expect(hooks.loader).not.toHaveBeenCalled();
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('loaded')).not.toBeNull();
+
+    const listItem = queryByText('Clara Zetkin');
+    expect(listItem?.tagName).toBe('LI');
+  });
+
+  it('returns stale data while re-fetching', async () => {
+    const { hooks, promise, render, store } = setupWrapperComponent({
+      ...remoteList([
+        {
+          id: 1,
+          name: 'Clara Zetkin',
+        },
+      ]),
+      loaded: new Date(1857, 6, 5).toISOString(),
+    });
+    hooks.cacheKey = 'list-future-stale';
+
+    const { queryByText } = render();
+
+    expect(queryByText('loading')).toBeNull();
+    expect(queryByText('Clara Zetkin')).not.toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports loading instead of stale data when staleWhileRevalidate is disabled', async () => {
+    const { hooks, promise, render } = setupWrapperComponent({
+      ...remoteList([
+        {
+          id: 1,
+          name: 'Clara Zetkin',
+        },
+      ]),
+      loaded: new Date(1857, 6, 5).toISOString(),
+    });
+    hooks.cacheKey = 'list-future-no-swr';
+    hooks.staleWhileRevalidate = false;
+
+    const { queryByText } = render();
+
+    expect(queryByText('loading')).not.toBeNull();
+    expect(queryByText('Clara Zetkin')).toBeNull();
+
+    await act(async () => {
+      await promise;
+    });
+  });
+
+  it('only fires one load for concurrent consumers', async () => {
+    const { hooks, promise, render } = setupWrapperComponent(undefined, 2);
+    hooks.cacheKey = 'list-future-dedupe';
+
+    render();
+
+    await act(async () => {
+      await promise;
+    });
+
+    expect(hooks.loader).toHaveBeenCalledTimes(1);
+  });
+});
+
+function setupWrapperComponent(
+  initialList?: RemoteList<ListObjectForTest>,
+  componentCount = 1
+) {
+  const store = configureStore<StoreState>({
+    preloadedState: {
+      list: initialList || remoteList(),
+    },
+    reducer: (state, action) => {
+      if (action.type == 'load') {
+        return {
+          list: {
+            ...remoteList(),
+            isLoading: true,
+          },
+        };
+      } else if (action.type == 'loaded') {
+        return {
+          list: {
+            ...remoteList(),
+            isLoading: false,
+            loaded: new Date().toISOString(),
+          },
+        };
+      }
+
+      return (
+        state || {
+          list: remoteList(),
+        }
+      );
+    },
+  });
+  jest.spyOn(store, 'dispatch');
+
+  const promise = Promise.resolve([{ id: 1, name: 'Clara Zetkin' }]);
+
+  const hooks: RemoteListHooksForTest = {
+    actionOnLoad: () => ({ payload: undefined, type: 'load' }),
+    actionOnSuccess: (data: ListObjectForTest[]) => ({
+      payload: data,
+      type: 'loaded',
+    }),
+    loader: () => promise,
+  };
+
+  jest.spyOn(hooks, 'loader');
+
+  const Component: FC = () => {
+    const list = useSelector<StoreState, RemoteList<ListObjectForTest>>(
+      (state) => state.list
+    );
+
+    const future = useRemoteListFuture(list, hooks);
+
+    if (future.isLoading && !future.data?.length) {
+      return <p>loading</p>;
+    }
+
+    return (
+      <div>
+        <p>loaded</p>
+        <ul>
+          {(future.data || []).map((item) => (
+            <li key={item.id}>{item.name}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
+  return {
+    hooks,
+    promise,
+    render: () =>
+      render(
+        <ReduxProvider store={store}>
+          {new Array(componentCount).fill(0).map((_, idx) => (
+            <Component key={idx} />
+          ))}
+        </ReduxProvider>
+      ),
+    store,
+  };
+}

--- a/src/core/hooks/useRemoteListFuture.spec.tsx
+++ b/src/core/hooks/useRemoteListFuture.spec.tsx
@@ -32,7 +32,6 @@ describe('useRemoteListFuture()', () => {
 
     const { queryByText } = render();
 
-    // No Suspense boundary exists: the hook must not suspend
     expect(queryByText('loading')).not.toBeNull();
     expect(queryByText('loaded')).toBeNull();
 

--- a/src/core/hooks/useRemoteListFuture.ts
+++ b/src/core/hooks/useRemoteListFuture.ts
@@ -6,13 +6,6 @@ import { useAppDispatch } from '.';
 import usePromiseCache from './usePromiseCache';
 import { IFuture, LoadingFuture, RemoteListFuture } from 'core/caching/futures';
 
-/**
- * Non-suspending variant of {@link useRemoteList}: identical loading and
- * caching behavior, but returns an {@link IFuture} instead of throwing the
- * fetch promise. Use it on paths that render on first mount, where committing
- * a Suspense fallback is undesirable (React 19 throttles fallback reveals by
- * up to 300ms, and suspending above a page-level boundary blanks the app).
- */
 export default function useRemoteListFuture<
   DataType,
   OnLoadPayload = void,
@@ -38,7 +31,7 @@ export default function useRemoteListFuture<
   const { cache, getExistingPromise } = usePromiseCache(promiseKey);
   const staleWhileRevalidate = hooks.staleWhileRevalidate ?? true;
 
-  const fireLoadIfNotInFlight = () => {
+  const loadOnce = () => {
     if (getExistingPromise()) {
       return;
     }
@@ -65,12 +58,12 @@ export default function useRemoteListFuture<
   };
 
   if (notLoaded) {
-    fireLoadIfNotInFlight();
+    loadOnce();
     return new LoadingFuture();
   }
 
   if (loadIsNecessary) {
-    fireLoadIfNotInFlight();
+    loadOnce();
 
     const hasData = !!remoteList.items?.length;
     if (!hasData || !staleWhileRevalidate) {

--- a/src/core/hooks/useRemoteListFuture.ts
+++ b/src/core/hooks/useRemoteListFuture.ts
@@ -1,0 +1,85 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import shouldLoad from 'core/caching/shouldLoad';
+import { RemoteList } from 'utils/storeUtils';
+import { useAppDispatch } from '.';
+import usePromiseCache from './usePromiseCache';
+import { IFuture, LoadingFuture, RemoteListFuture } from 'core/caching/futures';
+
+/**
+ * Non-suspending variant of {@link useRemoteList}: identical loading and
+ * caching behavior, but returns an {@link IFuture} instead of throwing the
+ * fetch promise. Use it on paths that render on first mount, where committing
+ * a Suspense fallback is undesirable (React 19 throttles fallback reveals by
+ * up to 300ms, and suspending above a page-level boundary blanks the app).
+ */
+export default function useRemoteListFuture<
+  DataType,
+  OnLoadPayload = void,
+  OnSuccessPayload = DataType[],
+>(
+  remoteList: RemoteList<DataType> | undefined,
+  hooks: {
+    actionOnError?: (err: unknown) => PayloadAction<unknown>;
+    actionOnLoad: () => PayloadAction<OnLoadPayload>;
+    actionOnSuccess: (items: DataType[]) => PayloadAction<OnSuccessPayload>;
+    cacheKey?: string;
+    isNecessary?: () => boolean;
+    loader: () => Promise<DataType[]>;
+    staleWhileRevalidate?: boolean;
+  }
+): IFuture<DataType[]> {
+  const dispatch = useAppDispatch();
+
+  const loadIsNecessary = hooks.isNecessary?.() ?? shouldLoad(remoteList);
+  const notLoaded = !remoteList || !remoteList.loaded;
+
+  const promiseKey = hooks.cacheKey || hooks.loader.toString();
+  const { cache, getExistingPromise } = usePromiseCache(promiseKey);
+  const staleWhileRevalidate = hooks.staleWhileRevalidate ?? true;
+
+  const fireLoadIfNotInFlight = () => {
+    if (getExistingPromise()) {
+      return;
+    }
+
+    const promise = Promise.resolve()
+      .then(() => {
+        dispatch(hooks.actionOnLoad());
+      })
+      .then(() => hooks.loader())
+      .then((val) => {
+        dispatch(hooks.actionOnSuccess(val));
+        return val;
+      })
+      .catch((err: unknown) => {
+        if (hooks.actionOnError) {
+          dispatch(hooks.actionOnError(err));
+          return null;
+        } else {
+          throw err;
+        }
+      });
+
+    cache(promise);
+  };
+
+  if (notLoaded) {
+    fireLoadIfNotInFlight();
+    return new LoadingFuture();
+  }
+
+  if (loadIsNecessary) {
+    fireLoadIfNotInFlight();
+
+    const hasData = !!remoteList.items?.length;
+    if (!hasData || !staleWhileRevalidate) {
+      return new LoadingFuture();
+    }
+  }
+
+  return new RemoteListFuture({
+    ...remoteList,
+    items: remoteList.items.filter((item) => !item.deleted),
+  });
+}

--- a/src/features/callAssignments/hooks/useMyCallAssignments.ts
+++ b/src/features/callAssignments/hooks/useMyCallAssignments.ts
@@ -1,28 +1,37 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
-import useRemoteList from 'core/hooks/useRemoteList';
+import useRemoteListFuture from 'core/hooks/useRemoteListFuture';
+import { IFuture, ResolvedFuture } from 'core/caching/futures';
 import { userAssignmentsLoad, userAssignmentsLoaded } from '../store';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 
-export default function useMyCallAssignments() {
+export default function useMyCallAssignments(): IFuture<
+  ZetkinCallAssignment[]
+> {
   const apiClient = useApiClient();
   const list = useAppSelector(
     (state) => state.callAssignments.userAssignmentList
   );
 
-  const assignments = useRemoteList(list, {
+  const future = useRemoteListFuture(list, {
     actionOnLoad: () => userAssignmentsLoad(),
     actionOnSuccess: (data) => userAssignmentsLoaded(data),
     loader: () =>
       apiClient.get<ZetkinCallAssignment[]>(`/api/users/me/call_assignments`),
   });
 
+  if (!future.data) {
+    return future;
+  }
+
   const now = new Date();
   const today = now.toISOString().slice(0, 10);
 
-  return assignments.filter(
-    ({ end_date, start_date }) =>
-      start_date &&
-      start_date <= today &&
-      (end_date == null || end_date >= today)
+  return new ResolvedFuture(
+    future.data.filter(
+      ({ end_date, start_date }) =>
+        start_date &&
+        start_date <= today &&
+        (end_date == null || end_date >= today)
+    )
   );
 }

--- a/src/features/canvass/hooks/useMyAreaAssignments.ts
+++ b/src/features/canvass/hooks/useMyAreaAssignments.ts
@@ -1,19 +1,29 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
 import { myAssignmentsLoad, myAssignmentsLoaded } from '../store';
 import useRemoteList from 'core/hooks/useRemoteList';
+import useRemoteListFuture from 'core/hooks/useRemoteListFuture';
+import { IFuture, ResolvedFuture } from 'core/caching/futures';
 import { ZetkinAreaAssignment } from 'features/areaAssignments/types';
 
-export default function useMyAreaAssignments() {
+function useListWithHooks() {
   const apiClient = useApiClient();
   const list = useAppSelector((state) => state.canvass.myAssignmentsList);
 
-  const assignments = useRemoteList(list, {
-    actionOnLoad: () => myAssignmentsLoad(),
-    actionOnSuccess: (data) => myAssignmentsLoaded(data),
-    loader: () =>
-      apiClient.get<ZetkinAreaAssignment[]>('/api2/users/me/area_assignments'),
-  });
+  return {
+    hooks: {
+      actionOnLoad: () => myAssignmentsLoad(),
+      actionOnSuccess: (data: ZetkinAreaAssignment[]) =>
+        myAssignmentsLoaded(data),
+      loader: () =>
+        apiClient.get<ZetkinAreaAssignment[]>(
+          '/api2/users/me/area_assignments'
+        ),
+    },
+    list,
+  };
+}
 
+function filterActive(assignments: ZetkinAreaAssignment[]) {
   const now = new Date();
   const today = now.toISOString().slice(0, 10);
 
@@ -23,4 +33,20 @@ export default function useMyAreaAssignments() {
       start_date.slice(0, 10) <= today &&
       (end_date == null || end_date.slice(0, 10) >= today)
   );
+}
+
+export default function useMyAreaAssignments() {
+  const { hooks, list } = useListWithHooks();
+  return filterActive(useRemoteList(list, hooks));
+}
+
+export function useMyAreaAssignmentsFuture(): IFuture<ZetkinAreaAssignment[]> {
+  const { hooks, list } = useListWithHooks();
+  const future = useRemoteListFuture(list, hooks);
+
+  if (!future.data) {
+    return future;
+  }
+
+  return new ResolvedFuture(filterActive(future.data));
 }

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -31,11 +31,13 @@ import ZUIButton from 'zui/components/ZUIButton';
 import ZUIText from 'zui/components/ZUIText';
 import ZUIDrawerModal from 'zui/components/ZUIDrawerModal';
 import { useEventTypeFilter } from 'features/events/hooks/useEventTypeFilter';
+import CenteredLoadingIndicator from 'features/my/components/CenteredLoadingIndicator';
 
 const AllEventsList: FC = () => {
   const intl = useIntl();
   const messages = useMessages(messageIds);
-  const allEvents = useAllEvents();
+  const allEventsFuture = useAllEvents();
+  const allEvents = allEventsFuture.data || [];
   const nextDelay = useIncrementalDelay();
 
   const searchParams = useSearchParams();
@@ -126,6 +128,10 @@ const AllEventsList: FC = () => {
     eventTypeLabelsToFilterBy: eventTypesToFilterBy,
     setEventTypeLabelsToFilterBy: (types: string[]) => setFilters({ types }),
   });
+
+  if (allEventsFuture.isLoading) {
+    return <CenteredLoadingIndicator />;
+  }
 
   const orgs = [
     ...new Map(

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -31,7 +31,7 @@ import ZUIButton from 'zui/components/ZUIButton';
 import ZUIText from 'zui/components/ZUIText';
 import ZUIDrawerModal from 'zui/components/ZUIDrawerModal';
 import { useEventTypeFilter } from 'features/events/hooks/useEventTypeFilter';
-import CenteredLoadingIndicator from 'features/my/components/CenteredLoadingIndicator';
+import LoadingIndicator from 'features/my/components/LoadingIndicator';
 
 const AllEventsList: FC = () => {
   const intl = useIntl();
@@ -130,7 +130,7 @@ const AllEventsList: FC = () => {
   });
 
   if (allEventsFuture.isLoading) {
-    return <CenteredLoadingIndicator />;
+    return <LoadingIndicator />;
   }
 
   const orgs = [

--- a/src/features/my/components/CenteredLoadingIndicator.tsx
+++ b/src/features/my/components/CenteredLoadingIndicator.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mui/material';
+import { FC } from 'react';
+
+import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
+
+const CenteredLoadingIndicator: FC = () => {
+  return (
+    <Box
+      alignItems="center"
+      display="flex"
+      flexDirection="column"
+      height="90dvh"
+      justifyContent="center"
+    >
+      <ZUILogoLoadingIndicator />
+    </Box>
+  );
+};
+
+export default CenteredLoadingIndicator;

--- a/src/features/my/components/LoadingIndicator.tsx
+++ b/src/features/my/components/LoadingIndicator.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react';
 
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 
-const CenteredLoadingIndicator: FC = () => {
+const LoadingIndicator: FC = () => {
   return (
     <Box
       alignItems="center"
@@ -17,4 +17,4 @@ const CenteredLoadingIndicator: FC = () => {
   );
 };
 
-export default CenteredLoadingIndicator;
+export default LoadingIndicator;

--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -15,14 +15,21 @@ import ZUIButton from 'zui/components/ZUIButton';
 import ZUIText from 'zui/components/ZUIText';
 import ZUIFilterButton from 'zui/components/ZUIFilterButton';
 import AreaAssignmentListItem from 'features/public/components/AreaAssignmentListItem';
+import CenteredLoadingIndicator from 'features/my/components/CenteredLoadingIndicator';
 
 const MyActivitiesList: FC = () => {
-  const activities = useMyActivities();
+  const activitiesFuture = useMyActivities();
   const messages = useMessages(messageIds);
   type KindOfActivity = MyActivity['kind'];
 
   const [filteredKinds, setFilteredKinds] = useState<KindOfActivity[]>([]);
   const nextDelay = useIncrementalDelay();
+
+  if (activitiesFuture.isLoading) {
+    return <CenteredLoadingIndicator />;
+  }
+
+  const activities = activitiesFuture.data || [];
 
   const kinds = Array.from(
     new Set(activities.map((activity) => activity.kind))

--- a/src/features/my/components/MyActivitiesList.tsx
+++ b/src/features/my/components/MyActivitiesList.tsx
@@ -15,7 +15,7 @@ import ZUIButton from 'zui/components/ZUIButton';
 import ZUIText from 'zui/components/ZUIText';
 import ZUIFilterButton from 'zui/components/ZUIFilterButton';
 import AreaAssignmentListItem from 'features/public/components/AreaAssignmentListItem';
-import CenteredLoadingIndicator from 'features/my/components/CenteredLoadingIndicator';
+import LoadingIndicator from 'features/my/components/LoadingIndicator';
 
 const MyActivitiesList: FC = () => {
   const activitiesFuture = useMyActivities();
@@ -26,7 +26,7 @@ const MyActivitiesList: FC = () => {
   const nextDelay = useIncrementalDelay();
 
   if (activitiesFuture.isLoading) {
-    return <CenteredLoadingIndicator />;
+    return <LoadingIndicator />;
   }
 
   const activities = activitiesFuture.data || [];

--- a/src/features/my/components/MyOrgsList.tsx
+++ b/src/features/my/components/MyOrgsList.tsx
@@ -6,14 +6,14 @@ import { Box, Fade } from '@mui/material';
 import MyOrgsListItem from './MyOrgsListItem';
 import { useUserMembershipsFuture } from 'features/public/hooks/useUserMemberships';
 import useIncrementalDelay from 'features/public/hooks/useIncrementalDelay';
-import CenteredLoadingIndicator from './CenteredLoadingIndicator';
+import LoadingIndicator from './LoadingIndicator';
 
 const MyOrgsList: FC = () => {
   const membershipsFuture = useUserMembershipsFuture();
   const nextDelay = useIncrementalDelay();
 
   if (membershipsFuture.isLoading) {
-    return <CenteredLoadingIndicator />;
+    return <LoadingIndicator />;
   }
 
   const sortedMemberships = (membershipsFuture.data || []).sort((m0, m1) =>

--- a/src/features/my/components/MyOrgsList.tsx
+++ b/src/features/my/components/MyOrgsList.tsx
@@ -4,14 +4,19 @@ import { FC } from 'react';
 import { Box, Fade } from '@mui/material';
 
 import MyOrgsListItem from './MyOrgsListItem';
-import useUserMemberships from 'features/public/hooks/useUserMemberships';
+import { useUserMembershipsFuture } from 'features/public/hooks/useUserMemberships';
 import useIncrementalDelay from 'features/public/hooks/useIncrementalDelay';
+import CenteredLoadingIndicator from './CenteredLoadingIndicator';
 
 const MyOrgsList: FC = () => {
-  const memberships = useUserMemberships();
+  const membershipsFuture = useUserMembershipsFuture();
   const nextDelay = useIncrementalDelay();
 
-  const sortedMemberships = memberships.sort((m0, m1) =>
+  if (membershipsFuture.isLoading) {
+    return <CenteredLoadingIndicator />;
+  }
+
+  const sortedMemberships = (membershipsFuture.data || []).sort((m0, m1) =>
     m0.organization.title.localeCompare(m1.organization.title)
   );
 

--- a/src/features/my/hooks/useAllEvents.ts
+++ b/src/features/my/hooks/useAllEvents.ts
@@ -1,18 +1,19 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
-import useRemoteList from 'core/hooks/useRemoteList';
+import useRemoteListFuture from 'core/hooks/useRemoteListFuture';
+import { IFuture, LoadingFuture, ResolvedFuture } from 'core/caching/futures';
 import { allEventsLoad, allEventsLoaded } from '../../events/store';
 import getAllEvents from '../../events/rpc/getAllEvents';
 import sortEventsByStartTime from '../../events/utils/sortEventsByStartTime';
 import { ZetkinEventWithStatus } from 'features/public/types';
-import useMyEvents from './useMyEvents';
+import { useMyEventsFuture } from './useMyEvents';
 
-export default function useAllEvents() {
+export default function useAllEvents(): IFuture<ZetkinEventWithStatus[]> {
   const apiClient = useApiClient();
   const allEventsList = useAppSelector((state) => state.events.allEventsList);
 
-  const myEvents = useMyEvents();
+  const myEventsFuture = useMyEventsFuture();
 
-  const events = useRemoteList(allEventsList, {
+  const eventsFuture = useRemoteListFuture(allEventsList, {
     actionOnLoad: () => allEventsLoad(),
     actionOnSuccess: (data) => {
       const sorted = data.sort(sortEventsByStartTime);
@@ -21,14 +22,22 @@ export default function useAllEvents() {
     loader: () => apiClient.rpc(getAllEvents, {}),
   });
 
-  return events.map<ZetkinEventWithStatus>((event) => {
-    const myEvent = myEvents.find((candidate) => candidate.id == event.id);
+  if (!eventsFuture.data || !myEventsFuture.data) {
+    return new LoadingFuture();
+  }
 
-    return (
-      myEvent || {
-        ...event,
-        status: null,
-      }
-    );
-  });
+  const myEvents = myEventsFuture.data;
+
+  return new ResolvedFuture(
+    eventsFuture.data.map<ZetkinEventWithStatus>((event) => {
+      const myEvent = myEvents.find((candidate) => candidate.id == event.id);
+
+      return (
+        myEvent || {
+          ...event,
+          status: null,
+        }
+      );
+    })
+  );
 }

--- a/src/features/my/hooks/useMyActivities.ts
+++ b/src/features/my/hooks/useMyActivities.ts
@@ -1,30 +1,41 @@
-import useMyAreaAssignments from 'features/canvass/hooks/useMyAreaAssignments';
+import { useMyAreaAssignmentsFuture } from 'features/canvass/hooks/useMyAreaAssignments';
 import useMyCallAssignments from 'features/callAssignments/hooks/useMyCallAssignments';
-import useMyEvents from 'features/my/hooks/useMyEvents';
+import { useMyEventsFuture } from 'features/my/hooks/useMyEvents';
+import { IFuture, LoadingFuture, ResolvedFuture } from 'core/caching/futures';
 import { MyActivity } from 'features/public/types';
 
-export default function useMyActivities() {
-  const areaAssignments = useMyAreaAssignments();
-  const callAssignments = useMyCallAssignments();
-  const events = useMyEvents();
+export default function useMyActivities(): IFuture<MyActivity[]> {
+  const areaAssignmentsFuture = useMyAreaAssignmentsFuture();
+  const callAssignmentsFuture = useMyCallAssignments();
+  const eventsFuture = useMyEventsFuture();
+
+  if (
+    !areaAssignmentsFuture.data ||
+    !callAssignmentsFuture.data ||
+    !eventsFuture.data
+  ) {
+    return new LoadingFuture();
+  }
 
   const activities: MyActivity[] = [
-    ...areaAssignments.map<MyActivity>((data) => ({
+    ...areaAssignmentsFuture.data.map<MyActivity>((data) => ({
       data,
       kind: 'canvass',
       start: new Date(data.start_date || 0),
     })),
-    ...callAssignments.map<MyActivity>((data) => ({
+    ...callAssignmentsFuture.data.map<MyActivity>((data) => ({
       data,
       kind: 'call',
       start: new Date(data.start_date || 0),
     })),
-    ...events.map<MyActivity>((data) => ({
+    ...eventsFuture.data.map<MyActivity>((data) => ({
       data,
       kind: 'event',
       start: new Date(data.start_time || 0),
     })),
   ];
 
-  return activities.sort((a, b) => a.start.getTime() - b.start.getTime());
+  return new ResolvedFuture(
+    activities.sort((a, b) => a.start.getTime() - b.start.getTime())
+  );
 }

--- a/src/features/my/hooks/useMyEvents.ts
+++ b/src/features/my/hooks/useMyEvents.ts
@@ -1,10 +1,12 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
 import useRemoteList from 'core/hooks/useRemoteList';
+import useRemoteListFuture from 'core/hooks/useRemoteListFuture';
+import { IFuture } from 'core/caching/futures';
 import { userEventsLoad, userEventsLoaded } from '../../events/store';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventWithStatus } from 'features/public/types';
 
-export default function useMyEvents() {
+function useMyEventsListWithHooks() {
   const apiClient = useApiClient();
   const list = useAppSelector((state) => state.events.userEventList);
 
@@ -12,42 +14,56 @@ export default function useMyEvents() {
   const today = now.toISOString().slice(0, 10);
   const url = `/api/users/me/actions?filter=end_time>=${today}`;
 
-  return useRemoteList(list, {
-    actionOnLoad: () => userEventsLoad(),
-    actionOnSuccess: (data) => userEventsLoaded(data),
-    cacheKey: url,
-    loader: async () => {
-      const bookedEventIds: number[] = [];
+  return {
+    hooks: {
+      actionOnLoad: () => userEventsLoad(),
+      actionOnSuccess: (data: ZetkinEventWithStatus[]) =>
+        userEventsLoaded(data),
+      cacheKey: url,
+      loader: async () => {
+        const bookedEventIds: number[] = [];
 
-      try {
-        const bookedEvents = await apiClient
-          .get<ZetkinEvent[]>(url)
-          .then((events) =>
-            events.map<ZetkinEventWithStatus>((event) => {
-              bookedEventIds.push(event.id);
-              return {
-                ...event,
-                status: 'booked',
-              };
-            })
-          );
+        try {
+          const bookedEvents = await apiClient
+            .get<ZetkinEvent[]>(url)
+            .then((events) =>
+              events.map<ZetkinEventWithStatus>((event) => {
+                bookedEventIds.push(event.id);
+                return {
+                  ...event,
+                  status: 'booked',
+                };
+              })
+            );
 
-        const signedUpEvents = await apiClient
-          .get<{ action: ZetkinEvent }[]>(`/api/users/me/action_responses`)
-          .then((events) =>
-            events
-              .map<ZetkinEventWithStatus>((signup) => ({
-                ...signup.action,
-                status: 'signedUp',
-              }))
-              .filter((event) => !bookedEventIds.includes(event.id))
-              .filter(({ end_time }) => end_time >= today)
-          );
+          const signedUpEvents = await apiClient
+            .get<{ action: ZetkinEvent }[]>(`/api/users/me/action_responses`)
+            .then((events) =>
+              events
+                .map<ZetkinEventWithStatus>((signup) => ({
+                  ...signup.action,
+                  status: 'signedUp',
+                }))
+                .filter((event) => !bookedEventIds.includes(event.id))
+                .filter(({ end_time }) => end_time >= today)
+            );
 
-        return [...bookedEvents, ...signedUpEvents];
-      } catch (err) {
-        return [];
-      }
+          return [...bookedEvents, ...signedUpEvents];
+        } catch (err) {
+          return [];
+        }
+      },
     },
-  });
+    list,
+  };
+}
+
+export default function useMyEvents() {
+  const { hooks, list } = useMyEventsListWithHooks();
+  return useRemoteList(list, hooks);
+}
+
+export function useMyEventsFuture(): IFuture<ZetkinEventWithStatus[]> {
+  const { hooks, list } = useMyEventsListWithHooks();
+  return useRemoteListFuture(list, hooks);
 }

--- a/src/features/my/hooks/useMyEvents.ts
+++ b/src/features/my/hooks/useMyEvents.ts
@@ -6,7 +6,7 @@ import { userEventsLoad, userEventsLoaded } from '../../events/store';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { ZetkinEventWithStatus } from 'features/public/types';
 
-function useMyEventsListWithHooks() {
+function useMyEventsList() {
   const apiClient = useApiClient();
   const list = useAppSelector((state) => state.events.userEventList);
 
@@ -59,11 +59,11 @@ function useMyEventsListWithHooks() {
 }
 
 export default function useMyEvents() {
-  const { hooks, list } = useMyEventsListWithHooks();
+  const { hooks, list } = useMyEventsList();
   return useRemoteList(list, hooks);
 }
 
 export function useMyEventsFuture(): IFuture<ZetkinEventWithStatus[]> {
-  const { hooks, list } = useMyEventsListWithHooks();
+  const { hooks, list } = useMyEventsList();
   return useRemoteListFuture(list, hooks);
 }

--- a/src/features/my/pages/AllEventsPage.tsx
+++ b/src/features/my/pages/AllEventsPage.tsx
@@ -1,29 +1,11 @@
 'use client';
 
-import { Box } from '@mui/material';
-import { FC, Suspense } from 'react';
+import { FC } from 'react';
 
-import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import AllEventsList from 'features/my/components/AllEventsList';
 
 const AllEventsPage: FC = () => {
-  return (
-    <Suspense
-      fallback={
-        <Box
-          alignItems="center"
-          display="flex"
-          flexDirection="column"
-          height="90dvh"
-          justifyContent="center"
-        >
-          <ZUILogoLoadingIndicator />
-        </Box>
-      }
-    >
-      <AllEventsList />
-    </Suspense>
-  );
+  return <AllEventsList />;
 };
 
 export default AllEventsPage;

--- a/src/features/my/pages/HomePage.tsx
+++ b/src/features/my/pages/HomePage.tsx
@@ -1,29 +1,11 @@
 'use client';
 
-import { FC, Suspense } from 'react';
-import { Box } from '@mui/material';
+import { FC } from 'react';
 
 import MyActivitiesList from 'features/my/components/MyActivitiesList';
-import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 
 const HomePage: FC = () => {
-  return (
-    <Suspense
-      fallback={
-        <Box
-          alignItems="center"
-          display="flex"
-          flexDirection="column"
-          height="90dvh"
-          justifyContent="center"
-        >
-          <ZUILogoLoadingIndicator />
-        </Box>
-      }
-    >
-      <MyActivitiesList />
-    </Suspense>
-  );
+  return <MyActivitiesList />;
 };
 
 export default HomePage;

--- a/src/features/my/pages/MyOrgsPage.tsx
+++ b/src/features/my/pages/MyOrgsPage.tsx
@@ -1,29 +1,14 @@
 'use client';
 
-import { FC, Suspense } from 'react';
-import { Box, NoSsr } from '@mui/material';
+import { FC } from 'react';
+import { NoSsr } from '@mui/material';
 
 import MyOrgsList from '../components/MyOrgsList';
-import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 
 const MyOrgsPage: FC = () => {
   return (
     <NoSsr>
-      <Suspense
-        fallback={
-          <Box
-            alignItems="center"
-            display="flex"
-            flexDirection="column"
-            height="90dvh"
-            justifyContent="center"
-          >
-            <ZUILogoLoadingIndicator />
-          </Box>
-        }
-      >
-        <MyOrgsList />
-      </Suspense>
+      <MyOrgsList />
     </NoSsr>
   );
 };

--- a/src/features/public/components/ActivistPortalHeader/index.tsx
+++ b/src/features/public/components/ActivistPortalHeader/index.tsx
@@ -13,7 +13,7 @@ import useUser from 'core/hooks/useUser';
 import { useMessages } from 'core/i18n';
 import ZUIMenu, { MenuItem } from 'zui/components/ZUIMenu';
 import ZUIButton from 'zui/components/ZUIButton';
-import useUserMemberships from 'features/public/hooks/useUserMemberships';
+import { useUserMembershipsFuture } from 'features/public/hooks/useUserMemberships';
 
 type Props = {
   button?: JSX.Element;
@@ -40,8 +40,10 @@ const ActivistPortalHeader: FC<Props> = ({
     useState<HTMLButtonElement | null>(null);
   const router = useRouter();
 
-  const memberships = useUserMemberships();
-  const isOfficial = memberships.find((membership) => membership.role != null);
+  const membershipsFuture = useUserMembershipsFuture();
+  const isOfficial = !!membershipsFuture.data?.find(
+    (membership) => membership.role != null
+  );
 
   const menuItems: MenuItem[] = useMemo(
     () => [

--- a/src/features/public/hooks/useUserMemberships.ts
+++ b/src/features/public/hooks/useUserMemberships.ts
@@ -1,22 +1,39 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
 import useRemoteList from 'core/hooks/useRemoteList';
+import useRemoteListFuture from 'core/hooks/useRemoteListFuture';
+import { IFuture } from 'core/caching/futures';
 import {
   userMembershipsLoad,
   userMembershipsLoaded,
 } from 'features/organizations/store';
 import { ZetkinMembership } from 'utils/types/zetkin';
 
-export default function useUserMemberships() {
+function useListWithHooks() {
   const apiClient = useApiClient();
   const list = useAppSelector(
     (state) => state.organizations.userMembershipList
   );
-  return useRemoteList(list, {
-    actionOnLoad: () => userMembershipsLoad(),
-    actionOnSuccess: (data) => userMembershipsLoaded(data),
-    loader: () =>
-      apiClient
-        .get<ZetkinMembership[]>('/api/users/me/memberships')
-        .catch(() => []),
-  });
+
+  return {
+    hooks: {
+      actionOnLoad: () => userMembershipsLoad(),
+      actionOnSuccess: (data: ZetkinMembership[]) =>
+        userMembershipsLoaded(data),
+      loader: () =>
+        apiClient
+          .get<ZetkinMembership[]>('/api/users/me/memberships')
+          .catch(() => []),
+    },
+    list,
+  };
+}
+
+export default function useUserMemberships() {
+  const { hooks, list } = useListWithHooks();
+  return useRemoteList(list, hooks);
+}
+
+export function useUserMembershipsFuture(): IFuture<ZetkinMembership[]> {
+  const { hooks, list } = useListWithHooks();
+  return useRemoteListFuture(list, hooks);
 }

--- a/src/features/public/hooks/useUserMemberships.ts
+++ b/src/features/public/hooks/useUserMemberships.ts
@@ -8,7 +8,7 @@ import {
 } from 'features/organizations/store';
 import { ZetkinMembership } from 'utils/types/zetkin';
 
-function useListWithHooks() {
+function useMembershipsList() {
   const apiClient = useApiClient();
   const list = useAppSelector(
     (state) => state.organizations.userMembershipList
@@ -29,11 +29,11 @@ function useListWithHooks() {
 }
 
 export default function useUserMemberships() {
-  const { hooks, list } = useListWithHooks();
+  const { hooks, list } = useMembershipsList();
   return useRemoteList(list, hooks);
 }
 
 export function useUserMembershipsFuture(): IFuture<ZetkinMembership[]> {
-  const { hooks, list } = useListWithHooks();
+  const { hooks, list } = useMembershipsList();
   return useRemoteListFuture(list, hooks);
 }


### PR DESCRIPTION
## Description

The activist portal pages currently take ~840ms to first content even with an instant API, measured on `main`:

| Page (median, 5 runs, mocked API) | main | this PR | Δ |
|---|---:|---:|---:|
| `/my/home` | 841ms | 129ms | **-85%** |
| `/my/orgs` | 841ms | 105ms | **-87%** |
| `/my/feed` | 843ms | 110ms | **-87%** |

The cause is a suspension cascade: `ActivistPortalHeader` — rendered by `HomeLayout` **above every `/my` page** — calls the suspending `useUserMemberships` hook just to compute an `isOfficial` flag, and the page content suspends on its own data hooks below it. React throttles Suspense fallback reveals (`FALLBACK_THROTTLE_MS` — in React 19 explicitly, and React 18 stacks the same windows), so the reveals queue up into a near-constant ~840ms even though all data has arrived by ~90ms. Full investigation with profiles: [react19-suspense-throttle.md](https://github.com/jfilter/zetkin-benchmark/blob/master/experiments/react19-suspense-throttle.md).

This PR introduces non-suspending variants of the remote-data hooks and converts the `/my` surface:

1. **`useRemoteListFuture` / `useRemoteItemFuture`** (new, in `core/hooks`): same parameters, caching, request-deduplication and stale-while-revalidate semantics as `useRemoteList`/`useRemoteItem`, but they return an `IFuture` instead of throwing the fetch promise. Each call-site conversion is mechanical.
2. **`/my` conversion**: `useMyActivities` (events + call assignments + area assignments), `useAllEvents` and `MyOrgsList` load without suspending; the list components render the same centered loading indicator that the pages previously declared as Suspense fallbacks, so the pages no longer need `<Suspense>` at all.
3. **`ActivistPortalHeader`** uses the non-suspending memberships future — the decisive change, since it sits in the layout. While memberships load, the "Organize" button/menu item is simply absent for a few frames.

Hooks that also have consumers in canvass/public (`useMyEvents`, `useMyAreaAssignments`, `useUserMemberships`) got future-returning siblings, so those call sites are untouched and can be converted incrementally later.

This also removes the main React 19 blocker for #3544 on these pages — on the Next 15 upgrade branch the same conversion takes `/my/home` from 842ms to 122ms.

## Screenshots

N/A — identical UI; the loading state changes from a long blank/indicator phase to the same indicator for a fraction of the time.

## Changes

- New: `useRemoteListFuture`, `useRemoteItemFuture` + specs (9 tests, incl. rendering without a Suspense boundary)
- New: `CenteredLoadingIndicator` (shared; was duplicated as Suspense fallback in three pages)
- Converted: `useMyActivities`, `useAllEvents`, `useMyCallAssignments` (in place); future siblings for `useMyEvents`, `useMyAreaAssignments`, `useUserMemberships`
- `MyActivitiesList`, `AllEventsList`, `MyOrgsList` render their own loading state; `HomePage`, `AllEventsPage`, `MyOrgsPage` drop their `<Suspense>` wrappers
- `ActivistPortalHeader` no longer suspends on memberships

## AI usage

Yes — used Claude Code (Opus 4.8) to profile the pages (timer instrumentation, React fiber inspection), identify the layout-level suspender, implement and benchmark the changes, and write this description.

## Instructions for reviewer

1. `npm test` — includes the new hook specs.
2. Compare `/my/home`, `/my/feed`, `/my/orgs` on main vs this branch with DevTools network throttling: content appears dramatically earlier; loading UI is unchanged.
3. The new hooks mirror `useRemoteList`/`useRemoteItem` except for the return path — diffing the files side by side is the quickest review.

## Related issues

Relates to #3544. Same series as #3692 and #3717.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally