### PR TITLE
Use Temporal types for `CalendarWeekView`

### DIFF
--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -1,7 +1,5 @@
-import { FormattedDate } from 'react-intl';
 import { Box, Typography } from '@mui/material';
 import { useMemo } from 'react';
-import dayjs from 'dayjs';
 
 import oldTheme from 'theme';
 import { getDstChangeAtDate } from '../utils';
@@ -9,13 +7,13 @@ import { Msg } from 'core/i18n';
 import messageIds from '../../l10n/messageIds';
 
 export interface DayHeaderProps {
-  date: Date;
+  date: Temporal.PlainDate;
   focused: boolean;
   onClick: () => void;
 }
 
 const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
-  const dstChange = useMemo(() => getDstChangeAtDate(dayjs(date)), [date]);
+  const dstChange = useMemo(() => getDstChangeAtDate(date), [date]);
 
   return (
     <Box
@@ -31,7 +29,7 @@ const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
       {/* Day string */}
       <Box alignItems="center" display="flex" justifyContent="flex-start">
         <Typography color={oldTheme.palette.grey[500]} variant="subtitle2">
-          <FormattedDate value={date} weekday="short" />
+          {date.toLocaleString(undefined, { weekday: 'short' })}
         </Typography>
       </Box>
       {/* Day number */}
@@ -50,7 +48,7 @@ const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
           }}
         >
           <Typography color={focused ? 'white' : 'inherit'} fontSize="1.2em">
-            <FormattedDate day="numeric" value={date} />
+            {date.toLocaleString(undefined, { day: 'numeric' })}
           </Typography>
         </Box>
       </Box>

--- a/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
+++ b/src/features/calendar/components/CalendarWeekView/DayHeader.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from '@mui/material';
+import { useIntl } from 'react-intl';
 import { useMemo } from 'react';
 
 import oldTheme from 'theme';
@@ -13,6 +14,7 @@ export interface DayHeaderProps {
 }
 
 const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
+  const intl = useIntl();
   const dstChange = useMemo(() => getDstChangeAtDate(date), [date]);
 
   return (
@@ -29,7 +31,7 @@ const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
       {/* Day string */}
       <Box alignItems="center" display="flex" justifyContent="flex-start">
         <Typography color={oldTheme.palette.grey[500]} variant="subtitle2">
-          {date.toLocaleString(undefined, { weekday: 'short' })}
+          {date.toLocaleString(intl.locale, { weekday: 'short' })}
         </Typography>
       </Box>
       {/* Day number */}
@@ -48,7 +50,7 @@ const DayHeader = ({ date, focused, onClick }: DayHeaderProps) => {
           }}
         >
           <Typography color={focused ? 'white' : 'inherit'} fontSize="1.2em">
-            {date.toLocaleString(undefined, { day: 'numeric' })}
+            {date.day}
           </Typography>
         </Box>
       </Box>

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -1,7 +1,4 @@
 import { Box, lighten } from '@mui/system';
