### PR TITLE
Activist Portal: Improve all events feed

### DIFF
--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -95,33 +95,74 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
   );
   const events = eventsByOrg.flat();
 
-  const filteredEvents = await Promise.all(
-    events.map(async (event) => {
-      let isPublished = false;
-      if (event.published) {
-        isPublished = new Date(event.published) < new Date();
+  const followedOrgs = allMemberships
+    .filter((mem) => mem.follow)
+    .reduce((prev, mem) => {
+      prev.add(mem.organization.id);
+      return prev;
+    }, new Set<number>());
+
+  const validEvents = events.filter((event) => {
+    if (!followedOrgs.has(event.organization.id)) {
+      return false;
+    }
+    const isPublished =
+      event.published && new Date(event.published) < new Date();
+    const state = getEventState(event);
+    return (
+      (state == EventState.OPEN || state == EventState.SCHEDULED) && isPublished
+    );
+  });
+
+  const projectsToFetch = validEvents.reduce(
+    (prev, event) => {
+      if (!event.campaign) {
+        return prev;
       }
-      if (event.campaign && isPublished) {
-        const project = await apiClient
-          .get<ZetkinProject>(
-            `/api/orgs/${event.organization.id}/campaigns/${event.campaign.id}`
-          )
-          .catch(() => null);
-        isPublished =
-          !!project &&
-          !project.archived &&
-          project.published &&
-          project.visibility == 'open';
-      }
-      const state = getEventState(event);
-      return (
-        (state == EventState.OPEN || state == EventState.SCHEDULED) &&
-        isPublished
-      );
-    })
+      prev[event.campaign.id] = {
+        orgId: event.organization.id,
+        projId: event.campaign.id,
+      };
+      return prev;
+    },
+    {} as Record<number, { orgId: number; projId: number }>
   );
 
-  return events.filter((event, i) => {
-    return filteredEvents[i];
+  const projects = await Promise.all(
+    Object.values(projectsToFetch).map((project) =>
+      apiClient
+        .get<ZetkinProject>(
+          `/api/orgs/${project.orgId}/campaigns/${project.projId}`
+        )
+        .catch(() => null)
+    )
+  );
+
+  const projectsById = projects.reduce(
+    (prev, project) => {
+      if (!project) {
+        return prev;
+      }
+      prev[project.id] = project;
+      return prev;
+    },
+    {} as Record<number, ZetkinProject>
+  );
+
+  const publicEvents = validEvents.filter((event) => {
+    if (!event.campaign) {
+      return true;
+    }
+
+    const project = projectsById[event.campaign.id];
+
+    return (
+      !!project &&
+      !project.archived &&
+      project.published &&
+      project.visibility == 'open'
+    );
   });
+
+  return publicEvents;
 }

--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -1,3 +1,4 @@
+import 'temporal-polyfill/global';
 import { z } from 'zod';
 
 import { makeRPCDef } from 'core/rpc/types';
@@ -83,13 +84,13 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
     { filteredMemberships: [], orgs: [] }
   );
 
-  const now = new Date().toISOString();
+  const now = Temporal.Now.instant();
 
   const eventsByOrg = await Promise.all(
     filteredMemberships.map(
       async (membership) =>
         await apiClient.get<ZetkinEvent[]>(
-          `/api/orgs/${membership.organization.id}/actions?filter=start_time%3E=${now}&recursive`
+          `/api/orgs/${membership.organization.id}/actions?filter=start_time%3E=${now.toString({ smallestUnit: 'millisecond' })}&recursive`
         )
     )
   );
@@ -107,7 +108,9 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
       return false;
     }
     const isPublished =
-      event.published && new Date(event.published) < new Date();
+      event.published &&
+      Temporal.Instant.compare(Temporal.Instant.from(event.published), now) <=
+        0;
     const state = getEventState(event);
     return (
       (state == EventState.OPEN || state == EventState.SCHEDULED) && isPublished


### PR DESCRIPTION
## Description

This PR improves performance and correctness of the /my/feed page. It ensures that only events from followed orgs are shown and project fetches aren't unnecessarily duplicated.

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds a check to ensure only events of followed orgs is returned
- Changes the way projects are fetched to check whether the project is published by clustering by project id. This way, long lists of events of the same project only request that project once.

## AI usage

Did you use AI to create the code in this PR?

No

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Run it locally to see the effect of reduced clustering calls. Switch between main and this branch to compare effects
- Go to /my/orgs and follow My Organization and unfollow My Other Organization
- Create two events in the same project in My Organization and one event in My Other Organization
- Go to /my/feed
- Observe that in main, the event in My Other Organization is shown even though it's not followed. In this PR branch, it doesn't
- Observe in the console that the project of the events is only fetched once

## Related issues

Related changes to this code were in

https://github.com/zetkin/app.zetkin.org/pull/2834
https://github.com/zetkin/app.zetkin.org/pull/3495
https://github.com/zetkin/app.zetkin.org/pull/3661

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
