### PR TITLE
Invalidate cached activities when switching organisation

### DIFF
--- a/src/features/call/hooks/useCallMutations.ts
+++ b/src/features/call/hooks/useCallMutations.ts
@@ -7,14 +7,25 @@ import {
   allocateCallError,
   switchedToUnfinishedCall,
   allocatePreviousCall,
+  upcomingEventsInvalidated,
 } from '../store';
 import { UnfinishedCall } from '../types';
 import useMyAssignments from './useMyAssignments';
+import { surveysInvalidated } from 'features/surveys/store';
 
 export default function useCallMutations(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const assignments = useMyAssignments();
+
+  // Activities are cached per org, so switching to a call in another org
+  // must invalidate them or the previous org's activities would linger.
+  const invalidateActivitiesOnOrgChange = (targetOrgId: number) => {
+    if (targetOrgId != orgId) {
+      dispatch(upcomingEventsInvalidated());
+      dispatch(surveysInvalidated());
+    }
+  };
 
   const abandonUnfinishedCall = async (
     assignmentId: number,
@@ -79,11 +90,19 @@ export default function useCallMutations(orgId: number) {
         }
       );
       dispatch(allocatePreviousCall(newCall));
+      invalidateActivitiesOnOrgChange(assignment.organization.id);
     }
   };
 
   const switchToUnfinishedCall = (callId: number, assignmentId: number) => {
     dispatch(switchedToUnfinishedCall([callId, assignmentId]));
+
+    const assignment = assignments.find(
+      (assignment) => assignment.id == assignmentId
+    );
+    if (assignment) {
+      invalidateActivitiesOnOrgChange(assignment.organization.id);
+    }
   };
 
   return {

--- a/src/features/call/store.ts
+++ b/src/features/call/store.ts
@@ -451,6 +451,9 @@ const CallSlice = createSlice({
       state.unfinishedCalls = remoteList(action.payload);
       state.unfinishedCalls.loaded = new Date().toISOString();
     },
+    upcomingEventsInvalidated: (state) => {
+      state.upcomingEventsList.isStale = true;
+    },
     updateLaneStep: (state, action: PayloadAction<LaneStep>) => {
       const step = action.payload;
       const activeLane = state.lanes[state.activeLaneIndex];
@@ -480,6 +483,7 @@ export const {
   clearReport,
   eventsLoad,
   eventsLoaded,
+  upcomingEventsInvalidated,
   allocateCallError,
   eventResponseAdded,
   eventResponseRemoved,

--- a/src/features/surveys/store.ts
+++ b/src/features/surveys/store.ts
@@ -454,6 +454,9 @@ const surveysSlice = createSlice({
         }
       }
     },
+    surveysInvalidated: (state) => {
+      state.surveyList.isStale = true;
+    },
     surveysLoad: (state) => {
       state.surveyList.isLoading = true;
     },
@@ -583,6 +586,7 @@ export const {
   surveySubmissionUpdated,
   surveySubmissionsLoad,
   surveySubmissionsLoaded,
+  surveysInvalidated,
   surveysLoad,
   surveysLoaded,
   surveyUpdate,


### PR DESCRIPTION
## Description

This PR fixes a known bug which shows activities for the wrong organisation when switching organisations.

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds
  - Mutation to invalidate activities when changing the orgs. 
  - Logic to mark surveys and upcoming events stale
- Changes
  - Uses this mutation when switching calls 

## AI usage

Did you use AI to create the code in this PR?

If yes - reviewed options for how to solve the bug with help of Claude

## Instructions for reviewer

**What to do:**
1. On `/my`, click "Start calling" on the "Mobilize carollers" card (belongs to My Organization).
2. Press "Call", note the person's name, then "Finish and report", fill it in, and "Send in report" to finish the call.
3. Go back to `/my` and click "Start calling" on "Calling for peace" (belongs to My Other Organization, a child of My Organization).
4. Press "Call" to start a call. Look at the activity list in the right panel: these are My Other Organization's activities.
5. Open the call log (bottom-left button). The person you called earlier should be at the top. Click "Log another call" next to them.
6. Once it switches, look at the activity list again. It should now show My Organization's activities, not My Other Organization's.

**Worth knowing:**
- The bug only shows when the switch crosses organisations. Switching between calls in the same org looks the same either way (and intentionally does not refetch).
- "Activities" is events + surveys, and both caches are invalidated, so check both if the fixture has surveys.
- To see the original bug, do the same steps on `main`: the list stays on My Other Organization's activities after the switch.
 
## Related issues

Resolves #3738

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
