### PR TITLE
Fix option keys generated from labels with digits

### DIFF
--- a/src/features/settings/components/fields/NewFieldForm.tsx
+++ b/src/features/settings/components/fields/NewFieldForm.tsx
@@ -7,18 +7,22 @@ import useCreateField from '../../hooks/useCreateField';
 import messageIds from '../../l10n/messageIds';
 import { Msg, useMessages } from 'core/i18n';
 import createSlug from '../../utils/createSlug';
+import createEnumChoiceKeys from '../../utils/createEnumChoiceKeys';
 import { AccessType } from '../../types';
 import { getOrgReadWrite } from '../../utils/orgReadWrite';
 
 export const parseEnumChoices = (input: string) => {
-  return input
+  const labels = input
     .split(',')
     .map((item) => item.trim())
-    .filter(Boolean)
-    .map((label) => ({
-      key: createSlug(label),
-      label,
-    }));
+    .filter(Boolean);
+
+  const keys = createEnumChoiceKeys(labels);
+
+  return labels.map((label, index) => ({
+    key: keys[index],
+    label,
+  }));
 };
 
 type Props = {

--- a/src/features/settings/utils/createEnumChoiceKeys.spec.ts
+++ b/src/features/settings/utils/createEnumChoiceKeys.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from '@jest/globals';
+
+import createEnumChoiceKeys from './createEnumChoiceKeys';
+
+describe('createEnumChoiceKeys()', () => {
+  it('returns an empty array when there are no labels', () => {
+    expect(createEnumChoiceKeys([])).toEqual([]);
+  });
+
+  it('slugifies plain labels', () => {
+    expect(createEnumChoiceKeys(['Yes', 'Trade union rep'])).toEqual([
+      'yes',
+      'trade_union_rep',
+    ]);
+  });
+
+  it('transliterates accented characters', () => {
+    expect(createEnumChoiceKeys(['Ålder', 'Kön', 'Über'])).toEqual([
+      'alder',
+      'kon',
+      'uber',
+    ]);
+  });
+
+  it('spells out digits instead of keeping them', () => {
+    expect(createEnumChoiceKeys(['Joined 2016'])).toEqual([
+      'joined_two_zero_one_six',
+    ]);
+  });
+
+  it('keeps labels that differ only by digits apart', () => {
+    expect(createEnumChoiceKeys(['Joined 2016', 'Joined 2017'])).toEqual([
+      'joined_two_zero_one_six',
+      'joined_two_zero_one_seven',
+    ]);
+  });
+
+  it('gives a label consisting of a single digit a usable key', () => {
+    expect(createEnumChoiceKeys(['2'])).toEqual(['two']);
+  });
+
+  it('falls back when a label has no usable characters', () => {
+    expect(createEnumChoiceKeys(['!!!', '日本語'])).toEqual([
+      'option_one',
+      'option_two',
+    ]);
+  });
+
+  it('numbers the fallback by position in the list', () => {
+    expect(createEnumChoiceKeys(['Yes', '???'])).toEqual(['yes', 'option_two']);
+  });
+
+  it('suffixes keys that would otherwise collide', () => {
+    expect(createEnumChoiceKeys(['Yes', 'Yes!', 'Yes?'])).toEqual([
+      'yes',
+      'yes_two',
+      'yes_three',
+    ]);
+  });
+
+  it('does not produce leading or trailing underscores', () => {
+    expect(createEnumChoiceKeys([' - Maybe - '])).toEqual(['maybe']);
+  });
+
+  it('collapses runs of separators into a single underscore', () => {
+    expect(createEnumChoiceKeys(['Writing / editing'])).toEqual([
+      'writing_editing',
+    ]);
+  });
+
+  it('never exceeds 40 characters', () => {
+    const keys = createEnumChoiceKeys([
+      'A really quite unreasonably long option label that keeps going',
+      'A really quite unreasonably long option label that keeps going too',
+    ]);
+
+    keys.forEach((key) => expect(key.length).toBeLessThanOrEqual(40));
+    expect(keys[0]).not.toEqual(keys[1]);
+  });
+
+  it('only ever produces keys made up of a-z and _', () => {
+    const keys = createEnumChoiceKeys([
+      '2',
+      'Joined 2016',
+      'Cost: 100kr, or more',
+      '1st of May',
+      'Ålder & kön',
+      '!!!',
+      '日本語',
+      'Yes',
+      'Yes!',
+    ]);
+
+    keys.forEach((key) => expect(key).toMatch(/^[a-z][a-z_]*$/));
+    expect(new Set(keys).size).toEqual(keys.length);
+  });
+});

--- a/src/features/settings/utils/createEnumChoiceKeys.spec.ts
+++ b/src/features/settings/utils/createEnumChoiceKeys.spec.ts
@@ -14,57 +14,29 @@ describe('createEnumChoiceKeys()', () => {
     ]);
   });
 
