### PR TITLE
Use batchSize as size when fetching paginated with fetchAllPaginated

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -16,12 +16,10 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
     actionOnLoad: () => assigneesLoad(areaAssId),
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
-      fetchAllPaginated(
-        (page) =>
-          apiClient.get<ZetkinAreaAssignee[]>(
-            `/api2/orgs/${orgId}/area_assignments/${areaAssId}/assignees?size=100&page=${page}`
-          ),
-        100
+      fetchAllPaginated((page, size) =>
+        apiClient.get<ZetkinAreaAssignee[]>(
+          `/api2/orgs/${orgId}/area_assignments/${areaAssId}/assignees?size=${size}&page=${page}`
+        )
       ),
   });
 }

--- a/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
@@ -35,7 +35,7 @@ export default function useAreaAssignmentActivities(
     loader: () =>
       fetchAllPaginated<ZetkinAreaAssignment>((page) =>
         apiClient.get(
-          `/api2/orgs/${orgId}/area_assignments?size=100&page=${page}`
+          `/api2/orgs/${orgId}/area_assignments?size=${size}&page=${page}`
         )
       ),
   });

--- a/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignmentActivities.ts
@@ -33,7 +33,7 @@ export default function useAreaAssignmentActivities(
     actionOnLoad: () => areaAssignmentsLoad(),
     actionOnSuccess: (data) => areaAssignmentsLoaded(data),
     loader: () =>
-      fetchAllPaginated<ZetkinAreaAssignment>((page) =>
+      fetchAllPaginated<ZetkinAreaAssignment>((page, size) =>
         apiClient.get(
           `/api2/orgs/${orgId}/area_assignments?size=${size}&page=${page}`
         )

--- a/src/features/areaAssignments/hooks/useAssignmentAreas.ts
+++ b/src/features/areaAssignments/hooks/useAssignmentAreas.ts
@@ -14,7 +14,7 @@ export default function useAssignmentAreas(orgId: number, areaAssId: number) {
     actionOnLoad: () => assignmentAreasLoad(areaAssId),
     actionOnSuccess: (data) => assignmentAreasLoaded([areaAssId, data]),
     loader: () =>
-      fetchAllPaginated<Zetkin2Area>((page) =>
+      fetchAllPaginated<Zetkin2Area>((page, size) =>
         apiClient.get(
           `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas?size=${size}&page=${page}`
         )

--- a/src/features/areaAssignments/hooks/useAssignmentAreas.ts
+++ b/src/features/areaAssignments/hooks/useAssignmentAreas.ts
@@ -16,7 +16,7 @@ export default function useAssignmentAreas(orgId: number, areaAssId: number) {
     loader: () =>
       fetchAllPaginated<Zetkin2Area>((page) =>
         apiClient.get(
-          `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas?size=100&page=${page}`
+          `/api2/orgs/${orgId}/area_assignments/${areaAssId}/areas?size=${size}&page=${page}`
         )
       ),
   });

--- a/src/features/canvass/rpc/loadLocationHouseholdVisits.ts
+++ b/src/features/canvass/rpc/loadLocationHouseholdVisits.ts
@@ -27,12 +27,10 @@ export default makeRPCDef<Params, Result>(loadLocationHouseholdVisitsDef.name);
 async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
   const { assignmentId, locationId, orgId } = params;
 
-  const households = await fetchAllPaginated<Zetkin2Household>(
-    (page) =>
-      apiClient.get(
-        `/api2/orgs/${orgId}/locations/${locationId}/households?size=100&page=${page}`
-      ),
-    100
+  const households = await fetchAllPaginated<Zetkin2Household>((page, size) =>
+    apiClient.get(
+      `/api2/orgs/${orgId}/locations/${locationId}/households?size=${size}&page=${page}`
+    )
   );
   const visits: ZetkinHouseholdVisit[] = [];
   for await (const household of households) {

--- a/src/features/events/hooks/useEventLocations.ts
+++ b/src/features/events/hooks/useEventLocations.ts
@@ -16,9 +16,9 @@ export default function useEventLocations(
     actionOnLoad: () => locationsLoad(),
     actionOnSuccess: (data) => locationsLoaded(data),
     loader: async () => {
-      const locations = await fetchAllPaginated<ZetkinLocation>((page) =>
+      const locations = await fetchAllPaginated<ZetkinLocation>((page, size) =>
         apiClient.get(
-          `/api2/orgs/${orgId}/locations?size=100&page=${page}&type=event`
+          `/api2/orgs/${orgId}/locations?size=${size}&page=${page}&type=event`
         )
       );
 

--- a/src/utils/fetchAllPaginated.ts
+++ b/src/utils/fetchAllPaginated.ts
@@ -1,11 +1,11 @@
 export async function fetchAllPaginated<T>(
-  fetchPage: (page: number) => Promise<T[]>,
+  fetchPage: (page: number, size: number) => Promise<T[]>,
   batchSize: number = 100
 ): Promise<T[]> {
   const result: T[] = [];
 
   async function loadNextBatch(page: number = 1) {
-    const batch = await fetchPage(page);
+    const batch = await fetchPage(page, batchSize);
     result.push(...batch);
 
     if (batch.length >= batchSize) {


### PR DESCRIPTION
## Description

This PR changes `fetchAllPaginated` utility function to use the `batchSize` parameter as the `size` query parameter value, instead of relying on the person coding remembering to put the correct "size" in the string.

## Screenshots

No visual changes

## Changes
- Changes `fetchAllPaginated` to use the batchSIze parameter as the size query parameter value

## AI usage

Did you use AI to create the code in this PR? nope

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- for example, you can go to /my and see that the list loads the correct number of canvass assingments.

## Related issues

none, builds on the fix of 3755

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
