### PR TITLE
Make call log visible on start page again

### DIFF
--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -23,6 +23,10 @@ import CallHeader from './CallHeader';
 import CallPanels from './CallPanels';
 import ZUILink from 'zui/components/ZUILink';
 
+const HEIGHT_OF_HEADER = '100px';
+//TODO Delete this when removing new ui alert
+const HEIGHT_OF_NEW_UI_ALERT = '56px';
+
 type Props = {
   onResetAfterError: (urlToNavigateTo: string) => void;
 };
@@ -155,7 +159,11 @@ const Call: FC<Props> = ({ onResetAfterError }) => {
           onSkipCall={() => setSkipCallModalOpen(true)}
           report={report}
         />
-        <Box height="calc(100dvh - 100px)" position="relative" width="100%">
+        <Box
+          height={`calc(100dvh - ${HEIGHT_OF_HEADER} ${lane.step === LaneStep.START ? `- ${HEIGHT_OF_NEW_UI_ALERT}` : ''})`}
+          position="relative"
+          width="100%"
+        >
           <CallPanels
             assignment={assignment}
             call={call}

--- a/src/features/call/components/Call.tsx
+++ b/src/features/call/components/Call.tsx
@@ -46,6 +46,7 @@ const NewUIAlert: FC<{ assignmentId: number }> = ({ assignmentId }) => {
           color: theme.palette.swatches.blue[textShade],
           display: 'flex',
           gap: '1rem',
+          height: HEIGHT_OF_NEW_UI_ALERT,
           padding: '1rem',
           textDecorationColor: theme.palette.swatches.blue[textShade],
         };


### PR DESCRIPTION
## Description

This PR fixes a small error after adding the new "welcome to the new call ui" alert, where i had missed to consider the height of the alert in the calcluation of the height of the page content, so the call log would not be visible

## Screenshots

<img width="1416" height="891" alt="bild" src="https://github.com/user-attachments/assets/e23fb3e4-1168-4053-a42c-88d81136430e" />

## Changes

- sets alert height to a fixed height
- uses that height when calculating page content height

## AI usage
no 

## Instructions for reviewer
- go to /my
- go into call assignment "chat with the cats"
- see that the call log is visible in the start page

## Related issues
none

## PR checklist

- [ ] I have run the code, tried out the changes I made and I think they work
- [ ] I have not included any changes outside the scope of the task I'm working on
- [ ] I have made sure that formatting, linting and type checks pass locally
- [ ] I have filled out this template and replaced all placeholders with the corresponding information
