### PR TITLE
Memoise a bunch of stuff in Call UI

### DIFF
--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Avatar,
   Box,
@@ -96,15 +96,18 @@ const Activities: FC<ActivitiesProps> = ({
     setDebouncedSearchString(value);
   }, 300);
 
-  const handleSearchStringChange = (value: string) => {
-    setSearchString(value);
-    debouncedSetSearchString(value);
-  };
+  const handleSearchStringChange = useCallback(
+    (value: string) => {
+      setSearchString(value);
+      debouncedSetSearchString(value);
+    },
+    [debouncedSetSearchString]
+  );
 
-  const clearSearchString = () => {
+  const clearSearchString = useCallback(() => {
     setSearchString('');
     setDebouncedSearchString('');
-  };
+  }, []);
 
   const filteredActivities = useMemo(
     () =>
@@ -263,27 +266,35 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
     },
   } = useAppSelector((state) => state.call.lanes[state.call.activeLaneIndex]);
 
-  const respondedSurveyIds = Object.keys(submissionDataBySurveyId);
+  const respondedSurveyIds = useMemo(
+    () => Object.keys(submissionDataBySurveyId),
+    [submissionDataBySurveyId]
+  );
 
   const [drawerContent, setDrawerContent] = useState<
     'orgs' | 'calendar' | 'context' | null
   >(null);
-  const selectedSurvey =
-    surveys.find((survey) => survey.id == selectedSurveyId) || null;
+  const selectedSurvey = useMemo(
+    () => surveys.find((survey) => survey.id == selectedSurveyId) || null,
+    [surveys, selectedSurveyId]
+  );
 
-  const getDatesFilteredBy = (end: Dayjs | null, start: Dayjs) => {
-    if (!end) {
-      return intl.formatDate(start.toDate(), {
-        day: 'numeric',
-        month: 'short',
-      });
-    } else {
-      return intl.formatDateTimeRange(start.toDate(), end.toDate(), {
-        day: 'numeric',
-        month: 'short',
-      });
-    }
-  };
+  const getDatesFilteredBy = useCallback(
+    (end: Dayjs | null, start: Dayjs) => {
+      if (!end) {
+        return intl.formatDate(start.toDate(), {
+          day: 'numeric',
+          month: 'short',
+        });
+      } else {
+        return intl.formatDateTimeRange(start.toDate(), end.toDate(), {
+          day: 'numeric',
+          month: 'short',
+        });
+      }
+    },
+    [intl]
+  );
 
   const isFiltered =
     filterState.alreadyIn ||
@@ -294,71 +305,96 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
   const showAll =
     !filterState.alreadyIn && !filterState.events && !filterState.surveys;
 
-  const orgs = [
-    ...new Map(
-      events.map((event) => event.organization).map((org) => [org['id'], org])
-    ).values(),
-  ].sort((a, b) => a.title.localeCompare(b.title));
+  const orgs = useMemo(
+    () =>
+      [
+        ...new Map(
+          events
+            .map((event) => event.organization)
+            .map((org) => [org['id'], org])
+        ).values(),
+      ].sort((a, b) => a.title.localeCompare(b.title)),
+    [events]
+  );
 
-  const surveysWithProject = surveys.filter((survey) => !!survey.campaign);
-  const eventsWithProject = events.filter((event) => !!event.campaign);
+  const surveysWithProject = useMemo(
+    () => surveys.filter((survey) => !!survey.campaign),
+    [surveys]
+  );
+  const eventsWithProject = useMemo(
+    () => events.filter((event) => !!event.campaign),
+    [events]
+  );
 
-  const activitiesWithProject = [...surveysWithProject, ...eventsWithProject];
+  const activitiesWithProject = useMemo(
+    () => [...surveysWithProject, ...eventsWithProject],
+    [eventsWithProject, surveysWithProject]
+  );
 
-  const projects: { id: 'noProject' | number; title: string }[] = [
-    ...new Map(
-      eventsWithProject
-        .map((event) => event.campaign)
-        .filter(notEmpty)
-        .map((project) => [project['title'], project])
-    ).values(),
-    ...new Map(
-      surveysWithProject
-        .map((survey) => survey.campaign)
-        .filter(notEmpty)
-        .map((project) => [project['title'], project])
-    ).values(),
-  ].sort((a, b) => a.title.localeCompare(b.title));
+  const projects: { id: 'noProject' | number; title: string }[] = useMemo(
+    () =>
+      [
+        ...new Map(
+          eventsWithProject
+            .map((event) => event.campaign)
+            .filter(notEmpty)
+            .map((project) => [project['title'], project])
+        ).values(),
+        ...new Map(
+          surveysWithProject
+            .map((survey) => survey.campaign)
+            .filter(notEmpty)
+            .map((project) => [project['title'], project])
+        ).values(),
+      ].sort((a, b) => a.title.localeCompare(b.title)),
+    [eventsWithProject, surveysWithProject]
+  );
 
   if (activitiesWithProject.length != surveys.length + events.length) {
     projects.push({ id: 'noProject', title: 'noProject' });
   }
 
