### PR TITLE
Rename Playwright fixture callbacks (React 19 linting compatibility)

### DIFF
--- a/integrationTesting/fixtures/next.ts
+++ b/integrationTesting/fixtures/next.ts
@@ -183,7 +183,7 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
       scope: 'worker',
     },
   ],
-  login: async ({ moxy }, use) => {
+  login: async ({ moxy }, applyFixture) => {
     /**
      * Mocks the responses for getting the current user and the user session.
      *
@@ -207,9 +207,9 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
         factors: ['email_password', 'phone_otp'],
       });
     };
-    await use(login);
+    await applyFixture(login);
   },
-  logout: async ({ moxy }, use) => {
+  logout: async ({ moxy }, applyFixture) => {
     /**
      * Removes mock responses for getting the current user and session. Does not navigate user to log out,
      * this is only used for handling the mocks, which unauthenticates the user.
@@ -219,9 +219,9 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
       moxy.removeMock('/session', 'get');
       moxy.removeMock('/users/me/memberships', 'get');
     };
-    await use(logout);
+    await applyFixture(logout);
   },
-  setBrowserDate: async ({ page }, use) => {
+  setBrowserDate: async ({ page }, applyFixture) => {
     const setBrowserDate = async (date: Date) => {
       // Pick the new/fake "now" for you test pages.
       const fakeNow = new Date(date).valueOf();
@@ -244,7 +244,7 @@ const test = base.extend<NextTestFixtures, NextWorkerFixtures>({
       Date.now = () => __DateNow() + __DateNowOffset;
     }`);
     };
-    await use(setBrowserDate);
+    await applyFixture(setBrowserDate);
   },
 });
 


### PR DESCRIPTION
## Description

This PR renames fixture callbacks to `applyFixture`. The motivation is that when upgrading to React 19, eslint ends up complaining about the usage of `use` in our tests, thinking it is the new "hook" that is not actually a hook `use`. I decided to rename it rather than disabling the linter check, since this codebase emphathises descriptive names for things, and `use` is less descriptive than `applyFixture` for example.

## Changes

- Renames `use` -> `applyFixture`

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Codex did it

## Instructions for reviewer

Run playwright tests

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
