### PR TITLE
implement min/max filter for logged calls

### DIFF
--- a/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
@@ -1,5 +1,6 @@
 import DisplayCallAssignmentTitle from '../CallHistory/DisplayCallAssignmentTitle';
 import { Msg } from 'core/i18n';
+import { getLoggedCallCountWithConfig } from './utils';
 import {
   CallerParticipationFilterConfig,
   OPERATION,
@@ -8,8 +9,6 @@ import {
 import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import { useNumericRouteParams } from 'core/hooks';
-
-const localMessageIds = messageIds.filters.callerParticipation;
 
 interface DisplayCallerParticipationProps {
   filter: SmartSearchFilterWithId<CallerParticipationFilterConfig>;
@@ -21,10 +20,12 @@ const DisplayCallerParticipation = ({
   const { orgId } = useNumericRouteParams();
   const assignmentId = filter.config.assignment;
   const op = filter.op || OPERATION.ADD;
+  const { config: callCountConfig, option: callCountOption } =
+    getLoggedCallCountWithConfig(filter.config.num_calls);
 
   return (
     <Msg
-      id={localMessageIds.previewString}
+      id={messageIds.filters.callerParticipation.previewString}
       values={{
         addRemoveSelect: <UnderlinedMsg id={messageIds.operators[op]} />,
         assignmentSelect: assignmentId ? (
@@ -33,7 +34,22 @@ const DisplayCallerParticipation = ({
             orgId={orgId}
           />
         ) : (
-          <UnderlinedMsg id={localMessageIds.assignmentSelect.any} />
+          <UnderlinedMsg
+            id={messageIds.filters.callerParticipation.assignmentSelect.any}
+          />
+        ),
+        callCountSelect: (
+          <UnderlinedMsg
+            id={
+              messageIds.filters.callerParticipation.callCount.preview[
+                callCountOption
+              ]
+            }
+            values={{
+              max: callCountConfig?.max ?? 0,
+              min: callCountConfig?.min ?? 0,
+            }}
+          />
         ),
       }}
     />

--- a/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
@@ -3,6 +3,7 @@ import { Msg } from 'core/i18n';
 import { getLoggedCallCountWithConfig } from './utils';
 import {
   CallerParticipationFilterConfig,
+  MATCHING,
   OPERATION,
   SmartSearchFilterWithId,
 } from 'features/smartSearch/components/types';
@@ -16,14 +17,31 @@ interface DisplayCallerParticipationProps {
   filter: SmartSearchFilterWithId<CallerParticipationFilterConfig>;
 }
 
+const getCallCountPreview = (
+  callCount: ReturnType<typeof getLoggedCallCountWithConfig>
+) => {
+  if (callCount.option === MATCHING.ONCE) {
+    return <UnderlinedMsg id={localMessageIds.callCount.preview.once} />;
+  }
+
+  return (
+    <UnderlinedMsg
+      id={localMessageIds.callCount.preview[callCount.option]}
+      values={{
+        max: callCount.config?.max ?? 0,
+        min: callCount.config?.min ?? 0,
+      }}
+    />
+  );
+};
+
 const DisplayCallerParticipation = ({
   filter,
 }: DisplayCallerParticipationProps): JSX.Element => {
   const { orgId } = useNumericRouteParams();
   const assignmentId = filter.config.assignment;
   const op = filter.op || OPERATION.ADD;
-  const { config: callCountConfig, option: callCountOption } =
-    getLoggedCallCountWithConfig(filter.config.num_calls);
+  const callCount = getLoggedCallCountWithConfig(filter.config.num_calls);
 
   return (
     <Msg
@@ -38,15 +56,7 @@ const DisplayCallerParticipation = ({
         ) : (
           <UnderlinedMsg id={localMessageIds.assignmentSelect.any} />
         ),
-        callCountSelect: (
-          <UnderlinedMsg
-            id={localMessageIds.callCount.preview[callCountOption]}
-            values={{
-              max: callCountConfig?.max ?? 0,
-              min: callCountConfig?.min ?? 0,
-            }}
-          />
-        ),
+        callCountSelect: getCallCountPreview(callCount),
       }}
     />
   );

--- a/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/DisplayCallerParticipation.tsx
@@ -10,6 +10,8 @@ import messageIds from 'features/smartSearch/l10n/messageIds';
 import UnderlinedMsg from '../../UnderlinedMsg';
 import { useNumericRouteParams } from 'core/hooks';
 
+const localMessageIds = messageIds.filters.callerParticipation;
+
 interface DisplayCallerParticipationProps {
   filter: SmartSearchFilterWithId<CallerParticipationFilterConfig>;
 }
@@ -25,7 +27,7 @@ const DisplayCallerParticipation = ({
 
   return (
     <Msg
-      id={messageIds.filters.callerParticipation.previewString}
+      id={localMessageIds.previewString}
       values={{
         addRemoveSelect: <UnderlinedMsg id={messageIds.operators[op]} />,
         assignmentSelect: assignmentId ? (
@@ -34,17 +36,11 @@ const DisplayCallerParticipation = ({
             orgId={orgId}
           />
         ) : (
-          <UnderlinedMsg
-            id={messageIds.filters.callerParticipation.assignmentSelect.any}
-          />
+          <UnderlinedMsg id={localMessageIds.assignmentSelect.any} />
         ),
         callCountSelect: (
           <UnderlinedMsg
-            id={
-              messageIds.filters.callerParticipation.callCount.preview[
-                callCountOption
-              ]
-            }
+            id={localMessageIds.callCount.preview[callCountOption]}
             values={{
               max: callCountConfig?.max ?? 0,
               min: callCountConfig?.min ?? 0,

--- a/src/features/smartSearch/components/filters/CallerParticipation/LoggedCallCount.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/LoggedCallCount.tsx
@@ -1,7 +1,10 @@
 import { MenuItem, Typography } from '@mui/material';
 import { useState } from 'react';
 
-import { getLoggedCallCountWithConfig } from './utils';
+import {
+  getLoggedCallCountWithConfig,
+  normalizeLoggedCallCountConfig,
+} from './utils';
 import { MATCHING } from 'features/smartSearch/components/types';
 import { Msg } from 'core/i18n';
 import StyledNumberInput from '../../inputs/StyledNumberInput';
@@ -18,22 +21,38 @@ interface LoggedCallCountProps {
 const DEFAULT_MIN = 1;
 const DEFAULT_MAX = 5;
 
+const MIN_CALL_COUNT = 1;
+
 const getLoggedCallCountConfig = (
   option: MATCHING,
   range: { max?: number; min?: number }
 ) => {
   if (option === MATCHING.MAX) {
-    return { max: range.max || DEFAULT_MAX, min: undefined };
+    return {
+      max: Math.max(MIN_CALL_COUNT, range.max ?? DEFAULT_MAX),
+      min: undefined,
+    };
   } else if (option === MATCHING.MIN) {
-    return { max: undefined, min: range.min || DEFAULT_MIN };
+    return {
+      max: undefined,
+      min: Math.max(MIN_CALL_COUNT, range.min ?? DEFAULT_MIN),
+    };
   } else if (option === MATCHING.BETWEEN) {
     return {
-      max: range.max || DEFAULT_MAX,
-      min: range.min || DEFAULT_MIN,
+      max: Math.max(MIN_CALL_COUNT, range.max ?? DEFAULT_MAX),
+      min: Math.max(MIN_CALL_COUNT, range.min ?? DEFAULT_MIN),
     };
   }
 
   return { max: undefined, min: DEFAULT_MIN };
+};
+
+const getCallCountInputValue = (value: string) => {
+  if (!value) {
+    return MIN_CALL_COUNT;
+  }
+
+  return +value;
 };
 
 const LoggedCallCount = ({
@@ -60,6 +79,18 @@ const LoggedCallCount = ({
     onChange(getLoggedCallCountConfig(option, { max: updatedMax, min }));
   };
 
+  const handleBlur = () => {
+    if (option === MATCHING.BETWEEN) {
+      const normalizedConfig = normalizeLoggedCallCountConfig({
+        max: max ?? DEFAULT_MAX,
+        min: min ?? DEFAULT_MIN,
+      });
+      setMax(normalizedConfig.max);
+      setMin(normalizedConfig.min);
+      onChange(normalizedConfig);
+    }
+  };
+
   const callCountSelect = (
     <StyledSelect
       onChange={(event) => handleOptionChange(event.target.value as MATCHING)}
@@ -75,15 +106,23 @@ const LoggedCallCount = ({
 
   const minInput = (
     <StyledNumberInput
-      onChange={(event) => handleMinChange(+event.target.value)}
-      value={min || DEFAULT_MIN}
+      onBlur={handleBlur}
+      onChange={(event) =>
+        handleMinChange(getCallCountInputValue(event.target.value))
+      }
+      slotProps={{ htmlInput: { min: '1' } }}
+      value={min ?? DEFAULT_MIN}
     />
   );
 
   const maxInput = (
     <StyledNumberInput
-      onChange={(event) => handleMaxChange(+event.target.value)}
-      value={max || DEFAULT_MAX}
+      onBlur={handleBlur}
+      onChange={(event) =>
+        handleMaxChange(getCallCountInputValue(event.target.value))
+      }
+      slotProps={{ htmlInput: { min: '1' } }}
+      value={max ?? DEFAULT_MAX}
     />
   );
 
@@ -98,13 +137,13 @@ const LoggedCallCount = ({
       {option === MATCHING.MAX && (
         <Msg
           id={localMessageIds.edit.max}
-          values={{ callCountSelect, max: max || DEFAULT_MAX, maxInput }}
+          values={{ callCountSelect, max: max ?? DEFAULT_MAX, maxInput }}
         />
       )}
       {option === MATCHING.MIN && (
         <Msg
           id={localMessageIds.edit.min}
-          values={{ callCountSelect, min: min || DEFAULT_MIN, minInput }}
+          values={{ callCountSelect, min: min ?? DEFAULT_MIN, minInput }}
         />
       )}
       {option === MATCHING.ONCE && (

--- a/src/features/smartSearch/components/filters/CallerParticipation/LoggedCallCount.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/LoggedCallCount.tsx
@@ -1,0 +1,117 @@
+import { MenuItem, Typography } from '@mui/material';
+import { useState } from 'react';
+
+import { getLoggedCallCountWithConfig } from './utils';
+import { MATCHING } from 'features/smartSearch/components/types';
+import { Msg } from 'core/i18n';
+import StyledNumberInput from '../../inputs/StyledNumberInput';
+import StyledSelect from '../../inputs/StyledSelect';
+import messageIds from 'features/smartSearch/l10n/messageIds';
+
+const localMessageIds = messageIds.filters.callerParticipation.callCount;
+
+interface LoggedCallCountProps {
+  filterConfig: { max?: number; min?: number };
+  onChange: (range: { max?: number; min?: number }) => void;
+}
+
+const DEFAULT_MIN = 1;
+const DEFAULT_MAX = 5;
+
+const getLoggedCallCountConfig = (
+  option: MATCHING,
+  range: { max?: number; min?: number }
+) => {
+  if (option === MATCHING.MAX) {
+    return { max: range.max || DEFAULT_MAX, min: undefined };
+  } else if (option === MATCHING.MIN) {
+    return { max: undefined, min: range.min || DEFAULT_MIN };
+  } else if (option === MATCHING.BETWEEN) {
+    return {
+      max: range.max || DEFAULT_MAX,
+      min: range.min || DEFAULT_MIN,
+    };
+  }
+
+  return { max: undefined, min: DEFAULT_MIN };
+};
+
+const LoggedCallCount = ({
+  filterConfig,
+  onChange,
+}: LoggedCallCountProps): JSX.Element => {
+  const loggedCallCount = getLoggedCallCountWithConfig(filterConfig);
+  const [option, setOption] = useState(loggedCallCount.option);
+  const [max, setMax] = useState(loggedCallCount.config?.max);
+  const [min, setMin] = useState(loggedCallCount.config?.min);
+
+  const handleOptionChange = (updatedOption: MATCHING) => {
+    setOption(updatedOption);
+    onChange(getLoggedCallCountConfig(updatedOption, { max, min }));
+  };
+
+  const handleMinChange = (updatedMin: number) => {
+    setMin(updatedMin);
+    onChange(getLoggedCallCountConfig(option, { max, min: updatedMin }));
+  };
+
+  const handleMaxChange = (updatedMax: number) => {
+    setMax(updatedMax);
+    onChange(getLoggedCallCountConfig(option, { max: updatedMax, min }));
+  };
+
+  const callCountSelect = (
+    <StyledSelect
+      onChange={(event) => handleOptionChange(event.target.value as MATCHING)}
+      value={option}
+    >
+      {Object.values(MATCHING).map((value) => (
+        <MenuItem key={value} value={value}>
+          <Msg id={localMessageIds.labels[value]} />
+        </MenuItem>
+      ))}
+    </StyledSelect>
+  );
+
+  const minInput = (
+    <StyledNumberInput
+      onChange={(event) => handleMinChange(+event.target.value)}
+      value={min || DEFAULT_MIN}
+    />
+  );
+
+  const maxInput = (
+    <StyledNumberInput
+      onChange={(event) => handleMaxChange(+event.target.value)}
+      value={max || DEFAULT_MAX}
+    />
+  );
+
+  return (
+    <Typography display="inline" variant="h4">
+      {option === MATCHING.BETWEEN && (
+        <Msg
+          id={localMessageIds.edit.between}
+          values={{ callCountSelect, maxInput, minInput }}
+        />
+      )}
+      {option === MATCHING.MAX && (
+        <Msg
+          id={localMessageIds.edit.max}
+          values={{ callCountSelect, max: max || DEFAULT_MAX, maxInput }}
+        />
+      )}
+      {option === MATCHING.MIN && (
+        <Msg
+          id={localMessageIds.edit.min}
+          values={{ callCountSelect, min: min || DEFAULT_MIN, minInput }}
+        />
+      )}
+      {option === MATCHING.ONCE && (
+        <Msg id={localMessageIds.edit.once} values={{ callCountSelect }} />
+      )}
+    </Typography>
+  );
+};
+
+export default LoggedCallCount;

--- a/src/features/smartSearch/components/filters/CallerParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/index.tsx
@@ -1,6 +1,7 @@
 import { FormEvent } from 'react';
 import { MenuItem } from '@mui/material';
 
+import LoggedCallCount from './LoggedCallCount';
 import FilterForm from '../../FilterForm';
 import { Msg, useMessages } from 'core/i18n';
 import StyledAutocomplete from '../../inputs/StyledAutocomplete';
@@ -70,6 +71,13 @@ const CallerParticipation = ({
     }
   };
 
+  const handleCallCountChange = (callCount: { max?: number; min?: number }) => {
+    setConfig({
+      ...filter.config,
+      num_calls: callCount,
+    });
+  };
+
   return (
     <FilterForm
       enableOrgSelect
@@ -117,6 +125,12 @@ const CallerParticipation = ({
                 ]}
                 onChange={(e) => handleAssignmentSelectChange(e.target.value)}
                 value={filter.config.assignment ?? ANY_ASSIGNMENT}
+              />
+            ),
+            callCountSelect: (
+              <LoggedCallCount
+                filterConfig={filter.config.num_calls}
+                onChange={handleCallCountChange}
               />
             ),
           }}

--- a/src/features/smartSearch/components/filters/CallerParticipation/index.tsx
+++ b/src/features/smartSearch/components/filters/CallerParticipation/index.tsx
@@ -2,6 +2,7 @@ import { FormEvent } from 'react';
 import { MenuItem } from '@mui/material';
 
 import LoggedCallCount from './LoggedCallCount';
+import { normalizeLoggedCallCountConfig } from './utils';
 import FilterForm from '../../FilterForm';
 import { Msg, useMessages } from 'core/i18n';
 import StyledAutocomplete from '../../inputs/StyledAutocomplete';
@@ -57,7 +58,7 @@ const CallerParticipation = ({
       ...filter,
       config: {
         assignment: filter.config.assignment,
-        num_calls: filter.config.num_calls,
+        num_calls: normalizeLoggedCallCountConfig(filter.config.num_calls),
         organizations: filter.config.organizations,
       },
     });

--- a/src/features/smartSearch/components/filters/CallerParticipation/utils.ts
+++ b/src/features/smartSearch/components/filters/CallerParticipation/utils.ts
@@ -1,0 +1,44 @@
+import {
+  CallerParticipationFilterConfig,
+  MATCHING,
+} from 'features/smartSearch/components/types';
+
+export const getLoggedCallCountWithConfig = (
+  config: CallerParticipationFilterConfig['num_calls']
+) => {
+  const max = config?.max;
+  const min = config?.min;
+
+  if (min === 1 && max === undefined) {
+    return {
+      config,
+      option: MATCHING.ONCE,
+    };
+  }
+
+  if (min !== undefined && max !== undefined) {
+    return {
+      config,
+      option: MATCHING.BETWEEN,
+    };
+  }
+
+  if (min !== undefined) {
+    return {
+      config,
+      option: MATCHING.MIN,
+    };
+  }
+
+  if (max !== undefined) {
+    return {
+      config,
+      option: MATCHING.MAX,
+    };
+  }
+
+  return {
+    config: { min: 1 },
+    option: MATCHING.ONCE,
+  };
+};

--- a/src/features/smartSearch/components/filters/CallerParticipation/utils.ts
+++ b/src/features/smartSearch/components/filters/CallerParticipation/utils.ts
@@ -3,36 +3,58 @@ import {
   MATCHING,
 } from 'features/smartSearch/components/types';
 
+const MIN_CALL_COUNT = 1;
+
+export const normalizeLoggedCallCountConfig = (
+  config: CallerParticipationFilterConfig['num_calls']
+) => {
+  const min =
+    config.min !== undefined ? Math.max(MIN_CALL_COUNT, config.min) : undefined;
+  const max =
+    config.max !== undefined ? Math.max(MIN_CALL_COUNT, config.max) : undefined;
+
+  if (min !== undefined && max !== undefined && max < min) {
+    return {
+      max: min,
+      min: max,
+    };
+  }
+
+  return {
+    max,
+    min,
+  };
+};
+
 export const getLoggedCallCountWithConfig = (
   config: CallerParticipationFilterConfig['num_calls']
 ) => {
-  const max = config?.max;
-  const min = config?.min;
+  const { max, min } = normalizeLoggedCallCountConfig(config);
 
   if (min === 1 && max === undefined) {
     return {
-      config,
+      config: { min },
       option: MATCHING.ONCE,
     };
   }
 
   if (min !== undefined && max !== undefined) {
     return {
-      config,
+      config: { max, min },
       option: MATCHING.BETWEEN,
     };
   }
 
   if (min !== undefined) {
     return {
-      config,
+      config: { min },
       option: MATCHING.MIN,
     };
   }
 
   if (max !== undefined) {
     return {
-      config,
+      config: { max },
       option: MATCHING.MAX,
     };
   }

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -316,23 +316,67 @@ export default makeMessages('feat.smartSearch', {
         ),
         none: m("This organization doesn't have any call assignments yet"),
       },
+      callCount: {
+        edit: {
+          between: m<{
+            callCountSelect: ReactElement;
+            maxInput: ReactElement;
+            minInput: ReactElement;
+          }>('{callCountSelect} {minInput} and {maxInput} calls'),
+          max: m<{
+            callCountSelect: ReactElement;
+            max: number;
+            maxInput: ReactElement;
+          }>(
+            '{callCountSelect} {maxInput} {max, plural, one {call} other {calls}}'
+          ),
+          min: m<{
+            callCountSelect: ReactElement;
+            min: number;
+            minInput: ReactElement;
+          }>(
+            '{callCountSelect} {minInput} {min, plural, one {call} other {calls}}'
+          ),
+          once: m<{ callCountSelect: ReactElement }>('{callCountSelect} call'),
+        },
+        labels: {
+          between: m('between'),
+          max: m('at most'),
+          min: m('at least'),
+          once: m('at least one'),
+        },
+        preview: {
+          between: m<{ max: number; min: number }>(
+            'between {min} and {max} calls'
+          ),
+          max: m<{ max: number; min: number }>(
+            'at most {max} {max, plural, one {call} other {calls}}'
+          ),
+          min: m<{ max: number; min: number }>(
+            'at least {min} {min, plural, one {call} other {calls}}'
+          ),
+          once: m<{ max: number; min: number }>('at least one call'),
+        },
+      },
       examples: {
-        one: m('Add people who have logged calls as callers.'),
+        one: m('Add people who have logged at least 50 calls.'),
         two: m(
-          "Remove people who have logged calls in assignment 'Activate old members'."
+          "Remove people who have logged at most 5 calls in assignment 'Activate old members'."
         ),
       },
       inputString: m<{
         addRemoveSelect: ReactElement;
         assignmentSelect: ReactElement;
+        callCountSelect: ReactElement;
       }>(
-        '{addRemoveSelect} people who have logged calls as callers in {assignmentSelect}.'
+        '{addRemoveSelect} people who have logged {callCountSelect} in {assignmentSelect}.'
       ),
       previewString: m<{
         addRemoveSelect: ReactElement;
         assignmentSelect: ReactElement;
+        callCountSelect: ReactElement;
       }>(
-        '{addRemoveSelect} people who have logged calls as callers in {assignmentSelect}.'
+        '{addRemoveSelect} people who have logged {callCountSelect} in {assignmentSelect}.'
       ),
     },
     emailBlacklist: {

--- a/src/features/smartSearch/l10n/messageIds.ts
+++ b/src/features/smartSearch/l10n/messageIds.ts
@@ -355,7 +355,7 @@ export default makeMessages('feat.smartSearch', {
           min: m<{ max: number; min: number }>(
             'at least {min} {min, plural, one {call} other {calls}}'
           ),
-          once: m<{ max: number; min: number }>('at least one call'),
+          once: m('at least one call'),
         },
       },
       examples: {


### PR DESCRIPTION
## Description

This PR adds call count limits to the caller participation smart search filter.

## Screenshots

<img width="970" height="355" alt="image" src="https://github.com/user-attachments/assets/d2857236-d143-4c62-a1fe-f7ac5f5eca01" />

## Changes

- Adds min/max/between call count selection to the “Callers who have logged calls” smart search filter.

## AI usage

Yes, Codex was used to run local checks and pre-reviewed the code before I created the PR.

## Instructions for reviewer

- Go to a people /organize/1/people/lists/new
- Add the “Callers who have logged calls” filter from the call category.
- Select “any assignment” and try:
- “at least one call”
- “at least 50 calls”
- “at most 5 calls”
- “between 1 and 5 calls”
- In combination with "add", "remove", "limit to", "any assignment" and one specific assignment of your choice

- Save the filter and verify the preview text matches the selected call count.
- Reopen the filter and verify the selected count mode and values persist.

## Related issues
No related issue.
## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information