### PR TITLE
Ignore error when 1fa user attemtps to fetch all assignees

### DIFF
--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -1,10 +1,10 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinAreaAssignee } from '../types';
-import { assigneesLoad, assigneesLoaded } from '../store';
+import { assigneesLoad, assigneesLoaded, assigneesLoadError } from '../store';
 import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
-export default function useAreaAssignees(orgId: number, areaAssId: number) {
+export default function useAreaAssigneecs(orgId: number, areaAssId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const sessions = useAppSelector(
@@ -12,8 +12,8 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
   );
 
   return loadListIfNecessary(sessions, dispatch, {
+    actionOnError: (err) => assigneesLoadError([areaAssId, err]),
     actionOnLoad: () => assigneesLoad(areaAssId),
-
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>
       fetchAllPaginated(

--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -4,7 +4,7 @@ import { ZetkinAreaAssignee } from '../types';
 import { assigneesLoad, assigneesLoaded, assigneesLoadError } from '../store';
 import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
-export default function useAreaAssigneecs(orgId: number, areaAssId: number) {
+export default function useAreaAssignees(orgId: number, areaAssId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
   const sessions = useAppSelector(

--- a/src/features/areaAssignments/hooks/useAreaAssignees.ts
+++ b/src/features/areaAssignments/hooks/useAreaAssignees.ts
@@ -1,7 +1,7 @@
 import { loadListIfNecessary } from 'core/caching/cacheUtils';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { ZetkinAreaAssignee } from '../types';
-import { assigneesLoad, assigneesLoaded, assigneesLoadError } from '../store';
+import { assigneesLoad, assigneesLoaded, assigneesError } from '../store';
 import { fetchAllPaginated } from 'utils/fetchAllPaginated';
 
 export default function useAreaAssignees(orgId: number, areaAssId: number) {
@@ -12,7 +12,7 @@ export default function useAreaAssignees(orgId: number, areaAssId: number) {
   );
 
   return loadListIfNecessary(sessions, dispatch, {
-    actionOnError: (err) => assigneesLoadError([areaAssId, err]),
+    actionOnError: (err) => assigneesError([areaAssId, err]),
     actionOnLoad: () => assigneesLoad(areaAssId),
     actionOnSuccess: (data) => assigneesLoaded([areaAssId, data]),
     loader: () =>

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -185,15 +185,15 @@ const areaAssignmentSlice = createSlice({
         };
       }
     },
+    assigneesError: (state, action: PayloadAction<[number, unknown]>) => {
+      const [areaAssId, error] = action.payload;
+      state.assigneesByAssignmentId[areaAssId].error = error;
+    },
     assigneesLoad: (state, action: PayloadAction<number>) => {
       const assignmentId = action.payload;
       state.assigneesByAssignmentId[assignmentId] = remoteListLoad(
         state.assigneesByAssignmentId[assignmentId]
       );
-    },
-    assigneesLoadError: (state, action: PayloadAction<[number, unknown]>) => {
-      const [areaAssId, error] = action.payload;
-      state.assigneesByAssignmentId[areaAssId].error = error;
     },
     assigneesLoaded: (
       state,
@@ -358,7 +358,7 @@ export const {
   areaAssignmentsLoaded,
   assigneeAdded,
   assigneesLoad,
-  assigneesLoadError,
+  assigneesError,
   assigneesLoaded,
   assignmentAreasLoad,
   assignmentAreasLoaded,

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -191,6 +191,10 @@ const areaAssignmentSlice = createSlice({
         state.assigneesByAssignmentId[assignmentId]
       );
     },
+    assigneesLoadError: (state, action: PayloadAction<[number, unknown]>) => {
+      const [areaAssId, error] = action.payload;
+      state.assigneesByAssignmentId[areaAssId].error = error;
+    },
     assigneesLoaded: (
       state,
       action: PayloadAction<[number, ZetkinAreaAssignee[]]>
@@ -354,6 +358,7 @@ export const {
   areaAssignmentsLoaded,
   assigneeAdded,
   assigneesLoad,
+  assigneesLoadError,
   assigneesLoaded,
   assignmentAreasLoad,
   assignmentAreasLoaded,

--- a/src/features/areaAssignments/store.ts
+++ b/src/features/areaAssignments/store.ts
@@ -188,6 +188,9 @@ const areaAssignmentSlice = createSlice({
     assigneesError: (state, action: PayloadAction<[number, unknown]>) => {
       const [areaAssId, error] = action.payload;
       state.assigneesByAssignmentId[areaAssId].error = error;
+      state.assigneesByAssignmentId[areaAssId].isLoading = false;
+      state.assigneesByAssignmentId[areaAssId].loaded =
+        new Date().toISOString();
     },
     assigneesLoad: (state, action: PayloadAction<number>) => {
       const assignmentId = action.payload;

--- a/src/features/canvass/components/CanvassSelectAreaPage.tsx
+++ b/src/features/canvass/components/CanvassSelectAreaPage.tsx
@@ -20,17 +20,17 @@ import { notFound, useRouter } from 'next/navigation';
 import useMyCanvassAssignments from '../hooks/useMyAreaAssignments';
 import { ZetkinAreaAssignment } from '../../areaAssignments/types';
 import useOrganization from 'features/organizations/hooks/useOrganization';
-import ZUIFutures from 'zui/ZUIFutures';
 import oldTheme from 'theme';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import useAssignmentAreas from 'features/areaAssignments/hooks/useAssignmentAreas';
 import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
+import ZUIFuture from 'zui/ZUIFuture';
 
 const Page: FC<{
   assignment: ZetkinAreaAssignment;
-  myUserId: number;
-}> = ({ assignment, myUserId }) => {
+  currentUserId: number;
+}> = ({ assignment, currentUserId }) => {
   const orgFuture = useOrganization(assignment.organization_id);
   const router = useRouter();
   const areas = useAssignmentAreas(assignment.organization_id, assignment.id);
@@ -52,9 +52,12 @@ const Page: FC<{
       .some((a) => a.user_id != assigneesFuture.data?.[0].user_id);
   }
 
+  const errorLoadingAssignees = !!assigneesFuture.error;
+  const assignees = errorLoadingAssignees ? [] : assigneesFuture.data || [];
+
   return (
-    <ZUIFutures futures={{ assignees: assigneesFuture, org: orgFuture }}>
-      {({ data: { assignees, org } }) => (
+    <ZUIFuture future={orgFuture}>
+      {(org) => (
         <Box
           sx={{
             display: 'flex',
@@ -96,48 +99,56 @@ const Page: FC<{
           <Box>
             {areas.length > 0 ? (
               <List disablePadding>
-                {areas.map((area) => (
-                  <React.Fragment key={area.id}>
-                    <ListItem key={area.id} disablePadding>
-                      <ListItemButton
-                        href={`/canvass/${assignment.id}/areas/${area.id}`}
-                        onClick={() => {
-                          setLoadingAreaId(area.id);
-                        }}
-                        sx={{
-                          alignItems: 'center',
-                          display: 'flex',
-                          height: 64,
-                          justifyContent: 'space-between',
-                          px: 2,
-                        }}
-                      >
-                        <Box
+                {areas.map((area) => {
+                  const currentUserIsAssignedToThisArea = assignees.find(
+                    (a) => a.area_id == area.id && a.user_id == currentUserId
+                  );
+                  const showAssignedToMeChip =
+                    hasMixedUsers && currentUserIsAssignedToThisArea;
+
+                  return (
+                    <React.Fragment key={area.id}>
+                      <ListItem key={area.id} disablePadding>
+                        <ListItemButton
+                          href={`/canvass/${assignment.id}/areas/${area.id}`}
+                          onClick={() => {
+                            setLoadingAreaId(area.id);
+                          }}
                           sx={{
+                            alignItems: 'center',
                             display: 'flex',
-                            flexDirection: 'column',
-                            height: '100%',
-                            justifyContent: area.description
-                              ? 'flex-start'
-                              : 'center',
+                            height: 64,
+                            justifyContent: 'space-between',
+                            px: 2,
                           }}
                         >
-                          <Typography variant="body1">{area.title}</Typography>
-                          {area.description && (
-                            <Typography color="text.secondary" variant="body2">
-                              {area.description}
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              flexDirection: 'column',
+                              height: '100%',
+                              justifyContent: area.description
+                                ? 'flex-start'
+                                : 'center',
+                            }}
+                          >
+                            <Typography variant="body1">
+                              {area.title}
                             </Typography>
-                          )}
-                        </Box>
-                        {loadingAreaId === area.id ? (
-                          <CircularProgress size={20} />
-                        ) : (
-                          <Box alignItems="center" display={'flex'}>
-                            {hasMixedUsers &&
-                              assignees.find(
-                                (a) =>
-                                  a.area_id == area.id && a.user_id == myUserId
-                              ) && (
+                            {area.description && (
+                              <Typography
+                                color="text.secondary"
+                                variant="body2"
+                              >
+                                {area.description}
+                              </Typography>
+                            )}
+                          </Box>
+                          {loadingAreaId === area.id ? (
+                            <CircularProgress size={20} />
+                          ) : (
+                            <Box alignItems="center" display={'flex'}>
+                              {showAssignedToMeChip && (
                                 <Chip
                                   label={messages.selectArea.assignedToMe()}
                                   sx={{
@@ -146,14 +157,15 @@ const Page: FC<{
                                   }}
                                 />
                               )}
-                            <ArrowForwardIos fontSize="small" />
-                          </Box>
-                        )}
-                      </ListItemButton>
-                    </ListItem>
-                    <Divider />
-                  </React.Fragment>
-                ))}
+                              <ArrowForwardIos fontSize="small" />
+                            </Box>
+                          )}
+                        </ListItemButton>
+                      </ListItem>
+                      <Divider />
+                    </React.Fragment>
+                  );
+                })}
               </List>
             ) : (
               <Typography>
@@ -163,7 +175,7 @@ const Page: FC<{
           </Box>
         </Box>
       )}
-    </ZUIFutures>
+    </ZUIFuture>
   );
 };
 
@@ -185,7 +197,7 @@ const CanvassSelectAreaPage: FC<CanvassSelectAreaPageProps> = ({
     notFound();
   }
 
-  return <Page assignment={assignment} myUserId={myUserId} />;
+  return <Page assignment={assignment} currentUserId={myUserId} />;
 };
 
 export default CanvassSelectAreaPage;


### PR DESCRIPTION
## Description

This PR adds logic to ignore the error when a user that is only logged in with 1fa attempts to fetch all the assignees for all areas in an area assignment.

I think this should be considered a temporary solution, but it makes it at least not fail heh. 

One open question is that in the reducer where I set the error, I don't set "loaded" to some timestamp and "isLoading" to false, so the `remoteList` is still set as "loading" on the store. It felt wrong to say that it had loaded, when the response was an error, but it also feels wrong that it stays as "loading" when it's not really, it just received a not successful response.

## Screenshots

<img width="1176" height="954" alt="bild" src="https://github.com/user-attachments/assets/ed612ef8-6f53-4c9e-839e-e2df867bd1f3" />

## Changes

- Adds a reducer to set an error when fetching assignees to the `remoteList` of assignees.
- Changes the component to see if there is such an error, and in that case have 

## AI usage
no

## Instructions for reviewer
- follow instructions from #3755

## Related issues

Resolves #3755

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
