### PR TITLE
grouped email links + changed identifier for emails

### DIFF
--- a/src/features/smartSearch/components/filters/EmailClick/DisplayEmailClick.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/DisplayEmailClick.tsx
@@ -67,24 +67,28 @@ const DisplayEmailClick = ({ filter }: DisplayEmailClickProps): JSX.Element => {
         linkSelect: links ? (
           <Box alignItems="start" display="inline-flex">
             :{' '}
-            {linkList
-              ?.filter((item) => filter.config.links?.includes(item.id))
-              .map((link) => {
-                return (
-                  <Tooltip key={`link-${link.id}`} title={link.url}>
-                    <Chip
-                      label={link.url.split('://')[1]}
-                      size="small"
-                      sx={{
-                        margin: '3px',
-                        maxWidth: '200px',
-                        textOverflow: 'ellipsis',
-                      }}
-                      variant="outlined"
-                    />
-                  </Tooltip>
-                );
-              })}
+            {[
+              ...new Map(
+                linkList
+                  ?.filter((item) => filter.config.links?.includes(item.id))
+                  .map((link) => [link.tag, link]) ?? []
+              ).values(),
+            ].map((link) => {
+              return (
+                <Tooltip key={`link-${link.id}`} title={link.url}>
+                  <Chip
+                    label={link.url.split('://')[1]}
+                    size="small"
+                    sx={{
+                      margin: '3px',
+                      maxWidth: '200px',
+                      textOverflow: 'ellipsis',
+                    }}
+                    variant="outlined"
+                  />
+                </Tooltip>
+              );
+            })}
           </Box>
         ) : null,
         operatorSelect: (

--- a/src/features/smartSearch/components/filters/EmailClick/index.tsx
+++ b/src/features/smartSearch/components/filters/EmailClick/index.tsx
@@ -60,7 +60,10 @@ const EmailClick = ({
       operator: 'clicked',
     });
   const linkList = useEmailLinks(orgId, filter.config?.email).data || [];
-  const linkListSorted = linkList.sort((l1, l2) => {
+  const linkListFilteredByUniqueTag = linkList.filter(
+    (link, index, self) => self.findIndex((l) => l.tag === link.tag) === index
+  );
+  const linkListSorted = linkListFilteredByUniqueTag.sort((l1, l2) => {
     return l1.url.localeCompare(l2.url);
   });
 
@@ -186,14 +189,17 @@ const EmailClick = ({
                         <Tooltip key={`link-${link.id}`} title={link.url}>
                           <Chip
                             label={link.url.split('://')[1]}
-                            onDelete={() =>
+                            onDelete={() => {
+                              const idsToRemove = linkList
+                                .filter((l) => l.tag === link.tag)
+                                .map((l) => l.id);
                               setValueToKey(
                                 'links',
                                 filter.config.links!.filter(
-                                  (linkId) => linkId !== link.id
+                                  (linkId) => !idsToRemove.includes(linkId)
                                 )
-                              )
-                            }
+                              );
+                            }}
                             sx={{
                               margin: '3px',
                               maxWidth: '200px',
@@ -219,17 +225,25 @@ const EmailClick = ({
                         <Msg id={messageIds.misc.noOptionsInvalidEmail} />
                       )
                     }
-                    onChange={(_, value) =>
-                      setValueToKey(
-                        'links',
-                        value.map((link) => link.id)
-                      )
-                    }
-                    options={linkList.map((link) => ({
+                    onChange={(_, value) => {
+                      const selectedTags = new Set(
+                        value.map(
+                          (selected) =>
+                            linkListFilteredByUniqueTag.find(
+                              (l) => l.id === selected.id
+                            )?.tag
+                        )
+                      );
+                      const allIds = linkList
+                        .filter((link) => selectedTags.has(link.tag))
+                        .map((link) => link.id);
+                      setValueToKey('links', allIds);
+                    }}
+                    options={linkListFilteredByUniqueTag.map((link) => ({
                       id: link.id,
                       title: link.url.split('://')[1],
                     }))}
-                    value={linkList
+                    value={linkListFilteredByUniqueTag
                       .filter(
                         (link) =>
                           filter.config.links?.includes(link.id) || false


### PR DESCRIPTION
# Summary of the isseue

#3658 issues resolved by grouping email content by tag. This resolved having duplicates with the same displayed name. If one is clicked, all are going to be selected by default.



## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
