### PR TITLE
Issue #3755 Fix endless loading spinner

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -13,7 +13,7 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
 
   return loadListIfNecessary(sessions, dispatch, {
     actionOnLoad: () => assigneesLoad(areaAssId),
-
+    actionOnError: () => assigneesLoaded([areaAssId, []]),
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
       fetchAllPaginated(

--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -13,7 +13,7 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
 
   return loadListIfNecessary(sessions, dispatch, {
     actionOnError: () => assigneesLoaded([areaAssId, []]),
-    actionOnLoad: () => assigneesLoad(areaAssId), 
+    actionOnLoad: () => assigneesLoad(areaAssId),
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
       fetchAllPaginated(

--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -12,8 +12,8 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
   );
 
   return loadListIfNecessary(sessions, dispatch, {
-    actionOnLoad: () => assigneesLoad(areaAssId),
     actionOnError: () => assigneesLoaded([areaAssId, []]),
+    actionOnLoad: () => assigneesLoad(areaAssId), 
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
       fetchAllPaginated(


### PR DESCRIPTION
## Description

Fixes the endless loading spinner in area assignments.

## Screenshots

_not applicable_

## Changes

- Changes `useAreaAssignment.ts` to return an empty array when the API call fails.

## AI usage

No.

## Instructions for reviewer

- Execute the instruction set in #3755. The expected behavior should be occurring.

## Related issues

Resolves #3755

## PR checklist

- [ x ] I have run the code, tried out the changes I made and I think they work
- [ x ] I have not included any changes outside the scope of the task I'm working on
- [ x ] I have made sure that formatting, linting and type checks pass locally
- [ x ] I have filled out this template and replaced all placeholders with the corresponding information
