### PR TITLE
[CSP]: Allow survey iframes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,7 @@ function setupCsp(path: string) {
   );
 
   const isEmbedJoinForm = /^\/o\/[^/]+\/embedjoinform(\/|$)/.test(path);
+  const isSurvey = /^\/o\/[^/]+\/surveys\/[^/]+(\/|$)/.test(path);
   const styleSrc = isEmbedJoinForm
     ? "* 'unsafe-inline'"
     : `'self' https://use.typekit.net https://p.typekit.net ${
@@ -54,7 +55,7 @@ function setupCsp(path: string) {
   object-src 'none';
   base-uri 'self';
   form-action 'self';
-  frame-ancestors ${isEmbedJoinForm ? '*' : "'none'"};
+  frame-ancestors ${isEmbedJoinForm || isSurvey ? '*' : "'none'"};
   upgrade-insecure-requests;
 `;
   const cspHeaderTrimmed = cspHeader.replace(/\s{2,}/g, ' ').trim();


### PR DESCRIPTION
## Description

This PR adjusts the CSP to allow surveys to be part of an iframe in any host.

## Changes

- Adds survey routes to iframe allow list (just like joinforms already have)

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Yes, Claude

## Instructions for reviewer

- Make a survey
- Copy its url
- Build an iframe to that survey
- Should work

I tested it with a local html file and the preview url https://app-zetkin-7j02ejbyo-zetkin.vercel.app/o/16/surveys/212 vs https://app.dev.zetkin.org/o/16/surveys/212 . This branche's preview works inside an iframe, the dev instance one doesn't.

```html
<!doctype html>
<html>
<head><title>iframe test</title></head>
<body>
<h3>Testing survey iframe embed</h3>
<iframe src="https://app-zetkin-7j02ejbyo-zetkin.vercel.app/o/16/surveys/212" width="800" height="600" style="border:1px solid #ccc"></iframe>
</body>
</html>
```

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
