### PR TITLE
Events: make participant list columns resizable

### DIFF
--- a/src/features/events/components/ParticipantListSection.tsx
+++ b/src/features/events/components/ParticipantListSection.tsx
@@ -140,7 +140,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           </ZUIPersonHoverCard>
         </Link>
       ),
-      resizable: false,
+
       sortable: false,
       width: 20,
     },
@@ -184,7 +184,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           );
         }
       },
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
       valueGetter: (value, row) => {
         return `${row.first_name || ''} ${row.last_name || ''}`;
@@ -208,7 +208,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           );
         }
       },
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
     },
     {
@@ -229,7 +229,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           );
         }
       },
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
     },
     {
@@ -247,7 +247,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           return <ZUIRelativeTime datetime={params.row.reminder_sent} />;
         }
       },
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
       type: 'date',
       valueGetter: (value, row) => {
@@ -384,7 +384,7 @@ const ParticipantListSection: FC<ParticipantListSectionListProps> = ({
           );
         }
       },
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
       valueGetter: (value, row) => {
         if (row.attended) {

--- a/src/features/events/components/UnverifiedSignupsSection.tsx
+++ b/src/features/events/components/UnverifiedSignupsSection.tsx
@@ -129,7 +129,7 @@ const UnverifiedSignupsSection: FC<UnverifiedSignupsSectionProps> = ({
           {params.row.first_name} {params.row.last_name}
         </Typography>
       ),
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
       valueGetter: (value, row) =>
         `${row.first_name || ''} ${row.last_name || ''}`,
@@ -143,7 +143,7 @@ const UnverifiedSignupsSection: FC<UnverifiedSignupsSectionProps> = ({
         params.row.phone ? (
           <Link href={`tel:${params.row.phone}`}>{params.row.phone}</Link>
         ) : null,
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
     },
     {
@@ -155,7 +155,7 @@ const UnverifiedSignupsSection: FC<UnverifiedSignupsSectionProps> = ({
         params.row.email ? (
           <Link href={`mailto:${params.row.email}`}>{params.row.email}</Link>
         ) : null,
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
     },
     {
@@ -170,7 +170,7 @@ const UnverifiedSignupsSection: FC<UnverifiedSignupsSectionProps> = ({
         ) : (
           <Typography>—</Typography>
         ),
-      resizable: false,
+
       sortingOrder: ['asc', 'desc', null],
       valueGetter: (value, row) => (row.created ? new Date(row.created) : null),
     },
@@ -196,7 +196,7 @@ const UnverifiedSignupsSection: FC<UnverifiedSignupsSectionProps> = ({
           </Box>
         );
       },
-      resizable: false,
+
       sortable: false,
     },
   ];


### PR DESCRIPTION
## Description

This PR removes the `resizable: false` property from the columns in the participant and signups tables (`ParticipantListSection` and `UnverifiedSignupsSection`). This solves a particular pain point with phone numbers of participants being truncated on typical Windows laptop screens (1920x1080 with default 150% Windows scaling). This could also be practical if you need to verify the email of a participant which is usually truncated as well.

### Background

As far as I could see, the resizable property was first set in PR #1268 alongside `disableColumnMenu` and seem to be intentional at the time (see e.g. this [PR comment](https://github.com/zetkin/app.zetkin.org/pull/1268#discussion_r1177881903)). However, I couldn't find any big discussion motivating *why* they shouldn't be resizable. Since this was a real end-user frustration, I figured it was worth flagging with a PR.

## Screenshots

<img width="1152" height="341" alt="image" src="https://github.com/user-attachments/assets/563a7d81-6b4d-442b-9934-4e85fa9b7de6" />

## Changes

* Remove `resizable` across columns in `ParticipantListSection.tsx` and `UnverifiedSignupsSection.tsx`

## AI usage

AI was used to search up which components had the `resizable` property set to false. Removal is by hand/Cmd X 😃 

## Instructions for reviewer

- URL, see e.g. `organize/1/projects/269/events/566/participants`
- The columns should be adjustable by dragging, which is the default behavior for MUI's DataGridPro component.
- Tested myself on Chromium-based browser (Brave)

## Related issues

None (undocumented)

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information