### PR TITLE
Dark mode for ZUIAlert

### DIFF
--- a/src/zui/components/ZUIAlert/index.tsx
+++ b/src/zui/components/ZUIAlert/index.tsx
@@ -71,18 +71,21 @@ const ZUIAlert: FC<ZUIAlertProps> = ({
 }) => {
   const theme = useTheme();
 
+  const backgroundShade = theme.palette.mode === 'dark' ? 900 : 100;
+  const textShade = theme.palette.mode === 'dark' ? 100 : 900;
+
   const backgroundColors = {
-    error: theme.palette.swatches.red[100],
-    info: theme.palette.swatches.blue[100],
-    success: theme.palette.swatches.green[100],
-    warning: theme.palette.swatches.yellow[100],
+    error: theme.palette.swatches.red[backgroundShade],
+    info: theme.palette.swatches.blue[backgroundShade],
+    success: theme.palette.swatches.green[backgroundShade],
+    warning: theme.palette.swatches.yellow[backgroundShade],
   } as const;
 
   const colors = {
-    error: theme.palette.swatches.red[900],
-    info: theme.palette.swatches.blue[900],
-    success: theme.palette.swatches.green[900],
-    warning: theme.palette.swatches.yellow[900],
+    error: theme.palette.swatches.red[textShade],
+    info: theme.palette.swatches.blue[textShade],
+    success: theme.palette.swatches.green[textShade],
+    warning: theme.palette.swatches.yellow[textShade],
   } as const;
 
   const Icon = () => {

--- a/src/zui/theme/palette.ts
+++ b/src/zui/theme/palette.ts
@@ -634,9 +634,9 @@ export const darkPalette: Omit<
   },
   error: {
     contrastText: uiSwatches.basic.white,
-    dark: uiSwatches.red[800],
-    light: uiSwatches.red[400],
-    main: uiSwatches.red[600],
+    dark: uiSwatches.red[600],
+    light: uiSwatches.red[200],
+    main: uiSwatches.red[500],
   },
   //TODO: Remove when use of theses color have been replaced everywhere.
   filterCategoryColors: {
@@ -669,9 +669,9 @@ export const darkPalette: Omit<
   },
   info: {
     contrastText: uiSwatches.basic.white,
-    dark: uiSwatches.blue[800],
-    light: uiSwatches.blue[400],
-    main: uiSwatches.blue[600],
+    dark: uiSwatches.blue[600],
+    light: uiSwatches.blue[200],
+    main: uiSwatches.blue[400],
   },
   mode: 'dark',
   //TODO: Remove when use of these colors have been replaced everywhere.
@@ -711,9 +711,9 @@ export const darkPalette: Omit<
   },
   success: {
     contrastText: uiSwatches.basic.white,
-    dark: uiSwatches.green[800],
-    light: uiSwatches.green[400],
-    main: uiSwatches.green[600],
+    dark: uiSwatches.green[600],
+    light: uiSwatches.green[200],
+    main: uiSwatches.green[400],
   },
   swatches: swatches,
   text: {


### PR DESCRIPTION
## Description

This PR adds dark mode for ZUIAlert. 

## Screenshots

[Add screenshots here]

<img width="2299" height="623" alt="zui-alert-dark-mode" src="https://github.com/user-attachments/assets/7cbcd4c9-41af-4eb5-9269-3cb9526510db" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds dark mode for ZUIAlert

## AI usage

Did you use AI to create the code in this PR?

No

## Instructions for reviewer

- Go to /storybook
- Go to ZUIAlert
- Test out a few options like info/warning

Note that the white box below Animates Out / Animates In And Out are from ZUISection, which doesn't support dark mode yet.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
