### PR TITLE
Add indicator when canvass assignment isn't for local user

### DIFF
--- a/src/app/canvass/[areaAssId]/areas/page.tsx
+++ b/src/app/canvass/[areaAssId]/areas/page.tsx
@@ -20,9 +20,9 @@ export default async function Page({ params }: PageProps) {
   const apiClient = new BackendApiClient(headersObject);
 
   try {
-    await apiClient.get<ZetkinOrganization>(`/api/users/me`);
+    const me = await apiClient.get<ZetkinOrganization>(`/api/users/me`);
 
-    return <CanvassSelectAreaPage areaAssId={areaAssId} />;
+    return <CanvassSelectAreaPage areaAssId={areaAssId} myUserId={me.id} />;
   } catch (err) {
     if (err instanceof ApiClientError && err.status === 401) {
       return redirect(`/login?redirect=/canvass/${areaAssId}`);

--- a/src/features/canvass/components/CanvassSelectAreaPage.tsx
+++ b/src/features/canvass/components/CanvassSelectAreaPage.tsx
@@ -6,6 +6,7 @@ import { ArrowForwardIos } from '@mui/icons-material';
 import {
   Avatar,
   Box,
+  Chip,
   CircularProgress,
   Divider,
   List,
@@ -21,20 +22,39 @@ import { ZetkinAreaAssignment } from '../../areaAssignments/types';
 import useOrganization from 'features/organizations/hooks/useOrganization';
 import ZUIFutures from 'zui/ZUIFutures';
 import oldTheme from 'theme';
-import { Msg } from 'core/i18n';
+import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import useAssignmentAreas from 'features/areaAssignments/hooks/useAssignmentAreas';
+import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
 
 const Page: FC<{
   assignment: ZetkinAreaAssignment;
-}> = ({ assignment }) => {
+  myUserId: number;
+}> = ({ assignment, myUserId }) => {
   const orgFuture = useOrganization(assignment.organization_id);
   const router = useRouter();
   const areas = useAssignmentAreas(assignment.organization_id, assignment.id);
+  const assigneesFuture = useAreaAssignees(
+    assignment.organization_id,
+    assignment.id
+  );
+  const messages = useMessages(messageIds);
   const [loadingAreaId, setLoadingAreaId] = useState<number | null>(null);
+
+  let hasMixedUsers = false;
+  if (
+    !assigneesFuture.isLoading &&
+    assigneesFuture.data &&
+    assigneesFuture.data.length != 1
+  ) {
+    hasMixedUsers = assigneesFuture.data
+      ?.slice(1)
+      .some((a) => a.user_id != assigneesFuture.data?.[0].user_id);
+  }
+
   return (
-    <ZUIFutures futures={{ org: orgFuture }}>
-      {({ data: { org } }) => (
+    <ZUIFutures futures={{ assignees: assigneesFuture, org: orgFuture }}>
+      {({ data: { assignees, org } }) => (
         <Box
           sx={{
             display: 'flex',
@@ -112,7 +132,22 @@ const Page: FC<{
                         {loadingAreaId === area.id ? (
                           <CircularProgress size={20} />
                         ) : (
-                          <ArrowForwardIos fontSize="small" />
+                          <Box alignItems="center" display={'flex'}>
+                            {hasMixedUsers &&
+                              assignees.find(
+                                (a) =>
+                                  a.area_id == area.id && a.user_id == myUserId
+                              ) && (
+                                <Chip
+                                  label={messages.selectArea.assignedToMe()}
+                                  sx={{
+                                    backgroundColor: '#f2c71b',
+                                    marginRight: 2,
+                                  }}
+                                />
+                              )}
+                            <ArrowForwardIos fontSize="small" />
+                          </Box>
                         )}
                       </ListItemButton>
                     </ListItem>
@@ -134,10 +169,12 @@ const Page: FC<{
 
 type CanvassSelectAreaPageProps = {
   areaAssId: number;
+  myUserId: number;
 };
 
 const CanvassSelectAreaPage: FC<CanvassSelectAreaPageProps> = ({
   areaAssId,
+  myUserId,
 }) => {
   const myAssignments = useMyCanvassAssignments() || [];
   const assignment = myAssignments.find(
@@ -148,7 +185,7 @@ const CanvassSelectAreaPage: FC<CanvassSelectAreaPageProps> = ({
     notFound();
   }
 
-  return <Page assignment={assignment} />;
+  return <Page assignment={assignment} myUserId={myUserId} />;
 };
 
 export default CanvassSelectAreaPage;

--- a/src/features/canvass/l10n/messageIds.ts
+++ b/src/features/canvass/l10n/messageIds.ts
@@ -145,6 +145,7 @@ export default makeMessages('feat.canvass', {
     ),
   },
   selectArea: {
+    assignedToMe: m('Assigned to me'),
     noAreas: m('No areas available'),
   },
   sidebar: {


### PR DESCRIPTION
## Description

This PR makes it clearer when a area assignment is not indicated to the local user.

## Screenshots

<img width="670" height="590" alt="image" src="https://github.com/user-attachments/assets/4c949482-9086-4366-8b91-8dabe9d68129" />

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds a yellow "Chip" to the area list when there's area assignments for multiple users in the list.

## AI usage

No ai used

## Instructions for reviewer

- I had trouble setting up a new area assignment and signing in with a non-admin user, I tested some cases with local workarounds.
- Open a canvas that has multiple areas with more than one person assigned with a admin user, you should see "Assigned to me" chips on the right side
- Open a canvas with a non-admin user, there should not be "Assigned to me" chips because they are all assigned to thus person

## Related issues

Resolves #3526

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
