### PR TITLE
Fix issue causing `Temporal` to fail to parse `published` date

### DIFF
--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -107,13 +107,9 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
     if (!followedOrgs.has(event.organization.id)) {
       return false;
     }
-    let publishDate = event.published;
-    if (publishDate && !publishDate.endsWith('Z')) {
-      publishDate += 'Z';
-    }
+    const publishInstant = parsePublishDate(event.published);
     const isPublished =
-      publishDate &&
-      Temporal.Instant.compare(Temporal.Instant.from(publishDate), now) <= 0;
+      publishInstant && Temporal.Instant.compare(publishInstant, now) <= 0;
     const state = getEventState(event);
     return (
       (state == EventState.OPEN || state == EventState.SCHEDULED) && isPublished
@@ -171,4 +167,20 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
   });
 
   return publicEvents;
+}
+
+function parsePublishDate(dateStr: string | null): Temporal.Instant | null {
+  if (!dateStr) {
+    return null;
+  }
+
+  try {
+    return Temporal.Instant.from(dateStr);
+  } catch (err) {
+    try {
+      return Temporal.Instant.from(dateStr + 'Z');
+    } catch (err) {
+      return null;
+    }
+  }
 }

--- a/src/features/events/rpc/getAllEvents.ts
+++ b/src/features/events/rpc/getAllEvents.ts
@@ -107,10 +107,13 @@ async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
     if (!followedOrgs.has(event.organization.id)) {
       return false;
     }
+    let publishDate = event.published;
+    if (publishDate && !publishDate.endsWith('Z')) {
+      publishDate += 'Z';
+    }
     const isPublished =
-      event.published &&
-      Temporal.Instant.compare(Temporal.Instant.from(event.published), now) <=
-        0;
+      publishDate &&
+      Temporal.Instant.compare(Temporal.Instant.from(publishDate), now) <= 0;
     const state = getEventState(event);
     return (
       (state == EventState.OPEN || state == EventState.SCHEDULED) && isPublished

--- a/src/features/events/store.ts
+++ b/src/features/events/store.ts
@@ -104,6 +104,11 @@ const eventsSlice = createSlice({
   initialState,
   name: 'events',
   reducers: {
+    allEventsError: (state, error: PayloadAction<unknown>) => {
+      state.allEventsList.isLoading = false;
+      state.allEventsList.error = error;
+      state.allEventsList.loaded = new Date().toISOString();
+    },
     allEventsLoad: (state) => {
       state.allEventsList.isLoading = true;
     },
@@ -817,6 +822,7 @@ export default eventsSlice;
 export const {
   allEventsLoad,
   allEventsLoaded,
+  allEventsError,
   allEventsUnload,
   projectEventsLoad,
   projectEventsLoaded,

--- a/src/features/my/hooks/useAllEvents.ts
+++ b/src/features/my/hooks/useAllEvents.ts
@@ -1,6 +1,10 @@
 import { useApiClient, useAppSelector } from 'core/hooks';
 import useRemoteList from 'core/hooks/useRemoteList';
-import { allEventsLoad, allEventsLoaded } from '../../events/store';
+import {
+  allEventsError,
+  allEventsLoad,
+  allEventsLoaded,
+} from '../../events/store';
 import getAllEvents from '../../events/rpc/getAllEvents';
 import sortEventsByStartTime from '../../events/utils/sortEventsByStartTime';
 import { ZetkinEventWithStatus } from 'features/public/types';
@@ -13,6 +17,7 @@ export default function useAllEvents() {
   const myEvents = useMyEvents();
 
   const events = useRemoteList(allEventsList, {
+    actionOnError: (err) => allEventsError(err),
     actionOnLoad: () => allEventsLoad(),
     actionOnSuccess: (data) => {
       const sorted = data.sort(sortEventsByStartTime);


### PR DESCRIPTION
## Description
This PR fixes an undocumented bug that was causing the "My feed" to fail to load, because some `published` dates could not be parsed by `Temporal`. It also prevents reloads when this happens.

## Screenshots
None

## Changes
- Adds a `Z` timezone (UTC) if timezone is missing
- Adds error handling in store when retrieving events feed, to prevent infinite reloads

## AI usage
No

## Instructions for reviewer
This only happens when there are events that have a `published` date without a timezone. Manually patch an event to have a published date without a timezone and then try on both `main` and this branch.

## Related issues
Undocumented

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information