### PR TITLE
render custom fields in duplicates popup

### DIFF
--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -72,9 +72,10 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
   };
 
   const getAvatars = (value: string) => {
-    const peopleWithMatchingValues = duplicates.filter(
-      (person) => person[field] == value
-    );
+    const peopleWithMatchingValues = duplicates.filter((person) => {
+      const personValue = person[field];
+      return (personValue ? personValue.toString() : '') == value;
+    });
 
     return (
       <Box display="flex" gap="2px">
@@ -124,6 +125,7 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
         {values.length > 1 && (
           <FormControl fullWidth size="small">
             <Select
+              displayEmpty
               onChange={(event) => {
                 setSelectedValue(event.target.value);
                 onChange(event.target.value);

--- a/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
+++ b/src/features/duplicates/components/FieldSettings/FieldSettingsRow.tsx
@@ -13,18 +13,25 @@ import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import { Msg, useMessages } from 'core/i18n';
 import globalMessageIds from 'core/i18n/messageIds';
 import { useNumericRouteParams } from 'core/hooks';
-import { ZetkinPerson } from 'utils/types/zetkin';
+import {
+  CUSTOM_FIELD_TYPE,
+  ZetkinCustomField,
+  ZetkinPerson,
+} from 'utils/types/zetkin';
 import ZUIAvatar from 'zui/ZUIAvatar';
+import ZUIDate from 'zui/ZUIDate';
 import useFieldTitle from 'utils/hooks/useFieldTitle';
 
 interface FieldSettingsRowProps {
+  customField?: ZetkinCustomField;
   duplicates: ZetkinPerson[];
-  field: NATIVE_PERSON_FIELDS;
+  field: string;
   onChange: (selectedValue: string) => void;
   values: string[];
 }
 
 const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
+  customField,
   duplicates,
   field,
   onChange,
@@ -50,6 +57,15 @@ const FieldSettingsRow: FC<FieldSettingsRowProps> = ({
           {messages.modal.fieldSettings.noValue()}
         </span>
       );
+    }
+
+    if (customField?.type === CUSTOM_FIELD_TYPE.DATE) {
+      return <ZUIDate datetime={value} />;
+    }
+
+    if (customField?.type === CUSTOM_FIELD_TYPE.ENUM) {
+      const choice = customField.enum_choices?.find((c) => c.key === value);
+      return choice?.label ?? value;
     }
 
     return value;

--- a/src/features/duplicates/components/FieldSettings/index.tsx
+++ b/src/features/duplicates/components/FieldSettings/index.tsx
@@ -19,7 +19,7 @@ import getFieldSettings from 'features/duplicates/utils/getFieldSettings';
 interface FieldSettingsProps {
   customFields: ZetkinCustomField[];
   duplicates: ZetkinPerson[];
-  onChange: (field: NATIVE_PERSON_FIELDS, selectedValue: string) => void;
+  onChange: (field: string, selectedValue: string) => void;
   resetKey: string;
   setOverrides: React.Dispatch<
     React.SetStateAction<Partial<ZetkinPerson> | null>
@@ -96,10 +96,13 @@ const FieldSettings: FC<FieldSettingsProps> = ({
               {field !== NATIVE_PERSON_FIELDS.FIRST_NAME && <Divider />}
               <FieldSettingsRow
                 key={field}
+                customField={customFields.find(
+                  (customField) => customField.slug === field
+                )}
                 duplicates={duplicates}
-                field={field as NATIVE_PERSON_FIELDS}
+                field={field}
                 onChange={(selectedValue: string) =>
-                  onChange(field as NATIVE_PERSON_FIELDS, selectedValue)
+                  onChange(field, selectedValue)
                 }
                 values={values}
               />

--- a/src/features/duplicates/utils/getFieldSettings.ts
+++ b/src/features/duplicates/utils/getFieldSettings.ts
@@ -1,6 +1,15 @@
 import { NATIVE_PERSON_FIELDS } from 'features/views/components/types';
 import sortValuesByFrequency from './sortValuesByFrequency';
-import { ZetkinCustomField, ZetkinPerson } from 'utils/types/zetkin';
+import {
+  CUSTOM_FIELD_TYPE,
+  ZetkinCustomField,
+  ZetkinPerson,
+} from 'utils/types/zetkin';
+
+const UNMERGEABLE_CUSTOM_FIELD_TYPES = [
+  CUSTOM_FIELD_TYPE.JSON,
+  CUSTOM_FIELD_TYPE.LNGLAT,
+];
 
 export default function getFieldSettings({
   duplicates,
@@ -9,6 +18,10 @@ export default function getFieldSettings({
   customFields: ZetkinCustomField[];
   duplicates: ZetkinPerson[];
 }) {
+  const mergeableCustomFields = customFields.filter(
+    (field) => !UNMERGEABLE_CUSTOM_FIELD_TYPES.includes(field.type)
+  );
+
   const sortedPersonFields: string[] = [
     NATIVE_PERSON_FIELDS.FIRST_NAME,
     NATIVE_PERSON_FIELDS.LAST_NAME,
@@ -22,7 +35,7 @@ export default function getFieldSettings({
     NATIVE_PERSON_FIELDS.CITY,
     NATIVE_PERSON_FIELDS.COUNTRY,
     NATIVE_PERSON_FIELDS.EXT_ID,
-    ...customFields.map((item) => item.slug),
+    ...mergeableCustomFields.map((item) => item.slug),
   ];
 
   const fieldValues: Record<string, string[]> = {};


### PR DESCRIPTION
## Description

This PR adds custom fields to the duplicates popup

## Screenshots

<img width="1159" height="549" alt="Screenshot 2026-09-10 at 10 33 49" src="https://github.com/user-attachments/assets/cf0fd0b1-17be-4e3a-958d-d59786fa7f31" />

## Changes

- Adds
  - Custom fields are rendered on the merge dialog. 
  - Does not show json or latlng fields because they would be stringified as "[Object object]" and sent to backend. Merging these fields could require more work
## AI usage

Did you use AI to create the code in this PR - Yes, investigated possible solutions with claude, but wrote code myself.

## Instructions for reviewer

- Go to: localhost:3000/organize/1/people/4
- Click the dots menu and click "Merge with..."
- Pick another user to merge with
- Check that custom fields are rendered, and any fields with values are there. 
- Save the merge
- Check that the old user is deleted and the original user has the merged custom fields.

## Related issues

Resolves #3051 

## Note on review changes and collaboration

We are a large group of people contributing at different intervals, and we are completely fine with everyone contributing at their own pace. At the same time we sometimes need to move things along to get all the good contributions merged into the code base. This means, that if you are not able to make any requested changes within around 2 weeks from review being given, someone else might take over to make these changes and get the PR merged.

## PR checklist

- [x] I have run the code, tried out the changes I made and I think they work
- [x] I have not included any changes outside the scope of the task I'm working on
- [x] I have made sure that formatting, linting and type checks pass locally
- [x] I have filled out this template and replaced all placeholders with the corresponding information
