### PR TITLE
Use colors from theme for the "assigned to me" chip.

### DIFF
--- a/src/features/canvass/components/CanvassSelectAreaPage.tsx
+++ b/src/features/canvass/components/CanvassSelectAreaPage.tsx
@@ -151,10 +151,11 @@ const Page: FC<{
                               {showAssignedToMeChip && (
                                 <Chip
                                   label={messages.selectArea.assignedToMe()}
-                                  sx={{
-                                    backgroundColor: '#f2c71b',
+                                  sx={(theme) => ({
+                                    backgroundColor: theme.palette.info.light,
+                                    color: theme.palette.common.white,
                                     marginRight: 2,
-                                  }}
+                                  })}
                                 />
                               )}
                               <ArrowForwardIos fontSize="small" />


### PR DESCRIPTION
## Description

This PR removes a hard-coded color string and replaces it with relevant colors from the theme. 

## Screenshots

<img width="445" height="654" alt="bild" src="https://github.com/user-attachments/assets/1bc8e957-c7c1-4a5f-befa-97fa579b9884" />

## Changes

- Changes the hard-coded hex string to be a color from the theme

## AI usage
no

## Instructions for reviewer
- be logged in with 2fa as testadmin and go to /canvass/143/areas on this branch and on main and see the difference

## Related issues
none

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
