### PR TITLE
Fix spelling mistake that caused projectId to be undefined

### DIFF
--- a/src/pages/organize/[orgId]/projects/[projectId]/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/archive/index.tsx
@@ -30,10 +30,10 @@ export const getServerSideProps: GetServerSideProps = scaffold(
 const ProjectArchivePage: PageWithLayout = () => {
   const messages = useMessages(messageIds);
   const onServer = useServerSide();
-  const { orgId, projectid } = useNumericRouteParams();
-  const archivedActivities = useActivityArchive(orgId, projectid);
+  const { orgId, projectId } = useNumericRouteParams();
+  const archivedActivities = useActivityArchive(orgId, projectId);
   const { filters, onFiltersChange, onSearchStringChange, searchString } =
-    useActivityFilters('archive', orgId, projectid);
+    useActivityFilters('archive', orgId, projectId);
 
   if (onServer) {
     return null;
@@ -45,7 +45,7 @@ const ProjectArchivePage: PageWithLayout = () => {
           if (data.length === 0) {
             return (
               <ZUIEmptyState
-                href={`/organize/${orgId}/projects/${projectid}/activities`}
+                href={`/organize/${orgId}/projects/${projectId}/activities`}
                 linkMessage={messages.activitiesOverview.goToActivities()}
                 message={messages.singleProject.noActivities()}
               />


### PR DESCRIPTION
## Description

This PR fixes a spelling mistake that caused `projectId` to be `undefined` on the project archive page, leading to it displaying all activities for the entire organisation instead of just the ones relating to the specific project. 

## Screenshots

On this branch - list only contains activities for this project
<img width="1469" height="967" alt="bild" src="https://github.com/user-attachments/assets/6d7c0f9d-2af2-467c-abd5-e801726e5990" />

On main - list contains all activities
<img width="1917" height="964" alt="bild" src="https://github.com/user-attachments/assets/6286715a-c93c-4621-b514-2a767b575c93" />


## Changes
- Changes spelling from `projectid` to `projectId`

## AI usage
no

## Instructions for reviewer
- look at organize/1/projects/174 on main and on this branch

## Related issues

Resolves #3757 

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
