### PR TITLE
Storybook: fix csp crashing storybook pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p 80",
     "devserver": "cross-env NODE_OPTIONS='--inspect' next dev -p 3000 --turbo",
-    "docs:build": "storybook build -o public/storybook",
+    "docs:build": "storybook build -o public/storybook && ts-node scripts/externalize-inline-scripts.ts public/storybook",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
     "lint:translations": "ts-node scripts/lint-translations.ts",

--- a/scripts/externalize-inline-scripts.ts
+++ b/scripts/externalize-inline-scripts.ts
@@ -1,0 +1,129 @@
+/* eslint-disable no-console */
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Moves inline <script> tags in statically built HTML into sibling files, so
+ * that they can be served under `script-src 'self'` without a nonce. See
+ * setupStaticSiteCsp() in src/middleware.ts.
+ *
+ * Usage: ts-node scripts/externalize-inline-scripts.ts <dir> [<dir> ...]
+ */
+
+const QUOTE_AWARE_ATTRIBUTES = `(?:"[^"]*"|'[^']*'|[^>"'])*`;
+const RAW_TEXT_UNTIL_CLOSING_TAG = `[\\s\\S]*?`;
+const ATTRIBUTE_VALUE = `("([^"]*)"|'([^']*)'|([^\\s"'>]+))`;
+
+const SCRIPT_TAG = new RegExp(
+  `<script(${QUOTE_AWARE_ATTRIBUTES})>(${RAW_TEXT_UNTIL_CLOSING_TAG})</script>`,
+  'gi'
+);
+const SRC_ATTRIBUTE = new RegExp(`\\bsrc\\s*=\\s*${ATTRIBUTE_VALUE}`, 'i');
+const TYPE_ATTRIBUTE = new RegExp(`\\btype\\s*=\\s*${ATTRIBUTE_VALUE}`, 'i');
+
+const JAVASCRIPT_MIME_TYPES = [
+  'application/ecmascript',
+  'application/javascript',
+  'module',
+  'text/ecmascript',
+  'text/javascript',
+];
+
+run();
+
+async function run() {
+  const dirs = process.argv.slice(2);
+
+  if (!dirs.length) {
+    console.error(
+      'Usage: ts-node scripts/externalize-inline-scripts.ts <dir> [<dir> ...]'
+    );
+    process.exit(1);
+  }
+
+  let total = 0;
+
+  for (const dir of dirs) {
+    const stat = await fs.stat(dir).catch(() => null);
+
+    if (!stat?.isDirectory()) {
+      console.error(`ERR: not a directory: ${dir}`);
+      process.exit(1);
+    }
+
+    for await (const htmlFilePath of findHtmlFiles(dir)) {
+      total += await externalizeInlineScripts(htmlFilePath);
+    }
+  }
+
+  console.log(`Externalized ${total} inline script(s).`);
+}
+
+async function externalizeInlineScripts(htmlFilePath: string): Promise<number> {
+  const html = await fs.readFile(htmlFilePath, 'utf-8');
+  const siblingDir = path.dirname(htmlFilePath);
+  const prefix = `csp-inline-${path.basename(htmlFilePath, '.html')}`;
+
+  const scripts: { content: string; siblingFileName: string }[] = [];
+
+  const rewritten = html.replace(
+    SCRIPT_TAG,
+    (tag: string, attrs: string, content: string) => {
+      const isInlineJavaScript =
+        !SRC_ATTRIBUTE.test(attrs) && isJavaScript(attrs) && !!content.trim();
+
+      if (!isInlineJavaScript) {
+        return tag;
+      }
+
+      const siblingFileName = `${prefix}-${scripts.length}.js`;
+      scripts.push({ content, siblingFileName });
+
+      return `<script${attrs} src="./${siblingFileName}"></script>`;
+    }
+  );
+
+  if (!scripts.length) {
+    return 0;
+  }
+
+  await Promise.all(
+    scripts.map((script) =>
+      fs.writeFile(
+        path.join(siblingDir, script.siblingFileName),
+        script.content
+      )
+    )
+  );
+  await fs.writeFile(htmlFilePath, rewritten);
+
+  console.log(
+    `${htmlFilePath}: externalized ${scripts.length} inline script(s)`
+  );
+
+  return scripts.length;
+}
+
+function isJavaScript(attrs: string): boolean {
+  const match = attrs.match(TYPE_ATTRIBUTE);
+  const declaredType = (match?.[2] ?? match?.[3] ?? match?.[4] ?? '')
+    .trim()
+    .toLowerCase();
+  const typeDefaultsToJavaScript = !declaredType;
+
+  return (
+    typeDefaultsToJavaScript || JAVASCRIPT_MIME_TYPES.includes(declaredType)
+  );
+}
+
+async function* findHtmlFiles(dir: string): AsyncIterable<string> {
+  const dirEnts = await fs.readdir(dir, { withFileTypes: true });
+  for (const dirEnt of dirEnts) {
+    const res = path.resolve(dir, dirEnt.name);
+    if (dirEnt.isDirectory()) {
+      yield* findHtmlFiles(res);
+    } else if (res.endsWith('.html')) {
+      yield res;
+    }
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,10 @@ import { AppSession } from 'utils/types';
 
 const protectedRoutes = ['/my', '/call'];
 
+const staticallyBuiltSitePath = /^\/(storybook|docs)(\/|$)/;
+
+const storybookGoogleFontHost = 'https://fonts.gstatic.com';
+
 function extractRootUrl(urlStr: string): string {
   const url = new URL(urlStr);
   return `https://${url.host}`;
@@ -16,6 +20,26 @@ function sanitizeUrl(urlStr: string): string {
   return new URL(urlStr).toString();
 }
 
+function setupStaticSiteCsp(nonce: string): string {
+  const externalizedInlineScripts = "'self'";
+  const nonceForNextErrorPages = `'nonce-${nonce}'`;
+
+  const cspHeader = `
+  default-src 'self';
+  script-src ${externalizedInlineScripts} ${nonceForNextErrorPages};
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' blob: data:;
+  font-src 'self' ${storybookGoogleFontHost};
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'self';
+  upgrade-insecure-requests;
+`;
+
+  return cspHeader.replace(/\s{2,}/g, ' ').trim();
+}
+
 function setupCsp(path: string) {
   if (process.env.PLAYWRIGHT === '1') {
     return ['', "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:"];
@@ -23,6 +47,10 @@ function setupCsp(path: string) {
 
   const isDev = process.env.NODE_ENV === 'development';
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+
+  if (staticallyBuiltSitePath.test(path)) {
+    return [nonce, setupStaticSiteCsp(nonce)] as const;
+  }
 
   if (!process.env.MAPLIBRE_STYLE) {
     throw new Error('Unexpected undefined MAPLIBRE_STYLE.');

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ import { AppSession } from 'utils/types';
 
 const protectedRoutes = ['/my', '/call'];
 
-const staticallyBuiltSitePath = /^\/(storybook|docs)(\/|$)/;
+const staticallyBuiltSitePath = /^\/(storybook)(\/|$)/;
 
 const storybookGoogleFontHost = 'https://fonts.gstatic.com';
 


### PR DESCRIPTION
## Description

This PR fixes the storybook deployment. It stopped working due to the new CSP. 

## Screenshots

[Add screenshots here]

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds a script to externalize inline scripts (static pages can't receive nonces, so externalizing is the best option I could think of)
- Adds an adjusted csp generator for static pages (currently would match only /storybook)

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Yes, AI wrote most of this code and suggested the solution.

## Instructions for reviewer

If building locally, do this:

```
npm run docs:build
npm run devserver
```

After that or if running remotely, go to
- /storybook
 
## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
