### PR TITLE
NoSsr around Call and Canvass apps

### DIFF
--- a/src/app/call/layout.tsx
+++ b/src/app/call/layout.tsx
@@ -1,0 +1,18 @@
+import { FC, ReactNode } from 'react';
+import { NoSsr } from '@mui/material';
+
+import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
+
+type Props = {
+  children: ReactNode;
+};
+
+const CallLayout: FC<Props> = ({ children }) => {
+  return (
+    <HomeThemeProvider>
+      <NoSsr>{children}</NoSsr>
+    </HomeThemeProvider>
+  );
+};
+
+export default CallLayout;

--- a/src/app/call/page.tsx
+++ b/src/app/call/page.tsx
@@ -3,7 +3,6 @@ import { Metadata } from 'next';
 import { Suspense } from 'react';
 
 import CallPage from 'features/call/pages/CallPage';
-import HomeThemeProvider from 'features/my/components/HomeThemeProvider';
 import redirectIfLoginNeeded from 'core/utils/redirectIfLoginNeeded';
 import ZUILogoLoadingIndicator from 'zui/ZUILogoLoadingIndicator';
 import Heartbeat from 'features/call/components/Heartbeat';
@@ -19,24 +18,22 @@ export default async function Page() {
   await redirectIfLoginNeeded();
 
   return (
-    <HomeThemeProvider>
-      <Suspense
-        fallback={
-          <Box
-            sx={{
-              alignItems: 'center',
-              display: 'flex',
-              height: '100dvh',
-              justifyContent: 'center',
-            }}
-          >
-            <ZUILogoLoadingIndicator />
-          </Box>
-        }
-      >
-        <Heartbeat />
-        <CallPage />
-      </Suspense>
-    </HomeThemeProvider>
+    <Suspense
+      fallback={
+        <Box
+          sx={{
+            alignItems: 'center',
+            display: 'flex',
+            height: '100dvh',
+            justifyContent: 'center',
+          }}
+        >
+          <ZUILogoLoadingIndicator />
+        </Box>
+      }
+    >
+      <Heartbeat />
+      <CallPage />
+    </Suspense>
   );
 }

--- a/src/app/canvass/[areaAssId]/layout.tsx
+++ b/src/app/canvass/[areaAssId]/layout.tsx
@@ -1,0 +1,12 @@
+import { FC, ReactNode } from 'react';
+import { NoSsr } from '@mui/material';
+
+type Props = {
+  children: ReactNode;
+};
+
+const CanvassLayout: FC<Props> = ({ children }) => {
+  return <NoSsr>{children}</NoSsr>;
+};
+
+export default CanvassLayout;


### PR DESCRIPTION
## Description

This PR adds the `NoSsr` component around the Call and Canvass apps, to prevent serverside rendering, for faster page rendering.

## Screenshots

none

## Changes
- Adds layout files at the top level of the Call and Canvass apps, with `NoSsr` around them
- Moves the `HomeThemeProvider` around the Call app into the layout file

## AI usage? no

## Instructions for reviewer
- go to /my
- open a way in your devtools to look at performance times
- click on a call assignment or a canvass assignment
- see the performance times for going to the call page
- do the same on `main`

## Related issues
None

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
