### PR TITLE
Join Forms: Fix SSR/client hydration mismatch

### DIFF
--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({ params, searchParams }: PageProps) {
               margin-bottom: 1rem;
             }
 
-            .zetkin-joinform__field input[type="text"], .zetkin-joinform__field select {
+            .zetkin-joinform__field input[type=text], .zetkin-joinform__field select {
               width: 100%;
               max-width: 600px;
               padding: 0.3rem;


### PR DESCRIPTION
## Description

This PR fixes a hydration issue in join forms.

Cause of this bug:

React HTML-entity-escapes quote characters in text-node children regardless of element type, but browsers don't decode entities inside `<style>/<script>` (raw-text elements per HTML5), so a quoted attribute selector inside the inline <style> block always mismatched between server and client. Dropping the quotes avoids the escaping asymmetry entirely (unquoted is a valid CSS attribute selector).

## Screenshots

[Add screenshots here]

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Removes quotes from joinform inline style

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Yes, Claude found this fixing bugs found through the new smoke test suite.

## Instructions for reviewer

- Make a join form or find one
- Go to its link
- Look in the console

On main: hydration issue
> Warning: Text content did not match. Server: [...]

On this PR: no hydration issue

## Related issues

Precondition to https://github.com/zetkin/app.zetkin.org/pull/3771
Spun out of https://github.com/zetkin/app.zetkin.org/pull/3691

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
