### PR TITLE
Hide long list of tags in Call ui

### DIFF
--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -28,6 +28,7 @@ type AboutSectionProps = {
 };
 
 export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
+  const messages = useMessages(messageIds);
   const [showAllTags, setShowAllTags] = useState(false);
   const isMobile = useIsMobile();
 
@@ -120,7 +121,11 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
                   {hiddenTags.length > 0 && (
                     <ZUIButton
                       endIcon={showAllTags ? ArrowUpward : ArrowDownward}
-                      label={showAllTags ? 'Collapse ' : 'Show all tags'}
+                      label={
+                        showAllTags
+                          ? messages.about.previousCalls.tags.hide()
+                          : messages.about.previousCalls.tags.show()
+                      }
                       onClick={() => setShowAllTags(!showAllTags)}
                     />
                   )}

--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -100,14 +100,14 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
         <ZUIResponsiveContainer ssrWidth={300}>
           {(width) => {
             const tags = call.target.tags;
-            const maxTags = Math.floor(width / 90);
+            const maxTags = Math.floor(width / 70);
             const displayedTags = tags.slice(0, maxTags);
             const hiddenTags = tags.slice(maxTags);
 
             const tooltipTitle = hiddenTags.map((tag) => tag.title).join(', ');
 
             return (
-              <Box sx={{ paddingBottom: 0.5 }}>
+              <Box>
                 <Box
                   sx={{
                     alignItems: 'center',
@@ -127,6 +127,7 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
                           : messages.about.previousCalls.tags.show()
                       }
                       onClick={() => setShowAllTags(!showAllTags)}
+                      size="small"
                     />
                   )}
                 </Box>
@@ -159,16 +160,16 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
                             alignItems: 'center',
                             backgroundColor: 'transparent',
                             borderColor: theme.palette.grey[500],
-                            borderRadius: '1em',
+                            borderRadius: '1rem',
                             borderWidth: '1px',
                             color: theme.palette.text.secondary,
                             cursor: 'pointer',
                             display: 'flex',
                             height: '30.4px',
                             lineHeight: 'normal',
-                            marginRight: '0.1em',
+                            marginRight: '0.1rem',
                             overflow: 'hidden',
-                            padding: '0.2em 0.7em',
+                            padding: '0.2rem 0.7rem',
                             textOverflow: 'ellipsis',
                           })}
                         >
@@ -199,7 +200,7 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
           }}
         </ZUIResponsiveContainer>
       )}
-      <Box>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
         <ZUIText variant="headingMd">
           <Msg id={messageIds.about.previousActivityHeader} />
         </ZUIText>

--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -1,7 +1,13 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { Box } from '@mui/system';
-import { Stack } from '@mui/material';
-import { HomeOutlined, MailOutline, Phone } from '@mui/icons-material';
+import { Collapse, Stack } from '@mui/material';
+import {
+  ArrowDownward,
+  ArrowUpward,
+  HomeOutlined,
+  MailOutline,
+  Phone,
+} from '@mui/icons-material';
 
 import ZUISection from 'zui/components/ZUISection';
 import ZUIText from 'zui/components/ZUIText';
@@ -15,12 +21,14 @@ import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
 import ZUIResponsiveContainer from 'zui/ZUIResponsiveContainer';
 import ZUITooltip from 'zui/components/ZUITooltip';
+import ZUIButton from 'zui/components/ZUIButton';
 
 type AboutSectionProps = {
   call: UnfinishedCall | null;
 };
 
 export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
