### PR TITLE
Use Select instead of TextField select for survey widget type picker

### DIFF
--- a/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
+++ b/src/features/surveys/components/SurveyEditor/blocks/ChoiceQuestionBlock.tsx
@@ -10,9 +10,12 @@ import {
   Box,
   Button,
   ClickAwayListener,
+  FormControl,
   IconButton,
+  InputLabel,
   ListItemIcon,
   MenuItem,
+  Select,
   TextField,
   Typography,
 } from '@mui/material';
@@ -180,33 +183,32 @@ const ChoiceQuestionBlock: FC<ChoiceQuestionBlockProps> = ({
           variant="content"
         />
         {editable && (
-          <TextField
-            fullWidth
-            label={messages.blocks.choice.widget()}
-            margin="normal"
-            onChange={(ev) => {
-              setWidgetType(ev.target.value as WidgetTypeValue);
-            }}
-            select
-            SelectProps={{
-              MenuProps: { disablePortal: true },
-            }}
-            sx={{ alignItems: 'center', display: 'flex' }}
-            value={widgetType}
-          >
-            {Object.entries(widgetTypes).map(([value, type]) => (
-              <MenuItem key={value} value={value}>
-                <Box alignItems="center" display="flex">
-                  <ListItemIcon>{type.icon}</ListItemIcon>
-                  <Msg
-                    id={
-                      messageIds.blocks.choice.widgets[value as WidgetTypeValue]
-                    }
-                  />
-                </Box>
-              </MenuItem>
-            ))}
-          </TextField>
+          <FormControl fullWidth margin="normal">
+            <InputLabel>{messages.blocks.choice.widget()}</InputLabel>
+            <Select
+              label={messages.blocks.choice.widget()}
+              MenuProps={{ disablePortal: true }}
+              onChange={(ev) => {
+                setWidgetType(ev.target.value as WidgetTypeValue);
+              }}
+              value={widgetType}
+            >
+              {Object.entries(widgetTypes).map(([value, type]) => (
+                <MenuItem key={value} value={value}>
+                  <Box alignItems="center" display="flex">
+                    <ListItemIcon>{type.icon}</ListItemIcon>
+                    <Msg
+                      id={
+                        messageIds.blocks.choice.widgets[
+                          value as WidgetTypeValue
+                        ]
+                      }
+                    />
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         )}
         <ZUIReorderable
           centerWidgets


### PR DESCRIPTION
## Description and Changes

Replaces `<TextField select>` with `<FormControl> + <InputLabel> + <Select>` so that MUI manages aria-activedescendant correctly, enabling screen readers to announce the focused option when navigating with arrow keys.

Fixes #3642


## AI usage

Used Claude CLI to read the issue, create the bugfix and verify the change in DOM. Reviewed the code change and tested manually.


## Instructions for reviewer

1. Open http://localhost:3000/organize/1/projects/5/surveys/7/questions in the browser
2. Log in: testadmin@example.com / password → click "Send SMS" → enter 999999
3. Toggle "Survey locked" in the top right → "Survey can be edited"
4. Scroll to the bottom choice block (title "asdasd", checkbox icons) and click it
5. The Widget dropdown appears with the label "Widget" and the value "Multi-choice (checkboxes)"

For the VoiceOver test itself:
- ⌘ F5 → enable VoiceOver
- Focus the Widget dropdown (Tab or click)
- Navigate through the three options with arrow keys (Checkboxes / Radio buttons / Dropdown)
- VoiceOver should now announce the focused option — previously it was silent


## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
