### PR TITLE
Force window reload when API returns 401 to frontend

### DIFF
--- a/src/core/api/client/FetchApiClient.ts
+++ b/src/core/api/client/FetchApiClient.ts
@@ -3,8 +3,18 @@ import IApiClient from './IApiClient';
 import { RPCDef, RPCRequestBody, RPCResponseBody } from 'core/rpc/types';
 import { ApiClientError } from '../errors';
 
+let reloadingToLogin = false;
+
 async function assertOk(res: Response) {
   if (!res.ok) {
+    if (res.status == 401 && typeof window !== 'undefined') {
+      if (!reloadingToLogin) {
+        reloadingToLogin = true;
+        window.location.reload();
+        return;
+      }
+    }
+
     throw await ApiClientError.fromResponse(res);
   }
 }


### PR DESCRIPTION
## Description

This PR adds a quite ugly, but potentially useful catch-all for when the API client fails because the user has been logged out. Instead of just failing, it forces the page to reload.

This solves some bugs where the UI would keep retrying indefinitely. Those bugs should of course also be fixed where they occur, but redirecting the user to the login page is still a good solution in general.

## Screenshots
None

## Changes
- Forces frontend to reload if an API request fails with 401

## AI usage
No

## Instructions for reviewer
1. Go to /my and log in
2. While keeping that tab open, go to /logout in another tab
3. Go back to the first tab and click any area assignment to navigate to that page

This would previously cause an infinite loop of requests, but should now make a single request, fail and then reload the page which redirects to login.

## Related issues
Undocumented

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
