### PR TITLE
Make CSP less strict in dev mode

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,11 +41,12 @@ function setupCsp(path: string) {
         // TODO: switch after https://github.com/zetkin/app.zetkin.org/issues/3176 to: isDev ? "'unsafe-inline'" : `'nonce-${nonce}'`
         "'unsafe-inline'"
       }`;
+  const scriptSrc = isDev
+    ? "'self' 'wasm-unsafe-eval' 'unsafe-eval' 'unsafe-inline'"
+    : `'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic'`;
   const cspHeader = `
   default-src 'self' ${mapTiler};
-  script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval' ${
-    isDev ? "'unsafe-eval'" : "'strict-dynamic'"
-  };
+  script-src ${scriptSrc};
   style-src ${styleSrc};
   style-src-attr 'unsafe-inline';
   img-src 'self' blob: data: ${tileServer} ${

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,8 +43,8 @@ function setupCsp(path: string) {
       }`;
   const cspHeader = `
   default-src 'self' ${mapTiler};
-  script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval' 'strict-dynamic' ${
-    isDev ? "'unsafe-eval'" : ''
+  script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval' ${
+    isDev ? "'unsafe-eval'" : "'strict-dynamic'"
   };
   style-src ${styleSrc};
   style-src-attr 'unsafe-inline';


### PR DESCRIPTION
## Description

This PR makes the CSP less strict in dev mode. Since next seems to not emit nonces in dev mode on some mui and other scripts under the app router (caller interface for example), I believe this is the most sensible way to enable the loading of those scripts again.

## Changes

[Add a list of features added/changed, bugs fixed etc]

- Updates dev mode CSP

## AI usage

Did you use AI to create the code in this PR?

If yes - how?

Codex

## Instructions for reviewer

Add instructions for how the reviewer tests that what you've built works.

Run Zetkin locally. I believe the preview deployment will fool us.

- Go to localhost:3000/my/home
- Look at console and see if it throws any CSP errors
- Select a call assignment
- Again look at the console

There should be no CSP errors anymore.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
