### PR TITLE
Set up resource streaming

### DIFF
--- a/src/app/o/[orgId]/events/[eventId]/page.tsx
+++ b/src/app/o/[orgId]/events/[eventId]/page.tsx
@@ -7,6 +7,9 @@ import BackendApiClient from 'core/api/client/BackendApiClient';
 import { ZetkinEvent } from 'utils/types/zetkin';
 import { PublicEventPage } from 'features/public/pages/PublicEventPage';
 import { ApiClientError } from 'core/api/errors';
+import prefetchResource from 'core/resources/prefetchResource';
+import { ResourceProvider } from 'core/resources/ResourceProvider';
+import myEventsResource from 'features/my/resources/myEventsResource';
 
 type Props = {
   params: {
@@ -20,6 +23,8 @@ export default async function Page({ params: { eventId, orgId } }: Props) {
   const headersEntries = headersList.entries();
   const headersObject = Object.fromEntries(headersEntries);
   const apiClient = new BackendApiClient(headersObject);
+  const today = new Date().toISOString().slice(0, 10);
+  const myEvents = prefetchResource(apiClient, myEventsResource, { today });
 
   const privacyUrl =
     process.env.ZETKIN_PRIVACY_POLICY_LINK || 'https://zetkin.org/privacy';
@@ -30,11 +35,13 @@ export default async function Page({ params: { eventId, orgId } }: Props) {
     );
 
     return (
-      <PublicEventPage
-        eventId={event.id}
-        orgId={event.organization.id}
-        privacyUrl={privacyUrl}
-      />
+      <ResourceProvider resources={[myEvents]}>
+        <PublicEventPage
+          eventId={event.id}
+          orgId={event.organization.id}
+          privacyUrl={privacyUrl}
+        />
+      </ResourceProvider>
     );
   } catch (e) {
     if (e instanceof ApiClientError && e.status === 404) {

--- a/src/core/resources/ResourceProvider.tsx
+++ b/src/core/resources/ResourceProvider.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useRef,
+} from 'react';
+
+import { StreamedResource } from './types';
+
+type ResourceCache = {
+  parent: ResourceCache | null;
+  serverResources: Map<string, Promise<unknown>>;
+  wrappedResources: Map<string, Promise<unknown>>;
+};
+
+const ResourceContext = createContext<ResourceCache | null>(null);
+
+type Props = PropsWithChildren<{
+  resources: StreamedResource[];
+}>;
+
+export const ResourceProvider: FC<Props> = ({ children, resources }) => {
+  const parent = useContext(ResourceContext);
+  const cacheRef = useRef<ResourceCache | null>(null);
+
+  if (!cacheRef.current) {
+    cacheRef.current = {
+      parent,
+      serverResources: new Map(),
+      wrappedResources: new Map(),
+    };
+  }
+
+  resources.forEach(({ key, resource }) => {
+    if (!cacheRef.current?.serverResources.has(key)) {
+      cacheRef.current?.serverResources.set(key, resource);
+    }
+  });
+
+  return (
+    <ResourceContext.Provider value={cacheRef.current}>
+      {children}
+    </ResourceContext.Provider>
+  );
+};
+
+export function useResourceCache() {
+  const cache = useContext(ResourceContext);
+
+  if (!cache) {
+    throw new Error('ResourceProvider is missing');
+  }
+
+  return cache;
+}

--- a/src/core/resources/createRemoteListResource.ts
+++ b/src/core/resources/createRemoteListResource.ts
@@ -1,0 +1,7 @@
+import { RemoteListResource } from './types';
+
+export default function createRemoteListResource<Context, Data>(
+  createConfig: RemoteListResource<Context, Data>['createConfig']
+): RemoteListResource<Context, Data> {
+  return { createConfig };
+}

--- a/src/core/resources/prefetchResource.ts
+++ b/src/core/resources/prefetchResource.ts
@@ -1,0 +1,15 @@
+import IApiClient from 'core/api/client/IApiClient';
+import { RemoteListResource, StreamedResource } from './types';
+
+export default function prefetchResource<Context, Data>(
+  apiClient: IApiClient,
+  definition: RemoteListResource<Context, Data>,
+  context: Context
+): StreamedResource {
+  const config = definition.createConfig(context);
+
+  return {
+    key: config.cacheKey,
+    resource: config.loader(apiClient),
+  };
+}

--- a/src/core/resources/types.ts
+++ b/src/core/resources/types.ts
@@ -1,0 +1,21 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import IApiClient from 'core/api/client/IApiClient';
+import { RootState } from 'core/store';
+import { RemoteList } from 'utils/storeUtils';
+
+export type RemoteListResource<Context, Data> = {
+  createConfig: (context: Context) => {
+    actionOnError?: (error: unknown) => PayloadAction<unknown>;
+    actionOnLoad: () => PayloadAction<unknown>;
+    actionOnSuccess: (data: Data[]) => PayloadAction<unknown>;
+    cacheKey: string;
+    loader: (apiClient: IApiClient) => Promise<Data[]>;
+    selector: (state: RootState) => RemoteList<Data> | undefined;
+  };
+};
+
+export type StreamedResource = {
+  key: string;
+  resource: Promise<unknown>;
+};

--- a/src/core/resources/useResource.ts
+++ b/src/core/resources/useResource.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import shouldLoad from 'core/caching/shouldLoad';
 import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
 import { useResourceCache } from './ResourceProvider';
@@ -23,6 +25,14 @@ export default function useResource<Context, Data>(
   const dispatch = useAppDispatch();
   const config = definition.createConfig(context);
   const remoteList = useAppSelector(config.selector);
+  const data = useMemo(
+    () =>
+      remoteList?.items
+        .filter((item) => !item.deleted)
+        .map((item) => item.data)
+        .filter((data): data is Data => data != null) ?? [],
+    [remoteList?.items]
+  );
   const existingResource = findResource(
     cache,
     'wrappedResources',
@@ -75,10 +85,5 @@ export default function useResource<Context, Data>(
     throw wrappedResource;
   }
 
-  return (
-    remoteList?.items
-      .filter((item) => !item.deleted)
-      .map((item) => item.data)
-      .filter((data): data is Data => data != null) ?? []
-  );
+  return data;
 }

--- a/src/core/resources/useResource.ts
+++ b/src/core/resources/useResource.ts
@@ -1,0 +1,84 @@
+import shouldLoad from 'core/caching/shouldLoad';
+import { useApiClient, useAppDispatch, useAppSelector } from 'core/hooks';
+import { useResourceCache } from './ResourceProvider';
+import { RemoteListResource } from './types';
+
+function findResource(
+  cache: ReturnType<typeof useResourceCache>,
+  collection: 'serverResources' | 'wrappedResources',
+  key: string
+): Promise<unknown> | undefined {
+  return (
+    cache[collection].get(key) ??
+    (cache.parent ? findResource(cache.parent, collection, key) : undefined)
+  );
+}
+
+export default function useResource<Context, Data>(
+  definition: RemoteListResource<Context, Data>,
+  context: Context
+): Data[] {
+  const apiClient = useApiClient();
+  const cache = useResourceCache();
+  const dispatch = useAppDispatch();
+  const config = definition.createConfig(context);
+  const remoteList = useAppSelector(config.selector);
+  const existingResource = findResource(
+    cache,
+    'wrappedResources',
+    config.cacheKey
+  );
+
+  if (!remoteList?.loaded && existingResource) {
+    throw existingResource;
+  }
+
+  if (shouldLoad(remoteList)) {
+    let wrappedResource = existingResource;
+
+    if (!wrappedResource) {
+      const serverResource = findResource(
+        cache,
+        'serverResources',
+        config.cacheKey
+      );
+
+      if (!serverResource && typeof window === 'undefined') {
+        throw new Error(
+          `Resource ${config.cacheKey} was not provided by the server`
+        );
+      }
+
+      wrappedResource = Promise.resolve()
+        .then(() => dispatch(config.actionOnLoad()))
+        .then(() => serverResource ?? config.loader(apiClient))
+        .then((data) => {
+          dispatch(config.actionOnSuccess(data as Data[]));
+        })
+        .catch((error) => {
+          if (config.actionOnError) {
+            dispatch(config.actionOnError(error));
+          } else {
+            throw error;
+          }
+        });
+      cache.wrappedResources.set(config.cacheKey, wrappedResource);
+      cache.serverResources.delete(config.cacheKey);
+      const removeResource = () => {
+        if (cache.wrappedResources.get(config.cacheKey) === wrappedResource) {
+          cache.wrappedResources.delete(config.cacheKey);
+        }
+      };
+      wrappedResource.then(removeResource, removeResource);
+    }
+
+    throw wrappedResource;
+  }
+
+  return (
+    remoteList?.items
+      .filter((item) => !item.deleted)
+      .map((item) => item.data)
+      .filter((data): data is Data => data != null) ?? []
+  );
+}

--- a/src/features/my/hooks/useMyEvents.ts
+++ b/src/features/my/hooks/useMyEvents.ts
@@ -1,53 +1,7 @@
-import { useApiClient, useAppSelector } from 'core/hooks';
-import useRemoteList from 'core/hooks/useRemoteList';
-import { userEventsLoad, userEventsLoaded } from '../../events/store';
-import { ZetkinEvent } from 'utils/types/zetkin';
-import { ZetkinEventWithStatus } from 'features/public/types';
+import useResource from 'core/resources/useResource';
+import myEventsResource from '../resources/myEventsResource';
 
 export default function useMyEvents() {
-  const apiClient = useApiClient();
-  const list = useAppSelector((state) => state.events.userEventList);
-
-  const now = new Date();
-  const today = now.toISOString().slice(0, 10);
-  const url = `/api/users/me/actions?filter=end_time>=${today}`;
-
-  return useRemoteList(list, {
-    actionOnLoad: () => userEventsLoad(),
-    actionOnSuccess: (data) => userEventsLoaded(data),
-    cacheKey: url,
-    loader: async () => {
-      const bookedEventIds: number[] = [];
-
-      try {
-        const bookedEvents = await apiClient
-          .get<ZetkinEvent[]>(url)
-          .then((events) =>
-            events.map<ZetkinEventWithStatus>((event) => {
-              bookedEventIds.push(event.id);
-              return {
-                ...event,
-                status: 'booked',
-              };
-            })
-          );
-
-        const signedUpEvents = await apiClient
-          .get<{ action: ZetkinEvent }[]>(`/api/users/me/action_responses`)
-          .then((events) =>
-            events
-              .map<ZetkinEventWithStatus>((signup) => ({
-                ...signup.action,
-                status: 'signedUp',
-              }))
-              .filter((event) => !bookedEventIds.includes(event.id))
-              .filter(({ end_time }) => end_time >= today)
-          );
-
-        return [...bookedEvents, ...signedUpEvents];
-      } catch (err) {
-        return [];
-      }
-    },
-  });
+  const today = new Date().toISOString().slice(0, 10);
+  return useResource(myEventsResource, { today });
 }

--- a/src/features/my/hooks/useMyEvents.ts
+++ b/src/features/my/hooks/useMyEvents.ts
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
+
 import useResource from 'core/resources/useResource';
 import myEventsResource from '../resources/myEventsResource';
 
 export default function useMyEvents() {
   const today = new Date().toISOString().slice(0, 10);
-  return useResource(myEventsResource, { today });
+  const context = useMemo(() => ({ today }), [today]);
+  return useResource(myEventsResource, context);
 }

--- a/src/features/my/resources/myEventsResource.ts
+++ b/src/features/my/resources/myEventsResource.ts
@@ -1,0 +1,46 @@
+import createRemoteListResource from 'core/resources/createRemoteListResource';
+import { userEventsLoad, userEventsLoaded } from 'features/events/store';
+import { ZetkinEventWithStatus } from 'features/public/types';
+import { ZetkinEvent } from 'utils/types/zetkin';
+
+const myEventsResource = createRemoteListResource<
+  { today: string },
+  ZetkinEventWithStatus
+>(({ today }: { today: string }) => ({
+  actionOnLoad: () => userEventsLoad(),
+  actionOnSuccess: (events) => userEventsLoaded(events),
+  cacheKey: `user-events:${today}`,
+  loader: async (apiClient) => {
+    const bookedEventIds: number[] = [];
+
+    try {
+      const bookedEvents = await apiClient
+        .get<ZetkinEvent[]>(`/api/users/me/actions?filter=end_time>=${today}`)
+        .then((events) =>
+          events.map<ZetkinEventWithStatus>((event) => {
+            bookedEventIds.push(event.id);
+            return { ...event, status: 'booked' };
+          })
+        );
+
+      const signedUpEvents = await apiClient
+        .get<{ action: ZetkinEvent }[]>('/api/users/me/action_responses')
+        .then((responses) =>
+          responses
+            .map<ZetkinEventWithStatus>(({ action }) => ({
+              ...action,
+              status: 'signedUp',
+            }))
+            .filter((event) => !bookedEventIds.includes(event.id))
+            .filter(({ end_time }) => end_time >= today)
+        );
+
+      return [...bookedEvents, ...signedUpEvents];
+    } catch (err) {
+      return [];
+    }
+  },
+  selector: (state) => state.events.userEventList,
+}));
+
+export default myEventsResource;


### PR DESCRIPTION
## Description

This PR is a concept for one solution to the suspense waterfall + double fetching problem. 

The idea is to move all resource fetches that are **required to render the page part** into the server-side `page.tsx` / `layout.tsx`. We then output the promise into a `ResourceProvider`. This provider provides these promises and supports nesting. Within the client, we now wrap the promise with the redux reducer calls and suspend until this is done. The same `useResource` hook supports emitting fetches as well. But not during server side generation, avoiding the double fetching problem. That way, when you'd load some page, it gets streamed to the client and when you switch tabs, we emit a new fetch client side. (unless it is a nextjs navigation event, then it likely re-prefetches. need to test that more. see below)

Very much inline with https://nextjs.org/docs/app/guides/streaming but adjusted to Zetkin's Redux cache.

## Things I want to think about more before merging any of this

- Error handling
- What about complex resource hooks
- Connection to the pending work on the index-based redux store
- Set up tests
- What happens when you havigate to another instance of the same page using a nextjs navigation event? Resources get re-prerendered? Is that good and can they be cached? We'd probably want to cache these things by moving all page-independent fetches (like say memberships) into `layout.tsx` instead of the `page.tsx`, so they don't get re-triggered on navigation.

## Screenshots

[Add screenshots here]

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Adds…
- Changes…

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

- Url to where in the app you can interact with it (for example: "Go to /organize/1/people/lists/2")
- Notes on what to do (for example: "Add a tag column, then click in an empty cell.")
- Notes about other potential things that could be of value to the reviewer (for example: "Have not tested it in Chrome!")

## Related issues

Alternative approach to https://github.com/zetkin/app.zetkin.org/pull/3718 - we do still suspend, but don't have the waterfall and don't have the double fetch problem. 

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
