### PR TITLE
Only show error indicator when there is an error

### DIFF
--- a/src/zui/ZUIFuture/index.tsx
+++ b/src/zui/ZUIFuture/index.tsx
@@ -131,6 +131,8 @@ function ZUIFuture<DataType>(props: ZUIFutureProps<DataType>): ReturnType<FC> {
         </Box>
       )
     );
+  } else {
+    return null;
   }
 }
 

--- a/src/zui/ZUIFuture/index.tsx
+++ b/src/zui/ZUIFuture/index.tsx
@@ -112,7 +112,7 @@ function ZUIFuture<DataType>(props: ZUIFutureProps<DataType>): ReturnType<FC> {
     }
   } else if (future.isLoading) {
     return skeleton;
-  } else {
+  } else if (future.error) {
     return (
       errorIndicator || (
         <Box


### PR DESCRIPTION
## Description

This PR changes the `ZUIFuture` to only show the error indicator component if there is an error on the future object. This solves the problem, because here in the email the stats data was `null` and with the previous logic that made the component fall back on showing the error indicator. 

On this branch 
<img width="1141" height="762" alt="bild" src="https://github.com/user-attachments/assets/2937cbb7-e24b-4311-a2f1-362e6a314b24" />

On main 
<img width="1272" height="845" alt="bild" src="https://github.com/user-attachments/assets/dc1cbe72-35d6-4da7-b7f3-aad892b64c45" />

## Changes
- Changes `ZUIFuture` to only show the error indicator component if there is an error

## AI usage
no

## Instructions for reviewer
- look at /organize/1/projects/174/emails/174 on main and on this branch

## Related issues

Resolves #3762 

## PR checklist
- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
