### PR TITLE
Show a specific reason when a field can't be saved

### DIFF
--- a/src/features/profile/store.ts
+++ b/src/features/profile/store.ts
@@ -31,6 +31,7 @@ export type PersonOrgData = {
 type SerializedError = {
   message: string;
   name: string;
+  status: number | null;
 };
 
 export interface ProfilesStoreSlice {

--- a/src/features/settings/components/fields/FieldsList.tsx
+++ b/src/features/settings/components/fields/FieldsList.tsx
@@ -25,6 +25,7 @@ import messageIds from '../../l10n/messageIds';
 import createSlug from '../../utils/createSlug';
 import { AccessType } from '../../types';
 import { getAccessType, getOrgReadWrite } from '../../utils/orgReadWrite';
+import getFieldErrorMessageId from '../../utils/getFieldErrorMessageId';
 import { parseEnumChoices } from './NewFieldForm';
 
 type EditFieldFormProps = {
@@ -216,7 +217,12 @@ const EditFieldForm: FC<EditFieldFormProps> = ({ onClose, orgId, fieldId }) => {
                 }}
                 severity="error"
               >
-                <Msg id={messageIds.fields.edit.errorMessage} />
+                <Msg
+                  id={
+                    getFieldErrorMessageId(fieldUpdateError.status) ??
+                    messageIds.fields.edit.errorMessage
+                  }
+                />
               </Alert>
             )}
           </Box>

--- a/src/features/settings/components/fields/NewFieldForm.tsx
+++ b/src/features/settings/components/fields/NewFieldForm.tsx
@@ -9,6 +9,7 @@ import { Msg, useMessages } from 'core/i18n';
 import createSlug from '../../utils/createSlug';
 import { AccessType } from '../../types';
 import { getOrgReadWrite } from '../../utils/orgReadWrite';
+import getFieldErrorMessageId from '../../utils/getFieldErrorMessageId';
 
 export const parseEnumChoices = (input: string) => {
   return input
@@ -168,7 +169,12 @@ const NewFieldForm: FC<Props> = ({ orgId }) => {
             }}
             severity="error"
           >
-            <Msg id={messageIds.fields.create.errorMessage} />
+            <Msg
+              id={
+                getFieldErrorMessageId(fieldCreateError.status) ??
+                messageIds.fields.create.errorMessage
+              }
+            />
           </Alert>
         </Box>
       )}