+  const [showAllTags, setShowAllTags] = useState(false);
   const isMobile = useIsMobile();
 
   return (
@@ -91,7 +99,7 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
         <ZUIResponsiveContainer ssrWidth={300}>
           {(width) => {
             const tags = call.target.tags;
-            const maxTags = Math.floor(width / 100);
+            const maxTags = Math.floor(width / 90);
             const displayedTags = tags.slice(0, maxTags);
             const hiddenTags = tags.slice(maxTags);
 
@@ -99,47 +107,87 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
 
             return (
               <Box sx={{ paddingBottom: 0.5 }}>
-                <ZUIText variant="headingMd">
-                  <Msg id={messageIds.about.tagsHeader} />
-                </ZUIText>
                 <Box
                   sx={{
                     alignItems: 'center',
                     display: 'flex',
-                    flexWrap: 'wrap',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <ZUIText variant="headingMd">
+                    <Msg id={messageIds.about.tagsHeader} />
+                  </ZUIText>
+                  {hiddenTags.length > 0 && (
+                    <ZUIButton
+                      endIcon={showAllTags ? ArrowUpward : ArrowDownward}
+                      label={showAllTags ? 'Collapse ' : 'Show all tags'}
+                      onClick={() => setShowAllTags(!showAllTags)}
+                    />
+                  )}
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
                     gap: 1,
                     paddingTop: 1,
                   }}
                 >
-                  {displayedTags.map((tag) => (
-                    <ZUITagChip key={tag.id} tag={tag} />
-                  ))}
-                  {hiddenTags.length > 0 && (
-                    <ZUITooltip label={tooltipTitle}>
-                      <Box
-                        border={2}
-                        sx={(theme) => ({
-                          alignItems: 'center',
-                          borderColor: theme.palette.grey[500],
-                          borderRadius: '1em',
-                          borderWidth: '1px',
-                          color: theme.palette.text.secondary,
-                          cursor: 'default',
-                          display: 'flex',
-                          height: '30.4px',
-                          lineHeight: 'normal',
-                          marginRight: '0.1em',
-                          overflow: 'hidden',
-                          padding: '0.2em 0.7em',
-                          textOverflow: 'ellipsis',
-                        })}
-                      >
-                        <ZUIText>
-                          {`${displayedTags.length > 0 ? '+' : ''}${hiddenTags.length}`}
-                        </ZUIText>
-                      </Box>
-                    </ZUITooltip>
-                  )}
+                  <Box
+                    sx={{
+                      alignItems: 'center',
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      gap: 1,
+                    }}
+                  >
+                    {displayedTags.map((tag) => (
+                      <ZUITagChip key={tag.id} tag={tag} />
+                    ))}
+                    {!showAllTags && hiddenTags.length > 0 && (
+                      <ZUITooltip label={tooltipTitle}>
+                        <Box
+                          border={2}
+                          component="button"
+                          onClick={() => setShowAllTags(true)}
+                          sx={(theme) => ({
+                            alignItems: 'center',
+                            backgroundColor: 'transparent',
+                            borderColor: theme.palette.grey[500],
+                            borderRadius: '1em',
+                            borderWidth: '1px',
+                            color: theme.palette.text.secondary,
+                            cursor: 'pointer',
+                            display: 'flex',
+                            height: '30.4px',
+                            lineHeight: 'normal',
+                            marginRight: '0.1em',
+                            overflow: 'hidden',
+                            padding: '0.2em 0.7em',
+                            textOverflow: 'ellipsis',
+                          })}
+                        >
+                          <ZUIText>
+                            {`${displayedTags.length > 0 ? '+' : ''}${hiddenTags.length}`}
+                          </ZUIText>
+                        </Box>
+                      </ZUITooltip>
+                    )}
+                  </Box>
+                  <Collapse in={showAllTags}>
+                    <Box
+                      sx={{
+                        alignItems: 'center',
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 1,
+                      }}
+                    >
+                      {hiddenTags.map((tag) => (
+                        <ZUITagChip key={tag.id} tag={tag} />
+                      ))}
+                    </Box>
+                  </Collapse>
                 </Box>
               </Box>
             );

--- a/src/features/call/components/AboutSection.tsx
+++ b/src/features/call/components/AboutSection.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { Box } from '@mui/system';
+import { Stack } from '@mui/material';
 import { HomeOutlined, MailOutline, Phone } from '@mui/icons-material';
 
 import ZUISection from 'zui/components/ZUISection';
@@ -12,6 +13,8 @@ import ZUIIcon from 'zui/components/ZUIIcon';
 import useIsMobile from 'utils/hooks/useIsMobile';
 import { Msg, useMessages } from 'core/i18n';
 import messageIds from '../l10n/messageIds';
+import ZUIResponsiveContainer from 'zui/ZUIResponsiveContainer';
+import ZUITooltip from 'zui/components/ZUITooltip';
 
 type AboutSectionProps = {
   call: UnfinishedCall | null;
@@ -21,7 +24,7 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
   const isMobile = useIsMobile();
 
   return (
-    <>
+    <Stack gap={1}>
       <Box>
         <Box display="flex" flex={1} flexDirection="column" gap={1}>
           {call.target.phone && (
@@ -85,73 +88,115 @@ export const AboutContent = ({ call }: { call: UnfinishedCall }) => {
         </Box>
       </Box>
       {call.target.tags.length > 0 && (
-        <>
-          <ZUIText variant="headingMd">
-            <Msg id={messageIds.about.tagsHeader} />
-          </ZUIText>
-          <Box
-            sx={{
-              alignItems: 'center',
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 1,
-            }}
-          >
-            {call.target.tags.map((tag) => {
-              return <ZUITagChip key={tag.id} tag={tag} />;
-            })}
-          </Box>
-        </>
+        <ZUIResponsiveContainer ssrWidth={300}>
+          {(width) => {
+            const tags = call.target.tags;
+            const maxTags = Math.floor(width / 100);
+            const displayedTags = tags.slice(0, maxTags);
+            const hiddenTags = tags.slice(maxTags);
+
+            const tooltipTitle = hiddenTags.map((tag) => tag.title).join(', ');
+
+            return (
+              <Box sx={{ paddingBottom: 0.5 }}>
+                <ZUIText variant="headingMd">
+                  <Msg id={messageIds.about.tagsHeader} />
+                </ZUIText>
+                <Box
+                  sx={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 1,
+                    paddingTop: 1,
+                  }}
+                >
+                  {displayedTags.map((tag) => (
+                    <ZUITagChip key={tag.id} tag={tag} />
+                  ))}
+                  {hiddenTags.length > 0 && (
+                    <ZUITooltip label={tooltipTitle}>
+                      <Box
+                        border={2}
+                        sx={(theme) => ({
+                          alignItems: 'center',
+                          borderColor: theme.palette.grey[500],
+                          borderRadius: '1em',
+                          borderWidth: '1px',
+                          color: theme.palette.text.secondary,
+                          cursor: 'default',
+                          display: 'flex',
+                          height: '30.4px',
+                          lineHeight: 'normal',
+                          marginRight: '0.1em',
+                          overflow: 'hidden',
+                          padding: '0.2em 0.7em',
+                          textOverflow: 'ellipsis',
+                        })}
+                      >
+                        <ZUIText>
+                          {`${displayedTags.length > 0 ? '+' : ''}${hiddenTags.length}`}
+                        </ZUIText>
+                      </Box>
+                    </ZUITooltip>
+                  )}
+                </Box>
+              </Box>
+            );
+          }}
+        </ZUIResponsiveContainer>
       )}
-      <ZUIText variant="headingMd">
-        <Msg id={messageIds.about.previousActivityHeader} />
-      </ZUIText>
-      {call.target.past_actions.num_actions > 0 && (
-        <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
-          <ZUIText component="span" display="inline">
-            <Msg
-              id={messageIds.about.participation}
-              values={{
-                events: (
-                  <ZUIText display="inline" variant="bodyMdSemiBold">
-                    <Msg
-                      id={messageIds.about.events}
-                      values={{
-                        numEvents: call.target.past_actions.num_actions,
-                      }}
+      <Box>
+        <ZUIText variant="headingMd">
+          <Msg id={messageIds.about.previousActivityHeader} />
+        </ZUIText>
+        {call.target.past_actions.num_actions > 0 && (
+          <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
+            <ZUIText component="span" display="inline">
+              <Msg
+                id={messageIds.about.participation}
+                values={{
+                  events: (
+                    <ZUIText display="inline" variant="bodyMdSemiBold">
+                      <Msg
+                        id={messageIds.about.events}
+                        values={{
+                          numEvents: call.target.past_actions.num_actions,
+                        }}
+                      />
+                    </ZUIText>
+                  ),
+                  name: call.target.first_name,
+                  time: (
+                    <ZUIRelativeTime
+                      datetime={
+                        call.target.past_actions.last_action?.end_time || ''
+                      }
                     />
-                  </ZUIText>
-                ),
-                name: call.target.first_name,
-                time: (
-                  <ZUIRelativeTime
-                    datetime={
-                      call.target.past_actions.last_action?.end_time || ''
-                    }
-                  />
-                ),
-                title: (
-                  <ZUIText display="inline" variant="bodyMdSemiBold">
-                    {call.target.past_actions.last_action?.title}
-                  </ZUIText>
-                ),
-              }}
-            />
-          </ZUIText>
-        </Box>
-      )}
-      {call.target.past_actions.num_actions == 0 && (
-        <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
-          <ZUIText color="secondary">
-            <Msg
-              id={messageIds.about.noParticipation}
-              values={{ name: call.target.first_name }}
-            />
-          </ZUIText>
-        </Box>
-      )}
+                  ),
+                  title: (
+                    <ZUIText display="inline" variant="bodyMdSemiBold">
+                      {call.target.past_actions.last_action?.title}
+                    </ZUIText>
+                  ),
+                }}
+              />
+            </ZUIText>
+          </Box>
+        )}
+        {call.target.past_actions.num_actions == 0 && (
+          <Box sx={{ minWidth: 0, overflowWrap: 'anywhere' }}>
+            <ZUIText color="secondary">
+              <Msg
+                id={messageIds.about.noParticipation}
+                values={{ name: call.target.first_name }}
+              />
+            </ZUIText>
+          </Box>
+        )}
+      </Box>
       <PreviousCallsInfo call={call} />
-    </>
+    </Stack>
   );
 };
 

--- a/src/features/call/components/PreviousCallsInfo.tsx
+++ b/src/features/call/components/PreviousCallsInfo.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { Box } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import {
   AccessTime,
   CallMade,
@@ -60,7 +60,7 @@ const PreviousCallsInfo: FC<PreviousCallsInfoProps> = ({ call }) => {
   const hasPreviousCalls = callLog.length > 0;
 
   return (
-    <>
+    <Box>
       <ZUIText variant="headingMd">
         <Msg id={messageIds.about.previousCalls.title} />
       </ZUIText>
@@ -69,109 +69,112 @@ const PreviousCallsInfo: FC<PreviousCallsInfoProps> = ({ call }) => {
           <Msg id={messageIds.about.previousCalls.hasNoPreviousCalls} />
         </ZUIText>
       )}
-      {hasPreviousCalls &&
-        callLog.map((previousCall, index) => {
-          const fullName = previousCall.caller.name;
-          const [callerFirstName, ...rest] = fullName.split(' ');
-          const callerLastName = rest.join(' ');
+      {hasPreviousCalls && (
+        <Stack gap={1}>
+          {callLog.map((previousCall, index) => {
+            const fullName = previousCall.caller.name;
+            const [callerFirstName, ...rest] = fullName.split(' ');
+            const callerLastName = rest.join(' ');
 
-          return (
-            <Box key={previousCall.id}>
-              <Box mb={1}>
-                <Box
-                  alignItems="center"
-                  display="flex"
-                  justifyContent="space-between"
-                >
+            return (
+              <Box key={previousCall.id}>
+                <Box mb={1}>
                   <Box
                     alignItems="center"
                     display="flex"
-                    gap={1}
-                    sx={(theme) => {
-                      const color = colors[previousCall.state];
-                      if (color == 'warning') {
-                        return { color: theme.palette.warning.dark };
-                      } else {
-                        return { color: theme.palette[color].main };
-                      }
-                    }}
+                    justifyContent="space-between"
                   >
-                    <ZUIIcon
-                      color={colors[previousCall.state]}
-                      icon={icons[previousCall.state]}
-                      size="small"
-                    />
-                    <ZUIText color="inherit">
-                      <Msg
-                        id={
-                          messageIds.about.previousCalls.status[
-                            callStateToString[previousCall.state]
-                          ]
+                    <Box
+                      alignItems="center"
+                      display="flex"
+                      gap={1}
+                      sx={(theme) => {
+                        const color = colors[previousCall.state];
+                        if (color == 'warning') {
+                          return { color: theme.palette.warning.dark };
+                        } else {
+                          return { color: theme.palette[color].main };
                         }
+                      }}
+                    >
+                      <ZUIIcon
+                        color={colors[previousCall.state]}
+                        icon={icons[previousCall.state]}
+                        size="small"
                       />
-                    </ZUIText>
-                  </Box>
-                  {isMobile ? (
-                    <ZUIPersonAvatar
-                      firstName={callerFirstName}
-                      id={previousCall.caller.id}
-                      lastName={callerLastName}
-                      size="small"
-                    />
-                  ) : (
-                    <Box alignItems="center" display="flex" gap={1}>
-                      <ZUIText color="secondary">
-                        <ZUIDateTime datetime={previousCall.update_time} />
+                      <ZUIText color="inherit">
+                        <Msg
+                          id={
+                            messageIds.about.previousCalls.status[
+                              callStateToString[previousCall.state]
+                            ]
+                          }
+                        />
                       </ZUIText>
+                    </Box>
+                    {isMobile ? (
                       <ZUIPersonAvatar
                         firstName={callerFirstName}
                         id={previousCall.caller.id}
                         lastName={callerLastName}
                         size="small"
                       />
+                    ) : (
+                      <Box alignItems="center" display="flex" gap={1}>
+                        <ZUIText color="secondary">
+                          <ZUIDateTime datetime={previousCall.update_time} />
+                        </ZUIText>
+                        <ZUIPersonAvatar
+                          firstName={callerFirstName}
+                          id={previousCall.caller.id}
+                          lastName={callerLastName}
+                          size="small"
+                        />
+                      </Box>
+                    )}
+                  </Box>
+                  {isMobile && (
+                    <Box ml="1.75rem">
+                      <ZUIText color="secondary">
+                        <ZUIDateTime datetime={previousCall.update_time} />
+                      </ZUIText>
+                    </Box>
+                  )}
+                  {previousCall.notes && (
+                    <Box display="flex" ml="1.75rem">
+                      <ZUIText>
+                        <Msg
+                          id={messageIds.about.previousCalls.note}
+                          values={{ note: previousCall.notes }}
+                        />
+                      </ZUIText>
+                    </Box>
+                  )}
+                  {previousCall.call_back_after && (
+                    <Box display="flex" ml="1.75rem">
+                      <ZUIText>
+                        <Msg
+                          id={messageIds.about.previousCalls.callBackAfter}
+                          values={{
+                            name: previousCall.target.first_name,
+                            time: (
+                              <ZUIDateTime
+                                datetime={previousCall.call_back_after}
+                              />
+                            ),
+                          }}
+                        />
+                      </ZUIText>
                     </Box>
                   )}
                 </Box>
-                {isMobile && (
-                  <Box ml="1.75rem">
-                    <ZUIText color="secondary">
-                      <ZUIDateTime datetime={previousCall.update_time} />
-                    </ZUIText>
-                  </Box>
-                )}
-                {previousCall.notes && (
-                  <Box display="flex" ml="1.75rem">
-                    <ZUIText>
-                      <Msg
-                        id={messageIds.about.previousCalls.note}
-                        values={{ note: previousCall.notes }}
-                      />
-                    </ZUIText>
-                  </Box>
-                )}
-                {previousCall.call_back_after && (
-                  <Box display="flex" ml="1.75rem">
-                    <ZUIText>
-                      <Msg
-                        id={messageIds.about.previousCalls.callBackAfter}
-                        values={{
-                          name: previousCall.target.first_name,
-                          time: (
-                            <ZUIDateTime
-                              datetime={previousCall.call_back_after}
-                            />
-                          ),
-                        }}
-                      />
-                    </ZUIText>
-                  </Box>
-                )}
+                {index < callLog.length - 1 && <ZUIDivider />}
               </Box>
-              {index < callLog.length - 1 && <ZUIDivider />}
-            </Box>
-          );
-        })}
-    </>
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
   );
 };
 

--- a/src/features/call/components/PreviousCallsInfo.tsx
+++ b/src/features/call/components/PreviousCallsInfo.tsx
@@ -60,7 +60,7 @@ const PreviousCallsInfo: FC<PreviousCallsInfoProps> = ({ call }) => {
   const hasPreviousCalls = callLog.length > 0;
 
   return (
-    <Box>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       <ZUIText variant="headingMd">
         <Msg id={messageIds.about.previousCalls.title} />
       </ZUIText>

--- a/src/features/call/l10n/messageIds.ts
+++ b/src/features/call/l10n/messageIds.ts
@@ -28,6 +28,10 @@ export default makeMessages('feat.call', {
         success: m('Successful'),
         wrongNumber: m('Wrong number'),
       },
+      tags: {
+        hide: m('Collapse'),
+        show: m('Show all tags'),
+      },
       title: m('Previous calls'),
     },
     tagsHeader: m('Tags'),

--- a/src/zui/components/ZUITagChip/index.tsx
+++ b/src/zui/components/ZUITagChip/index.tsx
@@ -101,7 +101,7 @@ const ZUITagChip: FC<ZUITagChipProps> = ({
     </IconButton>
   ) : null;
 
-  const hasValue = tag.value_type && 'value' in tag;
+  const isValueTag = !!tag.value_type;
 
   const deleteContainerPadding = () => {
     if (deletable) {
@@ -125,7 +125,7 @@ const ZUITagChip: FC<ZUITagChipProps> = ({
         overflow: 'hidden',
       }}
     >
-      {hasValue && (
+      {isValueTag && (
         <>
           <ZUITagTooltip tag={tag}>
             <Box
@@ -162,7 +162,7 @@ const ZUITagChip: FC<ZUITagChipProps> = ({
                 },
               },
             }}
-            title={tag.value || ''}
+            title={'value' in tag ? tag.value : ''}
           >
             <Box
               data-testid="TagChip-value"
@@ -180,13 +180,15 @@ const ZUITagChip: FC<ZUITagChipProps> = ({
                 whiteSpace: 'nowrap',
               })}
             >
-              <Typography variant="labelSmMedium">{tag.value}</Typography>
+              <Typography variant="labelSmMedium">
+                {'value' in tag ? tag.value : ''}
+              </Typography>
               {deleteButton}
             </Box>
           </Tooltip>
         </>
       )}
-      {!tag.value_type && (
+      {!isValueTag && (
         <ZUITagTooltip tag={tag}>
           <Box
             sx={(theme) => ({


### PR DESCRIPTION
## Description

This PR tries to solve the problem that when a call target has many tags, the list takes over and it gets hard to see other info. 

## Screenshots

<img width="1062" height="642" alt="bild" src="https://github.com/user-attachments/assets/aaa29df7-273f-4c6a-9c61-4621ff98dbde" />

<img width="1051" height="633" alt="bild" src="https://github.com/user-attachments/assets/62e7e8b5-fe4c-48c3-9f61-4ddb7f37df08" />


## Changes

- Uses the same logic from the `CallersList` where we calculate width of the parent and try to figure out how many tags will fit on 2 lines 
- Adds a button to show all tags
- Also adds logic to click the "this many more tags" chip to show all tags 

## AI usage
no

## Instructions for reviewer

- be logged in as testUSER (jane doe)
- go to /my
- select "chat with the cats" call assignment
- select unfinished call with VD, Victor Davidson (he has many  tags)
- see the "+xx" chip
- hover "+xx" chip
- test clicking the chip and the Show all tags button
- See how it looks, maybe resize the screen and try different zoom levels

## Thought
One thing I did think about was how tiny the text in the ZUI tooltips are. We have previously talked about this, and if we want, making the font size a bit larger in those could be done in this pr. Because honestly i think the tooltip that shows when you hover the "+xx" chip, with all the names of the hidden tags, is pretty much undreadable.

## Related issues
none

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
