### PR TITLE
change lang attribute in two files from hard coded to dynamic #3769

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({
   const messages = await getMessages(lang);
 
   return (
-    <html lang="en">
+    <html lang={lang}>
       <body>
         <AppRouterCacheProvider>
           <ClientContext

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,14 +3,21 @@ import { Children } from 'react';
 import ServerStyleSheets from '@mui/styles/ServerStyleSheets';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 
+import { getBrowserLanguage } from 'utils/locale';
+import { ZetkinUser } from 'utils/types/zetkin';
+import BackendApiClient from 'core/api/client/BackendApiClient';
 import oldTheme from '../theme';
 
 // boilerplate page taken from https://github.com/mui-org/material-ui/tree/master/examples/nextjs
 
-export default class MyDocument extends Document {
+interface MyDocumentProps {
+  lang: string;
+}
+
+export default class MyDocument extends Document<MyDocumentProps> {
   render(): JSX.Element {
     return (
-      <Html lang="en" style={{ overscrollBehaviorX: 'none' }}>
+      <Html lang={this.props.lang} style={{ overscrollBehaviorX: 'none' }}>
         <Head>
           {/* PWA primary color */}
           <meta content={oldTheme.palette.primary.main} name="theme-color" />
@@ -35,9 +42,27 @@ MyDocument.getInitialProps = async (ctx) => {
       enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
     });
 
+  const headersObject = {
+    'accept-language': ctx.req?.headers['accept-language'] || '',
+    cookie: ctx.req?.headers.cookie || '',
+  };
+  const apiClient = new BackendApiClient(headersObject);
+
+  let user: ZetkinUser | null = null;
+
+  try {
+    user = await apiClient.get<ZetkinUser>('/api/users/me');
+  } catch (e) {
+    user = null;
+  }
+
+  const lang =
+    user?.lang || getBrowserLanguage(ctx.req?.headers['accept-language'] || '');
+
   const initialProps = await Document.getInitialProps(ctx);
 
   return {
+    lang,
     ...initialProps,
     styles: [
       ...Children.toArray(initialProps.styles),


### PR DESCRIPTION
## Description

This PR sets the lang attribute of the html element to be set dynamically, per issue #3769

## Screenshots
language is set to norweigan an saved, attribute value changes to norweigan (nn)
<img width="1431" height="729" alt="dynamic-lang-my-settings" src="https://github.com/user-attachments/assets/3ba416cd-1541-47f6-b118-a97a5a7b37ad" />
routing to /orginize/1, language is still norweigan (nn)

## Changes
src/app/layout.tsx

lang is changed to the value of the previously available 'lang' variable:

 <html lang={lang}>

/src/pages/_document.tsx

-A headers object is constructed (#45-48)
-ApiClient instance is created using the BackendApiClient class. The header object is passed on instantiation (#49)
-user variable instantiated (#51)
-user variable is set using the apiClient (#53-57)
 lang variable created and set with value from the user object (#59-61)
 -the lang variable is added to the return value of the .getInitalProps method (#65)

## AI usage

Yes.

If yes - how?

Gemin was used to get familiar with the code and generate the correct syntax.

## Testing the code

-Go to /my/settings and inspect. Note the lang attribute value of the html element. 
-Select any language and save. Note again the lang attribute value of the html element. It should change to your selected language.
-when completed, note the currently selected language for the user.
-go to /organize/1 and inspect. The lang attribute value should be the same as selected in previous step.

## Related issues

I get error messages in the browser when changing to certain languages. However, this issue does not appear to be related to the changes. The error messages are there even without changes.
<img width="1426" height="912" alt="language-dynamic-errors" src="https://github.com/user-attachments/assets/8b707083-4c5d-460d-b73a-6410877432fd" />
<img width="1033" height="680" alt="language-dynamic-error-3" src="https://github.com/user-attachments/assets/769964a1-8968-4ba4-b694-6d9433ba2c3d" />
<img width="1033" height="680" alt="language-dynamic-error-2" src="https://github.com/user-attachments/assets/759bb72a-f37f-4035-9eaf-20cbf959cc1a" />
<img width="1426" height="912" alt="language-dynamic-error-1" src="https://github.com/user-attachments/assets/fedde114-fc2f-45da-af01-6b7a86aa0c7b" />

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