--- a/src/features/settings/hooks/useCreateField.ts
+++ b/src/features/settings/hooks/useCreateField.ts
@@ -1,3 +1,4 @@
+import { ApiClientError } from 'core/api/errors';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 import useApiClient from 'core/hooks/useApiClient';
 import {
@@ -31,6 +32,7 @@ export default function useCreateField(orgId: number) {
       const serialized = {
         message: createError.message,
         name: createError.name,
+        status: err instanceof ApiClientError ? err.status : null,
       };
       dispatch(fieldCreateErrorAdded(serialized));
       return createError;

--- a/src/features/settings/hooks/useFieldMutations.ts
+++ b/src/features/settings/hooks/useFieldMutations.ts
@@ -1,3 +1,4 @@
+import { ApiClientError } from 'core/api/errors';
 import { useAppDispatch, useAppSelector } from 'core/hooks';
 import useApiClient from 'core/hooks/useApiClient';
 import {
@@ -36,6 +37,7 @@ export default function useFieldMutations(orgId: number) {
       const serialized = {
         message: updateError.message,
         name: updateError.name,
+        status: e instanceof ApiClientError ? e.status : null,
       };
       dispatch(fieldUpdateErrorAdded([fieldId, serialized]));
       return updateError;

--- a/src/features/settings/l10n/messageIds.ts
+++ b/src/features/settings/l10n/messageIds.ts
@@ -126,6 +126,14 @@ export default makeMessages('feat.settings', {
       titleInput: m('Title'),
       typeInput: m('Type'),
     },
+    errors: {
+      invalidData: m(
+        'The server rejected this data. Check the slug and the options, then try again.'
+      ),
+      slugInUse: m(
+        'A field with this slug already exists. Please choose a different slug.'
+      ),
+    },
     list: {
       editButton: m('Edit'),
       headers: {

--- a/src/features/settings/utils/getFieldErrorMessageId.ts
+++ b/src/features/settings/utils/getFieldErrorMessageId.ts
@@ -1,0 +1,18 @@
+import messageIds from '../l10n/messageIds';
+
+/**
+ * Picks a message explaining why the API rejected a field, or returns null
+ * for statuses we have nothing more useful to say about, in which case the
+ * caller should fall back to its own generic message.
+ */
+export default function getFieldErrorMessageId(status: number | null) {
+  if (status === 409) {
+    return messageIds.fields.errors.slugInUse;
+  }
+
+  if (status === 400) {
+    return messageIds.fields.errors.invalidData;
+  }
+
+  return null;
+}


### PR DESCRIPTION
I ran into this issue when trying to create new fields. I created a field, deleted it, and tried creating a new field with the same slug but it error'd out with a generic message. I believe that the error received was because the slug remains unavailable even if the field is removed. This PR introduces a more specific message in the error so the user understands why the attempt failed.

## Description

Both field forms show one generic message no matter what the API said. So creating a field with a slug that's already taken returns the following:

```
409 {"error":{"title":"Slug in use",
              "description":"Field with this slug already exists"}}
```

and the organizer sees "There was an unexpected error when creating the field, please try again. If it keeps failing, contact support." To me, this error message suggests retrying, but retrying with the same slug won't work. 

`ApiClientError` already parses `error.title` and `error.description` off the response body, but `errorTitle` and `errorDescription` have no callers anywhere in the app and the field hooks keep only `message` and `name`. This PR keeps the status code from the failed request and uses it to show a message that says what actually went wrong.

## Screenshots

| Before  |  After |
|---|---|
|  <img width="634" height="562" alt="SCR-20260828-jvzd" src="https://github.com/user-attachments/assets/73f533d2-61eb-46b0-9cf9-e46d21ae31d2" /> |  <img width="648" height="526" alt="SCR-20260828-jvru" src="https://github.com/user-attachments/assets/f7f75669-ecdb-42c0-ac2f-ddb665b3d216" />  | 

## Changes

- Keeps the HTTP status from `ApiClientError` on the serialized error in the profiles store
- Adds messages for the two statuses these endpoints actually return: 409 (slug already in use) and 400 (data rejected)
- Uses them in both the create and the edit form, falling back to the existing generic message for anything else
- Adds a small helper that maps a status to a message, so both forms share one mapping

I followed the pattern already used in `useCreateNewAccount` and `usePublicEventSignup` (branch on status and render a localized message, rather than displaying the API's own strings). The API returns English only, and CONTRIBUTING is explicit that UI text goes through messageIds, so passing the raw `description` through would put an untranslatable string on screen. The text is still on `ApiClientError` if you'd rather show it.

## AI usage

Yes, I used AI for assistance. I ran into this on my organization's Zetkin instance, captured the API's actual 409 response, and set the direction for the fix. I used Claude Code to write it in line with the error-handling pattern this codebase already uses, and to run lint, type checks and the test suite. I reviewed the change and tested it against the development server myself.

## Instructions for reviewer

- Go to /organize/1/settings/fields
- Create a field with any slug, then create a second field reusing that slug
- On main this shows the generic "unexpected error" message
- With this branch it shows "A field with this slug already exists. Please choose a different slug."
- The same applies when renaming a slug to one already in use from the edit form

Worth knowing while testing: deleting a field does not seem to free up its slug, so a deleted field's slug returns 409 too. Whether that is intended is a separate question I can't answer from the frontend. This PR only changes which message is shown.

## Related issues

I couldn't find a related issue. I found this in production use rather than from an issue.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information