### PR TITLE
Dark mode for ZUIBreadcrumbs

### DIFF
--- a/src/zui/components/ZUIBreadcrumbs/index.tsx
+++ b/src/zui/components/ZUIBreadcrumbs/index.tsx
@@ -55,7 +55,10 @@ const BreadCrumbSibling: FC<{
             {Icon && !isCurrentItem ? (
               <Icon
                 sx={(theme) => ({
-                  color: theme.palette.grey[300],
+                  color:
+                    theme.palette.grey[
+                      theme.palette.mode === 'dark' ? 400 : 300
+                    ],
                   fontSize: '1.25rem',
                   marginRight: '0.375rem',
                 })}
@@ -85,7 +88,7 @@ const Breadcrumb: FC<{
     {!isTopLevel ? (
       <SubdirectoryArrowRight
         sx={(theme) => ({
-          color: theme.palette.grey[200],
+          color: theme.palette.grey[theme.palette.mode === 'dark' ? 800 : 200],
           fontSize: '1.25rem',
           marginRight: '0.25rem',
         })}
@@ -184,9 +187,10 @@ const ZUIBreadcrumbs: FC<ZUIBreadcrumbsProps> = ({ breadcrumbs }) => {
         <Box
           sx={(theme) => ({
             alignItems: 'center',
-            backgroundColor: theme.palette.grey[50],
+            backgroundColor:
+              theme.palette.grey[theme.palette.mode === 'dark' ? 900 : 50],
             borderRadius: '2rem 0 0 2rem',
-            borderRight: `0.063rem solid ${theme.palette.grey[200]}`,
+            borderRight: `0.063rem solid ${theme.palette.grey[theme.palette.mode === 'dark' ? 800 : 200]}`,
             display: 'flex',
             height: '1.625rem',
           })}
@@ -207,7 +211,8 @@ const ZUIBreadcrumbs: FC<ZUIBreadcrumbsProps> = ({ breadcrumbs }) => {
         }
         sx={(theme) => ({
           alignItems: 'center',
-          backgroundColor: theme.palette.grey[50],
+          backgroundColor:
+            theme.palette.grey[theme.palette.mode === 'dark' ? 900 : 50],
           borderRadius: '0 2rem 2rem 0',
           cursor: 'pointer',
           display: 'flex',


### PR DESCRIPTION
## Description

This PR adds dark mode for ZUIBreadcrumbs. 

## Screenshots
[Add screenshots here]

<img width="1032" height="1152" alt="zui-breadcrumbs-dark-mode" src="https://github.com/user-attachments/assets/37100be2-5448-42f6-b892-7f6360782969" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds dark mode for ZUIBreadcrumbs

## AI usage

Did you use AI to create the code in this PR?

No

## Instructions for reviewer

- Go to /storybook
- Go to ZUIBreadcrumbs
- Click on …

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