-  it('transliterates accented characters', () => {
-    expect(createEnumChoiceKeys(['Ålder', 'Kön', 'Über'])).toEqual([
-      'alder',
-      'kon',
-      'uber',
-    ]);
-  });
-
-  it('spells out digits instead of keeping them', () => {
-    expect(createEnumChoiceKeys(['Joined 2016'])).toEqual([
-      'joined_two_zero_one_six',
-    ]);
-  });
-
-  it('keeps labels that differ only by digits apart', () => {
+  it('keeps digits', () => {
     expect(createEnumChoiceKeys(['Joined 2016', 'Joined 2017'])).toEqual([
-      'joined_two_zero_one_six',
-      'joined_two_zero_one_seven',
+      'joined_2016',
+      'joined_2017',
     ]);
-  });
-
-  it('gives a label consisting of a single digit a usable key', () => {
-    expect(createEnumChoiceKeys(['2'])).toEqual(['two']);
   });
 
   it('falls back when a label has no usable characters', () => {
     expect(createEnumChoiceKeys(['!!!', '日本語'])).toEqual([
-      'option_one',
-      'option_two',
+      'option_1',
+      'option_2',
     ]);
   });
 
   it('numbers the fallback by position in the list', () => {
-    expect(createEnumChoiceKeys(['Yes', '???'])).toEqual(['yes', 'option_two']);
+    expect(createEnumChoiceKeys(['Yes', '???'])).toEqual(['yes', 'option_2']);
   });
 
   it('suffixes keys that would otherwise collide', () => {
     expect(createEnumChoiceKeys(['Yes', 'Yes!', 'Yes?'])).toEqual([
       'yes',
-      'yes_two',
-      'yes_three',
-    ]);
-  });
-
-  it('does not produce leading or trailing underscores', () => {
-    expect(createEnumChoiceKeys([' - Maybe - '])).toEqual(['maybe']);
-  });
-
-  it('collapses runs of separators into a single underscore', () => {
-    expect(createEnumChoiceKeys(['Writing / editing'])).toEqual([
-      'writing_editing',
+      'yes_2',
+      'yes_3',
     ]);
   });
 
@@ -78,12 +50,11 @@ describe('createEnumChoiceKeys()', () => {
     expect(keys[0]).not.toEqual(keys[1]);
   });
 
-  it('only ever produces keys made up of a-z and _', () => {
+  it('only ever produces valid, unique keys', () => {
     const keys = createEnumChoiceKeys([
       '2',
       'Joined 2016',
       'Cost: 100kr, or more',
-      '1st of May',
       'Ålder & kön',
       '!!!',
       '日本語',
@@ -91,7 +62,7 @@ describe('createEnumChoiceKeys()', () => {
       'Yes!',
     ]);
 
-    keys.forEach((key) => expect(key).toMatch(/^[a-z][a-z_]*$/));
+    keys.forEach((key) => expect(key).toMatch(/^[a-z][a-z0-9_]*$/));
     expect(new Set(keys).size).toEqual(keys.length);
   });
 });

--- a/src/features/settings/utils/createEnumChoiceKeys.ts
+++ b/src/features/settings/utils/createEnumChoiceKeys.ts
@@ -1,0 +1,92 @@
+import slugify from 'slugify';
+
+const DIGIT_NAMES = [
+  'zero',
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+];
+
+const FALLBACK_KEY = 'option';
+const MAX_KEY_LENGTH = 40;
+
+// Spells out a number one digit at a time, e.g. 12 becomes "one_two".
+function spellOut(number: number) {
+  return String(number)
+    .split('')
+    .map((digit) => DIGIT_NAMES[parseInt(digit)])
+    .join('_');
+}
+
+/**
+ * Derives a key from an option label, using only the characters a-z and _.
+ *
+ * Unlike field slugs, which may contain digits, the API rejects enum option
+ * keys that contain anything but a-z and _. Digits are therefore spelled out
+ * rather than dropped, so that labels like "Joined 2016" and "Joined 2017"
+ * don't end up with the same key.
+ *
+ * Returns an empty string for labels that contain nothing usable, e.g. "!!!"
+ * or a label written in a script that slugify cannot transliterate.
+ */
+function keyFromLabel(label: string) {
+  const spelledOut = label.replace(
+    /[0-9]/g,
+    (digit) => ` ${DIGIT_NAMES[parseInt(digit)]} `
+  );
+
+  const slugified = slugify(spelledOut.toLocaleLowerCase(), {
+    //Removes any character that is not a-z, _ and " "
+    remove: /[^a-z_ ]/,
+    //Replaces spaces with "_"
+    replacement: '_',
+  });
+
+  return trimUnderscores(slugified.replace(/_+/g, '_')).slice(
+    0,
+    MAX_KEY_LENGTH
+  );
+}
+
+function trimUnderscores(key: string) {
+  return key.replace(/^_+/, '').replace(/_+$/, '');
+}
+
+// Appends a suffix, making room for it within the maximum key length.
+function withSuffix(base: string, number: number) {
+  const suffix = `_${spellOut(number)}`;
+  return (
+    trimUnderscores(base.slice(0, MAX_KEY_LENGTH - suffix.length)) + suffix
+  );
+}
+
+/**
+ * Derives a unique, non-empty key for each of the given option labels.
+ *
+ * Labels that produce no usable characters fall back to "option_one",
+ * "option_two" and so on, and keys that would collide are suffixed in the
+ * same way, e.g. a second label keyed "yes" becomes "yes_two".
+ */
+export default function createEnumChoiceKeys(labels: string[]) {
+  const usedKeys = new Set<string>();
+
+  return labels.map((label, index) => {
+    const base = keyFromLabel(label) || withSuffix(FALLBACK_KEY, index + 1);
+
+    let key = base;
+    let attempt = 2;
+    while (usedKeys.has(key)) {
+      key = withSuffix(base, attempt);
+      attempt++;
+    }
+
+    usedKeys.add(key);
+    return key;
+  });
+}

--- a/src/features/settings/utils/createEnumChoiceKeys.ts
+++ b/src/features/settings/utils/createEnumChoiceKeys.ts
@@ -1,89 +1,31 @@
-import slugify from 'slugify';
+import createSlug from './createSlug';
 
-const DIGIT_NAMES = [
-  'zero',
-  'one',
-  'two',
-  'three',
-  'four',
-  'five',
-  'six',
-  'seven',
-  'eight',
-  'nine',
-];
-
-const FALLBACK_KEY = 'option';
 const MAX_KEY_LENGTH = 40;
-
-// Spells out a number one digit at a time, e.g. 12 becomes "one_two".
-function spellOut(number: number) {
-  return String(number)
-    .split('')
-    .map((digit) => DIGIT_NAMES[parseInt(digit)])
-    .join('_');
-}
-
-/**
- * Derives a key from an option label, using only the characters a-z and _.
- *
- * Unlike field slugs, which may contain digits, the API rejects enum option
- * keys that contain anything but a-z and _. Digits are therefore spelled out
- * rather than dropped, so that labels like "Joined 2016" and "Joined 2017"
- * don't end up with the same key.
- *
- * Returns an empty string for labels that contain nothing usable, e.g. "!!!"
- * or a label written in a script that slugify cannot transliterate.
- */
-function keyFromLabel(label: string) {
-  const spelledOut = label.replace(
-    /[0-9]/g,
-    (digit) => ` ${DIGIT_NAMES[parseInt(digit)]} `
-  );
-
-  const slugified = slugify(spelledOut.toLocaleLowerCase(), {
-    //Removes any character that is not a-z, _ and " "
-    remove: /[^a-z_ ]/,
-    //Replaces spaces with "_"
-    replacement: '_',
-  });
-
-  return trimUnderscores(slugified.replace(/_+/g, '_')).slice(
-    0,
-    MAX_KEY_LENGTH
-  );
-}
-
-function trimUnderscores(key: string) {
-  return key.replace(/^_+/, '').replace(/_+$/, '');
-}
 
 // Appends a suffix, making room for it within the maximum key length.
 function withSuffix(base: string, number: number) {
-  const suffix = `_${spellOut(number)}`;
+  const suffix = `_${number}`;
   return (
-    trimUnderscores(base.slice(0, MAX_KEY_LENGTH - suffix.length)) + suffix
+    base.slice(0, MAX_KEY_LENGTH - suffix.length).replace(/_+$/, '') + suffix
   );
 }
 
 /**
  * Derives a unique, non-empty key for each of the given option labels.
  *
- * Labels that produce no usable characters fall back to "option_one",
- * "option_two" and so on, and keys that would collide are suffixed in the
- * same way, e.g. a second label keyed "yes" becomes "yes_two".
+ * Keys follow the same rules as field slugs. Labels that produce no usable
+ * characters fall back to "option_1", "option_2" and so on, and keys that
+ * would collide are suffixed the same way, e.g. a second "Yes" becomes "yes_2".
  */
 export default function createEnumChoiceKeys(labels: string[]) {
   const usedKeys = new Set<string>();
 
   return labels.map((label, index) => {
-    const base = keyFromLabel(label) || withSuffix(FALLBACK_KEY, index + 1);
+    const base = createSlug(label) || withSuffix('option', index + 1);
 
     let key = base;
-    let attempt = 2;
-    while (usedKeys.has(key)) {
+    for (let attempt = 2; usedKeys.has(key); attempt++) {
       key = withSuffix(base, attempt);
-      attempt++;
     }
 
     usedKeys.add(key);


### PR DESCRIPTION
> **Update, Sept 8.** The backend has been fixed to accept digits in option keys (see the thread below), so I've reworked this PR. Struck-through text is the original description and no longer applies.

## Description

I ran into this creating an "Options" field for what year someone joined. Every option label with a digit in it failed with a generic error, and so did a label that was just a number.

~~Option keys are derived with `createSlug()`, which is written for field slugs. Slugs can contain digits and option keys can't, so the keys come out invalid:~~

| Option label | Key generated | ~~API response~~ |
|---------------|---------------|--------------|
| `Joined 2016` | `joined_2016` | ~~400~~ |
| `2` | empty string | 400 |
| `Yes` | `yes` | 201 |

~~The result is that no option with a digit in its label can be created through the UI at all.~~

~~I believe this is a regression from b5d7eabec ("allow numbers in slugs"). Before that commit `createSlug()` only produced `a-z` and `_`, which happens to be exactly what option keys need, so "Joined 2016" keyed as `joined_` and worked. Widening the character set was right for slugs but option keys broke as a side effect.~~

The digits turned out to be a backend bug, which @ziggabyte has since fixed (#3785). `joined_2016` is a valid key now and this PR no longer does anything special for digits.

~~This PR gives option keys their own helper so they stop sharing rules with slugs. It also fixes two things that were already broken before that commit.~~ What's left is two bugs in this repo. Labels with no usable characters like `2`, `日本語` or `!!!` produce an empty key, and two labels can quietly produce the same key, so `Yes` and `Yes!` both become `yes`. The API rejects the empty key, and it accepts the duplicate without complaint, so you end up with two options that can't be told apart.

## Changes

- Adds `createEnumChoiceKeys()`, which always returns a key that is non-empty, unique within the field, ~~at most 40 characters, and made up only of `a-z` and `_`~~ and follows the same rules as field slugs, since it uses `createSlug()` for the base key
- Changes `parseEnumChoices()` to use it instead of `createSlug()`
- Adds unit tests for the new helper (more on that below)*
- Leaves `createSlug()` and field slug behavior untouched

~~I don't really like how I handled digits here, kind of a hacky workaround. They get spelled out, so "Joined 2016" becomes `joined_two_zero_one_six`, which is kind of ugly :) I went with it because dropping the digits would collapse "Joined 2016" and "Joined 2017" onto the same key, and because keys are never shown in the UI. Labels with nothing usable fall back to `option_one` and `option_two`, spelled out for the same reason. If shorter keys matter more, we could drop the digits and add a suffix instead, though then which year is which depends on the order the options were entered.~~

Labels with nothing usable fall back to `option_1`, `option_2` and so on, and colliding keys get a suffix, so a second `Yes` becomes `yes_2`. One side effect of going through `createSlug()` is that keys can't start with a digit, so a label of `2016` keys as `option_1` rather than `2016`. Keys aren't shown in the UI so I think that's fine, but if the API is happy with keys starting with a digit I can skip that strip for option keys.

*This is the first test under `src/features/settings`. The helper is a pure function with a lot of edge cases, so it seemed worth covering, though I've kept the tests to the helper rather than adding component tests.

~~I'm not sure this is the right layer to fix it, and I've asked in #3785 whether the constraint is intended. If the API changes to accept digits the spelling can be dropped, but the empty key and collision handling are needed either way.~~

## Screenshots

No visual change. The form looks the same, the difference is that creating the field now succeeds.

## AI usage

Yes. I ran into this on my organization's Zetkin instance and bisected the API from the browser console to work out what it was rejecting. I worked with Claude Code to implement the fix and its tests, and to run lint, type checks and the test suite. I reviewed the change and tested it against the development server myself.

## Instructions for reviewer

- Go to /organize/1/settings/fields
- Create a field, set Type to "Options", and enter ~~`Joined 2016, Joined 2017, 2`~~ `Joined 2016, Joined 2017, 2, Yes, Yes!`
- On main this fails with the generic error message
- With this branch it is created, with the keys ~~`joined_two_zero_one_six`, `joined_two_zero_one_seven` and `two`~~ `joined_2016`, `joined_2017`, `option_3`, `yes` and `yes_2`
- `npx jest src/features/settings` covers the helper on its own

~~The constraint is enforced by the API, not this repo, so it can't be verified from the code here. #3785 has a three request walkthrough on the development server.~~

## Related issues

Relates to #3785, ~~which asks whether the API side constraint is deliberate. This PR is the frontend half and stands on its own, since the empty key and collision bugs need fixing either way.~~ The digit half of that issue was fixed on the backend, this PR covers the empty key and collision half.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
