### PR TITLE
Fix only loading first 50 assigned areas

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
@@ -12,6 +12,7 @@ import { ACTIVITIES, ProjectActivity } from 'features/projects/types';
 import useFeature from 'utils/featureFlags/useFeature';
 import { AREAS } from 'utils/featureFlags';
 import { getUTCDateWithoutTime } from '../../../utils/dateUtils';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useAreaAssignmentActivities(
   orgId: number,
@@ -31,9 +32,11 @@ export default function useAreaAssignmentActivities(
   const future = loadListIfNecessary(list, dispatch, {
     actionOnLoad: () => areaAssignmentsLoad(),
     actionOnSuccess: (data) => areaAssignmentsLoaded(data),
-    loader: () =>
-      apiClient.get<ZetkinAreaAssignment[]>(
-        `/api2/orgs/${orgId}/area_assignments`
+    loader: async () =>
+      fetchAllPaginated<ZetkinAreaAssignment>((page) =>
+        apiClient.get(
+          `/api2/orgs/${orgId}/area_assignments?size=100&page=${page}`
+        )
       ),
   });
 

--- a/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
@@ -32,7 +32,7 @@ export default function useAreaAssignmentActivities(
   const future = loadListIfNecessary(list, dispatch, {
     actionOnLoad: () => areaAssignmentsLoad(),
     actionOnSuccess: (data) => areaAssignmentsLoaded(data),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<ZetkinAreaAssignment>((page) =>
         apiClient.get(
           `/api2/orgs/${orgId}/area_assignments?size=100&page=${page}`

--- a/src/features/areaAssignments/hooks/useAssignmentAreas.ts
+++ b/src/features/areaAssignments/hooks/useAssignmentAreas.ts
@@ -13,7 +13,7 @@ export default function useAssignmentAreas(orgId: number, areaAssId: number) {
   return useRemoteList(list, {
     actionOnLoad: () => assignmentAreasLoad(areaAssId),
     actionOnSuccess: (data) => assignmentAreasLoaded([areaAssId, data]),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<Zetkin2Area>((page) =>
         apiClient.get(
           `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas?size=100&page=${page}`

--- a/src/features/areaAssignments/hooks/useAssignmentAreas.ts
+++ b/src/features/areaAssignments/hooks/useAssignmentAreas.ts
@@ -2,6 +2,7 @@ import { useApiClient, useAppSelector } from 'core/hooks';
 import { assignmentAreasLoad, assignmentAreasLoaded } from '../store';
 import { Zetkin2Area } from 'features/areas/types';
 import useRemoteList from 'core/hooks/useRemoteList';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useAssignmentAreas(orgId: number, areaAssId: number) {
   const apiClient = useApiClient();
@@ -12,9 +13,11 @@ export default function useAssignmentAreas(orgId: number, areaAssId: number) {
   return useRemoteList(list, {
     actionOnLoad: () => assignmentAreasLoad(areaAssId),
     actionOnSuccess: (data) => assignmentAreasLoaded([areaAssId, data]),
-    loader: () =>
-      apiClient.get<Zetkin2Area[]>(
-        `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas`
+    loader: async () =>
+      fetchAllPaginated<Zetkin2Area>((page) =>
+        apiClient.get(
+          `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas?size=100&page=${page}`
+        )
       ),
   });
 }

--- a/src/features/areas/hooks/useAreas.ts
+++ b/src/features/areas/hooks/useAreas.ts
@@ -12,7 +12,7 @@ export default function useAreas(orgId: number) {
   return loadListIfNecessary(list, dispatch, {
     actionOnLoad: () => areasLoad(),
     actionOnSuccess: (data) => areasLoaded(data),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<Zetkin2Area>((page) =>
         apiClient.get(`/api2/orgs/${orgId}/areas?size=100&page=${page}`)
       ),

--- a/src/features/canvass/hooks/useHouseholds.ts
+++ b/src/features/canvass/hooks/useHouseholds.ts
@@ -15,7 +15,7 @@ export default function useHouseholds(
   return useRemoteList(list, {
     actionOnLoad: () => householdsLoad(locationId),
     actionOnSuccess: (data) => householdsLoaded([locationId, data]),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<HouseholdWithColor>(
         (page) =>
           apiClient.get(

--- a/src/features/canvass/hooks/useLocationVisits.ts
+++ b/src/features/canvass/hooks/useLocationVisits.ts
@@ -17,7 +17,7 @@ export default function useLocationVisits(
   const visits = useRemoteList(visitList, {
     actionOnLoad: () => visitsLoad(assignmentId),
     actionOnSuccess: (items) => visitsLoaded([assignmentId, items]),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<ZetkinLocationVisit>((page) =>
         apiClient.get(
           `/api2/orgs/${orgId}/area_assignments/${assignmentId}/locations/${locationId}/visits?size=100&page=${page}`

--- a/src/features/canvass/hooks/useLocationVisits.ts
+++ b/src/features/canvass/hooks/useLocationVisits.ts
@@ -2,6 +2,7 @@ import { useApiClient, useAppSelector } from 'core/hooks';
 import { visitsLoad, visitsLoaded } from '../store';
 import useRemoteList from 'core/hooks/useRemoteList';
 import { ZetkinLocationVisit } from '../types';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useLocationVisits(
   orgId: number,
@@ -16,9 +17,11 @@ export default function useLocationVisits(
   const visits = useRemoteList(visitList, {
     actionOnLoad: () => visitsLoad(assignmentId),
     actionOnSuccess: (items) => visitsLoaded([assignmentId, items]),
-    loader: () =>
-      apiClient.get<ZetkinLocationVisit[]>(
-        `/api2/orgs/${orgId}/area_assignments/${assignmentId}/locations/${locationId}/visits`
+    loader: async () =>
+      fetchAllPaginated<ZetkinLocationVisit>((page) =>
+        apiClient.get(
+          `/api2/orgs/${orgId}/area_assignments/${assignmentId}/locations/${locationId}/visits?size=100&page=${page}`
+        )
       ),
   });
 

--- a/src/features/canvass/hooks/useMyAreaAssignments.ts
+++ b/src/features/canvass/hooks/useMyAreaAssignments.ts
@@ -2,6 +2,7 @@ import { useApiClient, useAppSelector } from 'core/hooks';
 import { myAssignmentsLoad, myAssignmentsLoaded } from '../store';
 import useRemoteList from 'core/hooks/useRemoteList';
 import { ZetkinAreaAssignment } from 'features/areaAssignments/types';
+import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useMyAreaAssignments() {
   const apiClient = useApiClient();
@@ -10,8 +11,10 @@ export default function useMyAreaAssignments() {
   const assignments = useRemoteList(list, {
     actionOnLoad: () => myAssignmentsLoad(),
     actionOnSuccess: (data) => myAssignmentsLoaded(data),
-    loader: () =>
-      apiClient.get<ZetkinAreaAssignment[]>('/api2/users/me/area_assignments'),
+    loader: async () =>
+      fetchAllPaginated<ZetkinAreaAssignment>((page) =>
+        apiClient.get(`/api2/users/me/area_assignments?size=100&page=${page}`)
+      ),
   });
 
   const now = new Date();

--- a/src/features/canvass/hooks/useMyAreaAssignments.ts
+++ b/src/features/canvass/hooks/useMyAreaAssignments.ts
@@ -11,7 +11,7 @@ export default function useMyAreaAssignments() {
   const assignments = useRemoteList(list, {
     actionOnLoad: () => myAssignmentsLoad(),
     actionOnSuccess: (data) => myAssignmentsLoaded(data),
-    loader: async () =>
+    loader: () =>
       fetchAllPaginated<ZetkinAreaAssignment>((page) =>
         apiClient.get(`/api2/users/me/area_assignments?size=100&page=${page}`)
       ),

--- a/src/features/user/hooks/useOrgUsers.ts
+++ b/src/features/user/hooks/useOrgUsers.ts
@@ -11,10 +11,9 @@ export default function useOrgUsers(orgId: number): ZetkinOrgUser[] {
     actionOnLoad: () => orgUsersLoad(),
     actionOnSuccess: (data) => orgUsersLoaded(data),
     // TODO: Use search API instead of loading all users
-    loader: async () => {
-      return await fetchAllPaginated<ZetkinOrgUser>((page) =>
+    loader: () =>
+      fetchAllPaginated<ZetkinOrgUser>((page) =>
         apiClient.get(`/api2/orgs/${orgId}/users?size=100&page=${page}`)
-      );
-    },
+      ),
   });
 }


### PR DESCRIPTION


## Description

This PR adds the use of `fetchAllPaginated` to four of the places that makes GET requests to Core 2 to get collections of activities, locations, areas and my assignments

## Screenshots

<img width="1415" height="552" alt="bild" src="https://github.com/user-attachments/assets/8594c663-d6b1-4e03-aad5-f3f538164583" />

Now loads full list of 65, instead of previously 50 

## Changes
- Changes hooks in the Area Assignments and Canvass features to use `fetchAllPaginated` 

## AI usage

Did you use AI to create the code in this PR? no

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

To test that listing all area assignments on /my works
- In organize, logged in as testadmin, create a new area assignment and give it a distinctive title 
- go to /my and see that it shows up in the list of assignments, on `main` it will not show up

To test that seeing all assigned areas works
- follow instructions on #3752  

## Related issues

Resolves #3752 

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
