### PR TITLE
Move where we check for 204 responses, so we don't crash everything trying to parse nothing into json

### DIFF
--- a/src/app/api2/[...path]/route.ts
+++ b/src/app/api2/[...path]/route.ts
@@ -70,6 +70,11 @@ async function proxy(
   }
 
   let zetkinResponse: Response = await makeZetkinApiRequest();
+
+  if (zetkinResponse.status == 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+
   let payload = await zetkinResponse.json();
 
   if (zetkinResponse.status == 401) {
@@ -100,9 +105,5 @@ async function proxy(
     }
   }
 
-  if (zetkinResponse.status == 204) {
-    return new NextResponse(null, { status: 204 });
-  } else {
-    return NextResponse.json(payload, { status: zetkinResponse.status });
-  }
+  return NextResponse.json(payload, { status: zetkinResponse.status });
 }


### PR DESCRIPTION
## Description

This PR solves the bug where removing an area assignee would not update in the UI. The reason was that the response from the DELETE request was a 204, which was not handled early enough. 

## Screenshots
hard to show something that is not there, but this is now how the ui looks directly after removing Rosa Luxemburg as assignee from this area - she is removed. 
<img width="1119" height="891" alt="bild" src="https://github.com/user-attachments/assets/54e18793-2ae5-43ed-94bb-282e0f86b178" />

## Changes
- Moves check for 204 responses to before we attempt to parse the response body to json. 
 
## AI usage

Did you use AI to create the code in this PR? 
No, I just asked Richard for advise but he is non-artificiall intelligence

Add instructions for how the reviewer tests that what you've built works.
- go to any area assignment 
- add someone to an area 
- remove the person from the area 

## Related issues

Resolves #3764

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