-import dayjs from 'dayjs';
-import { FormattedTime } from 'react-intl';
-import isoWeek from 'dayjs/plugin/isoWeek';
 import { Event, SplitscreenOutlined } from '@mui/icons-material';
 import {
   ListItemIcon,
@@ -18,7 +15,7 @@ import EventDayLane from './EventDayLane';
 import EventGhost from './EventGhost';
 import EventShiftModal from '../EventShiftModal';
 import HeaderWeekNumber from './HeaderWeekNumber';
-import { isSameDate } from 'utils/dateUtils';
+import { legacyDateFromPlainDate } from 'utils/dateUtils';
 import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import range from 'utils/range';
@@ -28,20 +25,16 @@ import useCreateEvent from 'features/events/hooks/useCreateEvent';
 import { useNumericRouteParams } from 'core/hooks';
 import useWeekCalendarEvents from 'features/calendar/hooks/useWeekCalendarEvents';
 
-dayjs.extend(isoWeek);
-
 const HOUR_HEIGHT = 80;
 const HOUR_COLUMN_WIDTH = '60px';
 
 const CurrentTimeCircleMarker = ({
   currentTime,
 }: {
-  currentTime: dayjs.Dayjs;
+  currentTime: Temporal.PlainTime;
 }) => {
   const topOffset =
-    (currentTime.hour() +
-      currentTime.minute() / 60 +
-      currentTime.second() / 60 / 60) *
+    currentTime.since({ hour: 0, minute: 0, second: 0 }).total('hours') *
     HOUR_HEIGHT;
   return (
     <Box
@@ -63,12 +56,10 @@ const CurrentTimeCircleMarker = ({
 const CurrentTimeLineMarker = ({
   currentTime,
 }: {
-  currentTime: dayjs.Dayjs;
+  currentTime: Temporal.PlainTime;
 }) => {
   const topOffset =
-    (currentTime.hour() +
-      currentTime.minute() / 60 +
-      currentTime.second() / 60 / 60) *
+    currentTime.since({ hour: 0, minute: 0, second: 0 }).total('hours') *
     HOUR_HEIGHT;
   return (
     <Box
@@ -88,43 +79,45 @@ const CurrentTimeLineMarker = ({
 };
 
 export interface CalendarWeekViewProps {
-  focusDate: Date;
+  focusDate: Temporal.PlainDate;
   onClickDay: (date: Date) => void;
 }
 const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
   const [creating, setCreating] = useState(false);
   const [shiftModalOpen, setShiftModalOpen] = useState(false);
-  const [pendingEvent, setPendingEvent] = useState<[Date, Date] | null>(null);
+  const [pendingEvent, setPendingEvent] = useState<
+    [Temporal.PlainDateTime, Temporal.PlainDateTime] | null
+  >(null);
   const [ghostAnchorEl, setGhostAnchorEl] = useState<HTMLDivElement | null>(
     null
   );
   const { orgId, projectId } = useNumericRouteParams();
   const createEvent = useCreateEvent(orgId);
-  const focusWeekStartDay =
-    dayjs(focusDate).isoWeekday() == 7
-      ? dayjs(focusDate).add(-1, 'day')
-      : dayjs(focusDate);
+  const focusWeekStartDay = focusDate.subtract({
+    days: focusDate.dayOfWeek - 1,
+  });
 
   const dayDates = range(7).map((weekday) => {
-    return focusWeekStartDay.day(weekday + 1).toDate();
+    return focusWeekStartDay.add({ days: weekday });
   });
 
   const dstChange = useMemo(
-    () =>
-      dayDates.map((d) => dayjs(d)).find((date) => getDstChangeAtDate(date)),
+    () => dayDates.find(getDstChangeAtDate),
     [dayDates]
   );
 
   const eventsByDate = useWeekCalendarEvents({
-    dates: dayDates,
+    dates: dayDates.map(legacyDateFromPlainDate),
     orgId,
     projectId,
   });
 
-  const [currentTime, setCurrentTime] = useState<dayjs.Dayjs>(dayjs());
+  const [currentTime, setCurrentTime] = useState<Temporal.PlainDateTime>(
+    Temporal.Now.plainDateTimeISO()
+  );
   useEffect(() => {
     const timer = setInterval(() => {
-      setCurrentTime(dayjs());
+      setCurrentTime(Temporal.Now.plainDateTimeISO());
     }, 1000);
     return () => {
       clearInterval(timer);
@@ -156,16 +149,14 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         position="relative"
       >
         {/* Empty */}
-        <HeaderWeekNumber weekNr={dayjs(dayDates[0]).isoWeek()} />
-        {dayDates.map((weekdayDate: Date, weekday: number) => {
+        <HeaderWeekNumber weekNr={dayDates[0].weekOfYear!} />
+        {dayDates.map((weekdayDate: Temporal.PlainDate, weekday: number) => {
           return (
             <Box key={`weekday-${weekday}`} position="relative">
               <DayHeader
                 date={weekdayDate}
-                focused={
-                  new Date().toDateString() == weekdayDate.toDateString()
-                }
-                onClick={() => onClickDay(weekdayDate)}
+                focused={Temporal.Now.plainDateISO().equals(weekdayDate)}
+                onClick={() => onClickDay(legacyDateFromPlainDate(weekdayDate))}
               />
               <Box
                 sx={{
@@ -204,7 +195,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
         {/* Hours column */}
         <Box>
           {range(24).map((hour: number) => {
-            const time = dayjs().set('hour', hour).set('minute', 0).toString();
+            const time = Temporal.PlainTime.from({ hour });
             return (
               <Box
                 key={`hour-${hour}`}
@@ -213,23 +204,22 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                 justifyContent="flex-end"
               >
                 <Typography color="textDisabled" variant="caption">
-                  <FormattedTime hour="numeric" minute="numeric" value={time} />
+                  {time.toLocaleString(undefined, {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
                 </Typography>
               </Box>
             );
           })}
         </Box>
         {/* Day columns */}
-        {dayDates.map((date: Date, index: number) => {
+        {dayDates.map((date: Temporal.PlainDate, index: number) => {
           const pendingTop = pendingEvent
-            ? (pendingEvent[0].getUTCHours() * 60 +
-                pendingEvent[0].getMinutes()) /
-              (24 * 60)
+            ? (pendingEvent[0].hour * 60 + pendingEvent[0].minute) / (24 * 60)
             : 0;
           const pendingHeight = pendingEvent
-            ? (pendingEvent[1].getUTCHours() * 60 +
-                pendingEvent[1].getMinutes()) /
-                (24 * 60) -
+            ? (pendingEvent[1].hour * 60 + pendingEvent[1].minute) / (24 * 60) -
               pendingTop
             : 0;
 
@@ -237,7 +227,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
 
           return (
             <Box
-              key={date.toISOString()}
+              key={date.toString()}
               ref={(elm: HTMLDivElement | null) => {
                 laneHeight = elm?.clientHeight ?? 0;
               }}
@@ -249,11 +239,14 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
               }}
             >
               {index === 0 && (
-                <CurrentTimeLineMarker currentTime={currentTime} />
+                <CurrentTimeLineMarker
+                  currentTime={currentTime.toPlainTime()}
+                />
               )}
-              {currentTime.toISOString().substring(0, 10) ===
-                date.toISOString().substring(0, 10) && (
-                <CurrentTimeCircleMarker currentTime={currentTime} />
+              {currentTime.toPlainDate().equals(date) && (
+                <CurrentTimeCircleMarker
+                  currentTime={currentTime.toPlainTime()}
+                />
               )}
               <Box
                 ref={(elm: HTMLDivElement) => {
@@ -268,25 +261,14 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
               >
                 <EventDayLane
                   onCreate={(startTime, endTime) => {
-                    const startDate = new Date(
-                      Date.UTC(
-                        date.getFullYear(),
-                        date.getMonth(),
-                        date.getDate(),
-                        startTime[0],
-                        startTime[1]
-                      )
-                    );
-
-                    const endDate = new Date(
-                      Date.UTC(
-                        date.getFullYear(),
-                        date.getMonth(),
-                        date.getDate(),
-                        endTime[0] >= 24 ? 23 : endTime[0],
-                        endTime[0] >= 24 ? 59 : endTime[1]
-                      )
-                    );
+                    const startDate = date.toPlainDateTime({
+                      hour: startTime[0],
+                      minute: startTime[1],
+                    });
+                    const endDate = date.toPlainDateTime({
+                      hour: endTime[0] >= 24 ? 23 : endTime[0],
+                      minute: endTime[0] >= 24 ? 59 : endTime[1],
+                    });
 
                     setPendingEvent([startDate, endDate]);
                   }}
@@ -339,80 +321,84 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                       );
                     });
                   })}
-                  {pendingEvent && isSameDate(date, pendingEvent[0]) && (
-                    <>
-                      <EventGhost
-                        ref={(div: HTMLDivElement) => setGhostAnchorEl(div)}
-                        height={pendingHeight * 100 + '%'}
-                        y={pendingTop * 100 + '%'}
-                      />
-                      {ghostAnchorEl && !creating && (
-                        <Menu
-                          anchorEl={ghostAnchorEl}
-                          anchorOrigin={{
-                            horizontal: index > 3 ? 'left' : 'right',
-                            vertical: 'bottom',
-                          }}
-                          onClose={() => {
-                            setPendingEvent(null);
-                            setGhostAnchorEl(null);
-                          }}
-                          open={true}
-                          transformOrigin={{
-                            horizontal: index > 3 ? 'right' : 'left',
-                            vertical: 'top',
-                          }}
-                        >
-                          <MenuItem
-                            onClick={async () => {
-                              setCreating(true);
-                              setGhostAnchorEl(null);
-                              await createEvent({
-                                activity_id: null,
-                                campaign_id: projectId,
-                                end_time: pendingEvent[1].toISOString(),
-                                location_id: null,
-                                start_time: pendingEvent[0].toISOString(),
-                                title: null,
-                              });
+                  {pendingEvent &&
+                    date.equals(pendingEvent[0].toPlainDate()) && (
+                      <>
+                        <EventGhost
+                          ref={(div: HTMLDivElement) => setGhostAnchorEl(div)}
+                          height={pendingHeight * 100 + '%'}
+                          y={pendingTop * 100 + '%'}
+                        />
+                        {ghostAnchorEl && !creating && (
+                          <Menu
+                            anchorEl={ghostAnchorEl}
+                            anchorOrigin={{
+                              horizontal: index > 3 ? 'left' : 'right',
+                              vertical: 'bottom',
+                            }}
+                            onClose={() => {
                               setPendingEvent(null);
-                              setCreating(false);
-                            }}
-                          >
-                            <ListItemIcon>
-                              <Event />
-                            </ListItemIcon>
-                            <ListItemText>
-                              <Msg id={messageIds.createMenu.singleEvent} />
-                            </ListItemText>
-                          </MenuItem>
-                          <MenuItem
-                            onClick={() => {
-                              setCreating(true);
                               setGhostAnchorEl(null);
-                              setShiftModalOpen(true);
+                            }}
+                            open={true}
+                            transformOrigin={{
+                              horizontal: index > 3 ? 'right' : 'left',
+                              vertical: 'top',
                             }}
                           >
-                            <ListItemIcon>
-                              <SplitscreenOutlined />
-                            </ListItemIcon>
-                            <ListItemText>
-                              <Msg id={messageIds.createMenu.shiftEvent} />
-                            </ListItemText>
-                          </MenuItem>
-                        </Menu>
-                      )}
-                      <EventShiftModal
-                        close={() => {
-                          setShiftModalOpen(false);
-                          setPendingEvent(null);
-                          setCreating(false);
-                        }}
-                        dates={pendingEvent}
-                        open={shiftModalOpen}
-                      />
-                    </>
-                  )}
+                            <MenuItem
+                              onClick={async () => {
+                                setCreating(true);
+                                setGhostAnchorEl(null);
+                                await createEvent({
+                                  activity_id: null,
+                                  campaign_id: projectId,
+                                  end_time: pendingEvent[1].toString(),
+                                  location_id: null,
+                                  start_time: pendingEvent[0].toString(),
+                                  title: null,
+                                });
+                                setPendingEvent(null);
+                                setCreating(false);
+                              }}
+                            >
+                              <ListItemIcon>
+                                <Event />
+                              </ListItemIcon>
+                              <ListItemText>
+                                <Msg id={messageIds.createMenu.singleEvent} />
+                              </ListItemText>
+                            </MenuItem>
+                            <MenuItem
+                              onClick={() => {
+                                setCreating(true);
+                                setGhostAnchorEl(null);
+                                setShiftModalOpen(true);
+                              }}
+                            >
+                              <ListItemIcon>
+                                <SplitscreenOutlined />
+                              </ListItemIcon>
+                              <ListItemText>
+                                <Msg id={messageIds.createMenu.shiftEvent} />
+                              </ListItemText>
+                            </MenuItem>
+                          </Menu>
+                        )}
+                        <EventShiftModal
+                          close={() => {
+                            setShiftModalOpen(false);
+                            setPendingEvent(null);
+                            setCreating(false);
+                          }}
+                          dates={[
+                            legacyDateFromPlainDateTime(pendingEvent[0]),
+                            legacyDateFromPlainDateTime(pendingEvent[1]),
+                          ]}
+                          open={shiftModalOpen}
+                        />
+                      </>
+                    )}
                   {/* TODO: Put events here */}
                 </EventDayLane>
               </Box>
@@ -423,5 +409,8 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
     </>
   );
 };
+
+const legacyDateFromPlainDateTime = (date: Temporal.PlainDateTime): Date =>
+  new Date(date.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds);
 
 export default CalendarWeekView;

--- a/src/features/calendar/components/CalendarWeekView/index.tsx
+++ b/src/features/calendar/components/CalendarWeekView/index.tsx
@@ -1,4 +1,5 @@
 import { Box, lighten } from '@mui/system';
+import { useIntl } from 'react-intl';
 import { Event, SplitscreenOutlined } from '@mui/icons-material';
 import {
   ListItemIcon,
@@ -15,7 +16,10 @@ import EventDayLane from './EventDayLane';
 import EventGhost from './EventGhost';
 import EventShiftModal from '../EventShiftModal';
 import HeaderWeekNumber from './HeaderWeekNumber';
-import { legacyDateFromPlainDate } from 'utils/dateUtils';
+import {
+  legacyDateFromPlainDate,
+  legacyDateFromPlainDateTime,
+} from 'utils/dateUtils';
 import messageIds from 'features/calendar/l10n/messageIds';
 import { Msg } from 'core/i18n';
 import range from 'utils/range';
@@ -83,6 +87,7 @@ export interface CalendarWeekViewProps {
   onClickDay: (date: Date) => void;
 }
 const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
+  const intl = useIntl();
   const [creating, setCreating] = useState(false);
   const [shiftModalOpen, setShiftModalOpen] = useState(false);
   const [pendingEvent, setPendingEvent] = useState<
@@ -204,7 +209,7 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
                 justifyContent="flex-end"
               >
                 <Typography color="textDisabled" variant="caption">
-                  {time.toLocaleString(undefined, {
+                  {time.toLocaleString(intl.locale, {
                     hour: 'numeric',
                     minute: 'numeric',
                   })}
@@ -409,8 +414,5 @@ const CalendarWeekView = ({ focusDate, onClickDay }: CalendarWeekViewProps) => {
     </>
   );
 };
-
-const legacyDateFromPlainDateTime = (date: Temporal.PlainDateTime): Date =>
-  new Date(date.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds);
 
 export default CalendarWeekView;

--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -120,7 +120,7 @@ const Calendar = () => {
           )}
           {timeScale === TimeScale.WEEK && (
             <CalendarWeekView
-              focusDate={focusDate}
+              focusDate={plainDateFromLegacyDate(focusDate)}
               onClickDay={(date) => navigateTo(TimeScale.DAY, date)}
             />
           )}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -114,3 +114,8 @@ export const legacyDateFromPlainDate = (plainDate: Temporal.PlainDate): Date =>
   new Date(
     plainDate.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds
   );
+
+export const legacyDateFromPlainDateTime = (
+  date: Temporal.PlainDateTime
+): Date =>
+  new Date(date.toZonedDateTime(Temporal.Now.timeZoneId()).epochMilliseconds);


### PR DESCRIPTION
## Description

This PR continues the Temporal migration by using the new `PlainDate` and `PlainTime` classes in the `CalendarWeekView`. This should not cause any changes in behavior.