### PR TITLE
Use `Promise.all` for loading officials

### DIFF
--- a/src/features/settings/rpc/getOfficialMemberships.tsx
+++ b/src/features/settings/rpc/getOfficialMemberships.tsx
@@ -21,22 +21,20 @@ export default makeRPCDef<Params, Result>(getOfficialMembershipsDef.name);
 
 async function handle(params: Params, apiClient: IApiClient): Promise<Result> {
   const { orgId } = params;
-  const memberships: ZetkinMembership[] = [];
 
   const officials = await apiClient.get<ZetkinOfficial[]>(
     `/api/orgs/${orgId}/officials`
   );
 
-  for (const official of officials) {
-    const membership = await apiClient.get<[ZetkinMembership]>(
-      `/api/orgs/${orgId}/people/${official.id}/connections`
-    );
-    const orgMembership = membership.find((m) => m.organization.id == orgId);
+  const memberships = await Promise.all(
+    officials.map((official) =>
+      apiClient.get<[ZetkinMembership]>(
+        `/api/orgs/${orgId}/people/${official.id}/connections`
+      )
+    )
+  );
 
-    if (orgMembership) {
-      memberships.push(orgMembership);
-    }
-  }
-
-  return memberships;
+  return memberships
+    .map((membership) => membership.find((m) => m.organization.id == orgId))
+    .filter((membership) => !!membership);
 }


### PR DESCRIPTION
## Description

This PR mitigates slow performance of the settings page by using `Promise.all` when loading all connections of all officials. Currently, we load them sequentially, which I expect is significantly slower than `Promise.all` here for a large number of officials. 

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Updates the RPC `getOfficialMemberships` to use `Promise.all`

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

To diagnose, wrote the fix myself.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Go to `/organize/1/settings`

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