-  const orgIdsWithEvents = events.reduce<number[]>((orgIds, event) => {
-    if (!orgIds.includes(event.organization.id)) {
-      orgIds = [...orgIds, event.organization.id];
-    }
-    return orgIds;
-  }, []);
-
-  const projectIdsWithSurveys = surveys.reduce<(number | 'noProject')[]>(
-    (projectIds, survey) => {
-      if (survey.campaign && !projectIds.includes(survey.campaign.id)) {
-        projectIds = [...projectIds, survey.campaign.id];
-      } else if (!survey.campaign && !projectIds.includes('noProject')) {
-        projectIds = [...projectIds, 'noProject'];
-      }
-      return projectIds;
-    },
-    []
+  const orgIdsWithEvents = useMemo(
+    () =>
+      events.reduce<number[]>((orgIds, event) => {
+        if (!orgIds.includes(event.organization.id)) {
+          orgIds = [...orgIds, event.organization.id];
+        }
+        return orgIds;
+      }, []),
+    [events]
   );
 
-  const projectIdsWithEvents = events.reduce<(number | 'noProject')[]>(
-    (projectIds, event) => {
-      if (event.campaign && !projectIds.includes(event.campaign.id)) {
-        projectIds = [...projectIds, event.campaign.id];
-      } else if (!event.campaign && !projectIds.includes('noProject')) {
-        projectIds = [...projectIds, 'noProject'];
-      }
-      return projectIds;
-    },
-    []
+  const projectIdsWithSurveys = useMemo(
+    () =>
+      surveys.reduce<(number | 'noProject')[]>((projectIds, survey) => {
+        if (survey.campaign && !projectIds.includes(survey.campaign.id)) {
+          projectIds = [...projectIds, survey.campaign.id];
+        } else if (!survey.campaign && !projectIds.includes('noProject')) {
+          projectIds = [...projectIds, 'noProject'];
+        }
+        return projectIds;
+      }, []),
+    [surveys]
   );
 
-  const projectIdsWithActivities = [
-    ...projectIdsWithEvents,
-    ...projectIdsWithSurveys,
-  ];
+  const projectIdsWithEvents = useMemo(
+    () =>
+      events.reduce<(number | 'noProject')[]>((projectIds, event) => {
+        if (event.campaign && !projectIds.includes(event.campaign.id)) {
+          projectIds = [...projectIds, event.campaign.id];
+        } else if (!event.campaign && !projectIds.includes('noProject')) {
+          projectIds = [...projectIds, 'noProject'];
+        }
+        return projectIds;
+      }, []),
+    [events]
+  );
+
+  const projectIdsWithActivities = useMemo(
+    () => [...projectIdsWithEvents, ...projectIdsWithSurveys],
+    [projectIdsWithEvents, projectIdsWithSurveys]
+  );
 
   const moreThanOneOrgHasEvents = orgIdsWithEvents.length > 1;
   const moreThanOneProjectHasActivities = projectIdsWithActivities.length > 1;

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -360,39 +360,31 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
   ]);
 
   const orgIdsWithEvents = useMemo(
-    () =>
-      events.reduce<number[]>((orgIds, event) => {
-        if (!orgIds.includes(event.organization.id)) {
-          orgIds = [...orgIds, event.organization.id];
-        }
-        return orgIds;
-      }, []),
+    () => Array.from(new Set(events.map((event) => event.organization.id))),
     [events]
   );
 
   const projectIdsWithSurveys = useMemo(
     () =>
-      surveys.reduce<(number | 'noProject')[]>((projectIds, survey) => {
-        if (survey.campaign && !projectIds.includes(survey.campaign.id)) {
-          projectIds = [...projectIds, survey.campaign.id];
-        } else if (!survey.campaign && !projectIds.includes('noProject')) {
-          projectIds = [...projectIds, 'noProject'];
-        }
-        return projectIds;
-      }, []),
+      Array.from(
+        new Set(
+          surveys.map((survey) =>
+            survey.campaign ? survey.campaign.id : 'noProject'
+          )
+        )
+      ),
     [surveys]
   );
 
   const projectIdsWithEvents = useMemo(
     () =>
-      events.reduce<(number | 'noProject')[]>((projectIds, event) => {
-        if (event.campaign && !projectIds.includes(event.campaign.id)) {
-          projectIds = [...projectIds, event.campaign.id];
-        } else if (!event.campaign && !projectIds.includes('noProject')) {
-          projectIds = [...projectIds, 'noProject'];
-        }
-        return projectIds;
-      }, []),
+      Array.from(
+        new Set(
+          events.map((event) =>
+            event.campaign ? event.campaign.id : 'noProject'
+          )
+        )
+      ),
     [events]
   );
 

--- a/src/features/call/components/ActivitiesSection.tsx
+++ b/src/features/call/components/ActivitiesSection.tsx
@@ -331,28 +331,33 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
     [eventsWithProject, surveysWithProject]
   );
 
