### PR TITLE
Message scoping [to be decided]

### DIFF
--- a/src/app/call/layout.tsx
+++ b/src/app/call/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,13 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function CallLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, ['feat.call']);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/canvass/[areaAssId]/layout.tsx
+++ b/src/app/canvass/[areaAssId]/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,16 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function CanvassLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, [
+    'feat.canvass',
+    'feat.organizations',
+  ]);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,9 @@
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
 import { headers } from 'next/headers';
 
-import BackendApiClient from 'core/api/client/BackendApiClient';
 import ClientContext from 'core/env/ClientContext';
-import { ZetkinUser } from 'utils/types/zetkin';
-import { getBrowserLanguage, getMessages } from 'utils/locale';
+import { getMessages } from 'utils/locale';
+import { getRequestLang, getRequestUser } from 'utils/requestLocale';
 
 export default async function RootLayout({
   children,
@@ -14,19 +13,11 @@ export default async function RootLayout({
   const headersList = headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
-  const apiClient = new BackendApiClient(headersObject);
 
-  let user: ZetkinUser | null;
+  const user = await getRequestUser();
+  const lang = await getRequestLang();
 
-  try {
-    user = await apiClient.get<ZetkinUser>('/api/users/me');
-  } catch (e) {
-    user = null;
-  }
-
-  const lang =
-    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
-  const messages = await getMessages(lang);
+  const sharedBaseMessages = await getMessages(lang, ['core', 'glob', 'zui']);
   const nonce = headers().get('x-nonce') ?? undefined;
 
   return (
@@ -56,7 +47,7 @@ export default async function RootLayout({
             }}
             headers={headersObject}
             lang={lang}
-            messages={messages}
+            messages={sharedBaseMessages}
             nonce={nonce}
             user={user}
           >

--- a/src/app/lost-password/layout.tsx
+++ b/src/app/lost-password/layout.tsx
@@ -1,18 +1,24 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import AccountLayout from 'features/account/layouts/AccountLayout';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 
 type Props = {
   children: ReactNode;
 };
 
-const LostPasswordLayout: FC<Props> = ({ children }) => {
-  return (
-    <HomeThemeProvider>
-      <AccountLayout>{children}</AccountLayout>
-    </HomeThemeProvider>
-  );
-};
+export default async function LostPasswordLayout({ children }: Props) {
+  const lang = await getRequestLang();
+  const messages = await getMessages(lang, ['feat.account']);
 
-export default LostPasswordLayout;
+  return (
+    <SectionIntlProvider lang={lang} messages={messages}>
+      <HomeThemeProvider>
+        <AccountLayout>{children}</AccountLayout>
+      </HomeThemeProvider>
+    </SectionIntlProvider>
+  );
+}

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -1,12 +1,14 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
 
 import HomeLayout from 'features/my/layouts/HomeLayout';
 import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import { getBrowserLanguage } from 'utils/locale';
+import { getBrowserLanguage, getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
 import getServerMessages from 'core/i18n/server';
 import messageIds from 'features/my/l10n/messageIds';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 import { getSeoTags } from '../../utils/seoTags';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -44,14 +46,20 @@ type Props = {
   children: ReactNode;
 };
 
-const MyHomeLayout: FC<Props> = ({ children }) => {
+export default async function MyHomeLayout({ children }: Props) {
   const homeTitle = process.env.HOME_TITLE;
+  const lang = await getRequestLang();
+  const messages = await getMessages(lang, [
+    'feat.events',
+    'feat.home',
+    'feat.organizations',
+  ]);
 
   return (
-    <HomeThemeProvider>
-      <HomeLayout title={homeTitle}>{children}</HomeLayout>
-    </HomeThemeProvider>
+    <SectionIntlProvider lang={lang} messages={messages}>
+      <HomeThemeProvider>
+        <HomeLayout title={homeTitle}>{children}</HomeLayout>
+      </HomeThemeProvider>
+    </SectionIntlProvider>
   );
-};
-
-export default MyHomeLayout;
+}

--- a/src/app/o/[orgId]/(home)/layout.tsx
+++ b/src/app/o/[orgId]/(home)/layout.tsx
@@ -6,6 +6,9 @@ import { notFound } from 'next/navigation';
 import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import PublicOrgLayout from 'features/public/layouts/PublicOrgLayout';
 import BackendApiClient from 'core/api/client/BackendApiClient';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 import { getOrganizationOpenGraphTags, getSeoTags } from 'utils/seoTags';
 import { ApiClientError } from 'core/api/errors';
@@ -56,10 +59,20 @@ const OrgLayout: FC<Props> = async ({ children, params }) => {
       `/api/orgs/${params.orgId}`
     );
 
+    const lang = await getRequestLang();
+    const messages = await getMessages(lang, [
+      'feat.events',
+      'feat.organizations',
+      'feat.home',
+      'feat.joinForms',
+    ]);
+
     return (
-      <HomeThemeProvider>
-        <PublicOrgLayout org={org}>{children}</PublicOrgLayout>
-      </HomeThemeProvider>
+      <SectionIntlProvider lang={lang} messages={messages}>
+        <HomeThemeProvider>
+          <PublicOrgLayout org={org}>{children}</PublicOrgLayout>
+        </HomeThemeProvider>
+      </SectionIntlProvider>
     );
   } catch (e) {
     if (e instanceof ApiClientError && e.status === 404) {

--- a/src/app/o/[orgId]/embedjoinform/[formData]/layout.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,13 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function EmbedJoinFormLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, ['feat.joinForms']);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/o/[orgId]/events/[eventId]/layout.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/layout.tsx
@@ -8,6 +8,8 @@ import PublicEventLayout from 'features/public/layouts/PublicEventLayout';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { getBrowserLanguage, getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 import { getSeoTags } from 'utils/seoTags';
 import { ApiClientError } from 'core/api/errors';
 
@@ -71,12 +73,22 @@ const EventLayout: FC<Props> = async ({ children, params }) => {
       `/api/orgs/${params.orgId}/actions/${params.eventId}`
     );
 
+    const lang = await getRequestLang();
+    const messages = await getMessages(lang, [
+      'feat.events',
+      'feat.home',
+      'feat.organizations',
+      'feat.campaigns',
+    ]);
+
     return (
-      <HomeThemeProvider>
-        <PublicEventLayout eventId={event.id} orgId={event.organization.id}>
-          {children}
-        </PublicEventLayout>
-      </HomeThemeProvider>
+      <SectionIntlProvider lang={lang} messages={messages}>
+        <HomeThemeProvider>
+          <PublicEventLayout eventId={event.id} orgId={event.organization.id}>
+            {children}
+          </PublicEventLayout>
+        </HomeThemeProvider>
+      </SectionIntlProvider>
     );
   } catch (e) {
     if (e instanceof ApiClientError && e.status === 404) {

--- a/src/app/o/[orgId]/joinformverified/layout.tsx
+++ b/src/app/o/[orgId]/joinformverified/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,13 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function JoinFormVerifiedLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, ['feat.joinForms']);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/o/[orgId]/projects/[projId]/layout.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/layout.tsx
@@ -8,6 +8,9 @@ import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ApiClientError } from 'core/api/errors';
 import { ZetkinProject } from 'utils/types/zetkin';
 import PublicProjectLayout from 'features/public/layouts/PublicProjectLayout';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 import { getOrganizationOpenGraphTags, getSeoTags } from 'utils/seoTags';
 
 type Props = {
@@ -54,10 +57,22 @@ const MyHomeLayout: FC<Props> = async ({ children, params }) => {
       `/api/orgs/${params.orgId}/campaigns/${params.projId}`
     );
 
+    const lang = await getRequestLang();
+    const messages = await getMessages(lang, [
+      'feat.campaigns',
+      'feat.home',
+      'feat.organizations',
+      'feat.events',
+    ]);
+
     return (
-      <HomeThemeProvider>
-        <PublicProjectLayout project={project}>{children}</PublicProjectLayout>
-      </HomeThemeProvider>
+      <SectionIntlProvider lang={lang} messages={messages}>
+        <HomeThemeProvider>
+          <PublicProjectLayout project={project}>
+            {children}
+          </PublicProjectLayout>
+        </HomeThemeProvider>
+      </SectionIntlProvider>
     );
   } catch (e) {
     if (e instanceof ApiClientError && e.status === 404) {

--- a/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
@@ -10,6 +10,9 @@ import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import PublicSurveyLayout from 'features/public/layouts/PublicSurveyLayout';
 import { ZetkinSurveyExtended } from 'utils/types/zetkin';
 import { ApiClientError } from 'core/api/errors';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 import { getSeoTags } from 'utils/seoTags';
 
 type Props = {
@@ -68,10 +71,18 @@ const SurveyLayout: FC<Props> = async ({
     }
   }
 
+  const lang = await getRequestLang();
+  const messages = await getMessages(lang, [
+    'feat.surveys',
+    'feat.organizations',
+  ]);
+
   return (
-    <HomeThemeProvider>
-      <PublicSurveyLayout survey={survey}>{children}</PublicSurveyLayout>
-    </HomeThemeProvider>
+    <SectionIntlProvider lang={lang} messages={messages}>
+      <HomeThemeProvider>
+        <PublicSurveyLayout survey={survey}>{children}</PublicSurveyLayout>
+      </HomeThemeProvider>
+    </SectionIntlProvider>
   );
 };
 

--- a/src/app/o/[orgId]/unsubscribe/layout.tsx
+++ b/src/app/o/[orgId]/unsubscribe/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,13 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function UnsubscribeLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, ['feat.emails']);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/o/[orgId]/unsubscribed/layout.tsx
+++ b/src/app/o/[orgId]/unsubscribed/layout.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
 
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
-import AccountLayout from 'features/account/layouts/AccountLayout';
 import { getMessages } from 'utils/locale';
 import { getRequestLang } from 'utils/requestLocale';
 import SectionIntlProvider from 'core/env/SectionIntlProvider';
@@ -10,15 +8,13 @@ type Props = {
   children: ReactNode;
 };
 
-export default async function RegisterLayout({ children }: Props) {
+export default async function UnsubscribedLayout({ children }: Props) {
   const lang = await getRequestLang();
-  const messages = await getMessages(lang, ['feat.account']);
+  const messages = await getMessages(lang, ['feat.emails']);
 
   return (
     <SectionIntlProvider lang={lang} messages={messages}>
-      <HomeThemeProvider>
-        <AccountLayout>{children}</AccountLayout>
-      </HomeThemeProvider>
+      {children}
     </SectionIntlProvider>
   );
 }

--- a/src/app/reset-password/layout.tsx
+++ b/src/app/reset-password/layout.tsx
@@ -1,18 +1,24 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import AccountLayout from 'features/account/layouts/AccountLayout';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 
 type Props = {
   children: ReactNode;
 };
 
-const ResetPasswordLayout: FC<Props> = ({ children }) => {
-  return (
-    <HomeThemeProvider>
-      <AccountLayout>{children}</AccountLayout>
-    </HomeThemeProvider>
-  );
-};
+export default async function ResetPasswordLayout({ children }: Props) {
+  const lang = await getRequestLang();
+  const messages = await getMessages(lang, ['feat.account']);
 
-export default ResetPasswordLayout;
+  return (
+    <SectionIntlProvider lang={lang} messages={messages}>
+      <HomeThemeProvider>
+        <AccountLayout>{children}</AccountLayout>
+      </HomeThemeProvider>
+    </SectionIntlProvider>
+  );
+}

--- a/src/app/verify/layout.tsx
+++ b/src/app/verify/layout.tsx
@@ -1,18 +1,24 @@
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import AccountLayout from 'features/account/layouts/AccountLayout';
+import { getMessages } from 'utils/locale';
+import { getRequestLang } from 'utils/requestLocale';
+import SectionIntlProvider from 'core/env/SectionIntlProvider';
 
 type Props = {
   children: ReactNode;
 };
 
-const VerifyLayout: FC<Props> = ({ children }) => {
-  return (
-    <HomeThemeProvider>
-      <AccountLayout>{children}</AccountLayout>
-    </HomeThemeProvider>
-  );
-};
+export default async function VerifyLayout({ children }: Props) {
+  const lang = await getRequestLang();
+  const messages = await getMessages(lang, ['feat.account']);
 
-export default VerifyLayout;
+  return (
+    <SectionIntlProvider lang={lang} messages={messages}>
+      <HomeThemeProvider>
+        <AccountLayout>{children}</AccountLayout>
+      </HomeThemeProvider>
+    </SectionIntlProvider>
+  );
+}

--- a/src/core/env/SectionIntlProvider.tsx
+++ b/src/core/env/SectionIntlProvider.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { FC, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { MessageList } from 'utils/locale';
+
+type Props = {
+  children: ReactNode;
+  lang: string;
+  messages: MessageList;
+};
+
+/**
+ * Nests a narrower IntlProvider inside RootLayout's, scoped to a section
+ * of the App Router tree. react-intl's IntlProvider doesn't merge messages
+ * with an ancestor provider, so `messages` here must be the full set this
+ * section needs, not just what it adds on top of the root.
+ */
+const SectionIntlProvider: FC<Props> = ({ children, lang, messages }) => (
+  <IntlProvider defaultLocale="en" locale={lang} messages={messages}>
+    {children}
+  </IntlProvider>
+);
+
+export default SectionIntlProvider;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ import { ZetkinUser } from '../utils/types/zetkin';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 
 const scaffoldOptions = {
-  localeScope: ['pages.my'],
+  localeScope: [],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(

--- a/src/pages/legacy.tsx
+++ b/src/pages/legacy.tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
     };
   },
   {
-    localeScope: ['pages.legacy'],
+    localeScope: [],
   }
 );
 

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       },
     };
   },
-  { allowUnverified: true }
+  { allowUnverified: true, localeScope: [] }
 );
 
 export default function NotUsed(): null {

--- a/src/pages/organize/[orgId]/geography/index.tsx
+++ b/src/pages/organize/[orgId]/geography/index.tsx
@@ -15,6 +15,7 @@ import GLGeographyMap from 'features/geography/components/GLGeographyMap';
 const scaffoldOptions = {
   authLevelRequired: 2,
   featuresRequired: [AREAS],
+  localeScope: ['feat.areas', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async () => {

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/[instanceId]/index.tsx
@@ -24,7 +24,7 @@ import { ZetkinJourneyInstance } from 'utils/types/zetkin';
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'misc', 'pages.organizeJourneyInstance'],
+  localeScope: ['feat.journeys', 'feat.breadcrumbs', 'feat.tags'],
 };
 
 export const getJourneyInstanceScaffoldProps: ScaffoldedGetServerSideProps =

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/closed.tsx
@@ -15,7 +15,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.organizeJourney'],
+  localeScope: ['feat.journeys', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/index.tsx
@@ -15,7 +15,7 @@ import ZUIFuture from 'zui/ZUIFuture';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.organizeJourney'],
+  localeScope: ['feat.journeys', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
+++ b/src/pages/organize/[orgId]/journeys/[journeyId]/new.tsx
@@ -27,12 +27,7 @@ import {
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: [
-    'layout.organize',
-    'misc',
-    'pages.organizeJourneyInstance',
-    'pages.organizeNewJourneyInstance',
-  ],
+  localeScope: ['feat.journeys', 'feat.breadcrumbs', 'feat.tags'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/journeys/index.tsx
+++ b/src/pages/organize/[orgId]/journeys/index.tsx
@@ -16,7 +16,7 @@ import ZUISection from 'zui/ZUISection';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.organizeJourneys'],
+  localeScope: ['feat.journeys', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/people/[personId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/[personId]/index.tsx
@@ -30,7 +30,12 @@ import PersonSurveySubmissionsCard from 'features/profile/components/PersonSurve
 
 export const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people'],
+  localeScope: [
+    'feat.profile',
+    'feat.journeys',
+    'feat.tags',
+    'feat.breadcrumbs',
+  ],
 };
 
 export const getPersonScaffoldProps: ScaffoldedGetServerSideProps = async (

--- a/src/pages/organize/[orgId]/people/duplicates/index.tsx
+++ b/src/pages/organize/[orgId]/people/duplicates/index.tsx
@@ -14,11 +14,14 @@ import { useMessages } from 'core/i18n';
 import { useNumericRouteParams } from 'core/hooks';
 import useServerSide from 'core/useServerSide';
 
-export const getServerSideProps: GetServerSideProps = scaffold(async () => {
-  return {
-    props: {},
-  };
-});
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async () => {
+    return {
+      props: {},
+    };
+  },
+  { localeScope: ['feat.duplicates', 'feat.breadcrumbs', 'feat.views'] }
+);
 
 const DuplicatesPage: PageWithLayout = () => {
   const onServer = useServerSide();

--- a/src/pages/organize/[orgId]/people/folders/[folderId].tsx
+++ b/src/pages/organize/[orgId]/people/folders/[folderId].tsx
@@ -12,7 +12,7 @@ import { ZetkinViewFolder } from 'features/views/components/types';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people'],
+  localeScope: ['feat.views', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/people/incoming/index.tsx
+++ b/src/pages/organize/[orgId]/people/incoming/index.tsx
@@ -24,12 +24,22 @@ import { usePanes } from 'utils/panes';
 import ZUIEmptyState from 'zui/ZUIEmptyState';
 import ZUIFuture from 'zui/ZUIFuture';
 
-export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
-  const { orgId } = ctx.params!;
-  return {
-    props: { orgId },
-  };
-});
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId } = ctx.params!;
+    return {
+      props: { orgId },
+    };
+  },
+  {
+    localeScope: [
+      'feat.import',
+      'feat.breadcrumbs',
+      'feat.joinForms',
+      'feat.views',
+    ],
+  }
+);
 
 type Props = {
   orgId: string;

--- a/src/pages/organize/[orgId]/people/index.tsx
+++ b/src/pages/organize/[orgId]/people/index.tsx
@@ -13,7 +13,7 @@ import { ZetkinView } from 'features/views/components/types';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people'],
+  localeScope: ['feat.views', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/people/joinforms/index.tsx
+++ b/src/pages/organize/[orgId]/people/joinforms/index.tsx
@@ -8,15 +8,18 @@ import { scaffold } from 'utils/next';
 import useJoinForms from 'features/joinForms/hooks/useJoinForms';
 import { usePanes } from 'utils/panes';
 
-export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
-  const { orgId } = ctx.params!;
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId } = ctx.params!;
 
-  return {
-    props: {
-      orgId,
-    },
-  };
-});
+    return {
+      props: {
+        orgId,
+      },
+    };
+  },
+  { localeScope: ['feat.joinForms', 'feat.breadcrumbs', 'feat.views'] }
+);
 
 type PageProps = {
   orgId: string;

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/index.tsx
@@ -18,7 +18,7 @@ import useCustomFields from 'features/profile/hooks/useCustomFields';
 const scaffoldOptions = {
   allowNonOfficials: true,
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people.lists'],
+  localeScope: ['feat.views', 'feat.profile', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
+++ b/src/pages/organize/[orgId]/people/lists/[viewId]/shared.tsx
@@ -20,7 +20,7 @@ import useCustomFields from 'features/profile/hooks/useCustomFields';
 const scaffoldOptions = {
   allowNonOfficials: true,
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.people.lists'],
+  localeScope: ['feat.views', 'feat.profile', 'feat.breadcrumbs'],
 };
 
 async function getAccessLevel(

--- a/src/pages/organize/[orgId]/people/lists/callblocked.tsx
+++ b/src/pages/organize/[orgId]/people/lists/callblocked.tsx
@@ -22,6 +22,7 @@ import {
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  localeScope: ['feat.views', 'feat.smartSearch', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/activities/index.tsx
@@ -28,7 +28,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.campaigns', 'feat.events', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/archive/index.tsx
@@ -23,7 +23,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.campaigns', 'feat.events', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/index.tsx
@@ -19,6 +19,7 @@ import useAreaAssignees from 'features/areaAssignments/hooks/useAreaAssignees';
 const scaffoldOptions = {
   authLevelRequired: 2,
   featuresRequired: [AREAS],
+  localeScope: ['feat.areaAssignments', 'feat.campaigns', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/instructions.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/instructions.tsx
@@ -17,6 +17,7 @@ import useAreaAssignment from 'features/areaAssignments/hooks/useAreaAssignment'
 const scaffoldOptions = {
   authLevelRequired: 2,
   featuresRequired: [AREAS],
+  localeScope: ['feat.areaAssignments', 'feat.campaigns', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/map.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/map.tsx
@@ -28,6 +28,12 @@ const OrganizerMap = dynamic(
 const scaffoldOptions = {
   authLevelRequired: 2,
   featuresRequired: [AREAS],
+  localeScope: [
+    'feat.areaAssignments',
+    'feat.areas',
+    'feat.campaigns',
+    'feat.breadcrumbs',
+  ],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/report.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/areaassignments/[areaAssId]/report.tsx
@@ -58,6 +58,12 @@ import useSortedMetrics from 'features/canvass/hooks/useSortedMetrics';
 const scaffoldOptions = {
   authLevelRequired: 2,
   featuresRequired: [AREAS],
+  localeScope: [
+    'feat.areaAssignments',
+    'feat.canvass',
+    'feat.campaigns',
+    'feat.breadcrumbs',
+  ],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/calendar/index.tsx
@@ -16,12 +16,10 @@ import { ZetkinProject } from 'utils/types/zetkin';
 const scaffoldOptions = {
   authLevelRequired: 2,
   localeScope: [
-    'layout.organize',
-    'misc.breadcrumbs',
-    'misc.calendar',
-    'misc.formDialog',
-    'misc.tasks',
-    'pages.organizeProjects',
+    'feat.campaigns',
+    'feat.calendar',
+    'feat.events',
+    'feat.breadcrumbs',
   ],
 };
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/callers.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/callers.tsx
@@ -38,11 +38,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: [
-      'misc.breadcrumbs',
-      'layout.organize.callAssignment',
-      'pages.organizeCallAssignment',
-    ],
+    localeScope: ['feat.callAssignments', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/conversation.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/conversation.tsx
@@ -18,11 +18,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: [
-      'misc.breadcrumbs',
-      'layout.organize.callAssignment',
-      'pages.organizeCallAssignment',
-    ],
+    localeScope: ['feat.callAssignments', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/callassignments/[callAssId]/index.tsx
@@ -39,10 +39,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: [
-      'layout.organize.callAssignment',
-      'pages.organizeCallAssignment',
-    ],
+    localeScope: ['feat.callAssignments', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/compose/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/compose/index.tsx
@@ -23,7 +23,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.email', 'pages.organizeEmail'],
+    localeScope: [
+      'feat.emails',
+      'feat.organizations',
+      'feat.campaigns',
+      'feat.breadcrumbs',
+    ],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/index.tsx
@@ -23,7 +23,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.email', 'pages.organizeEmail'],
+    localeScope: [
+      'feat.emails',
+      'feat.organizations',
+      'feat.campaigns',
+      'feat.breadcrumbs',
+    ],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/emails/[emailId]/insights.tsx
@@ -31,7 +31,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.email', 'pages.organizeEmail'],
+    localeScope: [
+      'feat.emails',
+      'feat.organizations',
+      'feat.campaigns',
+      'feat.breadcrumbs',
+    ],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/events/[eventId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/events/[eventId]/index.tsx
@@ -39,7 +39,12 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: [],
+    localeScope: [
+      'feat.events',
+      'feat.files',
+      'feat.campaigns',
+      'feat.breadcrumbs',
+    ],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/events/[eventId]/participants.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/events/[eventId]/participants.tsx
@@ -28,7 +28,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   {
     authLevelRequired: 2,
 
-    localeScope: [],
+    localeScope: ['feat.events', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/index.tsx
@@ -21,7 +21,7 @@ import ProjectDetailsForm from 'features/projects/components/ProjectDetailsForm'
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.organizeProjects'],
+  localeScope: ['feat.campaigns', 'feat.events', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/index.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.surveys', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/insights.tsx
@@ -45,7 +45,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.surveys', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/questions.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/questions.tsx
@@ -28,7 +28,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.surveys', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/submissions.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/surveys/[surveyId]/submissions.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.surveys', 'feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/assignees.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/assignees.tsx
@@ -23,7 +23,12 @@ import { ZetkinAssignedTask, ZetkinTask } from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.assignees'],
+  localeScope: [
+    'feat.tasks',
+    'feat.campaigns',
+    'feat.smartSearch',
+    'feat.breadcrumbs',
+  ],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/index.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/index.tsx
@@ -13,7 +13,12 @@ import { ZetkinTask } from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.organizeProjects'],
+  localeScope: [
+    'feat.tasks',
+    'feat.files',
+    'feat.campaigns',
+    'feat.breadcrumbs',
+  ],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/insights.tsx
+++ b/src/pages/organize/[orgId]/projects/[projectId]/tasks/[taskId]/insights.tsx
@@ -22,7 +22,7 @@ import { Msg, useMessages } from 'core/i18n';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: ['layout.organize', 'pages.assignees', 'pages.organizeProjects'],
+  localeScope: ['feat.tasks', 'feat.campaigns', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/activities/index.tsx
+++ b/src/pages/organize/[orgId]/projects/activities/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: ['layout.organize.surveys', 'pages.organizeSurvey'],
+    localeScope: ['feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/archive/index.tsx
+++ b/src/pages/organize/[orgId]/projects/archive/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
-    localeScope: [],
+    localeScope: ['feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/calendar/index.tsx
+++ b/src/pages/organize/[orgId]/projects/calendar/index.tsx
@@ -13,12 +13,7 @@ import { ZetkinOrganization } from 'utils/types/zetkin';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: [
-    'layout.organize',
-    'misc.breadcrumbs',
-    'misc.calendar',
-    'misc.formDialog',
-  ],
+  localeScope: ['feat.campaigns', 'feat.calendar', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/index.tsx
+++ b/src/pages/organize/[orgId]/projects/index.tsx
@@ -44,12 +44,7 @@ import { IFuture } from 'core/caching/futures';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
-  localeScope: [
-    'layout.organize',
-    'misc.breadcrumbs',
-    'pages.organizeAllProjects',
-    'misc.formDialog',
-  ],
+  localeScope: ['feat.campaigns', 'feat.surveys', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {

--- a/src/pages/organize/[orgId]/projects/shared/activities.tsx
+++ b/src/pages/organize/[orgId]/projects/shared/activities.tsx
@@ -25,7 +25,10 @@ export const getServerSideProps: GetServerSideProps = scaffold(
       },
     };
   },
-  { authLevelRequired: 2 }
+  {
+    authLevelRequired: 2,
+    localeScope: ['feat.campaigns', 'feat.breadcrumbs'],
+  }
 );
 
 interface SharedActivitiesPageProps {

--- a/src/pages/organize/[orgId]/projects/shared/archive.tsx
+++ b/src/pages/organize/[orgId]/projects/shared/archive.tsx
@@ -27,6 +27,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/projects/shared/index.tsx
+++ b/src/pages/organize/[orgId]/projects/shared/index.tsx
@@ -21,6 +21,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.campaigns', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/settings/email/themes/[themeId]/index.tsx
+++ b/src/pages/organize/[orgId]/settings/email/themes/[themeId]/index.tsx
@@ -20,6 +20,7 @@ import messageIds from 'features/settings/l10n/messageIds';
 
 const scaffoldOptions = {
   authLevelRequired: 2,
+  localeScope: ['feat.emails', 'feat.breadcrumbs'],
 };
 
 export const getServerSideProps: GetServerSideProps = scaffold(async () => {

--- a/src/pages/organize/[orgId]/settings/email/themes/index.tsx
+++ b/src/pages/organize/[orgId]/settings/email/themes/index.tsx
@@ -2,15 +2,18 @@ import { GetServerSideProps } from 'next';
 
 import { scaffold } from 'utils/next';
 
-export const getServerSideProps: GetServerSideProps = scaffold(async (ctx) => {
-  const { orgId } = ctx.params!;
-  return {
-    redirect: {
-      destination: `/organize/${orgId}/settings/email`,
-      permanent: false,
-    },
-  };
-});
+export const getServerSideProps: GetServerSideProps = scaffold(
+  async (ctx) => {
+    const { orgId } = ctx.params!;
+    return {
+      redirect: {
+        destination: `/organize/${orgId}/settings/email`,
+        permanent: false,
+      },
+    };
+  },
+  { localeScope: ['feat.emails', 'feat.settings', 'feat.breadcrumbs'] }
+);
 
 export default function NotUsed(): null {
   return null;

--- a/src/pages/organize/[orgId]/settings/fields.tsx
+++ b/src/pages/organize/[orgId]/settings/fields.tsx
@@ -20,6 +20,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.settings', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/settings/index.tsx
+++ b/src/pages/organize/[orgId]/settings/index.tsx
@@ -24,6 +24,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.settings', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/suborgOverview/index.tsx
+++ b/src/pages/organize/[orgId]/suborgOverview/index.tsx
@@ -35,6 +35,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.organizations', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/pages/organize/[orgId]/tags/index.tsx
+++ b/src/pages/organize/[orgId]/tags/index.tsx
@@ -32,6 +32,7 @@ export const getServerSideProps: GetServerSideProps = scaffold(
   },
   {
     authLevelRequired: 2,
+    localeScope: ['feat.tags', 'feat.breadcrumbs'],
   }
 );
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -93,7 +93,7 @@ export async function getMessages(
   if (scope.length) {
     const scoped: MessageList = {};
     Object.entries(localizedMessages).forEach(([key, val]) => {
-      if (scope.some((s) => key.startsWith(s))) {
+      if (scope.some((s) => key === s || key.startsWith(`${s}.`))) {
         scoped[key] = val;
       }
     });

--- a/src/utils/next.ts
+++ b/src/utils/next.ts
@@ -216,10 +216,10 @@ export const scaffold =
     // Figure out browser's preferred language
     const lang = ctx.user?.lang || getBrowserLanguage(contextFromNext.req);
 
-    // TODO: Respect scope from options again
-    //const localeScope = (options?.localeScope ?? []).concat(['misc', 'zui']);
-    const localeScope: string[] = [];
-    const messages = await getMessages(lang, localeScope);
+    const declaredLocaleScope = options?.localeScope
+      ? [...options.localeScope, 'core', 'glob', 'zui', 'feat.search']
+      : [];
+    const messages = await getMessages(lang, declaredLocaleScope);
 
     if (hasProps(result)) {
       result.props = {

--- a/src/utils/requestLocale.ts
+++ b/src/utils/requestLocale.ts
@@ -1,0 +1,29 @@
+import { cache } from 'react';
+import { headers } from 'next/headers';
+
+import BackendApiClient from 'core/api/client/BackendApiClient';
+import { getBrowserLanguage } from './locale';
+import { ZetkinUser } from './types/zetkin';
+
+/**
+ * Memoized per request (React cache()), so App Router layouts nested under
+ * RootLayout can each resolve the same user/lang without triggering a
+ * duplicate /api/users/me request per layout.
+ */
+export const getRequestUser = cache(async (): Promise<ZetkinUser | null> => {
+  const headersObject = Object.fromEntries(headers().entries());
+  const apiClient = new BackendApiClient(headersObject);
+
+  try {
+    return await apiClient.get<ZetkinUser>('/api/users/me');
+  } catch {
+    return null;
+  }
+});
+
+export const getRequestLang = cache(async (): Promise<string> => {
+  const user = await getRequestUser();
+  return (
+    user?.lang || getBrowserLanguage(headers().get('accept-language') || '')
+  );
+});


### PR DESCRIPTION
## Description

This PR is a documenting place for now for my research into next-intl, [locale] routes, json translation files and performance. This is spun out of https://github.com/zetkin/app.zetkin.org/pull/3681 as the one thing that is feasible and proved performance improvements. 

The term "message scoping" will from here on out refer to the practice of defining scopes like `['feat.events', 'feat.organizations']` to the root of a page render. This will limit the messages being sent to the client to only messages within the defined scopes.

This PR re-enables the message scoping having existed since https://github.com/zetkin/app.zetkin.org/pull/80 and previously disabled in https://github.com/zetkin/app.zetkin.org/pull/1129. 

## Analysis

### Previous work

@jfilter 's work in https://github.com/zetkin/app.zetkin.org/pull/3681 has shown performance improvements. In my analysis, these are the parts that it consists of:

1. Migration from `react-intl` to `next-intl`
2. Refactoring both routers to use invisible locale routing
3. Refactoring message loading from yaml to json, and adding a pre-build step for conversion
4. Adding message scoping to all pages

The PR also states that it 

> Provides proper SSR translations

but it didn't add really anything I can see that would fundamentally change how the app loads server side. We already loaded messages server side and rendered them. The only thing that comes close is `src/app/[locale]/[...rest]/route.ts`, which is a new approach to rendering pages server side, but it also bypasses React and Next rendering entirely. 

Another thing to cite is

> At runtime, src/i18n/request.ts reads the compiled JSON via readFileSync once per locale per process and caches it in memory — no per-request file I/O.

this existed before as well. We parsed yaml, saved it into the `MESSAGES` variable. Therefore, we don't I/O per-request.


### Considering migrating to `next-intl`

In attempt to execute (1), I found that `next-intl` uses a fundamentally different way for declaring placeholders that may end up `ReactNode`s. https://github.com/zetkin/app.zetkin.org/pull/3681 bypasses a typecheck here by simply saying `values as RichTranslationValues`. In reality, neither `t` nor `rich` supports anything like `react-intl`'s placeholders `Look at {my-link}`. A `next-intl` variant would be `Look at <mylink>sometext</mylink>`. This however needs refactoring of hundreds of messages in the translation files and may also need additional changes to Lyra. 

The branch containing only the next-intl migration is here: https://github.com/zetkin/app.zetkin.org/tree/undocumented/next-intl-migration, but as I said, it does not work fully due to the differing message formatting. 

As a consequence, I investigated whether the pure migration to `next-intl` had any performance improvements at all. Using https://github.com/jfilter/zetkin-benchmark, I found these numbers:

| Scenario                |           main |          next-intl-migration  |  Delta |
| ----------------------- | -------------: | -------------: | -----: |
| list-select-to-bulk-bar |   110 +/- 13ms |    137 +/- 9ms | +24.5% |
| nav-projects-load       |   413 +/- 16ms |   396 +/- 83ms |  -4.1% |
| nav-campaign-load       |   469 +/- 37ms |   517 +/- 49ms | +10.2% |
| nav-people-list-load    |  603 +/- 105ms |   475 +/- 34ms | -21.2% |
| nav-person-detail-load  |   288 +/- 71ms |  256 +/- 105ms | -11.1% |
| nav-back-to-projects    |   366 +/- 86ms |  446 +/- 103ms | +21.9% |
| nav-full-workflow       |  2131 +/- 71ms | 2095 +/- 177ms |  -1.7% |
| rapid-tab-switching     | 1793 +/- 216ms | 1654 +/- 439ms |  -7.8% |
| my-home-page-load       |    459 +/- 4ms |   498 +/- 17ms |  +8.5% |
| my-orgs-page-load       |    512 +/- 6ms |   530 +/- 16ms |  +3.5% |
| my-feed-page-load       |    456 +/- 9ms |    473 +/- 6ms |  +3.7% |
| campaign-page-load      |    284 +/- 8ms |   298 +/- 36ms |  +4.9% |
| person-page-load        |    193 +/- 8ms |    209 +/- 6ms |  +8.3% |
| search-type-to-results  |   808 +/- 47ms |    812 +/- 5ms |  +0.5% |
| tag-add-interaction     |   395 +/- 17ms |   393 +/- 32ms |  -0.5% |

So no consistent performance improvement on `next-intl` migration alone. 

I also believe that steps (2-4) don't necessarily rely on `next-intl` at all. 

### Considering adding locale routing

Not deeply investigated yet. The PR didn't provide clear benefits to this. It mostly just moved the routing. The performance improvement I belive comes from somewhere else. 

### Considering moving from yaml to json

Also not deeply investigated yet. The PR didn't also didn't say why we would need to do this here. It just migrates to a json parser instead of a yaml parser with no apparent reason? Even if the json parser is faster than yaml, this would likely be a millisecond difference for the first request within a next worker process. 

### This PR: Re-enableing message scoping

Here is what actually matters: I believe adding message scoping to all pages resulted in https://github.com/zetkin/app.zetkin.org/pull/3681's performance improvements. And it is a change that can be independently created without steps 1-3. The infrastructure baseline already existed in this repo but went dormant for a while. These are the results from the perf benchmark:

| Scenario                |           main | message scoping |  Delta |
| ----------------------- | -------------: | --------------: | -----: |
| list-select-to-bulk-bar |   110 +/- 13ms |     91 +/- 12ms | -17.3% |
| nav-projects-load       |   413 +/- 16ms |    365 +/- 16ms | -11.6% |
| nav-campaign-load       |   469 +/- 37ms |     447 +/- 7ms |  -4.7% |
| nav-people-list-load    |  603 +/- 105ms |    464 +/- 62ms | -23.1% |
| nav-person-detail-load  |   288 +/- 71ms |    256 +/- 16ms | -11.1% |
| nav-back-to-projects    |   366 +/- 86ms |     388 +/- 9ms |  +6.0% |
| nav-full-workflow       |   2131 +/- 71ms |   1896 +/- 66ms | -11.0% |
| rapid-tab-switching     | 1793 +/- 216ms |  1702 +/- 144ms |  -5.1% |
| my-home-page-load       |    459 +/- 4ms |     466 +/- 9ms |  +1.5% |
| my-orgs-page-load       |    512 +/- 6ms |     492 +/- 7ms |  -3.9% |
| my-feed-page-load       |    456 +/- 9ms |    441 +/- 11ms |  -3.3% |
| campaign-page-load      |    284 +/- 8ms |    271 +/- 44ms |  -4.6% |
| person-page-load        |    193 +/- 8ms |    184 +/- 23ms |  -4.7% |
| search-type-to-results  |   808 +/- 47ms |    806 +/- 22ms |  -0.2% |
| tag-add-interaction     |   395 +/- 17ms |    380 +/- 14ms |  -3.8% |

This shows a good performance improvement, roughly matching the results from https://github.com/zetkin/app.zetkin.org/pull/3681

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Re-enables message scoping within `next.ts`
- Adds message scoping to all pages in app router
- Adds message scoping to all pages in pages router

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Yes Claude and Codex to build this PR's code and investigate changes within @jfilter 's PR.

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

The route smoke suite from https://github.com/zetkin/app.zetkin.org/pull/3771 is a good baseline, but I believe we could build more tests to figure out whether we are missing any scopes. CI should fail when any page tries to load a message without declaring the scope. It should not just fail silently in prod.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
