### PR TITLE
Dark mode for ZUIButton

### DIFF
--- a/src/zui/theme/palette.ts
+++ b/src/zui/theme/palette.ts
@@ -686,7 +686,7 @@ export const darkPalette: Omit<
   },
   primary: {
     contrastText: uiSwatches.basic.black,
-    dark: uiSwatches.basic.black,
+    dark: uiSwatches.grey[200],
     focus: alpha(uiSwatches.basic.white, 0.12),
     focusVisible: alpha(uiSwatches.basic.white, 0.3),
     hover: alpha(uiSwatches.basic.white, 0.04),


### PR DESCRIPTION
## Description

This PR adds dark mode for ZUIButton, or more like fixes the only issue it was having by updating the primary dark color. But this PR has the goal of achieving dark mode support for ZUIButton.

## Screenshots
[Add screenshots here]


<img width="308" height="177" alt="zui-dark-mode-zui-button" src="https://github.com/user-attachments/assets/1dca9d9f-1e39-4e76-a734-489022389f0f" />


## Changes

[Add a list of features added/changed, bugs fixed etc]

- Updates primary dark color for dark theme palette

## AI usage

Did you use AI to create the code in this PR?

No

## Instructions for reviewer

- Go to /storybook
- Go to ZUIButton
- Explore all the buttons

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
