### PR TITLE
Add calendar button aria label

### DIFF
--- a/src/features/campaigns/l10n/messageIds.ts
+++ b/src/features/campaigns/l10n/messageIds.ts
@@ -193,6 +193,7 @@ export default makeMessages('feat.campaigns', {
       },
       filterButtonLabels: {
         locations: m<{ count: number }>('{count} locations'),
+        selectDate: m('Select a date'),
         thisWeek: m('This week'),
         today: m('Today'),
         tomorrow: m('Tomorrow'),

--- a/src/features/my/components/AllEventsList.tsx
+++ b/src/features/my/components/AllEventsList.tsx
@@ -279,6 +279,7 @@ const AllEventsList: FC = () => {
     },
     {
       active: dateFilterState === 'custom',
+      ariaLabel: messages.allEventsList.filterButtonLabels.selectDate(),
       key: 'custom',
       label:
         dateFilterState === 'custom' && customDatesToFilterBy[0]
@@ -375,6 +376,7 @@ const AllEventsList: FC = () => {
             <ZUIFilterButton
               key={filter.key}
               active={filter.active}
+              ariaLabel={filter.ariaLabel}
               label={filter.label}
               onClick={filter.onClick}
             />

--- a/src/features/my/l10n/messageIds.ts
+++ b/src/features/my/l10n/messageIds.ts
@@ -34,6 +34,7 @@ export default makeMessages('feat.home', {
       organizations: m<{ numOrgs: number }>(
         '{numOrgs, plural,=0 {Organizations} =1 {1 organization} other {# organizations}}'
       ),
+      selectDate: m('Select a date'),
       thisWeek: m('This week'),
       today: m('Today'),
       tomorrow: m('Tomorrow'),

--- a/src/features/organizations/l10n/messageIds.ts
+++ b/src/features/organizations/l10n/messageIds.ts
@@ -13,6 +13,7 @@ export default makeMessages('feat.organizations', {
       organizations: m<{ numOrgs: number }>(
         '{numOrgs, plural,=0 {Organizations} =1 {1 organization} other {# organizations}}'
       ),
+      selectDate: m('Select a date'),
       thisWeek: m('This week'),
       today: m('Today'),
       tomorrow: m('Tomorrow'),

--- a/src/features/public/pages/PublicOrgPage.tsx
+++ b/src/features/public/pages/PublicOrgPage.tsx
@@ -159,6 +159,7 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
     },
     {
       active: dateFilterState === 'custom',
+      ariaLabel: messages.allEventsList.filterButtonLabels.selectDate(),
       key: 'custom',
       label:
         dateFilterState === 'custom' && customDatesToFilterBy[0]
@@ -342,6 +343,7 @@ const PublicOrgPage: FC<Props> = ({ orgId }) => {
             <ZUIFilterButton
               key={filter.key}
               active={filter.active}
+              ariaLabel={filter.ariaLabel}
               label={filter.label}
               onClick={filter.onClick}
             />

--- a/src/features/public/pages/PublicProjPage.tsx
+++ b/src/features/public/pages/PublicProjPage.tsx
@@ -132,6 +132,8 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
     },
     {
       active: dateFilterState === 'custom',
+      ariaLabel:
+        messages.publicProjectPage.eventList.filterButtonLabels.selectDate(),
       key: 'custom',
       label:
         dateFilterState === 'custom' && customDatesToFilterBy[0]
@@ -280,6 +282,7 @@ const PublicProjectPage: FC<Props> = ({ campId, orgId }) => {
             <ZUIFilterButton
               key={filter.key}
               active={filter.active}
+              ariaLabel={filter.ariaLabel}
               label={filter.label}
               onClick={filter.onClick}
             />

--- a/src/zui/components/ZUIFilterButton/index.tsx
+++ b/src/zui/components/ZUIFilterButton/index.tsx
@@ -11,6 +11,12 @@ type ZUIFilterButtonProps = {
   active: boolean;
 
   /**
+   * If the button should have an aria label
+   * Buttons that has icons instead of labels needs aria-label to be understandable to screen readers
+   */
+  ariaLabel?: string;
+
+  /**
    * If the button should be circular.
    * For example, if it only contains a Close icon.
    *
@@ -31,6 +37,7 @@ type ZUIFilterButtonProps = {
 
 const ZUIFilterButton: FC<ZUIFilterButtonProps> = ({
   active,
+  ariaLabel,
   circular,
   label,
   onClick,
@@ -61,6 +68,7 @@ const ZUIFilterButton: FC<ZUIFilterButtonProps> = ({
 
   return (
     <Box
+      aria-label={ariaLabel}
       component="button"
       onClick={onClick}
       sx={(theme) => ({


### PR DESCRIPTION
## Description

This PR adds aria labels to calendar buttons which before only contained an icon.

## Screenshots

<img width="1406" height="552" alt="aria" src="https://github.com/user-attachments/assets/9db5f684-7da0-410e-b86a-7ba6143506d5" />


## Changes

- Adds support to ZUIFilterButton to have an aria-label attribute
- Add aria labels for calendar buttons in all events, org and project pages

## AI usage

None whatsoever. This code sings without AI usage.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.
- Go to http://localhost:3000/my/feed
- Use dev tools to look at calendar element.
- See that it contains aria-label="Select a date"
OR
- Download a screen reader. [NVDA](https://www.nvaccess.org/download/) is a free screen reader for windows. [Orca](https://orca.gnome.org/) exists for Linux
- Hover over the calendar icon
- The screen reader should say "Select a date"

## Related issues

Resolves #3640


## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
