### PR TITLE
Use tel links for phone numbers in caller interface

### DIFF
--- a/src/features/call/components/CallHeader.tsx
+++ b/src/features/call/components/CallHeader.tsx
@@ -1,6 +1,6 @@
 import { SkipNext } from '@mui/icons-material';
 import { FC, useState } from 'react';
-import { Box, Link } from '@mui/material';
+import { Box } from '@mui/material';
 
 import { LaneState, LaneStep, Report, UnfinishedCall } from '../types';
 import ZUIOrgLogoAvatar from 'zui/components/ZUIOrgLogoAvatar';
@@ -24,6 +24,7 @@ import { useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import useFilteredActivities from '../hooks/useFilteredActivities';
 import notEmpty from 'utils/notEmpty';
+import ZUILink from 'zui/components/ZUILink';
 
 type Props = {
   assignment: ZetkinCallAssignment;
@@ -152,9 +153,7 @@ const CallHeader: FC<Props> = ({
               {phoneNumbers.flatMap((phone, index) => {
                 return [
                   index > 0 ? '/' : null,
-                  <Link key={phone} href={`tel:${phone}`}>
-                    {phone}
-                  </Link>,
+                  <ZUILink key={phone} href={`tel:${phone}`} text={phone} />,
                 ];
               })}
             </ZUIText>

--- a/src/features/call/components/CallHeader.tsx
+++ b/src/features/call/components/CallHeader.tsx
@@ -1,6 +1,6 @@
 import { SkipNext } from '@mui/icons-material';
 import { FC, useState } from 'react';
-import { Box } from '@mui/material';
+import { Box, Link } from '@mui/material';
 
 import { LaneState, LaneStep, Report, UnfinishedCall } from '../types';
 import ZUIOrgLogoAvatar from 'zui/components/ZUIOrgLogoAvatar';
@@ -68,6 +68,10 @@ const CallHeader: FC<Props> = ({
     isLoading: isAllocatingCall,
   } = useAllocateCall(assignment.organization.id, assignment.id);
   const submitReport = useSubmitReport(assignment.organization.id);
+
+  const phoneNumbers = [call?.target.phone, call?.target.alt_phone].filter(
+    notEmpty
+  );
 
   return (
     <Box
@@ -145,9 +149,14 @@ const CallHeader: FC<Props> = ({
               sx={{ fontFamily: 'monospace' }}
               variant="headingLg"
             >
-              {[call.target.phone, call.target.alt_phone]
-                .filter(notEmpty)
-                .join('/')}
+              {phoneNumbers.flatMap((phone, index) => {
+                return [
+                  index > 0 ? '/' : null,
+                  <Link key={phone} href={`tel:${phone}`}>
+                    {phone}
+                  </Link>,
+                ];
+              })}
             </ZUIText>
           </>
         )}


### PR DESCRIPTION
## Description
This PR updates the caller interface to include `tel:` links for the numbers in the header. This makes it possible for the caller to click the number to initiate a call, provided that there is software on their computer to handle the call.

## Screenshots
### Dual numbers
<img width="1481" height="1091" alt="image" src="https://github.com/user-attachments/assets/742cd690-6666-4d2f-8cdb-02e218e0237c" />

### Single number, clicked
<img width="1481" height="1091" alt="image" src="https://github.com/user-attachments/assets/2d0627eb-bda0-45e0-a924-c642f219d841" />

## Changes
- Adds `tel:` links to the phone numbers in the caller interface

## AI usage
No

## Instructions for reviewer
Start any call assignment from /my.

## Related issues
Fixes #3250 (I realized this after creating the PR, which is why the branch is called `undocumented`)

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
