### PR TITLE
Migrate remaining request API usages to async (Next 15 compatibility)

### DIFF
--- a/src/app/api2/[...path]/route.ts
+++ b/src/app/api2/[...path]/route.ts
@@ -7,9 +7,9 @@ import { stringToBool } from 'utils/stringUtils';
 import { AppSession } from 'utils/types';
 
 type Context = {
-  params: {
+  params: Promise<{
     path: string[];
-  };
+  }>;
 };
 
 export const GET = proxy;
@@ -28,7 +28,7 @@ async function proxy(
   const port = process.env.ZETKIN_API_PORT;
   const ssl = stringToBool(process.env.ZETKIN_USE_TLS);
 
-  const path = context.params.path;
+  const path = (await context.params).path;
   const pathStr = path.join('/');
 
   const protocol = ssl ? 'https' : 'http';

--- a/src/app/o/[orgId]/(home)/layout.tsx
+++ b/src/app/o/[orgId]/(home)/layout.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       ...baseTags,
       openGraph: {
         ...baseTags.openGraph,
-        ...getOrganizationOpenGraphTags(org),
+        ...(await getOrganizationOpenGraphTags(org)),
       },
       robots: { follow: true, index: org.is_public },
     };

--- a/src/app/o/[orgId]/projects/[projId]/layout.tsx
+++ b/src/app/o/[orgId]/projects/[projId]/layout.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     ...baseTags,
     openGraph: {
       ...baseTags.openGraph,
-      ...getOrganizationOpenGraphTags(project.organization),
+      ...(await getOrganizationOpenGraphTags(project.organization)),
     },
     robots: { follow: true, index: project.published },
   };

--- a/src/core/utils/redirectIfLoginNeeded.ts
+++ b/src/core/utils/redirectIfLoginNeeded.ts
@@ -29,7 +29,7 @@ export default async function redirectIfLoginNeeded(
 ) {
   const { allowUnverified } = config;
 
-  const headersList = headers();
+  const headersList = await headers();
   const path = headersList.get('x-requested-path') || '';
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);

--- a/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
+++ b/src/features/joinForms/actions/submitEmbeddedJoinForm.ts
@@ -10,7 +10,7 @@ export default async function submitJoinForm(
   prevState: EmbeddedJoinFormStatus,
   inputFormData: FormData
 ): Promise<EmbeddedJoinFormStatus> {
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/features/surveys/actions/submit.ts
+++ b/src/features/surveys/actions/submit.ts
@@ -14,7 +14,7 @@ export async function submit(
   prevState: ZetkinSurveyFormStatus,
   formData: FormData
 ): Promise<ZetkinSurveyFormStatus> {
-  const headersList = headers();
+  const headersList = await headers();
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -79,7 +79,7 @@ export async function middleware(request: NextRequest) {
     return path.startsWith(route);
   });
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   const session = await getIronSession<AppSession>(cookieStore, {
     cookieName: 'zsid',

--- a/src/utils/seoTags.ts
+++ b/src/utils/seoTags.ts
@@ -63,13 +63,13 @@ export const getSeoTags = (
   };
 };
 
-export const getOrganizationOpenGraphTags = (
+export const getOrganizationOpenGraphTags = async (
   org: ZetkinOrganization
-): OpenGraph => {
+): Promise<OpenGraph> => {
   let regionNames: Intl.DisplayNames;
   try {
     regionNames = new Intl.DisplayNames(
-      [headers().get('accept-language')?.split('-')[0] || 'en'],
+      [(await headers()).get('accept-language')?.split('-')[0] || 'en'],
       { type: 'region' }
     );
   } catch (_e) {


### PR DESCRIPTION
## Description

This PR migrates the remaining instances of the request API to async for Next 15 compatibility. This extends the work done in https://github.com/zetkin/app.zetkin.org/pull/3792, which focused on app router changes. This PR contains the remaining migrations.

## Changes

- Updates some instances of Next request API to async

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Yes, Codex did it

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

Run tests. I ran the route smoke suite against it and it also succeded. (#3771)

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