-  const projects: { id: 'noProject' | number; title: string }[] = useMemo(
-    () =>
-      [
-        ...new Map(
-          eventsWithProject
-            .map((event) => event.campaign)
-            .filter(notEmpty)
-            .map((project) => [project['title'], project])
-        ).values(),
-        ...new Map(
-          surveysWithProject
-            .map((survey) => survey.campaign)
-            .filter(notEmpty)
-            .map((project) => [project['title'], project])
-        ).values(),
-      ].sort((a, b) => a.title.localeCompare(b.title)),
-    [eventsWithProject, surveysWithProject]
-  );
+  const projectOptions = useMemo(() => {
+    const projects: { id: 'noProject' | number; title: string }[] = [
+      ...new Map(
+        eventsWithProject
+          .map((event) => event.campaign)
+          .filter(notEmpty)
+          .map((project) => [project['title'], project])
+      ).values(),
+      ...new Map(
+        surveysWithProject
+          .map((survey) => survey.campaign)
+          .filter(notEmpty)
+          .map((project) => [project['title'], project])
+      ).values(),
+    ].sort((a, b) => a.title.localeCompare(b.title));
 
-  if (activitiesWithProject.length != surveys.length + events.length) {
-    projects.push({ id: 'noProject', title: 'noProject' });
-  }
+    if (activitiesWithProject.length != surveys.length + events.length) {
+      projects.push({ id: 'noProject', title: 'noProject' });
+    }
+    return projects;
+  }, [
+    eventsWithProject,
+    surveysWithProject,
+    activitiesWithProject.length,
+    surveys.length,
+    events.length,
+  ]);
 
   const orgIdsWithEvents = useMemo(
     () =>
@@ -495,7 +500,7 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
                 ? messages.activities.filters.projects({
                     numProjects: projectIdsToFilterActivitiesBy.length,
                   })
-                : projects.find(
+                : projectOptions.find(
                     (project) => project.id == projectIdsToFilterActivitiesBy[0]
                   )?.title ||
                   messages.activities.filters.projects({ numProjects: 0 }),
@@ -785,27 +790,27 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
         open={drawerContent == 'context'}
       >
         <List>
-          {projects.map((project) => (
-            <ListItem key={project.id} sx={{ justifyContent: 'space-between' }}>
+          {projectOptions.map((option) => (
+            <ListItem key={option.id} sx={{ justifyContent: 'space-between' }}>
               <Box alignItems="center" display="flex">
                 <ListItemAvatar>
                   <GroupWork />
                 </ListItemAvatar>
                 <ZUIText>
-                  {project.id == 'noProject'
+                  {option.id == 'noProject'
                     ? messages.activities.projects.wihoutProjectLabel()
-                    : project.title}
+                    : option.title}
                 </ZUIText>
               </Box>
               <Switch
-                checked={projectIdsToFilterActivitiesBy.includes(project.id)}
+                checked={projectIdsToFilterActivitiesBy.includes(option.id)}
                 onChange={(_event, checked) => {
                   if (checked) {
                     dispatch(
                       filtersUpdated({
                         projectIdsToFilterActivitiesBy: [
                           ...projectIdsToFilterActivitiesBy,
-                          project.id,
+                          option.id,
                         ],
                       })
                     );
@@ -814,7 +819,7 @@ const ActivitiesSection: FC<ActivitiesSectionProps> = ({
                       filtersUpdated({
                         projectIdsToFilterActivitiesBy:
                           projectIdsToFilterActivitiesBy.filter(
-                            (id) => id != project.id
+                            (id) => id != option.id
                           ),
                       })
                     );

--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Alert, Box, Slide, Snackbar } from '@mui/material';
-import { FC, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 
 import useCurrentCall from '../hooks/useCurrentCall';
 import { LaneStep } from '../types';
@@ -51,12 +51,17 @@ const Call: FC<Props> = ({ onResetAfterError }) => {
     (state) => state.call.lanes[state.call.activeLaneIndex].report
   );
 
-  const filteredUnfinishedCalls = unfinishedCalls.filter((unfinishedCall) =>
-    call ? call.id != unfinishedCall.id : true
+  const filteredUnfinishedCalls = useMemo(
+    () =>
+      unfinishedCalls.filter((unfinishedCall) =>
+        call ? call.id != unfinishedCall.id : true
+      ),
+    [unfinishedCalls, call]
   );
 
-  const switchedTo = allUserAssignments.find(
-    (oc) => oc.id == assignmentSwitchedTo
+  const switchedTo = useMemo(
+    () => allUserAssignments.find((oc) => oc.id == assignmentSwitchedTo),
+    [allUserAssignments, assignmentSwitchedTo]
   );
 
   if (onServer) {

--- a/src/features/call/components/CallSwitchModal.tsx
+++ b/src/features/call/components/CallSwitchModal.tsx
@@ -47,8 +47,12 @@ const UnfinishedCallsList: FC<{
   const currentCall = useCurrentCall();
   const unfinishedCalls = useUnfinishedCalls();
 
-  const unfinishedExceptCurrentCall = unfinishedCalls.filter((call) =>
-    currentCall ? currentCall.id != call.id : true
+  const unfinishedExceptCurrentCall = useMemo(
+    () =>
+      unfinishedCalls.filter((call) =>
+        currentCall ? currentCall.id != call.id : true
+      ),
+    [currentCall, unfinishedCalls]
   );
 
   const fuse = useMemo(() => {

--- a/src/features/call/components/EventCard.tsx
+++ b/src/features/call/components/EventCard.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import {
   Event,
@@ -34,14 +34,19 @@ const EventCard: FC<EventCardProps> = ({ event, target }) => {
     target.id
   );
 
-  const isTargetBooked = target.future_actions.some(
-    (futureEvent) => futureEvent.id == event.id
+  const isTargetBooked = useMemo(
+    () =>
+      target.future_actions.some((futureEvent) => futureEvent.id == event.id),
+    [event.id, target.future_actions]
   );
 
   const idsOfEventsRespondedTo = useAppSelector(
     (state) => state.call.lanes[state.call.activeLaneIndex].respondedEventIds
   );
-  const isSignedUp = idsOfEventsRespondedTo.includes(event.id);
+  const isSignedUp = useMemo(
+    () => idsOfEventsRespondedTo.includes(event.id),
+    [idsOfEventsRespondedTo, event.id]
+  );
 
   return (
     <MyActivityListItem

--- a/src/features/call/components/SurveyCard.tsx
+++ b/src/features/call/components/SurveyCard.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useState } from 'react';
+import { FC, Fragment, useMemo, useState } from 'react';
 import { Assignment, GroupWorkOutlined } from '@mui/icons-material';
 import { Box } from '@mui/material';
 
@@ -28,14 +28,17 @@ const SurveyCard: FC<SurveyCardProps> = ({ survey, onSelectSurvey }) => {
 
   const response = responseBySurveyId[survey.id];
 
-  const hasMeaningfulContent =
-    !!response &&
-    Object.entries(response).some(([, value]) => {
-      if (typeof value === 'string') {
-        return value.trim() !== '';
-      }
-      return true;
-    });
+  const hasMeaningfulContent = useMemo(
+    () =>
+      !!response &&
+      Object.entries(response).some(([, value]) => {
+        if (typeof value === 'string') {
+          return value.trim() !== '';
+        }
+        return true;
+      }),
+    [response]
+  );
 
   return (
     <>

--- a/src/features/call/hooks/useAllocateCall.ts
+++ b/src/features/call/hooks/useAllocateCall.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { allocateCallError, allocateNewCall, newCallAllocated } from '../store';
 import { UnfinishedCall } from '../types';
@@ -24,25 +26,26 @@ export default function useAllocateCall(
     (state) => state.call.lanes[state.call.activeLaneIndex].callIsBeingAllocated
   );
 
-  const allocateCall = async (): Promise<void | SerializedError> => {
-    dispatch(allocateNewCall());
-    try {
-      const call = await apiClient.post<UnfinishedCall>(
-        `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
-        {}
-      );
-      dispatch(newCallAllocated(call));
-    } catch (e) {
-      const queueError =
-        e instanceof Error ? e : new Error('Empty queue error');
-      const serialized = {
-        message: queueError.message,
-        name: queueError.name,
-      };
-      dispatch(allocateCallError(serialized));
-      return queueError;
-    }
-  };
+  const allocateCall =
+    useCallback(async (): Promise<void | SerializedError> => {
+      dispatch(allocateNewCall());
+      try {
+        const call = await apiClient.post<UnfinishedCall>(
+          `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
+          {}
+        );
+        dispatch(newCallAllocated(call));
+      } catch (e) {
+        const queueError =
+          e instanceof Error ? e : new Error('Empty queue error');
+        const serialized = {
+          message: queueError.message,
+          name: queueError.name,
+        };
+        dispatch(allocateCallError(serialized));
+        return queueError;
+      }
+    }, [apiClient, assignmentId, dispatch, orgId]);
 
   return {
     allocateCall,

--- a/src/features/call/hooks/useCallInitialization.ts
+++ b/src/features/call/hooks/useCallInitialization.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'next/navigation';
 import { useStore } from 'react-redux';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useAppDispatch } from 'core/hooks';
 import { initiateAssignment, initiateWithoutAssignment } from '../store';
@@ -96,16 +96,16 @@ export default function useCallInitialization() {
     canInitialize = thisUserHasSavedLanes && savedLanesAreFresh;
   }
 
-  const clearStaleCallLanes = () => {
+  const clearStaleCallLanes = useCallback(() => {
     const callLanesAreStale =
       callLanes && callLanes.timestamp < new Date().getTime() - LANES_TTL;
 
     if (callLanesAreStale) {
       setLanes(null);
     }
-  };
+  }, [callLanes, setLanes]);
 
-  const initialize = () => {
+  const initialize = useCallback(() => {
     if (assignmentIdFromQuery) {
       const thisUserHasSavedLanes =
         activeLanes.length > 0 && !!user && callLanes?.userId == user.id;
@@ -127,7 +127,7 @@ export default function useCallInitialization() {
         initiateWithoutAssignment([callLanes.activeLaneIndex, activeLanes])
       );
     }
-  };
+  }, [assignmentIdFromQuery, activeLanes, callLanes, dispatch, user]);
 
   return {
     canInitialize,

--- a/src/features/call/hooks/useCallInitialization.ts
+++ b/src/features/call/hooks/useCallInitialization.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'next/navigation';
 import { useStore } from 'react-redux';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useAppDispatch } from 'core/hooks';
 import { initiateAssignment, initiateWithoutAssignment } from '../store';
@@ -49,32 +49,39 @@ export default function useCallInitialization() {
 
   const assignmentIdFromQuery = queryParams?.get('assignment');
 
-  const lanesAssignedToUser =
-    callLanes && callLanes.version == CURRENT_CALL_LANES_VERSION
-      ? callLanes.lanes.filter((lane) =>
-          userCallAssignments.some(
-            (assignment) => assignment.id == lane.assignmentId
+  const lanesAssignedToUser = useMemo(
+    () =>
+      callLanes && callLanes.version == CURRENT_CALL_LANES_VERSION
+        ? callLanes.lanes.filter((lane) =>
+            userCallAssignments.some(
+              (assignment) => assignment.id == lane.assignmentId
+            )
           )
-        )
-      : [];
+        : [],
+    [callLanes, userCallAssignments]
+  );
 
-  const activeLanes = lanesAssignedToUser.filter((lane) => {
-    const assignment = userCallAssignments.find(
-      (assignment) => assignment.id == lane.assignmentId
-    );
+  const activeLanes = useMemo(
+    () =>
+      lanesAssignedToUser.filter((lane) => {
+        const assignment = userCallAssignments.find(
+          (assignment) => assignment.id == lane.assignmentId
+        );
 
-    if (assignment) {
-      const startDate = assignment.start_date;
-      const endDate = assignment.end_date;
-      const now = new Date();
+        if (assignment) {
+          const startDate = assignment.start_date;
+          const endDate = assignment.end_date;
+          const now = new Date();
 
-      const hasStarted = startDate && new Date(startDate) < now;
-      const isOngoing = !endDate || (endDate && new Date(endDate) > now);
-      return assignment && hasStarted && isOngoing;
-    }
+          const hasStarted = startDate && new Date(startDate) < now;
+          const isOngoing = !endDate || (endDate && new Date(endDate) > now);
+          return assignment && hasStarted && isOngoing;
+        }
 
-    return false;
-  });
+        return false;
+      }),
+    [lanesAssignedToUser, userCallAssignments]
+  );
 
   let canInitialize = false;
   if (assignmentIdFromQuery) {

--- a/src/features/call/hooks/useCallMutations.ts
+++ b/src/features/call/hooks/useCallMutations.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import {
   quitCall,
@@ -16,75 +18,81 @@ export default function useCallMutations(orgId: number) {
   const dispatch = useAppDispatch();
   const assignments = useMyAssignments();
 
-  const abandonUnfinishedCall = async (
-    assignmentId: number,
-    callId: number
-  ) => {
-    const assignment = assignments.find(
-      (assignment) => assignment.id == assignmentId
-    );
-
-    if (assignment) {
-      await apiClient.delete(
-        `/api/orgs/${assignment.organization.id}/calls/${callId}`
+  const abandonUnfinishedCall = useCallback(
+    async (assignmentId: number, callId: number) => {
+      const assignment = assignments.find(
+        (assignment) => assignment.id == assignmentId
       );
-      dispatch(unfinishedCallAbandoned(callId));
-    }
-  };
 
-  const quitCurrentCall = async (callId: number) => {
-    await apiClient.delete(`/api/orgs/${orgId}/calls/${callId}`);
-    dispatch(quitCall(callId));
-  };
+      if (assignment) {
+        await apiClient.delete(
+          `/api/orgs/${assignment.organization.id}/calls/${callId}`
+        );
+        dispatch(unfinishedCallAbandoned(callId));
+      }
+    },
+    [apiClient, assignments, dispatch]
+  );
 
-  const skipCurrentCall = async (
-    assignmentId: number,
-    skippedCallId: number
-  ) => {
-    dispatch(callSkippedLoad());
-    await apiClient.delete(`/api/orgs/${orgId}/calls/${skippedCallId}`);
-    try {
-      const newCall = await apiClient.post<UnfinishedCall>(
-        `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
-        {}
+  const quitCurrentCall = useCallback(
+    async (callId: number) => {
+      await apiClient.delete(`/api/orgs/${orgId}/calls/${callId}`);
+      dispatch(quitCall(callId));
+    },
+    [apiClient, dispatch, orgId]
+  );
+
+  const skipCurrentCall = useCallback(
+    async (assignmentId: number, skippedCallId: number) => {
+      dispatch(callSkippedLoad());
+      await apiClient.delete(`/api/orgs/${orgId}/calls/${skippedCallId}`);
+      try {
+        const newCall = await apiClient.post<UnfinishedCall>(
+          `/api/orgs/${orgId}/call_assignments/${assignmentId}/queue/head`,
+          {}
+        );
+        dispatch(callSkippedLoaded([skippedCallId, newCall]));
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error('Error skipping call');
+        const serialized = {
+          message: error.message,
+          name: error.name,
+        };
+        dispatch(allocateCallError(serialized));
+        return error;
+      }
+    },
+    [apiClient, dispatch, orgId]
+  );
+
+  const switchToPreviousCall = useCallback(
+    async (assignmentId: number, targetId: number) => {
+      const assignment = assignments.find(
+        (assignment) => assignment.id == assignmentId
       );
-      dispatch(callSkippedLoaded([skippedCallId, newCall]));
-    } catch (e) {
-      const error = e instanceof Error ? e : new Error('Error skipping call');
-      const serialized = {
-        message: error.message,
-        name: error.name,
-      };
-      dispatch(allocateCallError(serialized));
-      return error;
-    }
-  };
 
-  const switchToPreviousCall = async (
-    assignmentId: number,
-    targetId: number
-  ) => {
-    const assignment = assignments.find(
-      (assignment) => assignment.id == assignmentId
-    );
+      if (assignment) {
+        const newCall = await apiClient.post<
+          UnfinishedCall,
+          { target_id: number }
+        >(
+          `/api/orgs/${assignment.organization.id}/call_assignments/${assignmentId}/calls`,
+          {
+            target_id: targetId,
+          }
+        );
+        dispatch(allocatePreviousCall(newCall));
+      }
+    },
+    [apiClient, assignments, dispatch]
+  );
 
-    if (assignment) {
-      const newCall = await apiClient.post<
-        UnfinishedCall,
-        { target_id: number }
-      >(
-        `/api/orgs/${assignment.organization.id}/call_assignments/${assignmentId}/calls`,
-        {
-          target_id: targetId,
-        }
-      );
-      dispatch(allocatePreviousCall(newCall));
-    }
-  };
-
-  const switchToUnfinishedCall = (callId: number, assignmentId: number) => {
-    dispatch(switchedToUnfinishedCall([callId, assignmentId]));
-  };
+  const switchToUnfinishedCall = useCallback(
+    (callId: number, assignmentId: number) => {
+      dispatch(switchedToUnfinishedCall([callId, assignmentId]));
+    },
+    [dispatch]
+  );
 
   return {
     abandonUnfinishedCall,

--- a/src/features/call/hooks/useCurrentAssignment.ts
+++ b/src/features/call/hooks/useCurrentAssignment.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useAppSelector } from 'core/hooks';
 import useMyAssignments from 'features/call/hooks/useMyAssignments';
 
@@ -7,8 +9,10 @@ export default function useCurrentAssignment() {
   );
   const userAssignments = useMyAssignments();
 
-  const assignment = userAssignments.find(
-    (assignment) => assignment.id == lane.assignmentId
+  const assignment = useMemo(
+    () =>
+      userAssignments.find((assignment) => assignment.id == lane.assignmentId),
+    [lane.assignmentId, userAssignments]
   );
 
   if (!assignment) {

--- a/src/features/call/hooks/useCurrentCall.ts
+++ b/src/features/call/hooks/useCurrentCall.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useAppSelector } from 'core/hooks';
 import { UnfinishedCall } from '../types';
 
@@ -6,8 +8,9 @@ export default function useCurrentCall(): UnfinishedCall | null {
   const activeLane = state.lanes[state.activeLaneIndex];
   const currentCallId = activeLane.currentCallId;
 
-  const currentCall = state.unfinishedCalls.items.find(
-    (item) => item.id == currentCallId
+  const currentCall = useMemo(
+    () => state.unfinishedCalls.items.find((item) => item.id == currentCallId),
+    [currentCallId, state.unfinishedCalls]
   );
 
   return currentCall?.data ?? null;

--- a/src/features/call/hooks/useFilteredActivities.ts
+++ b/src/features/call/hooks/useFilteredActivities.ts
@@ -1,4 +1,5 @@
 import dayjs, { Dayjs } from 'dayjs';
+import { useCallback, useMemo } from 'react';
 
 import { useAppSelector } from 'core/hooks';
 import useUpcomingEvents from './useUpcomingEvents';
@@ -26,7 +27,7 @@ export type Activity = EventActivity | SurveyActivity;
 
 export default function useFilteredActivities(orgId: number) {
   const events = useUpcomingEvents(orgId);
-  const surveys = useSurveys(orgId).data || [];
+  const surveysFuture = useSurveys(orgId);
   const {
     filterState,
     customDatesToFilterEventsBy,
@@ -45,13 +46,16 @@ export default function useFilteredActivities(orgId: number) {
   );
   const target = useCurrentCall()?.target ?? null;
 
-  const today = new Date();
-  const activeSurveys = surveys.filter(
-    ({ published, expires }) =>
-      published && (!expires || new Date(expires) >= today)
-  );
+  const activeSurveys = useMemo(() => {
+    const surveys = surveysFuture.data || [];
+    const today = new Date();
+    return surveys.filter(
+      ({ published, expires }) =>
+        published && (!expires || new Date(expires) >= today)
+    );
+  }, [surveysFuture]);
 
-  const getDateRange = (): [Dayjs | null, Dayjs | null] => {
+  const getDateRange = useCallback((): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();
     if (!eventDateFilterState || eventDateFilterState == 'custom') {
       return customDatesToFilterEventsBy;
@@ -63,137 +67,172 @@ export default function useFilteredActivities(orgId: number) {
       //dateFilterState is 'thisWeek'
       return [today.startOf('week'), today.endOf('week')];
     }
-  };
+  }, [customDatesToFilterEventsBy, eventDateFilterState]);
 
-  const filteredEvents: EventActivity[] = events
-    .filter((event) => {
-      if (orgIdsToFilterEventsBy.length == 0) {
-        return true;
-      }
-      return orgIdsToFilterEventsBy.includes(event.organization.id);
-    })
-    .filter((event) => {
-      if (!filterState.alreadyIn) {
-        return true;
-      }
+  const filteredEvents: EventActivity[] = useMemo(
+    () =>
+      events
+        .filter((event) => {
+          if (orgIdsToFilterEventsBy.length == 0) {
+            return true;
+          }
+          return orgIdsToFilterEventsBy.includes(event.organization.id);
+        })
+        .filter((event) => {
+          if (!filterState.alreadyIn) {
+            return true;
+          }
 
-      if (!target) {
-        return false;
-      }
-      const isBooked = target.future_actions.some(
-        (futureEvent) => futureEvent.id == event.id
-      );
+          if (!target) {
+            return false;
+          }
+          const isBooked = target.future_actions.some(
+            (futureEvent) => futureEvent.id == event.id
+          );
 
-      const isSignedUp = idsOfEventsRespondedTo.includes(event.id);
+          const isSignedUp = idsOfEventsRespondedTo.includes(event.id);
 
-      return isSignedUp || isBooked;
-    })
-    .filter((event) => {
-      if (
-        !eventDateFilterState ||
-        (eventDateFilterState == 'custom' && !customDatesToFilterEventsBy[0])
-      ) {
-        return true;
-      }
+          return isSignedUp || isBooked;
+        })
+        .filter((event) => {
+          if (
+            !eventDateFilterState ||
+            (eventDateFilterState == 'custom' &&
+              !customDatesToFilterEventsBy[0])
+          ) {
+            return true;
+          }
 
-      const [start, end] = getDateRange();
-      const eventStart = dayjs(event.start_time);
-      const eventEnd = dayjs(event.end_time);
+          const [start, end] = getDateRange();
+          const eventStart = dayjs(event.start_time);
+          const eventEnd = dayjs(event.end_time);
 
-      if (!end) {
-        const isOngoing = eventStart.isBefore(start) && eventEnd.isAfter(start);
-        const startsOnSelectedDay = eventStart.isSame(start, 'day');
-        const endsOnSelectedDay = eventEnd.isSame(start, 'day');
-        return isOngoing || startsOnSelectedDay || endsOnSelectedDay;
-      } else {
-        const isOngoing =
-          eventStart.isBefore(start, 'day') && eventEnd.isAfter(end, 'day');
-        const startsInPeriod =
-          (eventStart.isSame(start, 'day') ||
-            eventStart.isAfter(start, 'day')) &&
-          (eventStart.isSame(end, 'day') || eventStart.isBefore(end, 'day'));
-        const endsInPeriod =
-          (eventEnd.isSame(start, 'day') || eventEnd.isAfter(start, 'day')) &&
-          (eventEnd.isBefore(end, 'day') || eventEnd.isSame(end, 'day'));
-        return isOngoing || startsInPeriod || endsInPeriod;
-      }
-    })
-    .map((event) => ({
-      data: event,
-      kind: 'event',
-      visibleFrom: getUTCDateWithoutTime(event.start_time || null),
-      visibleUntil: getUTCDateWithoutTime(event.end_time || null),
-    }));
+          if (!end) {
+            const isOngoing =
+              eventStart.isBefore(start) && eventEnd.isAfter(start);
+            const startsOnSelectedDay = eventStart.isSame(start, 'day');
+            const endsOnSelectedDay = eventEnd.isSame(start, 'day');
+            return isOngoing || startsOnSelectedDay || endsOnSelectedDay;
+          } else {
+            const isOngoing =
+              eventStart.isBefore(start, 'day') && eventEnd.isAfter(end, 'day');
+            const startsInPeriod =
+              (eventStart.isSame(start, 'day') ||
+                eventStart.isAfter(start, 'day')) &&
+              (eventStart.isSame(end, 'day') ||
+                eventStart.isBefore(end, 'day'));
+            const endsInPeriod =
+              (eventEnd.isSame(start, 'day') ||
+                eventEnd.isAfter(start, 'day')) &&
+              (eventEnd.isBefore(end, 'day') || eventEnd.isSame(end, 'day'));
+            return isOngoing || startsInPeriod || endsInPeriod;
+          }
+        })
+        .map((event) => ({
+          data: event,
+          kind: 'event',
+          visibleFrom: getUTCDateWithoutTime(event.start_time || null),
+          visibleUntil: getUTCDateWithoutTime(event.end_time || null),
+        })),
+    [
+      customDatesToFilterEventsBy,
+      eventDateFilterState,
+      events,
+      filterState.alreadyIn,
+      getDateRange,
+      idsOfEventsRespondedTo,
+      orgIdsToFilterEventsBy,
+      target,
+    ]
+  );
 
-  const filteredSurveys: SurveyActivity[] = activeSurveys.map((survey) => ({
-    data: survey,
-    kind: 'survey',
-    visibleFrom: getUTCDateWithoutTime(survey.published || null),
-    visibleUntil: getUTCDateWithoutTime(survey.expires || null),
-  }));
+  const filteredSurveys: SurveyActivity[] = useMemo(
+    () =>
+      activeSurveys.map((survey) => ({
+        data: survey,
+        kind: 'survey',
+        visibleFrom: getUTCDateWithoutTime(survey.published || null),
+        visibleUntil: getUTCDateWithoutTime(survey.expires || null),
+      })),
+    [activeSurveys]
+  );
 
-  const filteredActivities: Activity[] = [...filteredEvents, ...filteredSurveys]
-    .filter((activity) => {
-      if (filterState.alreadyIn && activity.kind == 'survey') {
-        return false;
-      }
+  const filteredActivities: Activity[] = useMemo(
+    () =>
+      [...filteredEvents, ...filteredSurveys]
+        .filter((activity) => {
+          if (filterState.alreadyIn && activity.kind == 'survey') {
+            return false;
+          }
 
-      if (filterState.events && activity.kind == 'survey') {
-        return false;
-      }
+          if (filterState.events && activity.kind == 'survey') {
+            return false;
+          }
 
-      if (filterState.surveys && activity.kind == 'event') {
-        return false;
-      }
+          if (filterState.surveys && activity.kind == 'event') {
+            return false;
+          }
 
-      return true;
-    })
-    .filter((activity) => {
-      if (projectIdsToFilterActivitiesBy.length == 0) {
-        return true;
-      }
+          return true;
+        })
+        .filter((activity) => {
+          if (projectIdsToFilterActivitiesBy.length == 0) {
+            return true;
+          }
 
-      if (
-        !activity.data.campaign &&
-        projectIdsToFilterActivitiesBy.includes('noProject')
-      ) {
-        return true;
-      }
+          if (
+            !activity.data.campaign &&
+            projectIdsToFilterActivitiesBy.includes('noProject')
+          ) {
+            return true;
+          }
 
-      return (
-        activity.data.campaign &&
-        projectIdsToFilterActivitiesBy.includes(activity.data.campaign.id)
-      );
-    })
-    .filter((activity) => {
-      if (!filterState.thisCall) {
-        return true;
-      }
+          return (
+            activity.data.campaign &&
+            projectIdsToFilterActivitiesBy.includes(activity.data.campaign.id)
+          );
+        })
+        .filter((activity) => {
+          if (!filterState.thisCall) {
+            return true;
+          }
 
-      if (activity.kind == 'event') {
-        return idsOfEventsRespondedTo.includes(activity.data.id);
-      }
+          if (activity.kind == 'event') {
+            return idsOfEventsRespondedTo.includes(activity.data.id);
+          }
 
-      if (activity.kind == 'survey') {
-        return Object.keys(surveySubmissionBySubmissionId).includes(
-          activity.data.id.toString()
-        );
-      }
-    })
-    .sort((a, b) => {
-      const aStart = a.visibleFrom;
-      const bStart = b.visibleFrom;
+          if (activity.kind == 'survey') {
+            return Object.keys(surveySubmissionBySubmissionId).includes(
+              activity.data.id.toString()
+            );
+          }
+        })
+        .sort((a, b) => {
+          const aStart = a.visibleFrom;
+          const bStart = b.visibleFrom;
 
-      if (!aStart && !bStart) {
-        return 0;
-      } else if (!aStart) {
-        return -1;
-      } else if (!bStart) {
-        return 1;
-      }
+          if (!aStart && !bStart) {
+            return 0;
+          } else if (!aStart) {
+            return -1;
+          } else if (!bStart) {
+            return 1;
+          }
 
-      return aStart.getTime() - bStart.getTime();
-    });
+          return aStart.getTime() - bStart.getTime();
+        }),
+    [
+      filterState.alreadyIn,
+      filterState.events,
+      filterState.surveys,
+      filterState.thisCall,
+      filteredEvents,
+      filteredSurveys,
+      idsOfEventsRespondedTo,
+      projectIdsToFilterActivitiesBy,
+      surveySubmissionBySubmissionId,
+    ]
+  );
 
   return {
     events,

--- a/src/features/call/hooks/useFilteredActivities.ts
+++ b/src/features/call/hooks/useFilteredActivities.ts
@@ -1,5 +1,5 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { useAppSelector } from 'core/hooks';
 import useUpcomingEvents from './useUpcomingEvents';
@@ -45,13 +45,13 @@ export default function useFilteredActivities(orgId: number) {
       state.call.lanes[state.call.activeLaneIndex].submissionDataBySurveyId
   );
   const target = useCurrentCall()?.target ?? null;
+  const todayRef = useRef(new Date());
 
   const activeSurveys = useMemo(() => {
     const surveys = surveysFuture.data || [];
-    const today = new Date();
     return surveys.filter(
       ({ published, expires }) =>
-        published && (!expires || new Date(expires) >= today)
+        published && (!expires || new Date(expires) >= todayRef.current)
     );
   }, [surveysFuture.data]);
 

--- a/src/features/call/hooks/useFilteredActivities.ts
+++ b/src/features/call/hooks/useFilteredActivities.ts
@@ -53,7 +53,7 @@ export default function useFilteredActivities(orgId: number) {
       ({ published, expires }) =>
         published && (!expires || new Date(expires) >= today)
     );
-  }, [surveysFuture]);
+  }, [surveysFuture.data]);
 
   const getDateRange = useCallback((): [Dayjs | null, Dayjs | null] => {
     const today = dayjs();

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -1,3 +1,5 @@
+import { useCallback, useMemo, useRef } from 'react';
+
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { FinishedCall } from '../types';
 import { finishedCallsLoad, finishedCallsLoaded } from '../store';
@@ -10,31 +12,43 @@ export default function useFinishedCalls() {
 
   const finishedCallsList = useAppSelector((state) => state.call.finishedCalls);
 
-  let allLoadedCalls: FinishedCall[] = [];
+  const allLoadedCallsRef = useRef<FinishedCall[]>([]);
 
-  const loadPage = async (pageNumber: number) => {
-    dispatch(finishedCallsLoad());
-    const newLoadedFinishedCalls = await apiClient.get<FinishedCall[]>(
-      `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
-    );
+  const loadPage = useCallback(
+    async (pageNumber: number) => {
+      dispatch(finishedCallsLoad());
+      const newLoadedFinishedCalls = await apiClient.get<FinishedCall[]>(
+        `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
+      );
 
-    allLoadedCalls = [...allLoadedCalls, ...newLoadedFinishedCalls];
-    dispatch(finishedCallsLoaded(allLoadedCalls));
+      allLoadedCallsRef.current = [
+        ...allLoadedCallsRef.current,
+        ...newLoadedFinishedCalls,
+      ];
+      dispatch(finishedCallsLoaded(allLoadedCallsRef.current));
 
-    if (newLoadedFinishedCalls.length > 0) {
-      loadPage(pageNumber + 1);
-    }
-  };
+      if (newLoadedFinishedCalls.length > 0) {
+        loadPage(pageNumber + 1);
+      }
+    },
+    [apiClient, dispatch]
+  );
 
   if (shouldLoad(finishedCallsList)) {
     loadPage(0);
   }
 
+  const filteredFinishedCalls = useMemo(
+    () =>
+      finishedCallsList.items
+        .filter((item) => !item.deleted)
+        .map((item) => item.data)
+        .filter(notEmpty),
+    [finishedCallsList.items]
+  );
+
   return {
-    finishedCalls: finishedCallsList.items
-      .filter((item) => !item.deleted)
-      .map((item) => item.data)
-      .filter(notEmpty),
+    finishedCalls: filteredFinishedCalls,
     isLoading: finishedCallsList.isLoading,
   };
 }

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -21,6 +21,10 @@ export default function useFinishedCalls() {
         `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
       );
 
+      if (pageNumber === 0) {
+        allLoadedCallsRef.current = [];
+      }
+
       allLoadedCallsRef.current = [
         ...allLoadedCallsRef.current,
         ...newLoadedFinishedCalls,

--- a/src/features/call/hooks/useFinishedCalls.ts
+++ b/src/features/call/hooks/useFinishedCalls.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { FinishedCall } from '../types';
@@ -12,31 +12,21 @@ export default function useFinishedCalls() {
 
   const finishedCallsList = useAppSelector((state) => state.call.finishedCalls);
 
-  const allLoadedCallsRef = useRef<FinishedCall[]>([]);
+  let allLoadedCalls: FinishedCall[] = [];
 
-  const loadPage = useCallback(
-    async (pageNumber: number) => {
-      dispatch(finishedCallsLoad());
-      const newLoadedFinishedCalls = await apiClient.get<FinishedCall[]>(
-        `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
-      );
+  const loadPage = async (pageNumber: number) => {
+    dispatch(finishedCallsLoad());
+    const newLoadedFinishedCalls = await apiClient.get<FinishedCall[]>(
+      `/api/users/me/outgoing_calls?p=${pageNumber}&pp=20&filter=state!=0`
+    );
 
-      if (pageNumber === 0) {
-        allLoadedCallsRef.current = [];
-      }
+    allLoadedCalls = [...allLoadedCalls, ...newLoadedFinishedCalls];
+    dispatch(finishedCallsLoaded(allLoadedCalls));
 
-      allLoadedCallsRef.current = [
-        ...allLoadedCallsRef.current,
-        ...newLoadedFinishedCalls,
-      ];
-      dispatch(finishedCallsLoaded(allLoadedCallsRef.current));
-
-      if (newLoadedFinishedCalls.length > 0) {
-        loadPage(pageNumber + 1);
-      }
-    },
-    [apiClient, dispatch]
-  );
+    if (newLoadedFinishedCalls.length > 0) {
+      loadPage(pageNumber + 1);
+    }
+  };
 
   if (shouldLoad(finishedCallsList)) {
     loadPage(0);

--- a/src/features/call/hooks/useSubmitReport.ts
+++ b/src/features/call/hooks/useSubmitReport.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { useApiClient, useAppDispatch } from 'core/hooks';
 import { ZetkinSurveyApiSubmission } from 'utils/types/zetkin';
 import submitSurveysRpc from '../rpc/submitSurveysAndUpdateCall';
@@ -15,36 +17,35 @@ export default function useSubmitReport(orgId: number) {
   const apiClient = useApiClient();
   const dispatch = useAppDispatch();
 
-  return async (
-    callId: number,
-    report: Report,
-    submissions: CallSubmissions
-  ) => {
-    const state = calculateReportState(report);
-    const reportData = {
-      call_back_after:
-        state == CallState.CALL_BACK || state == CallState.NOT_AVAILABLE
-          ? report.callBackAfter
-          : null,
-      message_to_organizer:
-        report.organizerActionNeeded && report.organizerLog
-          ? report.organizerLog
-          : null,
-      notes: report.callerLog || null,
-      organizer_action_needed: report.organizerActionNeeded,
-      state: state,
-    };
+  return useCallback(
+    async (callId: number, report: Report, submissions: CallSubmissions) => {
+      const state = calculateReportState(report);
+      const reportData = {
+        call_back_after:
+          state == CallState.CALL_BACK || state == CallState.NOT_AVAILABLE
+            ? report.callBackAfter
+            : null,
+        message_to_organizer:
+          report.organizerActionNeeded && report.organizerLog
+            ? report.organizerLog
+            : null,
+        notes: report.callerLog || null,
+        organizer_action_needed: report.organizerActionNeeded,
+        state: state,
+      };
 
-    const result = await apiClient.rpc(submitSurveysRpc, {
-      callId,
-      orgId,
-      reportData,
-      submissions,
-    });
-    if (result.kind == 'success') {
-      dispatch(reportSubmitted(result.updatedCall));
-    } else {
-      dispatch(reportSubmissionErrorAdded(result));
-    }
-  };
+      const result = await apiClient.rpc(submitSurveysRpc, {
+        callId,
+        orgId,
+        reportData,
+        submissions,
+      });
+      if (result.kind == 'success') {
+        dispatch(reportSubmitted(result.updatedCall));
+      } else {
+        dispatch(reportSubmissionErrorAdded(result));
+      }
+    },
+    [apiClient, dispatch, orgId]
+  );
 }


### PR DESCRIPTION
## Description

This PR attempts to solve some of the slowness in the Call UI by memoising a bunch of calculations and functions. 

(I cannot say that I experience any differences noticable to my eyes when I play with this compared to main in a test call assignment, but that does not mean it does not make a difference.)

## Screenshots
(nothing visual)

## Changes
- Adds `useCallback` and `useMemo` hooks around most functions and calculations in the `Call` featuer

## AI usage
no

## Instructions for reviewer
- Go through the caller flow, preferably on a "slow" computer
- I've tried looking at Profiler in react devtools, but am not yet understanding how to compare so cannot say how to see differences in there, but it could be worth looking at if you understand how to use that tool! 

## Related issues
none

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
