### PR TITLE
Move promise cache to context

### DIFF
--- a/src/core/Providers.tsx
+++ b/src/core/Providers.tsx
@@ -26,6 +26,7 @@ import { ZUIConfirmDialogProvider } from 'zui/ZUIConfirmDialogProvider';
 import { ZUISnackbarProvider } from 'zui/ZUISnackbarContext';
 import { UserProvider } from './env/UserContext';
 import { NonceContext } from 'core/hooks/useNonce';
+import { PromiseCacheProvider } from 'core/caching/PromiseCache';
 
 type ProviderData = {
   env: Environment;
@@ -77,36 +78,38 @@ const Providers: FC<ProvidersProps> = ({
   return (
     <ReduxProvider store={store}>
       <EnvProvider env={env}>
-        <UserProvider user={user}>
-          <StyledEngineProvider injectFirst>
-            <CacheProvider value={cache.current}>
-              <NonceContext.Provider value={nonce}>
-                <ThemeProvider theme={oldThemeWithLocale(lang)}>
-                  <LocalizationProvider
-                    adapterLocale={lang}
-                    dateAdapter={AdapterDayjs}
-                  >
-                    <IntlProvider
-                      defaultLocale="en"
-                      locale={lang}
-                      messages={messages}
+        <PromiseCacheProvider>
+          <UserProvider user={user}>
+            <StyledEngineProvider injectFirst>
+              <CacheProvider value={cache.current}>
+                <NonceContext.Provider value={nonce}>
+                  <ThemeProvider theme={oldThemeWithLocale(lang)}>
+                    <LocalizationProvider
+                      adapterLocale={lang}
+                      dateAdapter={AdapterDayjs}
                     >
-                      <ZUISnackbarProvider>
-                        <ZUIConfirmDialogProvider>
-                          <EventPopperProvider>
-                            <DndProvider backend={HTML5Backend}>
-                              <Suspense>{children}</Suspense>
-                            </DndProvider>
-                          </EventPopperProvider>
-                        </ZUIConfirmDialogProvider>
-                      </ZUISnackbarProvider>
-                    </IntlProvider>
-                  </LocalizationProvider>
-                </ThemeProvider>
-              </NonceContext.Provider>
-            </CacheProvider>
-          </StyledEngineProvider>
-        </UserProvider>
+                      <IntlProvider
+                        defaultLocale="en"
+                        locale={lang}
+                        messages={messages}
+                      >
+                        <ZUISnackbarProvider>
+                          <ZUIConfirmDialogProvider>
+                            <EventPopperProvider>
+                              <DndProvider backend={HTML5Backend}>
+                                <Suspense>{children}</Suspense>
+                              </DndProvider>
+                            </EventPopperProvider>
+                          </ZUIConfirmDialogProvider>
+                        </ZUISnackbarProvider>
+                      </IntlProvider>
+                    </LocalizationProvider>
+                  </ThemeProvider>
+                </NonceContext.Provider>
+              </CacheProvider>
+            </StyledEngineProvider>
+          </UserProvider>
+        </PromiseCacheProvider>
       </EnvProvider>
     </ReduxProvider>
   );

--- a/src/core/caching/PromiseCache.tsx
+++ b/src/core/caching/PromiseCache.tsx
@@ -1,0 +1,15 @@
+import { createContext, FC, PropsWithChildren, useRef } from 'react';
+
+type PromiseCache = Map<string, Promise<unknown>>;
+
+export const PromiseCacheContext = createContext<PromiseCache | null>(null);
+
+export const PromiseCacheProvider: FC<PropsWithChildren> = ({ children }) => {
+  const promiseCache = useRef<PromiseCache>(new Map());
+
+  return (
+    <PromiseCacheContext.Provider value={promiseCache.current}>
+      {children}
+    </PromiseCacheContext.Provider>
+  );
+};

--- a/src/core/caching/PromiseCache.tsx
+++ b/src/core/caching/PromiseCache.tsx
@@ -1,6 +1,6 @@
 import { createContext, FC, PropsWithChildren, useRef } from 'react';
 
-type PromiseCache = Map<string, Promise<unknown>>;
+export type PromiseCache = Map<string, Promise<unknown>>;
 
 export const PromiseCacheContext = createContext<PromiseCache | null>(null);
 

--- a/src/core/env/ClientContext.tsx
+++ b/src/core/env/ClientContext.tsx
@@ -29,6 +29,7 @@ import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZUIConfirmDialogProvider } from 'zui/ZUIConfirmDialogProvider';
 import { ZUISnackbarProvider } from 'zui/ZUISnackbarContext';
 import { NonceContext } from 'core/hooks/useNonce';
+import { PromiseCacheProvider } from 'core/caching/PromiseCache';
 
 type ClientContextProps = {
   children: ReactNode;
@@ -79,43 +80,45 @@ const ClientContext: FC<ClientContextProps> = ({
 
   return (
     <ReduxProvider store={storeRef.current}>
-      <StyledEngineProvider injectFirst>
-        <CacheProvider value={cache.current}>
-          <NonceContext.Provider value={nonce}>
-            <ThemeProvider theme={oldThemeWithLocale(lang)}>
-              <EnvProvider env={env}>
-                <UserProvider user={user}>
-                  <LocalizationProvider
-                    adapterLocale={lang}
-                    dateAdapter={AdapterDayjs}
-                  >
-                    <IntlProvider
-                      defaultLocale="en"
-                      locale={lang}
-                      messages={messages}
+      <PromiseCacheProvider>
+        <StyledEngineProvider injectFirst>
+          <CacheProvider value={cache.current}>
+            <NonceContext.Provider value={nonce}>
+              <ThemeProvider theme={oldThemeWithLocale(lang)}>
+                <EnvProvider env={env}>
+                  <UserProvider user={user}>
+                    <LocalizationProvider
+                      adapterLocale={lang}
+                      dateAdapter={AdapterDayjs}
                     >
-                      <AppRouterCacheProvider>
-                        <ZUISnackbarProvider>
-                          <IntlProvider
-                            defaultLocale="en"
-                            locale={lang}
-                            messages={messages}
-                          >
-                            <ZUIConfirmDialogProvider>
-                              <CssBaseline />
-                              <Suspense>{children}</Suspense>
-                            </ZUIConfirmDialogProvider>
-                          </IntlProvider>
-                        </ZUISnackbarProvider>
-                      </AppRouterCacheProvider>
-                    </IntlProvider>
-                  </LocalizationProvider>
-                </UserProvider>
-              </EnvProvider>
-            </ThemeProvider>
-          </NonceContext.Provider>
-        </CacheProvider>
-      </StyledEngineProvider>
+                      <IntlProvider
+                        defaultLocale="en"
+                        locale={lang}
+                        messages={messages}
+                      >
+                        <AppRouterCacheProvider>
+                          <ZUISnackbarProvider>
+                            <IntlProvider
+                              defaultLocale="en"
+                              locale={lang}
+                              messages={messages}
+                            >
+                              <ZUIConfirmDialogProvider>
+                                <CssBaseline />
+                                <Suspense>{children}</Suspense>
+                              </ZUIConfirmDialogProvider>
+                            </IntlProvider>
+                          </ZUISnackbarProvider>
+                        </AppRouterCacheProvider>
+                      </IntlProvider>
+                    </LocalizationProvider>
+                  </UserProvider>
+                </EnvProvider>
+              </ThemeProvider>
+            </NonceContext.Provider>
+          </CacheProvider>
+        </StyledEngineProvider>
+      </PromiseCacheProvider>
     </ReduxProvider>
   );
 };

--- a/src/core/hooks/usePromiseCache.ts
+++ b/src/core/hooks/usePromiseCache.ts
@@ -1,28 +1,36 @@
+import { useContext } from 'react';
+
+import { PromiseCacheContext } from 'core/caching/PromiseCache';
+
 type UsePromiseCacheReturn = {
   cache: (promise: Promise<unknown>) => void;
   getExistingPromise: () => Promise<unknown> | undefined;
 };
 
-// TODO: Store this in context?
-const promises: Record<string, Promise<unknown>> = {};
-
 export default function usePromiseCache(
   cacheKey: string
 ): UsePromiseCacheReturn {
+  const promiseCache = useContext(PromiseCacheContext);
+
+  if (!promiseCache) {
+    throw new Error(
+      'usePromiseCache must be used within a PromiseCacheProvider'
+    );
+  }
+
   return {
     cache(promise) {
-      promises[cacheKey] = promise;
+      promiseCache.set(cacheKey, promise);
 
-      promise.then(() => {
-        delete promises[cacheKey];
-      });
-
-      promise.catch(() => {
-        delete promises[cacheKey];
+      promise.finally(() => {
+        if (promiseCache.get(cacheKey) === promise) {
+          promiseCache.delete(cacheKey);
+        }
       });
     },
+
     getExistingPromise() {
-      return promises[cacheKey];
+      return promiseCache.get(cacheKey);
     },
   };
 }

--- a/src/core/hooks/useRemoteItem.spec.tsx
+++ b/src/core/hooks/useRemoteItem.spec.tsx
@@ -6,6 +6,7 @@ import { configureStore, PayloadAction } from '@reduxjs/toolkit';
 
 import { RemoteItem, remoteItem } from 'utils/storeUtils';
 import useRemoteItem from './useRemoteItem';
+import { PromiseCacheProvider } from 'core/caching/PromiseCache';
 
 type ItemObjectForTest = { id: number; name: string };
 type StoreState = {
@@ -154,9 +155,11 @@ function setupWrapperComponent(initialItem?: RemoteItem<ItemObjectForTest>) {
     render: () =>
       render(
         <ReduxProvider store={store}>
-          <Suspense fallback={<p>loading</p>}>
-            <Component />
-          </Suspense>
+          <PromiseCacheProvider>
+            <Suspense fallback={<p>loading</p>}>
+              <Component />
+            </Suspense>
+          </PromiseCacheProvider>
         </ReduxProvider>
       ),
     store,

--- a/src/core/hooks/useRemoteList.spec.tsx
+++ b/src/core/hooks/useRemoteList.spec.tsx
@@ -5,7 +5,6 @@ import { Provider as ReduxProvider, useSelector } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 
 import useRemoteList from './useRemoteList';
-import usePromiseCache from './usePromiseCache';
 import { RemoteList, remoteList } from 'utils/storeUtils';
 import {
   PromiseCache,

--- a/src/core/hooks/useRemoteList.spec.tsx
+++ b/src/core/hooks/useRemoteList.spec.tsx
@@ -7,6 +7,11 @@ import { configureStore } from '@reduxjs/toolkit';
 import useRemoteList from './useRemoteList';
 import usePromiseCache from './usePromiseCache';
 import { RemoteList, remoteList } from 'utils/storeUtils';
+import {
+  PromiseCache,
+  PromiseCacheContext,
+  PromiseCacheProvider,
+} from 'core/caching/PromiseCache';
 
 type ListObjectForTest = { id: number; name: string };
 type StoreState = {
@@ -91,15 +96,19 @@ describe('useRemoteList()', () => {
       return null;
     };
 
+    const promiseCache: PromiseCache = new Map();
+
     render(
       <ReduxProvider store={store}>
-        <Suspense fallback={<p>loading</p>}>
-          <ListComponent />
-        </Suspense>
+        <PromiseCacheContext.Provider value={promiseCache}>
+          <Suspense fallback={<p>loading</p>}>
+            <ListComponent />
+          </Suspense>
+        </PromiseCacheContext.Provider>
       </ReduxProvider>
     );
 
-    const cachedPromise = usePromiseCache(cacheKey).getExistingPromise();
+    const cachedPromise = promiseCache.get(cacheKey);
     expect(cachedPromise).toBeInstanceOf(Promise);
 
     await act(async () => {
@@ -203,9 +212,11 @@ function setupWrapperComponent(initialList?: RemoteList<ListObjectForTest>) {
     render: () =>
       render(
         <ReduxProvider store={store}>
-          <Suspense fallback={<p>loading</p>}>
-            <Component />
-          </Suspense>
+          <PromiseCacheProvider>
+            <Suspense fallback={<p>loading</p>}>
+              <Component />
+            </Suspense>
+          </PromiseCacheProvider>
         </ReduxProvider>
       ),
     store,

--- a/src/features/canvass/hooks/useLocationHouseholdVisits.spec.tsx
+++ b/src/features/canvass/hooks/useLocationHouseholdVisits.spec.tsx
@@ -10,6 +10,7 @@ import useLocationHouseholdVisits from './useLocationHouseholdVisits';
 import Environment from 'core/env/Environment';
 import { EnvProvider } from 'core/env/EnvContext';
 import { UserProvider } from 'core/env/UserContext';
+import { PromiseCacheProvider } from 'core/caching/PromiseCache';
 
 describe('useLocationHouseholdVisits', () => {
   it('returns aggregated household visits from RPC', async () => {
@@ -63,11 +64,13 @@ describe('useLocationHouseholdVisits', () => {
     const { queryByText } = render(
       <ReduxProvider store={store}>
         <EnvProvider env={env}>
-          <UserProvider user={null}>
-            <Suspense fallback={<p>loading</p>}>
-              <TestComponent />
-            </Suspense>
-          </UserProvider>
+          <PromiseCacheProvider>
+            <UserProvider user={null}>
+              <Suspense fallback={<p>loading</p>}>
+                <TestComponent />
+              </Suspense>
+            </UserProvider>
+          </PromiseCacheProvider>
         </EnvProvider>
       </ReduxProvider>
     );

--- a/src/utils/testing/index.tsx
+++ b/src/utils/testing/index.tsx
@@ -18,6 +18,7 @@ import zuiTheme from 'zui/theme';
 import { Store } from 'core/store';
 import { UserProvider } from 'core/env/UserContext';
 import mockApiClient from './mocks/mockApiClient';
+import { PromiseCacheProvider } from 'core/caching/PromiseCache';
 
 interface ZetkinAppProvidersProps {
   children: React.ReactNode;
@@ -109,7 +110,9 @@ export const makeWrapper = (
     return (
       <ReduxProvider store={store}>
         <EnvProvider env={env}>
-          <UserProvider user={RosaLuxemburgUser}>{children}</UserProvider>
+          <PromiseCacheProvider>
+            <UserProvider user={RosaLuxemburgUser}>{children}</UserProvider>
+          </PromiseCacheProvider>
         </EnvProvider>
       </ReduxProvider>
     );


### PR DESCRIPTION
## Description

This PR moves the promise cache into a context, which will have performance improvements for high load phases of things like the caller interface.

## Changes

- Adds a PromiseCacheContext and a provider
- Adds the provider to the two routers
- Migrates `usePromiseCache` to use the new provider

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

ChatGPT as consultant

## Instructions for reviewer

Navigate around pages? 

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
