### PR TITLE
Use Temporal types for `CalendarNavBar` and related components

### DIFF
--- a/src/features/calendar/components/CalendarNavBar/MonthSelect.tsx
+++ b/src/features/calendar/components/CalendarNavBar/MonthSelect.tsx
@@ -1,3 +1,4 @@
+import { useIntl } from 'react-intl';
 import { MenuItem, Select } from '@mui/material';
 
 import range from 'utils/range';
@@ -8,6 +9,7 @@ export interface MonthSelectProps {
 }
 
 const MonthSelect = ({ focusDate, onChange }: MonthSelectProps) => {
+  const intl = useIntl();
   return (
     <Select
       disableUnderline
@@ -21,7 +23,7 @@ const MonthSelect = ({ focusDate, onChange }: MonthSelectProps) => {
         const month = focusDate.with({ month: index + 1 });
         return (
           <MenuItem key={index} value={month.toString()}>
-            {month.toLocaleString(undefined, { month: 'long' })}
+            {month.toLocaleString(intl.locale, { month: 'long' })}
           </MenuItem>
         );
       })}

--- a/src/features/calendar/components/CalendarNavBar/MonthSelect.tsx
+++ b/src/features/calendar/components/CalendarNavBar/MonthSelect.tsx
@@ -1,12 +1,10 @@
-import dayjs from 'dayjs';
-import { FormattedDate } from 'react-intl';
 import { MenuItem, Select } from '@mui/material';
 
 import range from 'utils/range';
 
 export interface MonthSelectProps {
-  focusDate: Date;
-  onChange: (date: Date) => void;
+  focusDate: Temporal.PlainDate;
+  onChange: (date: Temporal.PlainDate) => void;
 }
 
 const MonthSelect = ({ focusDate, onChange }: MonthSelectProps) => {
@@ -14,21 +12,16 @@ const MonthSelect = ({ focusDate, onChange }: MonthSelectProps) => {
     <Select
       disableUnderline
       onChange={(event) => {
-        const selectedMonth =
-          typeof event.target.value === 'number'
-            ? event.target.value
-            : parseInt(event.target.value);
-        const newFocusDate = dayjs(focusDate).month(selectedMonth).toDate();
-        onChange(newFocusDate);
+        onChange(Temporal.PlainDate.from(event.target.value.toString()));
       }}
-      value={focusDate.getMonth()}
+      value={focusDate.toString()}
       variant="standard"
     >
       {range(12).map((index) => {
-        const month = dayjs().day(0).month(index).toDate();
+        const month = focusDate.with({ month: index + 1 });
         return (
-          <MenuItem key={index} value={index}>
-            <FormattedDate month="long" value={month} />
+          <MenuItem key={index} value={month.toString()}>
+            {month.toLocaleString(undefined, { month: 'long' })}
           </MenuItem>
         );
       })}

--- a/src/features/calendar/components/CalendarNavBar/YearSelect.tsx
+++ b/src/features/calendar/components/CalendarNavBar/YearSelect.tsx
@@ -24,7 +24,7 @@ const YearSelect = ({ focusDate, onChange }: YearSelectProps) => {
         const year = focusDate.with({ year: startYear + index });
         return (
           <MenuItem key={index} value={year.toString()}>
-            {year.toLocaleString(undefined, { year: 'numeric' })}
+            {year.year}
           </MenuItem>
         );
       })}

--- a/src/features/calendar/components/CalendarNavBar/YearSelect.tsx
+++ b/src/features/calendar/components/CalendarNavBar/YearSelect.tsx
@@ -1,37 +1,30 @@
-import dayjs from 'dayjs';
-import { FormattedDate } from 'react-intl';
 import { MenuItem, Select } from '@mui/material';
 
 import range from 'utils/range';
 
 export interface YearSelectProps {
-  focusDate: Date;
-  onChange: (date: Date) => void;
+  focusDate: Temporal.PlainDate;
+  onChange: (date: Temporal.PlainDate) => void;
 }
 
 const YearSelect = ({ focusDate, onChange }: YearSelectProps) => {
   const amountOfYears = 18;
-  const startYear = focusDate.getFullYear() - 8;
+  const startYear = focusDate.year - 8;
 
   return (
     <Select
       disableUnderline
       onChange={(event) => {
-        const newYear =
-          typeof event.target.value === 'number'
-            ? event.target.value
-            : parseInt(event.target.value);
-        const newDate = dayjs(focusDate).year(newYear);
-        onChange(newDate.toDate());
+        onChange(Temporal.PlainDate.from(event.target.value.toString()));
       }}
-      value={focusDate.getFullYear()}
+      value={focusDate.toString()}
       variant="standard"
     >
       {range(amountOfYears).map((index) => {
-        const year = dayjs(focusDate).year(startYear + index);
+        const year = focusDate.with({ year: startYear + index });
         return (
-          <MenuItem key={index} value={year.year()}>
-            <FormattedDate value={year.toDate()} year="numeric" />
+          <MenuItem key={index} value={year.toString()}>
+            {year.toLocaleString(undefined, { year: 'numeric' })}
           </MenuItem>
         );
       })}

--- a/src/features/calendar/components/CalendarNavBar/index.tsx
+++ b/src/features/calendar/components/CalendarNavBar/index.tsx
@@ -10,8 +10,8 @@ import { TimeScale } from '../index';
 import YearSelect from './YearSelect';
 
 export interface CalendarNavBarProps {
-  focusDate: Date;
-  onChangeFocusDate: (date: Date) => void;
+  focusDate: Temporal.PlainDate;
+  onChangeFocusDate: (date: Temporal.PlainDate) => void;
   onChangeTimeScale: (timeScale: TimeScale) => void;
   onStepBackward: () => void;
   onStepForward: () => void;
@@ -33,7 +33,7 @@ const CalendarNavBar = ({
       <Box alignItems="center" display="flex" gap="4px">
         <Button
           color="primary"
-          onClick={() => onChangeFocusDate(new Date())}
+          onClick={() => onChangeFocusDate(Temporal.Now.plainDateISO())}
           variant="outlined"
         >
           <Msg id={messageIds.today} />

--- a/src/features/calendar/components/index.tsx
+++ b/src/features/calendar/components/index.tsx
@@ -11,7 +11,10 @@ import CalendarWeekView from './CalendarWeekView';
 import SelectionBar from '../../events/components/SelectionBar';
 import useDayCalendarNav from '../hooks/useDayCalendarNav';
 import useTimeScale from '../hooks/useTimeScale';
-import { plainDateFromLegacyDate } from 'utils/dateUtils';
+import {
+  legacyDateFromPlainDate,
+  plainDateFromLegacyDate,
+} from 'utils/dateUtils';
 
 dayjs.extend(utc);
 
@@ -76,9 +79,9 @@ const Calendar = () => {
   return (
     <Box display="flex" flexDirection="column" height={'100%'} padding={2}>
       <CalendarNavBar
-        focusDate={focusDate}
+        focusDate={plainDateFromLegacyDate(focusDate)}
         onChangeFocusDate={(date) => {
-          setFocusDate(date);
+          setFocusDate(legacyDateFromPlainDate(date));
         }}
         onChangeTimeScale={(timeScale) => {
           setPersistentTimeScale(timeScale);


### PR DESCRIPTION
## Description

This PR continues the Temporal migration. My goal is to get all of the calendar components to use Temporal types instead of dates so this change adapts the CalendarNavBar and associated components to also use `PlainDate`s as the individual calendar views already do as well now.