### PR TITLE
Migrate app router request APIs to async (Next 15 compatibility)

### DIFF
--- a/src/app/api2/[...path]/route.ts
+++ b/src/app/api2/[...path]/route.ts
@@ -35,7 +35,7 @@ async function proxy(
   const hostAndPort = host + (port ? `:${port}` : '');
   const apiBase = `${protocol}://${hostAndPort}/v2/`;
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   const session = await getIronSession<AppSession>(cookieStore, {
     cookieName: 'zsid',

--- a/src/app/beta/orgs/[orgId]/actions/[action_id]/stats/route.ts
+++ b/src/app/beta/orgs/[orgId]/actions/[action_id]/stats/route.ts
@@ -6,16 +6,17 @@ import { EventSignupModel } from 'features/events/models';
 import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     action_id: string;
     orgId: string;
-  };
+  }>;
 };
 
 const actionIdSchema = z.coerce.number().int().positive();
 const orgIdSchema = z.coerce.number().int().positive();
 
-export async function GET(request: NextRequest, { params }: RouteMeta) {
+export async function GET(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   const actionIdResult = actionIdSchema.safeParse(params.action_id);
   if (!actionIdResult.success) {
     return NextResponse.json({ error: 'Invalid action_id' }, { status: 400 });

--- a/src/app/beta/orgs/[orgId]/events/[eventId]/book/route.ts
+++ b/src/app/beta/orgs/[orgId]/events/[eventId]/book/route.ts
@@ -11,10 +11,10 @@ import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { ZetkinPerson } from 'utils/types/zetkin';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     eventId: string;
     orgId: string;
-  };
+  }>;
 };
 
 type BookRequestBody = {
@@ -122,7 +122,8 @@ function fuzzyNameMatch(a?: string | null, b?: string | null): boolean {
   return distance(normalizedA, normalizedB) <= 1;
 }
 
-export async function POST(request: NextRequest, { params }: RouteMeta) {
+export async function POST(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   return asOrgAuthorized(
     {
       orgId: params.orgId,

--- a/src/app/beta/orgs/[orgId]/events/[eventId]/link/route.ts
+++ b/src/app/beta/orgs/[orgId]/events/[eventId]/link/route.ts
@@ -7,10 +7,10 @@ import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 import { ZetkinEventParticipant } from 'utils/types/zetkin';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     eventId: string;
     orgId: string;
-  };
+  }>;
 };
 
 type LinkRequestBody = {
@@ -18,7 +18,8 @@ type LinkRequestBody = {
   signupId: string;
 };
 
-export async function POST(request: NextRequest, { params }: RouteMeta) {
+export async function POST(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   return asOrgAuthorized(
     {
       orgId: params.orgId,

--- a/src/app/beta/orgs/[orgId]/events/[eventId]/route.ts
+++ b/src/app/beta/orgs/[orgId]/events/[eventId]/route.ts
@@ -6,10 +6,10 @@ import { EventSignupModel } from 'features/events/models';
 import asOrgAuthorized from 'utils/api/asOrgAuthorized';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     eventId: string;
     orgId: string;
-  };
+  }>;
 };
 
 type EventSignupBody = {
@@ -20,7 +20,8 @@ type EventSignupBody = {
   phone?: string;
 };
 
-export async function GET(request: NextRequest, { params }: RouteMeta) {
+export async function GET(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   return asOrgAuthorized(
     {
       orgId: params.orgId,
@@ -40,7 +41,8 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
   );
 }
 
-export async function POST(request: NextRequest, { params }: RouteMeta) {
+export async function POST(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   await mongoose.connect(process.env.MONGODB_URL || '');
 
   const body: EventSignupBody = await request.json();
@@ -80,7 +82,8 @@ export async function POST(request: NextRequest, { params }: RouteMeta) {
   return NextResponse.json({ data: eventSignup }, { status: 201 });
 }
 
-export async function DELETE(request: NextRequest, { params }: RouteMeta) {
+export async function DELETE(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   return asOrgAuthorized(
     {
       orgId: params.orgId,

--- a/src/app/beta/orgs/[orgId]/locations/[locationId]/households/[householdId]/route.ts
+++ b/src/app/beta/orgs/[orgId]/locations/[locationId]/households/[householdId]/route.ts
@@ -12,14 +12,15 @@ import { HouseholdColorModel } from 'features/areaAssignments/models';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     householdId: string;
     locationId: string;
     orgId: string;
-  };
+  }>;
 };
 
-export async function GET(request: NextRequest, { params }: RouteMeta) {
+export async function GET(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   await mongoose.connect(process.env.MONGODB_URL || '');
   const headers: IncomingHttpHeaders = {};
   request.headers.forEach((value, key) => (headers[key] = value));
@@ -41,7 +42,8 @@ export async function GET(request: NextRequest, { params }: RouteMeta) {
   return NextResponse.json({ data: householdWithColor });
 }
 
-export async function PATCH(request: NextRequest, { params }: RouteMeta) {
+export async function PATCH(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   await mongoose.connect(process.env.MONGODB_URL || '');
 
   const payload = await request.json();

--- a/src/app/beta/orgs/[orgId]/locations/[locationId]/households/route.ts
+++ b/src/app/beta/orgs/[orgId]/locations/[locationId]/households/route.ts
@@ -11,13 +11,14 @@ import BackendApiClient from 'core/api/client/BackendApiClient';
 import { HouseholdColorModel } from 'features/areaAssignments/models';
 
 type RouteMeta = {
-  params: {
+  params: Promise<{
     locationId: string;
     orgId: string;
-  };
+  }>;
 };
 
-export async function GET(request: NextRequest, { params }: RouteMeta) {
+export async function GET(request: NextRequest, props: RouteMeta) {
+  const params = await props.params;
   await mongoose.connect(process.env.MONGODB_URL || '');
   const headers: IncomingHttpHeaders = {};
   request.headers.forEach((value, key) => (headers[key] = value));

--- a/src/app/call/[callAssId]/page.tsx
+++ b/src/app/call/[callAssId]/page.tsx
@@ -8,9 +8,9 @@ import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinCallAssignment } from 'utils/types/zetkin';
 
 type Props = {
-  params: {
+  params: Promise<{
     callAssId: string;
-  };
+  }>;
 };
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -20,9 +20,10 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function Page({ params }: Props) {
+export default async function Page(props: Props) {
+  const params = await props.params;
   await redirectIfLoginNeeded();
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/canvass/[areaAssId]/areas/[areaId]/page.tsx
+++ b/src/app/canvass/[areaAssId]/areas/[areaId]/page.tsx
@@ -7,15 +7,16 @@ import CanvassPage from 'features/canvass/components/CanvassPage';
 import { ApiClientError } from 'core/api/errors';
 
 interface PageProps {
-  params: {
+  params: Promise<{
     areaAssId: number;
     areaId: number;
-  };
+  }>;
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page(props: PageProps) {
+  const params = await props.params;
   const { areaAssId, areaId } = params;
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/canvass/[areaAssId]/areas/page.tsx
+++ b/src/app/canvass/[areaAssId]/areas/page.tsx
@@ -7,14 +7,15 @@ import CanvassSelectAreaPage from 'features/canvass/components/CanvassSelectArea
 import { ApiClientError } from 'core/api/errors';
 
 interface PageProps {
-  params: {
+  params: Promise<{
     areaAssId: number;
-  };
+  }>;
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page(props: PageProps) {
+  const params = await props.params;
   const { areaAssId } = params;
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/canvass/[areaAssId]/page.tsx
+++ b/src/app/canvass/[areaAssId]/page.tsx
@@ -7,14 +7,15 @@ import CanvassInstructionsPage from 'features/canvass/components/CanvassInstruct
 import { ApiClientError } from 'core/api/errors';
 
 interface PageProps {
-  params: {
+  params: Promise<{
     areaAssId: number;
-  };
+  }>;
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page(props: PageProps) {
+  const params = await props.params;
   const { areaAssId } = params;
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
@@ -25,9 +25,10 @@ export default async function RootLayout({
   }
 
   const lang =
-    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+    user?.lang ||
+    getBrowserLanguage((await headers()).get('accept-language') || '');
   const messages = await getMessages(lang);
-  const nonce = headers().get('x-nonce') ?? undefined;
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
 
   return (
     <html lang="en">

--- a/src/app/my/layout.tsx
+++ b/src/app/my/layout.tsx
@@ -10,10 +10,12 @@ import messageIds from 'features/my/l10n/messageIds';
 import { getSeoTags } from '../../utils/seoTags';
 
 export async function generateMetadata(): Promise<Metadata> {
-  const lang = getBrowserLanguage(headers().get('accept-language') || '');
+  const lang = getBrowserLanguage(
+    (await headers()).get('accept-language') || ''
+  );
   const messages = await getServerMessages(lang, messageIds);
 
-  const headersList = headers();
+  const headersList = await headers();
   const pathname = headersList.get('x-requested-path') || '';
   const lastSegment = pathname.split('/').pop() ?? 'home';
 

--- a/src/app/o/[orgId]/(home)/layout.tsx
+++ b/src/app/o/[orgId]/(home)/layout.tsx
@@ -12,13 +12,14 @@ import { ApiClientError } from 'core/api/errors';
 
 type Props = {
   children: ReactNode;
-  params: {
+  params: Promise<{
     orgId: number;
-  };
+  }>;
 };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const headersList = headers();
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
@@ -45,8 +46,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-const OrgLayout: FC<Props> = async ({ children, params }) => {
-  const headersList = headers();
+const OrgLayout: FC<Props> = async (props) => {
+  const params = await props.params;
+
+  const { children } = props;
+
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/(home)/page.tsx
+++ b/src/app/o/[orgId]/(home)/page.tsx
@@ -10,7 +10,8 @@ type Props = {
   };
 };
 
-const Page: FC<Props> = ({ params }) => {
+const Page: FC<Props> = async (props) => {
+  const params = await props.params;
   return <PublicOrgPage orgId={params.orgId} />;
 };
 

--- a/src/app/o/[orgId]/(home)/suborgs/page.tsx
+++ b/src/app/o/[orgId]/(home)/suborgs/page.tsx
@@ -10,7 +10,8 @@ type Props = {
   };
 };
 
-const Page: FC<Props> = ({ params }) => {
+const Page: FC<Props> = async (props) => {
+  const params = await props.params;
   return <SubOrgsPage orgId={params.orgId} />;
 };
 

--- a/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
+++ b/src/app/o/[orgId]/embedjoinform/[formData]/page.tsx
@@ -7,20 +7,22 @@ import { EmbeddedJoinFormData } from 'features/joinForms/types';
 import { getNonce } from 'core/utils/getNonce';
 
 type PageProps = {
-  params: {
+  params: Promise<{
     formData: string;
     orgId: string;
-  };
-  searchParams: {
+  }>;
+  searchParams: Promise<{
     stylesheet?: string;
-  };
+  }>;
 };
 
 function sanitizeUrl(urlStr: string): string {
   return new URL(urlStr).toString();
 }
 
-export default async function Page({ params, searchParams }: PageProps) {
+export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const params = await props.params;
   const { formData } = params;
 
   try {
@@ -31,7 +33,7 @@ export default async function Page({ params, searchParams }: PageProps) {
       Iron.defaults
     )) as EmbeddedJoinFormData;
 
-    const nonce = getNonce(Object.fromEntries(headers().entries()));
+    const nonce = getNonce(Object.fromEntries((await headers()).entries()));
 
     return (
       <div>

--- a/src/app/o/[orgId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/events.ics/route.ts
@@ -48,7 +48,8 @@ export async function GET(
   }
 
   const lang =
-    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+    user?.lang ||
+    getBrowserLanguage((await headers()).get('accept-language') || '');
 
   const ics = await icsFromEvents(org.title, events, org, lang);
 

--- a/src/app/o/[orgId]/events/[eventId]/cal.ics/route.ts
+++ b/src/app/o/[orgId]/events/[eventId]/cal.ics/route.ts
@@ -41,7 +41,8 @@ export async function GET(
   }
 
   const lang =
-    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+    user?.lang ||
+    getBrowserLanguage((await headers()).get('accept-language') || '');
 
   const ics = await icsFromEvents(org.title, [event], org, lang);
 

--- a/src/app/o/[orgId]/events/[eventId]/layout.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/layout.tsx
@@ -18,8 +18,9 @@ type Props = PropsWithChildren<{
   };
 }>;
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const headersList = headers();
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
@@ -29,7 +30,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       `/api/orgs/${params.orgId}/actions/${params.eventId}`
     );
 
-    const lang = getBrowserLanguage(headers().get('accept-language') || '');
+    const lang = getBrowserLanguage(
+      (await headers()).get('accept-language') || ''
+    );
     const messages = await getMessages(lang);
 
     const baseTitle =
@@ -60,8 +63,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 }
 
-const EventLayout: FC<Props> = async ({ children, params }) => {
-  const headersList = headers();
+const EventLayout: FC<Props> = async (props) => {
+  const params = await props.params;
+
+  const { children } = props;
+
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/events/[eventId]/page.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/page.tsx
@@ -9,14 +9,18 @@ import { PublicEventPage } from 'features/public/pages/PublicEventPage';
 import { ApiClientError } from 'core/api/errors';
 
 type Props = {
-  params: {
+  params: Promise<{
     eventId: string;
     orgId: number;
-  };
+  }>;
 };
 
-export default async function Page({ params: { eventId, orgId } }: Props) {
-  const headersList = headers();
+export default async function Page(props: Props) {
+  const params = await props.params;
+
+  const { eventId, orgId } = params;
+
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/joinformverified/page.tsx
+++ b/src/app/o/[orgId]/joinformverified/page.tsx
@@ -6,13 +6,14 @@ import { ZetkinOrganization } from 'utils/types/zetkin';
 import JoinFormVerifiedPage from 'features/public/components/JoinFormVerifiedPage';
 
 type PageProps = {
-  params: {
+  params: Promise<{
     orgId: string;
-  };
+  }>;
 };
 
-export default async function Page({ params }: PageProps) {
-  const headersList = headers();
+export default async function Page(props: PageProps) {
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
+++ b/src/app/o/[orgId]/projects/[projId]/events.ics/route.ts
@@ -52,7 +52,8 @@ export async function GET(
   }
 
   const lang =
-    user?.lang || getBrowserLanguage(headers().get('accept-language') || '');
+    user?.lang ||
+    getBrowserLanguage((await headers()).get('accept-language') || '');
 
   const ics = await icsFromEvents(project.title, events, org, lang);
 

--- a/src/app/o/[orgId]/projects/[projId]/layout.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/layout.tsx
@@ -12,14 +12,15 @@ import { getOrganizationOpenGraphTags, getSeoTags } from 'utils/seoTags';
 
 type Props = {
   children: ReactNode;
-  params: {
+  params: Promise<{
     orgId: number;
     projId: number;
-  };
+  }>;
 };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const headersList = headers();
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
@@ -43,8 +44,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-const MyHomeLayout: FC<Props> = async ({ children, params }) => {
-  const headersList = headers();
+const MyHomeLayout: FC<Props> = async (props) => {
+  const params = await props.params;
+
+  const { children } = props;
+
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/projects/[projId]/page.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/page.tsx
@@ -11,7 +11,8 @@ type Props = {
   };
 };
 
-const Page: FC<Props> = ({ params }) => {
+const Page: FC<Props> = async (props) => {
+  const params = await props.params;
   return <PublicProjPage orgId={params.orgId} projectId={params.projId} />;
 };
 

--- a/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/layout.tsx
@@ -14,13 +14,14 @@ import { getSeoTags } from 'utils/seoTags';
 
 type Props = {
   children: ReactNode;
-  params: {
+  params: Promise<{
     orgId: string;
     surveyId: string;
-  };
+  }>;
 };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params;
   const { orgId, surveyId } = params;
   const apiClient = new BackendApiClient({});
 
@@ -44,11 +45,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   );
 }
 
-const SurveyLayout: FC<Props> = async ({
-  children,
-  params,
-}): Promise<ReactElement> => {
-  const headersList = headers();
+const SurveyLayout: FC<Props> = async (props): Promise<ReactElement> => {
+  const params = await props.params;
+
+  const { children } = props;
+
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
+++ b/src/app/o/[orgId]/surveys/[surveyId]/page.tsx
@@ -16,8 +16,9 @@ type Props = {
   };
 };
 
-const Page: FC<Props> = async ({ params }) => {
-  const headersList = headers();
+const Page: FC<Props> = async (props) => {
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/unsubscribe/page.tsx
+++ b/src/app/o/[orgId]/unsubscribe/page.tsx
@@ -6,18 +6,20 @@ import UnsubscribePage from 'features/public/pages/UnsubscribePage';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 
 type PageProps = {
-  params: {
+  params: Promise<{
     orgId: string;
-  };
-  searchParams: {
+  }>;
+  searchParams: Promise<{
     senderEmail?: string;
     senderName?: string;
     unsub?: string;
-  };
+  }>;
 };
 
-export default async function Page({ params, searchParams }: PageProps) {
-  const headersList = headers();
+export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/unsubscribed/page.tsx
+++ b/src/app/o/[orgId]/unsubscribed/page.tsx
@@ -6,17 +6,19 @@ import UnsubscribedPage from 'features/public/pages/UnsubscribedPage';
 import { ZetkinOrganization } from 'utils/types/zetkin';
 
 type PageProps = {
-  params: {
+  params: Promise<{
     orgId: string;
-  };
-  searchParams: {
+  }>;
+  searchParams: Promise<{
     senderEmail?: string;
     senderName?: string;
-  };
+  }>;
 };
 
-export default async function Page({ params, searchParams }: PageProps) {
-  const headersList = headers();
+export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/o/[orgId]/viewmail/[emailId]/page.tsx
+++ b/src/app/o/[orgId]/viewmail/[emailId]/page.tsx
@@ -10,19 +10,22 @@ import renderEmailHtml from 'features/emails/utils/rendering/renderEmailHtml';
 import { ZetkinEmail } from 'utils/types/zetkin';
 
 type PageProps = {
-  params: {
+  params: Promise<{
     emailId: string;
     orgId: string;
-  };
+  }>;
 };
 
-export default async function Page({ params }: PageProps) {
+export default async function Page(props: PageProps) {
+  const params = await props.params;
   const { emailId, orgId } = params;
 
-  const lang = getBrowserLanguage(headers().get('accept-language') || '');
+  const lang = getBrowserLanguage(
+    (await headers()).get('accept-language') || ''
+  );
   const messages = await getServerMessages(lang, messageIds);
 
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,7 +6,7 @@ import { ZetkinOrganization } from 'utils/types/zetkin';
 import organizationsDef from 'features/public/rpc/organizations';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/sitemaps/o/[orgId]/sitemap.xml/route.ts
+++ b/src/app/sitemaps/o/[orgId]/sitemap.xml/route.ts
@@ -17,9 +17,10 @@ const getUrlsXml = <T>(ts: T[], urlGen: (t: T) => string) => {
 
 export async function GET(
   _: Request,
-  { params }: { params: { orgId: number } }
+  props: { params: Promise<{ orgId: number }> }
 ) {
-  const headersList = headers();
+  const params = await props.params;
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/app/verify/[token]/page.tsx
+++ b/src/app/verify/[token]/page.tsx
@@ -5,15 +5,16 @@ import redirectIfLoginNeeded from 'core/utils/redirectIfLoginNeeded';
 import BackendApiClient from 'core/api/client/BackendApiClient';
 
 interface PageProps {
-  params: {
+  params: Promise<{
     token: string;
-  };
+  }>;
 }
-export default async function Page({ params }: PageProps) {
+export default async function Page(props: PageProps) {
+  const params = await props.params;
   await redirectIfLoginNeeded();
 
   const { token } = params;
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);


### PR DESCRIPTION
## Description

This PR prepares Next 15 upgrade by migrating Next's request APIs to async via codemod:

```
npx @next/codemod@canary next-async-request-api src/app
```

Spun out of https://github.com/zetkin/app.zetkin.org/pull/3544

## Changes

Runs `npx @next/codemod@canary next-async-request-api src/app`

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Kinda Codex, but code changes are done via codemod.

## Instructions for reviewer

Changes only affect the app router. There, I believe all pages are updated. A merged branch with the route smoke suite (https://github.com/zetkin/app.zetkin.org/pull/3771) passes for me. 

## Related issues

Spun out of https://github.com/zetkin/app.zetkin.org/pull/3544

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
