### PR TITLE
Add security.md and .txt files

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+Security is core to our values, and we value the input of hackers acting in good faith to help us maintain a high standard for the security and privacy for our users. This includes encouraging responsible vulnerability research and disclosure. This policy sets out our definition of good faith in the context of finding and reporting vulnerabilities, as well as what you can expect from us in return.
+
+## Expectations
+
+When working with us according to this policy, you can expect us to:
+
+- Extend Safe Harbor (see below) for your vulnerability research that is related to this policy;
+- Work with you to understand and validate your report
+- Work to remediate discovered vulnerabilities in a timely manner; and
+- Recognize your contribution to improving our security if you are the first to report a unique vulnerability, and your report triggers a code or configuration change.
+
+## Safe Harbor
+
+When conducting vulnerability research according to this policy, we consider this research to be:
+
+- Authorized in accordance with the law, and we will not initiate or support legal action against you for accidental, good faith violations of this policy;
+- Exempt from the Digital Millennium Copyright Act (DMCA), and we will not bring a claim against you for circumvention of technology controls;
+- Exempt from restrictions in our Terms & Conditions that would interfere with conducting security research, and we waive those restrictions on a limited basis for work done under this policy;
+- Lawful, helpful to the overall security of the Internet, and conducted in good faith.
+
+You are expected, as always, to comply with all applicable laws.
+
+If at any time you have concerns or are uncertain whether your security research is consistent with this policy, please submit a report through one of our Official Channels before going any further.
+
+## Ground Rules
+
+To encourage vulnerability research and to avoid any confusion between good-faith hacking and malicious attack, we ask that you:
+
+- Play by the rules. This includes following this policy, as well as any other relevant agreements. If there is any inconsistency between this policy and any other relevant terms, the terms of this policy will prevail.
+- Report any vulnerability you have discovered promptly.
+- Avoid violating the privacy of others, disrupting our systems, destroying data, and/or harming user experience.
+- Use only the Official Channels to discuss vulnerability information with us.
+- Keep the details of any discovered vulnerabilities confidential until they are fixed, according to the Disclosure Terms in this policy.
+- Perform testing only on in-scope systems, and respect systems and activities which are out-of-scope. Systems currently considered in-scope are the official demonstration/test servers provided by the Zetkin development team, http://www.dev.zetkin.org/ and http://login.dev.zetkin.org, as well as what you can self host from this repository.
+- If a vulnerability provides unintended access to data: Limit the amount of data you access to the minimum required for effectively demonstrating a Proof of Concept; and cease testing and submit a report immediately if you encounter any user data during testing, such as Personally Identifiable Information (PII), Personal Healthcare Information (PHI), credit card data, or proprietary information.
+- You should only interact with test accounts you own or with explicit permission from the account holder.
+- Do not engage in extortion.
+
+## Disclosure Terms
+
+The vulnerability is kept private until a fix has been deployed.
+
+## Official Channels
+
+To help us receive vulnerability submissions we use the following official reporting channel:
+
+- info@zetkin.org
+
+If you think you have found a vulnerability, please include the following details with your report and be as descriptive as possible:
+
+- The location and nature of the vulnerability,
+- A detailed description of the steps required to reproduce the vulnerability (screenshots, compressed screen recordings, and proof-of-concept scripts are all helpful), and
+- Your name/handle and a link for recognition.
+
+We may modify the terms of this program or terminate this program at any time. We will not apply any changes we make to these program terms retroactively.

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,10 @@
+# Zetkin security contacts and policy
+
+# Our security contact channels
+Contact: mailto:info@zetkin.org
+
+# Link to our vulnerability disclosure policy
+Policy: https://github.com/zetkin/app.zetkin.org/blob/main/SECURITY.md
+
+# Languages that our team speaks and understands
+Preferred-Languages: en-US


### PR DESCRIPTION
## Description
This PR adds information regarding security issue reporting.


## Screenshots


## Changes
[Add a list of features added/changed, bugs fixed etc]

* Adds SECURITY.md to the repository
* Adds a [standardized](https://securitytxt.org/) /security.txt file to the root of the app which contains the email address and links to the md file on github


## Notes to reviewer

Please check that the scope for testing defined in Ground Rules is correct.

The URL /security.txt should now contain links with information regarding vulnerability disclosure.

Another addition could be to enable [Private vulnerability reporting](https://github.com/zetkin/app.zetkin.org/security) on the repository and include this as a official reporting channel as well. A dedicated security email address with a optional PGP key could be a way to further improve the document and reassure commitment to secure reporting in the future.

## Related issues
Resolves #2704

--- 
This PR needed to be reopened, as this needs to be discussed by the board team first. 
### [The original PR can be found here](https://github.com/zetkin/app.zetkin.org/pull/2748)

All the credits of this work go to @Herover. I just reopened it, due to closing and merging the first one to early