### PR TITLE
Make `Day` component use Temporal.PlainDate

### DIFF
--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -56,7 +56,7 @@ const Day = ({
           }}
           variant="body2"
         >
-          {date.toLocaleString(undefined, { day: 'numeric' })}
+          {date.day}
         </Typography>
       </Box>
       {dstChange !== undefined && (

--- a/src/features/calendar/components/CalendarMonthView/Day.tsx
+++ b/src/features/calendar/components/CalendarMonthView/Day.tsx
@@ -1,5 +1,3 @@
-import dayjs from 'dayjs';
-import { FormattedDate } from 'react-intl';
 import { Box, Typography } from '@mui/material';
 import { useMemo } from 'react';
 
@@ -12,10 +10,10 @@ import { Msg } from 'core/i18n';
 
 type DayProps = {
   clusters: AnyClusteredEvent[];
-  date: Date;
+  date: Temporal.PlainDate;
   isInFocusMonth: boolean;
   itemHeight: number;
-  onClick: (date: Date) => void;
+  onClick: (date: Temporal.PlainDate) => void;
 };
 
 const Day = ({
@@ -25,8 +23,8 @@ const Day = ({
   itemHeight,
   onClick,
 }: DayProps) => {
-  const isToday = dayjs(date).isSame(new Date(), 'day');
-  const dstChange = useMemo(() => getDstChangeAtDate(dayjs(date)), [date]);
+  const isToday = date.equals(Temporal.Now.plainDateISO());
+  const dstChange = useMemo(() => getDstChangeAtDate(date), [date]);
 
   let textColor = oldTheme.palette.text.secondary;
   if (isToday) {
@@ -58,7 +56,7 @@ const Day = ({
           }}
           variant="body2"
         >
-          <FormattedDate day="numeric" value={date} />
+          {date.toLocaleString(undefined, { day: 'numeric' })}
         </Typography>
       </Box>
       {dstChange !== undefined && (

--- a/src/features/calendar/components/CalendarMonthView/index.tsx
+++ b/src/features/calendar/components/CalendarMonthView/index.tsx
@@ -9,6 +9,10 @@ import { useNumericRouteParams } from 'core/hooks';
 import useResizeObserver from 'zui/hooks/useResizeObserver';
 import WeekNumber from './WeekNumber';
 import { getDaysBeforeFirstDay, getWeekNumber } from './utils';
+import {
+  legacyDateFromPlainDate,
+  plainDateFromLegacyDate,
+} from 'utils/dateUtils';
 
 const gridGap = 8;
 const numberOfRows = 6;
@@ -93,10 +97,10 @@ const CalendarMonthView = ({
               <Day
                 key={gridItemKey}
                 clusters={clusters}
-                date={date}
+                date={plainDateFromLegacyDate(date)}
                 isInFocusMonth={isInFocusMonth}
                 itemHeight={itemHeight}
-                onClick={onClickDay}
+                onClick={(value) => onClickDay(legacyDateFromPlainDate(value))}
               />
             );
           })

--- a/src/features/calendar/components/utils.ts
+++ b/src/features/calendar/components/utils.ts
@@ -105,7 +105,19 @@ export const getActivitiesByDay = (
 };
 
 export type DSTChange = 'summertime' | 'wintertime';
-export function getDstChangeAtDate(date: dayjs.Dayjs): DSTChange | undefined {
+export function getDstChangeAtDate(
+  date: dayjs.Dayjs | Temporal.PlainDate
+): DSTChange | undefined {
+  if (date instanceof Temporal.PlainDate) {
+    const { hoursInDay } = date.toZonedDateTime(Temporal.Now.timeZoneId());
+    if (hoursInDay === 23) {
+      return 'summertime';
+    }
+    if (hoursInDay === 25) {
+      return 'wintertime';
+    }
+    return undefined;
+  }
   const change =
     getTimezoneAtDate(date.startOf('day')) -
     getTimezoneAtDate(date.endOf('day'));

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -104,3 +104,13 @@ export function getOffset(dateString: string) {
 export function getDayTimeInMinutes(dateString: string | dayjs.Dayjs) {
   return dayjs(dateString).hour() * 60 + dayjs(dateString).minute();
 }
+
+export const plainDateFromLegacyDate = (date: Date): Temporal.PlainDate =>
+  Temporal.Instant.fromEpochMilliseconds(date.valueOf())
+    .toZonedDateTimeISO(Temporal.Now.timeZoneId())
+    .toPlainDate();
+
+export const legacyDateFromPlainDate = (plainDate: Temporal.PlainDate): Date =>
+  new Date(
+    plainDate.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds
+  );


### PR DESCRIPTION
## Description

This PR replaces some more usages of dayjs with the new official Temporal API.


It changes the `Day` component from working with `Date`s (that is, millisecond precision time stamps) to `Temporal.PlainDate`s (that is just a year, month and date). I think that this semantically makes sense.

I have also introduced `legacyDateFromPlainDate` and `plainDateFromLegacyDate` helpers to keep this change as small as possible. I eventually want the changes to spread from here but in order to keep the PR reviewable, I tried to keep the existing boundaries mostly as they were. More PRs will follow.